### PR TITLE
Add missing explicit dependencies for gradle tasks

### DIFF
--- a/fdb-record-layer-jmh/fdb-record-layer-jmh.gradle
+++ b/fdb-record-layer-jmh/fdb-record-layer-jmh.gradle
@@ -34,6 +34,10 @@ dependencies {
     testCompileOnly(libs.bundles.test.compileOnly)
 }
 
+generateJmhProto {
+    dependsOn "extractIncludeProto"
+}
+
 jmh {
     environment = rootProject.ext.fdbEnvironment
 }

--- a/fdb-relational-cli/fdb-relational-cli.gradle
+++ b/fdb-relational-cli/fdb-relational-cli.gradle
@@ -84,6 +84,9 @@ jar {
     from {
         configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
     }
+
+    dependsOn ':fdb-extensions:jar'
+    dependsOn ':fdb-record-layer-core:jar'
     dependsOn ':fdb-relational-api:jar'
     dependsOn ':fdb-relational-core:jar'
     dependsOn ':fdb-relational-grpc:jar'


### PR DESCRIPTION
The JMH one is a little surprising to me, as that is just a plugin.

I basically just followed what gradle printed in the warnings. Also, I validated this locally running each task with a clean, e.g. ./gradlew clean :fdb-relational-cli:jar --warning-mode all on main, it fails because files don't exst, but on this branch they succeed.

This is part of the work to allow upgrading to gradle 8: https://github.com/FoundationDB/fdb-record-layer/issues/3242