### PR TITLE
Introduce a new `Option` to set `asyncToSync` timeout.

### DIFF
--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/Options.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/Options.java
@@ -192,6 +192,7 @@ public final class Options {
         /**
          * Timeout for asynchronous operations in milliseconds, this is usually used to set an upperbound time limit for
          * operations interacting with FDB.
+         * Scope: Engine
          */
         ASYNC_OPERATIONS_TIMEOUT_MILLIS
     }

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/Options.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/Options.java
@@ -188,6 +188,12 @@ public final class Options {
          * that can be used in EXECUTE CONTINUATION statements.
          */
         CONTINUATIONS_CONTAIN_COMPILED_STATEMENTS,
+
+        /**
+         * Timeout for asynchronous operations in milliseconds, this is usually used to set an upperbound time limit for
+         * operations interacting with FDB.
+         */
+        ASYNC_OPERATIONS_TIMEOUT_MILLIS
     }
 
     public enum IndexFetchMethod {
@@ -221,6 +227,7 @@ public final class Options {
         builder.put(Name.DRY_RUN, false);
         builder.put(Name.CASE_SENSITIVE_IDENTIFIERS, false);
         builder.put(Name.CONTINUATIONS_CONTAIN_COMPILED_STATEMENTS, true);
+        builder.put(Name.ASYNC_OPERATIONS_TIMEOUT_MILLIS, 10_000L);
         OPTIONS_DEFAULT_VALUES = builder.build();
     }
 
@@ -355,6 +362,7 @@ public final class Options {
         data.put(Name.CURRENT_PLAN_HASH_MODE, List.of(TypeContract.stringType()));
         data.put(Name.VALID_PLAN_HASH_MODES, List.of(TypeContract.stringType()));
         data.put(Name.CONTINUATIONS_CONTAIN_COMPILED_STATEMENTS, List.of(TypeContract.booleanType()));
+        data.put(Name.ASYNC_OPERATIONS_TIMEOUT_MILLIS, List.of(TypeContract.longType(), RangeContract.of(0L, Long.MAX_VALUE)));
 
         return Collections.unmodifiableMap(data);
     }

--- a/fdb-relational-server/src/main/java/com/apple/foundationdb/relational/server/FRL.java
+++ b/fdb-relational-server/src/main/java/com/apple/foundationdb/relational/server/FRL.java
@@ -63,6 +63,7 @@ import java.sql.Types;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Temporary class. "The Relational Database".
@@ -88,6 +89,10 @@ public class FRL implements AutoCloseable {
     @SpotBugsSuppressWarnings(value = "CT_CONSTRUCTOR_THROW", justification = "Should consider refactoring but throwing exceptions for now")
     public FRL(@Nonnull Options options) throws RelationalException {
         final FDBDatabase fdbDb = FDBDatabaseFactory.instance().getDatabase();
+        final Long asyncToSyncTimeout = options.getOption(Options.Name.ASYNC_OPERATIONS_TIMEOUT_MILLIS);
+        if (asyncToSyncTimeout > 0) {
+            fdbDb.setAsyncToSyncTimeout(asyncToSyncTimeout, TimeUnit.MILLISECONDS);
+        }
         this.fdbDatabase = new DirectFdbConnection(fdbDb, NoOpMetricRegistry.INSTANCE);
 
         final RelationalKeyspaceProvider keyspaceProvider = RelationalKeyspaceProvider.instance();


### PR DESCRIPTION
This introduces a new `Option` for setting `asyncToSyncTimeout` to avoiding blocking forever on futures that may never return. An example of such future is waiting for `getReadVersion` JNI call to comeback against an unreachable FDB instance.

This fixes #3213.