### PR TITLE
Fix warning from sphinxDocs about missing _static directory.

### DIFF
--- a/gradle/sphinx.gradle
+++ b/gradle/sphinx.gradle
@@ -111,6 +111,7 @@ task sphinxDocs(type: Exec) {
     dependsOn sphinxEnv
     dependsOn generateRailroadDiagrams
     dependsOn createSphinxApiPlaceholders
+    mkdir "${sphinxRoot}/source/_static"
     commandLine "${venvDir}/bin/sphinx-build", '-M', 'html', "${sphinxRoot}/source", sphinxBuildDir
 }
 


### PR DESCRIPTION
I was seeing in the release:
```
> Task :sphinxDocs
2025-03-28T19:10:22.0800951Z Running Sphinx v8.1.3
2025-03-28T19:10:22.0802497Z loading translations [en]... done
2025-03-28T19:10:22.0812351Z WARNING: html_static_path entry '_static' does not exist
```

I tried running:
```
./gradlew clean documentationSite  -PreleaseBuild=true --warning-mode=all
```
locally after this change, and it did not appear to have that warning, but it did when run without this change.