### PR TITLE
Fix deserialization of continuations for queries that contain LIKE

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/PatternForLikeValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/PatternForLikeValue.java
@@ -188,7 +188,7 @@ public class PatternForLikeValue extends AbstractValue {
     public static PatternForLikeValue fromProto(@Nonnull final PlanSerializationContext serializationContext,
                                                 @Nonnull final PPatternForLikeValue patternForLikeValueProto) {
         return new PatternForLikeValue(Value.fromValueProto(serializationContext, Objects.requireNonNull(patternForLikeValueProto.getPatternChild())),
-                Value.fromValueProto(serializationContext, Objects.requireNonNull(patternForLikeValueProto.getPatternChild())));
+                Value.fromValueProto(serializationContext, Objects.requireNonNull(patternForLikeValueProto.getEscapeChild())));
     }
 
     @Nonnull

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/CustomYamlConstructor.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/CustomYamlConstructor.java
@@ -132,6 +132,11 @@ public class CustomYamlConstructor extends SafeConstructor {
             Assert.thatUnchecked(obj instanceof LinedObject, ErrorCode.INTERNAL_ERROR, msg);
             return (LinedObject) obj;
         }
+
+        @Override
+        public String toString() {
+            return object + "@line:" + lineNumber;
+        }
     }
 
     private static class ConstructIgnore extends AbstractConstruct {

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/Block.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/Block.java
@@ -53,7 +53,8 @@ public interface Block {
      */
     static Block parse(@Nonnull Object document, int blockNumber, @Nonnull YamlExecutionContext executionContext) {
         final var blockObject = Matchers.map(document, "block");
-        Assert.thatUnchecked(blockObject.size() == 1, "Illegal Format: A block is expected to be a map of size 1");
+        Assert.thatUnchecked(blockObject.size() == 1,
+                "Illegal Format: A block is expected to be a map of size 1 (block: " + blockNumber + ") keys: " + blockObject.keySet());
         final var entry = Matchers.firstEntry(blockObject, "block key-value");
         final var linedObject = CustomYamlConstructor.LinedObject.cast(entry.getKey(), () -> "Invalid block key-value pair: " + entry);
         final var lineNumber = linedObject.getLineNumber();

--- a/yaml-tests/src/test/java/YamlIntegrationTests.java
+++ b/yaml-tests/src/test/java/YamlIntegrationTests.java
@@ -219,8 +219,6 @@ public class YamlIntegrationTests {
     }
 
     @TestTemplate
-    @ExcludeYamlTestConfig(value = YamlTestConfigFilters.DO_NOT_FORCE_CONTINUATIONS,
-            reason = "Like continuation failure (https://github.com/FoundationDB/fdb-record-layer/issues/3099)")
     void like(YamlTest.Runner runner) throws Exception {
         runner.runYamsql("like.yamsql");
     }

--- a/yaml-tests/src/test/resources/like.yamsql
+++ b/yaml-tests/src/test/resources/like.yamsql
@@ -26,6 +26,7 @@
 ---
 schema_template:
     create table A(a1 string, primary key(a1))
+    create table B(b1 integer, b2 string, primary key(b1))
 ---
 setup:
   steps:
@@ -45,11 +46,45 @@ setup:
         ('{abcdefghijk}'),
         ('^$'),
         ('\\||%');
+    - query: insert into B values
+        (1, 'Y'),
+        (2, 'Z'),
+        (3, 'A'),
+        (4, 'Z'),
+        (5, 'B');
 ---
-# TODO (Investigate `Missing binding for __const_CONSTANT` error with queries when using plan from cache)
 test_block:
+  # TODO (Investigate `Missing binding for __const_CONSTANT` error with queries when using plan from cache)
   preset: single_repetition_parallelized
   tests:
+    -
+      - query: select * from B WHERE B2 LIKE 'X'
+      - result: []
+    -
+      - query: select * from B WHERE B2 LIKE 'Y'
+      - result: [{1, 'Y'}]
+    -
+      # Issue #3099 found that the pattern was being put in the escape part of the LIKE on continuation
+      # which for all the other queries, would result in an error that the escape should be of length 1.
+      # This query attempts to catch a similar issue, where on continuation this would be:
+      # SELECT * FROM B WHERE B2 NOT LIKE 'Z' ESCAPE 'Z'
+      # But, escape characters only matter if they precede a non-escape character.
+      - query: select * from B WHERE B2 NOT LIKE 'Z'
+      - result: [{1, 'Y'}, {3, 'A'}, {5, 'B'}]
+    -
+      - query: select * from B WHERE B2 NOT LIKE 'Z' ESCAPE 'Z'
+      - result: [{1, 'Y'}, {3, 'A'}, {5, 'B'}]
+    -
+      - query: select * from B WHERE B2 LIKE 'Z'
+      - result: [{2, 'Z'}, {4, 'Z'}]
+---
+test_block:
+  # TODO (Investigate `Missing binding for __const_CONSTANT` error with queries when using plan from cache)
+  preset: single_repetition_parallelized
+  tests:
+    -
+      - query: select * from A WHERE A1 LIKE 'A'
+      - result: []
     -
       - query: select * from A WHERE A1 LIKE 'abc'
       - result: []
@@ -158,5 +193,6 @@ test_block:
           {'学校'},
           {'مدرسة'},
           {'^$'},
-          {'\\||%'} ]
+          {'\\||%'}
+          ]
 ...

--- a/yaml-tests/src/test/resources/like.yamsql
+++ b/yaml-tests/src/test/resources/like.yamsql
@@ -66,14 +66,18 @@ test_block:
     -
       # Issue #3099 found that the pattern was being put in the escape part of the LIKE on continuation
       # which for all the other queries, would result in an error that the escape should be of length 1.
-      # This query attempts to catch a similar issue, where on continuation this would be:
-      # SELECT * FROM B WHERE B2 NOT LIKE 'Z' ESCAPE 'Z'
-      # But, escape characters only matter if they precede a non-escape character.
+      # I added these queries to see if that issue would expose differently if the query was only one character,
+      # and it kind of did, it ended up exposing issue: https://github.com/FoundationDB/fdb-record-layer/issues/3216
       - query: select * from B WHERE B2 NOT LIKE 'Z'
       - result: [{1, 'Y'}, {3, 'A'}, {5, 'B'}]
     -
       - query: select * from B WHERE B2 NOT LIKE 'Z' ESCAPE 'Z'
+      # This should error; see https://github.com/FoundationDB/fdb-record-layer/issues/3216
       - result: [{1, 'Y'}, {3, 'A'}, {5, 'B'}]
+    -
+      - query: select * from B WHERE B2 NOT LIKE '\'
+      # This should error; see https://github.com/FoundationDB/fdb-record-layer/issues/3216
+      - result: [{1, 'Y'}, {2, 'Z'}, {3, 'A'}, {4, Z}, {5, 'B'}]
     -
       - query: select * from B WHERE B2 LIKE 'Z'
       - result: [{2, 'Z'}, {4, 'Z'}]

--- a/yaml-tests/src/test/resources/like.yamsql
+++ b/yaml-tests/src/test/resources/like.yamsql
@@ -17,12 +17,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#---
-#options:
-#  # Prior to #3099 being fixed, every query that returned any data failed if there are continuations
-#  # Without testing any continuations there's not a lot of value here to running with multi-server,
-#  # So this is just being disabled entirely for older versions.
-#  supported_version: !current_version # https://github.com/FoundationDB/fdb-record-layer/issues/3099
+---
+options:
+  # Prior to #3099 being fixed, every query that returned any data failed if there are continuations
+  # Without testing any continuations there's not a lot of value here to running with multi-server,
+  # So this is just being disabled entirely for older versions.
+  supported_version: !current_version # https://github.com/FoundationDB/fdb-record-layer/issues/3099
 ---
 schema_template:
     create table A(a1 string, primary key(a1))

--- a/yaml-tests/src/test/resources/like.yamsql
+++ b/yaml-tests/src/test/resources/like.yamsql
@@ -17,6 +17,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+#---
+#options:
+#  # Prior to #3099 being fixed, every query that returned any data failed if there are continuations
+#  # Without testing any continuations there's not a lot of value here to running with multi-server,
+#  # So this is just being disabled entirely for older versions.
+#  supported_version: !current_version # https://github.com/FoundationDB/fdb-record-layer/issues/3099
 ---
 schema_template:
     create table A(a1 string, primary key(a1))


### PR DESCRIPTION
Previously, it would parse the query pattern as the escape character, making continuations useless.
i.e. `LIKE 'XYZ' ESCAPE 'XYZ'`, regardless of what the original query had for the escape character, if it had one.

Because I was curious what happens if the query pattern was a single character, I added some additional tests, and ran them with the old code to see if it would break in different ways. It didn't, I think in part because: `LIKE 'Z' ESCAPE 'Z'` is the same as `LIKE 'Z'`. I don't know if that is correct behavior, but it is what we do.
Even though these tests didn't expose other issues, I felt like they were worth keeping.

This Resolves: #3099