### PR TITLE
Yaml tests: Only allow forced continuations on SELECT queries

### DIFF
--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryExecutor.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryExecutor.java
@@ -213,7 +213,7 @@ public class QueryExecutor {
     private Object executeStatementAndCheckForceContinuations(@Nonnull Statement s, @Nullable String queryString,
                                                               final YamlConnection connection, @Nullable Integer maxRows) throws SQLException {
         // Check if we need to force continuations
-        if ((maxRows == null) && forceContinuations) {
+        if ((maxRows == null) && forceContinuations && isForcedContinuationsEligible(queryString)) {
             return executeStatementWithForcedContinuations(s, queryString, connection);
         } else {
             if (maxRows != null) {

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryExecutor.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryExecutor.java
@@ -224,6 +224,10 @@ public class QueryExecutor {
         }
     }
 
+    private boolean isForcedContinuationsEligible(final String queryString) {
+        return ((queryString == null) || queryString.trim().toLowerCase().startsWith("select"));
+    }
+
     private Object executeStatementWithForcedContinuations(final @Nonnull Statement s,
                                                            final @Nullable String queryString,
                                                            final @Nonnull YamlConnection connection) throws SQLException {


### PR DESCRIPTION
The YAML tests are forcing continuations on every query right now. This runs into issues where the underlying implementation does not support setting `maxRows`. This change prevents forced continuations from taking place in any query but `SELECT`.
Queries such as `UPDATE` will not reject a `maxRows` but will ignore it (returning all rows) which will cause a test to fail validation when the rows returned are validated. 
Notes:
- All queries (UDPATE, INSERT, DROP etc) will now execute in "regular" mode even when forced continuation is taking place for SELECTs
- Most data modification is taking place in the `setup` blocks, and no validation is done, however, this will impact the way that these queries behave as well
- This change assumes that `SELECT` query begins with `"select"` string, a more elaborate test can be added later
