### PR TITLE
Set *.metrics.binpb to diff as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.metrics.binpb binary
+**/*.metrics.binpb binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.metrics.binpb -diff

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.metrics.binpb -diff
+*.metrics.binpb binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-**/*.metrics.binpb -text -merge
+**/*.metrics.binpb linguist-generated=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-**/*.metrics.binpb binary
+**/*.metrics.binpb -text -merge

--- a/yaml-tests/src/test/resources/union-empty-tables.metrics.binpb
+++ b/yaml-tests/src/test/resources/union-empty-tables.metrics.binpb
@@ -79,7 +79,7 @@ r
   15 -> 13 [ label=<&nbsp;q12> label="q12" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   16 -> 14 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   17 -> 15 [ label=<&nbsp;q55> label="q55" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  18 -> 16 [ label=<&nbsp;q74> label="q74" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  18 -> 16 [ foo=<&nbsp;q74> label="q74" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   19 -> 17 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   20 -> 18 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q26> label="q26" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];


### PR DESCRIPTION
These files have a large amount of binary data and are not inteded to be diffed by a human. They also have a fair amount of ascii, so sometimes git (and particularly github) considers them text files and displays the contens, which is not helpful.