### PR TITLE
Fix broken build in Main

### DIFF
--- a/yaml-tests/src/test/resources/recursive-cte.yamsql
+++ b/yaml-tests/src/test/resources/recursive-cte.yamsql
@@ -74,7 +74,7 @@ test_block:
             select id, parent from t1 where parent = -1
             union all
             select b.id, b.parent from c1 as a, t1 as b where a.id = b.parent) select id from c1
-      - supported_version: 4.1.4.0
+      - supported_version: !current_version
       - maxRows: 1
       - result: [{ID: 1}]
       - result: [{ID: 10}]
@@ -94,7 +94,7 @@ test_block:
             select b.id, b.parent from ancestorsOf250 as a, t1 as b where a.parent = b.id) select id, parent from ancestorsOf250
             union all
             select b.id, b.parent from allDescendants as a, t1 as b where a.id = b.parent) select id, parent from allDescendants
-      - supported_version: 4.1.4.0
+      - supported_version: !current_version
       - maxRows: 1
       - result: [{250, 50}]
       - result: [{50, 10}]


### PR DESCRIPTION
Two tests now fail on Main. The tests had a `supported_version` that was enabled once a release was cut but a plan hash change now make them fail when they are run on multi-server config.
This PR reintroduces the `!current_version` for the tests such that these will not run in multi-server mode
