### PR TITLE
Remove Artifactory publishing logic from gradle build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,6 @@ plugins {
     alias(libs.plugins.versions)
     alias(libs.plugins.spotbugs)
     alias(libs.plugins.nexus)
-    alias(libs.plugins.artifactory)
     alias(libs.plugins.download)
 }
 

--- a/fdb-record-layer-core-shaded/fdb-record-layer-core-shaded.gradle
+++ b/fdb-record-layer-core-shaded/fdb-record-layer-core-shaded.gradle
@@ -119,9 +119,6 @@ publishing {
         }
 
     }
-    artifactoryPublish {
-        publications (publishing.publications.shadow)
-    }
 }
 
 if (Boolean.parseBoolean(centralPublish)) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -150,7 +150,6 @@ test-compileOnly = [ "autoService", "jsr305" ]
 
 [plugins]
 
-artifactory = { id = "com.jfrog.artifactory", version = "4.29.2" }
 download = { id = "de.undercouch.download", version = "5.6.0" }
 gitversion = { id = "com.palantir.git-version", version = "3.1.0" }
 jmh = { id = "me.champeau.jmh", version = "0.7.2" }

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -18,7 +18,6 @@
  * limitations under the License.
  */
 
-apply plugin: 'com.jfrog.artifactory'
 apply plugin: 'signing'
 
 // Add various details to the pom file to allow for publishing
@@ -74,17 +73,6 @@ if (ext.publishLibrary) {
             }
         }
     }
-    artifactoryPublish {
-        // As a safeguard, only actually publish to artifactory if -PpublishBuild=true is passed to gradle
-        // Note: skip is documented, but onlyIf seems to also be required to make this work for some reason
-        // See: https://gist.github.com/DALDEI/40925568cef57e16e8a7
-        def publishBuild = Boolean.parseBoolean(publishBuild)
-        skip = !publishBuild
-        onlyIf {
-            publishBuild
-        }
-        publications(publishing.publications.library)
-    }
     createDistribution.configure {
         afterEvaluate {
             dependsOn generatePomFileForLibraryPublication
@@ -124,28 +112,6 @@ publishing {
                         password = System.getenv("GITHUB_TOKEN")
                     }
                 }
-            }
-        }
-    }
-}
-
-if (System.getenv('ARTIFACTORY_USER') != null && System.getenv('ARTIFACTORY_KEY') != null) {
-    artifactory {
-        clientConfig.setIncludeEnvVars(true)
-        publish {
-            def artifactoryUrl = System.getenv('ARTIFACTORY_URL') ?: 'https://ossartifacts.jfrog.io/artifactory/'
-            contextUrl = artifactoryUrl
-            repository {
-                repoKey = System.getenv('ARTIFACTORY_REPO') ?: 'fdb-record-layer'
-                username = System.getenv('ARTIFACTORY_USER')
-                password = System.getenv('ARTIFACTORY_KEY')
-            }
-            defaults {
-                publications('mavenJava')
-                publishPom = publishBuild
-                publishArtifacts = publishBuild
-                publishBuildInfo = publishBuild
-                publishIvy = false
             }
         }
     }


### PR DESCRIPTION
We no longer need the artifactory publishing logic that we used to use for publishing in the gradle build as new releases are no longer being published there. This removes the now dead code from the build, which means we no longer need to include the artficatory plugin in our build-time dependencies, which is nice.

There are a few other build files that appear to be dead code that we can remove, but this is more targeted. I've validated that I can still publish to maven local with this change, and all of the logic seems to be pretty specific to actually running an artifactory build, so this shouldn't disrupt our other build procedures, but I guess one never knows.

This resolves #3249.