### PR TITLE
Add illegal version tests to SupportedVersionTest

### DIFF
--- a/yaml-tests/src/test/java/SupportedVersionTest.java
+++ b/yaml-tests/src/test/java/SupportedVersionTest.java
@@ -85,7 +85,10 @@ public class SupportedVersionTest {
                 "lower-at-block",
                 "lower-at-query",
                 "late-query-supported-version",
-                "late-file-options"
+                "late-file-options",
+                "illegal-version-at-file",
+                "illegal-version-at-block",
+                "illegal-version-at-query"
         );
     }
 

--- a/yaml-tests/src/test/resources/supported-version/illegal-version-at-block.yamsql
+++ b/yaml-tests/src/test/resources/supported-version/illegal-version-at-block.yamsql
@@ -1,0 +1,31 @@
+#
+# current-version-at-block.yamsql
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2021-2025 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This test should pass
+---
+schema_template:
+    create table t1(id bigint, col1 bigint, primary key(id))
+---
+test_block:
+  options:
+    supported_version: illegal-version
+  tests:
+    -
+      - query: SHOULD ERROR WHEN RUN;
+      - result: []

--- a/yaml-tests/src/test/resources/supported-version/illegal-version-at-block.yamsql
+++ b/yaml-tests/src/test/resources/supported-version/illegal-version-at-block.yamsql
@@ -1,5 +1,5 @@
 #
-# current-version-at-block.yamsql
+# illegal-version-at-block.yamsql
 #
 # This source file is part of the FoundationDB open source project
 #
@@ -17,7 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This test should pass
+# This test should fail
 ---
 schema_template:
     create table t1(id bigint, col1 bigint, primary key(id))
@@ -27,5 +27,5 @@ test_block:
     supported_version: illegal-version
   tests:
     -
-      - query: SHOULD ERROR WHEN RUN;
+      - query: SELECT * FROM t1;
       - result: []

--- a/yaml-tests/src/test/resources/supported-version/illegal-version-at-file.yamsql
+++ b/yaml-tests/src/test/resources/supported-version/illegal-version-at-file.yamsql
@@ -17,7 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This test should be fail
+# This test should fail
 ---
 options:
     supported_version: illegal_version

--- a/yaml-tests/src/test/resources/supported-version/illegal-version-at-file.yamsql
+++ b/yaml-tests/src/test/resources/supported-version/illegal-version-at-file.yamsql
@@ -1,0 +1,32 @@
+#
+# current-version-at-file.yamsql
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2021-2025 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This test should be ignored
+---
+options:
+    supported_version: illegal_version
+---
+schema_template:
+    create table t1(id bigint, col1 bigint, primary key(id))
+---
+test_block:
+  tests:
+    -
+      - query: SHOULD ERROR WHEN RUN;
+      - result: []

--- a/yaml-tests/src/test/resources/supported-version/illegal-version-at-file.yamsql
+++ b/yaml-tests/src/test/resources/supported-version/illegal-version-at-file.yamsql
@@ -1,5 +1,5 @@
 #
-# current-version-at-file.yamsql
+# illegal-version-at-file.yamsql
 #
 # This source file is part of the FoundationDB open source project
 #
@@ -17,7 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This test should be ignored
+# This test should be fail
 ---
 options:
     supported_version: illegal_version
@@ -28,5 +28,5 @@ schema_template:
 test_block:
   tests:
     -
-      - query: SHOULD ERROR WHEN RUN;
+      - query: SELECT * FROM t1;
       - result: []

--- a/yaml-tests/src/test/resources/supported-version/illegal-version-at-query.yamsql
+++ b/yaml-tests/src/test/resources/supported-version/illegal-version-at-query.yamsql
@@ -1,5 +1,5 @@
 #
-# current-version-at-query.yamsql
+# illegal-version-at-query.yamsql
 #
 # This source file is part of the FoundationDB open source project
 #
@@ -17,7 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This test should pass
+# This test should fail
 ---
 schema_template:
     create table t1(id bigint, col1 bigint, primary key(id))
@@ -25,9 +25,6 @@ schema_template:
 test_block:
   tests:
     -
-      - query: SHOULD ERROR WHEN RUN;
-      - supported_version: illegal_version
-      - result: []
-    - # You need at least one query
       - query: SELECT * FROM t1;
+      - supported_version: illegal_version
       - result: []

--- a/yaml-tests/src/test/resources/supported-version/illegal-version-at-query.yamsql
+++ b/yaml-tests/src/test/resources/supported-version/illegal-version-at-query.yamsql
@@ -1,0 +1,33 @@
+#
+# current-version-at-query.yamsql
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2021-2025 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This test should pass
+---
+schema_template:
+    create table t1(id bigint, col1 bigint, primary key(id))
+---
+test_block:
+  tests:
+    -
+      - query: SHOULD ERROR WHEN RUN;
+      - supported_version: illegal_version
+      - result: []
+    - # You need at least one query
+      - query: SELECT * FROM t1;
+      - result: []


### PR DESCRIPTION
This resolves #3238
Adding a few tests that include illegal version clauses to the end-to-end YAML SupportedVersionTest
