### PR TITLE
Remove get_old_version step from release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,11 +125,6 @@ jobs:
   
       - name: Setup Base Environment
         uses: ./actions/setup-base-env
-      - name: Get old version
-        id: get_old_version
-        shell: bash
-        run: |
-          echo "version=$(python build/versionutils.py gradle.properties)" >> "$GITHUB_OUTPUT"
       # Push a version bump back to main. There are failure scenarios that can result
       # in published artifacts but an erroneous build, so it's safer to bump the version
       # at the beginning


### PR DESCRIPTION
PR #3275 removed the usage of this, but didn't remove the step itself, so I'm removing it.
If I search for `get_old_version` in `release.yml` now, it doesn't find anything, so I'm pretty confident there are no dangling references.