### PR TITLE
Add --warning-mode all to all our builds

### DIFF
--- a/actions/run-gradle/action.yml
+++ b/actions/run-gradle/action.yml
@@ -13,4 +13,4 @@ runs:
       run: sed -i -e "s/^org\.gradle\..*/#&/g" gradle.properties
     - name: Run Command
       shell: bash
-      run: GRADLE_OPTS="-XX:+HeapDumpOnOutOfMemoryError -Xverify:none -XX:+TieredCompilation -Xmx4096m -Dfile.encoding=UTF-8 -Duser.country -Duser.language=en -Duser.variant --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.prefs/java.util.prefs=ALL-UNNAMED" ./gradlew --no-daemon --console=plain ${{ inputs.gradle_command }}
+      run: GRADLE_OPTS="-XX:+HeapDumpOnOutOfMemoryError -Xverify:none -XX:+TieredCompilation -Xmx4096m -Dfile.encoding=UTF-8 -Duser.country -Duser.language=en -Duser.variant --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.prefs/java.util.prefs=ALL-UNNAMED" ./gradlew --no-daemon --console=plain  --warning-mode all ${{ inputs.gradle_command }}


### PR DESCRIPTION
I have done this for prb, and fixed the issues it found, now we need to expand it to other jobs, namely nightly and release.

This is part of the work to upgrade to gradle 8: #3242