### PR TITLE
Add protection against test running into an infinite loop

### DIFF
--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryExecutor.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryExecutor.java
@@ -53,6 +53,7 @@ import static com.apple.foundationdb.relational.yamltests.command.QueryCommand.r
 public class QueryExecutor {
     private static final Logger logger = LogManager.getLogger(QueryExecutor.class);
     private static final int FORCED_MAX_ROWS = 1; // The maxRows number to use when we are forcing it on the test
+    private static final int MAX_CONTINUATIONS_ALLOWED = 100;
 
     @Nonnull
     private final String query;
@@ -243,6 +244,7 @@ public class QueryExecutor {
             results.add(resultSet);
             // Have continuations - keep running the query
             Continuation continuation = resultSet.getContinuation();
+            int count = 0;
             while (!continuation.atEnd()) {
                 if (continuation.atBeginning()) {
                     reportTestFailure("Received continuation shouldn't be at beginning");
@@ -257,6 +259,9 @@ public class QueryExecutor {
                         // We assume that the last result is empty because of the maxRows:1
                         Assertions.assertFalse(hasNext);
                     }
+                }
+                if (++count > MAX_CONTINUATIONS_ALLOWED) {
+                    reportTestFailure("Too many continuations for query. Test aborted.");
                 }
             }
             // Use first metadata for the aggregated result set as they are all the same


### PR DESCRIPTION
Trying to improve the test experience, abort tests in case they are running into infinite loops when processing continuations.
This assumes that the test data will not produce more than a maximum number of rows (currently set to 100), and aborts the continuation loop after that number.
Note that the non-forced-continuation loop does not need that protection since it will require a "result" line in the yaml to trigger a continuation , and those are bound by a finite number.
