### PR TITLE
Fix NPE in YAML when running quick test

### DIFF
--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlTestExtension.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlTestExtension.java
@@ -30,6 +30,7 @@ import com.apple.foundationdb.relational.yamltests.configs.MultiServerConfig;
 import com.apple.foundationdb.relational.yamltests.configs.ShowPlanOnDiff;
 import com.apple.foundationdb.relational.yamltests.configs.YamlTestConfig;
 import com.apple.foundationdb.relational.yamltests.server.ExternalServer;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -69,6 +70,7 @@ public class YamlTestExtension implements TestTemplateInvocationContextProvider,
         if (Boolean.parseBoolean(System.getProperty("tests.runQuick", "false"))) {
             testConfigs = List.of(new EmbeddedConfig());
             maintainConfigs = List.of();
+            servers = ImmutableList.of();
         } else {
             AtomicInteger serverPort = new AtomicInteger(1111);
             List<File> jars = ExternalServer.getAvailableServers();


### PR DESCRIPTION
This fixes a NPE that was caused as a side-effect of #3138 when running quick-test mode.

When running in that mode, we're testing against the embedded relational server and not against any `servers`. The test harness initializes `servers` in the `beforeAll` only when not running in quick test mode, however the `afterAll` is iterating over `servers` regardless. This causes NPE in the `afterAll` since that variable was not initialized in the `beforeAll` block in quick test mode.