### PR TITLE
Fix connection name in Multiserver configs in YAML-tests

### DIFF
--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/SimpleYamlConnection.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/SimpleYamlConnection.java
@@ -41,10 +41,17 @@ public class SimpleYamlConnection implements YamlConnection {
     private final RelationalConnection underlying;
     @Nonnull
     private final List<SemanticVersion> versions;
+    @Nonnull
+    private final String connectionLabel;
 
     public SimpleYamlConnection(@Nonnull Connection connection, @Nonnull SemanticVersion version) throws SQLException {
+        this(connection, version, version.toString());
+    }
+
+    public SimpleYamlConnection(@Nonnull Connection connection, @Nonnull SemanticVersion version, @Nonnull String connectionLabel) throws SQLException {
         underlying = connection.unwrap(RelationalConnection.class);
         this.versions = List.of(version);
+        this.connectionLabel = connectionLabel;
     }
 
     @Override
@@ -93,5 +100,10 @@ public class SimpleYamlConnection implements YamlConnection {
     @Override
     public SemanticVersion getInitialVersion() {
         return versions.get(0);
+    }
+
+    @Override
+    public String toString() {
+        return connectionLabel;
     }
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCInProcessConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCInProcessConfig.java
@@ -74,6 +74,6 @@ public class JDBCInProcessConfig implements YamlTestConfig {
 
     @Override
     public String toString() {
-        return "JDBC In-Process";
+        return "JDBC In-Proc";
     }
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCInProcessConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCInProcessConfig.java
@@ -74,6 +74,6 @@ public class JDBCInProcessConfig implements YamlTestConfig {
 
     @Override
     public String toString() {
-        return "JDBC In-Proc";
+        return "JDBC In-Process";
     }
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCMultiServerConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCMultiServerConfig.java
@@ -64,9 +64,9 @@ public class JDBCMultiServerConfig extends JDBCInProcessConfig {
     @Override
     public String toString() {
         if (initialConnection == 0) {
-            return "MultiServer (Embedded then " + externalServer.getVersion() + ")";
+            return "MultiServer (" + super.toString() + " then " + externalServer.getVersion() + ")";
         } else {
-            return "MultiServer (" + externalServer.getVersion() + " then Embedded)";
+            return "MultiServer (" + externalServer.getVersion() + " then " + super.toString() + ")";
         }
     }
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/EmbeddedYamlConnectionFactory.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/EmbeddedYamlConnectionFactory.java
@@ -34,7 +34,7 @@ import java.util.Set;
 public class EmbeddedYamlConnectionFactory implements YamlConnectionFactory {
     @Override
     public YamlConnection getNewConnection(@Nonnull URI connectPath) throws SQLException {
-        return new SimpleYamlConnection(DriverManager.getConnection(connectPath.toString()), SemanticVersion.current());
+        return new SimpleYamlConnection(DriverManager.getConnection(connectPath.toString()), SemanticVersion.current(), "Embedded");
     }
 
     @Override

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/JDBCInProcessYamlConnectionFactory.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/JDBCInProcessYamlConnectionFactory.java
@@ -49,7 +49,7 @@ public class JDBCInProcessYamlConnectionFactory implements YamlConnectionFactory
         URI connectPathPlusServerName = JDBCURI.addQueryParameter(connectPath, JDBCURI.INPROCESS_URI_QUERY_SERVERNAME_KEY, server.getServerName());
         String uriStr = connectPathPlusServerName.toString().replaceFirst("embed:", "relational://");
         LOG.info("Rewrote {} as {}", connectPath, uriStr);
-        return new SimpleYamlConnection(DriverManager.getConnection(uriStr), SemanticVersion.current());
+        return new SimpleYamlConnection(DriverManager.getConnection(uriStr), SemanticVersion.current(), "JDBC In-Proc");
     }
 
     @Override

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/JDBCInProcessYamlConnectionFactory.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/JDBCInProcessYamlConnectionFactory.java
@@ -49,7 +49,7 @@ public class JDBCInProcessYamlConnectionFactory implements YamlConnectionFactory
         URI connectPathPlusServerName = JDBCURI.addQueryParameter(connectPath, JDBCURI.INPROCESS_URI_QUERY_SERVERNAME_KEY, server.getServerName());
         String uriStr = connectPathPlusServerName.toString().replaceFirst("embed:", "relational://");
         LOG.info("Rewrote {} as {}", connectPath, uriStr);
-        return new SimpleYamlConnection(DriverManager.getConnection(uriStr), SemanticVersion.current(), "JDBC In-Proc");
+        return new SimpleYamlConnection(DriverManager.getConnection(uriStr), SemanticVersion.current(), "JDBC In-Process");
     }
 
     @Override

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/MultiServerConnectionFactory.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/MultiServerConnectionFactory.java
@@ -227,7 +227,7 @@ public class MultiServerConnectionFactory implements YamlConnectionFactory {
             if (connectionSelectionPolicy == ConnectionSelectionPolicy.ALTERNATE) {
                 YamlConnection result = underlyingConnections.get(currentConnectionSelector);
                 if (logger.isInfoEnabled()) {
-                    logger.info("Sending operation {} to connection {}", op, currentConnectionSelector);
+                    logger.info("Sending operation {} to connection: {}", op, result.toString());
                 }
                 if (advance) {
                     currentConnectionSelector = (currentConnectionSelector + 1) % underlyingConnections.size();


### PR DESCRIPTION
While testing in YAML framework, I realized that a multiserver config like `MultiServer (4.0.575.0 then Embedded)` is actually connecting to 4.0.575.0 external server and JDBC in-process !current_version (instead of Embedded). This PR fixes this naming so as to avoid ambiguity. 

Also, `MultiServerConnection`s, while alternating their connections, logs operations like `Sending operation createStatement to connection 0` meaning, it is sending the current request to first (default, index 0) connection which is not super clear when debugging issues related to compatibility. This PR changes that log to explicitly specify the connection name. 