### PR TITLE
Add a test to verify setOption LOG_QUERY works per statement

### DIFF
--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/QueryLoggingTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/QueryLoggingTest.java
@@ -256,32 +256,6 @@ public class QueryLoggingTest {
     }
 
     @Test
-    void testExecuteContinuationSetLogOn() throws Exception {
-        insertRows();
-        final var driver = (RelationalDriver) DriverManager.getDriver(database.getConnectionUri().toString());
-        try (RelationalConnection conn = driver.connect(database.getConnectionUri(), Options.NONE)) {
-            Continuation continuation;
-            conn.setSchema(database.getSchemaName());
-            try (RelationalPreparedStatement ps = conn.prepareStatement("SELECT name from restaurant")) {
-                ps.setMaxRows(1);
-                try (RelationalResultSet rs = ps.executeQuery()) {
-                    rs.next();
-                    continuation = rs.getContinuation();
-                }
-                Assertions.assertThat(logAppender.getLogEvents()).isEmpty();
-            }
-            conn.setOption(Options.Name.LOG_QUERY, true);
-            try (RelationalPreparedStatement ps = conn.prepareStatement("EXECUTE CONTINUATION ?continuation")) {
-                ps.setBytes("continuation", continuation.serialize());
-                try (RelationalResultSet rs = ps.executeQuery()) {
-                    rs.next();
-                }
-                Assertions.assertThat(logAppender.getLogEvents()).isEmpty();
-            }
-        }
-    }
-
-    @Test
     void testLogQueryBecauseLoggerIsSetToDebug() throws Exception {
         try (LogAppenderRule debugRule = LogAppenderRule.of("DebugLogAppender", PlanGenerator.class, Level.DEBUG)) {
             try (final RelationalResultSet resultSet = statement.executeQuery("SELECT * FROM RESTAURANT")) {


### PR DESCRIPTION
This PR adds a test to verify that `RelationalConnection.setOption(LOG_QUERY, true)`, on an existing connection, works as expected. That is, we can put it `true` before executing a statement and set it to `false` to disable logging afterwards. 