### PR TITLE
Change netty logs to INFO when running tests

### DIFF
--- a/gradle/scripts/log4j-test.properties
+++ b/gradle/scripts/log4j-test.properties
@@ -29,3 +29,8 @@ appender.console.layout.pattern = %d [%level] %logger{1.} - %m %X%n%ex{full}
 rootLogger.level = debug
 rootLogger.appenderRefs = stdout
 rootLogger.appenderRef.stdout.ref = STDOUT
+
+logger.netty-grpc.name = io.grpc.netty
+logger.netty-grpc.level = INFO
+logger.netty.name = io.netty
+logger.netty.level = INFO


### PR DESCRIPTION
netty is really quite noisy at debug level making it hard to read the output of yaml tests