### PR TITLE
Fix unstable hash for NULL literal

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/typing/Type.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/typing/Type.java
@@ -1110,6 +1110,16 @@ public interface Type extends Narrowable<Type>, PlanSerializable {
                 return Null.fromProto(serializationContext, nullTypeProto);
             }
         }
+
+        @Override
+        public int hashCode() {
+            return getTypeCode().name().hashCode();
+        }
+
+        @Override
+        public boolean equals(final Object other) {
+            return other instanceof Null;
+        }
     }
 
     /**
@@ -1198,6 +1208,16 @@ public interface Type extends Narrowable<Type>, PlanSerializable {
                                   @Nonnull final PNoneType noneTypeProto) {
                 return None.fromProto(serializationContext, noneTypeProto);
             }
+        }
+
+        @Override
+        public int hashCode() {
+            return getTypeCode().name().hashCode();
+        }
+
+        @Override
+        public boolean equals(final Object other) {
+            return other instanceof None;
         }
     }
 

--- a/yaml-tests/src/test/java/YamlIntegrationTests.java
+++ b/yaml-tests/src/test/java/YamlIntegrationTests.java
@@ -186,8 +186,6 @@ public class YamlIntegrationTests {
     }
 
     @TestTemplate
-    @ExcludeYamlTestConfig(value = YamlTestConfigFilters.DO_NOT_FORCE_CONTINUATIONS,
-            reason = "Infinite continuation (https://github.com/FoundationDB/fdb-record-layer/issues/3095)")
     void booleanTypes(YamlTest.Runner runner) throws Exception {
         runner.runYamsql("boolean.yamsql");
     }

--- a/yaml-tests/src/test/java/YamlIntegrationTests.java
+++ b/yaml-tests/src/test/java/YamlIntegrationTests.java
@@ -222,8 +222,6 @@ public class YamlIntegrationTests {
     }
 
     @TestTemplate
-    @ExcludeYamlTestConfig(value = YamlTestConfigFilters.DO_NOT_FORCE_CONTINUATIONS,
-            reason = "Continuation mismatch (https://github.com/FoundationDB/fdb-record-layer/issues/3098)")
     void functions(YamlTest.Runner runner) throws Exception {
         runner.runYamsql("functions.yamsql");
     }

--- a/yaml-tests/src/test/resources/boolean.yamsql
+++ b/yaml-tests/src/test/resources/boolean.yamsql
@@ -96,6 +96,7 @@ test_block:
       - result: [ { false }, { false }, { false } ]
     -
       - query: select B AND NULL from lb
+      - supported_version: !current_version # This fails when running with continuations against older versions
       - result: [ { !null }, { false }, { !null } ]
     -
       - query: select B OR TRUE from lb
@@ -105,6 +106,7 @@ test_block:
       - result: [ { true }, { false }, { !null } ]
     -
       - query: select B OR NULL from lb
+      - supported_version: !current_version # This fails when running with continuations against older versions
       - result: [ { true }, { !null }, { !null } ]
     -
       - query: select NOT B from lb

--- a/yaml-tests/src/test/resources/functions.yamsql
+++ b/yaml-tests/src/test/resources/functions.yamsql
@@ -92,6 +92,7 @@ test_block:
       - result: [{_0: 1.0, _1: 1.0}]
     -
       - query: select coalesce(null, null, 5), coalesce(null, 1, null), coalesce(null, a1, a8) from A
+      - supported_version: !current_version # literal null in plan hash
       - result: [{_0: 5, _1: 1, _2: 1.0}]
     -
       - query: select b1, b2, coalesce(b1, b2, 42) from B
@@ -123,6 +124,7 @@ test_block:
           {!null _}]
     -
       - query: select coalesce(null, (1, 1.0, 'a', true)) from C
+      - supported_version: !current_version # literal null in plan hash
       - unorderedResult: [
           {{ _0: 1, _1: 1.0, _2: 'a', _3: true}},
           {{ _0: 1, _1: 1.0, _2: 'a', _3: true}},


### PR DESCRIPTION
Resolves #3218

This fixes an issue where the continuation for NULL literals is failing to execute since the hash code for the NULL literal is unstable. The tests now pass (and so enabled) for configurations other than forced continuations against older versions.

