### PR TITLE
Index scrubbing should support range id & range reset

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/logging/LogMessageKeys.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/logging/LogMessageKeys.java
@@ -241,6 +241,8 @@ public enum LogMessageKeys {
     RANGE_BYTES,
     RANGE_START,
     RANGE_END,
+    RANGE_ID,
+    RANGE_RESET,
     // meta-data evolution
     FIELD_NAME,
     OLD_FIELD_NAME,
@@ -307,6 +309,7 @@ public enum LogMessageKeys {
     FAILED_TRANSACTIONS_COUNT_IN_RUNNER,
     TOTAL_RECORDS_SCANNED,
     TOTAL_RECORDS_SCANNED_DURING_FAILURES,
+    SCRUB_TYPE,
 
     // time limits milliseconds
     TIME_LIMIT_MILLIS("time_limit_milliseconds"),

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -4710,8 +4710,8 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
         IndexingRangeSet.forIndexBuild(this, index).clear();
         // clear even if non-unique in case the index was previously unique
         context.clear(indexUniquenessViolationsSubspace(index).range());
-        // Under the index build subspace, there are multiple lower level subspaces - the lock space and few others.
-        // We are not supposed to clear the lock subspace, which might have used to an online index job that had invoked this method.
+        // Under the index build subspace, there are multiple lower level subspaces - the lock subspace and few others. We are
+        // not supposed to clear the lock subspace, which might have been used to an online index job that had invoked this method.
         IndexingSubspaces.eraseAllIndexingDataButTheLock(context, this, index);
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -3916,7 +3916,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     @API(API.Status.INTERNAL)
     @Nonnull
     public CompletableFuture<IndexBuildProto.IndexBuildIndexingStamp> loadIndexingTypeStampAsync(Index index) {
-        byte[] stampKey = OnlineIndexer.indexBuildTypeSubspace(this, index).pack();
+        byte[] stampKey = IndexingSubspaces.indexBuildTypeSubspace(this, index).pack();
         return ensureContextActive().get(stampKey).thenApply(serializedStamp -> {
             if (serializedStamp == null) {
                 return null;
@@ -3944,7 +3944,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
      */
     @API(API.Status.INTERNAL)
     public void saveIndexingTypeStamp(Index index, IndexBuildProto.IndexBuildIndexingStamp stamp) {
-        byte[] stampKey = OnlineIndexer.indexBuildTypeSubspace(this, index).pack();
+        byte[] stampKey = IndexingSubspaces.indexBuildTypeSubspace(this, index).pack();
         ensureContextActive().set(stampKey, stamp.toByteArray());
     }
 
@@ -4710,14 +4710,9 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
         IndexingRangeSet.forIndexBuild(this, index).clear();
         // clear even if non-unique in case the index was previously unique
         context.clear(indexUniquenessViolationsSubspace(index).range());
-        // Under the index build subspace, there are 3 lower level subspaces, the lock space, the scanned records
-        // subspace, and the type/stamp subspace. We are not supposed to clear the lock subspace, which is used to
-        // run online index jobs which may invoke this method. We should clear:
-        // * the scanned records subspace. Which, roughly speaking, counts how many records of this store are covered in
-        // index range subspace.
-        // * the type/stamp subspace. Which indicates which type of indexing is in progress.
-        context.clear(Range.startsWith(OnlineIndexer.indexBuildScannedRecordsSubspace(this, index).pack()));
-        context.clear(Range.startsWith(OnlineIndexer.indexBuildTypeSubspace(this, index).pack()));
+        // Under the index build subspace, there are multiple lower level subspaces - the lock space and few others.
+        // We are not supposed to clear the lock subspace, which might have used to an online index job that had invoked this method.
+        IndexingSubspaces.eraseAllIndexingDataButTheLock(context, this, index);
     }
 
     @SuppressWarnings("PMD.CloseResource")

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexBuildState.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexBuildState.java
@@ -99,7 +99,7 @@ public class IndexBuildState {
     @Nonnull
     public static CompletableFuture<Long> loadRecordsScannedAsync(FDBRecordStoreBase<?> store, Index index) {
         return store.getContext().ensureActive()
-                .get(OnlineIndexer.indexBuildScannedRecordsSubspace(store, index).getKey())
+                .get(IndexingSubspaces.indexBuildScannedRecordsSubspace(store, index).getKey())
                 .thenApply(FDBRecordStore::decodeRecordCount);
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexScrubbing.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexScrubbing.java
@@ -162,6 +162,7 @@ public class IndexScrubbing extends IndexingBase {
                 // Here: no more missing ranges - all done
                 // This scrubbing is done. Clear the rangeSet - the next time scrubbing is called it will start from scratch
                 rangeSet.clear();
+                logScrubberRangeReset("range exhausted");
                 return AsyncUtil.READY_FALSE;
             }
             final Tuple rangeStart = RangeSet.isFirstKey(range.begin) ? null : Tuple.fromBytes(range.begin);
@@ -263,7 +264,7 @@ public class IndexScrubbing extends IndexingBase {
                     if (recordRange == null) {
                         // Here: no un-scrubbed range was left for this call. We will
                         // erase the 'ranges' data to allow a fresh records re-scrubbing.
-                        logScrubberRangeReset("range exhausted");
+                        logScrubberRangeReset("range exhausted detected");
                         rangeSet.clear();
                     }
                 });

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexScrubbing.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexScrubbing.java
@@ -30,6 +30,7 @@ import com.apple.foundationdb.record.RecordCursorResult;
 import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.RecordMetaDataProvider;
 import com.apple.foundationdb.record.TupleRange;
+import com.apple.foundationdb.record.logging.KeyValueLogMessage;
 import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.MetaDataException;
@@ -86,6 +87,9 @@ public class IndexScrubbing extends IndexingBase {
         return Arrays.asList(
                 LogMessageKeys.INDEXING_METHOD, scrubberName,
                 LogMessageKeys.ALLOW_REPAIR, scrubbingPolicy.allowRepair(),
+                LogMessageKeys.RANGE_ID, scrubbingPolicy.getRangeId(),
+                LogMessageKeys.RANGE_RESET, scrubbingPolicy.isRangeReset(),
+                LogMessageKeys.SCRUB_TYPE, scrubbingType,
                 LogMessageKeys.SCAN_LIMIT, scrubbingPolicy.getEntriesScanLimit()
         );
     }
@@ -228,11 +232,49 @@ public class IndexScrubbing extends IndexingBase {
     IndexingRangeSet getRangeset(FDBRecordStore store, Index index) {
         switch (scrubbingType) {
             case MISSING:
-                return IndexingRangeSet.forScrubbingRecords(store, index);
+                return IndexingRangeSet.forScrubbingRecords(store, index, scrubbingPolicy.getRangeId());
             case DANGLING:
-                return IndexingRangeSet.forScrubbingIndex(store, index);
+                return IndexingRangeSet.forScrubbingIndex(store, index, scrubbingPolicy.getRangeId());
             default:
                 throw new RecordCoreArgumentException("Unpredicted scrubbing type ");
+        }
+    }
+
+    @Nonnull
+    @SuppressWarnings("PMD.CloseResource")
+    @Override
+    protected CompletableFuture<Void> setScrubberTypeOrThrow(FDBRecordStore store) {
+        // HERE: The index must be readable, checked by the caller
+        //   if scrubber had already run and still have missing ranges, do nothing
+        //   else: clear ranges and overwrite type-stamp
+        IndexBuildProto.IndexBuildIndexingStamp indexingTypeStamp = getIndexingTypeStamp(store);
+        validateOrThrowEx(indexingTypeStamp.getMethod().equals(IndexBuildProto.IndexBuildIndexingStamp.Method.SCRUB_REPAIR),
+                "Not a scrubber type-stamp");
+
+        final Index index = common.getIndex(); // Note: the scrubbers do not support multi target (yet)
+        final IndexingRangeSet rangeSet = getRangeset(store, index);
+        if (scrubbingPolicy.isRangeReset()) {
+            rangeSet.clear();
+            logScrubberRangeReset("force reset");
+            return AsyncUtil.DONE;
+        }
+        return rangeSet.firstMissingRangeAsync()
+                .thenAccept(recordRange -> {
+                    if (recordRange == null) {
+                        // Here: no un-scrubbed range was left for this call. We will
+                        // erase the 'ranges' data to allow a fresh records re-scrubbing.
+                        logScrubberRangeReset("range exhausted");
+                        rangeSet.clear();
+                    }
+                });
+    }
+
+    private void logScrubberRangeReset(String reason) {
+        if (LOGGER.isInfoEnabled()) {
+            LOGGER.info(KeyValueLogMessage.build("Reset index scrubbing range")
+                    .addKeysAndValues(common.indexLogMessageKeyValues())
+                            .addKeyAndValue(LogMessageKeys.REASON, reason)
+                    .toString());
         }
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
@@ -114,7 +114,8 @@ public abstract class IndexingBase {
 
 
     IndexingBase(@Nonnull IndexingCommon common,
-                 @Nonnull OnlineIndexer.IndexingPolicy policy, boolean isScrubber) {
+                 @Nonnull OnlineIndexer.IndexingPolicy policy,
+                 boolean isScrubber) {
         this.common = common;
         this.policy = policy;
         this.isScrubber = isScrubber;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
@@ -539,7 +539,7 @@ public abstract class IndexingBase {
     @Nonnull
     protected CompletableFuture<Void> setScrubberTypeOrThrow(FDBRecordStore store) {
         // This path should never be reached
-        throw new ValidationException("Called in a non-scrubbing path",
+        throw new ValidationException("Called setScrubberTypeOrThrow in a non-scrubbing path",
                 "isScrubber", isScrubber);
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
@@ -93,8 +93,10 @@ public abstract class IndexingBase {
     private static final Object INDEX_BUILD_LOCK_KEY = 0L;
     private static final Object INDEX_BUILD_SCANNED_RECORDS = 1L;
     private static final Object INDEX_BUILD_TYPE_VERSION = 2L;
-    private static final Object INDEX_SCRUBBED_INDEX_RANGES = 3L;
-    private static final Object INDEX_SCRUBBED_RECORDS_RANGES = 4L;
+    private static final Object INDEX_SCRUBBED_INDEX_RANGES_ZERO = 3L;
+    private static final Object INDEX_SCRUBBED_RECORDS_RANGES_ZERO = 4L;
+    private static final Object INDEX_SCRUBBED_INDEX_RANGES = 4L;
+    private static final Object INDEX_SCRUBBED_RECORDS_RANGES = 5L;
 
     @Nonnull
     private static final Logger LOGGER = LoggerFactory.getLogger(IndexingBase.class);
@@ -157,15 +159,21 @@ public abstract class IndexingBase {
     @Nonnull
     public static Subspace indexScrubIndexRangeSubspace(@Nonnull FDBRecordStoreBase<?> store, @Nonnull Index index, int rangeId) {
         // This subspace holds the scrubbed ranges of the index itself (when looking for dangling entries)
-        final Subspace subspace = indexBuildSubspace(store, index, INDEX_SCRUBBED_INDEX_RANGES);
-        return rangeId == 0 ? subspace : subspace.subspace(Tuple.from(rangeId));
+        if (rangeId == 0) {
+            // Backward compatible
+            return indexBuildSubspace(store, index, INDEX_SCRUBBED_INDEX_RANGES_ZERO);
+        }
+        return indexBuildSubspace(store, index, INDEX_SCRUBBED_INDEX_RANGES).subspace(Tuple.from(rangeId));
     }
 
     @Nonnull
     public static Subspace indexScrubRecordsRangeSubspace(@Nonnull FDBRecordStoreBase<?> store, @Nonnull Index index, int rangeId) {
         // This subspace hods the scrubbed ranges of the records (when looking for missing index entries)
-        final Subspace subspace = indexBuildSubspace(store, index, INDEX_SCRUBBED_RECORDS_RANGES);
-        return rangeId == 0 ? subspace : subspace.subspace(Tuple.from(rangeId));
+        if (rangeId == 0) {
+            // backward compatible
+            return indexBuildSubspace(store, index, INDEX_SCRUBBED_RECORDS_RANGES_ZERO);
+        }
+        return indexBuildSubspace(store, index, INDEX_SCRUBBED_RECORDS_RANGES).subspace(Tuple.from(rangeId));
     }
 
     @SuppressWarnings("squid:S1452")

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingScrubDangling.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingScrubDangling.java
@@ -88,6 +88,8 @@ public class IndexingScrubDangling extends IndexingBase {
         return Arrays.asList(
                 LogMessageKeys.INDEXING_METHOD, "scrub dangling index entries",
                 LogMessageKeys.ALLOW_REPAIR, scrubbingPolicy.allowRepair(),
+                LogMessageKeys.RANGE_ID, scrubbingPolicy.getRangeId(),
+                LogMessageKeys.RANGE_RESET, scrubbingPolicy.isRangeReset(),
                 LogMessageKeys.SCAN_LIMIT, scrubbingPolicy.getEntriesScanLimit()
         );
     }
@@ -147,7 +149,7 @@ public class IndexingScrubDangling extends IndexingBase {
         validateOrThrowEx(store.getIndexState(index).isScannable(), "scrubbed index is not readable");
 
         final ScanProperties scanProperties = scanPropertiesWithLimits(true);
-        final IndexingRangeSet rangeSet = IndexingRangeSet.forScrubbingIndex(store, index);
+        final IndexingRangeSet rangeSet = IndexingRangeSet.forScrubbingIndex(store, index, scrubbingPolicy.getRangeId());
         return rangeSet.firstMissingRangeAsync().thenCompose(range -> {
             if (range == null) {
                 // Here: no more missing ranges - all done
@@ -237,6 +239,44 @@ public class IndexingScrubDangling extends IndexingBase {
             }
             store.getContext().ensureActive().clear(keyBytes);
         }
+    }
+
+    @Nonnull
+    @SuppressWarnings("PMD.CloseResource")
+    @Override
+    protected CompletableFuture<Void> setScrubberTypeOrThrow(FDBRecordStore store) {
+        // Note: this duplicated function should be eliminated with this obsolete module (for legacy mode) is deleted
+        // HERE: The index must be readable, checked by the caller
+        //   if scrubber had already run and still have missing ranges, do nothing
+        //   else: clear ranges and overwrite type-stamp
+        IndexBuildProto.IndexBuildIndexingStamp indexingTypeStamp = getIndexingTypeStamp(store);
+        validateOrThrowEx(indexingTypeStamp.getMethod().equals(IndexBuildProto.IndexBuildIndexingStamp.Method.SCRUB_REPAIR),
+                "Not a scrubber type-stamp");
+
+        final Index index = common.getIndex(); // Note: the scrubbers do not support multi target (yet)
+        IndexingRangeSet indexRangeSet = IndexingRangeSet.forScrubbingIndex(store, index, scrubbingPolicy.getRangeId());
+        if (scrubbingPolicy.isRangeReset()) {
+            indexRangeSet.clear();
+            if (LOGGER.isInfoEnabled()) {
+                LOGGER.info(KeyValueLogMessage.build("Reset scrubber's index range - force reset")
+                        .addKeysAndValues(common.indexLogMessageKeyValues())
+                        .toString());
+            }
+            return AsyncUtil.DONE;
+        }
+        return indexRangeSet.firstMissingRangeAsync()
+                .thenAccept(indexRange -> {
+                    if (indexRange == null) {
+                        // Here: no un-scrubbed records range was left for this call. We will
+                        // erase the 'ranges' data to allow a fresh records re-scrubbing.
+                        if (LOGGER.isInfoEnabled()) {
+                            LOGGER.info(KeyValueLogMessage.build("Reset scrubber's index range - range exhausted")
+                                    .addKeysAndValues(common.indexLogMessageKeyValues())
+                                    .toString());
+                        }
+                        indexRangeSet.clear();
+                    }
+                });
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingSubspaces.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingSubspaces.java
@@ -65,6 +65,7 @@ public final class IndexingSubspaces {
 
     @Nonnull
     public static Subspace indexScrubRecordsRangeSubspaceLegacy(@Nonnull FDBRecordStoreBase<?> store, @Nonnull Index index) {
+        // Backward compatible subspace for range-id zero
         return indexBuildSubspace(store, index, INDEX_SCRUBBED_RECORDS_RANGES_ZERO);
     }
 
@@ -75,7 +76,7 @@ public final class IndexingSubspaces {
 
     @Nonnull
     public static Subspace indexScrubIndexRangeSubspaceLegacy(@Nonnull FDBRecordStoreBase<?> store, @Nonnull Index index) {
-        // Backward compatible
+        // Backward compatible subspace for range-id zero
         return indexBuildSubspace(store, index, INDEX_SCRUBBED_INDEX_RANGES_ZERO);
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingSubspaces.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingSubspaces.java
@@ -49,17 +49,17 @@ public final class IndexingSubspaces {
     }
 
     @Nonnull
-    protected static Subspace indexBuildLockSubspace(@Nonnull FDBRecordStoreBase<?> store, @Nonnull Index index) {
+    public static Subspace indexBuildLockSubspace(@Nonnull FDBRecordStoreBase<?> store, @Nonnull Index index) {
         return indexBuildSubspace(store, index, INDEX_BUILD_LOCK_KEY);
     }
 
     @Nonnull
-    protected static Subspace indexBuildScannedRecordsSubspace(@Nonnull FDBRecordStoreBase<?> store, @Nonnull Index index) {
+    public static Subspace indexBuildScannedRecordsSubspace(@Nonnull FDBRecordStoreBase<?> store, @Nonnull Index index) {
         return indexBuildSubspace(store, index, INDEX_BUILD_SCANNED_RECORDS);
     }
 
     @Nonnull
-    protected static Subspace indexBuildTypeSubspace(@Nonnull FDBRecordStoreBase<?> store, @Nonnull Index index) {
+    public static Subspace indexBuildTypeSubspace(@Nonnull FDBRecordStoreBase<?> store, @Nonnull Index index) {
         return indexBuildSubspace(store, index, INDEX_BUILD_TYPE_VERSION);
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingSubspaces.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingSubspaces.java
@@ -1,0 +1,99 @@
+/*
+ * IndexingSubspaces.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb;
+
+import com.apple.foundationdb.Range;
+import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.subspace.Subspace;
+import com.apple.foundationdb.tuple.Tuple;
+
+import javax.annotation.Nonnull;
+
+/**
+ * List of subspaces related to the indexing/index-scrubbing processes.
+ */
+public final class IndexingSubspaces {
+    private static final Object INDEX_BUILD_LOCK_KEY = 0L;
+    private static final Object INDEX_BUILD_SCANNED_RECORDS = 1L;
+    private static final Object INDEX_BUILD_TYPE_VERSION = 2L;
+    private static final Object INDEX_SCRUBBED_INDEX_RANGES_ZERO = 3L;
+    private static final Object INDEX_SCRUBBED_RECORDS_RANGES_ZERO = 4L;
+    private static final Object INDEX_SCRUBBED_INDEX_RANGES = 4L;
+    private static final Object INDEX_SCRUBBED_RECORDS_RANGES = 5L;
+
+    private IndexingSubspaces() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    @Nonnull
+    private static Subspace indexBuildSubspace(@Nonnull FDBRecordStoreBase<?> store, @Nonnull Index index, Object key) {
+        return store.getUntypedRecordStore().indexBuildSubspace(index).subspace(Tuple.from(key));
+    }
+
+    @Nonnull
+    protected static Subspace indexBuildLockSubspace(@Nonnull FDBRecordStoreBase<?> store, @Nonnull Index index) {
+        return indexBuildSubspace(store, index, INDEX_BUILD_LOCK_KEY);
+    }
+
+    @Nonnull
+    protected static Subspace indexBuildScannedRecordsSubspace(@Nonnull FDBRecordStoreBase<?> store, @Nonnull Index index) {
+        return indexBuildSubspace(store, index, INDEX_BUILD_SCANNED_RECORDS);
+    }
+
+    @Nonnull
+    protected static Subspace indexBuildTypeSubspace(@Nonnull FDBRecordStoreBase<?> store, @Nonnull Index index) {
+        return indexBuildSubspace(store, index, INDEX_BUILD_TYPE_VERSION);
+    }
+
+    @Nonnull
+    public static Subspace indexScrubRecordsRangeSubspaceLegacy(@Nonnull FDBRecordStoreBase<?> store, @Nonnull Index index) {
+        return indexBuildSubspace(store, index, INDEX_SCRUBBED_RECORDS_RANGES_ZERO);
+    }
+
+    @Nonnull
+    public static Subspace indexScrubRecordsRangeSubspace(@Nonnull FDBRecordStoreBase<?> store, @Nonnull Index index) {
+        return indexBuildSubspace(store, index, INDEX_SCRUBBED_RECORDS_RANGES);
+    }
+
+    @Nonnull
+    public static Subspace indexScrubIndexRangeSubspaceLegacy(@Nonnull FDBRecordStoreBase<?> store, @Nonnull Index index) {
+        // Backward compatible
+        return indexBuildSubspace(store, index, INDEX_SCRUBBED_INDEX_RANGES_ZERO);
+    }
+
+    @Nonnull
+    public static Subspace indexScrubIndexRangeSubspace(@Nonnull FDBRecordStoreBase<?> store, @Nonnull Index index) {
+        return indexBuildSubspace(store, index, INDEX_SCRUBBED_INDEX_RANGES);
+    }
+
+    public static void eraseAllIndexingScrubbingData(@Nonnull FDBRecordContext context, @Nonnull FDBRecordStore store, @Nonnull Index index) {
+        context.clear(Range.startsWith(indexScrubIndexRangeSubspaceLegacy(store, index).pack()));
+        context.clear(Range.startsWith(indexScrubIndexRangeSubspace(store, index).pack()));
+        context.clear(Range.startsWith(indexScrubRecordsRangeSubspaceLegacy(store, index).pack()));
+        context.clear(Range.startsWith(indexScrubRecordsRangeSubspace(store, index).pack()));
+    }
+
+    public static void eraseAllIndexingDataButTheLock(@Nonnull FDBRecordContext context, @Nonnull FDBRecordStore store, @Nonnull Index index) {
+        eraseAllIndexingScrubbingData(context, store, index);
+        context.clear(Range.startsWith(indexBuildScannedRecordsSubspace(store, index).pack()));
+        context.clear(Range.startsWith(indexBuildTypeSubspace(store, index).pack()));
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexOperationBaseBuilder.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexOperationBaseBuilder.java
@@ -569,7 +569,7 @@ public abstract class OnlineIndexOperationBaseBuilder<B extends OnlineIndexOpera
 
     /**
      * Set whether or not to track the index build progress by updating the number of records successfully scanned
-     * and processed. The progress is persisted in {@link OnlineIndexer#indexBuildScannedRecordsSubspace(FDBRecordStoreBase, Index)}
+     * and processed. The progress is persisted in {@link IndexingSubspaces#indexBuildScannedRecordsSubspace(FDBRecordStoreBase, Index)}
      * which can be accessed by {@link IndexBuildState#loadIndexBuildStateAsync(FDBRecordStoreBase, Index)}.
      * <p>
      * This setting does not affect the setting at {@link #setProgressLogIntervalMillis(long)}.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexScrubber.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexScrubber.java
@@ -136,7 +136,7 @@ public class OnlineIndexScrubber implements AutoCloseable {
      * A builder for the scrubbing policy.
      */
     public static class ScrubbingPolicy {
-        public static final ScrubbingPolicy DEFAULT = new ScrubbingPolicy(1000, true, 0, false, false, 0, true);
+        public static final ScrubbingPolicy DEFAULT = new ScrubbingPolicy(1000, false, 0, false, false, 0, false);
         private final int logWarningsLimit;
         private final boolean allowRepair;
         private final long entriesScanLimit;
@@ -289,7 +289,7 @@ public class OnlineIndexScrubber implements AutoCloseable {
 
             /**
              * Choose a specific "Already Scrubbed" rangeSet prefix. This may be useful for
-             * multiple scrubbing jobs that should not affect each other.
+             * multiple scrubbing jobs that may not affect each other.
              * 0 is the backward compatible default, which means no prefix.
              * @param rangeId a rangeSet prefix
              * @return this builder
@@ -300,8 +300,8 @@ public class OnlineIndexScrubber implements AutoCloseable {
             }
 
             /**
-             * If set to true, clear any previous "Already Scrubbed" range set - which means that the index scrubbing
-             * will begin from scratch.
+             * If set to true, clear any previous "Already Scrubbed" range set (in the given rangeId) - which means that
+             * the index scrubbing will begin from scratch.
              * @param rangeReset reset if true
              * @return this builder
              */

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexScrubber.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexScrubber.java
@@ -40,6 +40,7 @@ import java.util.function.UnaryOperator;
  * Scan indexes for problems and optionally report or repair.
  */
 @API(API.Status.UNSTABLE)
+@SuppressWarnings("PMD.AvoidUsingHardCodedIP") // Dear PMD, the version string in "deprecated since" is not an IP.
 public class OnlineIndexScrubber implements AutoCloseable {
 
     @Nonnull private final IndexingCommon common;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexScrubber.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexScrubber.java
@@ -126,21 +126,25 @@ public class OnlineIndexScrubber implements AutoCloseable {
      * A builder for the scrubbing policy.
      */
     public static class ScrubbingPolicy {
-        public static final ScrubbingPolicy DEFAULT = new ScrubbingPolicy(1000, true, 0, false, false);
+        public static final ScrubbingPolicy DEFAULT = new ScrubbingPolicy(1000, true, 0, false, false, 0, true);
         private final int logWarningsLimit;
         private final boolean allowRepair;
         private final long entriesScanLimit;
         private final boolean ignoreIndexTypeCheck;
         private final boolean useLegacy;
+        private final int rangeId;
+        private final boolean rangeReset;
 
         public ScrubbingPolicy(int logWarningsLimit, boolean allowRepair, long entriesScanLimit,
-                               boolean ignoreIndexTypeCheck, boolean useLgacy) {
+                               boolean ignoreIndexTypeCheck, boolean useLgacy, int rangeId, boolean rangeReset) {
 
             this.logWarningsLimit = logWarningsLimit;
             this.allowRepair = allowRepair;
             this.entriesScanLimit = entriesScanLimit;
             this.ignoreIndexTypeCheck = ignoreIndexTypeCheck;
             this.useLegacy = useLgacy;
+            this.rangeId = rangeId;
+            this.rangeReset = rangeReset;
         }
 
         boolean allowRepair() {
@@ -161,6 +165,14 @@ public class OnlineIndexScrubber implements AutoCloseable {
 
         public int getLogWarningsLimit() {
             return logWarningsLimit;
+        }
+
+        public int getRangeId() {
+            return rangeId;
+        }
+
+        public boolean isRangeReset() {
+            return rangeReset;
         }
 
         /**
@@ -187,6 +199,8 @@ public class OnlineIndexScrubber implements AutoCloseable {
             long entriesScanLimit = 0;
             boolean ignoreIndexTypeCheck = false;
             boolean useLegacy = false;
+            int rangeId = 0;
+            boolean rangeReset = false;
 
             protected Builder() {
             }
@@ -263,8 +277,32 @@ public class OnlineIndexScrubber implements AutoCloseable {
                 return this;
             }
 
+            /**
+             * Choose a specific "Already Scrubbed" rangeSet prefix. This may be useful for
+             * multiple scrubbing jobs that should not affect each other.
+             * 0 is the backward compatible default, which means no prefix.
+             * @param rangeId a rangeSet prefix
+             * @return this builder
+             */
+            public Builder setRangeId(final int rangeId) {
+                this.rangeId = rangeId;
+                return this;
+            }
+
+            /**
+             * If set to true, clear any previous "Already Scrubbed" range set - which means that the index scrubbing
+             * will begin from scratch.
+             * @param rangeReset reset if true
+             * @return this builder
+             */
+            public Builder setRangeReset(final boolean rangeReset) {
+                this.rangeReset = rangeReset;
+                return this;
+            }
+
             public ScrubbingPolicy build() {
-                return new ScrubbingPolicy(logWarningsLimit, allowRepair, entriesScanLimit, ignoreIndexTypeCheck, useLegacy);
+                return new ScrubbingPolicy(logWarningsLimit, allowRepair, entriesScanLimit, ignoreIndexTypeCheck,
+                        useLegacy, rangeId, rangeReset);
             }
         }
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexScrubber.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexScrubber.java
@@ -136,7 +136,7 @@ public class OnlineIndexScrubber implements AutoCloseable {
      * A builder for the scrubbing policy.
      */
     public static class ScrubbingPolicy {
-        public static final ScrubbingPolicy DEFAULT = new ScrubbingPolicy(1000, false, 0, false, false, 0, false);
+        public static final ScrubbingPolicy DEFAULT = new ScrubbingPolicy(1000, true, 0, false, false, 0, false);
         private final int logWarningsLimit;
         private final boolean allowRepair;
         private final long entriesScanLimit;
@@ -145,14 +145,15 @@ public class OnlineIndexScrubber implements AutoCloseable {
         private final int rangeId;
         private final boolean rangeReset;
 
+        @Deprecated(since = "4.2.2.1", forRemoval = true)
         public ScrubbingPolicy(int logWarningsLimit, boolean allowRepair, long entriesScanLimit,
-                               boolean ignoreIndexTypeCheck, boolean useLgacy, int rangeId, boolean rangeReset) {
+                               boolean ignoreIndexTypeCheck, boolean useLegacy, int rangeId, boolean rangeReset) {
 
             this.logWarningsLimit = logWarningsLimit;
             this.allowRepair = allowRepair;
             this.entriesScanLimit = entriesScanLimit;
             this.ignoreIndexTypeCheck = ignoreIndexTypeCheck;
-            this.useLegacy = useLgacy;
+            this.useLegacy = useLegacy;
             this.rangeId = rangeId;
             this.rangeReset = rangeReset;
         }
@@ -288,24 +289,25 @@ public class OnlineIndexScrubber implements AutoCloseable {
             }
 
             /**
-             * Choose a specific "Already Scrubbed" rangeSet prefix. This may be useful for
-             * multiple scrubbing jobs that may not affect each other.
+             * Choose a specific id for this scrubbing operation. If the scrubbing stops, then later it can be resumed
+             * at a later time by constructing the same builder.
+             * Work done with other ids will not affect work done with this id.
              * 0 is the backward compatible default, which means no prefix.
              * @param rangeId a rangeSet prefix
              * @return this builder
              */
-            public Builder setRangeId(final int rangeId) {
+            public Builder setScrubbingRangeId(final int rangeId) {
                 this.rangeId = rangeId;
                 return this;
             }
 
             /**
-             * If set to true, clear any previous "Already Scrubbed" range set (in the given rangeId) - which means that
-             * the index scrubbing will begin from scratch.
+             * Start the scrubbing from scratch, regardless of any progress already made for this scrubber range id
+             * (see {@link #setScrubbingRangeId(int)}).
              * @param rangeReset reset if true
              * @return this builder
              */
-            public Builder setRangeReset(final boolean rangeReset) {
+            public Builder setScrubbingRangeReset(final boolean rangeReset) {
                 this.rangeReset = rangeReset;
                 return this;
             }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexScrubber.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexScrubber.java
@@ -117,6 +117,16 @@ public class OnlineIndexScrubber implements AutoCloseable {
         return missingCount.get();
     }
 
+    /**
+     * Reset all index scrubbing data. This will make the index "forget" any previous index scrubbing
+     * sessions.
+     * This method was designed to be used as a global reset to clean unwanted partial index scrubbing information and
+     * should probably not be used as a routine.
+     */
+    public void eraseAllIndexingScrubbingData(@Nonnull FDBRecordContext context, @Nonnull FDBRecordStore store) {
+        IndexingSubspaces.eraseAllIndexingScrubbingData(context, store, common.getIndex());
+    }
+
     @Nonnull
     public static Builder newBuilder() {
         return new Builder();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
@@ -36,7 +36,6 @@ import com.apple.foundationdb.record.metadata.Key;
 import com.apple.foundationdb.record.metadata.MetaDataException;
 import com.apple.foundationdb.record.metadata.RecordType;
 import com.apple.foundationdb.record.provider.common.StoreTimer;
-import com.apple.foundationdb.subspace.Subspace;
 import com.apple.foundationdb.synchronizedsession.SynchronizedSession;
 import com.apple.foundationdb.tuple.Tuple;
 import com.google.common.annotations.VisibleForTesting;
@@ -403,7 +402,7 @@ public class OnlineIndexer implements AutoCloseable {
         return getRunner().runAsync(context -> openRecordStore(context).thenCompose(store -> {
             Transaction transaction = store.getContext().ensureActive();
             for (Index targetIndex: common.getTargetIndexes()) {
-                byte[] stampKey = indexBuildTypeSubspace(store, targetIndex).getKey();
+                byte[] stampKey = IndexingSubspaces.indexBuildTypeSubspace(store, targetIndex).getKey();
                 transaction.clear(stampKey);
             }
             return AsyncUtil.DONE;
@@ -616,7 +615,7 @@ public class OnlineIndexer implements AutoCloseable {
      * @param index the index whose builds need to be stopped
      */
     public static void stopOngoingOnlineIndexBuilds(@Nonnull FDBRecordStore recordStore, @Nonnull Index index) {
-        SynchronizedSession.endAnySession(recordStore.ensureContextActive(), indexBuildLockSubspace(recordStore, index));
+        SynchronizedSession.endAnySession(recordStore.ensureContextActive(), IndexingSubspaces.indexBuildLockSubspace(recordStore, index));
     }
 
     /**
@@ -645,7 +644,7 @@ public class OnlineIndexer implements AutoCloseable {
      * @return a future that will complete to <code>true</code> if the index is being built and <code>false</code> otherwise
      */
     public static CompletableFuture<Boolean> checkAnyOngoingOnlineIndexBuildsAsync(@Nonnull FDBRecordStore recordStore, @Nonnull Index index) {
-        return SynchronizedSession.checkActiveSessionExists(recordStore.ensureContextActive(), indexBuildLockSubspace(recordStore, index));
+        return SynchronizedSession.checkActiveSessionExists(recordStore.ensureContextActive(), IndexingSubspaces.indexBuildLockSubspace(recordStore, index));
     }
 
     /**
@@ -677,21 +676,6 @@ public class OnlineIndexer implements AutoCloseable {
     CompletableFuture<Void> buildIndexAsync(boolean markReadable) {
         boolean useSyncLock = (!indexingPolicy.isMutual() || fallbackToRecordsScan) && common.config.shouldUseSynchronizedSession();
         return indexingLauncher(() -> getIndexer().buildIndexAsync(markReadable, useSyncLock));
-    }
-
-    @Nonnull
-    private static Subspace indexBuildLockSubspace(@Nonnull FDBRecordStoreBase<?> store, @Nonnull Index index) {
-        return IndexingBase.indexBuildLockSubspace(store, index);
-    }
-
-    @Nonnull
-    protected static Subspace indexBuildScannedRecordsSubspace(@Nonnull FDBRecordStoreBase<?> store, @Nonnull Index index) {
-        return IndexingBase.indexBuildScannedRecordsSubspace(store, index);
-    }
-
-    @Nonnull
-    protected static Subspace indexBuildTypeSubspace(@Nonnull FDBRecordStoreBase<?> store, @Nonnull Index index) {
-        return IndexingBase.indexBuildTypeSubspace(store, index);
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexing/IndexingRangeSet.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexing/IndexingRangeSet.java
@@ -225,8 +225,8 @@ public class IndexingRangeSet {
      * @return a {@code WrappedRangeSet} for scrubbing the index's entries
      */
     @Nonnull
-    public static IndexingRangeSet forScrubbingIndex(@Nonnull FDBRecordStore store, @Nonnull Index index) {
-        RangeSet rangeSet = new RangeSet(IndexingBase.indexScrubIndexRangeSubspace(store, index));
+    public static IndexingRangeSet forScrubbingIndex(@Nonnull FDBRecordStore store, @Nonnull Index index, int rangeId) {
+        RangeSet rangeSet = new RangeSet(IndexingBase.indexScrubIndexRangeSubspace(store, index, rangeId));
         return new IndexingRangeSet(store.getRecordContext(), rangeSet);
     }
 
@@ -241,8 +241,8 @@ public class IndexingRangeSet {
      * @return a {@code WrappedRangeSet} for scrubbing the index's records
      */
     @Nonnull
-    public static IndexingRangeSet forScrubbingRecords(@Nonnull FDBRecordStore store, @Nonnull Index index) {
-        RangeSet rangeSet = new RangeSet(IndexingBase.indexScrubRecordsRangeSubspace(store, index));
+    public static IndexingRangeSet forScrubbingRecords(@Nonnull FDBRecordStore store, @Nonnull Index index, int rangeId) {
+        RangeSet rangeSet = new RangeSet(IndexingBase.indexScrubRecordsRangeSubspace(store, index, rangeId));
         return new IndexingRangeSet(store.getRecordContext(), rangeSet);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexing/IndexingRangeSet.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexing/IndexingRangeSet.java
@@ -254,7 +254,7 @@ public class IndexingRangeSet {
         final Subspace subspace;
         if (rangeId == 0) {
             // Backward compatible
-            subspace = IndexingSubspaces.indexScrubRecordsRangeSubspaceLegacy(store, index);
+            subspace = IndexingSubspaces.indexScrubRecordsRangeSubspaceZero(store, index);
         } else {
             subspace = IndexingSubspaces.indexScrubRecordsRangeSubspace(store, index).subspace(Tuple.from(rangeId));
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexing/IndexingRangeSet.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexing/IndexingRangeSet.java
@@ -30,7 +30,9 @@ import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStore;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
-import com.apple.foundationdb.record.provider.foundationdb.IndexingBase;
+import com.apple.foundationdb.record.provider.foundationdb.IndexingSubspaces;
+import com.apple.foundationdb.subspace.Subspace;
+import com.apple.foundationdb.tuple.Tuple;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -226,7 +228,14 @@ public class IndexingRangeSet {
      */
     @Nonnull
     public static IndexingRangeSet forScrubbingIndex(@Nonnull FDBRecordStore store, @Nonnull Index index, int rangeId) {
-        RangeSet rangeSet = new RangeSet(IndexingBase.indexScrubIndexRangeSubspace(store, index, rangeId));
+        final Subspace subspace;
+        if (rangeId == 0) {
+            // Backward compatible
+            subspace = IndexingSubspaces.indexScrubIndexRangeSubspaceLegacy(store, index);
+        } else {
+            subspace = IndexingSubspaces.indexScrubIndexRangeSubspace(store, index).subspace(Tuple.from(rangeId));
+        }
+        final RangeSet rangeSet = new RangeSet(subspace);
         return new IndexingRangeSet(store.getRecordContext(), rangeSet);
     }
 
@@ -242,7 +251,14 @@ public class IndexingRangeSet {
      */
     @Nonnull
     public static IndexingRangeSet forScrubbingRecords(@Nonnull FDBRecordStore store, @Nonnull Index index, int rangeId) {
-        RangeSet rangeSet = new RangeSet(IndexingBase.indexScrubRecordsRangeSubspace(store, index, rangeId));
+        final Subspace subspace;
+        if (rangeId == 0) {
+            // Backward compatible
+            subspace = IndexingSubspaces.indexScrubRecordsRangeSubspaceLegacy(store, index);
+        } else {
+            subspace = IndexingSubspaces.indexScrubRecordsRangeSubspace(store, index).subspace(Tuple.from(rangeId));
+        }
+        final RangeSet rangeSet = new RangeSet(subspace);
         return new IndexingRangeSet(store.getRecordContext(), rangeSet);
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreOpeningTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreOpeningTest.java
@@ -546,7 +546,7 @@ public class FDBRecordStoreOpeningTest extends FDBRecordStoreTestBase {
         // Delete everything except a value in the index build space
         try (FDBRecordContext context = openContext()) {
             FDBRecordStore store = storeBuilder.setContext(context).open();
-            final Subspace subspace = OnlineIndexer.indexBuildScannedRecordsSubspace(store, metaData.getIndex("MySimpleRecord$str_value_indexed"));
+            final Subspace subspace = IndexingSubspaces.indexBuildScannedRecordsSubspace(store, metaData.getIndex("MySimpleRecord$str_value_indexed"));
             context.ensureActive().set(subspace.getKey(), FDBRecordStore.encodeRecordCount(1215)); // set a key in the INDEX_BUILD_SPACE
             context.ensureActive().clear(store.getSubspace().getKey(), subspace.getKey());
             commit(context);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexScrubberTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexScrubberTest.java
@@ -367,8 +367,8 @@ class OnlineIndexScrubberTest extends OnlineIndexerTest {
 
     private ScrubbersMissingRanges getScrubbersMissingRange(Index index) {
         try (FDBRecordContext context = openContext()) {
-            Range indexes = IndexingRangeSet.forScrubbingIndex(recordStore, index).firstMissingRangeAsync().thenApply(Function.identity()).join();
-            Range records = IndexingRangeSet.forScrubbingRecords(recordStore, index).firstMissingRangeAsync().thenApply(Function.identity()).join();
+            Range indexes = IndexingRangeSet.forScrubbingIndex(recordStore, index, 0).firstMissingRangeAsync().thenApply(Function.identity()).join();
+            Range records = IndexingRangeSet.forScrubbingRecords(recordStore, index, 0).firstMissingRangeAsync().thenApply(Function.identity()).join();
             context.commit();
             return new ScrubbersMissingRanges(indexes, records);
         }


### PR DESCRIPTION
   Resolve #3297
   To allow users run different types of index scrubbing sessions, we should add the next items to the scrubbing policy:

   - scrubbing range reset: This will force the scrubber to start from scratch (default is false)
   - scrubbing range id: user can request to use another range set, not to disturb existing one (default, backward compatible, is range 0)
   - new scrubbing API function `eraseAllIndexingScrubbingData` can be used to delete all scrubbing data. This can be used as a scrubbing state cleanup. 