### PR TITLE
Fix release note since 4.2.1.0 release did not get published to maven central

### DIFF
--- a/docs/sphinx/source/ReleaseNotes.md
+++ b/docs/sphinx/source/ReleaseNotes.md
@@ -9,22 +9,6 @@ As the [versioning guide](Versioning.md) details, it cannot always be determined
 
 ### 4.2.2.0
 
-
-
-**[Full Changelog (4.2.1.0...4.2.2.0)](https://github.com/FoundationDB/fdb-record-layer/compare/4.2.1.0...4.2.2.0)**
-
-#### Mixed Mode Test Results
-
-Mixed mode testing run against the following previous versions:
-
-❌`4.0.559.1`, ❌`4.0.559.2`, ❌`4.0.559.3`, ❌`4.0.559.4`, ❌`4.0.559.6`, ❌`4.0.561.0`, ❌`4.0.562.0`, ❌`4.0.564.0`, ❌`4.0.565.0`, ❌`4.0.566.0`, ❌`4.0.567.0`, ❌`4.0.568.0`, ❌`4.0.569.0`, ❌`4.0.570.0`, ❌`4.0.571.0`, ❌`4.0.572.0`, ❌`4.0.573.0`, ❌`4.0.574.0`, ❌`4.0.575.0`, ❌`4.1.4.0`, ✅`4.1.5.0`, ✅`4.1.6.0`, ✅`4.1.8.0`, ✅`4.1.9.0`, ✅`4.1.10.0`
-
-[See full test run](https://github.com/FoundationDB/fdb-record-layer/actions/runs/14116508725)
-
-
-
-### 4.2.1.0
-
 <h4> Breaking Changes </h4>
 
 * Lucene: AnalyzerChooser no longer takes the text when choosing an analyzer - [PR #2994](https://github.com/FoundationDB/fdb-record-layer/pull/2994)
@@ -61,8 +45,7 @@ Mixed mode testing run against the following previous versions:
 
 </details>
 
-
-**[Full Changelog (4.1.10.0...4.2.1.0)](https://github.com/FoundationDB/fdb-record-layer/compare/4.1.10.0...4.2.1.0)**
+**[Full Changelog (4.1.10.0...4.2.2.0)](https://github.com/FoundationDB/fdb-record-layer/compare/4.1.10.0...4.2.2.0)**
 
 #### Mixed Mode Test Results
 
@@ -70,8 +53,7 @@ Mixed mode testing run against the following previous versions:
 
 ❌`4.0.559.1`, ❌`4.0.559.2`, ❌`4.0.559.3`, ❌`4.0.559.4`, ❌`4.0.559.6`, ❌`4.0.561.0`, ❌`4.0.562.0`, ❌`4.0.564.0`, ❌`4.0.565.0`, ❌`4.0.566.0`, ❌`4.0.567.0`, ❌`4.0.568.0`, ❌`4.0.569.0`, ❌`4.0.570.0`, ❌`4.0.571.0`, ❌`4.0.572.0`, ❌`4.0.573.0`, ❌`4.0.574.0`, ❌`4.0.575.0`, ❌`4.1.4.0`, ✅`4.1.5.0`, ✅`4.1.6.0`, ✅`4.1.8.0`, ✅`4.1.9.0`, ✅`4.1.10.0`
 
-[See full test run](https://github.com/FoundationDB/fdb-record-layer/actions/runs/14113907478)
-
+[See full test run](https://github.com/FoundationDB/fdb-record-layer/actions/runs/14116508725)
 
 
 ## 4.1


### PR DESCRIPTION
`4.2.1.0` was not published, so we should remove its entry in the release note and merge it with the `4.2.2.0` section