### PR TITLE
Another try at getting pull-request number through from a forked PR.

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -139,3 +139,13 @@ jobs:
           name: coverage-report
           path: |
             ${{ github.workspace }}/.out/reports/jacoco/codeCoverageReport/
+      - name: Save Pull Request Number
+        run: echo ${{ github.event.number }} >.pr_number
+      - name: Upload Pull Request Number
+        uses: actions/upload-artifact@v4.6.0
+        with:
+          name: pull-request-number
+          path: |
+            ${{ github.workspace }}/.pr_number
+          include-hidden-files: true
+          retention-days: 1

--- a/.github/workflows/pull_request_comments.yml
+++ b/.github/workflows/pull_request_comments.yml
@@ -7,7 +7,7 @@ on:
       - completed
 
 jobs:
-  download:
+  coverage_comment:
     runs-on: ubuntu-latest
     if: >
       github.event.workflow_run.event == 'pull_request' &&
@@ -17,36 +17,27 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - name: 'Download artifact(s)'
-        uses: actions/github-script@v7
+      - name: Download Pull Request Number
+        uses: actions/download-artifact@v4
         with:
-          script: |
-            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               run_id: context.payload.workflow_run.id,
-            });
-            let matchingArtifacts = allArtifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == 'coverage-report';
-            });
-            const fs = require('fs');
-            for (matchingArtifact of matchingArtifacts) {
-              core.info(`Downloading ${matchingArtifact.name}.`);
-              let download = await github.rest.actions.downloadArtifact({
-                 owner: context.repo.owner,
-                 repo: context.repo.repo,
-                 artifact_id: matchingArtifact.id,
-                 archive_format: 'zip',
-              });
-              fs.writeFileSync(`${{ github.workspace }}/${ matchingArtifact.name }.zip`, Buffer.from(download.data));
-            }
-      - name: 'Unzip artifact(s)'
-        run: unzip coverage-report.zip codeCoverageReport.xml
+          name: pull-request-number
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+      - name: Restore Pull Request Number
+        id: restore
+        run: echo "pr_number=$(cat ${{ github.workspace }}/.pr_number)" >>"$GITHUB_OUTPUT"
+      - name: Download Report
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-report
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
       - name: Test Coverage Comment
         uses: madrapps/jacoco-report@e4bbaf00a0b8920cb86a448ae3ec0fc6f6bfeacc
         with:
           paths: |
             ${{ github.workspace }}/codeCoverageReport.xml
           token: ${{ secrets.GITHUB_TOKEN }}
+          pr-number: ${{ steps.restore.outputs.pr_number }}
           min-coverage-overall: 75
           min-coverage-changed-files: 80


### PR DESCRIPTION
The `pull_request` attribute is empty in this case. So use an artifact between workflows.