### PR TITLE
Resolves #3155: FRL respects PLAN_CACHE_*_MAX_ENTRIES

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -32,7 +32,7 @@ Users performing online updates are encouraged to update from [4.0.559.4](#40559
 * **Feature** Feature 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Feature** Add enum column support to relational server [(Issue #3073)](https://github.com/FoundationDB/fdb-record-layer/issues/3073)
 * **Feature** Allow scrubbing of indexes in READABLE_UNIQUE_PENDING state [(Issue #3135)](https://github.com/FoundationDB/fdb-record-layer/issues/3135)
-* **Feature** Feature 4 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
+* **Feature** FRL now respects PLAN_CACHE_*_MAX_ENTRIES options [(Issue #3155)](https://github.com/FoundationDB/fdb-record-layer/issues/3155)
 * **Feature** Support Lucene index scrubbing [(Issue #3008)](https://github.com/FoundationDB/fdb-record-layer/issues/3008)
 * **Breaking change** Change 1 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)
 * **Breaking change** Change 2 [(Issue #NNN)](https://github.com/FoundationDB/fdb-record-layer/issues/NNN)

--- a/fdb-relational-server/src/main/java/com/apple/foundationdb/relational/server/FRL.java
+++ b/fdb-relational-server/src/main/java/com/apple/foundationdb/relational/server/FRL.java
@@ -115,8 +115,11 @@ public class FRL implements AutoCloseable {
                     ddlFactory,
                     RelationalPlanCache.newRelationalCacheBuilder()
                             .setTtl(options.getOption(Options.Name.PLAN_CACHE_PRIMARY_TIME_TO_LIVE_MILLIS))
+                            .setSize(options.getOption(Options.Name.PLAN_CACHE_PRIMARY_MAX_ENTRIES))
                             .setSecondaryTtl(options.getOption(Options.Name.PLAN_CACHE_SECONDARY_TIME_TO_LIVE_MILLIS))
+                            .setSecondarySize(options.getOption(Options.Name.PLAN_CACHE_SECONDARY_MAX_ENTRIES))
                             .setTertiaryTtl(options.getOption(Options.Name.PLAN_CACHE_TERTIARY_TIME_TO_LIVE_MILLIS))
+                            .setTertiarySize(options.getOption(Options.Name.PLAN_CACHE_TERTIARY_MAX_ENTRIES))
                             .build()));
 
             DriverManager.registerDriver(this.driver);

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/EmbeddedConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/EmbeddedConfig.java
@@ -44,6 +44,7 @@ public class EmbeddedConfig implements YamlTestConfig {
                 .withOption(Options.Name.PLAN_CACHE_PRIMARY_TIME_TO_LIVE_MILLIS, 3_600_000L)
                 .withOption(Options.Name.PLAN_CACHE_SECONDARY_TIME_TO_LIVE_MILLIS, 3_600_000L)
                 .withOption(Options.Name.PLAN_CACHE_TERTIARY_TIME_TO_LIVE_MILLIS, 3_600_000L)
+                .withOption(Options.Name.PLAN_CACHE_PRIMARY_MAX_ENTRIES, 10)
                 .build();
         frl = new FRL(options);
     }


### PR DESCRIPTION
I discovered that running a lot of YamlTestConfigs against the same Embedded server can result in exhausting a heap of 512MB. The main cause (at least 300mb) was the plan cache, but there was no way to control the size, so this passes those options along when running `FRL`.
`TransactionBoundEmbeddedRelationalEngine` already passes these options along.

A limit of 10 should cover any tests we have, and any short-term parallesim, or tests with multiple schema templates.