### PR TITLE
Prevent setting the format version to an unsupported version

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -5184,6 +5184,10 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
         @Override
         @Nonnull
         public Builder setFormatVersion(int formatVersion) {
+            if (formatVersion < MIN_FORMAT_VERSION || formatVersion > MAX_SUPPORTED_FORMAT_VERSION) {
+                throw new UnsupportedFormatVersionException("Invalid Format Version")
+                        .addLogInfo(LogMessageKeys.FORMAT_VERSION, formatVersion);
+            }
             this.formatVersion = formatVersion;
             return this;
         }


### PR DESCRIPTION
FDBRecordStore.Builder.setFormatVersion takes an integer, but only a limited set are supported, we should prevent setting it to a value that is unsupported.

Resolves: #3308