### PR TITLE
Resolves #1288: Automatically publish to maven central

### DIFF
--- a/.github/workflows/patch_release.yml
+++ b/.github/workflows/patch_release.yml
@@ -42,6 +42,9 @@ jobs:
 
       - name: Build and publish release
         uses: ./actions/release-build-publish
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MAVEN_USER: ${{ secrets.MAVEN_USER }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,9 @@ jobs:
 
       - name: Build and publish
         uses: ./actions/release-build-publish
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MAVEN_USER: ${{ secrets.MAVEN_USER }}

--- a/actions/release-build-publish/action.yml
+++ b/actions/release-build-publish/action.yml
@@ -1,5 +1,13 @@
 name: Build and publish release
 
+inputs:
+  gpg_private_key:
+    description: 'GPG key for artifact signing'
+    required: true
+  gpg_passphrase:
+    description: 'GPG passphrase for artifact signing'
+    required: true
+
 runs:
   using: "composite"
   steps:
@@ -15,7 +23,10 @@ runs:
     - name: Publish Artifacts
       uses: ./actions/run-gradle
       with:
-        gradle_command: publish -PreleaseBuild=true -PpublishBuild=true -PgithubPublish=true -PcentralPublish=true
+        gradle_command: publish closeAndReleaseStagingRepositories -PreleaseBuild=true -PpublishBuild=true -PgithubPublish=true -PcentralPublish=true
+      env:
+        ORG_GRADLE_PROJECT_signingKey: ${{ inputs.gpg_private_key }}
+        ORG_GRADLE_PROJECT_signingPassword: ${{ inputs.gpg_passphrase }}
 
     # Post release: Update various files which reference version
     - name: Update release notes

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ plugins {
     alias(libs.plugins.protobuf)
     alias(libs.plugins.versions)
     alias(libs.plugins.spotbugs)
+    alias(libs.plugins.nexus)
     alias(libs.plugins.artifactory)
     alias(libs.plugins.download)
 }
@@ -297,6 +298,28 @@ subprojects {
                     }
                 }
             }
+        }
+    }
+}
+
+// Configure publishing for maven central. This is done in the top-level build.gradle, and then
+// all of the subprojects configure the artifacts they want published by applying
+// ${rootDir}/gradle/publishing.gradle in the project gradle. By default, we publish a library
+// from each package, but this can be configured by adjusting the publishLibrary variable
+if (Boolean.parseBoolean(centralPublish)) {
+    nexusPublishing {
+        repositories {
+            sonatype {
+                username = System.getenv("MAVEN_USER")
+                password = System.getenv("MAVEN_PASSWORD")
+            }
+        }
+    }
+    signing {
+        def signingKey = findProperty("signingKey")
+        def signingPassword = findProperty("signingPassword")
+        if (signingKey != null && signingPassword != null) {
+            useInMemoryPgpKeys(signingKey, signingPassword)
         }
     }
 }

--- a/fdb-record-layer-core-shaded/fdb-record-layer-core-shaded.gradle
+++ b/fdb-record-layer-core-shaded/fdb-record-layer-core-shaded.gradle
@@ -123,3 +123,9 @@ publishing {
         publications (publishing.publications.shadow)
     }
 }
+
+if (Boolean.parseBoolean(centralPublish)) {
+    signing {
+        sign publishing.publications.shadow
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -154,6 +154,7 @@ artifactory = { id = "com.jfrog.artifactory", version = "4.29.2" }
 download = { id = "de.undercouch.download", version = "5.6.0" }
 gitversion = { id = "com.palantir.git-version", version = "3.1.0" }
 jmh = { id = "me.champeau.jmh", version = "0.7.2" }
+nexus = { id = "io.github.gradle-nexus.publish-plugin", version = "2.0.0" }
 protobuf = { id = "com.google.protobuf", version = "0.8.19" }
 serviceloader = { id = "com.github.harbby.gradle.serviceloader", version = "1.1.8" }
 shadow = { id = "com.github.johnrengelman.shadow", version = "7.1.2" }

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -19,6 +19,7 @@
  */
 
 apply plugin: 'com.jfrog.artifactory'
+apply plugin: 'signing'
 
 // Add various details to the pom file to allow for publishing
 def addPublishingInfo(publication) {
@@ -99,6 +100,11 @@ if (ext.publishLibrary) {
             }
         }
     }
+    if (Boolean.parseBoolean(centralPublish)) {
+        signing {
+            sign publishing.publications.library
+        }
+    }
 }
 
 ext {
@@ -116,17 +122,6 @@ publishing {
                     credentials {
                         username = System.getenv("GITHUB_ACTOR")
                         password = System.getenv("GITHUB_TOKEN")
-                    }
-                }
-            }
-
-            if (Boolean.parseBoolean(centralPublish)) {
-                maven {
-                    name = "OSSRH"
-                    url = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
-                    credentials {
-                        username = System.getenv("MAVEN_USER")
-                        password = System.getenv("MAVEN_PASSWORD")
                     }
                 }
             }


### PR DESCRIPTION
This should complete our maven central automation. It configures artifact signing (required for maven central upload), and it makes use of the nexus publishing plugin to upload artifacts to maven central to a staging repository, close the staging repository (which validates the expected invariants from maven central), and then release the artifacts it just uploaded. Once the final step has happened, the new artifacts should be available for maven central download (modulo the time it takes for CDNs to be updated).

This resolves #1288.