### PR TITLE
Decrease the number of builds compared during mixed mode to the most recent 10

### DIFF
--- a/yaml-tests/yaml-tests.gradle
+++ b/yaml-tests/yaml-tests.gradle
@@ -142,7 +142,7 @@ static def getAttributesFromJar(File file) {
 ext.resolveManyServers = { ->
     Set<File> selectedServers = new HashSet<>();
     Set<String> rejectedVersions = new HashSet<>();
-    while (selectedServers.size() < 50) {
+    while (selectedServers.size() < 10) {
         def serverFile = resolveOtherServer(rejectedVersions)
         def attributes = getAttributesFromJar(serverFile)
         // 4.0.559.0 is the first version that introduced the server, so we won't be able to find anything


### PR DESCRIPTION
This cherry picks #3289 onto the 4.2.2 release branch, as the same issue that is affecting main is also affecting that branch. We may want to wait for that first build to merge, for us to release a new build like 4.2.4.0, and then merge this in to cut a 4.2.2.1.