### PR TITLE
Decrease the number of builds compared during mixed mode to the most recent 10

### DIFF
--- a/yaml-tests/yaml-tests.gradle
+++ b/yaml-tests/yaml-tests.gradle
@@ -142,7 +142,7 @@ static def getAttributesFromJar(File file) {
 ext.resolveManyServers = { ->
     Set<File> selectedServers = new HashSet<>();
     Set<String> rejectedVersions = new HashSet<>();
-    while (selectedServers.size() < 50) {
+    while (selectedServers.size() < 10) {
         def serverFile = resolveOtherServer(rejectedVersions)
         def attributes = getAttributesFromJar(serverFile)
         // 4.0.559.0 is the first version that introduced the server, so we won't be able to find anything


### PR DESCRIPTION
This decreases the maximum number of builds we will compare during mixed mode testing from 50 to 10. (Note that we didn't actually have 50 versions that were mixed-mode testing compatible as it required 4.0.559.0, but we do have more than 10.) This is in response to release build failures (see: https://github.com/FoundationDB/fdb-record-layer/actions/runs/14217433940 and https://github.com/FoundationDB/fdb-record-layer/actions/runs/14222485395). Those appear to have been caused by the mixed mode test job running out of resources, as it started experiencing timeouts and didn't fail locally. The hope is that decreasing this number makes the run able to complete.

We may need to consider adjusting this in the future to be smarter (e.g., comparing the most recent version to all versions in the this and the previous minor version, as those should be the primary candidates for upgrades), but that's something we could think about later. There are already (intentaional) incompatibilities between the current 4.2 version and the 4.0 versions that make up the majority of the versions that will currently be excluded by this change, and so continuing to validate that those are incompatible is probably of little value.