### PR TITLE
Fix gradle warnings in prb

### DIFF
--- a/actions/run-gradle/action.yml
+++ b/actions/run-gradle/action.yml
@@ -13,4 +13,4 @@ runs:
       run: sed -i -e "s/^org\.gradle\..*/#&/g" gradle.properties
     - name: Run Command
       shell: bash
-      run: GRADLE_OPTS="-XX:+HeapDumpOnOutOfMemoryError -Xverify:none -XX:+TieredCompilation -Xmx4096m -Dfile.encoding=UTF-8 -Duser.country -Duser.language=en -Duser.variant --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.prefs/java.util.prefs=ALL-UNNAMED" ./gradlew --no-daemon --console=plain -b ./build.gradle ${{ inputs.gradle_command }}
+      run: GRADLE_OPTS="-XX:+HeapDumpOnOutOfMemoryError -Xverify:none -XX:+TieredCompilation -Xmx4096m -Dfile.encoding=UTF-8 -Duser.country -Duser.language=en -Duser.variant --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.prefs/java.util.prefs=ALL-UNNAMED" ./gradlew --no-daemon --console=plain ${{ inputs.gradle_command }}

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -93,7 +93,7 @@ if (ext.publishLibrary) {
                 GenerateMavenPom pomTask = tasks.generatePomFileForLibraryPublication
                 Jar jarTask = tasks.jar
                 if (filename == pomTask.destination.name) {
-                    jarTask.archiveName.replace "jar", "pom"
+                    jarTask.archiveFileName.map { archive -> archive.replace("jar", "pom") }
                 } else {
                     filename
                 }


### PR DESCRIPTION
I ran the gradle tasks with `--warning-mode all` and found the following warnings, and resolved them:
- Remove `-b ./build.gradle` from our actions. This has been deprecated, and seems unnecessary.
- Replace `jarTask.archiveName` with `jarTask.archiveFileName` because `archiveName` has been deprecated