### PR TITLE
Fix typo in action output reference

### DIFF
--- a/actions/release-build-publish/action.yml
+++ b/actions/release-build-publish/action.yml
@@ -43,7 +43,7 @@ runs:
     # Create and push the tag
     - name: Create tag
       shell: bash
-      run: git tag -m "Release ${{ steps.get_version_outputs.version }}" -f "${{ steps.get_version.outputs.version }}"
+      run: git tag -m "Release ${{ steps.get_version.outputs.version }}" -f "${{ steps.get_version.outputs.version }}"
     - name: Push tag
       shell: bash
       run: git push origin "${{ steps.get_version.outputs.version }}"


### PR DESCRIPTION
This typo resulted in the 4.1.6.0 tag being titled just "Release " instead of "Release 4.1.6.0". :cry: