### PR TITLE
When downloading old servers, only cache latest version for 10 minutes

### DIFF
--- a/yaml-tests/yaml-tests.gradle
+++ b/yaml-tests/yaml-tests.gradle
@@ -81,7 +81,19 @@ dependencies {
 ext.resolveOtherServer = { Set<String> rejectedVersions ->
     def configurationName = "resolveArtifact-${UUID.randomUUID()}"
     return rootProject.with {
-        configurations.create(configurationName, { })
+        configurations.create(configurationName, {
+        resolutionStrategy {
+                // Cache the latest version for 10 minutes to make sure we actually get the latest.
+                // This should be long enough that we can do this resolution, but means that if we had a release
+                // in the last 10 minutes.
+                // Note: In the actions we have a build cache, which means that these versions will be cached across
+                // builds.
+                // The default value for this is 24 hours, which is probably, generally, fine, but in the case where
+                // we do have two releases within 24 hours (as we did for 4.2.3.0) we don't want to miss the last
+                // version.
+                cacheDynamicVersionsFor 10, 'minutes'
+            }
+        })
         // If you're wondering why this doesn't just use `latest.release`:
         // `latest.release` becomes `LatestVersionSelector` which `requiresMetadata` in order to determine if the
         // version in question is a release. This means that it can't just look at the version listing, it has to


### PR DESCRIPTION
The 4.2.3.0 release did not do a mixed-mode test against 4.2.2.0 because that was released less than 24 hours before. This changes it so that it refreshes the dynamic version after 10 minutes. This does mean that builds will have to fetch the latest version metadata more often, including for developers running locally.

If this becomes a burden, we could try to add something to our release process to ensure that after a release we force an update to the cached version, but that seems trickier to manage, and we'd only really be able to test it by doing releases within 24 hours of each other.