### PR TITLE
Make test output in gradle much more compact

### DIFF
--- a/gradle/testing.gradle
+++ b/gradle/testing.gradle
@@ -228,12 +228,12 @@ tasks.withType(Test) { theTask ->
     }
 
     beforeTest { descriptor -> 
-        println "${Instant.now()} ${getFullDisplayName(descriptor)} STARTED"
+        print("${Instant.now()} ${getFullDisplayName(descriptor)}")
+        System.out.flush()
     } 
     afterTest { descriptor, result ->
         def duration = String.format(Locale.ROOT, "%,d", result.endTime - result.startTime)
-        println "${Instant.now()} ${getFullDisplayName(descriptor)} ${result.resultType} (${duration}ms)"
-        println()
+        println " ${result.resultType} (${duration}ms)"
         if (result.resultType == TestResult.ResultType.FAILURE) {
             failures.append(
                 "<details>\n" +


### PR DESCRIPTION
I've been looking at gradle outputs in builds a bunch recently and the existing format means that the logs are very large. This changes it to one line per successful test, instead of 3. Since it prints when it starts, and flushes, you can see what test is taking a long time when that happens.
Since each test is only one line of text, the blank line seems completely unnecessary now.