### PR TITLE
Create FutureManagerRunner and convert FDBDatabaseRunnerImpl to use it.

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseRunnerImpl.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseRunnerImpl.java
@@ -311,7 +311,7 @@ public class FDBDatabaseRunnerImpl implements FDBDatabaseRunner {
             return;
         }
         closed = true;
-        // Ensure we call both close() methods, give preference to the transactionalRunner's exception if both throw one
+        // Ensure we call both close() methods, capturing all exceptions
         RuntimeException caught = null;
         try {
             futureManager.close();
@@ -322,10 +322,10 @@ public class FDBDatabaseRunnerImpl implements FDBDatabaseRunner {
             transactionalRunner.close();
         } catch (RuntimeException e) {
             if (caught != null) {
-                LOGGER.warn("Caught exception while closing", caught);
+                caught.addSuppressed(e);
+            } else {
+                caught = e;
             }
-            // replace
-            caught = e;
         }
         if (caught != null) {
             throw caught;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/runners/FutureAutoClose.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/runners/FutureAutoClose.java
@@ -1,5 +1,5 @@
 /*
- * FutureManagerRunner.java
+ * FutureAutoClose.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/runners/FutureManagerRunner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/runners/FutureManagerRunner.java
@@ -1,0 +1,83 @@
+/*
+ * FutureManagerRunner.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb.runners;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.provider.foundationdb.FDBDatabase;
+import com.apple.foundationdb.record.provider.foundationdb.FDBDatabaseRunner;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContextConfig;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * A simple runner that extends {@link TransactionalRunner} by completing futures once the runner closes.
+ * Futures created externally can be registered with this runner. This runner can also create new futures (and register them).
+ * Once registered, the incomplete futures will be completed exceptionally (with a
+ * {@link com.apple.foundationdb.record.provider.foundationdb.FDBDatabaseRunner.RunnerClosed} exception) once the runner closes.
+ * It is the responsbility of the users of the runner to ensure futures that it creates are registered.
+ * <p>
+ * Normally, only the top level (root) of the future chain needs registration. Completing this future
+ * will cause the completion to trickle down to the dependent futures.
+ */
+@API(API.Status.INTERNAL)
+public class FutureManagerRunner extends TransactionalRunner {
+    @Nonnull
+    private final List<CompletableFuture<?>> futuresToClose;
+
+    public FutureManagerRunner(@Nonnull final FDBDatabase database, @Nonnull final FDBRecordContextConfig.Builder contextConfigBuilder) {
+        super(database, contextConfigBuilder);
+        futuresToClose = new ArrayList<>();
+    }
+
+    public <T> CompletableFuture<T> newFuture() {
+        return registerFuture(new CompletableFuture<>());
+    }
+
+    public synchronized <T> CompletableFuture<T> registerFuture(CompletableFuture<T> future) {
+        if (isClosed()) {
+            final FDBDatabaseRunner.RunnerClosed exception = new FDBDatabaseRunner.RunnerClosed();
+            future.completeExceptionally(exception);
+            throw exception;
+        }
+        futuresToClose.removeIf(CompletableFuture::isDone);
+        futuresToClose.add(future);
+        return future;
+    }
+
+    @Override
+    public synchronized void close() {
+        if (!isClosed()) {
+            // Close super first, to prevent same-thread nested calls from proceeding
+            super.close();
+
+            if (!futuresToClose.stream().allMatch(CompletableFuture::isDone)) {
+                final Exception exception = new FDBDatabaseRunner.RunnerClosed();
+                for (CompletableFuture<?> future : futuresToClose) {
+                    future.completeExceptionally(exception);
+                }
+            }
+            futuresToClose.clear();
+        }
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/runners/TransactionalRunner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/runners/TransactionalRunner.java
@@ -176,4 +176,7 @@ public class TransactionalRunner implements AutoCloseable {
         this.closed = true;
     }
 
+    public boolean isClosed() {
+        return closed;
+    }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/runners/TransactionalRunner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/runners/TransactionalRunner.java
@@ -175,8 +175,4 @@ public class TransactionalRunner implements AutoCloseable {
         contextsToClose.forEach(FDBRecordContext::close);
         this.closed = true;
     }
-
-    public boolean isClosed() {
-        return closed;
-    }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/runners/FutureAutoCloseTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/runners/FutureAutoCloseTest.java
@@ -1,0 +1,203 @@
+/*
+ * FutureAutoCloseTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb.runners;
+
+import com.apple.foundationdb.record.provider.foundationdb.FDBDatabaseRunner;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class FutureAutoCloseTest {
+    @Test
+    void closeClosesFutures() {
+        CompletableFuture<Void> f1;
+        CompletableFuture<Void> f2;
+        try (FutureAutoClose classUnderTest = new FutureAutoClose()) {
+            f1 = classUnderTest.registerFuture(new CompletableFuture<>());
+            f2 = classUnderTest.newFuture();
+        }
+
+        assertCompletedExceptionally(f1);
+        assertCompletedExceptionally(f2);
+    }
+
+    @Test
+    void registerAfterClose() {
+        FutureAutoClose classUnderTest = new FutureAutoClose();
+        classUnderTest.registerFuture(new CompletableFuture<>());
+        classUnderTest.newFuture();
+        classUnderTest.close();
+
+        Assertions.assertThatThrownBy(classUnderTest::newFuture).isInstanceOf(FDBDatabaseRunner.RunnerClosed.class);
+    }
+
+    @Test
+    void closeIgnoresCompletedFutures() {
+        CompletableFuture<Void> f1;
+        CompletableFuture<Void> f2;
+        try (FutureAutoClose classUnderTest = new FutureAutoClose()) {
+            f1 = classUnderTest.registerFuture(new CompletableFuture<>());
+            f2 = classUnderTest.newFuture();
+
+            f1.complete(null);
+            f2.complete(null);
+        }
+
+        assertCompletedNormally(f1);
+        assertCompletedNormally(f2);
+    }
+
+    @Test
+    void closeIgnoreCompletedFuturesMixed() {
+        CompletableFuture<Void> f1;
+        CompletableFuture<Void> f2;
+        CompletableFuture<Void> f3;
+        CompletableFuture<Void> f4;
+        try (FutureAutoClose classUnderTest = new FutureAutoClose()) {
+            f1 = classUnderTest.registerFuture(new CompletableFuture<>());
+            f2 = classUnderTest.registerFuture(new CompletableFuture<>());
+            f3 = classUnderTest.newFuture();
+            f4 = classUnderTest.newFuture();
+
+            f1.complete(null);
+            f3.complete(null);
+        }
+
+        assertCompletedNormally(f1);
+        assertCompletedExceptionally(f2);
+        assertCompletedNormally(f3);
+        assertCompletedExceptionally(f4);
+    }
+
+    @Test
+    void futureWithDependentCompletesExceptionally() {
+        CompletableFuture<Void> f1;
+        CompletableFuture<Boolean> f2;
+        try (FutureAutoClose classUnderTest = new FutureAutoClose()) {
+            f1 = classUnderTest.newFuture();
+            f2 = f1.thenApply(ignore -> true);
+        }
+
+        assertCompletedExceptionally(f1);
+        assertCompletedExceptionally(f2);
+    }
+
+    @Test
+    void futureWithDependentCompletesNormally() {
+        CompletableFuture<Void> f1;
+        CompletableFuture<Boolean> f2;
+        try (FutureAutoClose classUnderTest = new FutureAutoClose()) {
+            f1 = classUnderTest.newFuture();
+            f2 = f1.thenApply(ignore -> true);
+            f1.complete(null);
+        }
+
+        assertCompletedNormally(f1);
+        assertCompletedNormally(f2);
+    }
+
+    @Test
+    void futureCreatesAnotherCompletesNormally() {
+        CompletableFuture<Void> f1;
+        CompletableFuture<Void> f2;
+        final AtomicReference<CompletableFuture<Void>> f3 = new AtomicReference<>();
+        try (FutureAutoClose classUnderTest = new FutureAutoClose()) {
+            f1 = classUnderTest.newFuture();
+            f2 = f1.thenApply(ignore -> {
+                f3.set(classUnderTest.newFuture());
+                return null;
+            });
+            f1.complete(null);
+        }
+
+        assertCompletedNormally(f1);
+        assertCompletedNormally(f2);
+        assertCompletedExceptionally(f3.get());
+    }
+
+    @Test
+    void futureCreatesAnotherAfterClose() {
+        CompletableFuture<Void> f1;
+        CompletableFuture<Void> f2;
+        final AtomicReference<CompletableFuture<Void>> f3 = new AtomicReference<>();
+        try (FutureAutoClose classUnderTest = new FutureAutoClose()) {
+            f1 = classUnderTest.newFuture();
+            f2 = f1.handle((val, ex) -> {
+                // This would happen during the close() call, in the same thread
+                Assertions.assertThatThrownBy(classUnderTest::newFuture).isInstanceOf(FDBDatabaseRunner.RunnerClosed.class);
+                return null;
+            });
+        }
+
+        assertCompletedExceptionally(f1);
+        assertCompletedNormally(f2);
+    }
+
+    @Test
+    void nestedClose() {
+        CompletableFuture<Void> f1;
+        CompletableFuture<Void> f2;
+        FutureAutoClose classUnderTest = new FutureAutoClose();
+        f1 = classUnderTest.newFuture();
+        f2 = f1.handle((val, ex) -> {
+            // This would happen during the close() call, in the same thread
+            classUnderTest.close();
+            return null;
+        });
+        classUnderTest.close();
+
+        assertCompletedExceptionally(f1);
+        assertCompletedNormally(f2);
+    }
+
+    @Test
+    void futureThrowsException() {
+        CompletableFuture<Void> f1;
+        CompletableFuture<Void> f2;
+        CompletableFuture<Void> f3;
+        try (FutureAutoClose classUnderTest = new FutureAutoClose()) {
+            f1 = classUnderTest.newFuture();
+            f2 = f1.handle((val, ex) -> {
+                throw new RuntimeException("Blah");
+            });
+            f3 = classUnderTest.newFuture();
+        }
+
+        assertCompletedExceptionally(f1);
+        assertCompletedExceptionally(f2, RuntimeException.class);
+        assertCompletedExceptionally(f3);
+    }
+
+    private void assertCompletedNormally(final CompletableFuture<?> future) {
+        future.join();
+    }
+
+    private void assertCompletedExceptionally(final CompletableFuture<?> future) {
+        assertCompletedExceptionally(future, FDBDatabaseRunner.RunnerClosed.class);
+    }
+
+    private void assertCompletedExceptionally(final CompletableFuture<?> future, Class<? extends Exception> ex) {
+        Assertions.assertThat(future.isCompletedExceptionally()).isTrue();
+        Assertions.assertThatThrownBy(future::join).hasCauseInstanceOf(ex);
+    }
+}


### PR DESCRIPTION
This refactoring moves the future management (completing of futures once the runner closes) out of the FDBDatabaseRunnerImpl into a subclass of TransactionalRunner. 
This allows the new subclass of TransactionalRunner to be used (e.g in the case where we want another throttling implementation).

Resolves #3346