### PR TITLE
Fix path to FDB logo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img alt="FoundationDB logo" src="docs/FDB_logo.png?raw=true" width="400">
+<img alt="FoundationDB logo" src="docs/sphinx/source/FDB_logo.png?raw=true" width="400">
 
 FoundationDB is a distributed database designed to handle large volumes of structured data across clusters of commodity servers. It organizes data as an ordered key-value store and employs ACID transactions for all operations. It is especially well-suited for read/write workloads but also has excellent performance for write-intensive workloads. Users interact with the database using API language binding.
 


### PR DESCRIPTION
This was moved as part of the switch to sphinx, but the link was not updated.