### PR TITLE
Remove more @ExcludeFromJacocoGeneratedReport

### DIFF
--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/ddl/NoOpQueryFactory.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/ddl/NoOpQueryFactory.java
@@ -22,12 +22,9 @@ package com.apple.foundationdb.relational.api.ddl;
 
 import com.apple.foundationdb.annotation.API;
 
-import com.apple.foundationdb.relational.util.ExcludeFromJacocoGeneratedReport;
-
 import javax.annotation.Nonnull;
 import java.net.URI;
 
-@ExcludeFromJacocoGeneratedReport //nothing to test
 @API(API.Status.EXPERIMENTAL)
 public class NoOpQueryFactory implements DdlQueryFactory {
     public static final DdlQueryFactory INSTANCE = new NoOpQueryFactory();

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/HollowTransactionManager.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/HollowTransactionManager.java
@@ -21,17 +21,14 @@
 package com.apple.foundationdb.relational.recordlayer;
 
 import com.apple.foundationdb.annotation.API;
-
 import com.apple.foundationdb.relational.api.Options;
 import com.apple.foundationdb.relational.api.Transaction;
 import com.apple.foundationdb.relational.api.TransactionManager;
 import com.apple.foundationdb.relational.api.exceptions.OperationUnsupportedException;
 import com.apple.foundationdb.relational.api.exceptions.RelationalException;
-import com.apple.foundationdb.relational.util.ExcludeFromJacocoGeneratedReport;
 
 import javax.annotation.Nonnull;
 
-@ExcludeFromJacocoGeneratedReport
 @API(API.Status.EXPERIMENTAL)
 public class HollowTransactionManager implements TransactionManager {
     public static final HollowTransactionManager INSTANCE = new HollowTransactionManager();

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ddl/NoOpMetadataOperationsFactory.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ddl/NoOpMetadataOperationsFactory.java
@@ -21,19 +21,16 @@
 package com.apple.foundationdb.relational.recordlayer.ddl;
 
 import com.apple.foundationdb.annotation.API;
-
 import com.apple.foundationdb.relational.api.Options;
 import com.apple.foundationdb.relational.api.Transaction;
 import com.apple.foundationdb.relational.api.ddl.ConstantAction;
 import com.apple.foundationdb.relational.api.ddl.MetadataOperationsFactory;
 import com.apple.foundationdb.relational.api.exceptions.RelationalException;
 import com.apple.foundationdb.relational.api.metadata.SchemaTemplate;
-import com.apple.foundationdb.relational.util.ExcludeFromJacocoGeneratedReport;
 
 import javax.annotation.Nonnull;
 import java.net.URI;
 
-@ExcludeFromJacocoGeneratedReport //nothing to test
 @API(API.Status.EXPERIMENTAL)
 public final class NoOpMetadataOperationsFactory implements MetadataOperationsFactory {
     public static final NoOpMetadataOperationsFactory INSTANCE = new NoOpMetadataOperationsFactory();

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/transactionbound/catalog/HollowSchemaTemplateCatalog.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/transactionbound/catalog/HollowSchemaTemplateCatalog.java
@@ -21,18 +21,15 @@
 package com.apple.foundationdb.relational.transactionbound.catalog;
 
 import com.apple.foundationdb.annotation.API;
-
-import com.apple.foundationdb.relational.api.Transaction;
 import com.apple.foundationdb.relational.api.RelationalResultSet;
+import com.apple.foundationdb.relational.api.Transaction;
 import com.apple.foundationdb.relational.api.catalog.SchemaTemplateCatalog;
 import com.apple.foundationdb.relational.api.exceptions.OperationUnsupportedException;
 import com.apple.foundationdb.relational.api.exceptions.RelationalException;
 import com.apple.foundationdb.relational.api.metadata.SchemaTemplate;
-import com.apple.foundationdb.relational.util.ExcludeFromJacocoGeneratedReport;
 
 import javax.annotation.Nonnull;
 
-@ExcludeFromJacocoGeneratedReport
 @API(API.Status.EXPERIMENTAL)
 public class HollowSchemaTemplateCatalog implements SchemaTemplateCatalog {
 

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/transactionbound/catalog/HollowStoreCatalog.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/transactionbound/catalog/HollowStoreCatalog.java
@@ -21,22 +21,19 @@
 package com.apple.foundationdb.relational.transactionbound.catalog;
 
 import com.apple.foundationdb.annotation.API;
-
 import com.apple.foundationdb.relational.api.Continuation;
-import com.apple.foundationdb.relational.api.Transaction;
 import com.apple.foundationdb.relational.api.RelationalResultSet;
+import com.apple.foundationdb.relational.api.Transaction;
 import com.apple.foundationdb.relational.api.catalog.SchemaTemplateCatalog;
 import com.apple.foundationdb.relational.api.catalog.StoreCatalog;
 import com.apple.foundationdb.relational.api.exceptions.OperationUnsupportedException;
 import com.apple.foundationdb.relational.api.exceptions.RelationalException;
 import com.apple.foundationdb.relational.api.metadata.Schema;
 import com.apple.foundationdb.relational.api.metadata.SchemaTemplate;
-import com.apple.foundationdb.relational.util.ExcludeFromJacocoGeneratedReport;
 
 import javax.annotation.Nonnull;
 import java.net.URI;
 
-@ExcludeFromJacocoGeneratedReport
 @API(API.Status.EXPERIMENTAL)
 public class HollowStoreCatalog implements StoreCatalog {
 

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/api/ddl/AbstractMetadataOperationsFactory.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/api/ddl/AbstractMetadataOperationsFactory.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@ package com.apple.foundationdb.relational.api.ddl;
 import com.apple.foundationdb.relational.api.Options;
 import com.apple.foundationdb.relational.api.metadata.SchemaTemplate;
 import com.apple.foundationdb.relational.recordlayer.ddl.NoOpMetadataOperationsFactory;
-import com.apple.foundationdb.relational.util.ExcludeFromJacocoGeneratedReport;
 
 import javax.annotation.Nonnull;
 import java.net.URI;
@@ -31,7 +30,6 @@ import java.net.URI;
 /**
  * Skeleton implementation of a ConstantActionFactory.
  */
-@ExcludeFromJacocoGeneratedReport //excluded because it doesn't do anything by default, so there's nothing to test
 public abstract class AbstractMetadataOperationsFactory implements MetadataOperationsFactory {
     @Nonnull
     @Override

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/api/ddl/AbstractQueryFactory.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/api/ddl/AbstractQueryFactory.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,12 +20,9 @@
 
 package com.apple.foundationdb.relational.api.ddl;
 
-import com.apple.foundationdb.relational.util.ExcludeFromJacocoGeneratedReport;
-
 import javax.annotation.Nonnull;
 import java.net.URI;
 
-@ExcludeFromJacocoGeneratedReport //nothing to test
 public abstract class AbstractQueryFactory implements DdlQueryFactory {
     @Override
     public DdlQuery getListDatabasesQueryAction(@Nonnull URI prefixPath) {


### PR DESCRIPTION
This removes the annotation from the Hollow* and NoOp* classes that were previously annotated.
Since AbstractMetadataOperationsFactory and AbstractQueryFactory are only used by tests I moved them there.

This is a continuation of #3269