### PR TITLE
Remove caching settings when downloading old server

### DIFF
--- a/yaml-tests/yaml-tests.gradle
+++ b/yaml-tests/yaml-tests.gradle
@@ -76,13 +76,7 @@ dependencies {
 ext.resolveOtherServer = { Set<String> rejectedVersions ->
     def configurationName = "resolveArtifact-${UUID.randomUUID()}"
     return rootProject.with {
-        configurations.create(configurationName, {
-            resolutionStrategy {
-                // Note: In the root of the project we set cacheChangingModulesFor and cacheDynamicVersionFor to 0
-                // We explicitly change that for changing modules, because we should reject those anyways.
-                cacheChangingModulesFor 1000, "days" // TTL for snapshots
-            }
-        })
+        configurations.create(configurationName, { })
         // If you're wondering why this doesn't just use `latest.release`:
         // `latest.release` becomes `LatestVersionSelector` which `requiresMetadata` in order to determine if the
         // version in question is a release. This means that it can't just look at the version listing, it has to


### PR DESCRIPTION
yaml-tests resolveOtherServer had settings to override the caching settings. I think this was to override something that was otherwise removed.