### PR TITLE
Add support for record validation

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -1194,6 +1194,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
 
     @Nonnull
     @Override
+    @SuppressWarnings("PMD.CloseResource")
     public RecordCursor<Tuple> scanRecordKeys(@Nonnull final TupleRange range, @Nullable final byte[] continuation, @Nonnull final ScanProperties scanProperties) {
         if (scanProperties.isReverse()) {
             throw new UnsupportedOperationException("scanRecordKeys does not support reverse scan");

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBase.java
@@ -78,6 +78,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
@@ -883,6 +884,23 @@ public interface FDBRecordStoreBase<M extends Message> extends RecordMetaDataPro
                                                  @Nonnull EndpointType lowEndpoint, @Nonnull EndpointType highEndpoint,
                                                  @Nullable byte[] continuation,
                                                  @Nonnull ScanProperties scanProperties);
+
+    @Nonnull
+    RecordCursor<FDBRawRecord> scanRawRecords(@Nonnull TupleRange range, @Nullable byte[] continuation, @Nonnull ScanProperties scanProperties);
+
+    enum RecordValidationOptions {
+        RECORD_EXISTS,
+        VALID_KEY,
+        VALID_VERSION,
+        VALID_VALUE,
+        DESERIALIZABLE
+    }
+
+    default CompletableFuture<EnumSet<RecordValidationOptions>> validateRecordAsync(Tuple primaryKey, boolean allowRepair) {
+        return validateRecordAsync(primaryKey, EnumSet.allOf(RecordValidationOptions.class), allowRepair);
+    }
+
+    CompletableFuture<EnumSet<RecordValidationOptions>> validateRecordAsync(Tuple primaryKey, EnumSet<RecordValidationOptions> options, boolean allowRepair);
 
     /**
      * Count the number of records in the database in a range.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBTypedRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBTypedRecordStore.java
@@ -58,6 +58,7 @@ import com.google.protobuf.Message;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
@@ -181,6 +182,17 @@ public class FDBTypedRecordStore<M extends Message> implements FDBRecordStoreBas
     @Override
     public RecordCursor<FDBStoredRecord<M>> scanRecords(@Nullable Tuple low, @Nullable Tuple high, @Nonnull EndpointType lowEndpoint, @Nonnull EndpointType highEndpoint, @Nullable byte[] continuation, @Nonnull ScanProperties scanProperties) {
         return untypedStore.scanTypedRecords(typedSerializer, low, high, lowEndpoint, highEndpoint, continuation, scanProperties);
+    }
+
+    @Nonnull
+    @Override
+    public RecordCursor<FDBRawRecord> scanRawRecords(@Nonnull final TupleRange range, @Nullable final byte[] continuation, @Nonnull final ScanProperties scanProperties) {
+        return untypedStore.scanRawRecords(range, continuation, scanProperties);
+    }
+
+    @Override
+    public CompletableFuture<EnumSet<RecordValidationOptions>> validateRecordAsync(final Tuple primaryKey, final EnumSet<RecordValidationOptions> options, final boolean allowRepair) {
+        return untypedStore.validateRecordAsync(primaryKey, options, allowRepair);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBTypedRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBTypedRecordStore.java
@@ -186,8 +186,8 @@ public class FDBTypedRecordStore<M extends Message> implements FDBRecordStoreBas
 
     @Nonnull
     @Override
-    public RecordCursor<FDBRawRecord> scanRawRecords(@Nonnull final TupleRange range, @Nullable final byte[] continuation, @Nonnull final ScanProperties scanProperties) {
-        return untypedStore.scanRawRecords(range, continuation, scanProperties);
+    public RecordCursor<Tuple> scanRecordKeys(@Nonnull final TupleRange range, @Nullable final byte[] continuation, @Nonnull final ScanProperties scanProperties) {
+        return untypedStore.scanRecordKeys(range, continuation, scanProperties);
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/RecordKeyCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/RecordKeyCursor.java
@@ -1,0 +1,378 @@
+/*
+ * RecordKeyCursor.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb;
+
+import com.apple.foundationdb.KeyValue;
+import com.apple.foundationdb.async.AsyncUtil;
+import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.RecordCursorContinuation;
+import com.apple.foundationdb.record.RecordCursorResult;
+import com.apple.foundationdb.record.RecordCursorVisitor;
+import com.apple.foundationdb.record.ScanProperties;
+import com.apple.foundationdb.record.cursors.BaseCursor;
+import com.apple.foundationdb.record.cursors.CursorLimitManager;
+import com.apple.foundationdb.record.logging.KeyValueLogMessage;
+import com.apple.foundationdb.record.logging.LogMessageKeys;
+import com.apple.foundationdb.subspace.Subspace;
+import com.apple.foundationdb.tuple.ByteArrayUtil;
+import com.apple.foundationdb.tuple.ByteArrayUtil2;
+import com.apple.foundationdb.tuple.Tuple;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * This cursor may exceed out-of-band limits in order to ensure that it only ever stops in between (split) records.
+ * It is therefore unusual since it may exceed the record scan limit arbitrarily based on the size of the record
+ * and the maximum value size.
+ */
+public class RecordKeyCursor implements BaseCursor<Tuple> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RecordKeyCursor.class);
+
+    @Nonnull
+    private final FDBRecordContext context;
+    @Nonnull
+    private final RecordCursor<KeyValue> inner;
+    private final boolean oldVersionFormat;
+    @Nonnull
+    private final SplitHelper.SizeInfo sizeInfo;
+    @Nonnull
+    private final Subspace subspace;
+    @Nullable
+    private Tuple next;
+    @Nullable
+    private Tuple nextKey;
+    @Nullable
+    private Subspace nextSubspace;
+    @Nullable
+    private FDBRecordVersion nextVersion;
+    @Nullable
+    private byte[] nextPrefix;
+    private long nextIndex;
+    @Nullable
+    private NoNextReason innerNoNextReason;
+    @Nullable
+    private RecordCursorResult<KeyValue> pending;
+    @Nullable
+    private RecordCursorContinuation continuation;
+    @Nonnull
+    private final CursorLimitManager limitManager;
+    private long readLastKeyNanos = 0L; // for logging purposes
+
+    // for supporting old cursor API
+    @Nullable
+    private RecordCursorResult<Tuple> nextResult;
+
+    public RecordKeyCursor(@Nonnull FDBRecordContext context, @Nonnull final Subspace subspace,
+                              @Nonnull final RecordCursor<KeyValue> inner, final boolean oldVersionFormat,
+                              @Nullable final SplitHelper.SizeInfo sizeInfo, @Nonnull ScanProperties scanProperties) {
+        this(context, subspace, inner, oldVersionFormat, sizeInfo, new CursorLimitManager(scanProperties));
+    }
+
+    public RecordKeyCursor(@Nonnull FDBRecordContext context, @Nonnull final Subspace subspace,
+                              @Nonnull final RecordCursor<KeyValue> inner, final boolean oldVersionFormat,
+                              @Nullable final SplitHelper.SizeInfo sizeInfo,
+                           @Nonnull CursorLimitManager limitManager) {
+        this.context = context;
+        this.subspace = subspace;
+        this.inner = inner;
+        this.oldVersionFormat = oldVersionFormat;
+        this.sizeInfo = sizeInfo == null ? new SplitHelper.SizeInfo() : sizeInfo;
+        this.limitManager = limitManager;
+    }
+
+    @Nonnull
+    @Override
+    public CompletableFuture<RecordCursorResult<Tuple>> onNext() {
+        if (nextResult != null && !nextResult.hasNext()) {
+            return CompletableFuture.completedFuture(nextResult);
+        }
+        if (limitManager.isStopped()) {
+            final NoNextReason noNextReason = mergeNoNextReason();
+            if (noNextReason.isSourceExhausted()) {
+                // Can happen if the limit is reached while reading the final record, so the inner cursor
+                // completes with SOURCE_EXHAUSTED
+                nextResult = RecordCursorResult.exhausted();
+            } else {
+                nextResult = RecordCursorResult.withoutNextValue(continuation, mergeNoNextReason());
+            }
+            return CompletableFuture.completedFuture(nextResult);
+        } else {
+            return appendUntilNewKey().thenApply(vignore -> {
+                if (nextVersion != null && next == null) {
+                    throw new SplitHelper.FoundSplitWithoutStartException(SplitHelper.RECORD_VERSION, false)
+                            .addLogInfo(LogMessageKeys.KEY_TUPLE, nextKey)
+                            .addLogInfo(LogMessageKeys.SUBSPACE, ByteArrayUtil2.loggable(subspace.pack()))
+                            .addLogInfo(LogMessageKeys.VERSION, nextVersion);
+                }
+                if (!oldVersionFormat && nextKey != null) {
+                    // Account for incomplete version
+                    final byte[] versionKey = subspace.subspace(nextKey).pack(SplitHelper.RECORD_VERSION);
+                    context.getLocalVersion(versionKey).ifPresent(localVersion -> {
+                        nextVersion = FDBRecordVersion.incomplete(localVersion);
+                        sizeInfo.setVersionedInline(true);
+                        sizeInfo.setKeyCount(sizeInfo.getKeyCount() + 1);
+                        sizeInfo.setKeySize(sizeInfo.getKeySize() + versionKey.length);
+                        sizeInfo.setValueSize(sizeInfo.getValueSize() + 1 + FDBRecordVersion.VERSION_LENGTH);
+                    });
+                }
+
+                if (next == null) { // no next result
+                    nextResult = RecordCursorResult.withoutNextValue(continuation, mergeNoNextReason());
+                    if (LOGGER.isTraceEnabled()) {
+                        LOGGER.trace(KeyValueLogMessage.of("unsplitter stopped",
+                                LogMessageKeys.NEXT_CONTINUATION, continuation == null ? "null" : ByteArrayUtil2.loggable(continuation.toBytes()),
+                                LogMessageKeys.NO_NEXT_REASON, nextResult.getNoNextReason(),
+                                LogMessageKeys.SUBSPACE, ByteArrayUtil2.loggable(subspace.getKey())));
+                    }
+                } else { // has next result
+                    sizeInfo.setVersionedInline(nextVersion != null);
+                    final Tuple result = nextKey;
+                    next = null;
+                    nextKey = null;
+                    nextVersion = null;
+                    nextPrefix = null;
+                    nextResult = RecordCursorResult.withNextValue(result, continuation);
+                    if (LOGGER.isTraceEnabled()) {
+                        KeyValueLogMessage msg = KeyValueLogMessage.build("unsplitter assembled new record",
+                                LogMessageKeys.NEXT_CONTINUATION, continuation == null ? "null" : ByteArrayUtil2.loggable(continuation.toBytes()),
+                                LogMessageKeys.KEY_TUPLE, result,
+                                LogMessageKeys.SUBSPACE, ByteArrayUtil2.loggable(subspace.getKey()));
+                        LOGGER.trace(msg.toString());
+                    }
+                }
+                return nextResult;
+            });
+        }
+    }
+
+    @Nonnull
+    @Override
+    public RecordCursorResult<Tuple> getNext() {
+        return context.asyncToSync(FDBStoreTimer.Waits.WAIT_ADVANCE_CURSOR, onNext());
+    }
+
+    @Nonnull
+    public NoNextReason mergeNoNextReason() {
+        if (innerNoNextReason == NoNextReason.SOURCE_EXHAUSTED) {
+            return innerNoNextReason;
+        }
+        return limitManager.getStoppedReason().orElse(innerNoNextReason);
+    }
+
+    @Override
+    public void close() {
+        inner.close();
+    }
+
+    @Override
+    public boolean isClosed() {
+        return inner.isClosed();
+    }
+
+    @Nonnull
+    @Override
+    public Executor getExecutor() {
+        return inner.getExecutor();
+    }
+
+    @Override
+    public boolean accept(@Nonnull RecordCursorVisitor visitor) {
+        if (visitor.visitEnter(this)) {
+            inner.accept(visitor);
+        }
+        return visitor.visitLeave(this);
+    }
+
+    // Process all elements from the scan until we get a new primary key
+    @SuppressWarnings("PMD.UnnecessaryLocalBeforeReturn") // Name and negation make it much clearer as is
+    private CompletableFuture<Void> appendUntilNewKey() {
+        return AsyncUtil.whileTrue(() -> {
+            if (pending != null) {
+                boolean complete = append(pending);
+                pending = null;
+                if (complete) {
+                    // Split followed by unsplit; available right away.
+                    return AsyncUtil.READY_FALSE;
+                }
+            }
+            return inner.onNext().thenApply(innerResult -> {
+                if (!innerResult.hasNext()) {
+                    innerNoNextReason = innerResult.getNoNextReason();
+                    // If we already built up some values, then we already cached an appropriate continuation.
+                    // If we haven't the continuation might have changed so we need to refresh it.
+                    if (next == null) {
+                        continuation = innerResult.getContinuation();
+                    }
+                    if (LOGGER.isTraceEnabled()) {
+                        LOGGER.trace(KeyValueLogMessage.of("unsplitter inner cursor stopped",
+                                LogMessageKeys.NEXT_CONTINUATION, continuation == null ? "null" : ByteArrayUtil2.loggable(continuation.toBytes()),
+                                LogMessageKeys.NO_NEXT_REASON, innerNoNextReason,
+                                LogMessageKeys.SUBSPACE, ByteArrayUtil2.loggable(subspace.getKey())
+                        ));
+                    }
+                    return false;
+                } else {
+                    innerNoNextReason = null; // currently, we have a next value
+                    limitManager.tryRecordScan();
+                    boolean complete = append(innerResult);
+                    return !complete;
+                }
+            });
+        }, inner.getExecutor());
+    }
+
+    // Process the next key-value pair from the inner cursor; return whether unsplit complete.
+    protected boolean append(@Nonnull RecordCursorResult<KeyValue> resultWithKv) {
+        @Nonnull KeyValue kv = resultWithKv.get(); // KeyValue is non-null since we only pass in a result that has one
+        limitManager.reportScannedBytes(kv.getKey().length + kv.getValue().length);
+        if (nextPrefix == null) {
+            continuation = resultWithKv.getContinuation();
+            return appendFirst(kv);
+        } else if (ByteArrayUtil.startsWith(kv.getKey(), nextPrefix)) {
+            continuation = resultWithKv.getContinuation();
+            return appendNext(kv);
+        } else {
+            pending = resultWithKv;
+            logEndFound();
+            return true;
+        }
+    }
+
+    // Process the first key-value pair for a given record; return whether the record is complete
+    private boolean appendFirst(@Nonnull KeyValue kv) {
+        final Tuple keyTuple = subspace.unpack(kv.getKey());
+        nextKey = keyTuple.popBack(); // Remove index item
+        nextSubspace = subspace.subspace(nextKey);
+        nextPrefix = nextSubspace.pack();
+        next = Tuple.fromBytes(nextPrefix);
+        nextIndex = keyTuple.getLong(keyTuple.size() - 1);
+        sizeInfo.set(kv);
+        boolean done;
+        if (nextIndex == SplitHelper.UNSPLIT_RECORD) {
+            // First key is an unsplit record key. Since this is going
+            // in the forward direction, this is the only key
+            sizeInfo.setSplit(false);
+            done = true;
+        } else if (nextIndex == SplitHelper.RECORD_VERSION) {
+            if (oldVersionFormat) {
+                throw new RecordCoreException("Found record version when old format specified")
+                        .addLogInfo(LogMessageKeys.KEY, ByteArrayUtil2.loggable(kv.getKey()))
+                        .addLogInfo(LogMessageKeys.KEY_TUPLE, keyTuple);
+            }
+            // First key is a record version. This should only happen in
+            // the forward scan direction, so if this happens in
+            // the reverse direction, it means that there isn't any
+            // data associated with the record, but there is a version.
+            sizeInfo.setVersionedInline(true);
+            nextVersion = SplitHelper.unpackVersion(kv.getValue());
+            next = null;
+            done = false;
+        } else if (nextIndex == SplitHelper.START_SPLIT_RECORD) {
+            // The data is at the beginning of the split
+            sizeInfo.setSplit(true);
+            done = false;
+        } else {
+            throw new SplitHelper.FoundSplitWithoutStartException(nextIndex, false)
+                    .addLogInfo(LogMessageKeys.KEY, ByteArrayUtil2.loggable(kv.getKey()))
+                    .addLogInfo(LogMessageKeys.KEY_TUPLE, keyTuple);
+        }
+        logFirstKey(done);
+        return done;
+    }
+
+    // Process the key-value pair (other than the first one) for a given record; return whether the record is complete
+    private boolean appendNext(@Nonnull KeyValue kv) {
+        long index = nextSubspace.unpack(kv.getKey()).getLong(0);
+        sizeInfo.add(kv);
+        boolean done;
+        if (nextIndex == SplitHelper.RECORD_VERSION && (index == SplitHelper.UNSPLIT_RECORD || index == SplitHelper.START_SPLIT_RECORD)) {
+            // The first key (in a forward) scan was a version. Set the key (so far) to be
+            // just what has been read from this key. If it is the beginning of
+            // a split record, we have more to do. Otherwise, we know this is the
+            // end of the record.
+            next = Tuple.fromBytes(nextPrefix);
+            nextIndex = index;
+            sizeInfo.setSplit(index == SplitHelper.START_SPLIT_RECORD);
+            done = nextIndex == SplitHelper.UNSPLIT_RECORD;
+        } else if (index == nextIndex + 1) {
+            // This is the second or later key (not counting a possible version key)
+            // in the forward scan. Append its value to the end of the current
+            // key-value pair being accumulated. Return false because there is
+            // no way to know if this is the last key or not.
+            next = Tuple.fromBytes(nextPrefix);
+            nextIndex = index;
+            done = false;
+        } else {
+            if (nextIndex == SplitHelper.RECORD_VERSION) {
+                throw new SplitHelper.FoundSplitWithoutStartException(index, false)
+                        .addLogInfo(LogMessageKeys.KEY, ByteArrayUtil2.loggable(kv.getKey()))
+                        .addLogInfo(LogMessageKeys.KEY_TUPLE, nextKey)
+                        .addLogInfo(LogMessageKeys.SUBSPACE, ByteArrayUtil2.loggable(subspace.pack()));
+            } else {
+                throw new RecordCoreException("Split record segments out of order")
+                        .addLogInfo(LogMessageKeys.KEY, ByteArrayUtil2.loggable(kv.getKey()))
+                        .addLogInfo(LogMessageKeys.KEY_TUPLE, nextKey)
+                        .addLogInfo(LogMessageKeys.EXPECTED_INDEX, nextIndex +  1)
+                        .addLogInfo(LogMessageKeys.FOUND_INDEX, index)
+                        .addLogInfo(LogMessageKeys.SUBSPACE, ByteArrayUtil2.loggable(subspace.pack()));
+            }
+        }
+        logNextKey(done);
+        return done;
+    }
+
+    private void logFirstKey(boolean done) {
+        logKey("found first key in new split record", done);
+    }
+
+    private void logNextKey(boolean done) {
+        logKey("found next key in split record", done);
+    }
+
+    private void logEndFound() {
+        logKey("end key found for split record", true);
+    }
+
+    private void logKey(@Nonnull String staticMessage, boolean done) {
+        if (LOGGER.isTraceEnabled()) {
+            KeyValueLogMessage msg = KeyValueLogMessage.build(staticMessage,
+                    LogMessageKeys.KEY_TUPLE, nextKey,
+                    LogMessageKeys.SPLIT_REVERSE, false,
+                    LogMessageKeys.SPLIT_NEXT_INDEX, nextIndex,
+                    LogMessageKeys.KNOWN_LAST_KEY, done,
+                    LogMessageKeys.SUBSPACE, ByteArrayUtil2.loggable(subspace.getKey()));
+            sizeInfo.addSizeLogInfo(msg);
+            long currentNanos = System.nanoTime();
+            if (readLastKeyNanos != 0) {
+                msg.addKeyAndValue(LogMessageKeys.READ_LAST_KEY_MICROS, TimeUnit.NANOSECONDS.toMicros(currentNanos - readLastKeyNanos));
+            }
+            readLastKeyNanos = currentNanos;
+            LOGGER.trace(msg.toString());
+        }
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/RecordValidationHelper.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/RecordValidationHelper.java
@@ -29,6 +29,8 @@ import java.util.EnumSet;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 
+// TODO: Add logs
+
 public class RecordValidationHelper {
     public static CompletableFuture<EnumSet<FDBRecordStoreBase.RecordValidationOptions>> validateRecordAsync(
             final FDBRecordStore store,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/RecordValidationHelper.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/RecordValidationHelper.java
@@ -1,0 +1,80 @@
+/*
+ * RecordValidationHelper.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb;
+
+import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.tuple.Tuple;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.EnumSet;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+public class RecordValidationHelper {
+    public static CompletableFuture<EnumSet<FDBRecordStoreBase.RecordValidationOptions>> validateRecordAsync(
+            final FDBRecordStore store,
+            final Tuple primaryKey,
+            final EnumSet<FDBRecordStoreBase.RecordValidationOptions> options,
+            final boolean allowRepair) {
+
+        if (allowRepair) {
+            throw new UnsupportedOperationException("Allow repair is not yet supported");
+        }
+
+        // TODO: Do we want to load the raw record and deserialize separately?
+        return store.loadRecordAsync(primaryKey).handle((rec, exception) -> {
+            EnumSet<FDBRecordStoreBase.RecordValidationOptions> result = EnumSet.noneOf(FDBRecordStoreBase.RecordValidationOptions.class);
+            if (exception != null) {
+                if (exception instanceof CompletionException) {
+                    exception = exception.getCause();
+                }
+                if ((exception instanceof SplitHelper.FoundSplitWithoutStartException) ||
+                        (exception instanceof SplitHelper.FoundSplitOutOfOrderException) ||
+                        (exception instanceof FDBRecordStore.RecordDeserializationException)) {
+                    if (options.contains(FDBRecordStoreBase.RecordValidationOptions.VALID_VALUE)) {
+                        result.add(FDBRecordStoreBase.RecordValidationOptions.VALID_VALUE);
+                    }
+                } else {
+                    throw new UnknownValidationException("Unknown exception caught", exception);
+                }
+            } else {
+                if (rec == null) {
+                    if (options.contains(FDBRecordStoreBase.RecordValidationOptions.RECORD_EXISTS)) {
+                        result.add(FDBRecordStoreBase.RecordValidationOptions.RECORD_EXISTS);
+                    }
+                } else if ( ! rec.hasVersion()) {
+                    if (options.contains(FDBRecordStoreBase.RecordValidationOptions.VALID_VERSION)) {
+                        result.add(FDBRecordStoreBase.RecordValidationOptions.VALID_VERSION);
+                    }
+                }
+            }
+            return result;
+        });
+    }
+
+    @SuppressWarnings({"serial"})
+    public static class UnknownValidationException extends RecordCoreException {
+        public UnknownValidationException(@Nonnull final String msg, @Nullable final Throwable cause) {
+            super(msg, cause);
+        }
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/SplitHelper.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/SplitHelper.java
@@ -770,8 +770,7 @@ public class SplitHelper {
                 sizeInfo.add(kv);
             } else {
                 if (lastIndex >= SplitHelper.START_SPLIT_RECORD) {
-                    throw new RecordCoreException("Split record segments out of order: expected " +
-                                                  lastIndex + 1 + ", found " + index)
+                    throw new FoundSplitOutOfOrderException(lastIndex + 1, index)
                             .addLogInfo(LogMessageKeys.KEY_TUPLE, key)
                             .addLogInfo(LogMessageKeys.SUBSPACE, ByteArrayUtil2.loggable(keySplitSubspace.pack()));
                 } else {
@@ -1163,6 +1162,18 @@ public class SplitHelper {
             super("Found split record without start");
             addLogInfo(LogMessageKeys.SPLIT_NEXT_INDEX, nextIndex);
             addLogInfo(LogMessageKeys.SPLIT_REVERSE, reverse);
+        }
+    }
+
+    /**
+     * Exception thrown when splits are out of order.
+     */
+    @SuppressWarnings("serial")
+    public static class FoundSplitOutOfOrderException extends RecordCoreException {
+        public FoundSplitOutOfOrderException(long expected, long found) {
+            super("Found split record out of order");
+            addLogInfo(LogMessageKeys.EXPECTED_INDEX, expected);
+            addLogInfo(LogMessageKeys.FOUND_INDEX, found);
         }
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreConcurrentTestBase.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreConcurrentTestBase.java
@@ -91,6 +91,13 @@ public class FDBRecordStoreConcurrentTestBase {
         return Pair.of(store, setupPlanner(store, null));
     }
 
+    protected FDBRecordStore createOrOpenRecordStore(@Nonnull FDBRecordContext context,
+                                                     @Nonnull RecordMetaDataProvider metaData,
+                                                     @Nonnull final KeySpacePath path,
+                                                     final int formatVersion) {
+        return getStoreBuilder(context, metaData, path, formatVersion).createOrOpen();
+    }
+
     public QueryPlanner setupPlanner(@Nonnull FDBRecordStore recordStore, @Nullable PlannableIndexTypes indexTypes) {
         final QueryPlanner planner;
         if (useCascadesPlanner) {
@@ -112,8 +119,17 @@ public class FDBRecordStoreConcurrentTestBase {
     protected FDBRecordStore.Builder getStoreBuilder(@Nonnull FDBRecordContext context,
                                                      @Nonnull RecordMetaDataProvider metaData,
                                                      @Nonnull final KeySpacePath path) {
+        // set to max format version to test newest features (unsafe for real deployments)
+        return getStoreBuilder(context, metaData, path, FDBRecordStore.MAX_SUPPORTED_FORMAT_VERSION);
+    }
+
+    @Nonnull
+    protected FDBRecordStore.Builder getStoreBuilder(@Nonnull FDBRecordContext context,
+                                                     @Nonnull RecordMetaDataProvider metaData,
+                                                     @Nonnull final KeySpacePath path,
+                                                     final int formatVersion) {
         return FDBRecordStore.newBuilder()
-                .setFormatVersion(FDBRecordStore.MAX_SUPPORTED_FORMAT_VERSION) // set to max to test newest features (unsafe for real deployments)
+                .setFormatVersion(formatVersion)
                 .setKeySpacePath(path)
                 .setContext(context)
                 .setMetaDataProvider(metaData);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreTestBase.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreTestBase.java
@@ -118,6 +118,10 @@ public abstract class FDBRecordStoreTestBase extends FDBRecordStoreConcurrentTes
         return recordStoreQueryPlannerPair;
     }
 
+    public FDBRecordStore openSimpleRecordStore(FDBRecordContext context, @Nullable RecordMetaDataHook hook, final int formatVersion) {
+        return createOrOpenRecordStore(context, simpleMetaData(hook), path, formatVersion);
+    }
+
     @Nonnull
     protected FDBRecordStore.Builder getStoreBuilder(@Nonnull FDBRecordContext context, @Nonnull RecordMetaData metaData) {
         return getStoreBuilder(context, metaData, path);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreTestBase.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreTestBase.java
@@ -75,8 +75,13 @@ public abstract class FDBRecordStoreTestBase extends FDBRecordStoreConcurrentTes
     }
 
     @Nonnull
+    public static Stream<Integer> formatVersions() {
+        return Stream.of(FDBRecordStore.SAVE_UNSPLIT_WITH_SUFFIX_FORMAT_VERSION - 1, FDBRecordStore.SAVE_UNSPLIT_WITH_SUFFIX_FORMAT_VERSION, FDBRecordStore.MAX_SUPPORTED_FORMAT_VERSION);
+    }
+
+    @Nonnull
     public static Stream<Arguments> formatVersionAndSplitArgs() {
-        return Stream.of(FDBRecordStore.SAVE_UNSPLIT_WITH_SUFFIX_FORMAT_VERSION - 1, FDBRecordStore.SAVE_UNSPLIT_WITH_SUFFIX_FORMAT_VERSION, FDBRecordStore.MAX_SUPPORTED_FORMAT_VERSION)
+        return formatVersions()
                 .flatMap(formatVersion -> Stream.of(Arguments.of(formatVersion, false), Arguments.of(formatVersion, true)));
     }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RecordKeyCursorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RecordKeyCursorTest.java
@@ -20,10 +20,10 @@
 
 package com.apple.foundationdb.record.provider.foundationdb;
 
-import com.apple.foundationdb.KeyValue;
 import com.apple.foundationdb.record.ExecuteProperties;
-import com.apple.foundationdb.record.RecordCursor;
-import com.apple.foundationdb.record.RecordMetaData;
+import com.apple.foundationdb.record.IsolationLevel;
+import com.apple.foundationdb.record.RecordCursorContinuation;
+import com.apple.foundationdb.record.RecordCursorResult;
 import com.apple.foundationdb.record.ScanProperties;
 import com.apple.foundationdb.record.TestRecords1Proto;
 import com.apple.foundationdb.record.TupleRange;
@@ -35,16 +35,18 @@ import com.google.common.base.Strings;
 import com.google.protobuf.Message;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import javax.annotation.Nonnull;
-import java.util.EnumSet;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Stream;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 // TODO: Add omitUnsplitRecordSuffix, remove formatVersion
 
@@ -52,177 +54,231 @@ public class RecordKeyCursorTest extends FDBRecordStoreTestBase {
     @ParameterizedTest(name = "testIterateRecordsNoIssue [splitLongRecords = {0}]")
     @BooleanSource()
     public void testIterateRecordsNoIssue(boolean splitLongRecords) throws Exception {
-//    @Test
-//    public void testIterateRecordsNoIssue() throws Exception {
-//        boolean splitLongRecords = true;
-
-        final RecordMetaDataHook hook = metaData -> {
-            metaData.setSplitLongRecords(splitLongRecords);
-            // index cannot be used with large fields
-            metaData.removeIndex("MySimpleRecord$str_value_indexed");
-        };
-        final List<FDBStoredRecord<Message>> result = saveRecords(splitLongRecords, hook);
+        final RecordMetaDataHook hook = getRecordMetaDataHook(splitLongRecords);
+        saveRecords(splitLongRecords, hook, 100);
 
         // Scan records
+        final List<Tuple> actualKeys;
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, hook);
-            final Subspace recordsSubspace = recordStore.recordsSubspace();
-            final SplitHelper.SizeInfo sizeInfo = new SplitHelper.SizeInfo();
-            RecordCursor<KeyValue> inner = KeyValueCursor.Builder
-                    .withSubspace(recordsSubspace)
-                    .setContext(context)
-                    .setContinuation(null)
-                    .setRange(TupleRange.allOf(null))
-                    .setScanProperties(ScanProperties.FORWARD_SCAN)
-                    .build();
-            final RecordKeyCursor recordKeyCursor = new RecordKeyCursor(context, recordsSubspace, inner, false, sizeInfo, ScanProperties.FORWARD_SCAN);
-
-            final List<Tuple> keys = recordKeyCursor.asList().get();
+            actualKeys = scanKeys(context, null, false);
             // TODO: limit manager, Skip, limit etc.
-
             context.commit();
         }
+        List<Tuple> expectedKeys = IntStream.range(1, 101).boxed().map(Tuple::from).collect(Collectors.toList());
+        assertEquals(expectedKeys, actualKeys);
     }
 
-    @ParameterizedTest(name = "testValidateRecordsMissingRecord [formatVersion = {0}, splitLongRecords = {1}]")
-    @MethodSource("formatVersionAndSplitArgs")
-    public void testValidateRecordsMissingRecord(int formatVersion, boolean splitLongRecords) throws Exception {
-        final RecordMetaDataHook hook = metaData -> {
-            metaData.setSplitLongRecords(splitLongRecords);
-            // index cannot be used with large fields
-            metaData.removeIndex("MySimpleRecord$str_value_indexed");
-        };
-        List<FDBStoredRecord<Message>> result = saveRecords(splitLongRecords, hook);
+    @ParameterizedTest(name = "testIterateRecordsNoIssueWithContinuation [splitLongRecords = {0}]")
+    @BooleanSource()
+    public void testIterateRecordsNoIssueWithContinuation(boolean splitLongRecords) throws Exception {
+        final RecordMetaDataHook hook = getRecordMetaDataHook(splitLongRecords);
+        saveRecords(splitLongRecords, hook, 100);
+
+        // Scan records
+        final List<Tuple> actualKeys;
+        final List<FDBRawRecord> actualKeysOld;
+        ExecuteProperties executeProperties = ExecuteProperties.newBuilder()
+                .setReturnedRowLimit(19) // TODO: It seems we're only getting 10 results back with limit of 19
+                .setIsolationLevel(IsolationLevel.SERIALIZABLE)
+                .build();
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, hook);
+            actualKeys = scanKeys(context, new ScanProperties(executeProperties), true);
+            context.commit();
+        }
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, hook);
+            actualKeysOld = scanKeysOld(context, new ScanProperties(executeProperties), true);
+            context.commit();
+        }
+        List<Tuple> expectedKeys = IntStream.range(1, 101).boxed().map(Tuple::from).collect(Collectors.toList());
+        assertEquals(expectedKeys, actualKeys);
+    }
+
+    @ParameterizedTest(name = "testIterateRecordsMissingRecord [splitLongRecords = {0}]")
+    @BooleanSource
+    public void testIterateRecordsMissingRecord(boolean splitLongRecords) throws Exception {
+        final RecordMetaDataHook hook = getRecordMetaDataHook(splitLongRecords);
+        List<FDBStoredRecord<Message>> result = saveRecords(splitLongRecords, hook, 100);
         // Delete a record
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, hook);
-            recordStore.deleteRecord(result.get(0).getPrimaryKey());
+            // Note that the PK start with 1, so the location is one-off when removed
+            recordStore.deleteRecord(result.get(20).getPrimaryKey());
+            recordStore.deleteRecord(result.get(21).getPrimaryKey());
+            recordStore.deleteRecord(result.get(22).getPrimaryKey());
+            recordStore.deleteRecord(result.get(23).getPrimaryKey());
             commit(context);
         }
-        // Validate by primary key
+        final List<Tuple> actualKeys;
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, hook);
-            validateRecord(result.get(0), FDBRecordStoreBase.RecordValidationOptions.RECORD_EXISTS);
-            validateRecord(result.get(1), null);
+            actualKeys = scanKeys(context, null, false);
             context.commit();
         }
+        List<Tuple> expectedKeys = IntStream.range(1, 101).filter(i -> !Set.of(21, 22, 23, 24).contains(i)).boxed().map(Tuple::from).collect(Collectors.toList());
+        assertEquals(expectedKeys, actualKeys);
     }
 
-    @Nonnull
-    public static Stream<Arguments> formatVersionAndSplitNumber() {
-        return formatVersions()
-                .flatMap(formatVersion -> Stream.of(
-                        Arguments.of(formatVersion, 0),
-                        Arguments.of(formatVersion, 1),
-                        Arguments.of(formatVersion, 2),
-                        Arguments.of(formatVersion, 3)));
-    }
-
-    @ParameterizedTest(name = "testValidateRecordsMissingSplit [formatVersion = {0}, splitNumber = {1}]")
-    @MethodSource("formatVersionAndSplitNumber")
-    public void testValidateRecordsMissingSplit(int formatVersion, int splitNumber) throws Exception {
+    @ParameterizedTest(name = "testIterateRecordsMissingSplit [splitNumber = {0}]")
+    @CsvSource({"0", "1", "2", "3"})
+    public void testIterateRecordsMissingSplit(int splitNumber) throws Exception {
         boolean splitLongRecords = true;
-        // unsplit (short) records have split #0; split records splits start at #1
-        // Use this number to decide which record to operate on
-        int recordNumber = (splitNumber == 0) ? 0 : 1;
 
-        final RecordMetaDataHook hook = metaData -> {
-            metaData.setSplitLongRecords(splitLongRecords);
-            // index cannot be used with large fields
-            metaData.removeIndex("MySimpleRecord$str_value_indexed");
-        };
-        List<FDBStoredRecord<Message>> result = saveRecords(splitLongRecords, hook);
+        final RecordMetaDataHook hook = getRecordMetaDataHook(splitLongRecords);
+        List<FDBStoredRecord<Message>> savedRecords = saveRecords(splitLongRecords, hook, 100);
         // Delete a split
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, hook);
             // If operating on the short record, #0 is the only split
             // If operating on the long record, splits can be 1,2,3
-            final Tuple pkAndSplit = result.get(recordNumber).getPrimaryKey().add(splitNumber);
+            // Use splitNumber to decide which record to operate on.
+            // Record #1 in the saved records is a short record, #17 is a long (split) record)
+            int recordNumber = (splitNumber == 0) ? 1 : 17;
+            final Tuple pkAndSplit = savedRecords.get(recordNumber).getPrimaryKey().add(splitNumber);
             byte[] split = recordStore.recordsSubspace().pack(pkAndSplit);
             recordStore.ensureContextActive().clear(split);
+            // Also delete a split from the first record in the list TODO
             commit(context);
         }
 
-        // Validate by primary key
+        // Scan records
+        final List<Tuple> actualKeys;
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, hook);
-            validateRecord(result.get(recordNumber), FDBRecordStoreBase.RecordValidationOptions.VALID_VALUE);
+            actualKeys = scanKeys(context, null, false);
             context.commit();
         }
+        List<Tuple> expectedKeys = IntStream.range(1, 101).boxed().map(Tuple::from).collect(Collectors.toList());
+        assertEquals(expectedKeys, actualKeys);
     }
 
-    @ParameterizedTest(name = "testValidateRecordsMissingVersion [formatVersion = {0}]")
-    @MethodSource("formatVersions")
-    public void testValidateRecordsMissingVersion(int formatVersion) throws Exception {
+    @Test
+    public void testIterateRecordsMissingVersion() throws Exception {
         boolean splitLongRecords = true;
 
-        final RecordMetaDataHook hook = metaData -> {
+        final RecordMetaDataHook hook = getRecordMetaDataHook(splitLongRecords);
+        List<FDBStoredRecord<Message>> records = saveRecords(splitLongRecords, hook, 100);
+        // Delete the versions for the first 20 records
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, hook);
+            for (int i = 0; i < 20; i++) {
+                Tuple pkAndVersion = records.get(i).getPrimaryKey().add(-1);
+                byte[] versionKey = recordStore.recordsSubspace().pack(pkAndVersion);
+                recordStore.ensureContextActive().clear(versionKey);
+            }
+            commit(context);
+        }
+
+        // Scan records
+        final List<Tuple> actualKeys;
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, hook);
+            actualKeys = scanKeys(context, null, true);
+            context.commit();
+        }
+        List<Tuple> expectedKeys = IntStream.range(1, 101).boxed().map(Tuple::from).collect(Collectors.toList());
+        assertEquals(expectedKeys, actualKeys);
+    }
+
+    @Nonnull
+    private static RecordMetaDataHook getRecordMetaDataHook(final boolean splitLongRecords) {
+        return metaData -> {
             metaData.setSplitLongRecords(splitLongRecords);
             // index cannot be used with large fields
             metaData.removeIndex("MySimpleRecord$str_value_indexed");
         };
-        List<FDBStoredRecord<Message>> result = saveRecords(splitLongRecords, hook);
-        // Delete the versions
-        try (FDBRecordContext context = openContext()) {
-            openSimpleRecordStore(context, hook);
-            Tuple pkAndVersion = result.get(0).getPrimaryKey().add(-1);
-            byte[] versionKey = recordStore.recordsSubspace().pack(pkAndVersion);
-            recordStore.ensureContextActive().clear(versionKey);
-
-            pkAndVersion = result.get(1).getPrimaryKey().add(-1);
-            versionKey = recordStore.recordsSubspace().pack(pkAndVersion);
-            recordStore.ensureContextActive().clear(versionKey);
-            commit(context);
-        }
-
-        // Validate by primary key
-        try (FDBRecordContext context = openContext()) {
-            openSimpleRecordStore(context, hook);
-            validateRecord(result.get(0), FDBRecordStoreBase.RecordValidationOptions.VALID_VERSION);
-            validateRecord(result.get(1), FDBRecordStoreBase.RecordValidationOptions.VALID_VERSION);
-            commit(context);
-        }
-    }
-
-    private void validateRecord(final FDBStoredRecord<Message> rec, final FDBRecordStoreBase.RecordValidationOptions validationOption) throws Exception {
-        EnumSet<FDBRecordStoreBase.RecordValidationOptions> recordValidationOptions;
-        recordValidationOptions = recordStore.validateRecordAsync(rec.getPrimaryKey(), EnumSet.allOf(FDBRecordStoreBase.RecordValidationOptions.class), false).get();
-        assertNotNull(recordValidationOptions);
-        EnumSet<FDBRecordStoreBase.RecordValidationOptions> expected = (validationOption == null) ?
-                                                                       EnumSet.noneOf(FDBRecordStoreBase.RecordValidationOptions.class) :
-                                                                       EnumSet.of(validationOption);
-        assertEquals(expected, recordValidationOptions);
-
-        recordValidationOptions = recordStore.validateRecordAsync(rec.getPrimaryKey(), EnumSet.noneOf(FDBRecordStoreBase.RecordValidationOptions.class), false).get();
-        assertNotNull(recordValidationOptions);
-        assertEquals(EnumSet.noneOf(FDBRecordStoreBase.RecordValidationOptions.class), recordValidationOptions);
     }
 
     @Nonnull
-    private List<FDBStoredRecord<Message>> saveRecords(final boolean splitLongRecords, final RecordMetaDataHook hook) throws Exception {
-        final TestRecords1Proto.MySimpleRecord record1 = TestRecords1Proto.MySimpleRecord.newBuilder()
-                .setRecNo(1L)
-                .setStrValueIndexed("foo")
-                .setNumValue3Indexed(1066)
-                .build();
-        final String someText = splitLongRecords ? Strings.repeat("x", SplitHelper.SPLIT_RECORD_SIZE * 2 + 2) : "some text (short)";
-        final TestRecords1Proto.MySimpleRecord record2 = TestRecords1Proto.MySimpleRecord.newBuilder()
-                .setRecNo(2L)
-                .setStrValueIndexed(someText)
-                .setNumValue3Indexed(1415)
-                .build();
-        // Save the two records
-        final FDBStoredRecord<Message> savedRecord1;
-        final FDBStoredRecord<Message> savedRecord2;
+    private List<FDBStoredRecord<Message>> saveRecords(final boolean splitLongRecords, final RecordMetaDataHook hook, int numRecords) throws Exception {
+        List<FDBStoredRecord<Message>> result = new ArrayList<>(numRecords);
         try (FDBRecordContext context = openContext()) {
-            uncheckedOpenSimpleRecordStore(context, hook);
-            // Save with various formats
-            final FDBRecordStore.Builder storeBuilder = recordStore.asBuilder();
-            final FDBRecordStore store = storeBuilder.create();
-            savedRecord1 = store.saveRecord(record1);
-            savedRecord2 = store.saveRecord(record2);
+            openSimpleRecordStore(context, hook);
+            for (int i = 1; i <= numRecords; i++) {
+                final String someText = (splitLongRecords && ((i % 17) == 0)) ? Strings.repeat("x", SplitHelper.SPLIT_RECORD_SIZE * 2 + 2) : "some text (short)";
+                final TestRecords1Proto.MySimpleRecord record = TestRecords1Proto.MySimpleRecord.newBuilder()
+                        .setRecNo(i)
+                        .setStrValueIndexed(someText)
+                        .setNumValue3Indexed(1415 + i * 7)
+                        .build();
+                result.add(recordStore.saveRecord(record));
+            }
             commit(context);
         }
-        return List.of(savedRecord1, savedRecord2);
+        return result;
+    }
+
+    private List<Tuple> scanKeys(final FDBRecordContext context, @Nullable ScanProperties scanProperties, boolean withContinuations) throws InterruptedException, ExecutionException {
+        final Subspace recordsSubspace = recordStore.recordsSubspace();
+        final SplitHelper.SizeInfo sizeInfo = new SplitHelper.SizeInfo();
+        if (scanProperties == null) {
+            scanProperties = ScanProperties.FORWARD_SCAN;
+        }
+        RecordKeyCursor recordKeyCursor = new RecordKeyCursor(context, recordsSubspace, TupleRange.allOf(null), sizeInfo, scanProperties);
+        if (!withContinuations) {
+            return recordKeyCursor.asList().get();
+        } else {
+            boolean done = false;
+            List<Tuple> result = new ArrayList<>();
+            while (!done) {
+                RecordCursorResult<Tuple> currentRecord = recordKeyCursor.getNext();
+                while (currentRecord.hasNext()) {
+                    result.add(currentRecord.get());
+                    currentRecord = recordKeyCursor.getNext();
+                }
+                RecordCursorContinuation continuation = currentRecord.getContinuation();
+                if (continuation.isEnd()) {
+                    done = true;
+                } else {
+                    recordKeyCursor = new RecordKeyCursor(context, recordsSubspace, TupleRange.allOf(null), continuation.toBytes(), new SplitHelper.SizeInfo(), scanProperties, new CursorLimitManager(scanProperties));
+                }
+            }
+            return result;
+        }
+    }
+
+    private List<FDBRawRecord> scanKeysOld(final FDBRecordContext context, @Nullable ScanProperties scanProperties, boolean withContinuations) throws InterruptedException, ExecutionException {
+        final Subspace recordsSubspace = recordStore.recordsSubspace();
+        final SplitHelper.SizeInfo sizeInfo = new SplitHelper.SizeInfo();
+        if (scanProperties == null) {
+            scanProperties = ScanProperties.FORWARD_SCAN;
+        }
+        KeyValueCursor inner = KeyValueCursor.Builder
+                .withSubspace(recordsSubspace)
+                .setContext(context)
+                .setContinuation(null)
+                .setRange(TupleRange.allOf(null))
+                .setScanProperties(scanProperties)
+                .build();
+        SplitHelper.KeyValueUnsplitter recordKeyCursor = new SplitHelper.KeyValueUnsplitter(context, recordsSubspace, inner, false, sizeInfo, scanProperties);
+        if (!withContinuations) {
+            return recordKeyCursor.asList().get();
+        } else {
+            boolean done = false;
+            List<FDBRawRecord> result = new ArrayList<>();
+            while (!done) {
+                RecordCursorResult<FDBRawRecord> currentRecord = recordKeyCursor.getNext();
+                while (currentRecord.hasNext()) {
+                    result.add(currentRecord.get());
+                    currentRecord = recordKeyCursor.getNext();
+                }
+                RecordCursorContinuation continuation = currentRecord.getContinuation();
+                if (continuation.isEnd()) {
+                    done = true;
+                } else {
+                    inner = KeyValueCursor.Builder
+                            .withSubspace(recordsSubspace)
+                            .setContext(context)
+                            .setContinuation(continuation.toBytes())
+                            .setRange(TupleRange.allOf(null))
+                            .setScanProperties(scanProperties)
+                            .build();
+                    recordKeyCursor = new SplitHelper.KeyValueUnsplitter(context, recordsSubspace, inner, false, sizeInfo, scanProperties);
+                }
+            }
+            return result;
+        }
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RecordValidationTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RecordValidationTest.java
@@ -1,0 +1,199 @@
+/*
+ * RecordValidationTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb;
+
+import com.apple.foundationdb.record.TestRecords1Proto;
+import com.apple.foundationdb.tuple.Tuple;
+import com.google.common.base.Strings;
+import com.google.protobuf.Message;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import javax.annotation.Nonnull;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class RecordValidationTest extends FDBRecordStoreTestBase {
+    @ParameterizedTest(name = "testValidateRecordsNoIssue [formatVersion = {0}, splitLongRecords = {1}]")
+    @MethodSource("formatVersionAndSplitArgs")
+    public void testValidateRecordsNoIssue(int formatVersion, boolean splitLongRecords) throws Exception {
+        final RecordMetaDataHook hook = metaData -> {
+            metaData.setSplitLongRecords(splitLongRecords);
+            // index cannot be used with large fields
+            metaData.removeIndex("MySimpleRecord$str_value_indexed");
+        };
+        final List<FDBStoredRecord<Message>> result = saveRecords(formatVersion, splitLongRecords, hook);
+        // Validate by primary key
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, hook);
+            validateRecord(result.get(0), null);
+            validateRecord(result.get(1), null);
+            context.commit();
+        }
+    }
+
+    @ParameterizedTest(name = "testValidateRecordsMissingRecord [formatVersion = {0}, splitLongRecords = {1}]")
+    @MethodSource("formatVersionAndSplitArgs")
+    public void testValidateRecordsMissingRecord(int formatVersion, boolean splitLongRecords) throws Exception {
+        final RecordMetaDataHook hook = metaData -> {
+            metaData.setSplitLongRecords(splitLongRecords);
+            // index cannot be used with large fields
+            metaData.removeIndex("MySimpleRecord$str_value_indexed");
+        };
+        List<FDBStoredRecord<Message>> result = saveRecords(formatVersion, splitLongRecords, hook);
+        // Delete a record
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, hook);
+            recordStore.deleteRecord(result.get(0).getPrimaryKey());
+            commit(context);
+        }
+        // Validate by primary key
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, hook);
+            validateRecord(result.get(0), FDBRecordStoreBase.RecordValidationOptions.RECORD_EXISTS);
+            validateRecord(result.get(1), null);
+            context.commit();
+        }
+    }
+
+    @Nonnull
+    public static Stream<Arguments> formatVersionAndSplitNumber() {
+        return formatVersions()
+                .flatMap(formatVersion -> Stream.of(
+                        Arguments.of(formatVersion, 0),
+                        Arguments.of(formatVersion, 1),
+                        Arguments.of(formatVersion, 2),
+                        Arguments.of(formatVersion, 3)));
+    }
+
+    @ParameterizedTest(name = "testValidateRecordsMissingSplit [formatVersion = {0}, splitNumber = {1}]")
+    @MethodSource("formatVersionAndSplitNumber")
+    public void testValidateRecordsMissingSplit(int formatVersion, int splitNumber) throws Exception {
+        boolean splitLongRecords = true;
+        // unsplit (short) records have split #0; split records splits start at #1
+        // Use this number to decide which record to operate on
+        int recordNumber = (splitNumber == 0) ? 0 : 1;
+
+        final RecordMetaDataHook hook = metaData -> {
+            metaData.setSplitLongRecords(splitLongRecords);
+            // index cannot be used with large fields
+            metaData.removeIndex("MySimpleRecord$str_value_indexed");
+        };
+        List<FDBStoredRecord<Message>> result = saveRecords(formatVersion, splitLongRecords, hook);
+        // Delete a split
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, hook);
+            // If operating on the short record, #0 is the only split
+            // If operating on the long record, splits can be 1,2,3
+            final Tuple pkAndSplit = result.get(recordNumber).getPrimaryKey().add(splitNumber);
+            byte[] split = recordStore.recordsSubspace().pack(pkAndSplit);
+            recordStore.ensureContextActive().clear(split);
+            commit(context);
+        }
+
+        // Validate by primary key
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, hook);
+            validateRecord(result.get(recordNumber), FDBRecordStoreBase.RecordValidationOptions.VALID_VALUE);
+            context.commit();
+        }
+    }
+
+    @ParameterizedTest(name = "testValidateRecordsMissingVersion [formatVersion = {0}]")
+    @MethodSource("formatVersions")
+    public void testValidateRecordsMissingVersion(int formatVersion) throws Exception {
+        boolean splitLongRecords = true;
+
+        final RecordMetaDataHook hook = metaData -> {
+            metaData.setSplitLongRecords(splitLongRecords);
+            // index cannot be used with large fields
+            metaData.removeIndex("MySimpleRecord$str_value_indexed");
+        };
+        List<FDBStoredRecord<Message>> result = saveRecords(formatVersion, splitLongRecords, hook);
+        // Delete the versions
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, hook);
+            Tuple pkAndVersion = result.get(0).getPrimaryKey().add(-1);
+            byte[] versionKey = recordStore.recordsSubspace().pack(pkAndVersion);
+            recordStore.ensureContextActive().clear(versionKey);
+
+            pkAndVersion = result.get(1).getPrimaryKey().add(-1);
+            versionKey = recordStore.recordsSubspace().pack(pkAndVersion);
+            recordStore.ensureContextActive().clear(versionKey);
+            commit(context);
+        }
+
+        // Validate by primary key
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, hook);
+            validateRecord(result.get(0), FDBRecordStoreBase.RecordValidationOptions.VALID_VERSION);
+            validateRecord(result.get(1), FDBRecordStoreBase.RecordValidationOptions.VALID_VERSION);
+            commit(context);
+        }
+    }
+
+    private void validateRecord(final FDBStoredRecord<Message> rec, final FDBRecordStoreBase.RecordValidationOptions validationOption) throws Exception {
+        EnumSet<FDBRecordStoreBase.RecordValidationOptions> recordValidationOptions;
+        recordValidationOptions = recordStore.validateRecordAsync(rec.getPrimaryKey(), EnumSet.allOf(FDBRecordStoreBase.RecordValidationOptions.class), false).get();
+        assertNotNull(recordValidationOptions);
+        EnumSet<FDBRecordStoreBase.RecordValidationOptions> expected = (validationOption == null) ?
+                                                                       EnumSet.noneOf(FDBRecordStoreBase.RecordValidationOptions.class) :
+                                                                       EnumSet.of(validationOption);
+        assertEquals(expected, recordValidationOptions);
+
+        recordValidationOptions = recordStore.validateRecordAsync(rec.getPrimaryKey(), EnumSet.noneOf(FDBRecordStoreBase.RecordValidationOptions.class), false).get();
+        assertNotNull(recordValidationOptions);
+        assertEquals(EnumSet.noneOf(FDBRecordStoreBase.RecordValidationOptions.class), recordValidationOptions);
+    }
+
+    @Nonnull
+    private List<FDBStoredRecord<Message>> saveRecords(final int formatVersion, final boolean splitLongRecords, final RecordMetaDataHook hook) throws Exception {
+        final TestRecords1Proto.MySimpleRecord record1 = TestRecords1Proto.MySimpleRecord.newBuilder()
+                .setRecNo(1L)
+                .setStrValueIndexed("foo")
+                .setNumValue3Indexed(1066)
+                .build();
+        final String someText = splitLongRecords ? Strings.repeat("x", SplitHelper.SPLIT_RECORD_SIZE * 2 + 2) : "some text (short)";
+        final TestRecords1Proto.MySimpleRecord record2 = TestRecords1Proto.MySimpleRecord.newBuilder()
+                .setRecNo(2L)
+                .setStrValueIndexed(someText)
+                .setNumValue3Indexed(1415)
+                .build();
+        // Save the two records
+        final FDBStoredRecord<Message> savedRecord1;
+        final FDBStoredRecord<Message> savedRecord2;
+        try (FDBRecordContext context = openContext()) {
+            uncheckedOpenSimpleRecordStore(context, hook);
+            // Save with various formats
+            final FDBRecordStore.Builder storeBuilder = recordStore.asBuilder().setFormatVersion(formatVersion);
+            final FDBRecordStore store = storeBuilder.create();
+            savedRecord1 = store.saveRecord(record1);
+            savedRecord2 = store.saveRecord(record2);
+            commit(context);
+        }
+        return List.of(savedRecord1, savedRecord2);
+    }
+}


### PR DESCRIPTION
This PR adds two new facilities in support of record validation:
- Scan record keys in a store
- Validate record (no repair yet)

Record validation is meant to detect cases of missing KVs in the database and (optionally) repair them.
The combination of the two facilities mentioned above would allow for the scanning of a store that may have suffered data missing and repair records such that the store is in consistent state.
Constraints of the solution:
- Missing KV only (no mis-ordered splits or corrupt keys)
- Format versions of 3 and higher (no upgrades of data from one format to another tested)
- With and without split long record option
- With and without inline versions

Resolves #3313