### PR TITLE
Types defined in the records file descriptor can be excluded from the final `RecordMetaData`

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordMetaData.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordMetaData.java
@@ -635,6 +635,9 @@ public class RecordMetaData implements RecordMetaDataProvider {
         if (usesLocalRecordsDescriptor) {
             throw new MetaDataException("cannot serialize meta-data with a local records descriptor to proto");
         }
+        if (recordTypes.size() != unionFields.size()) {
+            throw new MetaDataException("cannot serialize meta-data with any excluded types");
+        }
         RecordMetaDataProto.MetaData.Builder builder = RecordMetaDataProto.MetaData.newBuilder();
 
         // Set the root records.

--- a/fdb-record-layer-core/src/test/proto/evolution/test_new_record_type.proto
+++ b/fdb-record-layer-core/src/test/proto/evolution/test_new_record_type.proto
@@ -23,6 +23,7 @@ package com.apple.foundationdb.record.evolution.newtype;
 
 option java_package = "com.apple.foundationdb.record.evolution";
 option java_outer_classname = "TestNewRecordTypeProto";
+option (schema).store_record_versions = true;
 
 import "record_metadata_options.proto";
 import "test_records_1.proto";
@@ -30,6 +31,11 @@ import "test_records_1.proto";
 message NewRecord {
     optional int64 rec_no = 1 [(field).primary_key = true];
     optional int32 num_value_3_indexed = 2;
+    message Nested {
+        optional int64 a = 1;
+        optional int64 b = 2;
+    }
+    repeated Nested nested = 3;
 }
 
 message RecordTypeUnion {


### PR DESCRIPTION
To support certain upgrade paths, this allows types to be configured so that they are excluded from the final `RecordMetaData` even if they are present in the file descriptor. This allows the user to update a checked-in copy of the meta-data file descriptor (which is useful for ergonomically writing the messages that go into the store), but it allows them to have a way of enforcing that the new type isn't written to. Once the new file descriptor is everywhere, then the meta-data version can be safely updated.

The approach I took here was I introduced a new method, `excludeRecordType`, on the `RecordMetaDataBuilder`. This method just then updates a data structure that the meta-data builder was already maintaining that included the list of types. It validates that there aren't any indexes or synthetic types that used the record type, which in addition to the obvious (it means that there is a part of the meta-data that relies on this type), it also can be a sign that the meta-data version has been updated in a way that means that excluding the type won't actually do what the user intends. There are some tests to ensure that the meta-data produced is identical to the original, though with the new type added.

I put some thought into what an alternative would look like where instead, we required that all types in the meta-data are somehow explicitly added. The problem is that this doesn't play super well with our type processing logic. For example, when the records are added to the type, we currently add the type to a map and do some processing to handle things like the primary key annotation. If we modified the types to require some kind of explicit initialization, then we'd need to do something like keep another structure of "types in the file but not initialized" or something, and we'd need to make a decision like "is referencing the type enough to move it from the unitialized to initialized map?" It's not impossible to do, but it's a little more intricate than I'd like.

This resolves #3264.