### PR TITLE
`EXISTS` queries now honor continuation from previous runs to avoid infinite loops

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/FutureCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/FutureCursor.java
@@ -50,6 +50,15 @@ public class FutureCursor<T> implements RecordCursor<T> {
     @Nonnull
     private static final RecordCursorContinuation notDoneContinuation = ByteArrayContinuation.fromNullable(new byte[] {0});
 
+    /**
+     * Internal constructor. Users should generally call
+     * {@link RecordCursor#fromFuture(Executor, java.util.function.Supplier, byte[])}
+     * in order to ensure that continuations from this cursor are properly handled.
+     *
+     * @param executor the executor to associate with this cursor
+     * @param future a future that when completed will provide the single element returned by this cursor
+     */
+    @API(API.Status.INTERNAL)
     public FutureCursor(@Nonnull Executor executor, @Nonnull CompletableFuture<T> future) {
         this.executor = executor;
         this.future = future;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryFirstOrDefaultPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryFirstOrDefaultPlan.java
@@ -28,12 +28,10 @@ import com.apple.foundationdb.record.PlanDeserializer;
 import com.apple.foundationdb.record.PlanHashable;
 import com.apple.foundationdb.record.PlanSerializationContext;
 import com.apple.foundationdb.record.RecordCursor;
-import com.apple.foundationdb.record.cursors.FutureCursor;
 import com.apple.foundationdb.record.planprotos.PRecordQueryFirstOrDefaultPlan;
 import com.apple.foundationdb.record.planprotos.PRecordQueryPlan;
 import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
-import com.apple.foundationdb.record.query.plan.explain.ExplainPlanVisitor;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.Memoizer;
@@ -47,6 +45,7 @@ import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalE
 import com.apple.foundationdb.record.query.plan.cascades.values.DerivedValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.Value;
 import com.apple.foundationdb.record.query.plan.cascades.values.translation.TranslationMap;
+import com.apple.foundationdb.record.query.plan.explain.ExplainPlanVisitor;
 import com.google.auto.service.AutoService;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
@@ -96,19 +95,17 @@ public class RecordQueryFirstOrDefaultPlan implements RecordQueryPlanWithChild, 
                                                                      @Nonnull final EvaluationContext context,
                                                                      @Nullable final byte[] continuation,
                                                                      @Nonnull final ExecuteProperties executeProperties) {
-        if (continuation == null) {
-            return new FutureCursor<>(store.getExecutor(),
-                    getChild().executePlan(store, context, null, executeProperties).first()
-                            .thenApply(resultOptional ->
-                                    resultOptional.orElseGet(() -> QueryResult.ofComputed(onEmptyResultValue.eval(store, context)))));
-        } else {
-            // The FutureCursor only ever returns a single continuation, indicating that the future
-            // has been completed. So, if we get a non-null continuation back, that means we've already
-            // completed the work done and returned something, so send an empty cursor back.
-            // Note that this doesn't handle out-of-band cursor no-next-reasons
-            // See: https://github.com/FoundationDB/fdb-record-layer/issues/3220
-            return RecordCursor.empty(store.getExecutor());
-        }
+        // Note that a null child continuation is always handed to the child cursor below.
+        // This is because the returned FutureCursor only ever returns a single value, and so if
+        // if that lambda is called, it indicates that the original continuation is null, and we
+        // are starting the plan from the beginning. That this doesn't handle the inner cursor
+        // halting with an out-of-band no-next-reasons, which currently is treated the same way
+        // as the inner cursor being empty.
+        // See: https://github.com/FoundationDB/fdb-record-layer/issues/3220
+        return RecordCursor.fromFuture(store.getExecutor(),
+                () -> getChild().executePlan(store, context, null, executeProperties).first()
+                        .thenApply(resultOptional -> resultOptional.orElseGet(() -> QueryResult.ofComputed(onEmptyResultValue.eval(store, context)))),
+                continuation);
     }
 
     @Override

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/RecordCursorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/RecordCursorTest.java
@@ -24,7 +24,6 @@ import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.async.MoreAsyncUtil;
 import com.apple.foundationdb.record.cursors.FilterCursor;
 import com.apple.foundationdb.record.cursors.FirableCursor;
-import com.apple.foundationdb.record.cursors.FutureCursor;
 import com.apple.foundationdb.record.cursors.LazyCursor;
 import com.apple.foundationdb.record.cursors.MapResultCursor;
 import com.apple.foundationdb.record.cursors.RowLimitedCursor;
@@ -63,6 +62,7 @@ import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
@@ -81,6 +81,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.oneOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -1314,7 +1315,7 @@ public class RecordCursorTest {
     private static RecordCursor<String> singletonFlatMapPipelinedCursorToClose(int iteration, CompletableFuture<Void> signal) {
         return RecordCursor.flatMapPipelined(
                 outerContinuation -> RecordCursor.fromList(EXECUTOR, IntStream.range(0, iteration % 199).boxed().collect(Collectors.toList()), outerContinuation),
-                (outerValue, innerContinuation) -> new FutureCursor<>(EXECUTOR, signal.thenApplyAsync(ignore -> String.valueOf(outerValue), EXECUTOR)),
+                (outerValue, innerContinuation) -> RecordCursor.fromFuture(EXECUTOR, signal.thenApplyAsync(ignore -> String.valueOf(outerValue), EXECUTOR), innerContinuation),
                 null,
                 null,
                 iteration % 19 + 2
@@ -1451,6 +1452,56 @@ public class RecordCursorTest {
             assertFalse(result.hasNext(), "future should not have value when resuming from a continuation");
             assertEquals(RecordCursor.NoNextReason.SOURCE_EXHAUSTED, result.getNoNextReason());
             assertTrue(result.getContinuation().isEnd());
+        }
+    }
+
+    @Test
+    void futureCursorCompletesWhenUnderlyingCompletes() throws Exception {
+        final CompletableFuture<Integer> future = new CompletableFuture<>();
+        final RecordCursorContinuation continuation;
+        try (RecordCursor<Integer> fromFuture = RecordCursor.fromFuture(EXECUTOR, future, null)) {
+            assertSame(EXECUTOR, fromFuture.getExecutor());
+            CompletableFuture<RecordCursorResult<Integer>> resultFuture = fromFuture.onNext();
+            assertFalse(resultFuture.isDone(), "result should not be done until underlying completes");
+            future.complete(1819);
+
+            // The previous result future should complete quickly. The timeout here is
+            // a bit of a hedge, but as currently written, the resultFuture should actually complete
+            // on this thread, and so the resultFuture should already be completed
+            // by now. But that's not necessarily part of the contract of the cursor, so
+            // instead, just assert here that we complete in a reasonable amount of time
+            RecordCursorResult<Integer> result = resultFuture.get(1, TimeUnit.SECONDS);
+            assertTrue(result.hasNext());
+            assertEquals(1819, result.get());
+            continuation = result.getContinuation();
+            assertFalse(continuation.isEnd());
+            assertFalse(continuation.toByteString().isEmpty());
+            assertThat(continuation.toBytes(), notNullValue());
+        }
+
+        try (RecordCursor<Integer> fromFuture = RecordCursor.fromFuture(EXECUTOR, () -> fail("should not run"), continuation.toBytes())) {
+            assertSame(EXECUTOR, fromFuture.getExecutor());
+            CompletableFuture<RecordCursorResult<Integer>> resultFuture = fromFuture.onNext();
+            assertTrue(resultFuture.isDone(), "empty result should not need to wait");
+            RecordCursorResult<Integer> result = resultFuture.get();
+            assertFalse(result.hasNext());
+            assertEquals(RecordCursor.NoNextReason.SOURCE_EXHAUSTED, result.getNoNextReason());
+            assertTrue(result.getContinuation().isEnd());
+        }
+    }
+
+    @Test
+    void futureCursorPropagatesError() {
+        final CompletableFuture<Integer> future = new CompletableFuture<>();
+        try (RecordCursor<Integer> fromFuture = RecordCursor.fromFuture(EXECUTOR, future, null)) {
+            assertSame(EXECUTOR, fromFuture.getExecutor());
+            CompletableFuture<RecordCursorResult<Integer>> resultFuture = fromFuture.onNext();
+            assertFalse(resultFuture.isDone(), "result should not be done until underlying completes");
+
+            final RecordCoreException error = new RecordCoreException("test error");
+            future.completeExceptionally(error);
+            CompletionException futureError = assertThrows(CompletionException.class, future::join);
+            assertSame(error, futureError.getCause(), "result should complete exception while propagating the cause");
         }
     }
 }

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/storage/BackingLocatableResolverStore.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/storage/BackingLocatableResolverStore.java
@@ -21,14 +21,14 @@
 package com.apple.foundationdb.relational.recordlayer.storage;
 
 import com.apple.foundationdb.annotation.API;
-
+import com.apple.foundationdb.record.ExecuteProperties;
 import com.apple.foundationdb.record.IndexEntry;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.ResolverStateProto;
+import com.apple.foundationdb.record.ScanProperties;
 import com.apple.foundationdb.record.TupleRange;
-import com.apple.foundationdb.record.cursors.FutureCursor;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.RecordType;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
@@ -37,8 +37,6 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBStoredRecord;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.LocatableResolver;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.ResolverCreateHooks;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.ResolverResult;
-import com.apple.foundationdb.tuple.Tuple;
-import com.apple.foundationdb.tuple.TupleHelpers;
 import com.apple.foundationdb.relational.api.Continuation;
 import com.apple.foundationdb.relational.api.Options;
 import com.apple.foundationdb.relational.api.Row;
@@ -50,7 +48,8 @@ import com.apple.foundationdb.relational.api.exceptions.RelationalException;
 import com.apple.foundationdb.relational.recordlayer.MessageTuple;
 import com.apple.foundationdb.relational.recordlayer.QueryPropertiesUtils;
 import com.apple.foundationdb.relational.recordlayer.util.ExceptionUtil;
-
+import com.apple.foundationdb.tuple.Tuple;
+import com.apple.foundationdb.tuple.TupleHelpers;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
@@ -207,19 +206,23 @@ public final class BackingLocatableResolverStore implements BackingStore {
             throw new InternalErrorException("unsupported range");
         }
 
+        final byte[] continuationBytes = continuation == null ? null : continuation.getExecutionState();
+        final ScanProperties scanProperties = QueryPropertiesUtils.getScanProperties(options);
         if (type.getName().equals(LocatableResolverMetaDataProvider.RESOLVER_STATE_TYPE_NAME)) {
-            CompletableFuture<FDBStoredRecord<Message>> future = locatableResolver.loadResolverState(context)
-                    .thenApply(state -> {
+            // todo: this does not use the scanProperties to track runtime information like rows scanned
+            final ExecuteProperties executeProperties = scanProperties.getExecuteProperties();
+            return RecordCursor.fromFuture(context.getExecutor(),
+                    () -> locatableResolver.loadResolverState(context).thenApply(state -> {
                         Message msg = metaDataProvider.wrapResolverState(state);
                         return FDBStoredRecord.newBuilder(msg)
                                 .setRecordType(type)
                                 .setPrimaryKey(TupleHelpers.EMPTY)
                                 .build();
-                    });
-            return new FutureCursor<>(context.getExecutor(), future);
+                    }),
+                    continuationBytes
+            ).skipThenLimit(executeProperties.getSkip(), executeProperties.getReturnedRowLimit());
         } else if (type.getName().equals(LocatableResolverMetaDataProvider.INTERNING_TYPE_NAME)) {
-            byte[] continuationBytes = continuation == null ? null : continuation.getExecutionState();
-            return locatableResolver.scan(context, continuationBytes, QueryPropertiesUtils.getScanProperties(options))
+            return locatableResolver.scan(context, continuationBytes, scanProperties)
                     .map(resolverKeyValue -> {
                         Message msg = metaDataProvider.wrapResolverResult(resolverKeyValue.getKey(), resolverKeyValue.getValue());
                         return FDBStoredRecord.newBuilder(msg)

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/storage/BackingLocatableResolverStore.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/storage/BackingLocatableResolverStore.java
@@ -210,6 +210,7 @@ public final class BackingLocatableResolverStore implements BackingStore {
         final ScanProperties scanProperties = QueryPropertiesUtils.getScanProperties(options);
         if (type.getName().equals(LocatableResolverMetaDataProvider.RESOLVER_STATE_TYPE_NAME)) {
             // todo: this does not use the scanProperties to track runtime information like rows scanned
+            // see: https://github.com/FoundationDB/fdb-record-layer/issues/3226
             final ExecuteProperties executeProperties = scanProperties.getExecuteProperties();
             return RecordCursor.fromFuture(context.getExecutor(),
                     () -> locatableResolver.loadResolverState(context).thenApply(state -> {

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/storage/BackingLocatableResolverStoreTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/storage/BackingLocatableResolverStoreTest.java
@@ -267,6 +267,9 @@ public class BackingLocatableResolverStoreTest {
                         ResultSetAssert.assertThat(resultSet)
                                 .hasNoNextRow();
                         continuation = resultSet.getContinuation();
+                        Assertions.assertThat(continuation.getReason())
+                                .as("Continuation reasons are all erroneously null due to: https://github.com/FoundationDB/fdb-record-layer/issues/3227")
+                                .isNull();
                     }
                 }
             }
@@ -496,6 +499,9 @@ public class BackingLocatableResolverStoreTest {
                             .isFalse();
                     Assertions.assertThat(continuation.atEnd())
                             .isFalse();
+                    Assertions.assertThat(continuation.getReason())
+                            .as("Continuation reasons are all erroneously null due to: https://github.com/FoundationDB/fdb-record-layer/issues/3227")
+                            .isNull();
                 }
                 // There's always only a single record, so just assert that there is not another row returned
                 // when resumed from a continuation
@@ -507,6 +513,9 @@ public class BackingLocatableResolverStoreTest {
                             .isFalse();
                     Assertions.assertThat(continuation.atEnd())
                             .isTrue();
+                    Assertions.assertThat(continuation.getReason())
+                            .as("Continuation reasons are all erroneously null due to: https://github.com/FoundationDB/fdb-record-layer/issues/3227")
+                            .isNull();
                 }
             }
         }

--- a/yaml-tests/src/test/java/YamlIntegrationTests.java
+++ b/yaml-tests/src/test/java/YamlIntegrationTests.java
@@ -97,8 +97,6 @@ public class YamlIntegrationTests {
     }
 
     @TestTemplate
-    @ExcludeYamlTestConfig(value = YamlTestConfigFilters.DO_NOT_FORCE_CONTINUATIONS,
-            reason = "Infinite continuation loop (https://github.com/FoundationDB/fdb-record-layer/issues/3095)")
     public void joinTests(YamlTest.Runner runner) throws Exception {
         runner.runYamsql("join-tests.yamsql");
     }
@@ -111,8 +109,6 @@ public class YamlIntegrationTests {
     }
 
     @TestTemplate
-    @ExcludeYamlTestConfig(value = YamlTestConfigFilters.DO_NOT_FORCE_CONTINUATIONS,
-            reason = "Infinite continuation loop (https://github.com/FoundationDB/fdb-record-layer/issues/3095)")
     public void selectAStar(YamlTest.Runner runner) throws Exception {
         runner.runYamsql("select-a-star.yamsql");
     }

--- a/yaml-tests/src/test/resources/join-tests.yamsql
+++ b/yaml-tests/src/test/resources/join-tests.yamsql
@@ -67,16 +67,45 @@ test_block:
     -
       # Get names of people working on a project
       - query: select fname, lname from emp where exists (select * from project where emp_id = emp.id);
+      - supported_version: !current_version
       - unorderedResult: [{"Emily", "Martinez"},
                           {"Daniel", "Miller"},
                           {"Megan", "Miller"}]
+    -
+      # Version of above query to simulate force_continuations with older versions.
+      # Can remove once we do not care about cross-version compatibility before !current_version
+      # See: https://github.com/FoundationDB/fdb-record-layer/issues/3219
+      - query: select fname, lname from emp where exists (select * from project where emp_id = emp.id);
+      - maxRows: 1
+      - initialVersionLessThan: !current_version
+      - result: [{"Emily", "Martinez"}]
+      - result: [{"Daniel", "Miller"}]
+      - result: [{"Daniel", "Miller"}]
+      - result: [{"Megan", "Miller"}]
+      - result: [{"Megan", "Miller"}]
+      - result: []
+      - initialVersionAtLeast: !current_version
     -
       # Get names of people working on a project in Sales department
       - query: select fname, lname from
                   (select fname, lname, dept_id from emp where exists (select * from project where emp_id = emp.id)) as sq,
                   dept
                where sq.dept_id = dept.id and dept.name = 'Sales';
+      - supported_version: !current_version
       - unorderedResult: [{"Daniel", "Miller"}]
+    -
+      # Version of above query to simulate force_continuations with older versions.
+      # Can remove once we do not care about cross-version compatibility before !current_version
+      # See: https://github.com/FoundationDB/fdb-record-layer/issues/3219
+      - query: select fname, lname from
+                  (select fname, lname, dept_id from emp where exists (select * from project where emp_id = emp.id)) as sq,
+                  dept
+               where sq.dept_id = dept.id and dept.name = 'Sales';
+      - maxRows: 1
+      - initialVersionLessThan: !current_version
+      - result: [{"Daniel", "Miller"}]
+      - result: []
+      - initialVersionAtLeast: !current_version
     -
       # three-way join to find which departments' corresponding projects.
       - query: select dept.name, project.name from emp, dept, project where emp.dept_id = dept.id and project.emp_id = emp.id;

--- a/yaml-tests/src/test/resources/join-tests.yamsql
+++ b/yaml-tests/src/test/resources/join-tests.yamsql
@@ -85,6 +85,9 @@ test_block:
       - result: [{"Megan", "Miller"}]
       - result: []
       - initialVersionAtLeast: !current_version
+      # Covered by the previous query if the second server version is >= !current_version
+      # If the second server version is < !current_version, then this repeats the previous value when returned.
+      # That behavior is checked by the other branch on individual responses.
     -
       # Get names of people working on a project in Sales department
       - query: select fname, lname from
@@ -106,6 +109,10 @@ test_block:
       - result: [{"Daniel", "Miller"}]
       - result: []
       - initialVersionAtLeast: !current_version
+      # Covered by the previous query if the second server version is >= !current_version
+      # If the second server version is < !current_version, then this repeats the previous value when returned.
+      # That behavior is checked by another query. As this returns a single row, the only thing we can test can
+      # really validate is that the continuation is parsed correctly during up-level testing
     -
       # three-way join to find which departments' corresponding projects.
       - query: select dept.name, project.name from emp, dept, project where emp.dept_id = dept.id and project.emp_id = emp.id;

--- a/yaml-tests/src/test/resources/select-a-star.metrics.binpb
+++ b/yaml-tests/src/test/resources/select-a-star.metrics.binpb
@@ -1,0 +1,67 @@
+´+
+e
+select-star-testsPEXPLAIN select B1 from B where exists (select A.*, B1 from A group by A1,A2,A3);Ê*
+½ÕýÛ5‘ «Íž"($0øŠ‚8&@‰SCAN(<,>) | TFILTER B | FLATMAP q0 -> { ISCAN(A_IDX <,>) | MAP (_ AS _0) | AGG () GROUP BY (_._0.A1 AS _0, _._0.A2 AS _1, _._0.A3 AS _2) | MAP (_._0._0 AS A1, _._0._1 AS A2, _._0._2 AS A3, q0.B1 AS B1) | DEFAULT NULL | FILTER _ NOT_NULL AS q0 RETURN (q0.B1 AS B1) }ž(digraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=polyline;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Nested Loop Join</td></tr><tr><td align="left">FLATMAP (q2.B1 AS B1)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS B1)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Type Filter</td></tr><tr><td align="left">WHERE record IS [B]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS B1, )" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Scan</td></tr><tr><td align="left">range: &lt;-âˆž, âˆž&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(RECORD)" ];
+  4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Primary Storage</td></tr><tr><td align="left">record types: [A, B]</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(RECORD)" ];
+  5 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE q14 NOT_NULL</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS A1, )" ];
+  6 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">FIRST $q14 OR NULL</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS A1, )" ];
+  7 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q10._0._0 AS A1, q10._0._1 AS A2, q10._0._2 AS A3, q2.B1 AS B1)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS A1, )" ];
+  8 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Streaming Aggregate</td></tr><tr><td align="left">COLLECT ()</td></tr><tr><td align="left">GROUP BY (q48._0.A1 AS _0, q48._0.A2 AS _1, q48._0.A3 AS _2)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS _0,  AS _0, )" ];
+  9 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q6 AS _0)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS A1,  AS _0)" ];
+  10 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">range: &lt;-âˆž, âˆž&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS A1, )" ];
+  11 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">A_IDX</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS A1, )" ];
+  3 -> 2 [ label=<&nbsp;q52> label="q52" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  4 -> 3 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q2> label="q2" color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  6 -> 5 [ label=<&nbsp;q14> label="q14" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  7 -> 6 [ label=<&nbsp;q14> label="q14" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  8 -> 7 [ label=<&nbsp;q10> label="q10" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  9 -> 8 [ label=<&nbsp;q48> label="q48" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  10 -> 9 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  11 -> 10 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  5 -> 1 [ label=<&nbsp;q14> label="q14" color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  {
+    rank=same;
+    rankDir=LR;
+    2 -> 5 [ color="red" style="invis" ];
+  }
+}Õ+
+g
+select-star-testsREXPLAIN select B.* from B where exists (select A.*, B.* from A group by A1,A2,A3);é*
+½ÜÂô‘ ×í®($0‡ÝF8&@˜SCAN(<,>) | TFILTER B | FLATMAP q0 -> { ISCAN(A_IDX <,>) | MAP (_ AS _0) | AGG () GROUP BY (_._0.A1 AS _0, _._0.A2 AS _1, _._0.A3 AS _2) | MAP (_._0._0 AS A1, _._0._1 AS A2, _._0._2 AS A3, q0.B1 AS B1, q0.B2 AS B2, q0.B3 AS B3) | DEFAULT NULL | FILTER _ NOT_NULL AS q0 RETURN q0 }¯(digraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=polyline;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Nested Loop Join</td></tr><tr><td align="left">FLATMAP q2</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS B1, )" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Type Filter</td></tr><tr><td align="left">WHERE record IS [B]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS B1, )" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Scan</td></tr><tr><td align="left">range: &lt;-âˆž, âˆž&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(RECORD)" ];
+  4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Primary Storage</td></tr><tr><td align="left">record types: [A, B]</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(RECORD)" ];
+  5 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE q14 NOT_NULL</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS A1, )" ];
+  6 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">FIRST $q14 OR NULL</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS A1, )" ];
+  7 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q10._0._0 AS A1, q10._0._1 AS A2, q10._0._2 AS A3, q2.B1 AS B1, q2.B2 AS B2, q2.B3 AS B3)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS A1, )" ];
+  8 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Streaming Aggregate</td></tr><tr><td align="left">COLLECT ()</td></tr><tr><td align="left">GROUP BY (q48._0.A1 AS _0, q48._0.A2 AS _1, q48._0.A3 AS _2)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS _0,  AS _0, )" ];
+  9 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q6 AS _0)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS A1,  AS _0)" ];
+  10 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">range: &lt;-âˆž, âˆž&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS A1, )" ];
+  11 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">A_IDX</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS A1, )" ];
+  3 -> 2 [ label=<&nbsp;q52> label="q52" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  4 -> 3 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q2> label="q2" color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  6 -> 5 [ label=<&nbsp;q14> label="q14" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  7 -> 6 [ label=<&nbsp;q14> label="q14" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  8 -> 7 [ label=<&nbsp;q10> label="q10" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  9 -> 8 [ label=<&nbsp;q48> label="q48" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  10 -> 9 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  11 -> 10 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  5 -> 1 [ label=<&nbsp;q14> label="q14" color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  {
+    rank=same;
+    rankDir=LR;
+    2 -> 5 [ color="red" style="invis" ];
+  }
+}

--- a/yaml-tests/src/test/resources/select-a-star.metrics.yaml
+++ b/yaml-tests/src/test/resources/select-a-star.metrics.yaml
@@ -1,0 +1,41 @@
+select-star-tests:
+-   query: EXPLAIN select B1 from B where exists (select A.*, B1 from A group by A1,A2,A3);
+    explain: SCAN(<,>) | TFILTER B | FLATMAP q0 -> { ISCAN(A_IDX <,>) | MAP (_ AS
+        _0) | AGG () GROUP BY (_._0.A1 AS _0, _._0.A2 AS _1, _._0.A3 AS _2) | MAP
+        (_._0._0 AS A1, _._0._1 AS A2, _._0._2 AS A3, q0.B1 AS B1) | DEFAULT NULL
+        | FILTER _ NOT_NULL AS q0 RETURN (q0.B1 AS B1) }
+    task_count: 445
+    task_total_time_ms: 112
+    transform_count: 145
+    transform_time_ms: 71
+    transform_yield_count: 36
+    insert_time_ms: 6
+    insert_new_count: 38
+    insert_reused_count: 4
+-   query: EXPLAIN select B1 from B where exists (select A.*, B1 from A group by A1,A2,A3);
+    explain: SCAN(<,>) | TFILTER B | FLATMAP q0 -> { ISCAN(A_IDX <,>) | MAP (_ AS
+        _0) | AGG () GROUP BY (_._0.A1 AS _0, _._0.A2 AS _1, _._0.A3 AS _2) | MAP
+        (_._0._0 AS A1, _._0._1 AS A2, _._0._2 AS A3, q0.B1 AS B1) | DEFAULT NULL
+        | FILTER _ NOT_NULL AS q0 RETURN (q0.B1 AS B1) }
+    task_count: 445
+    task_total_time_ms: 112
+    transform_count: 145
+    transform_time_ms: 71
+    transform_yield_count: 36
+    insert_time_ms: 6
+    insert_new_count: 38
+    insert_reused_count: 4
+-   query: EXPLAIN select B.* from B where exists (select A.*, B.* from A group by
+        A1,A2,A3);
+    explain: SCAN(<,>) | TFILTER B | FLATMAP q0 -> { ISCAN(A_IDX <,>) | MAP (_ AS
+        _0) | AGG () GROUP BY (_._0.A1 AS _0, _._0.A2 AS _1, _._0.A3 AS _2) | MAP
+        (_._0._0 AS A1, _._0._1 AS A2, _._0._2 AS A3, q0.B1 AS B1, q0.B2 AS B2, q0.B3
+        AS B3) | DEFAULT NULL | FILTER _ NOT_NULL AS q0 RETURN q0 }
+    task_count: 445
+    task_total_time_ms: 27
+    transform_count: 145
+    transform_time_ms: 11
+    transform_yield_count: 36
+    insert_time_ms: 1
+    insert_new_count: 38
+    insert_reused_count: 4

--- a/yaml-tests/src/test/resources/select-a-star.yamsql
+++ b/yaml-tests/src/test/resources/select-a-star.yamsql
@@ -40,7 +40,23 @@ test_block:
   tests:
     -
       - query: select B1 from B where exists (select A.*, B1 from A group by A1,A2,A3);
+      - supported_version: !current_version
+      - explain: "SCAN(<,>) | TFILTER B | FLATMAP q0 -> { ISCAN(A_IDX <,>) | MAP (_ AS _0) | AGG () GROUP BY (_._0.A1 AS _0, _._0.A2 AS _1, _._0.A3 AS _2) | MAP (_._0._0 AS A1, _._0._1 AS A2, _._0._2 AS A3, q0.B1 AS B1) | DEFAULT NULL | FILTER _ NOT_NULL AS q0 RETURN (q0.B1 AS B1) }"
       - result: [{1}, {2}, {3}]
+    -
+      # Version of above query to simulate force_continuations with older versions.
+      # Can remove once we do not care about cross-version compatibility before !current_version
+      # See: https://github.com/FoundationDB/fdb-record-layer/issues/3219
+      - query: select B1 from B where exists (select A.*, B1 from A group by A1,A2,A3);
+      - maxRows: 1
+      - initialVersionLessThan: !current_version
+      - result: [{1}]
+      - result: [{2}]
+      - result: [{2}]
+      - result: [{3}]
+      - result: [{3}]
+      - result: []
+      - initialVersionAtLeast: !current_version # Handled by above query in force_continuations mode
     -
       - query: select A.* from A;
       - result: [{A1: 1 , A2: 10, A3: 1}, {A1: 2, A2: 10, A3: 2}, {A1: 3, A2: 10, A3: 3}]
@@ -78,12 +94,44 @@ test_block:
       - error: "42803"
     -
       - query: select B1 from B where exists (select A.*, B1 from A group by A1,A2,A3);
+      - supported_version: !current_version
+      - explain: "SCAN(<,>) | TFILTER B | FLATMAP q0 -> { ISCAN(A_IDX <,>) | MAP (_ AS _0) | AGG () GROUP BY (_._0.A1 AS _0, _._0.A2 AS _1, _._0.A3 AS _2) | MAP (_._0._0 AS A1, _._0._1 AS A2, _._0._2 AS A3, q0.B1 AS B1) | DEFAULT NULL | FILTER _ NOT_NULL AS q0 RETURN (q0.B1 AS B1) }"
       - result: [{1}, {2}, {3}]
     -
+      # Version of above query to simulate force_continuations with older versions.
+      # Can remove once we do not care about cross-version compatibility before !current_version
+      # See: https://github.com/FoundationDB/fdb-record-layer/issues/3219
+      - query: select B1 from B where exists (select A.*, B1 from A group by A1,A2,A3);
+      - maxRows: 1
+      - initialVersionLessThan: !current_version
+      - result: [{1}]
+      - result: [{2}]
+      - result: [{2}]
+      - result: [{3}]
+      - result: [{3}]
+      - result: []
+      - initialVersionAtLeast: !current_version # Handled by above query in force_continuations mode
+    -
       - query: select B.* from B where exists (select A.*, B.* from A group by A1,A2,A3);
+      - supported_version: !current_version
+      - explain: "SCAN(<,>) | TFILTER B | FLATMAP q0 -> { ISCAN(A_IDX <,>) | MAP (_ AS _0) | AGG () GROUP BY (_._0.A1 AS _0, _._0.A2 AS _1, _._0.A3 AS _2) | MAP (_._0._0 AS A1, _._0._1 AS A2, _._0._2 AS A3, q0.B1 AS B1, q0.B2 AS B2, q0.B3 AS B3) | DEFAULT NULL | FILTER _ NOT_NULL AS q0 RETURN q0 }"
       - result: [{1, 20, {4, 40}},
                  {2, 20, {5, 50}},
                  {3, 20, {6, 60}}]
+    -
+      # Version of above query to simulate force_continuations with older versions.
+      # Can remove once we do not care about cross-version compatibility before !current_version
+      # See: https://github.com/FoundationDB/fdb-record-layer/issues/3219
+      - query: select B.* from B where exists (select A.*, B.* from A group by A1,A2,A3);
+      - maxRows: 1
+      - initialVersionLessThan: !current_version
+      - result: [{1, 20, {4, 40}}]
+      - result: [{2, 20, {5, 50}}]
+      - result: [{2, 20, {5, 50}}]
+      - result: [{3, 20, {6, 60}}]
+      - result: [{3, 20, {6, 60}}]
+      - result: []
+      - initialVersionAtLeast: !current_version # Handled by above query in force_continuations mode
     -
       # Not yet supported
       - query: select B.B3.* from B;


### PR DESCRIPTION
The `RecordQueryFirstOrDefaultPlan` constructs a special cursor which has cardinality at most one. The continuation it returns back to the user is not based on the inner cursor but only on whether the cursor has returned any data. Previously, we were taking the `FutureCursor`'s continuation (which is always `\x00`) and giving it back to the `inner` plan, which would generally result in the plan resuming from the beginning. That is not the appropriate way to interpret the continuation, so this updates the logic to instead skip creating the inner cursor if we get a non-beginning continuation, which is in line with what the `FutureCursor`'s continuation means.

This fixes #3219.