### PR TITLE
Adjust serialization of `VersionValue` to make continuations compatible with versions older than 4.0.564.0

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/VersionValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/VersionValue.java
@@ -149,10 +149,23 @@ public class VersionValue extends AbstractValue {
     @Nonnull
     @Override
     public PVersionValue toProto(@Nonnull final PlanSerializationContext serializationContext) {
-        return PVersionValue.newBuilder()
-                .setBaseAlias(getChildQuantifiedRecordValue().getAlias().getId())  // deprecated
-                .setChild(childValue.toValueProto(serializationContext))
-                .build();
+        if (childValue instanceof QuantifiedRecordValue) {
+            // Deprecated. This value previously required that the child by a QuantifiedRecordValue and only
+            // contained the alias. To preserve cross-version compatibility with versions older than 4.0.561.0,
+            // send messages without the full value.
+            // Note: it's tempting to also include the full value in the `child` field, but doing so can
+            // lead to mixed-mode errors. If there are types or plans referenced in the child, those can
+            // be registered with the serializationContext, which means they may only be included
+            // by reference elsewhere in the serialized plan. Older versions of the deserialization
+            // logic don't know about the field, and so they will trip over any dangling references
+            return PVersionValue.newBuilder()
+                    .setBaseAlias(getChildQuantifiedRecordValue().getAlias().getId())
+                    .build();
+        } else {
+            return PVersionValue.newBuilder()
+                    .setChild(childValue.toValueProto(serializationContext))
+                    .build();
+        }
     }
 
     @Nonnull


### PR DESCRIPTION
The serialization of the `VersionValue` was modified by #2934. However, there was a flaw with the serialization, namely that it added a new field. For background, there are certain planner objects that for space reasons only get serialized fully the first time they are encountered during a query (for example, `Type` definitions). When serializing the new field in the `PVersionValue` message, if there were one of those objects, we could end up inserting a value that if referenced would later would only include the reference and not the data itself. That meant that when _deserializing_ one of these continuations on older versions, the older code would skip over the new field (not knowing what it is for) and then encounter the reference for the very first time somewhere else. Because it hadn't seen the full definition before, it didn't know what to do and threw an error.

This addresses the issue by making the older serialization more closely mirror the old code. In the future, once we no longer care about being compatible with pre-4.0.564.0, we can drop the legacy mode, though we'll have to keep the deserialization path for an additional cycle. I did consider a slightly more invovled solution, where we adjust the serialization path to avoid adding to the reference registry for this field, and I got something that worked, but it ended up being a little more fiddly than I'd like, so I went with this conceptually simpler change. This does have the downside that the `Type` information gets erased after a continuation, a disadvantage the other approach would not have, but we have to be able to handle that anyway to correctly handle upgrading continuations from older versions.

I've been able to validate locally that the updated continuations work, and that the failing mixed-mode tests now pass.

This fixes #3178.