### PR TITLE
Fixes signing configuration location

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -159,12 +159,10 @@ allprojects {
     }
 
     signing {
-        if (System.getenv("GPG_KEY_ID") != null) {
-            def signingKeyId = System.getenv('GPG_KEY_ID')
-            def signingKey = System.getenv('GPG_KEY')
-            def signingPassword = System.getenv('GPG_PASSPHRASE')
-            useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
-            sign configurations.archives
+        def signingKey = findProperty("signingKey")
+        def signingPassword = findProperty("signingPassword")
+        if (signingKey != null && signingPassword != null) {
+            useInMemoryPgpKeys(signingKey, signingPassword)
         }
     }
 
@@ -313,13 +311,6 @@ if (Boolean.parseBoolean(centralPublish)) {
                 username = System.getenv("MAVEN_USER")
                 password = System.getenv("MAVEN_PASSWORD")
             }
-        }
-    }
-    signing {
-        def signingKey = findProperty("signingKey")
-        def signingPassword = findProperty("signingPassword")
-        if (signingKey != null && signingPassword != null) {
-            useInMemoryPgpKeys(signingKey, signingPassword)
         }
     }
 }


### PR DESCRIPTION
The [release for 4.1.5.0](https://github.com/FoundationDB/fdb-record-layer/actions/runs/13327676640/job/37224445663) failed due to the signing key not being configured correctly:

```
Cannot perform signing task ':fdb-extensions:signLibraryPublication' because it has no configured signatory
```

I tracked it down, and it's because the signing is done in the wrong place in `build.gradle`. We have a section in `allprojects` where we were previously attempting to configure the signing key information. I've now updated that location with the new method, and I've validated that signing locally works. I've also double checked that the secrets in the build were populated, so it should be configured to use the right keys, but we haven't tested that in CI (yet).