### PR TITLE
Remove a bunch of references to @ExcludeFromJacocoGeneratedReport

### DIFF
--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/RelationalDatabaseMetaData.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/RelationalDatabaseMetaData.java
@@ -243,13 +243,11 @@ public interface RelationalDatabaseMetaData extends java.sql.DatabaseMetaData {
     }
 
     @Override
-    @ExcludeFromJacocoGeneratedReport
     default String getDatabaseProductName() throws SQLException {
         return DATABASE_PRODUCT_NAME;
     }
 
     @Override
-    @ExcludeFromJacocoGeneratedReport
     default String getDatabaseProductVersion() throws SQLException {
         return BuildVersion.getInstance().getVersion();
     }
@@ -261,13 +259,11 @@ public interface RelationalDatabaseMetaData extends java.sql.DatabaseMetaData {
     }
 
     @Override
-    @ExcludeFromJacocoGeneratedReport
     default String getDriverVersion() throws SQLException {
         return BuildVersion.getInstance().getVersion();
     }
 
     @Override
-    @ExcludeFromJacocoGeneratedReport //nothing to test
     default int getDriverMajorVersion() {
         try {
             return BuildVersion.getInstance().getMajorVersion();
@@ -277,7 +273,6 @@ public interface RelationalDatabaseMetaData extends java.sql.DatabaseMetaData {
     }
 
     @Override
-    @ExcludeFromJacocoGeneratedReport //nothing to test
     default int getDriverMinorVersion() {
         try {
             return BuildVersion.getInstance().getMinorVersion();
@@ -347,13 +342,11 @@ public interface RelationalDatabaseMetaData extends java.sql.DatabaseMetaData {
     }
 
     @Override
-    @ExcludeFromJacocoGeneratedReport
     default String getIdentifierQuoteString() throws SQLException {
         return "\"";
     }
 
     @Override
-    @ExcludeFromJacocoGeneratedReport
     default String getSQLKeywords() throws SQLException {
         return "";
     }
@@ -515,13 +508,11 @@ public interface RelationalDatabaseMetaData extends java.sql.DatabaseMetaData {
     }
 
     @Override
-    @ExcludeFromJacocoGeneratedReport
     default boolean supportsANSI92EntryLevelSQL() throws SQLException {
         return true;
     }
 
     @Override
-    @ExcludeFromJacocoGeneratedReport
     default boolean supportsANSI92IntermediateSQL() throws SQLException {
         return false;
     }

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/RelationalDriver.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/RelationalDriver.java
@@ -22,7 +22,6 @@ package com.apple.foundationdb.relational.api;
 
 import com.apple.foundationdb.relational.api.exceptions.RelationalException;
 import com.apple.foundationdb.relational.util.BuildVersion;
-import com.apple.foundationdb.relational.util.ExcludeFromJacocoGeneratedReport;
 
 import javax.annotation.Nonnull;
 import java.net.URI;
@@ -36,7 +35,6 @@ import java.util.logging.Logger;
 /**
  * A Driver which is used to connect to a Relational Database.
  */
-@ExcludeFromJacocoGeneratedReport
 public interface RelationalDriver extends Driver {
 
     default RelationalConnection connect(@Nonnull URI url) throws SQLException {

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/RelationalPreparedStatement.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/RelationalPreparedStatement.java
@@ -498,7 +498,6 @@ public interface RelationalPreparedStatement extends java.sql.PreparedStatement 
     }
 
     @Override
-    @ExcludeFromJacocoGeneratedReport
     default SQLWarning getWarnings() throws SQLException {
         // For now, return null until warnings are implemented.
         // Throwing an exception stops all processing. See TODO (Implement JDBC Warnings in Relational embedded Driver)

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/RelationalResultSet.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/RelationalResultSet.java
@@ -359,13 +359,11 @@ public interface RelationalResultSet extends java.sql.ResultSet, RelationalStruc
         throw new SQLFeatureNotSupportedException("Not implemented in the relational layer", ErrorCode.UNSUPPORTED_OPERATION.getErrorCode());
     }
 
-    @ExcludeFromJacocoGeneratedReport
     @Override
     default <T> T unwrap(Class<T> iface) throws SQLException {
         return iface.cast(this);
     }
 
-    @ExcludeFromJacocoGeneratedReport
     @Override
     default boolean isWrapperFor(Class<?> iface) throws SQLException {
         return iface.isInstance(this);

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/RelationalResultSetMetaData.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/RelationalResultSetMetaData.java
@@ -101,7 +101,6 @@ public interface RelationalResultSetMetaData extends ResultSetMetaData, StructMe
     }
 
     @Override
-    @ExcludeFromJacocoGeneratedReport
     default String getTableName(int column) throws SQLException {
         // Throwing an exception here messes up sqlline drawing results. Just do what Oracle apparently does here
         // and return an empty String for now until we implement ResultSet context attributes like table name.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/RelationalStatement.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/RelationalStatement.java
@@ -123,7 +123,6 @@ public interface RelationalStatement extends java.sql.Statement, RelationalDirec
     }
 
     @Override
-    @ExcludeFromJacocoGeneratedReport
     default SQLWarning getWarnings() throws SQLException {
         // Return null warnings for now until implemented.
         // Throwing an exception stops all processing.

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/SqlTypeNamesSupport.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/SqlTypeNamesSupport.java
@@ -22,8 +22,6 @@ package com.apple.foundationdb.relational.api;
 
 import com.apple.foundationdb.annotation.API;
 
-import com.apple.foundationdb.relational.util.ExcludeFromJacocoGeneratedReport;
-
 import java.sql.Array;
 import java.sql.Struct;
 import java.sql.Types;
@@ -36,7 +34,6 @@ import java.sql.Types;
  * recordlayer.
  */
 // Used by fdb-relational-jdbc module in JDBCRelationalArray.
-@ExcludeFromJacocoGeneratedReport
 @API(API.Status.EXPERIMENTAL)
 public final class SqlTypeNamesSupport {
     private SqlTypeNamesSupport() {

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/util/Assert.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/util/Assert.java
@@ -32,7 +32,6 @@ import java.util.function.Supplier;
 /**
  * A set of helper methods for validating input, pre-conditions, ... etc.
  */
-@ExcludeFromJacocoGeneratedReport //just assertions, hard to test in a useful way
 @API(API.Status.EXPERIMENTAL)
 public final class Assert {
 

--- a/fdb-relational-cli/src/main/java/com/apple/foundationdb/relational/cli/sqlline/Customize.java
+++ b/fdb-relational-cli/src/main/java/com/apple/foundationdb/relational/cli/sqlline/Customize.java
@@ -21,9 +21,6 @@
 package com.apple.foundationdb.relational.cli.sqlline;
 
 import com.apple.foundationdb.annotation.API;
-
-import com.apple.foundationdb.relational.util.ExcludeFromJacocoGeneratedReport;
-
 import sqlline.BuiltInProperty;
 import sqlline.CommandHandler;
 import sqlline.OutputFormat;
@@ -45,6 +42,7 @@ import java.util.Map;
  * on how this works. The main thing we add is output of Relational STRUCT and ARRAY missing from basic sqlline.
  */
 @API(API.Status.EXPERIMENTAL)
+@SuppressWarnings("unused") // retrieved by sqlline via reflection
 public class Customize extends sqlline.Application {
     // Overriding {@link #getDefaultInteractiveMode()}, and {@link #getConnectInteractiveModes()} doesn't work -- bug
     // because sqlline does this <code>new HashSet<>(new Application().getConnectInteractiveModes()))</code> -- so we have
@@ -57,7 +55,6 @@ public class Customize extends sqlline.Application {
      * @return Our options instance.
      */
     @Override
-    @ExcludeFromJacocoGeneratedReport // Hard to make a test that makes sense given this an sqlline internal.
     public SqlLineOpts getOpts(SqlLine sqlLine) {
         // Set do-not-ask-for-login credentials -- login not supported on Relational, not yet.
         sqlLine.getOpts().set(BuiltInProperty.CONNECT_INTERACTION_MODE, "notAskCredentials");
@@ -65,14 +62,12 @@ public class Customize extends sqlline.Application {
     }
 
     @Override
-    @ExcludeFromJacocoGeneratedReport // Hard to make a test that makes sense given this an sqlline internal.
     public String getInfoMessage() {
         // Prepend 'Relational' to hint Relational context.
         return "Relational " + getVersion();
     }
 
     @Override
-    @ExcludeFromJacocoGeneratedReport // Hard to make a test that makes sense given this an sqlline internal.
     public Map<String, OutputFormat> getOutputFormats(SqlLine sqlLine) {
         //        final Map<String, OutputFormat> outputFormats = new HashMap<>();
         //        outputFormats.put("vertical", new VerticalOutputFormat(sqlLine));
@@ -97,7 +92,6 @@ public class Customize extends sqlline.Application {
     }
 
     @Override
-    @ExcludeFromJacocoGeneratedReport // Hard to make a test that makes sense given this an sqlline internal.
     public Collection<CommandHandler> getCommandHandlers(SqlLine sqlLine) {
         // Make a copy of super handlers list to get around the super making the list unmodifiable.
         List<CommandHandler> handlers = new ArrayList<>(super.getCommandHandlers(sqlLine));

--- a/fdb-relational-cli/src/main/java/sqlline/SetSchema.java
+++ b/fdb-relational-cli/src/main/java/sqlline/SetSchema.java
@@ -21,8 +21,6 @@
 package sqlline;
 
 import com.apple.foundationdb.annotation.API;
-
-import com.apple.foundationdb.relational.util.ExcludeFromJacocoGeneratedReport;
 import org.jline.reader.Completer;
 
 import java.sql.SQLException;
@@ -36,7 +34,6 @@ import java.util.Collections;
 @SuppressWarnings("PMD.GuardLogStatement")
 @API(API.Status.EXPERIMENTAL)
 public class SetSchema extends AbstractCommandHandler {
-    @ExcludeFromJacocoGeneratedReport // Hard to make a test that makes sense given this an sqlline internal.
     public SetSchema(SqlLine sqlLine) {
         super(sqlLine, new String[]{"setschema", "ss"}, "Set Relational Schema: e.g. !ss <SCHEMA_NAME>.",
                 Collections.<Completer>emptyList());

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/ProtobufDataBuilder.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/ProtobufDataBuilder.java
@@ -21,14 +21,11 @@
 package com.apple.foundationdb.relational.api;
 
 import com.apple.foundationdb.annotation.API;
-
 import com.apple.foundationdb.relational.api.ddl.ProtobufDdlUtil;
 import com.apple.foundationdb.relational.api.exceptions.ErrorCode;
 import com.apple.foundationdb.relational.api.exceptions.InvalidTypeException;
 import com.apple.foundationdb.relational.api.exceptions.RelationalException;
-import com.apple.foundationdb.relational.util.ExcludeFromJacocoGeneratedReport;
 import com.apple.foundationdb.relational.util.NullableArrayUtils;
-
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.DynamicMessage;
 import com.google.protobuf.Message;
@@ -67,7 +64,6 @@ public class ProtobufDataBuilder implements DynamicMessageBuilder {
         return ProtobufDdlUtil.getTypeName(field);
     }
 
-    @ExcludeFromJacocoGeneratedReport // currently, used only for YAML testing
     @Override
     public boolean isPrimitive(int fieldNumber) throws SQLException {
         final var field = typeDescriptor.getFields().get(fieldNumber - 1);
@@ -90,7 +86,6 @@ public class ProtobufDataBuilder implements DynamicMessageBuilder {
         }
     }
 
-    @ExcludeFromJacocoGeneratedReport // currently, used only for YAML testing
     @Override
     public DynamicMessageBuilder setField(int fieldNumber, Object value) throws SQLException {
         try {
@@ -125,7 +120,6 @@ public class ProtobufDataBuilder implements DynamicMessageBuilder {
         }
     }
 
-    @ExcludeFromJacocoGeneratedReport // currently, used only for YAML testing
     @Override
     public DynamicMessageBuilder addRepeatedField(int fieldNumber, Object value) throws SQLException {
         try {
@@ -176,7 +170,6 @@ public class ProtobufDataBuilder implements DynamicMessageBuilder {
         return addRepeatedFields(fieldName, values, true);
     }
 
-    @ExcludeFromJacocoGeneratedReport // currently, used only for YAML testing
     @Override
     public DynamicMessageBuilder addRepeatedFields(int fieldNumber, Iterable<? extends Object> values) throws SQLException {
         for (Object value : values) {
@@ -217,7 +210,6 @@ public class ProtobufDataBuilder implements DynamicMessageBuilder {
         }
     }
 
-    @ExcludeFromJacocoGeneratedReport // currently, used only for YAML testing
     @Override
     public DynamicMessageBuilder getNestedMessageBuilder(int fieldNumber) throws SQLException {
         try {

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/metrics/NoOpMetricRegistry.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/metrics/NoOpMetricRegistry.java
@@ -21,9 +21,6 @@
 package com.apple.foundationdb.relational.api.metrics;
 
 import com.apple.foundationdb.annotation.API;
-
-import com.apple.foundationdb.relational.util.ExcludeFromJacocoGeneratedReport;
-
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.NoopMetricRegistry;
 
@@ -36,7 +33,6 @@ import javax.annotation.Nonnull;
  * on an prometheus endpoint, codahale will require translation (there are translators but better not
  * to translate at all). What is the story for clients? RL is codahale?
  */
-@ExcludeFromJacocoGeneratedReport //it doesn't do anything to be tested
 @API(API.Status.EXPERIMENTAL)
 public final class NoOpMetricRegistry {
 

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/EmbeddedRelationalConnection.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/EmbeddedRelationalConnection.java
@@ -21,7 +21,6 @@
 package com.apple.foundationdb.relational.recordlayer;
 
 import com.apple.foundationdb.annotation.API;
-
 import com.apple.foundationdb.record.ExecuteProperties;
 import com.apple.foundationdb.record.IsolationLevel;
 import com.apple.foundationdb.record.RecordCoreException;
@@ -30,11 +29,6 @@ import com.apple.foundationdb.relational.api.EmbeddedRelationalDriver;
 import com.apple.foundationdb.relational.api.FieldDescription;
 import com.apple.foundationdb.relational.api.ImmutableRowStruct;
 import com.apple.foundationdb.relational.api.Options;
-import com.apple.foundationdb.relational.api.RowArray;
-import com.apple.foundationdb.relational.api.SqlTypeNamesSupport;
-import com.apple.foundationdb.relational.api.SqlTypeSupport;
-import com.apple.foundationdb.relational.api.Transaction;
-import com.apple.foundationdb.relational.api.TransactionManager;
 import com.apple.foundationdb.relational.api.RelationalArray;
 import com.apple.foundationdb.relational.api.RelationalArrayMetaData;
 import com.apple.foundationdb.relational.api.RelationalConnection;
@@ -43,6 +37,11 @@ import com.apple.foundationdb.relational.api.RelationalPreparedStatement;
 import com.apple.foundationdb.relational.api.RelationalStatement;
 import com.apple.foundationdb.relational.api.RelationalStruct;
 import com.apple.foundationdb.relational.api.RelationalStructMetaData;
+import com.apple.foundationdb.relational.api.RowArray;
+import com.apple.foundationdb.relational.api.SqlTypeNamesSupport;
+import com.apple.foundationdb.relational.api.SqlTypeSupport;
+import com.apple.foundationdb.relational.api.Transaction;
+import com.apple.foundationdb.relational.api.TransactionManager;
 import com.apple.foundationdb.relational.api.catalog.StoreCatalog;
 import com.apple.foundationdb.relational.api.exceptions.ErrorCode;
 import com.apple.foundationdb.relational.api.exceptions.InternalErrorException;
@@ -56,10 +55,8 @@ import com.apple.foundationdb.relational.recordlayer.structuredsql.expression.Ex
 import com.apple.foundationdb.relational.recordlayer.structuredsql.statement.StatementBuilderFactoryImpl;
 import com.apple.foundationdb.relational.recordlayer.util.ExceptionUtil;
 import com.apple.foundationdb.relational.util.Assert;
-import com.apple.foundationdb.relational.util.ExcludeFromJacocoGeneratedReport;
 import com.apple.foundationdb.relational.util.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.relational.util.Supplier;
-
 import com.google.common.annotations.VisibleForTesting;
 
 import javax.annotation.Nonnull;
@@ -150,7 +147,6 @@ public class EmbeddedRelationalConnection implements RelationalConnection {
         return new EmbeddedRelationalPreparedStatement(sql, this);
     }
 
-    @ExcludeFromJacocoGeneratedReport
     @Override
     public void setReadOnly(boolean readOnly) throws SQLException {
         // Do nothing. Swallow rather than return useless complaint about not being implemented
@@ -365,7 +361,6 @@ public class EmbeddedRelationalConnection implements RelationalConnection {
         return transactionIsolation;
     }
 
-    @ExcludeFromJacocoGeneratedReport
     @Override
     public SQLWarning getWarnings() throws SQLException {
         // Return null for now until we implement Warnings. Returning an exception breaks processing.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ErrorCapturingResultSet.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ErrorCapturingResultSet.java
@@ -21,19 +21,16 @@
 package com.apple.foundationdb.relational.recordlayer;
 
 import com.apple.foundationdb.annotation.API;
-
 import com.apple.foundationdb.relational.api.Continuation;
 import com.apple.foundationdb.relational.api.RelationalArray;
 import com.apple.foundationdb.relational.api.RelationalResultSet;
 import com.apple.foundationdb.relational.api.RelationalResultSetMetaData;
 import com.apple.foundationdb.relational.api.RelationalStruct;
 import com.apple.foundationdb.relational.recordlayer.util.ExceptionUtil;
-import com.apple.foundationdb.relational.util.ExcludeFromJacocoGeneratedReport;
 
 import javax.annotation.Nonnull;
 import java.sql.SQLException;
 
-@ExcludeFromJacocoGeneratedReport //there's nothing to test, just exception translation
 @API(API.Status.EXPERIMENTAL)
 public class ErrorCapturingResultSet implements RelationalResultSet {
     private final RelationalResultSet delegate;

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/catalog/systables/SystemTableRegistry.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/catalog/systables/SystemTableRegistry.java
@@ -22,8 +22,6 @@ package com.apple.foundationdb.relational.recordlayer.catalog.systables;
 
 import com.apple.foundationdb.annotation.API;
 
-import com.apple.foundationdb.relational.util.ExcludeFromJacocoGeneratedReport;
-
 import javax.annotation.Nonnull;
 import java.util.Map;
 
@@ -32,7 +30,6 @@ import java.util.Map;
  * is to provide a placeholder of these tables that could be consulted e.g. during database
  * bootstrapping.
  */
-@ExcludeFromJacocoGeneratedReport //We don't need to test map accesses
 @API(API.Status.EXPERIMENTAL)
 public final class SystemTableRegistry {
 

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ddl/RecordLayerMetadataOperationsFactory.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ddl/RecordLayerMetadataOperationsFactory.java
@@ -21,7 +21,6 @@
 package com.apple.foundationdb.relational.recordlayer.ddl;
 
 import com.apple.foundationdb.annotation.API;
-
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpace;
 import com.apple.foundationdb.relational.api.Options;
 import com.apple.foundationdb.relational.api.catalog.StoreCatalog;
@@ -30,7 +29,6 @@ import com.apple.foundationdb.relational.api.ddl.CreateSchemaTemplateConstantAct
 import com.apple.foundationdb.relational.api.ddl.MetadataOperationsFactory;
 import com.apple.foundationdb.relational.api.metadata.SchemaTemplate;
 import com.apple.foundationdb.relational.recordlayer.RecordLayerConfig;
-import com.apple.foundationdb.relational.util.ExcludeFromJacocoGeneratedReport;
 
 import javax.annotation.Nonnull;
 import java.net.URI;
@@ -85,7 +83,6 @@ public class RecordLayerMetadataOperationsFactory implements MetadataOperationsF
         return new DropSchemaConstantAction(dbPath, schema, baseKeySpace, catalog);
     }
 
-    @ExcludeFromJacocoGeneratedReport
     @Nonnull
     public ConstantAction getSetStoreStateConstantAction(@Nonnull URI dbUri, @Nonnull String schemaName) {
         return new RecordLayerSetStoreStateConstantAction(dbUri, schemaName, rlConfig, baseKeySpace, catalog);

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ddl/RecordLayerSetStoreStateConstantAction.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ddl/RecordLayerSetStoreStateConstantAction.java
@@ -21,7 +21,6 @@
 package com.apple.foundationdb.relational.recordlayer.ddl;
 
 import com.apple.foundationdb.annotation.API;
-
 import com.apple.foundationdb.record.IndexState;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
@@ -38,12 +37,10 @@ import com.apple.foundationdb.relational.recordlayer.RecordLayerConfig;
 import com.apple.foundationdb.relational.recordlayer.RelationalKeyspaceProvider;
 import com.apple.foundationdb.relational.recordlayer.catalog.CatalogMetaDataProvider;
 import com.apple.foundationdb.relational.recordlayer.util.ExceptionUtil;
-import com.apple.foundationdb.relational.util.ExcludeFromJacocoGeneratedReport;
 
 import java.net.URI;
 import java.util.Map;
 
-@ExcludeFromJacocoGeneratedReport
 @API(API.Status.EXPERIMENTAL)
 public class RecordLayerSetStoreStateConstantAction implements ConstantAction {
     private final StoreCatalog catalog;

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/cache/MultiStageCache.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/cache/MultiStageCache.java
@@ -21,13 +21,10 @@
 package com.apple.foundationdb.relational.recordlayer.query.cache;
 
 import com.apple.foundationdb.annotation.API;
-
 import com.apple.foundationdb.record.util.pair.NonnullPair;
 import com.apple.foundationdb.relational.api.exceptions.ErrorCode;
 import com.apple.foundationdb.relational.api.metrics.RelationalMetric;
 import com.apple.foundationdb.relational.util.Assert;
-import com.apple.foundationdb.relational.util.ExcludeFromJacocoGeneratedReport;
-
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.RemovalListener;
@@ -462,7 +459,6 @@ public class MultiStageCache<K, S, T, V> extends AbstractCache<K, S, T, V> {
         };
     }
 
-    @ExcludeFromJacocoGeneratedReport
     public abstract static class Builder<K, S, T, V, B extends Builder<K, S, T, V, B>> {
 
         private static final int DEFAULT_SIZE = 256;
@@ -628,7 +624,6 @@ public class MultiStageCache<K, S, T, V> extends AbstractCache<K, S, T, V> {
         }
     }
 
-    @ExcludeFromJacocoGeneratedReport
     public static class MultiStageCacheBuilder<K, S, T, V> extends Builder<K, S, T, V, MultiStageCacheBuilder<K, S, T, V>> {
         @Nonnull
         @Override

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/cache/RelationalPlanCache.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/cache/RelationalPlanCache.java
@@ -21,11 +21,8 @@
 package com.apple.foundationdb.relational.recordlayer.query.cache;
 
 import com.apple.foundationdb.annotation.API;
-
 import com.apple.foundationdb.relational.api.Options;
 import com.apple.foundationdb.relational.recordlayer.query.Plan;
-import com.apple.foundationdb.relational.util.ExcludeFromJacocoGeneratedReport;
-
 import com.google.common.base.Ticker;
 
 import javax.annotation.Nonnull;
@@ -36,7 +33,6 @@ import java.util.concurrent.TimeUnit;
 /**
  * This is just a specialization of {@link MultiStageCache} with concrete types specific to plan caching.
  */
-@ExcludeFromJacocoGeneratedReport
 @API(API.Status.EXPERIMENTAL)
 public final class RelationalPlanCache extends MultiStageCache<String, QueryCacheKey, PhysicalPlanEquivalence, Plan<?>> {
 
@@ -65,7 +61,6 @@ public final class RelationalPlanCache extends MultiStageCache<String, QueryCach
         super(size, secondarySize, tertiarySize, ttl, ttlTimeUnit, secondaryTtl, secondaryTtlTimeUnit, tertiaryTtl, tertiaryTtlTimeUnit, executor, secondaryExecutor, tertiaryExecutor, ticker);
     }
 
-    @ExcludeFromJacocoGeneratedReport // this is just a mechanical builder.
     public static final class RelationalCacheBuilder extends MultiStageCache.Builder<String, QueryCacheKey, PhysicalPlanEquivalence, Plan<?>, RelationalCacheBuilder> {
 
         public RelationalCacheBuilder() {

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/memory/InMemorySchemaTemplateCatalog.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/memory/InMemorySchemaTemplateCatalog.java
@@ -21,17 +21,16 @@
 package com.apple.foundationdb.relational.memory;
 
 import com.apple.foundationdb.relational.api.FieldDescription;
-import com.apple.foundationdb.relational.api.Row;
-import com.apple.foundationdb.relational.api.Transaction;
 import com.apple.foundationdb.relational.api.RelationalResultSet;
 import com.apple.foundationdb.relational.api.RelationalStructMetaData;
+import com.apple.foundationdb.relational.api.Row;
+import com.apple.foundationdb.relational.api.Transaction;
 import com.apple.foundationdb.relational.api.catalog.SchemaTemplateCatalog;
 import com.apple.foundationdb.relational.api.exceptions.ErrorCode;
 import com.apple.foundationdb.relational.api.exceptions.RelationalException;
 import com.apple.foundationdb.relational.api.metadata.SchemaTemplate;
 import com.apple.foundationdb.relational.recordlayer.IteratorResultSet;
 import com.apple.foundationdb.relational.recordlayer.ValueTuple;
-import com.apple.foundationdb.relational.util.ExcludeFromJacocoGeneratedReport;
 
 import javax.annotation.Nonnull;
 import java.sql.DatabaseMetaData;
@@ -109,7 +108,6 @@ class InMemorySchemaTemplateCatalog implements SchemaTemplateCatalog {
     }
 
     @Override
-    @ExcludeFromJacocoGeneratedReport
     public void createTemplate(@Nonnull Transaction txn, @Nonnull SchemaTemplate newTemplate) throws RelationalException {
         var versions = backingStore.get(newTemplate.getName());
         if (versions == null) {

--- a/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/RelationalResultSetFacade.java
+++ b/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/RelationalResultSetFacade.java
@@ -265,7 +265,6 @@ class RelationalResultSetFacade implements RelationalResultSet {
     }
 
     @Override
-    @ExcludeFromJacocoGeneratedReport
     @Nonnull
     @SpotBugsSuppressWarnings("NP") // TODO: Will need to fix null handling
     public Continuation getContinuation() throws SQLException {
@@ -283,7 +282,6 @@ class RelationalResultSetFacade implements RelationalResultSet {
     }
 
     @Override
-    @ExcludeFromJacocoGeneratedReport
     public RelationalStruct getStruct(int oneBasedColumn) throws SQLException {
         RelationalStruct s = TypeConversion.getStruct(this.delegate, this.rowIndex, oneBasedColumn);
         wasNull = s == null;
@@ -336,13 +334,11 @@ class RelationalResultSetFacade implements RelationalResultSet {
     }
 
     @Override
-    @ExcludeFromJacocoGeneratedReport
     public Object getObject(String columnLabel) throws SQLException {
         return getObject(RelationalStruct.getOneBasedPosition(columnLabel, this));
     }
 
     @Override
-    @ExcludeFromJacocoGeneratedReport
     public RelationalArray getArray(int oneBasedColumn) throws SQLException {
         int index = PositionalIndex.toProtobuf(oneBasedColumn);
         ColumnMetadata columnMetadata = this.delegate.getMetadata().getColumnMetadata().getColumnMetadata(index);

--- a/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/RelationalResultSetMetaDataFacade.java
+++ b/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/RelationalResultSetMetaDataFacade.java
@@ -48,7 +48,6 @@ class RelationalResultSetMetaDataFacade implements RelationalResultSetMetaData  
     }
 
     @Override
-    @ExcludeFromJacocoGeneratedReport
     public StructMetaData getStructMetaData(int oneBasedColumn) throws SQLException {
         return new RelationalStructFacade.RelationalStructFacadeMetaData(
                 this.delegate.getColumnMetadata().getColumnMetadata(PositionalIndex.toProtobuf(oneBasedColumn)).getStructMetadata());

--- a/fdb-relational-jdbc/src/main/java/com/apple/foundationdb/relational/jdbc/JDBCRelationalConnection.java
+++ b/fdb-relational-jdbc/src/main/java/com/apple/foundationdb/relational/jdbc/JDBCRelationalConnection.java
@@ -188,7 +188,6 @@ class JDBCRelationalConnection implements RelationalConnection {
     }
 
     @Override
-    @ExcludeFromJacocoGeneratedReport
     public void setAutoCommit(boolean autoCommit) throws SQLException {
         if (!autoCommit) {
             throw new SQLException("Not implemented " + Thread.currentThread() .getStackTrace()[1] .getMethodName());
@@ -290,7 +289,6 @@ class JDBCRelationalConnection implements RelationalConnection {
     }
 
     @Override
-    @ExcludeFromJacocoGeneratedReport
     public URI getPath() {
         return null;
     }

--- a/fdb-relational-jdbc/src/main/java/com/apple/foundationdb/relational/jdbc/JDBCRelationalStatement.java
+++ b/fdb-relational-jdbc/src/main/java/com/apple/foundationdb/relational/jdbc/JDBCRelationalStatement.java
@@ -38,9 +38,7 @@ import com.apple.foundationdb.relational.jdbc.grpc.v1.ScanRequest;
 import com.apple.foundationdb.relational.jdbc.grpc.v1.ScanResponse;
 import com.apple.foundationdb.relational.jdbc.grpc.v1.StatementRequest;
 import com.apple.foundationdb.relational.jdbc.grpc.v1.StatementResponse;
-import com.apple.foundationdb.relational.util.ExcludeFromJacocoGeneratedReport;
 import com.apple.foundationdb.relational.util.SpotBugsSuppressWarnings;
-
 import io.grpc.StatusRuntimeException;
 
 import javax.annotation.Nonnull;
@@ -269,7 +267,6 @@ class JDBCRelationalStatement implements RelationalStatement {
     @Nonnull
     @Override
     @SpotBugsSuppressWarnings(value = "NP_NONNULL_RETURN_VIOLATION", justification = "Temporary until implemented.")
-    @ExcludeFromJacocoGeneratedReport
     public RelationalResultSet executeGet(@Nonnull String tableName, @Nonnull KeySet keySet, @Nonnull Options options) throws SQLException {
         checkOpen();
         GetResponse getResponse;
@@ -295,7 +292,6 @@ class JDBCRelationalStatement implements RelationalStatement {
     @Nonnull
     @Override
     @SpotBugsSuppressWarnings(value = "NP_NONNULL_RETURN_VIOLATION", justification = "Temporary until implemented.")
-    @ExcludeFromJacocoGeneratedReport
     public RelationalResultSet executeScan(@Nonnull String tableName, @Nonnull KeySet keySet, @Nonnull Options options)
             throws SQLException {
         checkOpen();
@@ -319,7 +315,6 @@ class JDBCRelationalStatement implements RelationalStatement {
     }
 
     @Override
-    @ExcludeFromJacocoGeneratedReport
     public int executeInsert(@Nonnull String tableName, @Nonnull List<RelationalStruct> data, @Nonnull Options options)
             throws SQLException {
         checkOpen();
@@ -344,14 +339,12 @@ class JDBCRelationalStatement implements RelationalStatement {
     }
 
     @Override
-    @ExcludeFromJacocoGeneratedReport
     public int executeDelete(@Nonnull String tableName, @Nonnull Iterator<KeySet> keys, @Nonnull Options options) throws SQLException {
         checkOpen();
         return -1;
     }
 
     @Override
-    @ExcludeFromJacocoGeneratedReport
     public void executeDeleteRange(@Nonnull String tableName, @Nonnull KeySet keyPrefix, @Nonnull Options options) throws SQLException {
         checkOpen();
     }

--- a/fdb-relational-server/src/main/java/com/apple/foundationdb/relational/server/RelationalServer.java
+++ b/fdb-relational-server/src/main/java/com/apple/foundationdb/relational/server/RelationalServer.java
@@ -21,13 +21,10 @@
 package com.apple.foundationdb.relational.server;
 
 import com.apple.foundationdb.annotation.API;
-
 import com.apple.foundationdb.relational.api.exceptions.RelationalException;
 import com.apple.foundationdb.relational.jdbc.grpc.GrpcConstants;
 import com.apple.foundationdb.relational.jdbc.grpc.v1.JDBCServiceGrpc;
 import com.apple.foundationdb.relational.server.jdbc.v1.JDBCService;
-import com.apple.foundationdb.relational.util.ExcludeFromJacocoGeneratedReport;
-
 import com.google.common.annotations.VisibleForTesting;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
@@ -242,7 +239,6 @@ public class RelationalServer implements Closeable {
         return port;
     }
 
-    @ExcludeFromJacocoGeneratedReport
     public static void main(String[] args) throws IOException, InterruptedException {
         Options options = new Options();
         Option help = new Option("h", "help", false, "Output this help message.");


### PR DESCRIPTION
This marks a bunch of methods to be included in our code coverage report.

I went through all the references, and I believe I left 3 categories of things that are excluded:
1. Methods that are simply some variant of throw OperationNotSupported. We have a lot of these, because we override parts of JDBC, but haven't implemented all of it yet.
2. There's a handful of Hollow or NoOp classes. I want to investigate these further, and validate whether we should (a) remove them or (b) at least have tests that have them where there supposed to go
3. `PlannerDebuggerCommandHandler` -- I believe this command starts the planner repl, so that you can step through the cascades planner execution. Given that the planner repl is entirely internal, and interactive, I feel like this is ok.
4. `LaunchSQLLine` - as noted in the comment on the class, this is just a little helper to make it easier to debug with sqlline. I will add though, that I removed some of the exceptions for things used by SQLLine, so we may want tests that test SQLLine integration, at which point we could debug from those tests, and thus delete `LaunchSQLLine` entirely.