### PR TITLE
Kill abandoned external servers started during Yaml Tests

### DIFF
--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/ExternalServer.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/ExternalServer.java
@@ -76,7 +76,9 @@ public class ExternalServer {
                                         argument.startsWith(serverPath)))
                         .orElse(false))
                 .forEach(process -> {
-                    logger.info("Killing existing server: pid=" + process.pid() + " " + process.info());
+                    if (logger.isInfoEnabled()) {
+                        logger.info("Killing existing server: pid=" + process.pid() + " " + process.info());
+                    }
                     process.destroy();
                 });
     }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/ExternalServer.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/ExternalServer.java
@@ -74,7 +74,10 @@ public class ExternalServer {
                 process.info().arguments().map(arguments ->
                                 Arrays.stream(arguments).anyMatch(argument ->
                                         argument.startsWith(serverPath)))
-                        .orElse(false))
+                        .orElse(false) &&
+                        process.info().command().map(command ->
+                                        command.endsWith("/java"))
+                                .orElse(false))
                 .forEach(process -> {
                     if (logger.isInfoEnabled()) {
                         logger.info("Killing existing server: pid=" + process.pid() + " " + process.info());

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/ExternalServer.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/ExternalServer.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Assertions;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.jar.Attributes;
@@ -64,6 +65,20 @@ public class ExternalServer {
         this.serverJar = serverJar;
         this.grpcPort = grpcPort;
         this.httpPort = httpPort;
+    }
+
+    static {
+        final String serverPath = Objects.requireNonNull(System.getProperty(EXTERNAL_SERVER_PROPERTY_NAME));
+        // kill all existing processes
+        ProcessHandle.allProcesses().filter(process ->
+                process.info().arguments().map(arguments ->
+                                Arrays.stream(arguments).anyMatch(argument ->
+                                        argument.startsWith(serverPath)))
+                        .orElse(false))
+                .forEach(process -> {
+                    logger.info("Killing existing server: pid=" + process.pid() + " " + process.info());
+                    process.destroy();
+                });
     }
 
     /**


### PR DESCRIPTION
This adds a static constructor that will find all processes matching the directory for external servers and kill them.
This is most important when running/debugging locally, if you stop the debugger, or SIGKILL, there will be a bunch of processes left behind. This changes it so that we will kill them the next time you run the test.