### PR TITLE
Do not drop AllTime leaderboard if deleteBefore is Long.Max_VALUE

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowLeaderboard.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowLeaderboard.java
@@ -154,4 +154,15 @@ public class TimeWindowLeaderboard implements Comparable<TimeWindowLeaderboard> 
                 .setSubspaceKey(ZeroCopyByteString.wrap(subspaceKey.pack()))
                 .setNlevels(nlevels);
     }
+
+    @Override
+    public String toString() {
+        return "TimeWindowLeaderboard{" +
+                "type=" + type +
+                ", startTimestamp=" + startTimestamp +
+                ", endTimestamp=" + endTimestamp +
+                ", subspaceKey=" + subspaceKey +
+                ", nlevels=" + nlevels +
+                '}';
+    }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowLeaderboardIndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowLeaderboardIndexMaintainer.java
@@ -756,7 +756,10 @@ public class TimeWindowLeaderboardIndexMaintainer extends StandardIndexMaintaine
                 Iterator<TimeWindowLeaderboard> iter = leaderboards.iterator();
                 while (iter.hasNext()) {
                     TimeWindowLeaderboard leaderboard = iter.next();
-                    if (update.getDeleteBefore() >= leaderboard.getEndTimestamp()) {
+                    // We don't want to delete the allTime leaderboard, even if the request sets `deleteBefore` to
+                    // Long.MAX_VALUE
+                    if (leaderboard.getType() != TimeWindowLeaderboard.ALL_TIME_LEADERBOARD_TYPE &&
+                            update.getDeleteBefore() >= leaderboard.getEndTimestamp()) {
                         state.transaction.clear(indexSubspace.pack(leaderboard.getSubspaceKey()));
                         state.transaction.clear(extraSubspace.pack(leaderboard.getSubspaceKey()));
                         iter.remove();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowLeaderboardWindowUpdate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowLeaderboardWindowUpdate.java
@@ -73,7 +73,8 @@ public class TimeWindowLeaderboardWindowUpdate extends IndexOperation {
      * Create a time window update operation.
      * @param updateTimestamp a timestamp to be recorded if any changes are made
      * @param highScoreFirst if <code>true</code>, numerically higher scores come first in the index
-     * @param deleteBefore delete any time windows ending at this time or before
+     * @param deleteBefore delete any time windows ending at this time or before;
+     * this will not delete the all-time leaderboard, if there is one
      * @param allTime include an all-time leaderboard
      * @param specs specifications for time windows to create
      * @param rebuild completely rebuild the index using the new time windows by scanning all existing records

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowLeaderboardWindowUpdate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowLeaderboardWindowUpdate.java
@@ -33,7 +33,32 @@ public class TimeWindowLeaderboardWindowUpdate extends IndexOperation {
      * When to completely rebuild an index.
      */
     public enum Rebuild {
-        ALWAYS, NEVER, IF_OVERLAPPING_CHANGED
+        /**
+         * Rebuild the index even if nothing has changed.
+         * <p>
+         *     Note: This rebuild happens in a single transaction, and thus, will fail if the store is sufficiently large.
+         * </p>
+         */
+        ALWAYS,
+        /**
+         * Do not rebuild the index no matter what.
+         */
+        NEVER,
+        /**
+         * Rebuild the index if it is necessary to have the leaderboards contain the records they're supposed to.
+         * <p>
+         *     This can happen in a few situations:
+         *     <ul>
+         *         <li>If {@link #isHighScoreFirst()} is changed</li>
+         *         <li>If {@link #isAllTime()} is changed</li>
+         *         <li>If a record has been saved that has a timestamp greater than the earliest timestamp for one of
+         *         the provided specs</li>
+         *     </ul>
+         * <p>
+         *     Note: This rebuild happens in a single transaction, and thus, will fail if the store is sufficiently large.
+         * </p>
+         */
+        IF_OVERLAPPING_CHANGED
     }
 
     private final long updateTimestamp;

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/LeaderboardIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/LeaderboardIndexTest.java
@@ -1161,7 +1161,6 @@ public class LeaderboardIndexTest {
         }
     }
 
-
     @Test
     void deleteBefore() {
         final Leaderboards leaderboards = new UngroupedNestedLeaderboards();
@@ -1230,7 +1229,7 @@ public class LeaderboardIndexTest {
             leaderboards.openRecordStore(context, false);
             final TimeWindowLeaderboardDirectory directory = leaderboards.getDirectory();
             Assertions.assertThat(directory.getLeaderboards().get(TEN_UNITS))
-                    .hasSize(7)// 3 kept, 3 new
+                    .hasSize(7)// 4 kept, 3 new
                     .allSatisfy(leaderboard -> {
                         Assertions.assertThat(leaderboard.getEndTimestamp()).isGreaterThan(deleteBefore);
                     });

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/LeaderboardIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/LeaderboardIndexTest.java
@@ -1069,6 +1069,8 @@ public class LeaderboardIndexTest {
 
     @Test
     public void rebuildOverlapping() {
+        // Warning: rebuilding tries to rebuild the entire index transactionally, so if this is done on a reasonably
+        // sized record store it will always fail
         updateOverlapping(true);
     }        
 


### PR DESCRIPTION
Resolves: #3240

I am opting not to add a control to drop the allTime leaderboard at this time, and instead just change the `deleteBefore` behavior.