### PR TITLE
Fix link to documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ layer on which more complex systems can be constructed.
 
 ## Documentation
 
-* [Documentation Home](docs/index.md)
+* [Documentation Home](docs/sphinx/source/index.md)
 * [Contributing](CONTRIBUTING.md)
 * [Code of Conduct](CODE_OF_CONDUCT.md)
 * [License](LICENSE)


### PR DESCRIPTION
As the title describes, it should be that [this PR](https://github.com/FoundationDB/fdb-record-layer/pull/3078) did not synchronize the modification of the root directory's README.