### PR TITLE
Run the PR label check whenever the HEAD commit changes to ensure it is applied to the final commit of each PR

### DIFF
--- a/.github/workflows/pr_labels.yml
+++ b/.github/workflows/pr_labels.yml
@@ -2,7 +2,9 @@ name: Pull Request Labels
 
 on:
   pull_request:
-    types: [opened, labeled, unlabeled]
+    # Run whenever the labels change or the PR HEAD changes. In theory, the latter is a bit redundant,
+    # but it's necessary to make sure that the check is applied to the final commit for a PR
+    types: [opened, reopened, labeled, unlabeled, synchronize]
 
 jobs:
   labels:


### PR DESCRIPTION
This makes sure the PR label check is run every time the commit changes on a PR. Strictly speaking, this seems like it shouldn't be necessary, but if it isn't added, then the check may not be applied to the final commit in a PR, which in turn means that the check won't be there to block a PR missing an appropriate label.