### PR TITLE
Change some error messages to format with Locale.ROOT

### DIFF
--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/util/Assert.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/util/Assert.java
@@ -21,12 +21,12 @@
 package com.apple.foundationdb.relational.util;
 
 import com.apple.foundationdb.annotation.API;
-
 import com.apple.foundationdb.relational.api.exceptions.ErrorCode;
-import com.apple.foundationdb.relational.api.exceptions.UncheckedRelationalException;
 import com.apple.foundationdb.relational.api.exceptions.RelationalException;
+import com.apple.foundationdb.relational.api.exceptions.UncheckedRelationalException;
 
 import javax.annotation.Nonnull;
+import java.util.Locale;
 import java.util.function.Supplier;
 
 /**
@@ -58,13 +58,13 @@ public final class Assert {
 
     public static void that(boolean mustBeTrue, @Nonnull final ErrorCode errorCodeIfNotTrue, @Nonnull final String messageFormat, @Nonnull Object messageValue) throws RelationalException {
         if (!mustBeTrue) {
-            throw new RelationalException(String.format(messageFormat, messageValue), errorCodeIfNotTrue);
+            throw new RelationalException(String.format(Locale.ROOT, messageFormat, messageValue), errorCodeIfNotTrue);
         }
     }
 
     public static void that(boolean mustBeTrue, @Nonnull final ErrorCode errorCodeIfNotTrue, @Nonnull final String messageFormat, @Nonnull Object messageValue1, @Nonnull Object messageValue2) throws RelationalException {
         if (!mustBeTrue) {
-            throw new RelationalException(String.format(messageFormat, messageValue1, messageValue2), errorCodeIfNotTrue);
+            throw new RelationalException(String.format(Locale.ROOT, messageFormat, messageValue1, messageValue2), errorCodeIfNotTrue);
         }
     }
 
@@ -132,13 +132,13 @@ public final class Assert {
 
     public static void thatUnchecked(boolean mustBeTrue, @Nonnull final ErrorCode errorCodeIfNotTrue, @Nonnull final String messageTemplate, @Nonnull final Object messageValue) {
         if (!mustBeTrue) {
-            throw new RelationalException(String.format(messageTemplate, messageValue), errorCodeIfNotTrue).toUncheckedWrappedException();
+            throw new RelationalException(String.format(Locale.ROOT, messageTemplate, messageValue), errorCodeIfNotTrue).toUncheckedWrappedException();
         }
     }
 
     public static void thatUnchecked(boolean mustBeTrue, @Nonnull final ErrorCode errorCodeIfNotTrue, @Nonnull final String messageTemplate, @Nonnull final Object messageValue1, @Nonnull final Object messageValue2) {
         if (!mustBeTrue) {
-            throw new RelationalException(String.format(messageTemplate, messageValue1, messageValue2), errorCodeIfNotTrue).toUncheckedWrappedException();
+            throw new RelationalException(String.format(Locale.ROOT, messageTemplate, messageValue1, messageValue2), errorCodeIfNotTrue).toUncheckedWrappedException();
         }
     }
 
@@ -168,7 +168,7 @@ public final class Assert {
 
     public static <T> T notNullUnchecked(T object, @Nonnull final ErrorCode errorCodeIfNull, @Nonnull final String messageTemplate, @Nonnull final Object messageValue) {
         if (object == null) {
-            throw new RelationalException(String.format(messageTemplate, messageValue), errorCodeIfNull).toUncheckedWrappedException();
+            throw new RelationalException(String.format(Locale.ROOT, messageTemplate, messageValue), errorCodeIfNull).toUncheckedWrappedException();
         } else {
             return object;
         }

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/metadata/SchemaTemplateSerDeTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/metadata/SchemaTemplateSerDeTests.java
@@ -29,6 +29,8 @@ import com.apple.foundationdb.relational.api.exceptions.RelationalException;
 import com.apple.foundationdb.relational.api.exceptions.UncheckedRelationalException;
 import com.apple.foundationdb.relational.api.metadata.DataType;
 import com.google.protobuf.DescriptorProtos;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -260,7 +262,7 @@ public class SchemaTemplateSerDeTests {
             final var schemaTemplate = getTestRecordLayerSchemaTemplate(testcase);
             schemaTemplate.toRecordMetadata();
         });
-        Assertions.assertTrue(thrown.getMessage().contains(message));
+        MatcherAssert.assertThat(thrown.getMessage(), Matchers.containsString(message));
     }
 
     @Test


### PR DESCRIPTION
The Assert utility used for checking conditions and throwing exceptions was using the default locale, causing the message to change based on the default locale for the JVM.
This caused SchemaTemplateSerDeTests to fail in the nightly build.

This resolves: #3247