### PR TITLE
Add cleanup to list of potential labels for PRs

### DIFF
--- a/build/release-notes-config.json
+++ b/build/release-notes-config.json
@@ -10,12 +10,13 @@
     "labels": ["performance"]},
    {"title": "Dependency Updates",
     "labels": ["dependencies"]},
-   {"title": "Build/Test/Documentation Improvements",
+   {"title": "Build/Test/Documentation/Style Improvements",
     "collapsed": true,
     "labels": [
       "build improvement",
       "documentation",
-      "testing improvement"]}
+      "testing improvement",
+      "cleanup"]}
  ],
  "catch_all": "Other Changes"
 }


### PR DESCRIPTION
I created a PR to cleanup some whitespace, and there was no good label for it. I saw that we already had a https://github.com/FoundationDB/fdb-record-layer/labels/cleanup label, so adding that to the Build/Test/Documentation group in the release notes seems like a good idea to me.

The description for https://github.com/FoundationDB/fdb-record-layer/labels/cleanup is `Stylistic code cleanup`, but I'm not sure if we should have a more descriptive label, to avoid other types of cleanup, such as deleting unused, private code. 