### PR TITLE
Restrict repository of nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   gradle:
+    if: github.repository == 'FoundationDB/fdb-record-layer'
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources


### PR DESCRIPTION
It is currently running nightly on all forks (unless the developer disabled actions), this limits it to this repository.