### PR TITLE
Enable a few tests where the force continuation option does not fail anymore

### DIFF
--- a/yaml-tests/src/test/java/YamlIntegrationTests.java
+++ b/yaml-tests/src/test/java/YamlIntegrationTests.java
@@ -170,8 +170,6 @@ public class YamlIntegrationTests {
     }
 
     @TestTemplate
-    @ExcludeYamlTestConfig(value = YamlTestConfigFilters.DO_NOT_FORCE_CONTINUATIONS,
-            reason = "Infinite loop (https://github.com/FoundationDB/fdb-record-layer/issues/3095)")
     public void primaryKey(YamlTest.Runner runner) throws Exception {
         runner.runYamsql("primary-key-tests.yamsql");
     }

--- a/yaml-tests/src/test/java/YamlIntegrationTests.java
+++ b/yaml-tests/src/test/java/YamlIntegrationTests.java
@@ -150,8 +150,6 @@ public class YamlIntegrationTests {
     }
 
     @TestTemplate
-    @ExcludeYamlTestConfig(value = YamlTestConfigFilters.DO_NOT_FORCE_CONTINUATIONS,
-            reason = "Infinite continuation loop (https://github.com/FoundationDB/fdb-record-layer/issues/3095)")
     public void aggregateIndexTestsCountEmpty(YamlTest.Runner runner) throws Exception {
         runner.runYamsql("aggregate-index-tests-count-empty.yamsql");
     }
@@ -292,8 +290,6 @@ public class YamlIntegrationTests {
     }
 
     @TestTemplate
-    @ExcludeYamlTestConfig(value = YamlTestConfigFilters.DO_NOT_FORCE_CONTINUATIONS,
-            reason = "maxRows ignored (https://github.com/FoundationDB/fdb-record-layer/issues/3100)")
     public void recursiveCte(YamlTest.Runner runner) throws Exception {
         runner.runYamsql("recursive-cte.yamsql");
     }


### PR DESCRIPTION
Testing with forced continuations between `main` and 4.0.559.6 showed that some tests that were excluded because of `FORCED_CONTINUATIONS` can now be enabled. 
The tests that were enabled pass on the main -> `4.1.6.0` mixed-mode tests, though they do fail when run against `4.0.559.6`. This is how we want it, since it would flag them as needing attention. 
