### PR TITLE
Enforce all PRs are labeled for Release Note generation

### DIFF
--- a/.github/workflows/pr_labels.yml
+++ b/.github/workflows/pr_labels.yml
@@ -1,0 +1,34 @@
+name: Pull Request Labels
+
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled]
+
+jobs:
+  labels:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4.2.2
+        with:
+          sparse-checkout: build/release-notes-config.json
+      - name: Check Labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Gather required labels from release notes configuration
+            const releaseNotesConfig = require('./build/release-notes-config.json');
+            var requiredLabels = new Set();
+            releaseNotesConfig.categories
+                .flatMap(category => category.labels)
+                .forEach(label => requiredLabels.add(label)); 
+            
+            // Check if the current PR has a label in the required set
+            const pr_labels = context.payload.pull_request.labels.map(l => l.name); 
+            if (!pr_labels.some(l => requiredLabels.has(l))) {
+              core.setFailed("PR is not labeled with any of the required labels: " + JSON.stringify(Array.from(requiredLabels)));
+            }

--- a/build/release-notes-config.json
+++ b/build/release-notes-config.json
@@ -1,0 +1,21 @@
+{"categories":
+ [
+   {"title": "Breaking Changes",
+    "labels": ["breaking change"]},
+   {"title": "New Features",
+    "labels": ["enhancement"]},
+   {"title": "Bug Fixes",
+    "labels": ["bug fix"]},
+   {"title": "Performance Improvements",
+    "labels": ["performance"]},
+   {"title": "Dependency Updates",
+    "labels": ["dependencies"]},
+   {"title": "Build/Test/Documentation Improvements",
+    "collapsed": true,
+    "labels": [
+      "build improvement",
+      "documentation",
+      "testing improvement"]}
+ ],
+ "catch_all": "Other Changes"
+}


### PR DESCRIPTION
This reads the release notes config to generate a list of expected labels. It then compares the list of labels set on the PR and checks to make sure the PR has one of the labels provided.

Not in this PR: in theory, there are some GraphQL queries we could run so that if we have an associated issue, we could try and guess the label from the issue. This keeps it simple, though, and just makes sure that the label has been set. If the check fails, it should be a pretty straightforward and fast thing to fix.