### PR TITLE
Make INDEX_SCRUBBED_INDEX_RANGES unique + more

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexScrubbing.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexScrubbing.java
@@ -87,8 +87,8 @@ public class IndexScrubbing extends IndexingBase {
         return Arrays.asList(
                 LogMessageKeys.INDEXING_METHOD, scrubberName,
                 LogMessageKeys.ALLOW_REPAIR, scrubbingPolicy.allowRepair(),
-                LogMessageKeys.RANGE_ID, scrubbingPolicy.getRangeId(),
-                LogMessageKeys.RANGE_RESET, scrubbingPolicy.isRangeReset(),
+                LogMessageKeys.RANGE_ID, scrubbingPolicy.getScrubbingRangeId(),
+                LogMessageKeys.RANGE_RESET, scrubbingPolicy.isScrubbingRangeReset(),
                 LogMessageKeys.SCRUB_TYPE, scrubbingType,
                 LogMessageKeys.SCAN_LIMIT, scrubbingPolicy.getEntriesScanLimit()
         );
@@ -233,9 +233,9 @@ public class IndexScrubbing extends IndexingBase {
     IndexingRangeSet getRangeset(FDBRecordStore store, Index index) {
         switch (scrubbingType) {
             case MISSING:
-                return IndexingRangeSet.forScrubbingRecords(store, index, scrubbingPolicy.getRangeId());
+                return IndexingRangeSet.forScrubbingRecords(store, index, scrubbingPolicy.getScrubbingRangeId());
             case DANGLING:
-                return IndexingRangeSet.forScrubbingIndex(store, index, scrubbingPolicy.getRangeId());
+                return IndexingRangeSet.forScrubbingIndex(store, index, scrubbingPolicy.getScrubbingRangeId());
             default:
                 throw new RecordCoreArgumentException("Unpredicted scrubbing type ");
         }
@@ -252,7 +252,7 @@ public class IndexScrubbing extends IndexingBase {
 
         final Index index = common.getIndex(); // Note: multi targets mode is not supported (yet)
         final IndexingRangeSet rangeSet = getRangeset(store, index);
-        if (scrubbingPolicy.isRangeReset()) {
+        if (scrubbingPolicy.isScrubbingRangeReset()) {
             logScrubberRangeReset("forced reset");
             rangeSet.clear();
             return AsyncUtil.DONE;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingScrubDangling.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingScrubDangling.java
@@ -88,8 +88,8 @@ public class IndexingScrubDangling extends IndexingBase {
         return Arrays.asList(
                 LogMessageKeys.INDEXING_METHOD, "scrub dangling index entries",
                 LogMessageKeys.ALLOW_REPAIR, scrubbingPolicy.allowRepair(),
-                LogMessageKeys.RANGE_ID, scrubbingPolicy.getRangeId(),
-                LogMessageKeys.RANGE_RESET, scrubbingPolicy.isRangeReset(),
+                LogMessageKeys.RANGE_ID, scrubbingPolicy.getScrubbingRangeId(),
+                LogMessageKeys.RANGE_RESET, scrubbingPolicy.isScrubbingRangeReset(),
                 LogMessageKeys.SCAN_LIMIT, scrubbingPolicy.getEntriesScanLimit()
         );
     }
@@ -149,7 +149,7 @@ public class IndexingScrubDangling extends IndexingBase {
         validateOrThrowEx(store.getIndexState(index).isScannable(), "scrubbed index is not readable");
 
         final ScanProperties scanProperties = scanPropertiesWithLimits(true);
-        final IndexingRangeSet rangeSet = IndexingRangeSet.forScrubbingIndex(store, index, scrubbingPolicy.getRangeId());
+        final IndexingRangeSet rangeSet = IndexingRangeSet.forScrubbingIndex(store, index, scrubbingPolicy.getScrubbingRangeId());
         return rangeSet.firstMissingRangeAsync().thenCompose(range -> {
             if (range == null) {
                 // Here: no more missing ranges - all done
@@ -258,8 +258,8 @@ public class IndexingScrubDangling extends IndexingBase {
                 "Not a scrubber type-stamp");
 
         final Index index = common.getIndex(); // Note: the scrubbers do not support multi target (yet)
-        IndexingRangeSet indexRangeSet = IndexingRangeSet.forScrubbingIndex(store, index, scrubbingPolicy.getRangeId());
-        if (scrubbingPolicy.isRangeReset()) {
+        IndexingRangeSet indexRangeSet = IndexingRangeSet.forScrubbingIndex(store, index, scrubbingPolicy.getScrubbingRangeId());
+        if (scrubbingPolicy.isScrubbingRangeReset()) {
             indexRangeSet.clear();
             if (LOGGER.isInfoEnabled()) {
                 LOGGER.info(KeyValueLogMessage.build("Reset index scrubbing range")

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingScrubMissing.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingScrubMissing.java
@@ -87,8 +87,8 @@ public class IndexingScrubMissing extends IndexingBase {
         return Arrays.asList(
                 LogMessageKeys.INDEXING_METHOD, "scrub missing index entries",
                 LogMessageKeys.ALLOW_REPAIR, scrubbingPolicy.allowRepair(),
-                LogMessageKeys.RANGE_ID, scrubbingPolicy.getRangeId(),
-                LogMessageKeys.RANGE_RESET, scrubbingPolicy.isRangeReset(),
+                LogMessageKeys.RANGE_ID, scrubbingPolicy.getScrubbingRangeId(),
+                LogMessageKeys.RANGE_RESET, scrubbingPolicy.isScrubbingRangeReset(),
                 LogMessageKeys.SCAN_LIMIT, scrubbingPolicy.getEntriesScanLimit()
         );
     }
@@ -147,7 +147,7 @@ public class IndexingScrubMissing extends IndexingBase {
         validateOrThrowEx(store.getIndexState(index).isScannable(), "scrubbed index is not readable");
 
         final ScanProperties scanProperties = scanPropertiesWithLimits(true);
-        final IndexingRangeSet rangeSet = IndexingRangeSet.forScrubbingRecords(store, index, scrubbingPolicy.getRangeId());
+        final IndexingRangeSet rangeSet = IndexingRangeSet.forScrubbingRecords(store, index, scrubbingPolicy.getScrubbingRangeId());
         return rangeSet.firstMissingRangeAsync().thenCompose(range -> {
             if (range == null) {
                 // Here: no more missing ranges - all done
@@ -284,8 +284,8 @@ public class IndexingScrubMissing extends IndexingBase {
                 "Not a scrubber type-stamp");
 
         final Index index = common.getIndex(); // Note: the scrubbers do not support multi target (yet)
-        IndexingRangeSet recordsRangeSet = IndexingRangeSet.forScrubbingRecords(store, index, scrubbingPolicy.getRangeId());
-        if (scrubbingPolicy.isRangeReset()) {
+        IndexingRangeSet recordsRangeSet = IndexingRangeSet.forScrubbingRecords(store, index, scrubbingPolicy.getScrubbingRangeId());
+        if (scrubbingPolicy.isScrubbingRangeReset()) {
             if (LOGGER.isInfoEnabled()) {
                 LOGGER.info(KeyValueLogMessage.build("Reset index scrubbing range")
                         .addKeysAndValues(common.indexLogMessageKeyValues())

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingSubspaces.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingSubspaces.java
@@ -38,8 +38,8 @@ public final class IndexingSubspaces {
     private static final Object INDEX_BUILD_TYPE_VERSION = 2L;
     private static final Object INDEX_SCRUBBED_INDEX_RANGES_ZERO = 3L;
     private static final Object INDEX_SCRUBBED_RECORDS_RANGES_ZERO = 4L;
-    private static final Object INDEX_SCRUBBED_INDEX_RANGES = 4L;
     private static final Object INDEX_SCRUBBED_RECORDS_RANGES = 5L;
+    private static final Object INDEX_SCRUBBED_INDEX_RANGES = 6L;
 
     private IndexingSubspaces() {
         throw new IllegalStateException("Utility class");
@@ -50,6 +50,12 @@ public final class IndexingSubspaces {
         return store.getUntypedRecordStore().indexBuildSubspace(index).subspace(Tuple.from(key));
     }
 
+    /**
+     * Subspace that stores the lock for a synced indexing session.
+     * @param store store
+     * @param index index
+     * @return subspace
+     */
     @Nonnull
     public static Subspace indexBuildLockSubspace(@Nonnull FDBRecordStoreBase<?> store, @Nonnull Index index) {
         return indexBuildSubspace(store, index, INDEX_BUILD_LOCK_KEY);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexScrubber.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexScrubber.java
@@ -146,8 +146,7 @@ public class OnlineIndexScrubber implements AutoCloseable {
         private final int rangeId;
         private final boolean rangeReset;
 
-        @Deprecated(since = "4.2.2.1", forRemoval = true)
-        public ScrubbingPolicy(int logWarningsLimit, boolean allowRepair, long entriesScanLimit,
+        private ScrubbingPolicy(int logWarningsLimit, boolean allowRepair, long entriesScanLimit,
                                boolean ignoreIndexTypeCheck, boolean useLegacy, int rangeId, boolean rangeReset) {
 
             this.logWarningsLimit = logWarningsLimit;
@@ -179,11 +178,11 @@ public class OnlineIndexScrubber implements AutoCloseable {
             return logWarningsLimit;
         }
 
-        public int getRangeId() {
+        public int getScrubbingRangeId() {
             return rangeId;
         }
 
-        public boolean isRangeReset() {
+        public boolean isScrubbingRangeReset() {
             return rangeReset;
         }
 
@@ -290,11 +289,11 @@ public class OnlineIndexScrubber implements AutoCloseable {
             }
 
             /**
-             * Choose a specific id for this scrubbing operation. If the scrubbing stops, then later it can be resumed
-             * at a later time by constructing the same builder.
+             * Choose a specific id for this scrubbing operation. If the scrubbing stops, then it can be resumed
+             * by constructing the same builder.
              * Work done with other ids will not affect work done with this id.
              * 0 is the backward compatible default, which means no prefix.
-             * @param rangeId a rangeSet prefix
+             * @param rangeId an id for isolating this scrubbing work
              * @return this builder
              */
             public Builder setScrubbingRangeId(final int rangeId) {


### PR DESCRIPTION
  Resolve #3305
1. Make `INDEX_SCRUBBED_INDEX_RANGES` unique (bug fix)
2. Make the constructor of `ScrubbingPolicy` private (it was never meant to be public)
3. Rename new `ScrubbingPolicy.getRangeId` to `getScrubbingRangeId`
4. Rename new `ScrubbingPolicy.isRangeReset` to `isScrubbingRangeReset`