### PR TITLE
ParameterizedTest utilities

### DIFF
--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/MoreAsyncUtilTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/MoreAsyncUtilTest.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.async;
 
 import com.apple.foundationdb.test.TestExecutors;
+import com.apple.test.ParameterizedTestUtils;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.hamcrest.Matcher;
 import org.junit.jupiter.api.Test;
@@ -215,10 +216,10 @@ public class MoreAsyncUtilTest {
     }
 
     public static Stream<Arguments> combineAndFailFast() {
-        return Arrays.stream(FutureBehavior.values())
-                .flatMap(future1 ->
-                        Arrays.stream(FutureBehavior.values())
-                                .map(future2 -> Arguments.of(future1, future2)));
+        return ParameterizedTestUtils.cartesianProduct(
+                Arrays.stream(FutureBehavior.values()),
+                Arrays.stream(FutureBehavior.values())
+        );
     }
 
     @ParameterizedTest

--- a/fdb-extensions/src/test/java/com/apple/test/BooleanArguments.java
+++ b/fdb-extensions/src/test/java/com/apple/test/BooleanArguments.java
@@ -1,0 +1,50 @@
+/*
+ * BooleanArguments.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.test;
+
+import org.junit.jupiter.api.Named;
+
+import java.util.stream.Stream;
+
+/**
+ * Helper class for generating boolean arguments for {@link org.junit.jupiter.params.ParameterizedTest}s.
+ */
+public class BooleanArguments {
+
+    /**
+     * Provides a stream of boolean, named arguments.
+     * @param trueName the name to provide for {@code true}
+     * @param falseName the name to provide for {@code false}
+     * @return a stream to be used as a return value for a {@link org.junit.jupiter.params.provider.MethodSource}
+     */
+    public static Stream<Named<Boolean>> of(String trueName, String falseName) {
+        return Stream.of(Named.of(trueName, true), Named.of(falseName, false));
+    }
+
+    /**
+     * Provides a stream of boolean, named arguments.
+     * @param name the name to provide for {@code true}, {@code false} will prefix with {@code "not "}
+     * @return a stream to be used as a return value for a {@link org.junit.jupiter.params.provider.MethodSource}
+     */
+    public static Stream<Named<Boolean>> of(String name) {
+        return Stream.of(Named.of(name, true), Named.of("not " + name, false));
+    }
+}

--- a/fdb-extensions/src/test/java/com/apple/test/BooleanArgumentsProvider.java
+++ b/fdb-extensions/src/test/java/com/apple/test/BooleanArgumentsProvider.java
@@ -37,7 +37,7 @@ class BooleanArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<
 
     @Override
     public void accept(BooleanSource booleanSource) {
-        this.name = booleanSource.name();
+        this.name = booleanSource.value();
     }
 
     @Override

--- a/fdb-extensions/src/test/java/com/apple/test/BooleanArgumentsProvider.java
+++ b/fdb-extensions/src/test/java/com/apple/test/BooleanArgumentsProvider.java
@@ -20,7 +20,6 @@
 
 package com.apple.test;
 
-import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
@@ -31,7 +30,8 @@ import java.util.stream.Stream;
 
 /**
  * Argument provider for the {@link BooleanSource} annotation for providing booleans to parameterized
- * tests. Regardless of the source or context, this always returns {@code false} and {@code true} in that order.
+ * tests. Regardless of the source or context, this always returns {@code false} and {@code true} in that order for each
+ * argument.
  */
 class BooleanArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<BooleanSource> {
     private String[] names;
@@ -44,13 +44,10 @@ class BooleanArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<
     @Override
     public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) throws Exception {
         if (names.length == 0) {
-            throw new IllegalStateException("@BooleanSource has an empty strings");
+            throw new IllegalStateException("@BooleanSource has an empty list of names");
         }
-        return ParameterizedTestUtils.cartesianProduct(
-                Arrays.stream(names).map(name ->
-                        Stream.of(
-                                Named.of(name.isBlank() ? "true" : name, true),
-                                Named.of(name.isBlank() ? "false" : "! " + name, false)
-                        )).toArray(Stream[]::new));
+        return ParameterizedTestUtils.cartesianProduct(Arrays.stream(names)
+                .map(ParameterizedTestUtils::booleans)
+                .toArray(Stream[]::new));
     }
 }

--- a/fdb-extensions/src/test/java/com/apple/test/BooleanArgumentsProvider.java
+++ b/fdb-extensions/src/test/java/com/apple/test/BooleanArgumentsProvider.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.support.AnnotationConsumer;
 
+import java.util.Arrays;
 import java.util.stream.Stream;
 
 /**
@@ -33,18 +34,23 @@ import java.util.stream.Stream;
  * tests. Regardless of the source or context, this always returns {@code false} and {@code true} in that order.
  */
 class BooleanArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<BooleanSource> {
-    private String name;
+    private String[] names;
 
     @Override
     public void accept(BooleanSource booleanSource) {
-        this.name = booleanSource.value();
+        this.names = booleanSource.value();
     }
 
     @Override
     public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) throws Exception {
-        return Stream.of(
-                Arguments.of(Named.of(name.isBlank() ? "true" : name, true)),
-                Arguments.of(Named.of(name.isBlank() ? "false" : "not " + name, false))
-        );
+        if (names.length == 0) {
+            throw new IllegalStateException("@BooleanSource has an empty strings");
+        }
+        return ParameterizedTestUtils.cartesianProduct(
+                Arrays.stream(names).map(name ->
+                        Stream.of(
+                                Named.of(name.isBlank() ? "true" : name, true),
+                                Named.of(name.isBlank() ? "false" : "! " + name, false)
+                        )).toArray(Stream[]::new));
     }
 }

--- a/fdb-extensions/src/test/java/com/apple/test/BooleanArgumentsProvider.java
+++ b/fdb-extensions/src/test/java/com/apple/test/BooleanArgumentsProvider.java
@@ -20,14 +20,12 @@
 
 package com.apple.test;
 
+import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.support.AnnotationConsumer;
 
-import javax.annotation.Nonnull;
-import java.util.Arrays;
-import java.util.List;
 import java.util.stream.Stream;
 
 /**
@@ -35,15 +33,18 @@ import java.util.stream.Stream;
  * tests. Regardless of the source or context, this always returns {@code false} and {@code true} in that order.
  */
 class BooleanArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<BooleanSource> {
-    @Nonnull
-    private static final List<Arguments> BOOLEANS = Arrays.asList(Arguments.of(false), Arguments.of(true));
+    private String name;
 
     @Override
     public void accept(BooleanSource booleanSource) {
+        this.name = booleanSource.name();
     }
 
     @Override
     public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) throws Exception {
-        return BOOLEANS.stream();
+        return Stream.of(
+                Arguments.of(Named.of(name.isBlank() ? "true" : name, true)),
+                Arguments.of(Named.of(name.isBlank() ? "false" : "not " + name, false))
+        );
     }
 }

--- a/fdb-extensions/src/test/java/com/apple/test/BooleanSource.java
+++ b/fdb-extensions/src/test/java/com/apple/test/BooleanSource.java
@@ -43,5 +43,5 @@ public @interface BooleanSource {
      * A name to give the boolean values; if unspecified, {@code "true"} and {@code "false"} will be used.
      * @return the name
      */
-    String value() default "";
+    String[] value() default "";
 }

--- a/fdb-extensions/src/test/java/com/apple/test/BooleanSource.java
+++ b/fdb-extensions/src/test/java/com/apple/test/BooleanSource.java
@@ -43,5 +43,5 @@ public @interface BooleanSource {
      * A name to give the boolean values; if unspecified, {@code "true"} and {@code "false"} will be used.
      * @return the name
      */
-    String name() default "";
+    String value() default "";
 }

--- a/fdb-extensions/src/test/java/com/apple/test/BooleanSource.java
+++ b/fdb-extensions/src/test/java/com/apple/test/BooleanSource.java
@@ -29,10 +29,13 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * An annotation for parameterized tests that take a single boolean argument. One might think one could use
- * {@link org.junit.jupiter.params.provider.ValueSource} for that, but that annotation does not allow
- * one to set a boolean value. This will always provide {@code false} and {@code true} as the single argument
- * to parameterized tests that have this annotation in that order.
+ * An annotation for parameterized tests that take boolean arguments.
+ * One could use {@link org.junit.jupiter.params.provider.ValueSource} for that, but it requires you to explicitly state
+ * that you want to run for {@code true} and {@code false}.
+ * By default, this will provide {@code false} and {@code true} as the single argument to parameterized tests that have
+ * this annotation in that order.
+ * If more than one {@code value} is provided, this will produce the same number of boolean arguments, each with the
+ * given name.
  */
 @Documented
 @Target(ElementType.METHOD)
@@ -41,7 +44,9 @@ import java.lang.annotation.Target;
 public @interface BooleanSource {
     /**
      * A name to give the boolean values; if unspecified, {@code "true"} and {@code "false"} will be used.
-     * @return the name
+     * If multiple values are given, the cartesian product of {@code true} and {@code false} will be used for each of
+     * the names, giving all combinations. There should be one value in this array per boolean parameter to the test.
+     * @return the names to be used for the true value for each argument, the false value will be prefixed with "!"
      */
     String[] value() default "";
 }

--- a/fdb-extensions/src/test/java/com/apple/test/BooleanSource.java
+++ b/fdb-extensions/src/test/java/com/apple/test/BooleanSource.java
@@ -39,4 +39,9 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @ArgumentsSource(BooleanArgumentsProvider.class)
 public @interface BooleanSource {
+    /**
+     * A name to give the boolean values; if unspecified, {@code "true"} and {@code "false"} will be used.
+     * @return the name
+     */
+    String name() default "";
 }

--- a/fdb-extensions/src/test/java/com/apple/test/ParameterizedTestUtils.java
+++ b/fdb-extensions/src/test/java/com/apple/test/ParameterizedTestUtils.java
@@ -21,13 +21,16 @@
 package com.apple.test;
 
 import org.junit.jupiter.api.Named;
+import org.junit.jupiter.params.provider.Arguments;
 
+import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
  * Helper class for generating boolean arguments for {@link org.junit.jupiter.params.ParameterizedTest}s.
  */
-public class BooleanArguments {
+public class ParameterizedTestUtils {
 
     /**
      * Provides a stream of boolean, named arguments.
@@ -35,7 +38,7 @@ public class BooleanArguments {
      * @param falseName the name to provide for {@code false}
      * @return a stream to be used as a return value for a {@link org.junit.jupiter.params.provider.MethodSource}
      */
-    public static Stream<Named<Boolean>> of(String trueName, String falseName) {
+    public static Stream<Named<Boolean>> booleans(String trueName, String falseName) {
         return Stream.of(Named.of(trueName, true), Named.of(falseName, false));
     }
 
@@ -44,7 +47,26 @@ public class BooleanArguments {
      * @param name the name to provide for {@code true}, {@code false} will prefix with {@code "not "}
      * @return a stream to be used as a return value for a {@link org.junit.jupiter.params.provider.MethodSource}
      */
-    public static Stream<Named<Boolean>> of(String name) {
+    public static Stream<Named<Boolean>> booleans(String name) {
         return Stream.of(Named.of(name, true), Named.of("not " + name, false));
+    }
+
+    public static Stream<Arguments> cartesianProduct(Stream<?>... sources) {
+        return cartesianProduct(
+                Stream.of(sources)
+                        .map(stream -> stream.collect(Collectors.toList())).collect(Collectors.toList()))
+                .map(arguments -> Arguments.of(arguments.toArray()));
+    }
+
+    private static Stream<Stream<Object>> cartesianProduct(List<List<?>> sources) {
+        if (sources.isEmpty()) {
+            return Stream.of();
+        }
+        if (sources.size() == 1) {
+            return sources.get(0).stream().map(Stream::of);
+        }
+        return sources.get(0).stream().flatMap(arg ->
+                cartesianProduct(sources.subList(1, sources.size()))
+                        .map(recursed -> Stream.concat(Stream.of(arg), recursed)));
     }
 }

--- a/fdb-extensions/src/test/java/com/apple/test/ParameterizedTestUtils.java
+++ b/fdb-extensions/src/test/java/com/apple/test/ParameterizedTestUtils.java
@@ -51,6 +51,12 @@ public class ParameterizedTestUtils {
         return Stream.of(Named.of(name, true), Named.of("not " + name, false));
     }
 
+    /**
+     * Produce the cartesian product of the given streams as {@link Arguments}.
+     * @param sources a list of sources to combine.
+     * @return a stream of {@link Arguments} where the 0th element is from the first source, the 1st is from the first,
+     * and so-on. Producing all combinations of an element from each source.
+     */
     public static Stream<Arguments> cartesianProduct(Stream<?>... sources) {
         return cartesianProduct(
                 Stream.of(sources)

--- a/fdb-extensions/src/test/java/com/apple/test/ParameterizedTestUtils.java
+++ b/fdb-extensions/src/test/java/com/apple/test/ParameterizedTestUtils.java
@@ -28,7 +28,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * Helper class for generating boolean arguments for {@link org.junit.jupiter.params.ParameterizedTest}s.
+ * Helper utility class for interacting with {@link org.junit.jupiter.params.ParameterizedTest}s.
  */
 public class ParameterizedTestUtils {
 
@@ -39,16 +39,21 @@ public class ParameterizedTestUtils {
      * @return a stream to be used as a return value for a {@link org.junit.jupiter.params.provider.MethodSource}
      */
     public static Stream<Named<Boolean>> booleans(String trueName, String falseName) {
-        return Stream.of(Named.of(trueName, true), Named.of(falseName, false));
+        return Stream.of(Named.of(falseName, false), Named.of(trueName, true));
     }
 
     /**
      * Provides a stream of boolean, named arguments.
-     * @param name the name to provide for {@code true}, {@code false} will prefix with {@code "not "}
+     * @param name the name to provide for {@code true}, {@code false} will prefix with {@code "!"}. If blank,
+     * {@code "true"} and {@code "false"} will be used respectively.
      * @return a stream to be used as a return value for a {@link org.junit.jupiter.params.provider.MethodSource}
      */
     public static Stream<Named<Boolean>> booleans(String name) {
-        return Stream.of(Named.of(name, true), Named.of("not " + name, false));
+        if (name.isBlank()) {
+            return booleans("true", "false");
+        } else {
+            return booleans(name, "!" + name);
+        }
     }
 
     /**

--- a/fdb-extensions/src/test/java/com/apple/test/ParameterizedTestUtilsTest.java
+++ b/fdb-extensions/src/test/java/com/apple/test/ParameterizedTestUtilsTest.java
@@ -1,0 +1,79 @@
+/*
+ * ParameterizedTestUtilsTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.test;
+
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ParameterizedTestUtilsTest {
+
+    @Test
+    void cartesianProduct1() {
+        final Supplier<Stream<Integer>> integers = () -> Stream.of(1, 2, 3);
+        assertEquals(integers.get().map(List::of).collect(Collectors.toList()),
+                ParameterizedTestUtils.cartesianProduct(integers.get())
+                        .map(args -> List.of(args.get())).collect(Collectors.toList()));
+    }
+
+    @Test
+    void cartesianProduct2() {
+        final Supplier<Stream<Integer>> integers = () -> Stream.of(1, 2, 3);
+        final Supplier<Stream<Boolean>> booleans = () -> Stream.of(true, false);
+        assertEquals(
+                integers.get().flatMap(i ->
+                                booleans.get().map(b -> List.of(i, b)))
+                        .collect(Collectors.toList()),
+                ParameterizedTestUtils.cartesianProduct(
+                        integers.get(),
+                        booleans.get()
+                ).map(args -> List.of(args.get())).collect(Collectors.toList()));
+    }
+
+    @Test
+    void cartesianProduct5() {
+        final List<Integer> integers = List.of(1, 2, 3);
+        final List<Boolean> booleans = List.of(true, false);
+        final List<String> strings = List.of("foo", "bar", "something", "or other");
+        final List<Named<Supplier<String>>> namedThings = List.of(Named.of("banana", () -> "banana"),
+                Named.of("apple", () -> "apple"));
+        assertEquals(
+                integers.stream().flatMap(i ->
+                                booleans.stream().flatMap(b ->
+                                        strings.stream().flatMap(s ->
+                                                namedThings.stream().map(named ->
+                                                        List.of(i, b, s, named, 4.2)))))
+                        .collect(Collectors.toList()),
+                ParameterizedTestUtils.cartesianProduct(
+                        integers.stream(),
+                        booleans.stream(),
+                        strings.stream(),
+                        namedThings.stream(),
+                        Stream.of(4.2)
+                ).map(args -> List.of(args.get())).collect(Collectors.toList()));
+    }
+}

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/APIVersionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/APIVersionTest.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.provider.foundationdb;
 
+import com.apple.test.ParameterizedTestUtils;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -34,13 +35,13 @@ class APIVersionTest {
 
     @SuppressWarnings("unused") // used as argument source for parameterized test
     static Stream<Arguments> isAtLeast() {
-        return Arrays.stream(APIVersion.values())
-                .flatMap(version1 -> Arrays.stream(APIVersion.values())
-                        .map(version2 -> Arguments.of(version1, version2))
-                );
+        return ParameterizedTestUtils.cartesianProduct(
+                Arrays.stream(APIVersion.values()),
+                Arrays.stream(APIVersion.values())
+        );
     }
 
-    @ParameterizedTest(name = "isAtLeast[{arguments}]")
+    @ParameterizedTest
     @MethodSource
     void isAtLeast(@Nonnull APIVersion version1, @Nonnull APIVersion version2) {
         assertEquals(version1.getVersionNumber() >= version2.getVersionNumber(), version1.isAtLeast(version2));

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreUniqueIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreUniqueIndexTest.java
@@ -62,8 +62,6 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -81,7 +79,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static com.apple.foundationdb.record.metadata.Key.Expressions.field;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -231,12 +228,6 @@ public class FDBRecordStoreUniqueIndexTest extends FDBRecordStoreTestBase {
 
             commit(context);
         }
-    }
-
-    static Stream<Arguments> removeUniquenessConstraintArguments() {
-        return Stream.of(true, false)
-                .flatMap(withViolations -> Stream.of(true, false)
-                        .map(allowReadableUniquePending -> Arguments.of(withViolations, allowReadableUniquePending)));
     }
 
     @Test
@@ -462,8 +453,8 @@ public class FDBRecordStoreUniqueIndexTest extends FDBRecordStoreTestBase {
         dropUniquenessConstraint.openWithNonUnique(false, true);
     }
 
-    @ParameterizedTest(name = "removeUniquenessConstraintAfterBuild(withViolations={0}, allowReadableUniquePending={1})")
-    @MethodSource("removeUniquenessConstraintArguments")
+    @ParameterizedTest
+    @BooleanSource({"withViolations", "allowReadableUniquePenidng"})
     void removeUniquenessConstraintAfterBuild(boolean withViolations, boolean allowReadableUniquePending) throws Exception {
         final DropUniquenessConstraint dropUniquenessConstraint = new DropUniquenessConstraint(allowReadableUniquePending);
         dropUniquenessConstraint.setupStore();
@@ -474,8 +465,8 @@ public class FDBRecordStoreUniqueIndexTest extends FDBRecordStoreTestBase {
         dropUniquenessConstraint.openWithNonUnique(false, true);
     }
 
-    @ParameterizedTest(name = "removeUniquenessConstraintDuringTransaction(clearViolations={0}, allowReadableUniquePending={1})")
-    @MethodSource("removeUniquenessConstraintArguments")
+    @ParameterizedTest
+    @BooleanSource({"clearViolations", "allowReadableUniquePending"})
     void removeUniquenessConstraintDuringTransaction(boolean clearViolations, boolean allowReadableUniquePending) throws Exception {
         final DropUniquenessConstraint dropUniquenessConstraint = new DropUniquenessConstraint(allowReadableUniquePending);
         dropUniquenessConstraint.setupStore();
@@ -489,8 +480,8 @@ public class FDBRecordStoreUniqueIndexTest extends FDBRecordStoreTestBase {
      * @param allowReadableUniquePending whether to allow {@link IndexState#READABLE_UNIQUE_PENDING}
      * @throws Exception if there is an issue
      */
-    @ParameterizedTest(name = "removeUniquenessConstraintDuringTransactionWithNewDuplications(addViolations={0}, allowReadableUniquePending={1})")
-    @MethodSource("removeUniquenessConstraintArguments")
+    @ParameterizedTest
+    @BooleanSource("allowReadableUniquePending")
     void removeUniquenessConstraintDuringTransactionWithNewDuplications(boolean allowReadableUniquePending) throws Exception {
         final DropUniquenessConstraint dropUniquenessConstraint = new DropUniquenessConstraint(allowReadableUniquePending);
         dropUniquenessConstraint.setupStore();
@@ -509,8 +500,8 @@ public class FDBRecordStoreUniqueIndexTest extends FDBRecordStoreTestBase {
      * @param allowReadableUniquePending whether to allow {@link IndexState#READABLE_UNIQUE_PENDING}
      * @throws Exception if there is an issue
      */
-    @ParameterizedTest(name = "removeUniquenessConstraintDuringTransactionWithNewViolations(allowReadableUniquePending={0})")
-    @BooleanSource
+    @ParameterizedTest
+    @BooleanSource("allowReadableUniquePending")
     void removeUniquenessConstraintDuringTransactionWithNewViolations(boolean allowReadableUniquePending) throws Exception {
         final DropUniquenessConstraint dropUniquenessConstraint = new DropUniquenessConstraint(allowReadableUniquePending);
         dropUniquenessConstraint.setupStore();
@@ -524,8 +515,8 @@ public class FDBRecordStoreUniqueIndexTest extends FDBRecordStoreTestBase {
      * still works.
      * @param allowReadableUniquePending whether to allow {@link IndexState#READABLE_UNIQUE_PENDING}
      */
-    @ParameterizedTest(name = "bumpVersionWhenChangingToNonUnique(allowReadableUniquePending={0})")
-    @BooleanSource
+    @ParameterizedTest
+    @BooleanSource("allowReadableUniquePending")
     void bumpVersionWhenChangingToNonUnique(boolean allowReadableUniquePending) throws Exception {
         final DropUniquenessConstraint dropUniquenessConstraint = new DropUniquenessConstraint(
                 allowReadableUniquePending, NO_UNIQUE_CLEAR_INDEX_TYPE, true);
@@ -540,8 +531,8 @@ public class FDBRecordStoreUniqueIndexTest extends FDBRecordStoreTestBase {
      * instructions on {@link IndexOptions#UNIQUE_OPTION}.
      * @param allowReadableUniquePending whether to test with allowing {@link IndexState#READABLE_UNIQUE_PENDING}
      */
-    @ParameterizedTest(name = "unsupportedChangeToNonUniqueWithoutBumpingVersion(allowReadableUniquePending={0})")
-    @BooleanSource
+    @ParameterizedTest
+    @BooleanSource("allowReadableUniquePending")
     void unsupportedChangeToNonUniqueWithoutBumpingVersion(boolean allowReadableUniquePending) throws Exception {
         // this won't fail, it will just leave the violations sitting around, but as per the
         final DropUniquenessConstraint dropUniquenessConstraint = new DropUniquenessConstraint(

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreUniqueIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreUniqueIndexTest.java
@@ -454,7 +454,7 @@ public class FDBRecordStoreUniqueIndexTest extends FDBRecordStoreTestBase {
     }
 
     @ParameterizedTest
-    @BooleanSource({"withViolations", "allowReadableUniquePenidng"})
+    @BooleanSource({"withViolations", "allowReadableUniquePending"})
     void removeUniquenessConstraintAfterBuild(boolean withViolations, boolean allowReadableUniquePending) throws Exception {
         final DropUniquenessConstraint dropUniquenessConstraint = new DropUniquenessConstraint(allowReadableUniquePending);
         dropUniquenessConstraint.setupStore();

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/runners/TransactionalRunnerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/runners/TransactionalRunnerTest.java
@@ -454,8 +454,8 @@ class TransactionalRunnerTest {
         }
     }
 
-    @ParameterizedTest(name = "closesAfterCompletion({argumentsWithNames})")
-    @BooleanSource
+    @ParameterizedTest
+    @BooleanSource("successful")
     void closesAfterCompletion(boolean success) {
         AtomicReference<FDBRecordContext> contextRef = new AtomicReference<>();
         try (TransactionalRunner runner = defaultTransactionalRunner()) {
@@ -489,8 +489,8 @@ class TransactionalRunnerTest {
         }
     }
 
-    @ParameterizedTest(name = "closesAfterCompletionSynchronous({argumentsWithNames})")
-    @BooleanSource
+    @ParameterizedTest
+    @BooleanSource("successful")
     void closesAfterCompletionSynchronous(boolean success) throws Exception {
         AtomicReference<FDBRecordContext> contextRef = new AtomicReference<>();
         try (TransactionalRunner runner = defaultTransactionalRunner()) {


### PR DESCRIPTION
This adds a couple utilities to our testing frameworks:
1. An optional name for `@BooleanSource`, so that it doesn't just appear as `true` / `false`
2. Methods for producing similar named boolean streams for use in a `@MethodSource`
3. A method to produce the cartesian product of a bunch of streams, instead of having to chain a whole bunch of `flatMap`s.

Below is a screenshot of the test results after this change, for `FDBRecordStoreUniqueIndexTest` that takes full advantage of the new `@BooleanSource` functionality
![image](https://github.com/user-attachments/assets/a6e168a5-f7ae-4759-90fa-0fd5b60073e8)
vs the old way:
![image](https://github.com/user-attachments/assets/2d33456d-eb4e-4077-87f1-dc3e12fe3f01)
vs if you don't have the `name=` on all the tests
![image](https://github.com/user-attachments/assets/079d6d8d-7516-48c6-aa92-673a5b2eb950)


(Note: `removeUniquenessConstraintDuringTransactionWithNewDuplications` was taking `removeUniquenessConstraintArguments` but only actually used one of the parameters, causing it to run twice as many times as needed)