### PR TITLE
Backport prepared statement changes to the patch release

### DIFF
--- a/fdb-relational-grpc/src/main/proto/grpc/relational/jdbc/v1/column.proto
+++ b/fdb-relational-grpc/src/main/proto/grpc/relational/jdbc/v1/column.proto
@@ -50,6 +50,9 @@ message Struct {
 // Relational Array.
 message Array {
   repeated Column element = 1;
+  // The java.sql.Types of the elements of the array. This is somewhat redundant with the type of the
+  // columns, but it makes it easier to verify correctness.
+  int32 elementType = 2;
 }
 
 // `Column` represents a dynamically typed column which can be either
@@ -59,7 +62,7 @@ message Array {
 message Column {
   // The kind/type of column.
   oneof kind {
-    // Represents a null column.
+    // Deprecated
     NullColumn null = 1;
     // Represents a double column.
     double double = 2;
@@ -75,15 +78,13 @@ message Column {
     Struct struct = 7;
     Array array = 8;
     bytes binary = 9;
-
     float float = 10;
+    // Represents a null value. These can be typed, so the value is the java.sql.Types of the parameter
+    int32 nullType = 11;
   }
 }
 
-// `NullValue` is a singleton enumeration to represent the null value for the
-// `Column` type union.
-//
-//  The JSON representation for `NullValue` is JSON `null`.
+// Deprecated
 enum NullColumn {
   // Null value.
   NULL_COLUMN = 0;


### PR DESCRIPTION
Backport parts of PR #3116 in order to allow prepared statement multi-version tests to run against the 4.0.459 release.
This only takes in the JDBC server pieces that are required to allow prepared statement to run on JDBC, so that newer versions of the project can test against this server to prove backwards compatibility.
The original PR had additional changes to the client side that are not required for this purpose and so were left out of this PR.
