### PR TITLE
Prepare for upgrade to Protobuf 4 by removing deprecated or removed calls

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/MetaDataEvolutionValidator.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/MetaDataEvolutionValidator.java
@@ -251,10 +251,9 @@ public class MetaDataEvolutionValidator {
         }
     }
 
-    @SuppressWarnings("deprecation") // checks the deprecated syntax field
     private void validateProtoSyntax(@Nonnull Descriptors.Descriptor oldDescriptor, @Nonnull Descriptors.Descriptor newDescriptor) {
-        if (!oldDescriptor.getFile().getSyntax().equals(newDescriptor.getFile().getSyntax())
-                || !oldDescriptor.getFile().getEdition().equals(newDescriptor.getFile().getEdition())) {
+        if (!oldDescriptor.getFile().toProto().getSyntax().equals(newDescriptor.getFile().toProto().getSyntax())
+                || !oldDescriptor.getFile().toProto().getEdition().equals(newDescriptor.getFile().toProto().getEdition())) {
             throw new MetaDataException("message descriptor proto syntax changed",
                     LogMessageKeys.RECORD_TYPE, oldDescriptor.getName());
         }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/MetaDataEvolutionValidatorTestV3.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/MetaDataEvolutionValidatorTestV3.java
@@ -148,7 +148,7 @@ public class MetaDataEvolutionValidatorTestV3 {
     @SuppressWarnings("deprecation") // test focuses on checking the (deprecated) syntax field
     @Test
     public void onlyFileProto2ToProto3() throws InvalidProtocolBufferException {
-        assertNotEquals(TestRecords1Proto.getDescriptor().getSyntax(), TestRecords1ImportedProto.getDescriptor().getSyntax());
+        assertNotEquals(TestRecords1Proto.getDescriptor().toProto().getSyntax(), TestRecords1ImportedProto.getDescriptor().toProto().getSyntax());
         MetaDataEvolutionValidator.getDefaultInstance().validateUnion(
                 TestRecords1Proto.RecordTypeUnion.getDescriptor(),
                 TestRecords1ImportedProto.RecordTypeUnion.getDescriptor()

--- a/fdb-relational-server/src/test/java/com/apple/foundationdb/relational/server/RelationalServerTest.java
+++ b/fdb-relational-server/src/test/java/com/apple/foundationdb/relational/server/RelationalServerTest.java
@@ -110,7 +110,9 @@ public class RelationalServerTest {
         } catch (Throwable t) {
             com.google.rpc.Status status = StatusProto.fromThrowable(t);
             if (status != null) {
-                logger.fatal(t + ", " + TextFormat.shortDebugString(status));
+                // V3: printer().shortDebugString(status)
+                // V4: printer().emittingSingleLine(true).printToString(status)
+                logger.fatal(t + ", " + TextFormat.printer().printToString(status).replace("\n", " "));
             }
             throw t;
         } finally {

--- a/yaml-tests/yaml-tests.gradle
+++ b/yaml-tests/yaml-tests.gradle
@@ -63,6 +63,7 @@ dependencies {
     implementation(libs.junit.api)
     implementation(libs.junit.params)
     implementation(libs.log4j.api)
+    implementation(libs.guava)
     implementation(libs.protobuf)
     implementation(libs.protobuf.util)
     implementation(libs.snakeyaml)


### PR DESCRIPTION
Address some small incompatibilities between Protobuf 3 and Protobuf 4, attempting to have code that will compile against both.
* `Descriptors.FileDescriptor.getSyntax`, which was deprecated, is now removed. Use `DescriptorProtos.FileDescriptorProto.getSyntax`.
* `TextFormat.shortDebugString` is deprecated. Remove newlines manually for now (only in test failure codepath).
* guava is no longer a transitive dependency; add it explicitly where needed.