### PR TITLE
Test concurrent indexing sessions without sync lock

### DIFF
--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerIndexFromIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerIndexFromIndexTest.java
@@ -23,16 +23,21 @@ package com.apple.foundationdb.record.provider.foundationdb;
 import com.apple.foundationdb.record.IndexBuildProto;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.TestRecords1Proto;
+import com.apple.foundationdb.record.logging.KeyValueLogMessage;
+import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.IndexOptions;
 import com.apple.foundationdb.record.metadata.IndexTypes;
 import com.apple.foundationdb.record.metadata.expressions.EmptyKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.GroupingKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
+import com.apple.foundationdb.synchronizedsession.SynchronizedSessionLockedException;
 import com.apple.test.BooleanSource;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -52,6 +57,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Tests for building indexes from other indexes with {@link OnlineIndexer}.
  */
 class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
+    private static final Logger LOGGER = LoggerFactory.getLogger(OnlineIndexerIndexFromIndexTest.class);
+
 
     private void populateData(final long numRecords, final long numOtherRecords) {
         openSimpleMetaData();
@@ -1148,6 +1155,47 @@ class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
         assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED));
         assertEquals(numChunks , timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RANGES_BY_COUNT));
         assertReadable(tgtIndex);
+        scrubAndValidate(List.of(tgtIndex));
+    }
+
+    @Test
+    void testIndexFromIndexIgnoreSyncLock() {
+
+        final long numRecords = 180;
+
+        Index srcIndex = new Index("src_index", field("num_value_2"), EmptyKeyExpression.EMPTY, IndexTypes.VALUE, IndexOptions.UNIQUE_OPTIONS);
+        Index tgtIndex = new Index("tgt_index", field("num_value_3_indexed"), IndexTypes.VALUE);
+        FDBRecordStoreTestBase.RecordMetaDataHook hook = myHook(srcIndex, tgtIndex);
+
+        populateData(numRecords);
+
+        openSimpleMetaData(hook);
+        buildIndexClean(srcIndex);
+        disableAll(List.of(tgtIndex));
+
+        openSimpleMetaData(hook);
+
+        IntStream.rangeClosed(0, 4).parallel().forEach(id -> {
+            snooze(100 - id);
+            try {
+                try (OnlineIndexer indexBuilder = newIndexerBuilder(tgtIndex)
+                        .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
+                                        .setSourceIndex("src_index")
+                                        .forbidRecordScan())
+                        .setLimit(5)
+                        .setUseSynchronizedSession(id == 0)
+                        .setMaxRetries(100) // enough to avoid giving up
+                        .build()) {
+                    indexBuilder.buildIndex(true);
+                }
+            } catch (SynchronizedSessionLockedException | IndexingBase.UnexpectedReadableException ex) {
+                LOGGER.info(KeyValueLogMessage.of("Ignoring lock, got exception",
+                        LogMessageKeys.SESSION_ID, id,
+                        LogMessageKeys.ERROR, ex.getMessage()));
+            }
+        });
+
+        assertReadable(List.of(tgtIndex));
         scrubAndValidate(List.of(tgtIndex));
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerIndexFromIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerIndexFromIndexTest.java
@@ -31,7 +31,6 @@ import com.apple.foundationdb.record.metadata.IndexTypes;
 import com.apple.foundationdb.record.metadata.expressions.EmptyKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.GroupingKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
-import com.apple.foundationdb.synchronizedsession.SynchronizedSessionLockedException;
 import com.apple.test.BooleanSource;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -1188,7 +1187,7 @@ class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
                         .build()) {
                     indexBuilder.buildIndex(true);
                 }
-            } catch (SynchronizedSessionLockedException | IndexingBase.UnexpectedReadableException ex) {
+            } catch (IndexingBase.UnexpectedReadableException ex) {
                 LOGGER.info(KeyValueLogMessage.of("Ignoring lock, got exception",
                         LogMessageKeys.SESSION_ID, id,
                         LogMessageKeys.ERROR, ex.getMessage()));

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMultiTargetTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMultiTargetTest.java
@@ -1048,7 +1048,7 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
                         .build()) {
                     indexBuilder.buildIndex(true);
                 }
-            } catch (SynchronizedSessionLockedException | IndexingBase.UnexpectedReadableException ex) {
+            } catch (IndexingBase.UnexpectedReadableException ex) {
                 LOGGER.info(KeyValueLogMessage.of("Ignoring lock, got exception",
                         LogMessageKeys.SESSION_ID, id,
                         LogMessageKeys.ERROR, ex.getMessage()));

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMultiTargetTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMultiTargetTest.java
@@ -23,6 +23,8 @@ package com.apple.foundationdb.record.provider.foundationdb;
 import com.apple.foundationdb.record.IndexBuildProto;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.TestRecords1Proto;
+import com.apple.foundationdb.record.logging.KeyValueLogMessage;
+import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.IndexOptions;
 import com.apple.foundationdb.record.metadata.IndexTypes;
@@ -35,6 +37,8 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
@@ -46,6 +50,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 
 import static com.apple.foundationdb.record.metadata.Key.Expressions.field;
@@ -58,6 +63,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 @Tag(Tags.Slow)
 class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
+    private static final Logger LOGGER = LoggerFactory.getLogger(OnlineIndexerMultiTargetTest.class);
 
     private void populateOtherData(final long numRecords) {
         List<TestRecords1Proto.MyOtherRecord> records = LongStream.range(0, numRecords).mapToObj(val ->
@@ -882,14 +888,6 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
         scrubAndValidate(indexes);
     }
 
-    void snooze(int millis) {
-        try {
-            Thread.sleep(millis);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
     @Test
     void testForbidConversionOfActiveMultiTarget() throws InterruptedException {
         // Do not let a conversion of few indexes of an active multi-target session
@@ -1018,4 +1016,47 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
         // happy indexes assertion
         assertReadable(indexes);
     }
+
+    @ParameterizedTest
+    @BooleanSource
+    void testMultiTargetIgnoringSyncLock(boolean reverseScan) {
+        // Simply build the index
+
+        final long numRecords = 180;
+
+        List<Index> indexes = new ArrayList<>();
+        indexes.add(new Index("indexA", field("num_value_2"), EmptyKeyExpression.EMPTY, IndexTypes.VALUE, IndexOptions.UNIQUE_OPTIONS));
+        indexes.add(new Index("indexB", field("num_value_3_indexed"), IndexTypes.VALUE));
+        indexes.add(new Index("indexC", field("num_value_unique"), EmptyKeyExpression.EMPTY, IndexTypes.VALUE, IndexOptions.UNIQUE_OPTIONS));
+        indexes.add(new Index("indexD", new GroupingKeyExpression(EmptyKeyExpression.EMPTY, 0), IndexTypes.COUNT));
+
+        populateData(numRecords);
+
+        FDBRecordStoreTestBase.RecordMetaDataHook hook = allIndexesHook(indexes);
+        openSimpleMetaData(hook);
+        disableAll(indexes);
+
+        IntStream.rangeClosed(0, 4).parallel().forEach(id -> {
+            snooze(100 - id);
+            try {
+                try (OnlineIndexer indexBuilder = newIndexerBuilder(indexes)
+                        .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
+                                .setReverseScanOrder(reverseScan))
+                        .setLimit(5)
+                        .setUseSynchronizedSession(id == 0)
+                        .setMaxRetries(100) // enough to avoid giving up
+                        .build()) {
+                    indexBuilder.buildIndex(true);
+                }
+            } catch (SynchronizedSessionLockedException | IndexingBase.UnexpectedReadableException ex) {
+                LOGGER.info(KeyValueLogMessage.of("Ignoring lock, got exception",
+                        LogMessageKeys.SESSION_ID, id,
+                        LogMessageKeys.ERROR, ex.getMessage()));
+            }
+        });
+
+        assertReadable(indexes);
+        scrubAndValidate(indexes);
+    }
+
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
@@ -373,6 +373,7 @@ public abstract class OnlineIndexerTest {
             Thread.sleep(millis);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();  //set the flag back to true
+            throw new RuntimeException(e);
         }
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
@@ -367,4 +367,12 @@ public abstract class OnlineIndexerTest {
         boundaries.add(null);
         return boundaries;
     }
+
+    protected void snooze(int millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
@@ -372,7 +372,7 @@ public abstract class OnlineIndexerTest {
         try {
             Thread.sleep(millis);
         } catch (InterruptedException e) {
-            throw new RuntimeException(e);
+            Thread.currentThread().interrupt();  //set the flag back to true
         }
     }
 }


### PR DESCRIPTION
  Since synchronized lock is optional, it would be nice to test concurrent indexing sessions (by records and by source index) that  do not use this lock. These indexing sessions will be getting many conflicts, but the index' integrity is expected to be maintained.

Resolve #3199
