### PR TITLE
(non)-partitioning properties for `Reference`s

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ExpressionPartition.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ExpressionPartition.java
@@ -32,11 +32,25 @@ import java.util.Set;
  * @param <E> type parameter to indicate the type of expression this partition holds.
  */
 public class ExpressionPartition<E extends RelationalExpression> {
+    /**
+     * Grouping property map which holds all properties and their values that are common to all plans and therefore
+     * defining the partition.
+     */
     @Nonnull
     private final Map<ExpressionProperty<?>, ?> groupingPropertyMap;
+    /**
+     * Grouped property map which is a map from each individual plan in the partition to properties and their values
+     * for properties that are not defining the partition.
+     */
     @Nonnull
     private final Map<E, Map<ExpressionProperty<?>, ?>> groupedPropertyMap;
 
+    /**
+     * Constructor. Note that we do not defensively copy here as it is dependent on the use case if we need a copy or
+     * not. The caller needs to ensure that the maps being passed in are either immutable or owned.
+     * @param groupingPropertyMap grouping property map
+     * @param groupedPropertyMap grouped property map
+     */
     public ExpressionPartition(@Nonnull final Map<ExpressionProperty<?>, ?> groupingPropertyMap,
                                @Nonnull final Map<E, Map<ExpressionProperty<?>, ?>> groupedPropertyMap) {
         this.groupingPropertyMap = groupingPropertyMap;
@@ -54,8 +68,15 @@ public class ExpressionPartition<E extends RelationalExpression> {
     }
 
     @Nonnull
-    public <A> A getPropertyValue(@Nonnull final ExpressionProperty<A> expressionProperty) {
+    public <A> A getGroupingPropertyValue(@Nonnull final ExpressionProperty<A> expressionProperty) {
         return expressionProperty.narrowAttribute(Objects.requireNonNull(groupingPropertyMap.get(expressionProperty)));
+    }
+
+    @Nonnull
+    public <A> A getGroupedPropertyValue(@Nonnull final E expression,
+                                         @Nonnull final ExpressionProperty<A> expressionProperty) {
+        final var propertyMapForExpression = groupedPropertyMap.get(expression);
+        return expressionProperty.narrowAttribute(Objects.requireNonNull(propertyMapForExpression.get(expressionProperty)));
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ExpressionPartition.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ExpressionPartition.java
@@ -37,50 +37,50 @@ public class ExpressionPartition<E extends RelationalExpression> {
      * defining the partition.
      */
     @Nonnull
-    private final Map<ExpressionProperty<?>, ?> groupingPropertyMap;
+    private final Map<ExpressionProperty<?>, ?> partitionPropertiesMap;
     /**
      * Grouped property map which is a map from each individual plan in the partition to properties and their values
      * for properties that are not defining the partition.
      */
     @Nonnull
-    private final Map<E, Map<ExpressionProperty<?>, ?>> groupedPropertyMap;
+    private final Map<E, Map<ExpressionProperty<?>, ?>> nonPartitioningPropertiesMap;
 
     /**
      * Constructor. Note that we do not defensively copy here as it is dependent on the use case if we need a copy or
      * not. The caller needs to ensure that the maps being passed in are either immutable or owned.
-     * @param groupingPropertyMap grouping property map
-     * @param groupedPropertyMap grouped property map
+     * @param partitionPropertiesMap property map common to the entire partition
+     * @param nonPartitioningPropertiesMap expression property map for expression-specific properties
      */
-    public ExpressionPartition(@Nonnull final Map<ExpressionProperty<?>, ?> groupingPropertyMap,
-                               @Nonnull final Map<E, Map<ExpressionProperty<?>, ?>> groupedPropertyMap) {
-        this.groupingPropertyMap = groupingPropertyMap;
-        this.groupedPropertyMap = groupedPropertyMap;
+    public ExpressionPartition(@Nonnull final Map<ExpressionProperty<?>, ?> partitionPropertiesMap,
+                               @Nonnull final Map<E, Map<ExpressionProperty<?>, ?>> nonPartitioningPropertiesMap) {
+        this.partitionPropertiesMap = partitionPropertiesMap;
+        this.nonPartitioningPropertiesMap = nonPartitioningPropertiesMap;
     }
 
     @Nonnull
-    public Map<ExpressionProperty<?>, ?> getGroupingPropertyMap() {
-        return groupingPropertyMap;
+    public Map<ExpressionProperty<?>, ?> getPartitionPropertiesMap() {
+        return partitionPropertiesMap;
     }
 
     @Nonnull
-    public Map<E, Map<ExpressionProperty<?>, ?>> getGroupedPropertyMap() {
-        return groupedPropertyMap;
+    public Map<E, Map<ExpressionProperty<?>, ?>> getNonPartitioningPropertiesMap() {
+        return nonPartitioningPropertiesMap;
     }
 
     @Nonnull
-    public <A> A getGroupingPropertyValue(@Nonnull final ExpressionProperty<A> expressionProperty) {
-        return expressionProperty.narrowAttribute(Objects.requireNonNull(groupingPropertyMap.get(expressionProperty)));
+    public <A> A getPartitionPropertyValue(@Nonnull final ExpressionProperty<A> expressionProperty) {
+        return expressionProperty.narrowAttribute(Objects.requireNonNull(partitionPropertiesMap.get(expressionProperty)));
     }
 
     @Nonnull
-    public <A> A getGroupedPropertyValue(@Nonnull final E expression,
-                                         @Nonnull final ExpressionProperty<A> expressionProperty) {
-        final var propertyMapForExpression = groupedPropertyMap.get(expression);
+    public <A> A getExpressionPropertyValue(@Nonnull final E expression,
+                                            @Nonnull final ExpressionProperty<A> expressionProperty) {
+        final var propertyMapForExpression = nonPartitioningPropertiesMap.get(expression);
         return expressionProperty.narrowAttribute(Objects.requireNonNull(propertyMapForExpression.get(expressionProperty)));
     }
 
     @Nonnull
     public Set<E> getExpressions() {
-        return groupedPropertyMap.keySet();
+        return nonPartitioningPropertiesMap.keySet();
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ExpressionPartition.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ExpressionPartition.java
@@ -21,10 +21,8 @@
 package com.apple.foundationdb.record.query.plan.cascades;
 
 import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpression;
-import com.google.common.collect.ImmutableMap;
 
 import javax.annotation.Nonnull;
-import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -35,27 +33,33 @@ import java.util.Set;
  */
 public class ExpressionPartition<E extends RelationalExpression> {
     @Nonnull
-    private final Map<ExpressionProperty<?>, ?> propertyValuesMap;
+    private final Map<ExpressionProperty<?>, ?> groupingPropertyMap;
     @Nonnull
-    private final Set<E> expressions;
+    private final Map<E, Map<ExpressionProperty<?>, ?>> groupedPropertyMap;
 
-    public ExpressionPartition(final Map<ExpressionProperty<?>, ?> propertyValuesMap, final Collection<E> expressions) {
-        this.propertyValuesMap = ImmutableMap.copyOf(propertyValuesMap);
-        this.expressions = new LinkedIdentitySet<>(expressions);
+    public ExpressionPartition(@Nonnull final Map<ExpressionProperty<?>, ?> groupingPropertyMap,
+                               @Nonnull final Map<E, Map<ExpressionProperty<?>, ?>> groupedPropertyMap) {
+        this.groupingPropertyMap = groupingPropertyMap;
+        this.groupedPropertyMap = groupedPropertyMap;
     }
 
     @Nonnull
-    public Map<ExpressionProperty<?>, ?> getPropertyValuesMap() {
-        return propertyValuesMap;
+    public Map<ExpressionProperty<?>, ?> getGroupingPropertyMap() {
+        return groupingPropertyMap;
+    }
+
+    @Nonnull
+    public Map<E, Map<ExpressionProperty<?>, ?>> getGroupedPropertyMap() {
+        return groupedPropertyMap;
     }
 
     @Nonnull
     public <A> A getPropertyValue(@Nonnull final ExpressionProperty<A> expressionProperty) {
-        return expressionProperty.narrowAttribute(Objects.requireNonNull(propertyValuesMap.get(expressionProperty)));
+        return expressionProperty.narrowAttribute(Objects.requireNonNull(groupingPropertyMap.get(expressionProperty)));
     }
 
     @Nonnull
     public Set<E> getExpressions() {
-        return expressions;
+        return groupedPropertyMap.keySet();
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ExpressionPartition.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ExpressionPartition.java
@@ -73,8 +73,8 @@ public class ExpressionPartition<E extends RelationalExpression> {
     }
 
     @Nonnull
-    public <A> A getExpressionPropertyValue(@Nonnull final E expression,
-                                            @Nonnull final ExpressionProperty<A> expressionProperty) {
+    public <A> A getNonPartitioningPropertyValue(@Nonnull final E expression,
+                                                 @Nonnull final ExpressionProperty<A> expressionProperty) {
         final var propertyMapForExpression = nonPartitioningPropertiesMap.get(expression);
         return expressionProperty.narrowAttribute(Objects.requireNonNull(propertyMapForExpression.get(expressionProperty)));
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ExpressionPartitions.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ExpressionPartitions.java
@@ -69,7 +69,7 @@ public class ExpressionPartitions {
         final Map<Map<ExpressionProperty<?>, ?>, Map<E, Map<ExpressionProperty<?>, ?>>> rolledUpMap =
                 new LinkedHashMap<>();
         for (final P partition : partitions) {
-            final var groupingPropertyMap = partition.getGroupingPropertyMap();
+            final var groupingPropertyMap = partition.getPartitionPropertiesMap();
             final Map<ExpressionProperty<?>, ?> filteredPropertiesMap =
                     groupingPropertyMap
                             .entrySet()
@@ -79,9 +79,9 @@ public class ExpressionPartitions {
                             .collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
             rolledUpMap.compute(filteredPropertiesMap, (key, oldValue) -> {
                 if (oldValue == null) {
-                    return partition.getGroupedPropertyMap();
+                    return partition.getNonPartitioningPropertiesMap();
                 }
-                oldValue.putAll(partition.getGroupedPropertyMap());
+                oldValue.putAll(partition.getNonPartitioningPropertiesMap());
                 return oldValue;
             });
         }
@@ -101,8 +101,8 @@ public class ExpressionPartitions {
     @Nonnull
     protected static <E extends RelationalExpression, P extends ExpressionPartition<E>> List<P> toPartitions(@Nonnull final ExpressionPropertiesMap<E> propertiesMap,
                                                                                                              @Nonnull final PartitionCreator<E, P> partitionCreator) {
-        return toPartitions(propertiesMap.getGroupingPropertiesExpressionsMap(),
-                propertiesMap.computeNonGroupingPropertiesMap(), partitionCreator);
+        return toPartitions(propertiesMap.getPartitioningPropertiesExpressionsMap(),
+                propertiesMap.computeNonPartitioningPropertiesMap(), partitionCreator);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ExpressionPartitions.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ExpressionPartitions.java
@@ -31,8 +31,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.BiFunction;
-import java.util.stream.Collectors;
 
 /**
  * Helpers for collections of {@link ExpressionPartition}.
@@ -47,65 +45,90 @@ public class ExpressionPartitions {
                                                                                          @Nonnull final ExpressionProperty<?> property) {
         return rollUpTo(expressionPartitions,
                 ImmutableSet.of(property),
-                ExpressionPartition::new);
+                (PartitionCreator<E, ExpressionPartition<E>>)ExpressionPartition::new);
     }
 
     @Nonnull
     protected static <E extends RelationalExpression, P extends ExpressionPartition<E>> List<P> rollUpTo(@Nonnull final Collection<P> expressionPartitions,
                                                                                                          @Nonnull final ExpressionProperty<?> property,
-                                                                                                         @Nonnull final BiFunction<Map<ExpressionProperty<?>, ?>, Collection<E>, P> partitionCreatorFunction) {
-        return rollUpTo(expressionPartitions, ImmutableSet.of(property), partitionCreatorFunction);
+                                                                                                         @Nonnull final PartitionCreator<E, P> partitionCreator) {
+        return rollUpTo(expressionPartitions, ImmutableSet.of(property), partitionCreator);
     }
 
     @Nonnull
     public static <E extends RelationalExpression> List<ExpressionPartition<E>> rollUpTo(@Nonnull final Collection<ExpressionPartition<E>> expressionPartitions,
                                                                                          @Nonnull final Set<ExpressionProperty<?>> rollupProperties) {
-        return rollUpTo(expressionPartitions, rollupProperties, ExpressionPartition::new);
+        return rollUpTo(expressionPartitions, rollupProperties,
+                (PartitionCreator<E, ExpressionPartition<E>>)ExpressionPartition::new);
     }
 
     @Nonnull
-    static <E extends RelationalExpression, P extends ExpressionPartition<E>> List<P> rollUpTo(@Nonnull final Collection<P> planPartitions,
+    static <E extends RelationalExpression, P extends ExpressionPartition<E>> List<P> rollUpTo(@Nonnull final Collection<P> partitions,
                                                                                                @Nonnull final Set<ExpressionProperty<?>> rollupProperties,
-                                                                                               @Nonnull final BiFunction<Map<ExpressionProperty<?>, ?>, Collection<E>, P> partitionCreatorFunction) {
-        final Map<Map<ExpressionProperty<?>, ?>, ? extends Set<E>> rolledUpAttributesMap =
-                planPartitions
-                        .stream()
-                        .map(planPartition -> {
-                            final var attributesMap = planPartition.getPropertyValuesMap();
-                            final Map<ExpressionProperty<?>, ?> filteredAttributesMap =
-                                    attributesMap
-                                            .entrySet()
-                                            .stream()
-                                            .filter(attributeEntry -> rollupProperties.contains(attributeEntry.getKey()))
-                                            .collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
+                                                                                               @Nonnull final PartitionCreator<E, P> partitionCreator) {
+        final Map<Map<ExpressionProperty<?>, ?>, Map<E, Map<ExpressionProperty<?>, ?>>> rolledUpMap =
+                new LinkedHashMap<>();
+        for (final P partition : partitions) {
+            final var groupingPropertyMap = partition.getGroupingPropertyMap();
+            final Map<ExpressionProperty<?>, ?> filteredPropertiesMap =
+                    groupingPropertyMap
+                            .entrySet()
+                            .stream()
+                            .filter(attributeEntry ->
+                                    rollupProperties.contains(attributeEntry.getKey()))
+                            .collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
+            rolledUpMap.compute(filteredPropertiesMap, (key, oldValue) -> {
+                if (oldValue == null) {
+                    return partition.getGroupedPropertyMap();
+                }
+                oldValue.putAll(partition.getGroupedPropertyMap());
+                return oldValue;
+            });
+        }
 
-                            // create a new partition that uses only the rollup attributes
-                            return new ExpressionPartition<>(filteredAttributesMap, planPartition.getExpressions());
-                        })
-                        // group by the filtered attributes rolling up to form new sets of plans
-                        .collect(Collectors.groupingBy(ExpressionPartition::getPropertyValuesMap,
-                                LinkedHashMap::new,
-                                Collectors.flatMapping(planPartition -> planPartition.getExpressions().stream(), LinkedIdentitySet.toLinkedIdentitySet())));
-
-        return toPartitions(rolledUpAttributesMap, partitionCreatorFunction);
+        final var resultsBuilder = ImmutableList.<P>builder();
+        for (final var entry : rolledUpMap.entrySet()) {
+            resultsBuilder.add(partitionCreator.create(entry.getKey(), entry.getValue()));
+        }
+        return resultsBuilder.build();
     }
 
     @Nonnull
-    protected static <E extends RelationalExpression> List<ExpressionPartition<E>> toPartitions(@Nonnull final Map<Map<ExpressionProperty<?>, ?>, ? extends Set<E>> propertiesToExpressionsMap) {
-        return toPartitions(propertiesToExpressionsMap, ExpressionPartition::new);
+    protected static <E extends RelationalExpression> List<ExpressionPartition<E>> toPartitions(@Nonnull final ExpressionPropertiesMap<E> propertiesMap) {
+        return toPartitions(propertiesMap, (PartitionCreator<E, ExpressionPartition<E>>)ExpressionPartition::new);
     }
 
     @Nonnull
-    protected static <E extends RelationalExpression, P extends ExpressionPartition<E>> List<P> toPartitions(@Nonnull final Map<Map<ExpressionProperty<?>, ?>, ? extends Set<E>> propertiesToExpressionsMap,
-                                                                                                             @Nonnull final BiFunction<Map<ExpressionProperty<?>, ?>, Collection<E>, P> partitionCreatorFunction) {
-        return propertiesToExpressionsMap
+    protected static <E extends RelationalExpression, P extends ExpressionPartition<E>> List<P> toPartitions(@Nonnull final ExpressionPropertiesMap<E> propertiesMap,
+                                                                                                             @Nonnull final PartitionCreator<E, P> partitionCreator) {
+        return toPartitions(propertiesMap.getGroupingPropertiesExpressionsMap(),
+                propertiesMap.computeNonGroupingPropertiesMap(), partitionCreator);
+    }
+
+    @Nonnull
+    protected static <E extends RelationalExpression, P extends ExpressionPartition<E>> List<P> toPartitions(@Nonnull final Map<Map<ExpressionProperty<?>, ?>, ? extends Set<E>> groupingPropertiesMap,
+                                                                                                             @Nonnull Map<E, Map<ExpressionProperty<?>, ?>> nonGroupingPropertiesMap,
+                                                                                                             @Nonnull final PartitionCreator<E, P> partitionCreator) {
+        return groupingPropertiesMap
                 .entrySet()
                 .stream()
                 .map(entry -> {
-                    final var attributesMap = entry.getKey();
-                    final var plans = entry.getValue();
-                    return partitionCreatorFunction.apply(attributesMap, plans);
+                    final var groupingPropertyMap = entry.getKey();
+                    final var expressions = entry.getValue();
+                    final var expressionPropertyMap = new LinkedIdentityMap<E, Map<ExpressionProperty<?>, ?>>();
+                    for (final var expression : expressions) {
+                        final var propertiesMapForExpression =
+                                nonGroupingPropertiesMap.get(expression);
+                        expressionPropertyMap.put(expression, propertiesMapForExpression);
+                    }
+                    return partitionCreator.create(ImmutableMap.copyOf(groupingPropertyMap), expressionPropertyMap);
                 })
                 .collect(ImmutableList.toImmutableList());
+    }
+
+    @FunctionalInterface
+    protected interface PartitionCreator<E extends RelationalExpression, P extends ExpressionPartition<E>> {
+        P create(@Nonnull Map<ExpressionProperty<?>, ?> groupingPropertyMap,
+                 @Nonnull Map<E, Map<ExpressionProperty<?>, ?>> groupedPropertyMap);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/FindExpressionVisitor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/FindExpressionVisitor.java
@@ -75,6 +75,7 @@ public class FindExpressionVisitor implements SimpleExpressionVisitor<Map<Class<
         return Iterables.getOnlyElement(memberResults);
     }
 
+    @Nonnull
     @SuppressWarnings({"SameParameterValue", "java:S4276"})
     private Map<Class<? extends RelationalExpression>, Set<RelationalExpression>> mergeMaps(@Nonnull final Iterable<Map<Class<? extends RelationalExpression>, Set<RelationalExpression>>> childResults) {
         final ImmutableMap.Builder<Class<? extends RelationalExpression>, Set<RelationalExpression>> resultMap = ImmutableMap.builder();
@@ -91,10 +92,12 @@ public class FindExpressionVisitor implements SimpleExpressionVisitor<Map<Class<
         return resultMap.build();
     }
 
+    @Nonnull
     public static Set<? extends RelationalExpression> findExpressions(@Nonnull final Class<? extends RelationalExpression> expressionClass, @Nonnull final RelationalExpression expression) {
         return findExpressions(ImmutableSet.of(expressionClass), expression);
     }
 
+    @Nonnull
     public static Set<? extends RelationalExpression> findExpressions(@Nonnull final Set<Class<? extends RelationalExpression>> expressionClasses, @Nonnull final RelationalExpression expression) {
         final Map<Class<? extends RelationalExpression>, Set<RelationalExpression>> expressionClassToExpressionsMap = new FindExpressionVisitor(expressionClasses).visit(expression);
         if (expressionClassToExpressionsMap == null) {
@@ -108,6 +111,7 @@ public class FindExpressionVisitor implements SimpleExpressionVisitor<Map<Class<
         return accumulated;
     }
 
+    @Nonnull
     @SafeVarargs
     public static Set<? extends RelationalExpression> slice(@Nonnull final Map<Class<? extends RelationalExpression>, Set<RelationalExpression>> inMap, @Nonnull final Class<? extends RelationalExpression>... expressionClasses) {
         final Set<RelationalExpression> accumulated = new LinkedIdentitySet<>();
@@ -117,7 +121,6 @@ public class FindExpressionVisitor implements SimpleExpressionVisitor<Map<Class<
                 accumulated.addAll(childResultForClass);
             }
         }
-
         return accumulated;
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/LinkedIdentityMap.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/LinkedIdentityMap.java
@@ -22,6 +22,7 @@ package com.apple.foundationdb.record.query.plan.cascades;
 
 import com.google.common.base.Equivalence;
 import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 
 import javax.annotation.Nonnull;
@@ -50,8 +51,13 @@ public class LinkedIdentityMap<K, V> extends AbstractMap<K, V> {
     private final Supplier<Set<Entry<K, V>>> entrySetSupplier;
 
     public LinkedIdentityMap() {
+        this(ImmutableMap.of());
+    }
+
+    public LinkedIdentityMap(@Nonnull final Map<K, V> sourceMap) {
         this.map = Maps.newLinkedHashMap();
         this.entrySetSupplier = Suppliers.memoize(this::computeEntrySet);
+        putAll(sourceMap);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PlanPartition.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PlanPartition.java
@@ -26,7 +26,6 @@ import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 import com.google.common.base.Verify;
 
 import javax.annotation.Nonnull;
-import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 
@@ -35,8 +34,8 @@ import java.util.Set;
  */
 public class PlanPartition extends ExpressionPartition<RecordQueryPlan> {
     private PlanPartition(@Nonnull final Map<ExpressionProperty<?>, ?> propertyValuesMap,
-                          @Nonnull final Collection<RecordQueryPlan> plans) {
-        super(propertyValuesMap, plans);
+                          @Nonnull final Map<RecordQueryPlan, Map<ExpressionProperty<?>, ?>> planPropertyMap) {
+        super(propertyValuesMap, planPropertyMap);
     }
 
     @Nonnull
@@ -46,16 +45,18 @@ public class PlanPartition extends ExpressionPartition<RecordQueryPlan> {
 
     @Nonnull
     public static PlanPartition ofPlans(@Nonnull final Map<ExpressionProperty<?>, ?> propertyValuesMap,
-                                        @Nonnull final Collection<RecordQueryPlan> plans) {
-        return new PlanPartition(propertyValuesMap, plans);
+                                        @Nonnull final Map<RecordQueryPlan, Map<ExpressionProperty<?>, ?>> planPropertyMap) {
+        return new PlanPartition(propertyValuesMap, planPropertyMap);
     }
 
     @Nonnull
     @SuppressWarnings("unchecked")
     public static PlanPartition ofExpressions(@Nonnull final Map<ExpressionProperty<?>, ?> propertyValuesMap,
-                                              @Nonnull final Collection<? extends RelationalExpression> expressions) {
+                                              @Nonnull final Map<? extends RelationalExpression, Map<ExpressionProperty<?>, ?>> expressionPropertyMap) {
         Debugger.sanityCheck(() ->
-                Verify.verify(expressions.stream().allMatch(plan -> plan instanceof RecordQueryPlan)));
-        return new PlanPartition(propertyValuesMap, (Collection<RecordQueryPlan>)expressions);
+                Verify.verify(expressionPropertyMap.keySet()
+                        .stream()
+                        .allMatch(plan -> plan instanceof RecordQueryPlan)));
+        return new PlanPartition(propertyValuesMap, (Map<RecordQueryPlan, Map<ExpressionProperty<?>, ?>>)expressionPropertyMap);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PlanPartitions.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PlanPartitions.java
@@ -20,13 +20,11 @@
 
 package com.apple.foundationdb.record.query.plan.cascades;
 
-import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 import com.google.common.collect.ImmutableSet;
 
 import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 /**
@@ -49,7 +47,7 @@ public class PlanPartitions {
     }
 
     @Nonnull
-    public static List<PlanPartition> toPartitions(@Nonnull Map<Map<ExpressionProperty<?>, ?>, ? extends Set<RecordQueryPlan>> attributesToPlansMap) {
-        return ExpressionPartitions.toPartitions(attributesToPlansMap, PlanPartition::ofPlans);
+    public static List<PlanPartition> toPartitions(@Nonnull final PlanPropertiesMap propertiesMap) {
+        return ExpressionPartitions.toPartitions(propertiesMap, PlanPartition::ofPlans);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PlanPropertiesMap.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PlanPropertiesMap.java
@@ -27,13 +27,11 @@ import com.apple.foundationdb.record.query.plan.cascades.properties.PrimaryKeyPr
 import com.apple.foundationdb.record.query.plan.cascades.properties.StoredRecordProperty;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Multimaps;
 import com.google.common.collect.Sets;
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -59,7 +57,7 @@ public class PlanPropertiesMap extends ExpressionPropertiesMap<RecordQueryPlan> 
     }
 
     public PlanPropertiesMap(@Nonnull Collection<? extends RelationalExpression> plans) {
-        super(RecordQueryPlan.class, expressionProperties, plans);
+        super(RecordQueryPlan.class, expressionProperties, ImmutableSet.of(), plans);
     }
 
     @Nonnull
@@ -70,9 +68,8 @@ public class PlanPropertiesMap extends ExpressionPropertiesMap<RecordQueryPlan> 
 
     @Nonnull
     @Override
-    public List<PlanPartition> toPlanPartitions() {
-        update();
-        return PlanPartitions.toPartitions(Multimaps.asMap(getPropertyGroupedExpressionsMap()));
+    public Map<Map<ExpressionProperty<?>, ?>, Set<RecordQueryPlan>> getGroupingPropertiesPlansMap() {
+        return getGroupingPropertiesExpressionsMap();
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PlanPropertiesMap.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PlanPropertiesMap.java
@@ -69,7 +69,7 @@ public class PlanPropertiesMap extends ExpressionPropertiesMap<RecordQueryPlan> 
     @Nonnull
     @Override
     public Map<Map<ExpressionProperty<?>, ?>, Set<RecordQueryPlan>> getGroupingPropertiesPlansMap() {
-        return getGroupingPropertiesExpressionsMap();
+        return getPartitioningPropertiesExpressionsMap();
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PlannerStage.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PlannerStage.java
@@ -79,12 +79,12 @@ public enum PlannerStage {
      *     </li>
      * </ul>
      */
-    INITIAL(ExpressionPropertiesMap::defaultForExpressions),
+    INITIAL(ExpressionPropertiesMap::defaultForRewritePhase),
     /**
      * Canonical stage. The {@link Reference} is tagged with {@code CANONICAL} iff it was created by the Cascades
      * planner and is the direct result of the rewrite phase of a query graph.
      */
-    CANONICAL(ExpressionPropertiesMap::defaultForExpressions),
+    CANONICAL(ExpressionPropertiesMap::defaultForRewritePhase),
     /**
      * The {@link Reference} is tagged with {@code PLANNED} iff it was created by the Cascades planner and it
      * the direct result of the physical planning of a query. All final {@link RelationalExpression}s contained in

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/Reference.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/Reference.java
@@ -585,12 +585,12 @@ public class Reference implements Correlated<Reference>, Typed {
 
     @Nonnull
     public List<? extends ExpressionPartition<? extends RelationalExpression>> toExpressionPartitions() {
-        return propertiesMap.toExpressionPartitions();
+        return ExpressionPartitions.toPartitions(propertiesMap);
     }
 
     @Nonnull
     public List<PlanPartition> toPlanPartitions() {
-        return propertiesMap.toPlanPartitions();
+        return PlanPartitions.toPartitions((PlanPropertiesMap)propertiesMap);
     }
 
     @Nullable

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/Reference.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/Reference.java
@@ -579,7 +579,12 @@ public class Reference implements Correlated<Reference>, Typed {
     }
 
     @Nonnull
-    public <A> Map<RecordQueryPlan, A> getProperty(@Nonnull final ExpressionProperty<A> expressionProperty) {
+    public <A> Map<? extends RelationalExpression, A> getPropertyForExpressions(@Nonnull final ExpressionProperty<A> expressionProperty) {
+        return propertiesMap.propertyValueForExpressions(expressionProperty);
+    }
+
+    @Nonnull
+    public <A> Map<RecordQueryPlan, A> getPropertyForPlans(@Nonnull final ExpressionProperty<A> expressionProperty) {
         return propertiesMap.propertyValueForPlans(expressionProperty);
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/structure/ExpressionsPartitionMatchers.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/structure/ExpressionsPartitionMatchers.java
@@ -102,7 +102,7 @@ public class ExpressionsPartitionMatchers {
                                         .stream()
                                         .min(Comparator.comparing(
                                                 expression ->
-                                                        partition.getGroupedPropertyValue(expression,
+                                                        partition.getExpressionPropertyValue(expression,
                                                                 expressionProperty))),
                         name -> "argmin(" + name + ")"),
                 OptionalIfPresentMatcher.present(downstream));
@@ -119,7 +119,7 @@ public class ExpressionsPartitionMatchers {
                                         .stream()
                                         .max(Comparator.comparing(
                                                 expression ->
-                                                        partition.getGroupedPropertyValue(expression,
+                                                        partition.getExpressionPropertyValue(expression,
                                                                 expressionProperty))),
                         name -> "argmax(" + name + ")"),
                 OptionalIfPresentMatcher.present(downstream));

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/structure/ExpressionsPartitionMatchers.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/structure/ExpressionsPartitionMatchers.java
@@ -30,6 +30,7 @@ import com.google.common.collect.ImmutableSet;
 
 import javax.annotation.Nonnull;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -88,5 +89,39 @@ public class ExpressionsPartitionMatchers {
     @SuppressWarnings("unchecked")
     public static BindingMatcher<ExpressionPartition<RelationalExpression>> anyExpressionPartition() {
         return typed((Class<ExpressionPartition<RelationalExpression>>)(Class<?>)ExpressionPartition.class);
+    }
+
+    @Nonnull
+    @SuppressWarnings("unchecked")
+    public static <P extends Comparable<P>> BindingMatcher<ExpressionPartition<RelationalExpression>> argmin(@Nonnull final ExpressionProperty<P> expressionProperty,
+                                                                                                             @Nonnull final BindingMatcher<RelationalExpression> downstream) {
+        return TypedMatcherWithExtractAndDownstream.typedWithDownstream(
+                (Class<ExpressionPartition<RelationalExpression>>)(Class<?>)Collection.class,
+                Extractor.of(partition ->
+                                partition.getExpressions()
+                                        .stream()
+                                        .min(Comparator.comparing(
+                                                expression ->
+                                                        partition.getGroupedPropertyValue(expression,
+                                                                expressionProperty))),
+                        name -> "argmin(" + name + ")"),
+                OptionalIfPresentMatcher.present(downstream));
+    }
+
+    @Nonnull
+    @SuppressWarnings("unchecked")
+    public static <P extends Comparable<P>> BindingMatcher<ExpressionPartition<RelationalExpression>> argmax(@Nonnull final ExpressionProperty<P> expressionProperty,
+                                                                                                             @Nonnull final BindingMatcher<RelationalExpression> downstream) {
+        return TypedMatcherWithExtractAndDownstream.typedWithDownstream(
+                (Class<ExpressionPartition<RelationalExpression>>)(Class<?>)Collection.class,
+                Extractor.of(partition ->
+                                partition.getExpressions()
+                                        .stream()
+                                        .max(Comparator.comparing(
+                                                expression ->
+                                                        partition.getGroupedPropertyValue(expression,
+                                                                expressionProperty))),
+                        name -> "argmax(" + name + ")"),
+                OptionalIfPresentMatcher.present(downstream));
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/structure/ExpressionsPartitionMatchers.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/structure/ExpressionsPartitionMatchers.java
@@ -102,7 +102,7 @@ public class ExpressionsPartitionMatchers {
                                         .stream()
                                         .min(Comparator.comparing(
                                                 expression ->
-                                                        partition.getExpressionPropertyValue(expression,
+                                                        partition.getNonPartitioningPropertyValue(expression,
                                                                 expressionProperty))),
                         name -> "argmin(" + name + ")"),
                 OptionalIfPresentMatcher.present(downstream));
@@ -119,7 +119,7 @@ public class ExpressionsPartitionMatchers {
                                         .stream()
                                         .max(Comparator.comparing(
                                                 expression ->
-                                                        partition.getExpressionPropertyValue(expression,
+                                                        partition.getNonPartitioningPropertyValue(expression,
                                                                 expressionProperty))),
                         name -> "argmax(" + name + ")"),
                 OptionalIfPresentMatcher.present(downstream));

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/DistinctRecordsProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/DistinctRecordsProperty.java
@@ -424,7 +424,7 @@ public class DistinctRecordsProperty implements ExpressionProperty<Boolean> {
 
         private boolean evaluateForReference(@Nonnull Reference reference) {
             final var memberDistinctRecordsCollection =
-                    reference.getProperty(DISTINCT_RECORDS).values();
+                    reference.getPropertyForPlans(DISTINCT_RECORDS).values();
 
             return memberDistinctRecordsCollection
                     .stream()

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/OrderingProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/OrderingProperty.java
@@ -708,7 +708,7 @@ public class OrderingProperty implements ExpressionProperty<Ordering> {
         @Nonnull
         private Ordering evaluateForReference(@Nonnull Reference reference) {
             final var memberOrderings =
-                    reference.getProperty(ORDERING).values();
+                    reference.getPropertyForPlans(ORDERING).values();
             final var allAreDistinct =
                     memberOrderings
                             .stream()

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/PrimaryKeyProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/PrimaryKeyProperty.java
@@ -456,7 +456,7 @@ public class PrimaryKeyProperty implements ExpressionProperty<Optional<List<Valu
 
         private Optional<List<Value>> evaluateForReference(@Nonnull Reference reference) {
             final var memberPrimaryKeysCollection =
-                    reference.getProperty(PRIMARY_KEY).values();
+                    reference.getPropertyForPlans(PRIMARY_KEY).values();
 
             return commonPrimaryKeyValuesMaybeFromOptionals(memberPrimaryKeysCollection);
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/SelectCountProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/SelectCountProperty.java
@@ -1,0 +1,94 @@
+/*
+ * ExpressionDepthProperty.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.cascades.properties;
+
+import com.apple.foundationdb.record.query.plan.cascades.ExpressionProperty;
+import com.apple.foundationdb.record.query.plan.cascades.Reference;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpression;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpressionVisitorWithDefaults;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.SelectExpression;
+import com.google.common.base.Verify;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A property representing the minimum depth of any of a set of relational planner expression types in a relational
+ * planner expression: that is, the smallest integer such that one of those types is exactly that many relational
+ * planner expressions away from the root expression.
+ */
+public class SelectCountProperty implements ExpressionProperty<Integer> {
+    private static final SelectCountProperty SELECT_COUNT = new SelectCountProperty();
+
+    private SelectCountProperty() {
+    }
+
+    @Nonnull
+    @Override
+    public SelectCountVisitor createVisitor() {
+        return new SelectCountVisitor();
+    }
+
+    public int evaluate(@Nonnull final Reference reference) {
+        return evaluate(reference.get());
+    }
+
+    public int evaluate(@Nonnull final RelationalExpression expression) {
+        return Objects.requireNonNull(createVisitor().visit(expression));
+    }
+
+    @Nonnull
+    public static SelectCountProperty selectCount() {
+        return SELECT_COUNT;
+    }
+
+    public static class SelectCountVisitor implements RelationalExpressionVisitorWithDefaults<Integer> {
+        @Nonnull
+        @Override
+        public Integer visitSelectExpression(@Nonnull final SelectExpression selectExpression) {
+            return visitDefault(selectExpression) + 1;
+        }
+
+        @Nonnull
+        @Override
+        public Integer visitDefault(@Nonnull final RelationalExpression expression) {
+            return fromChildren(expression).stream().mapToInt(Integer::intValue).sum();
+        }
+
+        @Nonnull
+        private List<Integer> fromChildren(@Nonnull final RelationalExpression expression) {
+            return expression.getQuantifiers()
+                    .stream()
+                    .map(quantifier -> forReference(quantifier.getRangesOver()))
+                    .collect(ImmutableList.toImmutableList());
+        }
+
+        private int forReference(@Nonnull Reference reference) {
+            final var memberResults =
+                    reference.getPropertyForExpressions(SELECT_COUNT).values();
+            Verify.verify(memberResults.size() == 1);
+            return Iterables.getOnlyElement(memberResults);
+        }
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/StoredRecordProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/StoredRecordProperty.java
@@ -413,7 +413,7 @@ public class StoredRecordProperty implements ExpressionProperty<Boolean> {
 
         private boolean evaluateForReference(@Nonnull Reference reference) {
             final var memberStoredRecordsCollection =
-                    reference.getProperty(STORED_RECORD).values();
+                    reference.getPropertyForPlans(STORED_RECORD).values();
 
             return memberStoredRecordsCollection
                     .stream()

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/FinalizeExpressionsRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/FinalizeExpressionsRule.java
@@ -56,7 +56,7 @@ public class FinalizeExpressionsRule extends ImplementationCascadesRule<Relation
     @Nonnull
     private static final BindingMatcher<ExpressionPartition<RelationalExpression>> childPartitionsMatcher =
             anyExpressionPartition();
-
+    
     @Nonnull
     private static final BindingMatcher<Reference> childReferenceMatcher =
             expressionPartitions(rollUpPartitions(any(childPartitionsMatcher)));

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementDeleteRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementDeleteRule.java
@@ -53,7 +53,7 @@ public class ImplementDeleteRule extends ImplementationCascadesRule<DeleteExpres
 
     @Nonnull
     private static final BindingMatcher<Reference> innerReferenceMatcher =
-            planPartitions(filterPartition(planPartition -> planPartition.getPropertyValue(StoredRecordProperty.storedRecord()),
+            planPartitions(filterPartition(planPartition -> planPartition.getGroupingPropertyValue(StoredRecordProperty.storedRecord()),
                     any(innerPlanPartitionMatcher)));
 
     private static final BindingMatcher<Quantifier.ForEach> innerQuantifierMatcher =
@@ -77,7 +77,7 @@ public class ImplementDeleteRule extends ImplementationCascadesRule<DeleteExpres
         final var planPartitionReference =
                 call.memoizeMemberPlansFromOther(innerReference, innerPlanPartition.getPlans());
         final var distinctPlansReference =
-                innerPlanPartition.getPropertyValue(DistinctRecordsProperty.distinctRecords())
+                innerPlanPartition.getGroupingPropertyValue(DistinctRecordsProperty.distinctRecords())
                 ? planPartitionReference
                 : call.memoizePlan(new RecordQueryUnorderedPrimaryKeyDistinctPlan(Quantifier.physical(planPartitionReference)));
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementDeleteRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementDeleteRule.java
@@ -53,7 +53,7 @@ public class ImplementDeleteRule extends ImplementationCascadesRule<DeleteExpres
 
     @Nonnull
     private static final BindingMatcher<Reference> innerReferenceMatcher =
-            planPartitions(filterPartition(planPartition -> planPartition.getGroupingPropertyValue(StoredRecordProperty.storedRecord()),
+            planPartitions(filterPartition(planPartition -> planPartition.getPartitionPropertyValue(StoredRecordProperty.storedRecord()),
                     any(innerPlanPartitionMatcher)));
 
     private static final BindingMatcher<Quantifier.ForEach> innerQuantifierMatcher =
@@ -77,7 +77,7 @@ public class ImplementDeleteRule extends ImplementationCascadesRule<DeleteExpres
         final var planPartitionReference =
                 call.memoizeMemberPlansFromOther(innerReference, innerPlanPartition.getPlans());
         final var distinctPlansReference =
-                innerPlanPartition.getGroupingPropertyValue(DistinctRecordsProperty.distinctRecords())
+                innerPlanPartition.getPartitionPropertyValue(DistinctRecordsProperty.distinctRecords())
                 ? planPartitionReference
                 : call.memoizePlan(new RecordQueryUnorderedPrimaryKeyDistinctPlan(Quantifier.physical(planPartitionReference)));
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementDistinctRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementDistinctRule.java
@@ -65,7 +65,7 @@ public class ImplementDistinctRule extends ImplementationCascadesRule<LogicalDis
 
     @Nonnull
     private static final BindingMatcher<Reference> innerReferenceMatcher =
-            planPartitions(filterPartition(planPartition -> planPartition.getGroupingPropertyValue(StoredRecordProperty.storedRecord()),
+            planPartitions(filterPartition(planPartition -> planPartition.getPartitionPropertyValue(StoredRecordProperty.storedRecord()),
                     any(innerPlanPartitionMatcher)));
 
     @Nonnull
@@ -81,7 +81,7 @@ public class ImplementDistinctRule extends ImplementationCascadesRule<LogicalDis
         final var innerPlanPartition = call.get(innerPlanPartitionMatcher);
         final var innerReference = call.get(innerReferenceMatcher);
 
-        if (innerPlanPartition.getGroupingPropertyValue(DistinctRecordsProperty.distinctRecords())) {
+        if (innerPlanPartition.getPartitionPropertyValue(DistinctRecordsProperty.distinctRecords())) {
             call.yieldPlans(innerPlanPartition.getPlans());
         } else {
             // these create duplicates

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementDistinctRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementDistinctRule.java
@@ -65,7 +65,7 @@ public class ImplementDistinctRule extends ImplementationCascadesRule<LogicalDis
 
     @Nonnull
     private static final BindingMatcher<Reference> innerReferenceMatcher =
-            planPartitions(filterPartition(planPartition -> planPartition.getPropertyValue(StoredRecordProperty.storedRecord()),
+            planPartitions(filterPartition(planPartition -> planPartition.getGroupingPropertyValue(StoredRecordProperty.storedRecord()),
                     any(innerPlanPartitionMatcher)));
 
     @Nonnull
@@ -81,7 +81,7 @@ public class ImplementDistinctRule extends ImplementationCascadesRule<LogicalDis
         final var innerPlanPartition = call.get(innerPlanPartitionMatcher);
         final var innerReference = call.get(innerReferenceMatcher);
 
-        if (innerPlanPartition.getPropertyValue(DistinctRecordsProperty.distinctRecords())) {
+        if (innerPlanPartition.getGroupingPropertyValue(DistinctRecordsProperty.distinctRecords())) {
             call.yieldPlans(innerPlanPartition.getPlans());
         } else {
             // these create duplicates

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementDistinctUnionRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementDistinctUnionRule.java
@@ -78,8 +78,8 @@ public class ImplementDistinctUnionRule extends ImplementationCascadesRule<Logic
 
     @Nonnull
     private static final BindingMatcher<Reference> unionLegReferenceMatcher =
-            planPartitions(filterPartition(planPartition -> planPartition.getGroupingPropertyValue(StoredRecordProperty.storedRecord()) &&
-                                                  planPartition.getGroupingPropertyValue(PrimaryKeyProperty.primaryKey()).isPresent(),
+            planPartitions(filterPartition(planPartition -> planPartition.getPartitionPropertyValue(StoredRecordProperty.storedRecord()) &&
+                                                  planPartition.getPartitionPropertyValue(PrimaryKeyProperty.primaryKey()).isPresent(),
                     rollUpPartitionsTo(unionLegPlanPartitionsMatcher, allAttributesExcept(DistinctRecordsProperty.distinctRecords()))));
 
     private static final CollectionMatcher<Quantifier.ForEach> allForEachQuantifiersMatcher =
@@ -150,7 +150,7 @@ public class ImplementDistinctUnionRule extends ImplementationCascadesRule<Logic
 
                 final var commonPrimaryKeyValuesMaybe =
                         PrimaryKeyProperty.commonPrimaryKeyValuesMaybeFromOptionals(partitions.stream()
-                                .map(partition -> partition.getGroupingPropertyValue(PrimaryKeyProperty.primaryKey()))
+                                .map(partition -> partition.getPartitionPropertyValue(PrimaryKeyProperty.primaryKey()))
                                 .collect(ImmutableList.toImmutableList()));
 
                 if (commonPrimaryKeyValuesMaybe.isEmpty()) {
@@ -161,7 +161,7 @@ public class ImplementDistinctUnionRule extends ImplementationCascadesRule<Logic
                 final ImmutableList<Ordering> orderings =
                         partitions
                                 .stream()
-                                .map(planPartition -> planPartition.getGroupingPropertyValue(OrderingProperty.ordering()))
+                                .map(planPartition -> planPartition.getPartitionPropertyValue(OrderingProperty.ordering()))
                                 .collect(ImmutableList.toImmutableList());
                 pushInterestingOrders(call, unionForEachQuantifier, orderings, requestedOrdering);
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementDistinctUnionRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementDistinctUnionRule.java
@@ -78,8 +78,8 @@ public class ImplementDistinctUnionRule extends ImplementationCascadesRule<Logic
 
     @Nonnull
     private static final BindingMatcher<Reference> unionLegReferenceMatcher =
-            planPartitions(filterPartition(planPartition -> planPartition.getPropertyValue(StoredRecordProperty.storedRecord()) &&
-                                                  planPartition.getPropertyValue(PrimaryKeyProperty.primaryKey()).isPresent(),
+            planPartitions(filterPartition(planPartition -> planPartition.getGroupingPropertyValue(StoredRecordProperty.storedRecord()) &&
+                                                  planPartition.getGroupingPropertyValue(PrimaryKeyProperty.primaryKey()).isPresent(),
                     rollUpPartitionsTo(unionLegPlanPartitionsMatcher, allAttributesExcept(DistinctRecordsProperty.distinctRecords()))));
 
     private static final CollectionMatcher<Quantifier.ForEach> allForEachQuantifiersMatcher =
@@ -150,7 +150,7 @@ public class ImplementDistinctUnionRule extends ImplementationCascadesRule<Logic
 
                 final var commonPrimaryKeyValuesMaybe =
                         PrimaryKeyProperty.commonPrimaryKeyValuesMaybeFromOptionals(partitions.stream()
-                                .map(partition -> partition.getPropertyValue(PrimaryKeyProperty.primaryKey()))
+                                .map(partition -> partition.getGroupingPropertyValue(PrimaryKeyProperty.primaryKey()))
                                 .collect(ImmutableList.toImmutableList()));
 
                 if (commonPrimaryKeyValuesMaybe.isEmpty()) {
@@ -161,7 +161,7 @@ public class ImplementDistinctUnionRule extends ImplementationCascadesRule<Logic
                 final ImmutableList<Ordering> orderings =
                         partitions
                                 .stream()
-                                .map(planPartition -> planPartition.getPropertyValue(OrderingProperty.ordering()))
+                                .map(planPartition -> planPartition.getGroupingPropertyValue(OrderingProperty.ordering()))
                                 .collect(ImmutableList.toImmutableList());
                 pushInterestingOrders(call, unionForEachQuantifier, orderings, requestedOrdering);
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementInJoinRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementInJoinRule.java
@@ -144,7 +144,7 @@ public class ImplementInJoinRule extends ImplementationCascadesRule<SelectExpres
         final var planPartitions = PlanPartitions.rollUpTo(innerReference.toPlanPartitions(), OrderingProperty.ordering());
 
         for (final var planPartition  : planPartitions) {
-            final var providedOrdering = planPartition.getGroupingPropertyValue(OrderingProperty.ordering());
+            final var providedOrdering = planPartition.getPartitionPropertyValue(OrderingProperty.ordering());
 
             for (final RequestedOrdering requestedOrdering : requestedOrderings) {
                 final var sourcesStream =

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementInJoinRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementInJoinRule.java
@@ -144,7 +144,7 @@ public class ImplementInJoinRule extends ImplementationCascadesRule<SelectExpres
         final var planPartitions = PlanPartitions.rollUpTo(innerReference.toPlanPartitions(), OrderingProperty.ordering());
 
         for (final var planPartition  : planPartitions) {
-            final var providedOrdering = planPartition.getPropertyValue(OrderingProperty.ordering());
+            final var providedOrdering = planPartition.getGroupingPropertyValue(OrderingProperty.ordering());
 
             for (final RequestedOrdering requestedOrdering : requestedOrderings) {
                 final var sourcesStream =

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementInUnionRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementInUnionRule.java
@@ -166,7 +166,7 @@ public class ImplementInUnionRule extends ImplementationCascadesRule<SelectExpre
         final int attemptFailedInJoinAsUnionMaxSize = call.getContext().getPlannerConfiguration().getAttemptFailedInJoinAsUnionMaxSize();
 
         for (final var planPartition : planPartitions) {
-            final var providedOrdering = planPartition.getPropertyValue(OrderingProperty.ordering());
+            final var providedOrdering = planPartition.getGroupingPropertyValue(OrderingProperty.ordering());
 
             for (final var requestedOrdering : requestedOrderings) {
                 if (requestedOrdering.isPreserve()) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementInUnionRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementInUnionRule.java
@@ -166,7 +166,7 @@ public class ImplementInUnionRule extends ImplementationCascadesRule<SelectExpre
         final int attemptFailedInJoinAsUnionMaxSize = call.getContext().getPlannerConfiguration().getAttemptFailedInJoinAsUnionMaxSize();
 
         for (final var planPartition : planPartitions) {
-            final var providedOrdering = planPartition.getGroupingPropertyValue(OrderingProperty.ordering());
+            final var providedOrdering = planPartition.getPartitionPropertyValue(OrderingProperty.ordering());
 
             for (final var requestedOrdering : requestedOrderings) {
                 if (requestedOrdering.isPreserve()) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementIntersectionRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementIntersectionRule.java
@@ -63,7 +63,7 @@ public class ImplementIntersectionRule extends ImplementationCascadesRule<Logica
 
     @Nonnull
     private static final BindingMatcher<Reference> intersectionLegReferenceMatcher =
-            planPartitions(filterPartition(planPartition -> planPartition.getPropertyValue(StoredRecordProperty.storedRecord()),
+            planPartitions(filterPartition(planPartition -> planPartition.getGroupingPropertyValue(StoredRecordProperty.storedRecord()),
                     rollUpPartitionsTo(any(intersectionLegPlanPartitionMatcher), PlanPropertiesMap.allAttributesExcept(DistinctRecordsProperty.distinctRecords(), OrderingProperty.ordering()))));
     @Nonnull
     private static final CollectionMatcher<Quantifier.ForEach> allForEachQuantifiersMatcher =

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementIntersectionRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementIntersectionRule.java
@@ -63,7 +63,7 @@ public class ImplementIntersectionRule extends ImplementationCascadesRule<Logica
 
     @Nonnull
     private static final BindingMatcher<Reference> intersectionLegReferenceMatcher =
-            planPartitions(filterPartition(planPartition -> planPartition.getGroupingPropertyValue(StoredRecordProperty.storedRecord()),
+            planPartitions(filterPartition(planPartition -> planPartition.getPartitionPropertyValue(StoredRecordProperty.storedRecord()),
                     rollUpPartitionsTo(any(intersectionLegPlanPartitionMatcher), PlanPropertiesMap.allAttributesExcept(DistinctRecordsProperty.distinctRecords(), OrderingProperty.ordering()))));
     @Nonnull
     private static final CollectionMatcher<Quantifier.ForEach> allForEachQuantifiersMatcher =

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementStreamingAggregationRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementStreamingAggregationRule.java
@@ -94,7 +94,7 @@ public class ImplementStreamingAggregationRule extends ImplementationCascadesRul
         final var planPartitions = PlanPartitions.rollUpTo(innerReference.toPlanPartitions(), OrderingProperty.ordering());
 
         for (final var planPartition : planPartitions) {
-            final var providedOrdering = planPartition.getPropertyValue(OrderingProperty.ordering());
+            final var providedOrdering = planPartition.getGroupingPropertyValue(OrderingProperty.ordering());
             if (requiredOrderingKeyValues == null || providedOrdering.satisfiesGroupingValues(requiredOrderingKeyValues)) {
                 call.yieldPlan(implementGroupBy(call, planPartition, groupByExpression));
             }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementStreamingAggregationRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementStreamingAggregationRule.java
@@ -94,7 +94,7 @@ public class ImplementStreamingAggregationRule extends ImplementationCascadesRul
         final var planPartitions = PlanPartitions.rollUpTo(innerReference.toPlanPartitions(), OrderingProperty.ordering());
 
         for (final var planPartition : planPartitions) {
-            final var providedOrdering = planPartition.getGroupingPropertyValue(OrderingProperty.ordering());
+            final var providedOrdering = planPartition.getPartitionPropertyValue(OrderingProperty.ordering());
             if (requiredOrderingKeyValues == null || providedOrdering.satisfiesGroupingValues(requiredOrderingKeyValues)) {
                 call.yieldPlan(implementGroupBy(call, planPartition, groupByExpression));
             }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementTypeFilterRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementTypeFilterRule.java
@@ -62,7 +62,7 @@ public class ImplementTypeFilterRule extends ImplementationCascadesRule<LogicalT
 
     @Nonnull
     private static final BindingMatcher<Reference> innerReferenceMatcher =
-            planPartitions(filterPartition(planPartition -> planPartition.getGroupingPropertyValue(StoredRecordProperty.storedRecord()),
+            planPartitions(filterPartition(planPartition -> planPartition.getPartitionPropertyValue(StoredRecordProperty.storedRecord()),
                     any(innerPlanPartitionMatcher)));
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementTypeFilterRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementTypeFilterRule.java
@@ -62,7 +62,7 @@ public class ImplementTypeFilterRule extends ImplementationCascadesRule<LogicalT
 
     @Nonnull
     private static final BindingMatcher<Reference> innerReferenceMatcher =
-            planPartitions(filterPartition(planPartition -> planPartition.getPropertyValue(StoredRecordProperty.storedRecord()),
+            planPartitions(filterPartition(planPartition -> planPartition.getGroupingPropertyValue(StoredRecordProperty.storedRecord()),
                     any(innerPlanPartitionMatcher)));
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementUniqueRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementUniqueRule.java
@@ -54,7 +54,7 @@ public class ImplementUniqueRule extends ImplementationCascadesRule<LogicalUniqu
 
     @Nonnull
     private static final BindingMatcher<Reference> innerReferenceMatcher = planPartitions(
-            filterPartition(planPartition -> planPartition.getPropertyValuesMap().containsKey(DistinctRecordsProperty.distinctRecords())
+            filterPartition(planPartition -> planPartition.getGroupingPropertyMap().containsKey(DistinctRecordsProperty.distinctRecords())
                                    && planPartition.getPropertyValue(PrimaryKeyProperty.primaryKey()).isPresent(),
                     rollUpPartitions(anyPlanPartitionMatcher)));
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementUniqueRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementUniqueRule.java
@@ -54,8 +54,8 @@ public class ImplementUniqueRule extends ImplementationCascadesRule<LogicalUniqu
 
     @Nonnull
     private static final BindingMatcher<Reference> innerReferenceMatcher = planPartitions(
-            filterPartition(planPartition -> planPartition.getGroupingPropertyMap().containsKey(DistinctRecordsProperty.distinctRecords())
-                                   && planPartition.getGroupingPropertyValue(PrimaryKeyProperty.primaryKey()).isPresent(),
+            filterPartition(planPartition -> planPartition.getPartitionPropertiesMap().containsKey(DistinctRecordsProperty.distinctRecords())
+                                   && planPartition.getPartitionPropertyValue(PrimaryKeyProperty.primaryKey()).isPresent(),
                     rollUpPartitions(anyPlanPartitionMatcher)));
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementUniqueRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementUniqueRule.java
@@ -55,7 +55,7 @@ public class ImplementUniqueRule extends ImplementationCascadesRule<LogicalUniqu
     @Nonnull
     private static final BindingMatcher<Reference> innerReferenceMatcher = planPartitions(
             filterPartition(planPartition -> planPartition.getGroupingPropertyMap().containsKey(DistinctRecordsProperty.distinctRecords())
-                                   && planPartition.getPropertyValue(PrimaryKeyProperty.primaryKey()).isPresent(),
+                                   && planPartition.getGroupingPropertyValue(PrimaryKeyProperty.primaryKey()).isPresent(),
                     rollUpPartitions(anyPlanPartitionMatcher)));
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementUpdateRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementUpdateRule.java
@@ -52,7 +52,7 @@ public class ImplementUpdateRule extends ImplementationCascadesRule<UpdateExpres
 
     @Nonnull
     private static final BindingMatcher<Reference> innerReferenceMatcher =
-            planPartitions(filterPartition(planPartition -> planPartition.getGroupingPropertyValue(StoredRecordProperty.storedRecord()),
+            planPartitions(filterPartition(planPartition -> planPartition.getPartitionPropertyValue(StoredRecordProperty.storedRecord()),
                     any(innerPlanPartitionMatcher)));
 
     private static final BindingMatcher<Quantifier.ForEach> innerQuantifierMatcher =

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementUpdateRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementUpdateRule.java
@@ -52,7 +52,7 @@ public class ImplementUpdateRule extends ImplementationCascadesRule<UpdateExpres
 
     @Nonnull
     private static final BindingMatcher<Reference> innerReferenceMatcher =
-            planPartitions(filterPartition(planPartition -> planPartition.getPropertyValue(StoredRecordProperty.storedRecord()),
+            planPartitions(filterPartition(planPartition -> planPartition.getGroupingPropertyValue(StoredRecordProperty.storedRecord()),
                     any(innerPlanPartitionMatcher)));
 
     private static final BindingMatcher<Quantifier.ForEach> innerQuantifierMatcher =

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/RemoveSortRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/RemoveSortRule.java
@@ -92,7 +92,7 @@ public class RemoveSortRule extends ImplementationCascadesRule<LogicalSortExpres
         final List<OrderingPart.RequestedOrderingPart> requestedOrderingParts = requestedOrdering.getOrderingParts();
         final Set<Value> sortValuesSet = requestedOrderingParts.stream().map(OrderingPart::getValue).collect(Collectors.toSet());
 
-        final Ordering ordering = innerPlanPartition.getPropertyValue(OrderingProperty.ordering());
+        final Ordering ordering = innerPlanPartition.getGroupingPropertyValue(OrderingProperty.ordering());
         final Set<Value> equalityBoundKeys = ordering.getEqualityBoundValues();
         int equalityBoundUnsorted = equalityBoundKeys.size();
 
@@ -109,7 +109,7 @@ public class RemoveSortRule extends ImplementationCascadesRule<LogicalSortExpres
             return;
         }
 
-        final boolean isDistinct = innerPlanPartition.getPropertyValue(DistinctRecordsProperty.distinctRecords());
+        final boolean isDistinct = innerPlanPartition.getGroupingPropertyValue(DistinctRecordsProperty.distinctRecords());
         if (isDistinct) {
             if (ordering.getOrderingSet()
                     .getSet()

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/RemoveSortRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/RemoveSortRule.java
@@ -92,7 +92,7 @@ public class RemoveSortRule extends ImplementationCascadesRule<LogicalSortExpres
         final List<OrderingPart.RequestedOrderingPart> requestedOrderingParts = requestedOrdering.getOrderingParts();
         final Set<Value> sortValuesSet = requestedOrderingParts.stream().map(OrderingPart::getValue).collect(Collectors.toSet());
 
-        final Ordering ordering = innerPlanPartition.getGroupingPropertyValue(OrderingProperty.ordering());
+        final Ordering ordering = innerPlanPartition.getPartitionPropertyValue(OrderingProperty.ordering());
         final Set<Value> equalityBoundKeys = ordering.getEqualityBoundValues();
         int equalityBoundUnsorted = equalityBoundKeys.size();
 
@@ -109,7 +109,7 @@ public class RemoveSortRule extends ImplementationCascadesRule<LogicalSortExpres
             return;
         }
 
-        final boolean isDistinct = innerPlanPartition.getGroupingPropertyValue(DistinctRecordsProperty.distinctRecords());
+        final boolean isDistinct = innerPlanPartition.getPartitionPropertyValue(DistinctRecordsProperty.distinctRecords());
         if (isDistinct) {
             if (ordering.getOrderingSet()
                     .getSet()


### PR DESCRIPTION
This PR provides a distinction among the properties that are being maintained for `References`. Before this PR, all properties were only used to derive `ExpressionPartition`s, i.e. they would define a set of properties all plans in the reference could be partitioned by. There are, however, also other properties which should be maintained in the same way but should be accessible individually for each expression in the reference.