### PR TITLE
Put Build/Test/Documentation changes in separate section of release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -7,9 +7,6 @@ changelog:
     - title: New Features
       labels:
         - enhancement
-    - title: Documentation improvements
-      labels:
-        - documentation
     - title: Bug Fixes
       labels:
         - "bug fix"
@@ -19,6 +16,11 @@ changelog:
     - title: Dependency Updates
       labels:
         - dependencies
+    - title: Build/Test/Documentation Improvements
+      labels:
+        - "build improvement"
+        - "documentation"
+        - "testing improvement"
     - title: Other Changes
       labels:
         - "*"


### PR DESCRIPTION
This updates .github/release.yml so that it will combine build, test, and documentation changes into a separate section.

I highly doubt this is the final iteration on the release notes generation, even in the very near future, but when you generate notes it takes the config from the tag being generated, so I want something better for the next release than having _all_ the build/test changes under `Other Changes`