### PR TITLE
Queries using versions now use a serialization that requires 4.1

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/VersionValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/VersionValue.java
@@ -149,23 +149,9 @@ public class VersionValue extends AbstractValue {
     @Nonnull
     @Override
     public PVersionValue toProto(@Nonnull final PlanSerializationContext serializationContext) {
-        if (childValue instanceof QuantifiedRecordValue) {
-            // Deprecated. This value previously required that the child be a QuantifiedRecordValue and only
-            // contained the alias. To preserve cross-version compatibility with versions older than 4.0.561.0,
-            // send messages without the full value.
-            // Note: it's tempting to also include the full value in the `child` field, but doing so can
-            // lead to mixed-mode errors. If there are types or plans referenced in the child, those can
-            // be registered with the serializationContext, which means they may only be included
-            // by reference elsewhere in the serialized plan. Older versions of the deserialization
-            // logic don't know about the field, and so they will trip over any dangling references
-            return PVersionValue.newBuilder()
-                    .setBaseAlias(getChildQuantifiedRecordValue().getAlias().getId())
-                    .build();
-        } else {
-            return PVersionValue.newBuilder()
-                    .setChild(childValue.toValueProto(serializationContext))
-                    .build();
-        }
+        return PVersionValue.newBuilder()
+                .setChild(childValue.toValueProto(serializationContext))
+                .build();
     }
 
     @Nonnull

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@
 #
 
 rootProject.name=fdb-record-layer
-version=4.1.9.0
+version=4.2.0.0
 releaseBuild=false
 
 # this should be false for release branches (i.e. if there is no -SNAPSHOT on the above version)


### PR DESCRIPTION
In #2943, a new serialization of the `VersionValue` was introduced, though we had to modify it in #3179 so to avoid deserialization problems when serializing and deserializing continuations across 4.0 and 4.1. With 4.2, we want to start using the new serialization path to serialize `VersionValue` children more completely.

The mixed mode testing in PRB validate this change is compatible with 4.1.9.0. I've also run the full mixed mode battery for the `versionsTest` tests, and the serialization is compatible between this change and all 4.1 versions, as well as all 4.0 versions after 4.0.562.0, which is in line with what we'd expect.

This resolves #3203.