### PR TITLE
Add version information to yaml test exceptions

### DIFF
--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/MultiServerConnectionFactory.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/MultiServerConnectionFactory.java
@@ -30,6 +30,7 @@ import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.net.URI;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -173,16 +174,19 @@ public class MultiServerConnectionFactory implements YamlConnectionFactory {
             return getCurrentConnection(true, "prepareStatement").prepareStatement(sql);
         }
 
+        @Nullable
         @Override
         public MetricCollector getMetricCollector() {
             throw new UnsupportedOperationException("MultiServer does not support getting the metric collector");
         }
 
+        @Nullable
         @Override
         public EmbeddedRelationalConnection tryGetEmbedded() {
             return null;
         }
 
+        @Nonnull
         @Override
         public List<String> getVersions() {
             return this.versions;

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/MultiServerConnectionFactory.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/MultiServerConnectionFactory.java
@@ -197,7 +197,7 @@ public class MultiServerConnectionFactory implements YamlConnectionFactory {
         }
 
         @Override
-        public boolean supportsCacheCheck() {
+        public boolean supportsMetricCollector() {
             return false;
         }
 

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/MultiServerConnectionFactory.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/MultiServerConnectionFactory.java
@@ -93,8 +93,8 @@ public class MultiServerConnectionFactory implements YamlConnectionFactory {
     }
 
     @Override
-    public Connection getNewConnection(@Nonnull URI connectPath) throws SQLException {
-        return new MultiServerRelationalConnection(connectionSelectionPolicy, getNextConnectionNumber(), defaultFactory.getNewConnection(connectPath), alternateConnections(connectPath));
+    public YamlConnection getNewConnection(@Nonnull URI connectPath) throws SQLException {
+        return null; //new MultiServerRelationalConnection(connectionSelectionPolicy, getNextConnectionNumber(), defaultFactory.getNewConnection(connectPath), alternateConnections(connectPath));
     }
 
     @Override
@@ -112,7 +112,7 @@ public class MultiServerConnectionFactory implements YamlConnectionFactory {
     }
 
     @Nonnull
-    private List<Connection> alternateConnections(URI connectPath) {
+    private List<YamlConnection> alternateConnections(URI connectPath) {
         return alternateFactories.stream().map(factory -> {
             try {
                 return factory.getNewConnection(connectPath);

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/MultiServerConnectionFactory.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/MultiServerConnectionFactory.java
@@ -48,7 +48,7 @@ import java.util.stream.Stream;
  * running concurrently, and verify that the results (e.g. Continuations) are correctly handled through the entire
  * setup.
  */
-public class MultiServerConnectionFactory implements YamlRunner.YamlConnectionFactory {
+public class MultiServerConnectionFactory implements YamlConnectionFactory {
     // The fixed index of the default connection
     public static final int DEFAULT_CONNECTION = 0;
     private final Set<String> versionsUnderTest;
@@ -63,22 +63,22 @@ public class MultiServerConnectionFactory implements YamlRunner.YamlConnectionFa
     @Nonnull
     private final ConnectionSelectionPolicy connectionSelectionPolicy;
     @Nonnull
-    private final YamlRunner.YamlConnectionFactory defaultFactory;
+    private final YamlConnectionFactory defaultFactory;
     @Nonnull
-    private final List<YamlRunner.YamlConnectionFactory> alternateFactories;
+    private final List<YamlConnectionFactory> alternateFactories;
     private final int totalFactories;
     @Nonnull
     private final AtomicInteger currentConnectionSelector;
 
-    public MultiServerConnectionFactory(@Nonnull final YamlRunner.YamlConnectionFactory defaultFactory,
-                                        @Nonnull final List<YamlRunner.YamlConnectionFactory> alternateFactories) {
+    public MultiServerConnectionFactory(@Nonnull final YamlConnectionFactory defaultFactory,
+                                        @Nonnull final List<YamlConnectionFactory> alternateFactories) {
         this(ConnectionSelectionPolicy.DEFAULT, 0, defaultFactory, alternateFactories);
     }
 
     public MultiServerConnectionFactory(@Nonnull final ConnectionSelectionPolicy connectionSelectionPolicy,
                                         final int initialConnection,
-                                        @Nonnull final YamlRunner.YamlConnectionFactory defaultFactory,
-                                        @Nonnull final List<YamlRunner.YamlConnectionFactory> alternateFactories) {
+                                        @Nonnull final YamlConnectionFactory defaultFactory,
+                                        @Nonnull final List<YamlConnectionFactory> alternateFactories) {
         this.connectionSelectionPolicy = connectionSelectionPolicy;
         this.defaultFactory = defaultFactory;
         this.alternateFactories = alternateFactories;

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/SimpleYamlConnection.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/SimpleYamlConnection.java
@@ -1,0 +1,83 @@
+/*
+ * YamlConnection.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.relational.yamltests;
+
+import com.apple.foundationdb.relational.api.RelationalConnection;
+import com.apple.foundationdb.relational.api.RelationalPreparedStatement;
+import com.apple.foundationdb.relational.api.RelationalStatement;
+import com.apple.foundationdb.relational.api.metrics.MetricCollector;
+import com.apple.foundationdb.relational.recordlayer.EmbeddedRelationalConnection;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.List;
+
+/**
+ * A simple version of {@link YamlConnection} for interacting with a single {@link RelationalConnection}.
+ */
+public class SimpleYamlConnection implements YamlConnection {
+    private final RelationalConnection underlying;
+    private final List<String> versions;
+
+    public SimpleYamlConnection(final Connection connection, final String version) throws SQLException {
+        underlying = connection.unwrap(RelationalConnection.class);
+        this.versions = List.of(version);
+    }
+
+    @Override
+    public void close() throws SQLException {
+        underlying.close();
+    }
+
+    @Override
+    public boolean supportsCacheCheck() {
+        return underlying instanceof EmbeddedRelationalConnection;
+    }
+
+    @Override
+    public RelationalStatement createStatement() throws SQLException {
+        return underlying.createStatement();
+    }
+
+    @Override
+    public RelationalPreparedStatement prepareStatement(final String sql) throws SQLException {
+        return underlying.prepareStatement(sql);
+    }
+
+    @Override
+    public MetricCollector getMetricCollector() {
+        return ((EmbeddedRelationalConnection) underlying).getMetricCollector();
+    }
+
+    @Override
+    public EmbeddedRelationalConnection tryGetEmbedded() {
+        if (underlying instanceof EmbeddedRelationalConnection) {
+            return (EmbeddedRelationalConnection)underlying;
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public List<String> getVersions() {
+        return versions;
+    }
+}

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/SimpleYamlConnection.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/SimpleYamlConnection.java
@@ -48,7 +48,7 @@ public class SimpleYamlConnection implements YamlConnection {
     }
 
     @Override
-    public boolean supportsCacheCheck() {
+    public boolean supportsMetricCollector() {
         return underlying instanceof EmbeddedRelationalConnection;
     }
 

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/SimpleYamlConnection.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/SimpleYamlConnection.java
@@ -26,6 +26,8 @@ import com.apple.foundationdb.relational.api.RelationalStatement;
 import com.apple.foundationdb.relational.api.metrics.MetricCollector;
 import com.apple.foundationdb.relational.recordlayer.EmbeddedRelationalConnection;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.List;
@@ -34,10 +36,12 @@ import java.util.List;
  * A simple version of {@link YamlConnection} for interacting with a single {@link RelationalConnection}.
  */
 public class SimpleYamlConnection implements YamlConnection {
+    @Nonnull
     private final RelationalConnection underlying;
+    @Nonnull
     private final List<String> versions;
 
-    public SimpleYamlConnection(final Connection connection, final String version) throws SQLException {
+    public SimpleYamlConnection(@Nonnull Connection connection, @Nonnull String version) throws SQLException {
         underlying = connection.unwrap(RelationalConnection.class);
         this.versions = List.of(version);
     }
@@ -62,11 +66,13 @@ public class SimpleYamlConnection implements YamlConnection {
         return underlying.prepareStatement(sql);
     }
 
+    @Nullable
     @Override
     public MetricCollector getMetricCollector() {
         return ((EmbeddedRelationalConnection) underlying).getMetricCollector();
     }
 
+    @Nullable
     @Override
     public EmbeddedRelationalConnection tryGetEmbedded() {
         if (underlying instanceof EmbeddedRelationalConnection) {
@@ -76,6 +82,7 @@ public class SimpleYamlConnection implements YamlConnection {
         }
     }
 
+    @Nonnull
     @Override
     public List<String> getVersions() {
         return versions;

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlConnection.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlConnection.java
@@ -1,0 +1,68 @@
+/*
+ * YamlConnection.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.relational.yamltests;
+
+import com.apple.foundationdb.relational.api.RelationalConnection;
+import com.apple.foundationdb.relational.api.RelationalPreparedStatement;
+import com.apple.foundationdb.relational.api.RelationalStatement;
+import com.apple.foundationdb.relational.api.metrics.MetricCollector;
+import com.apple.foundationdb.relational.recordlayer.EmbeddedRelationalConnection;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.List;
+
+/**
+ * A wrapper around {@link java.sql.Connection} to support yaml tests.
+ */
+public class YamlConnection implements AutoCloseable {
+    RelationalConnection underlying;
+
+    public YamlConnection(final Connection connection) throws SQLException {
+        underlying = connection.unwrap(RelationalConnection.class);
+    }
+
+    @Override
+    public void close() throws SQLException {
+        underlying.close();
+    }
+
+    public boolean supportsCacheCheck() {
+        return underlying instanceof EmbeddedRelationalConnection;
+    }
+
+    public RelationalStatement createStatement() throws SQLException {
+        return underlying.createStatement();
+    }
+
+    public RelationalPreparedStatement prepareStatement(final String sql) throws SQLException {
+        return underlying.prepareStatement(sql);
+    }
+
+    public RelationalConnection getUnderlying() {
+        return underlying;
+    }
+
+    public MetricCollector getMetricCollector() {
+        return ((EmbeddedRelationalConnection) underlying).getMetricCollector();
+    }
+    //
+}

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlConnection.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlConnection.java
@@ -26,6 +26,8 @@ import com.apple.foundationdb.relational.api.RelationalStatement;
 import com.apple.foundationdb.relational.api.metrics.MetricCollector;
 import com.apple.foundationdb.relational.recordlayer.EmbeddedRelationalConnection;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.sql.SQLException;
 import java.util.List;
 
@@ -68,14 +70,17 @@ public interface YamlConnection extends AutoCloseable {
 
     /**
      * Return the underlying metrics collector if possible.
+     *
      * @return the underlying metrics collector
      */
+    @Nullable
     MetricCollector getMetricCollector();
 
     /**
      * Try to get the underlying embedded relational connection in support of a few specific setup methods.
      * @return the underlying embedded connection, or {@code null} if one is not (easily) available.
      */
+    @Nullable
     EmbeddedRelationalConnection tryGetEmbedded();
 
     /**
@@ -85,5 +90,6 @@ public interface YamlConnection extends AutoCloseable {
      * </p>
      * @return the ordered list of versions
      */
+    @Nonnull
     List<String> getVersions();
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlConnection.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlConnection.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.relational.yamltests;
 
+import com.apple.foundationdb.relational.api.RelationalConnection;
 import com.apple.foundationdb.relational.api.RelationalPreparedStatement;
 import com.apple.foundationdb.relational.api.RelationalStatement;
 import com.apple.foundationdb.relational.api.metrics.MetricCollector;
@@ -32,20 +33,57 @@ import java.util.List;
  * A wrapper around {@link java.sql.Connection} to support yaml tests.
  */
 public interface YamlConnection extends AutoCloseable {
+    /**
+     * String for representing the current version of the code.
+     */
     String CURRENT_VERSION = "!currentVersion";
 
+    /**
+     * Close this connection.
+     * @throws SQLException if there was an issue closing the underlying connection(s).
+     */
     @Override
     void close() throws SQLException;
 
-    boolean supportsCacheCheck();
-
+    /**
+     * Creates a statement (see {@link RelationalConnection#createStatement()}).
+     * @return a new statement
+     * @throws SQLException if something goes wrong
+     */
     RelationalStatement createStatement() throws SQLException;
 
+    /**
+     * Creates a prepared statement (see {@link RelationalConnection#prepareStatement(String)}).
+     * @param sql the query
+     * @return a new prepared statement
+     * @throws SQLException if something goes wrong
+     */
     RelationalPreparedStatement prepareStatement(String sql) throws SQLException;
 
+    /**
+     * Returns true if this connection supports getting the metrics collector.
+     * @return true if it is possible to get the metrics collector
+     */
+    boolean supportsMetricCollector();
+
+    /**
+     * Return the underlying metrics collector if possible.
+     * @return the underlying metrics collector
+     */
     MetricCollector getMetricCollector();
 
+    /**
+     * Try to get the underlying embedded relational connection in support of a few specific setup methods.
+     * @return the underlying embedded connection, or {@code null} if one is not (easily) available.
+     */
     EmbeddedRelationalConnection tryGetEmbedded();
 
+    /**
+     * Return the ordered list of versions that this will test against.
+     * <p>
+     *     This does not reset as {@link #createStatement}/{@link #prepareStatement}, etc. are called.
+     * </p>
+     * @return the ordered list of versions
+     */
     List<String> getVersions();
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlConnection.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlConnection.java
@@ -20,59 +20,32 @@
 
 package com.apple.foundationdb.relational.yamltests;
 
-import com.apple.foundationdb.relational.api.RelationalConnection;
 import com.apple.foundationdb.relational.api.RelationalPreparedStatement;
 import com.apple.foundationdb.relational.api.RelationalStatement;
 import com.apple.foundationdb.relational.api.metrics.MetricCollector;
 import com.apple.foundationdb.relational.recordlayer.EmbeddedRelationalConnection;
 
-import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.List;
 
 /**
  * A wrapper around {@link java.sql.Connection} to support yaml tests.
  */
-public class YamlConnection implements AutoCloseable {
-    public static final List<String> CURRENT_VERSION_ONLY = List.of("!currentVersion");
-    private final RelationalConnection underlying;
-    private final List<String> versions;
-
-    public YamlConnection(final Connection connection, final List<String> versions) throws SQLException {
-        underlying = connection.unwrap(RelationalConnection.class);
-        this.versions = versions;
-    }
+public interface YamlConnection extends AutoCloseable {
+    String CURRENT_VERSION = "!currentVersion";
 
     @Override
-    public void close() throws SQLException {
-        underlying.close();
-    }
+    void close() throws SQLException;
 
-    public boolean supportsCacheCheck() {
-        return underlying instanceof EmbeddedRelationalConnection;
-    }
+    boolean supportsCacheCheck();
 
-    public RelationalStatement createStatement() throws SQLException {
-        return underlying.createStatement();
-    }
+    RelationalStatement createStatement() throws SQLException;
 
-    public RelationalPreparedStatement prepareStatement(final String sql) throws SQLException {
-        return underlying.prepareStatement(sql);
-    }
+    RelationalPreparedStatement prepareStatement(String sql) throws SQLException;
 
-    public MetricCollector getMetricCollector() {
-        return ((EmbeddedRelationalConnection) underlying).getMetricCollector();
-    }
+    MetricCollector getMetricCollector();
 
-    public EmbeddedRelationalConnection tryGetEmbedded() {
-        if (underlying instanceof EmbeddedRelationalConnection) {
-            return (EmbeddedRelationalConnection)underlying;
-        } else {
-            return null;
-        }
-    }
+    EmbeddedRelationalConnection tryGetEmbedded();
 
-    public List<String> getVersions() {
-        return versions;
-    }
+    List<String> getVersions();
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlConnection.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlConnection.java
@@ -34,10 +34,13 @@ import java.util.List;
  * A wrapper around {@link java.sql.Connection} to support yaml tests.
  */
 public class YamlConnection implements AutoCloseable {
-    RelationalConnection underlying;
+    public static final List<String> CURRENT_VERSION_ONLY = List.of("!currentVersion");
+    private final RelationalConnection underlying;
+    private final List<String> versions;
 
-    public YamlConnection(final Connection connection) throws SQLException {
+    public YamlConnection(final Connection connection, final List<String> versions) throws SQLException {
         underlying = connection.unwrap(RelationalConnection.class);
+        this.versions = versions;
     }
 
     @Override
@@ -57,12 +60,19 @@ public class YamlConnection implements AutoCloseable {
         return underlying.prepareStatement(sql);
     }
 
-    public RelationalConnection getUnderlying() {
-        return underlying;
-    }
-
     public MetricCollector getMetricCollector() {
         return ((EmbeddedRelationalConnection) underlying).getMetricCollector();
     }
-    //
+
+    public EmbeddedRelationalConnection tryGetEmbedded() {
+        if (underlying instanceof EmbeddedRelationalConnection) {
+            return (EmbeddedRelationalConnection)underlying;
+        } else {
+            return null;
+        }
+    }
+
+    public List<String> getVersions() {
+        return versions;
+    }
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlConnectionFactory.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlConnectionFactory.java
@@ -24,7 +24,6 @@ import com.apple.foundationdb.relational.api.RelationalConnection;
 
 import javax.annotation.Nonnull;
 import java.net.URI;
-import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Set;
 
@@ -41,7 +40,7 @@ public interface YamlConnectionFactory {
      *
      * @throws SQLException if we cannot connect
      */
-    Connection getNewConnection(@Nonnull URI connectPath) throws SQLException;
+    YamlConnection getNewConnection(@Nonnull URI connectPath) throws SQLException;
 
     /**
      * The versions that the connection has, other than the current code.

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlConnectionFactory.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlConnectionFactory.java
@@ -1,0 +1,69 @@
+/*
+ * YamlConnectionFactory.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.relational.yamltests;
+
+import com.apple.foundationdb.relational.api.RelationalConnection;
+
+import javax.annotation.Nonnull;
+import java.net.URI;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Set;
+
+/**
+ * Connection factory to support yaml tests (see {@link YamlRunner}.
+ */
+public interface YamlConnectionFactory {
+    /**
+     * Convert a connection uri into an actual connection.
+     *
+     * @param connectPath the path to connect to
+     *
+     * @return A new {@link RelationalConnection} for the given path appropriate for this test class
+     *
+     * @throws SQLException if we cannot connect
+     */
+    Connection getNewConnection(@Nonnull URI connectPath) throws SQLException;
+
+    /**
+     * The versions that the connection has, other than the current code.
+     * <p>
+     * If we are just testing against the current code, this will be empty, but otherwise it will include the
+     * versions that we're testing. In the future we may want to support tests that don't run against the
+     * current version, but that's not currently needed, so not supported.
+     * </p>
+     *
+     * @return A set of versions that we are testing against, or an empty set if just testing against the current
+     * version
+     */
+    Set<String> getVersionsUnderTest();
+
+    /**
+     * Whether the connection supports multiple servers.
+     * There are some changes to the behavior that are to be expected when running the tests in multi-server mode,
+     * this method allows the system to make that decision.
+     *
+     * @return TRUE if this connection factory can support multiple servers, false otherwise.
+     */
+    default boolean isMultiServer() {
+        return false;
+    }
+}

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlExecutionContext.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlExecutionContext.java
@@ -76,7 +76,7 @@ public final class YamlExecutionContext {
     private final Map<QueryAndLocation, PlannerMetricsProto.Info> actualMetricsMap;
     private boolean isDirtyMetrics;
     @Nonnull
-    private final YamlRunner.YamlConnectionFactory connectionFactory;
+    private final YamlConnectionFactory connectionFactory;
     @Nonnull
     private final List<Block> finalizeBlocks = new ArrayList<>();
     @SuppressWarnings("AbbreviationAsWordInName")
@@ -93,7 +93,7 @@ public final class YamlExecutionContext {
         }
     }
 
-    YamlExecutionContext(@Nonnull String resourcePath, @Nonnull YamlRunner.YamlConnectionFactory factory,
+    YamlExecutionContext(@Nonnull String resourcePath, @Nonnull YamlConnectionFactory factory,
                          @Nonnull final ContextOptions additionalOptions) throws RelationalException {
         this.connectionFactory = factory;
         this.resourcePath = resourcePath;
@@ -117,7 +117,7 @@ public final class YamlExecutionContext {
     }
 
     @Nonnull
-    public YamlRunner.YamlConnectionFactory getConnectionFactory() {
+    public YamlConnectionFactory getConnectionFactory() {
         return connectionFactory;
     }
 

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlRunner.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlRunner.java
@@ -20,7 +20,6 @@
 
 package com.apple.foundationdb.relational.yamltests;
 
-import com.apple.foundationdb.relational.api.RelationalConnection;
 import com.apple.foundationdb.relational.api.exceptions.RelationalException;
 import com.apple.foundationdb.relational.util.Assert;
 import com.apple.foundationdb.relational.util.SpotBugsSuppressWarnings;
@@ -40,16 +39,12 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
-import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.sql.Connection;
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
-import java.util.Set;
 
 @SuppressWarnings({"PMD.GuardLogStatement"}) // It already is, but PMD is confused and reporting error in unrelated locations.
 public final class YamlRunner {
@@ -66,38 +61,6 @@ public final class YamlRunner {
 
     @Nonnull
     private final YamlExecutionContext executionContext;
-
-    public interface YamlConnectionFactory {
-        /**
-         * Convert a connection uri into an actual connection.
-         * @param connectPath the path to connect to
-         * @return A new {@link RelationalConnection} for the given path appropriate for this test class
-         * @throws SQLException if we cannot connect
-         */
-        Connection getNewConnection(@Nonnull URI connectPath) throws SQLException;
-
-        /**
-         * The versions that the connection has, other than the current code.
-         * <p>
-         *     If we are just testing against the current code, this will be empty, but otherwise it will include the
-         *     versions that we're testing. In the future we may want to support tests that don't run against the
-         *     current version, but that's not currently needed, so not supported.
-         * </p>
-         * @return A set of versions that we are testing against, or an empty set if just testing against the current
-         * version
-         */
-        Set<String> getVersionsUnderTest();
-
-        /**
-         * Whether the connection supports multiple servers.
-         * There are some changes to the behavior that are to be expected when running the tests in multi-server mode,
-         * this method allows the system to make that decision.
-         * @return TRUE if this connection factory can support multiple servers, false otherwise.
-         */
-        default boolean isMultiServer() {
-            return false;
-        }
-    }
 
     public YamlRunner(@Nonnull String resourcePath, @Nonnull YamlConnectionFactory factory,
                       @Nonnull final YamlExecutionContext.ContextOptions additionalOptions) throws RelationalException {

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/ConnectedBlock.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/ConnectedBlock.java
@@ -20,7 +20,7 @@
 
 package com.apple.foundationdb.relational.yamltests.block;
 
-import com.apple.foundationdb.relational.api.RelationalConnection;
+import com.apple.foundationdb.relational.yamltests.YamlConnection;
 import com.apple.foundationdb.relational.yamltests.YamlConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
 import org.apache.logging.log4j.LogManager;
@@ -56,9 +56,9 @@ public abstract class ConnectedBlock implements Block {
     @Nonnull
     private final URI connectionURI;
     @Nonnull
-    final List<Consumer<RelationalConnection>> executables;
+    final List<Consumer<YamlConnection>> executables;
 
-    ConnectedBlock(int lineNumber, @Nonnull List<Consumer<RelationalConnection>> executables, @Nonnull URI connectionURI, @Nonnull YamlExecutionContext executionContext) {
+    ConnectedBlock(int lineNumber, @Nonnull List<Consumer<YamlConnection>> executables, @Nonnull URI connectionURI, @Nonnull YamlExecutionContext executionContext) {
         this.lineNumber = lineNumber;
         this.executables = executables;
         this.connectionURI = connectionURI;
@@ -70,7 +70,7 @@ public abstract class ConnectedBlock implements Block {
         return lineNumber;
     }
 
-    protected final void executeExecutables(@Nonnull Collection<Consumer<RelationalConnection>> list) {
+    protected final void executeExecutables(@Nonnull Collection<Consumer<YamlConnection>> list) {
         connectToDatabaseAndExecute(connection -> list.forEach(t -> t.accept(connection)));
     }
 
@@ -79,11 +79,11 @@ public abstract class ConnectedBlock implements Block {
      *
      * @param consumer operations to be performed on the database using the established connection.
      */
-    void connectToDatabaseAndExecute(Consumer<RelationalConnection> consumer) {
+    void connectToDatabaseAndExecute(Consumer<YamlConnection> consumer) {
         logger.debug("🚠 Connecting to database: `{}`", connectionURI);
         try (var connection = executionContext.getConnectionFactory().getNewConnection(connectionURI)) {
             logger.debug("✅ Connected to database: `{}`", connectionURI);
-            consumer.accept(connection.unwrap(RelationalConnection.class));
+            consumer.accept(connection);
         } catch (SQLException sqle) {
             throw executionContext.wrapContext(sqle,
                     () -> String.format(Locale.ROOT, "‼️ Error connecting to the database `%s` in block at line %d", connectionURI, lineNumber),

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/ConnectedBlock.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/ConnectedBlock.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.relational.yamltests.block;
 
 import com.apple.foundationdb.relational.api.RelationalConnection;
+import com.apple.foundationdb.relational.yamltests.YamlConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -38,7 +39,7 @@ import java.util.function.Consumer;
  * <p>
  * Each block needs to be associated with a `connectionURI` which provides it with the address to the database to which
  * the block connects to for running its executables. The block does so through the
- * {@link com.apple.foundationdb.relational.yamltests.YamlRunner.YamlConnectionFactory}. A block is free to implement `how` and `when`
+ * {@link YamlConnectionFactory}. A block is free to implement `how` and `when`
  * it wants to use the factory to create a connection and also manages the lifecycle of the established connection.
  * </p>
  */

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/SetupBlock.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/SetupBlock.java
@@ -20,7 +20,6 @@
 
 package com.apple.foundationdb.relational.yamltests.block;
 
-import com.apple.foundationdb.relational.api.RelationalConnection;
 import com.apple.foundationdb.relational.util.Assert;
 import com.apple.foundationdb.relational.yamltests.Matchers;
 import com.apple.foundationdb.relational.yamltests.YamlConnection;

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/SetupBlock.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/SetupBlock.java
@@ -23,6 +23,7 @@ package com.apple.foundationdb.relational.yamltests.block;
 import com.apple.foundationdb.relational.api.RelationalConnection;
 import com.apple.foundationdb.relational.util.Assert;
 import com.apple.foundationdb.relational.yamltests.Matchers;
+import com.apple.foundationdb.relational.yamltests.YamlConnection;
 import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
 import com.apple.foundationdb.relational.yamltests.command.Command;
 import com.apple.foundationdb.relational.yamltests.command.QueryCommand;
@@ -51,7 +52,7 @@ public class SetupBlock extends ConnectedBlock {
 
     public static final String SETUP_BLOCK = "setup";
 
-    protected SetupBlock(int lineNumber, @Nonnull List<Consumer<RelationalConnection>> executables, @Nonnull URI connectionURI,
+    protected SetupBlock(int lineNumber, @Nonnull List<Consumer<YamlConnection>> executables, @Nonnull URI connectionURI,
                          @Nonnull YamlExecutionContext executionContext) {
         super(lineNumber, executables, connectionURI, executionContext);
     }
@@ -78,7 +79,7 @@ public class SetupBlock extends ConnectedBlock {
                 if (stepsObject == null) {
                     Assert.failUnchecked("Illegal Format: No steps provided in setup block.");
                 }
-                final var executables = new ArrayList<Consumer<RelationalConnection>>();
+                final var executables = new ArrayList<Consumer<YamlConnection>>();
                 for (final var step : Matchers.arrayList(stepsObject, "setup steps")) {
                     Assert.thatUnchecked(Matchers.map(step, "setup step").size() == 1, "Illegal Format: A setup step should be a single command");
                     final var resolvedCommand = Objects.requireNonNull(Command.parse(List.of(step), "unnamed-setup-block", executionContext));
@@ -91,7 +92,7 @@ public class SetupBlock extends ConnectedBlock {
             }
         }
 
-        private ManualSetupBlock(int lineNumber, @Nonnull List<Consumer<RelationalConnection>> executables, @Nonnull URI connectionURI,
+        private ManualSetupBlock(int lineNumber, @Nonnull List<Consumer<YamlConnection>> executables, @Nonnull URI connectionURI,
                                  @Nonnull YamlExecutionContext executionContext) {
             super(lineNumber, executables, connectionURI, executionContext);
         }
@@ -114,7 +115,7 @@ public class SetupBlock extends ConnectedBlock {
                 steps.add("DROP DATABASE IF EXISTS " + databasePath);
                 steps.add("CREATE DATABASE " + databasePath);
                 steps.add("CREATE SCHEMA " + databasePath + "/" + schemaName + " WITH TEMPLATE " + schemaTemplateName);
-                final var executables = new ArrayList<Consumer<RelationalConnection>>();
+                final var executables = new ArrayList<Consumer<YamlConnection>>();
                 for (final var step : steps) {
                     final var resolvedCommand = QueryCommand.withQueryString(lineNumber, step, executionContext);
                     executables.add(resolvedCommand::execute);
@@ -128,7 +129,7 @@ public class SetupBlock extends ConnectedBlock {
             }
         }
 
-        private SchemaTemplateBlock(int lineNumber, @Nonnull List<Consumer<RelationalConnection>> executables, @Nonnull YamlExecutionContext executionContext) {
+        private SchemaTemplateBlock(int lineNumber, @Nonnull List<Consumer<YamlConnection>> executables, @Nonnull YamlExecutionContext executionContext) {
             super(lineNumber, executables, executionContext.inferConnectionURI(0), executionContext);
         }
     }
@@ -141,7 +142,7 @@ public class SetupBlock extends ConnectedBlock {
                 final var steps = new ArrayList<String>();
                 steps.add("DROP DATABASE " + databasePath);
                 steps.add("DROP SCHEMA TEMPLATE " + schemaTemplateName);
-                final var executables = new ArrayList<Consumer<RelationalConnection>>();
+                final var executables = new ArrayList<Consumer<YamlConnection>>();
                 for (final var step : steps) {
                     final var resolvedCommand = QueryCommand.withQueryString(lineNumber, step, executionContext);
                     executables.add(resolvedCommand::execute);
@@ -152,7 +153,7 @@ public class SetupBlock extends ConnectedBlock {
             }
         }
 
-        private DestructTemplateBlock(int lineNumber, @Nonnull List<Consumer<RelationalConnection>> executables, @Nonnull YamlExecutionContext executionContext) {
+        private DestructTemplateBlock(int lineNumber, @Nonnull List<Consumer<YamlConnection>> executables, @Nonnull YamlExecutionContext executionContext) {
             super(lineNumber, executables, executionContext.inferConnectionURI(0), executionContext);
         }
     }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/TestBlock.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/TestBlock.java
@@ -20,7 +20,6 @@
 
 package com.apple.foundationdb.relational.yamltests.block;
 
-import com.apple.foundationdb.relational.api.RelationalConnection;
 import com.apple.foundationdb.relational.util.Assert;
 import com.apple.foundationdb.relational.yamltests.CustomYamlConstructor;
 import com.apple.foundationdb.relational.yamltests.Matchers;
@@ -477,7 +476,7 @@ public final class TestBlock extends ConnectedBlock {
 
     @Nonnull
     private static Consumer<YamlConnection> createTestExecutable(QueryCommand queryCommand, boolean checkCache,
-                                                                       @Nonnull Random random, boolean runAsPreparedStatement) {
+                                                                 @Nonnull Random random, boolean runAsPreparedStatement) {
         final var executor = queryCommand.instantiateExecutor(random, runAsPreparedStatement);
         return connection -> queryCommand.execute(connection, checkCache, executor);
     }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/Command.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/Command.java
@@ -144,6 +144,7 @@ public abstract class Command {
         }
     }
 
+    @SuppressWarnings({"PMD.CloseResource"}) // We "borrow" from the connection via tryGetEmbedded, but the connection will close it
     private static Command getLoadSchemaTemplateCommand(int lineNumber, @Nonnull final YamlExecutionContext executionContext, @Nonnull String value) {
         return new Command(lineNumber, executionContext) {
             @Override
@@ -164,6 +165,7 @@ public abstract class Command {
         };
     }
 
+    @SuppressWarnings({"PMD.CloseResource"}) // We "borrow" from the connection via tryGetEmbedded, but the connection will close it
     private static Command getSetSchemaStateCommand(int lineNumber, @Nonnull final YamlExecutionContext executionContext, @Nonnull String value) {
         return new Command(lineNumber, executionContext) {
             @Override

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/Command.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/Command.java
@@ -153,8 +153,9 @@ public abstract class Command {
                 ApplyState applyState = (RecordLayerMetadataOperationsFactory factory, Transaction txn) -> {
                     factory.getCreateSchemaTemplateConstantAction(CommandUtil.fromProto(value), Options.NONE).execute(txn);
                 };
-                if (connection.getUnderlying() instanceof EmbeddedRelationalConnection) {
-                    Command.applyMetadataOperationEmbedded((EmbeddedRelationalConnection) connection.getUnderlying(), RecordLayerConfig.getDefault(), applyState);
+                final EmbeddedRelationalConnection embedded = connection.tryGetEmbedded();
+                if (embedded != null) {
+                    Command.applyMetadataOperationEmbedded(embedded, RecordLayerConfig.getDefault(), applyState);
                 } else {
                     Command.applyMetadataOperationDirectly(RecordLayerConfig.getDefault(), applyState);
                 }
@@ -176,8 +177,9 @@ public abstract class Command {
                 ApplyState applyState = (RecordLayerMetadataOperationsFactory factory, Transaction txn) -> {
                     factory.getSetStoreStateConstantAction(URI.create(schemaInstance.getDatabaseId()), schemaInstance.getName()).execute(txn);
                 };
-                if (connection.getUnderlying() instanceof EmbeddedRelationalConnection) {
-                    Command.applyMetadataOperationEmbedded((EmbeddedRelationalConnection) connection.getUnderlying(), rlConfig, applyState);
+                final EmbeddedRelationalConnection embedded = connection.tryGetEmbedded();
+                if (embedded != null) {
+                    Command.applyMetadataOperationEmbedded(embedded, rlConfig, applyState);
                 } else {
                     Command.applyMetadataOperationDirectly(rlConfig, applyState);
                 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/Command.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/Command.java
@@ -26,7 +26,6 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContextConfi
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpace;
 import com.apple.foundationdb.relational.api.Options;
 import com.apple.foundationdb.relational.api.Transaction;
-import com.apple.foundationdb.relational.api.RelationalConnection;
 import com.apple.foundationdb.relational.api.catalog.StoreCatalog;
 import com.apple.foundationdb.relational.api.exceptions.RelationalException;
 import com.apple.foundationdb.relational.recordlayer.EmbeddedRelationalConnection;

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/Command.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/Command.java
@@ -100,7 +100,9 @@ public abstract class Command {
         try {
             executeInternal(connection);
         } catch (Throwable e) {
-            throw executionContext.wrapContext(e, () -> "‼️ Error executing command at line " + getLineNumber(), "command", getLineNumber());
+            throw executionContext.wrapContext(e,
+                    () -> "‼️ Error executing command at line " + getLineNumber() + " against connection for versions " + connection.getVersions(),
+                    "command", getLineNumber());
         }
     }
 

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryCommand.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryCommand.java
@@ -139,7 +139,7 @@ public final class QueryCommand extends Command {
         } catch (Throwable e) {
             if (maybeExecutionThrowable.get() == null) {
                 maybeExecutionThrowable.set(executionContext.wrapContext(e,
-                        () -> "‼️ Error executing query command at line " + getLineNumber(),
+                        () -> "‼️ Error executing query command at line " + getLineNumber() + " against connection for versions " + connection.getVersions(),
                         String.format(Locale.ROOT, "query [%s] ", executor), getLineNumber()));
             }
         }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryCommand.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryCommand.java
@@ -131,7 +131,10 @@ public final class QueryCommand extends Command {
 
     public void execute(@Nonnull final YamlConnection connection, boolean checkCache, @Nonnull QueryExecutor executor) {
         try {
-            if (!connection.supportsMetricCollector() && checkCache) {
+            // checkCache implies that we are repeating the query to check that it hits the cache
+            // If the underlying connection does not support access to the metric collector, we won't be able to
+            // actually check whether the cache was used, so we can skip this execution entirely.
+            if (checkCache && !connection.supportsMetricCollector()) {
                 logger.debug("⚠️ Not possible to check for cache hit with non-EmbeddedRelationalConnection!");
             } else {
                 executeInternal(connection, checkCache, executor);

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryCommand.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryCommand.java
@@ -131,7 +131,7 @@ public final class QueryCommand extends Command {
 
     public void execute(@Nonnull final YamlConnection connection, boolean checkCache, @Nonnull QueryExecutor executor) {
         try {
-            if (!connection.supportsCacheCheck() && checkCache) {
+            if (!connection.supportsMetricCollector() && checkCache) {
                 logger.debug("⚠️ Not possible to check for cache hit with non-EmbeddedRelationalConnection!");
             } else {
                 executeInternal(connection, checkCache, executor);

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryCommand.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryCommand.java
@@ -24,14 +24,13 @@ import com.apple.foundationdb.record.TestHelpers;
 import com.apple.foundationdb.record.query.plan.cascades.debug.Debugger;
 import com.apple.foundationdb.record.query.plan.debug.DebuggerWithSymbolTables;
 import com.apple.foundationdb.relational.api.Continuation;
-import com.apple.foundationdb.relational.api.RelationalConnection;
 import com.apple.foundationdb.relational.api.exceptions.RelationalException;
-import com.apple.foundationdb.relational.recordlayer.EmbeddedRelationalConnection;
 import com.apple.foundationdb.relational.recordlayer.util.ExceptionUtil;
 import com.apple.foundationdb.relational.util.Assert;
 import com.apple.foundationdb.relational.util.Environment;
 import com.apple.foundationdb.relational.yamltests.CustomYamlConstructor;
 import com.apple.foundationdb.relational.yamltests.Matchers;
+import com.apple.foundationdb.relational.yamltests.YamlConnection;
 import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -130,9 +129,9 @@ public final class QueryCommand extends Command {
                 "SkipConfig should not have gotten into QueryCommand " + lineNumber);
     }
 
-    public void execute(@Nonnull final RelationalConnection connection, boolean checkCache, @Nonnull QueryExecutor executor) {
+    public void execute(@Nonnull final YamlConnection connection, boolean checkCache, @Nonnull QueryExecutor executor) {
         try {
-            if (!(connection instanceof EmbeddedRelationalConnection) && checkCache) {
+            if (!connection.supportsCacheCheck() && checkCache) {
                 logger.debug("⚠️ Not possible to check for cache hit with non-EmbeddedRelationalConnection!");
             } else {
                 executeInternal(connection, checkCache, executor);
@@ -147,11 +146,11 @@ public final class QueryCommand extends Command {
     }
 
     @Override
-    void executeInternal(@Nonnull final RelationalConnection connection) throws SQLException, RelationalException {
+    void executeInternal(@Nonnull final YamlConnection connection) throws SQLException, RelationalException {
         executeInternal(connection, false, instantiateExecutor(null, false));
     }
 
-    private void executeInternal(@Nonnull final RelationalConnection connection, boolean checkCache, @Nonnull QueryExecutor executor)
+    private void executeInternal(@Nonnull final YamlConnection connection, boolean checkCache, @Nonnull QueryExecutor executor)
             throws SQLException, RelationalException {
         enableCascadesDebugger();
         boolean queryIsRunning = false;

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryConfig.java
@@ -26,6 +26,7 @@ import com.apple.foundationdb.relational.recordlayer.ErrorCapturingResultSet;
 import com.apple.foundationdb.relational.util.Assert;
 import com.apple.foundationdb.relational.yamltests.CustomYamlConstructor;
 import com.apple.foundationdb.relational.yamltests.Matchers;
+import com.apple.foundationdb.relational.yamltests.YamlConnection;
 import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
 import com.apple.foundationdb.relational.yamltests.block.FileOptions;
 import com.apple.foundationdb.relational.yamltests.generated.stats.PlannerMetricsProto;
@@ -117,30 +118,31 @@ public abstract class QueryConfig {
         return query;
     }
 
-    final void checkResult(@Nonnull String currentQuery, @Nonnull Object actual, @Nonnull String queryDescription) {
+    final void checkResult(@Nonnull String currentQuery, @Nonnull Object actual, @Nonnull String queryDescription,
+                           @Nonnull YamlConnection connection) {
         try {
             checkResultInternal(currentQuery, actual, queryDescription);
         } catch (AssertionFailedError e) {
             throw executionContext.wrapContext(e,
-                    () -> "‼️Check result failed in config at line " + getLineNumber(),
+                    () -> "‼️Check result failed in config at line " + getLineNumber() + " against connection for versions " + connection.getVersions(),
                     String.format(Locale.ROOT, "config [%s: %s] ", getConfigName(), getVal()), getLineNumber());
         } catch (Throwable e) {
             throw executionContext.wrapContext(e,
-                    () -> "‼️Failed to test config at line " + getLineNumber(),
+                    () -> "‼️Failed to test config at line " + getLineNumber() + " against connection for versions " + connection.getVersions(),
                     String.format(Locale.ROOT, "config [%s: %s] ", getConfigName(), getVal()), getLineNumber());
         }
     }
 
-    final void checkError(@Nonnull SQLException actual, @Nonnull String queryDescription) {
+    final void checkError(@Nonnull SQLException actual, @Nonnull String queryDescription, final YamlConnection connection) {
         try {
             checkErrorInternal(actual, queryDescription);
         } catch (AssertionFailedError e) {
             throw executionContext.wrapContext(e,
-                    () -> "‼️Check result failed in config at line " + getLineNumber(),
+                    () -> "‼️Check result failed in config at line " + getLineNumber() + " against connection for versions " + connection.getVersions(),
                     String.format(Locale.ROOT, "config [%s: %s] ", getConfigName(), getVal()), getLineNumber());
         } catch (Throwable e) {
             throw executionContext.wrapContext(e,
-                    () -> "‼️Failed to test config at line " + getLineNumber(),
+                    () -> "‼️Failed to test config at line " + getLineNumber() + " against connection for versions " + connection.getVersions(),
                     String.format(Locale.ROOT, "config [%s: %s] ", getConfigName(), getVal()), getLineNumber());
         }
     }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryExecutor.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryExecutor.java
@@ -148,7 +148,7 @@ public class QueryExecutor {
                 logger.debug("⏳ Executing query '{}'", this.toString());
                 try (var s = connection.createStatement()) {
                     final var queryResult = executeStatementAndCheckCacheIfNeeded(s, connection, currentQuery, checkCache, maxRows);
-                    config.checkResult(currentQuery, queryResult, this.toString());
+                    config.checkResult(currentQuery, queryResult, this.toString(), connection);
                     if (queryResult instanceof RelationalResultSet) {
                         continuationAfter = ((RelationalResultSet) queryResult).getContinuation();
                     }
@@ -158,7 +158,7 @@ public class QueryExecutor {
                 try (var s = connection.prepareStatement(currentQuery)) {
                     setParametersInPreparedStatement(s);
                     final var queryResult = executeStatementAndCheckCacheIfNeeded(s, connection, null, checkCache, maxRows);
-                    config.checkResult(currentQuery, queryResult, this.toString());
+                    config.checkResult(currentQuery, queryResult, this.toString(), connection);
                     if (queryResult instanceof RelationalResultSet) {
                         continuationAfter = ((RelationalResultSet) queryResult).getContinuation();
                     }
@@ -166,7 +166,7 @@ public class QueryExecutor {
             }
             logger.debug("👍 Finished executing query '{}'", this.toString());
         } catch (SQLException sqle) {
-            config.checkError(sqle, query);
+            config.checkError(sqle, query, connection);
         }
         return continuationAfter;
     }
@@ -182,14 +182,14 @@ public class QueryExecutor {
                 // We bypass checking for cache since the "EXECUTE CONTINUATION ..." statement does not need to be checked
                 // for caching.
                 final var queryResult = executeStatement(s, null);
-                config.checkResult(executeContinuationQuery, queryResult, this.toString());
+                config.checkResult(executeContinuationQuery, queryResult, this.toString(), connection);
                 if (queryResult instanceof RelationalResultSet) {
                     continuationAfter = ((RelationalResultSet) queryResult).getContinuation();
                 }
             }
             logger.debug("👍 Finished Executing continuation for query '{}'", this.toString());
         } catch (SQLException sqle) {
-            config.checkError(sqle, query);
+            config.checkError(sqle, query, connection);
         }
         return continuationAfter;
     }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryExecutor.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryExecutor.java
@@ -156,7 +156,7 @@ public class QueryExecutor {
             } else {
                 logger.debug("⏳ Executing query '{}'", this.toString());
                 try (var s = connection.prepareStatement(currentQuery)) {
-                    setParametersInPreparedStatement(s, connection);
+                    setParametersInPreparedStatement(s);
                     final var queryResult = executeStatementAndCheckCacheIfNeeded(s, connection, null, checkCache, maxRows);
                     config.checkResult(currentQuery, queryResult, this.toString());
                     if (queryResult instanceof RelationalResultSet) {
@@ -202,7 +202,7 @@ public class QueryExecutor {
             s.setMaxRows(maxRows);
         }
         if (parameters != null) {
-            setParametersInPreparedStatement(s, connection);
+            setParametersInPreparedStatement(s);
         }
         // set continuation
         s.setBytes(1, continuation.serialize());
@@ -272,10 +272,10 @@ public class QueryExecutor {
         return execResult ? s.getResultSet() : s.getUpdateCount();
     }
 
-    private void setParametersInPreparedStatement(@Nonnull RelationalPreparedStatement s, @Nonnull YamlConnection connection) throws SQLException {
+    private void setParametersInPreparedStatement(@Nonnull RelationalPreparedStatement statement) throws SQLException {
         int counter = 1;
         for (var parameter : Objects.requireNonNull(parameters)) {
-            s.setObject(counter++, parameter.getSqlObject(connection.getUnderlying()));
+            statement.setObject(counter++, parameter.getSqlObject(statement.getConnection()));
         }
     }
 

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/SkippedCommand.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/SkippedCommand.java
@@ -20,9 +20,9 @@
 
 package com.apple.foundationdb.relational.yamltests.command;
 
-import com.apple.foundationdb.relational.api.RelationalConnection;
 import com.apple.foundationdb.relational.api.exceptions.RelationalException;
 import com.apple.foundationdb.relational.util.Assert;
+import com.apple.foundationdb.relational.yamltests.YamlConnection;
 import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -50,7 +50,7 @@ public class SkippedCommand extends Command {
     }
 
     @Override
-    void executeInternal(@Nonnull final RelationalConnection connection) throws SQLException, RelationalException {
+    void executeInternal(@Nonnull final YamlConnection connection) throws SQLException, RelationalException {
         Assert.fail("Skipped commands should not be called");
     }
 

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/ConfigWithOptions.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/ConfigWithOptions.java
@@ -20,8 +20,8 @@
 
 package com.apple.foundationdb.relational.yamltests.configs;
 
+import com.apple.foundationdb.relational.yamltests.YamlConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
-import com.apple.foundationdb.relational.yamltests.YamlRunner;
 
 import javax.annotation.Nonnull;
 
@@ -41,7 +41,7 @@ public class ConfigWithOptions implements YamlTestConfig {
 
 
     @Override
-    public YamlRunner.YamlConnectionFactory createConnectionFactory() {
+    public YamlConnectionFactory createConnectionFactory() {
         return underlying.createConnectionFactory();
     }
 

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/EmbeddedConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/EmbeddedConfig.java
@@ -22,17 +22,15 @@ package com.apple.foundationdb.relational.yamltests.configs;
 
 import com.apple.foundationdb.relational.api.Options;
 import com.apple.foundationdb.relational.server.FRL;
+import com.apple.foundationdb.relational.yamltests.SimpleYamlConnection;
 import com.apple.foundationdb.relational.yamltests.YamlConnection;
 import com.apple.foundationdb.relational.yamltests.YamlConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
-import org.yaml.snakeyaml.Yaml;
 
 import javax.annotation.Nonnull;
 import java.net.URI;
-import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
-import java.util.List;
 import java.util.Set;
 
 /**
@@ -65,7 +63,7 @@ public class EmbeddedConfig implements YamlTestConfig {
         return new YamlConnectionFactory() {
             @Override
             public YamlConnection getNewConnection(@Nonnull URI connectPath) throws SQLException {
-                return new YamlConnection(DriverManager.getConnection(connectPath.toString()), YamlConnection.CURRENT_VERSION_ONLY);
+                return new SimpleYamlConnection(DriverManager.getConnection(connectPath.toString()), YamlConnection.CURRENT_VERSION);
             }
 
             @Override

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/EmbeddedConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/EmbeddedConfig.java
@@ -32,6 +32,7 @@ import java.net.URI;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -64,7 +65,7 @@ public class EmbeddedConfig implements YamlTestConfig {
         return new YamlConnectionFactory() {
             @Override
             public YamlConnection getNewConnection(@Nonnull URI connectPath) throws SQLException {
-                return new YamlConnection(DriverManager.getConnection(connectPath.toString()));
+                return new YamlConnection(DriverManager.getConnection(connectPath.toString()), YamlConnection.CURRENT_VERSION_ONLY);
             }
 
             @Override

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/EmbeddedConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/EmbeddedConfig.java
@@ -22,8 +22,10 @@ package com.apple.foundationdb.relational.yamltests.configs;
 
 import com.apple.foundationdb.relational.api.Options;
 import com.apple.foundationdb.relational.server.FRL;
+import com.apple.foundationdb.relational.yamltests.YamlConnection;
 import com.apple.foundationdb.relational.yamltests.YamlConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
+import org.yaml.snakeyaml.Yaml;
 
 import javax.annotation.Nonnull;
 import java.net.URI;
@@ -61,8 +63,8 @@ public class EmbeddedConfig implements YamlTestConfig {
     public YamlConnectionFactory createConnectionFactory() {
         return new YamlConnectionFactory() {
             @Override
-            public Connection getNewConnection(@Nonnull URI connectPath) throws SQLException {
-                return DriverManager.getConnection(connectPath.toString());
+            public YamlConnection getNewConnection(@Nonnull URI connectPath) throws SQLException {
+                return new YamlConnection(DriverManager.getConnection(connectPath.toString()));
             }
 
             @Override

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/EmbeddedConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/EmbeddedConfig.java
@@ -22,8 +22,8 @@ package com.apple.foundationdb.relational.yamltests.configs;
 
 import com.apple.foundationdb.relational.api.Options;
 import com.apple.foundationdb.relational.server.FRL;
+import com.apple.foundationdb.relational.yamltests.YamlConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
-import com.apple.foundationdb.relational.yamltests.YamlRunner;
 
 import javax.annotation.Nonnull;
 import java.net.URI;
@@ -58,8 +58,8 @@ public class EmbeddedConfig implements YamlTestConfig {
     }
 
     @Override
-    public YamlRunner.YamlConnectionFactory createConnectionFactory() {
-        return new YamlRunner.YamlConnectionFactory() {
+    public YamlConnectionFactory createConnectionFactory() {
+        return new YamlConnectionFactory() {
             @Override
             public Connection getNewConnection(@Nonnull URI connectPath) throws SQLException {
                 return DriverManager.getConnection(connectPath.toString());

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCInProcessConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCInProcessConfig.java
@@ -22,8 +22,8 @@ package com.apple.foundationdb.relational.yamltests.configs;
 
 import com.apple.foundationdb.relational.jdbc.JDBCURI;
 import com.apple.foundationdb.relational.server.InProcessRelationalServer;
+import com.apple.foundationdb.relational.yamltests.YamlConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
-import com.apple.foundationdb.relational.yamltests.YamlRunner;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -62,8 +62,8 @@ public class JDBCInProcessConfig implements YamlTestConfig {
     }
 
     @Override
-    public YamlRunner.YamlConnectionFactory createConnectionFactory() {
-        return new YamlRunner.YamlConnectionFactory() {
+    public YamlConnectionFactory createConnectionFactory() {
+        return new YamlConnectionFactory() {
             @Override
             public Connection getNewConnection(@Nonnull URI connectPath) throws SQLException {
                 // Add name of the in-process running server to the connectPath.

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCInProcessConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCInProcessConfig.java
@@ -22,6 +22,7 @@ package com.apple.foundationdb.relational.yamltests.configs;
 
 import com.apple.foundationdb.relational.jdbc.JDBCURI;
 import com.apple.foundationdb.relational.server.InProcessRelationalServer;
+import com.apple.foundationdb.relational.yamltests.SimpleYamlConnection;
 import com.apple.foundationdb.relational.yamltests.YamlConnection;
 import com.apple.foundationdb.relational.yamltests.YamlConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
@@ -31,7 +32,6 @@ import org.apache.logging.log4j.Logger;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.net.URI;
-import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Set;
@@ -71,7 +71,7 @@ public class JDBCInProcessConfig implements YamlTestConfig {
                 URI connectPathPlusServerName = JDBCURI.addQueryParameter(connectPath, JDBCURI.INPROCESS_URI_QUERY_SERVERNAME_KEY, server.getServerName());
                 String uriStr = connectPathPlusServerName.toString().replaceFirst("embed:", "relational://");
                 LOG.info("Rewrote {} as {}", connectPath, uriStr);
-                return new YamlConnection(DriverManager.getConnection(uriStr), YamlConnection.CURRENT_VERSION_ONLY);
+                return new SimpleYamlConnection(DriverManager.getConnection(uriStr), YamlConnection.CURRENT_VERSION);
             }
 
             @Override

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCInProcessConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCInProcessConfig.java
@@ -71,7 +71,7 @@ public class JDBCInProcessConfig implements YamlTestConfig {
                 URI connectPathPlusServerName = JDBCURI.addQueryParameter(connectPath, JDBCURI.INPROCESS_URI_QUERY_SERVERNAME_KEY, server.getServerName());
                 String uriStr = connectPathPlusServerName.toString().replaceFirst("embed:", "relational://");
                 LOG.info("Rewrote {} as {}", connectPath, uriStr);
-                return new YamlConnection(DriverManager.getConnection(uriStr));
+                return new YamlConnection(DriverManager.getConnection(uriStr), YamlConnection.CURRENT_VERSION_ONLY);
             }
 
             @Override

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCInProcessConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCInProcessConfig.java
@@ -22,6 +22,7 @@ package com.apple.foundationdb.relational.yamltests.configs;
 
 import com.apple.foundationdb.relational.jdbc.JDBCURI;
 import com.apple.foundationdb.relational.server.InProcessRelationalServer;
+import com.apple.foundationdb.relational.yamltests.YamlConnection;
 import com.apple.foundationdb.relational.yamltests.YamlConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
 import org.apache.logging.log4j.LogManager;
@@ -65,12 +66,12 @@ public class JDBCInProcessConfig implements YamlTestConfig {
     public YamlConnectionFactory createConnectionFactory() {
         return new YamlConnectionFactory() {
             @Override
-            public Connection getNewConnection(@Nonnull URI connectPath) throws SQLException {
+            public YamlConnection getNewConnection(@Nonnull URI connectPath) throws SQLException {
                 // Add name of the in-process running server to the connectPath.
                 URI connectPathPlusServerName = JDBCURI.addQueryParameter(connectPath, JDBCURI.INPROCESS_URI_QUERY_SERVERNAME_KEY, server.getServerName());
                 String uriStr = connectPathPlusServerName.toString().replaceFirst("embed:", "relational://");
                 LOG.info("Rewrote {} as {}", connectPath, uriStr);
-                return DriverManager.getConnection(uriStr);
+                return new YamlConnection(DriverManager.getConnection(uriStr));
             }
 
             @Override

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/MultiServerConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/MultiServerConfig.java
@@ -21,13 +21,13 @@
 package com.apple.foundationdb.relational.yamltests.configs;
 
 import com.apple.foundationdb.relational.yamltests.MultiServerConnectionFactory;
+import com.apple.foundationdb.relational.yamltests.SimpleYamlConnection;
 import com.apple.foundationdb.relational.yamltests.YamlConnection;
 import com.apple.foundationdb.relational.yamltests.YamlConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.server.ExternalServer;
 
 import javax.annotation.Nonnull;
 import java.net.URI;
-import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.List;
@@ -66,7 +66,7 @@ public class MultiServerConfig extends JDBCInProcessConfig {
             @Override
             public YamlConnection getNewConnection(@Nonnull URI connectPath) throws SQLException {
                 String uriStr = connectPath.toString().replaceFirst("embed:", "relational://localhost:" + externalServer.getPort());
-                return new YamlConnection(DriverManager.getConnection(uriStr), List.of(externalServer.getVersion()));
+                return new SimpleYamlConnection(DriverManager.getConnection(uriStr), externalServer.getVersion());
             }
 
             @Override

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/MultiServerConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/MultiServerConfig.java
@@ -21,7 +21,7 @@
 package com.apple.foundationdb.relational.yamltests.configs;
 
 import com.apple.foundationdb.relational.yamltests.MultiServerConnectionFactory;
-import com.apple.foundationdb.relational.yamltests.YamlRunner;
+import com.apple.foundationdb.relational.yamltests.YamlConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.server.ExternalServer;
 
 import javax.annotation.Nonnull;
@@ -52,7 +52,7 @@ public class MultiServerConfig extends JDBCInProcessConfig {
     }
 
     @Override
-    public YamlRunner.YamlConnectionFactory createConnectionFactory() {
+    public YamlConnectionFactory createConnectionFactory() {
         return new MultiServerConnectionFactory(
                 MultiServerConnectionFactory.ConnectionSelectionPolicy.ALTERNATE,
                 initialConnection,
@@ -60,8 +60,8 @@ public class MultiServerConfig extends JDBCInProcessConfig {
                 List.of(createExternalServerConnection()));
     }
 
-    YamlRunner.YamlConnectionFactory createExternalServerConnection() {
-        return new YamlRunner.YamlConnectionFactory() {
+    YamlConnectionFactory createExternalServerConnection() {
+        return new YamlConnectionFactory() {
             @Override
             public Connection getNewConnection(@Nonnull URI connectPath) throws SQLException {
                 String uriStr = connectPath.toString().replaceFirst("embed:", "relational://localhost:" + externalServer.getPort());

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/MultiServerConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/MultiServerConfig.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.relational.yamltests.configs;
 
 import com.apple.foundationdb.relational.yamltests.MultiServerConnectionFactory;
+import com.apple.foundationdb.relational.yamltests.YamlConnection;
 import com.apple.foundationdb.relational.yamltests.YamlConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.server.ExternalServer;
 
@@ -63,9 +64,9 @@ public class MultiServerConfig extends JDBCInProcessConfig {
     YamlConnectionFactory createExternalServerConnection() {
         return new YamlConnectionFactory() {
             @Override
-            public Connection getNewConnection(@Nonnull URI connectPath) throws SQLException {
+            public YamlConnection getNewConnection(@Nonnull URI connectPath) throws SQLException {
                 String uriStr = connectPath.toString().replaceFirst("embed:", "relational://localhost:" + externalServer.getPort());
-                return DriverManager.getConnection(uriStr);
+                return new YamlConnection(DriverManager.getConnection(uriStr));
             }
 
             @Override

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/MultiServerConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/MultiServerConfig.java
@@ -66,7 +66,7 @@ public class MultiServerConfig extends JDBCInProcessConfig {
             @Override
             public YamlConnection getNewConnection(@Nonnull URI connectPath) throws SQLException {
                 String uriStr = connectPath.toString().replaceFirst("embed:", "relational://localhost:" + externalServer.getPort());
-                return new YamlConnection(DriverManager.getConnection(uriStr));
+                return new YamlConnection(DriverManager.getConnection(uriStr), List.of(externalServer.getVersion()));
             }
 
             @Override

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/YamlTestConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/YamlTestConfig.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.relational.yamltests.configs;
 
+import com.apple.foundationdb.relational.yamltests.YamlConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
 import com.apple.foundationdb.relational.yamltests.YamlRunner;
 
@@ -38,7 +39,7 @@ public interface YamlTestConfig {
      * Creates the connection to the database.
      * @return a new connection factory
      */
-    YamlRunner.YamlConnectionFactory createConnectionFactory();
+    YamlConnectionFactory createConnectionFactory();
 
     /**
      * A list of options to be provided to {@link YamlRunner}.

--- a/yaml-tests/src/test/java/MultiServerConnectionFactoryTest.java
+++ b/yaml-tests/src/test/java/MultiServerConnectionFactoryTest.java
@@ -21,6 +21,7 @@
 import com.apple.foundationdb.relational.api.RelationalConnection;
 import com.apple.foundationdb.relational.api.RelationalPreparedStatement;
 import com.apple.foundationdb.relational.yamltests.MultiServerConnectionFactory;
+import com.apple.foundationdb.relational.yamltests.SimpleYamlConnection;
 import com.apple.foundationdb.relational.yamltests.YamlConnection;
 import com.apple.foundationdb.relational.yamltests.YamlConnectionFactory;
 import org.junit.jupiter.api.Test;
@@ -150,7 +151,7 @@ public class MultiServerConnectionFactoryTest {
             public YamlConnection getNewConnection(@Nonnull URI connectPath) throws SQLException {
                 // Add query string to connection so we can tell where it came from
                 URI newPath = URI.create(connectPath + "?version=" + version);
-                return new YamlConnection(dummyConnection(newPath), List.of(version));
+                return new SimpleYamlConnection(dummyConnection(newPath), version);
             }
 
             @Override

--- a/yaml-tests/src/test/java/MultiServerConnectionFactoryTest.java
+++ b/yaml-tests/src/test/java/MultiServerConnectionFactoryTest.java
@@ -21,6 +21,7 @@
 import com.apple.foundationdb.relational.api.RelationalConnection;
 import com.apple.foundationdb.relational.api.RelationalPreparedStatement;
 import com.apple.foundationdb.relational.yamltests.MultiServerConnectionFactory;
+import com.apple.foundationdb.relational.yamltests.YamlConnection;
 import com.apple.foundationdb.relational.yamltests.YamlConnectionFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -46,18 +47,19 @@ public class MultiServerConnectionFactoryTest {
                 dummyConnectionFactory("Primary"),
                 List.of(dummyConnectionFactory("Alternate")));
 
+        // TODO this file should not need to use getUnderlying, or directly reference MultiServerRelationalConnection
         MultiServerConnectionFactory.MultiServerRelationalConnection connection =
-                (MultiServerConnectionFactory.MultiServerRelationalConnection)classUnderTest.getNewConnection(URI.create("Blah"));
+                (MultiServerConnectionFactory.MultiServerRelationalConnection)classUnderTest.getNewConnection(URI.create("Blah")).getUnderlying();
         assertConnection(connection, "Primary");
         assertStatement(connection.prepareStatement("SQL"), "Primary");
         assertStatement(connection.prepareStatement("SQL"), "Primary");
 
-        connection = (MultiServerConnectionFactory.MultiServerRelationalConnection)classUnderTest.getNewConnection(URI.create("Blah"));
+        connection = (MultiServerConnectionFactory.MultiServerRelationalConnection)classUnderTest.getNewConnection(URI.create("Blah")).getUnderlying();
         assertConnection(connection, "Primary");
         assertStatement(connection.prepareStatement("SQL"), "Primary");
         assertStatement(connection.prepareStatement("SQL"), "Primary");
 
-        connection = (MultiServerConnectionFactory.MultiServerRelationalConnection)classUnderTest.getNewConnection(URI.create("Blah"));
+        connection = (MultiServerConnectionFactory.MultiServerRelationalConnection)classUnderTest.getNewConnection(URI.create("Blah")).getUnderlying();
         assertConnection(connection, "Primary");
         assertStatement(connection.prepareStatement("SQL"), "Primary");
         assertStatement(connection.prepareStatement("SQL"), "Primary");
@@ -81,7 +83,7 @@ public class MultiServerConnectionFactoryTest {
         // - connection current connection: initial connection
         // - statement: initial connection (2 statements)
         MultiServerConnectionFactory.MultiServerRelationalConnection connection =
-                (MultiServerConnectionFactory.MultiServerRelationalConnection)classUnderTest.getNewConnection(URI.create("Blah"));
+                (MultiServerConnectionFactory.MultiServerRelationalConnection)classUnderTest.getNewConnection(URI.create("Blah")).getUnderlying();
         assertConnection(connection, initialConnectionName);
         assertStatement(connection.prepareStatement("SQL"), initialConnectionName);
         // next statement
@@ -91,7 +93,7 @@ public class MultiServerConnectionFactoryTest {
         // - Factory current connection: alternate connection
         // - connection current connection: alternate connection
         // - statement: alternate connection (2 statements)
-        connection = (MultiServerConnectionFactory.MultiServerRelationalConnection)classUnderTest.getNewConnection(URI.create("Blah"));
+        connection = (MultiServerConnectionFactory.MultiServerRelationalConnection)classUnderTest.getNewConnection(URI.create("Blah")).getUnderlying();
         assertConnection(connection, otherConnectionName);
         assertStatement(connection.prepareStatement("SQL"), otherConnectionName);
         // next statement
@@ -101,7 +103,7 @@ public class MultiServerConnectionFactoryTest {
         // - Factory current connection: initial connection
         // - connection current connection: initial connection
         // - statement: initial connection (1 statement)
-        connection = (MultiServerConnectionFactory.MultiServerRelationalConnection)classUnderTest.getNewConnection(URI.create("Blah"));
+        connection = (MultiServerConnectionFactory.MultiServerRelationalConnection)classUnderTest.getNewConnection(URI.create("Blah")).getUnderlying();
         assertConnection(connection, initialConnectionName);
         // just one statement for this connection
         assertStatement(connection.prepareStatement("SQL"), initialConnectionName);
@@ -110,7 +112,7 @@ public class MultiServerConnectionFactoryTest {
         // - Factory current connection: alternate connection
         // - connection current connection: alternate connection
         // - statement: alternate connection (3 statements)
-        connection = (MultiServerConnectionFactory.MultiServerRelationalConnection)classUnderTest.getNewConnection(URI.create("Blah"));
+        connection = (MultiServerConnectionFactory.MultiServerRelationalConnection)classUnderTest.getNewConnection(URI.create("Blah")).getUnderlying();
         assertConnection(connection, otherConnectionName);
         assertStatement(connection.prepareStatement("SQL"), otherConnectionName);
         // next statements
@@ -143,10 +145,10 @@ public class MultiServerConnectionFactoryTest {
     YamlConnectionFactory dummyConnectionFactory(@Nonnull String name) {
         return new YamlConnectionFactory() {
             @Override
-            public RelationalConnection getNewConnection(@Nonnull URI connectPath) throws SQLException {
+            public YamlConnection getNewConnection(@Nonnull URI connectPath) throws SQLException {
                 // Add query string to connection so we can tell where it came from
                 URI newPath = URI.create(connectPath + "?name=" + name);
-                return dummyConnection(newPath);
+                return new YamlConnection(dummyConnection(newPath));
             }
 
             @Override

--- a/yaml-tests/src/test/java/MultiServerConnectionFactoryTest.java
+++ b/yaml-tests/src/test/java/MultiServerConnectionFactoryTest.java
@@ -21,7 +21,7 @@
 import com.apple.foundationdb.relational.api.RelationalConnection;
 import com.apple.foundationdb.relational.api.RelationalPreparedStatement;
 import com.apple.foundationdb.relational.yamltests.MultiServerConnectionFactory;
-import com.apple.foundationdb.relational.yamltests.YamlRunner;
+import com.apple.foundationdb.relational.yamltests.YamlConnectionFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -140,8 +140,8 @@ public class MultiServerConnectionFactoryTest {
         assertEquals("name=" + query, connection.getPath().getQuery());
     }
 
-    YamlRunner.YamlConnectionFactory dummyConnectionFactory(@Nonnull String name) {
-        return new YamlRunner.YamlConnectionFactory() {
+    YamlConnectionFactory dummyConnectionFactory(@Nonnull String name) {
+        return new YamlConnectionFactory() {
             @Override
             public RelationalConnection getNewConnection(@Nonnull URI connectPath) throws SQLException {
                 // Add query string to connection so we can tell where it came from

--- a/yaml-tests/src/test/java/SupportedVersionTest.java
+++ b/yaml-tests/src/test/java/SupportedVersionTest.java
@@ -19,6 +19,7 @@
  */
 
 import com.apple.foundationdb.relational.api.RelationalConnection;
+import com.apple.foundationdb.relational.yamltests.YamlConnection;
 import com.apple.foundationdb.relational.yamltests.YamlConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
 import com.apple.foundationdb.relational.yamltests.YamlRunner;
@@ -61,8 +62,8 @@ public class SupportedVersionTest {
     YamlConnectionFactory createConnectionFactory() {
         return new YamlConnectionFactory() {
             @Override
-            public RelationalConnection getNewConnection(@Nonnull URI connectPath) throws SQLException {
-                return DriverManager.getConnection(connectPath.toString()).unwrap(RelationalConnection.class);
+            public YamlConnection getNewConnection(@Nonnull URI connectPath) throws SQLException {
+                return new YamlConnection(DriverManager.getConnection(connectPath.toString()));
             }
 
             @Override

--- a/yaml-tests/src/test/java/SupportedVersionTest.java
+++ b/yaml-tests/src/test/java/SupportedVersionTest.java
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 
-import com.apple.foundationdb.relational.api.RelationalConnection;
+import com.apple.foundationdb.relational.yamltests.SimpleYamlConnection;
 import com.apple.foundationdb.relational.yamltests.YamlConnection;
 import com.apple.foundationdb.relational.yamltests.YamlConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
@@ -33,7 +33,6 @@ import javax.annotation.Nonnull;
 import java.net.URI;
 import java.sql.DriverManager;
 import java.sql.SQLException;
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -65,7 +64,7 @@ public class SupportedVersionTest {
         return new YamlConnectionFactory() {
             @Override
             public YamlConnection getNewConnection(@Nonnull URI connectPath) throws SQLException {
-                return new YamlConnection(DriverManager.getConnection(connectPath.toString()), List.of(VERSION));
+                return new SimpleYamlConnection(DriverManager.getConnection(connectPath.toString()), VERSION);
             }
 
             @Override

--- a/yaml-tests/src/test/java/SupportedVersionTest.java
+++ b/yaml-tests/src/test/java/SupportedVersionTest.java
@@ -19,6 +19,7 @@
  */
 
 import com.apple.foundationdb.relational.api.RelationalConnection;
+import com.apple.foundationdb.relational.yamltests.YamlConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
 import com.apple.foundationdb.relational.yamltests.YamlRunner;
 import com.apple.foundationdb.relational.yamltests.configs.EmbeddedConfig;
@@ -57,8 +58,8 @@ public class SupportedVersionTest {
         new YamlRunner(fileName, createConnectionFactory(), YamlExecutionContext.ContextOptions.EMPTY_OPTIONS).run();
     }
 
-    YamlRunner.YamlConnectionFactory createConnectionFactory() {
-        return new YamlRunner.YamlConnectionFactory() {
+    YamlConnectionFactory createConnectionFactory() {
+        return new YamlConnectionFactory() {
             @Override
             public RelationalConnection getNewConnection(@Nonnull URI connectPath) throws SQLException {
                 return DriverManager.getConnection(connectPath.toString()).unwrap(RelationalConnection.class);

--- a/yaml-tests/src/test/java/SupportedVersionTest.java
+++ b/yaml-tests/src/test/java/SupportedVersionTest.java
@@ -33,6 +33,7 @@ import javax.annotation.Nonnull;
 import java.net.URI;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -43,7 +44,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  */
 public class SupportedVersionTest {
 
-    private static EmbeddedConfig config = new EmbeddedConfig();
+    private static final String VERSION = "3.0.18.0";
+    private static final EmbeddedConfig config = new EmbeddedConfig();
 
     @BeforeAll
     static void beforeAll() throws Exception {
@@ -63,12 +65,12 @@ public class SupportedVersionTest {
         return new YamlConnectionFactory() {
             @Override
             public YamlConnection getNewConnection(@Nonnull URI connectPath) throws SQLException {
-                return new YamlConnection(DriverManager.getConnection(connectPath.toString()));
+                return new YamlConnection(DriverManager.getConnection(connectPath.toString()), List.of(VERSION));
             }
 
             @Override
             public Set<String> getVersionsUnderTest() {
-                return Set.of("3.0.18.0");
+                return Set.of(VERSION);
             }
         };
     }


### PR DESCRIPTION
This does the following:
1. It introduces a `YamlConnection` interface that wraps the underlying connection.
2. This makes it easier to have the connection expose what versions it is testing against

The issue we found is that when running in mixed-mode it runs the same query multiple times in parallel (as intended, I just didn't realize). This makes it incredibly hard to tell if a failing test is failing because it fails when going from the old version to the new version, or vice-versa. 