### PR TITLE
Support multiple server versions in multi-version tests

### DIFF
--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlTestExtension.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlTestExtension.java
@@ -121,7 +121,9 @@ public class YamlTestExtension implements TestTemplateInvocationContextProvider,
             try {
                 server.stop();
             } catch (Exception ex) {
-                logger.warn("Failed to stop server " + server.getVersion() + " on " + server.getPort());
+                if (logger.isWarnEnabled()) {
+                    logger.warn("Failed to stop server " + server.getVersion() + " on " + server.getPort());
+                }
             }
         }
         if (exception.isPresent()) {

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlTestExtension.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlTestExtension.java
@@ -121,7 +121,7 @@ public class YamlTestExtension implements TestTemplateInvocationContextProvider,
             try {
                 server.stop();
             } catch (Exception ex) {
-                logger.info("Failed to stop server " + server.getVersion() + " on " + server.getPort());
+                logger.warn("Failed to stop server " + server.getVersion() + " on " + server.getPort());
             }
         }
         if (exception.isPresent()) {

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/MultiServerConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/MultiServerConfig.java
@@ -40,25 +40,15 @@ public class MultiServerConfig extends JDBCInProcessConfig {
     private final ExternalServer externalServer;
     private final int initialConnection;
 
-    public MultiServerConfig(final int initialConnection, final int grpcPort, final int httpPort) {
+    public MultiServerConfig(final int initialConnection, ExternalServer externalServer) {
         super();
         this.initialConnection = initialConnection;
-        externalServer = new ExternalServer(grpcPort, httpPort);
+        this.externalServer = externalServer;
     }
 
     @Override
     public void beforeAll() throws Exception {
         super.beforeAll();
-        externalServer.start();
-    }
-
-    @Override
-    public void afterAll() throws Exception {
-        try {
-            externalServer.stop();
-        } finally {
-            super.afterAll();
-        }
     }
 
     @Override
@@ -88,9 +78,9 @@ public class MultiServerConfig extends JDBCInProcessConfig {
     @Override
     public String toString() {
         if (initialConnection == 0) {
-            return "MultiServer (Embedded then External)";
+            return "MultiServer version " + externalServer.getVersion() + " (Embedded then External)";
         } else {
-            return "MultiServer (External then Embedded)";
+            return "MultiServer version " + externalServer.getVersion() + " (External then Embedded)";
         }
     }
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/MultiServerConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/MultiServerConfig.java
@@ -78,9 +78,9 @@ public class MultiServerConfig extends JDBCInProcessConfig {
     @Override
     public String toString() {
         if (initialConnection == 0) {
-            return "MultiServer version " + externalServer.getVersion() + " (Embedded then External)";
+            return "MultiServer (Embedded then " + externalServer.getVersion() + ")";
         } else {
-            return "MultiServer version " + externalServer.getVersion() + " (External then Embedded)";
+            return "MultiServer (" + externalServer.getVersion() + " then Embedded)";
         }
     }
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/ExternalServer.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/ExternalServer.java
@@ -94,6 +94,7 @@ public class ExternalServer {
             jar = serverJar;
         }
         Assertions.assertTrue(jar.exists(), "Jar could not be found " + jar.getAbsolutePath());
+        this.version = getVersion(jar);
         ProcessBuilder processBuilder = new ProcessBuilder("java",
                 // TODO add support for debugging by adding, but need to take care with ports
                 // "-agentlib:jdwp=transport=dt_socket,server=y,address=8000,suspend=n",
@@ -112,7 +113,6 @@ public class ExternalServer {
             Assertions.fail("Failed to start the external server");
         }
 
-        this.version = getVersion(jar);
         logger.info("Started {} Version: {}", jar, version);
     }
 


### PR DESCRIPTION
This enables the execution of multi-version tests against various server versions. Assuming the availability of multiple server versions, this PR achieves the following:
- Reuses servers across different configurations, ensuring each version is run only once.
- Starts all servers located in the download directory.
- Runs all multi-server tests with all available servers.
