### PR TITLE
Revert "Add RecordCountKey State"

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -559,21 +559,13 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
 
     @SuppressWarnings("PMD.CloseResource")
     private <M extends Message> void addRecordCount(@Nonnull RecordMetaData metaData, @Nonnull FDBStoredRecord<M> rec, @Nonnull byte[] increment) {
-        if (metaData.getRecordCountKey() != null) {
-            beginRecordStoreStateRead();
-            try {
-                RecordMetaDataProto.DataStoreInfo header = recordStoreStateRef.get().getStoreHeader();
-                // We do not need to check the format version here. In order for it to be DISABLED we would have to be
-                // on a format version that supports such a state.
-                if (header.getRecordCountState() != RecordMetaDataProto.DataStoreInfo.RecordCountState.DISABLED) {
-                    Key.Evaluated subkey = metaData.getRecordCountKey().evaluateSingleton(rec);
-                    final byte[] keyBytes = getSubspace().pack(Tuple.from(RECORD_COUNT_KEY).addAll(subkey.toTupleAppropriateList()));
-                    ensureContextActive().mutate(MutationType.ADD, keyBytes, increment);
-                }
-            } finally {
-                endRecordStoreStateRead();
-            }
+        if (metaData.getRecordCountKey() == null) {
+            return;
         }
+        final Transaction tr = ensureContextActive();
+        Key.Evaluated subkey = metaData.getRecordCountKey().evaluateSingleton(rec);
+        final byte[] keyBytes = getSubspace().pack(Tuple.from(RECORD_COUNT_KEY).addAll(subkey.toTupleAppropriateList()));
+        tr.mutate(MutationType.ADD, keyBytes, increment);
     }
 
     @Nullable
@@ -1859,9 +1851,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
             }
 
             final KeyExpression recordCountKey = getRecordMetaData().getRecordCountKey();
-            if (recordCountKey != null
-                    // we don't need to call beginRecordStoreStateRead(), that is checked in deleteRecordsWhereAsync
-                    && recordStoreStateRef.get().getStoreHeader().getRecordCountState() != RecordMetaDataProto.DataStoreInfo.RecordCountState.DISABLED) {
+            if (recordCountKey != null) {
                 final QueryToKeyMatcher.Match match = matcher.matchesSatisfyingQuery(recordCountKey);
                 if (match.getType() != QueryToKeyMatcher.MatchType.EQUALITY) {
                     throw new Query.InvalidExpressionException("Record count key not matching for deleteRecordsWhere");
@@ -2087,11 +2077,8 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
                 context.clear(versionRange);
             }
 
-
             final KeyExpression recordCountKey = getRecordMetaData().getRecordCountKey();
-            if (recordCountKey != null
-                    // we don't need to call beginRecordStoreStateRead(), that is checked in deleteRecordsWhereAsync
-                    && recordStoreStateRef.get().getStoreHeader().getRecordCountState() != RecordMetaDataProto.DataStoreInfo.RecordCountState.DISABLED) {
+            if (recordCountKey != null) {
                 if (prefix.size() == recordCountKey.getColumnSize()) {
                     // Delete a single record used for counting
                     context.clear(getSubspace().pack(Tuple.from(RECORD_COUNT_KEY).addAll(prefix)));
@@ -2166,39 +2153,17 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     @Override
     public CompletableFuture<Long> getSnapshotRecordCount(@Nonnull KeyExpression key, @Nonnull Key.Evaluated value,
                                                           @Nonnull IndexQueryabilityFilter indexQueryabilityFilter) {
-        final RecordMetaData recordMetaData = getRecordMetaData();
-        if (recordMetaData.getRecordCountKey() != null) {
-            beginRecordStoreStateRead();
-            boolean futureCreated = false;
-            try {
-                RecordMetaDataProto.DataStoreInfo header = recordStoreStateRef.get().getStoreHeader();
-                // We can always check the state, even if the formatVersion is older, because older versions will always
-                // have the default of READABLE
-                if (header.getRecordCountState() == RecordMetaDataProto.DataStoreInfo.RecordCountState.READABLE) {
-                    if (key.getColumnSize() != value.size()) {
-                        throw recordCoreException("key and value are not the same size");
-                    }
-                    final ReadTransaction tr = context.readTransaction(true);
-                    final Tuple subkey = Tuple.from(RECORD_COUNT_KEY).addAll(value.toTupleAppropriateList());
-                    if (recordMetaData.getRecordCountKey().equals(key)) {
-                        final CompletableFuture<Long> result = tr.get(getSubspace().pack(subkey))
-                                .thenApply(FDBRecordStore::decodeRecordCount)
-                                .whenComplete((ignored, error) -> endRecordStoreStateRead());
-                        futureCreated = true;
-                        return result;
-                    } else if (key.isPrefixKey(recordMetaData.getRecordCountKey())) {
-                        AsyncIterable<KeyValue> kvs = tr.getRange(getSubspace().range(Tuple.from(RECORD_COUNT_KEY)));
-                        final CompletableFuture<Long> result = MoreAsyncUtil.reduce(getExecutor(), kvs.iterator(), 0L,
-                                (count, kv) -> count + decodeRecordCount(kv.getValue()))
-                                .whenComplete((ignored, error) -> endRecordStoreStateRead());
-                        futureCreated = true;
-                        return result;
-                    }
-                }
-            } finally {
-                if (!futureCreated) {
-                    endRecordStoreStateRead();
-                }
+        if (getRecordMetaData().getRecordCountKey() != null) {
+            if (key.getColumnSize() != value.size()) {
+                throw recordCoreException("key and value are not the same size");
+            }
+            final ReadTransaction tr = context.readTransaction(true);
+            final Tuple subkey = Tuple.from(RECORD_COUNT_KEY).addAll(value.toTupleAppropriateList());
+            if (getRecordMetaData().getRecordCountKey().equals(key)) {
+                return tr.get(getSubspace().pack(subkey)).thenApply(FDBRecordStore::decodeRecordCount);
+            } else if (key.isPrefixKey(getRecordMetaData().getRecordCountKey())) {
+                AsyncIterable<KeyValue> kvs = tr.getRange(getSubspace().range(Tuple.from(RECORD_COUNT_KEY)));
+                return MoreAsyncUtil.reduce(getExecutor(), kvs.iterator(), 0L, (count, kv) -> count + decodeRecordCount(kv.getValue()));
             }
         }
         return evaluateAggregateFunction(Collections.emptyList(), IndexFunctionHelper.count(key),
@@ -3270,48 +3235,6 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
      */
     public void clearHeaderUserField(@Nonnull String userField) {
         context.asyncToSync(FDBStoreTimer.Waits.WAIT_EDIT_HEADER_USER_FIELD, clearHeaderUserFieldAsync(userField));
-    }
-
-    /**
-     * Update the RecordCount to have a new state.
-     * <p>
-     *     The state can go from {@code READABLE} to {@code WRITE_ONLY}, which is mostly useful to validate that if you
-     *     drop the {@link RecordMetaData#getRecordCountKey() recordCountKey} from the metadata, it won't have adverse
-     *     affects.
-     *     The state can always be set to {@code DISABLED}, at which point there is no way to any other state. This
-     *     limitation exists, in large part, because there is not a way to rebuild the count across indexes, and since
-     *     it is long deprecated, investing in that doesn't make sense.
-     * </p>
-     * @param newState the new state to update it to.
-     * @return a future once that completes once the state is updated, and the data is cleared.
-     */
-    public CompletableFuture<Void> updateRecordCountStateAsync(@Nonnull RecordMetaDataProto.DataStoreInfo.RecordCountState newState) {
-        return updateStoreHeaderAsync(builder -> {
-            if (!getFormatVersionEnum().isAtLeast(FormatVersion.RECORD_COUNT_STATE)) {
-                throw new RecordCoreException("Store does not support updating record count state")
-                        .addLogInfo(LogMessageKeys.FORMAT_VERSION, getFormatVersionEnum());
-            }
-            final RecordMetaDataProto.DataStoreInfo.RecordCountState existing = getRecordStoreState().getStoreHeader().getRecordCountState();
-            if (existing == newState) {
-                return builder;
-            }
-            boolean toWriteOnly = existing == RecordMetaDataProto.DataStoreInfo.RecordCountState.READABLE &&
-                    newState == RecordMetaDataProto.DataStoreInfo.RecordCountState.WRITE_ONLY;
-            boolean toReadable = existing == RecordMetaDataProto.DataStoreInfo.RecordCountState.WRITE_ONLY &&
-                    newState == RecordMetaDataProto.DataStoreInfo.RecordCountState.READABLE;
-            if (toWriteOnly || toReadable || newState == RecordMetaDataProto.DataStoreInfo.RecordCountState.DISABLED) {
-                builder.setRecordCountState(newState);
-                if (newState == RecordMetaDataProto.DataStoreInfo.RecordCountState.DISABLED) {
-                    // Note: getSubspace().range(tuple) does not include getSubspace().pack(tuple), but this does.
-                    // Ungrouped recordCountKey will be stored directly at getSubspace().pack(tuple).
-                    ensureContextActive().clear(Range.startsWith(getSubspace().pack(Tuple.from(RECORD_COUNT_KEY))));
-                }
-                return builder;
-            }
-            throw new RecordCoreException("Invalid state transition for RecordCountState")
-                    .addLogInfo(LogMessageKeys.OLD, existing)
-                    .addLogInfo(LogMessageKeys.NEW, newState);
-        });
     }
 
     // Actually (1) writes the index state to the database and (2) updates the cached state with the new state
@@ -4918,8 +4841,6 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
 
         if (rebuildRecordCounts) {
             // We want to clear all record counts.
-            // This code will leave data behind if the previous RecordCountKey was not grouped
-            // https://github.com/FoundationDB/fdb-record-layer/issues/3335
             if (existingStore) {
                 context.clear(getSubspace().range(Tuple.from(RECORD_COUNT_KEY)));
             }
@@ -4944,8 +4865,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     @SuppressWarnings("PMD.CloseResource")
     public void addRebuildRecordCountsJob(List<CompletableFuture<Void>> work) {
         final KeyExpression recordCountKey = getRecordMetaData().getRecordCountKey();
-        if (recordCountKey == null ||
-                getRecordStoreState().getStoreHeader().getRecordCountState() == RecordMetaDataProto.DataStoreInfo.RecordCountState.DISABLED) {
+        if (recordCountKey == null) {
             return;
         }
         if (LOGGER.isDebugEnabled()) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FormatVersion.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FormatVersion.java
@@ -21,7 +21,6 @@
 package com.apple.foundationdb.record.provider.foundationdb;
 
 import com.apple.foundationdb.annotation.API;
-import com.apple.foundationdb.record.RecordMetaDataProto;
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
@@ -54,7 +53,7 @@ public enum FormatVersion implements Comparable<FormatVersion> {
      */
     INFO_ADDED(1),
     /**
-     * This FormatVersion introduces support for tracking record counts as defined by:
+     * This FormatVersion introduces support for tracking record conuts as defined by:
      * {@link com.apple.foundationdb.record.RecordMetaData#getRecordCountKey()}.
      */
     RECORD_COUNT_ADDED(2),
@@ -146,12 +145,7 @@ public enum FormatVersion implements Comparable<FormatVersion> {
     /**
      * This FormatVersion allows building non-idempotent indexes (e.g. COUNT) from a source index.
      */
-    CHECK_INDEX_BUILD_TYPE_DURING_UPDATE(10),
-    /**
-     * This FormatVersion allows setting a state for the RecordCountKey on an individual store.
-     * @see RecordMetaDataProto.DataStoreInfo#getRecordCountState()
-     */
-    RECORD_COUNT_STATE(11);
+    CHECK_INDEX_BUILD_TYPE_DURING_UPDATE(10);
 
     private final int value;
 

--- a/fdb-record-layer-core/src/main/proto/record_metadata.proto
+++ b/fdb-record-layer-core/src/main/proto/record_metadata.proto
@@ -95,27 +95,6 @@ message DataStoreInfo {
   // When considering using this, one should also consider introducing a new record type to store the data.
   // This was introduced with FormatVersion.HEADER_USER_FIELDS.
   repeated UserFieldEntry user_field = 8;
-
-  // The state of the RecordCount as defined by record_count_key. This is similar to IndexState, but since there is no
-  // mechanism for building the RecordCount across multiple transactions, the state transitions are slightly different.
-  enum RecordCountState {
-    // The RecordCountKey is maintained and usable for FDBRecordStore.getSnapshotRecordCount
-    READABLE = 1;
-    // The RecordCount as defined by record_count_key is maintained, but not queryable
-    // This can be freely updated back to READABLE
-    WRITE_ONLY = 2;
-    // The RecordCount as defined by record_count_key is not maintained.
-    // Once disabled, there is no way to go back to WriteOnly
-    DISABLED = 3;
-  }
-
-  // Whether the RecordCount as defined by record_count_key is usable by FDBRecordStore.getSnapshotRecordCount and
-  // whether it is maintained at all.
-  // This helps as a mechanism to de-risk removing the deprecated RecordCountKey from metadata by disabling it for
-  // queries first, and then disabling entirely, but only for specific stores. Once validated that the necessary COUNT
-  // indexes are working sufficiently, the RecordCountKey can be removed from the metadata more safely.
-  // This was introduced with FormatVersion.RECORD_COUNT_STATE
-  optional RecordCountState record_count_state = 9;
 }
 
 message Index {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreCountRecordsTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreCountRecordsTest.java
@@ -20,8 +20,6 @@
 
 package com.apple.foundationdb.record.provider.foundationdb;
 
-import com.apple.foundationdb.KeyValue;
-import com.apple.foundationdb.Range;
 import com.apple.foundationdb.record.EndpointType;
 import com.apple.foundationdb.record.ExecuteProperties;
 import com.apple.foundationdb.record.IndexState;
@@ -39,31 +37,22 @@ import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.IndexTypes;
 import com.apple.foundationdb.record.metadata.Key;
 import com.apple.foundationdb.record.metadata.expressions.EmptyKeyExpression;
-import com.apple.foundationdb.record.metadata.expressions.FieldKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.GroupingKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.query.expressions.Query;
-import com.apple.foundationdb.record.query.expressions.QueryComponent;
 import com.apple.foundationdb.tuple.Tuple;
 import com.apple.test.Tags;
 import com.google.protobuf.Message;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.EnumSource;
-import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nonnull;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.IntConsumer;
-import java.util.stream.Stream;
 
 import static com.apple.foundationdb.record.metadata.Key.Expressions.concat;
 import static com.apple.foundationdb.record.metadata.Key.Expressions.concatenateFields;
@@ -81,9 +70,6 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 @Tag(Tags.RequiresFDB)
 public class FDBRecordStoreCountRecordsTest extends FDBRecordStoreTestBase {
-
-    private static final String GROUPING_FIELD = "num_value_3_indexed";
-    private static final FieldKeyExpression GROUP_EXPRESSION = field(GROUPING_FIELD);
 
     @Test
     @SuppressWarnings("deprecation")
@@ -153,14 +139,22 @@ public class FDBRecordStoreCountRecordsTest extends FDBRecordStoreTestBase {
     private void countRecords(boolean useIndex) {
         final RecordMetaDataHook hook = countKeyHook(EmptyKeyExpression.EMPTY, useIndex, 0);
 
-        saveRecords(simpleMetaData(hook), 0, 100,
-                () -> assertUngroupedCount(0),
-                () -> assertUngroupedCount(100));
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, hook);
+
+            assertEquals(0, recordStore.getSnapshotRecordCount().join().longValue());
+
+            for (int i = 0; i < 100; i++) {
+                int numBucket = i % 5;
+                recordStore.saveRecord(makeRecord(i, 0, numBucket));
+            }
+            commit(context);
+        }
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, hook);
 
-            assertUngroupedCount(100);
+            assertEquals(100, recordStore.getSnapshotRecordCount().join().longValue());
         }
 
         try (FDBRecordContext context = openContext()) {
@@ -176,7 +170,7 @@ public class FDBRecordStoreCountRecordsTest extends FDBRecordStoreTestBase {
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, hook);
 
-            assertUngroupedCount(95);
+            assertEquals(95, recordStore.getSnapshotRecordCount().join().longValue());
             commit(context);
         }
     }
@@ -192,7 +186,7 @@ public class FDBRecordStoreCountRecordsTest extends FDBRecordStoreTestBase {
     }
 
     private void countRecordsKeyed(boolean useIndex) {
-        final KeyExpression key = GROUP_EXPRESSION;
+        final KeyExpression key = field("num_value_3_indexed");
         final RecordMetaDataHook hook = countKeyHook(key, useIndex, 0);
 
         try (FDBRecordContext context = openContext()) {
@@ -207,7 +201,7 @@ public class FDBRecordStoreCountRecordsTest extends FDBRecordStoreTestBase {
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, hook);
 
-            assertUngroupedCount(100);
+            assertEquals(100, recordStore.getSnapshotRecordCount().join().longValue());
             assertEquals(20, recordStore.getSnapshotRecordCount(key, Key.Evaluated.scalar(1)).join().longValue());
             commit(context);
         }
@@ -244,7 +238,7 @@ public class FDBRecordStoreCountRecordsTest extends FDBRecordStoreTestBase {
             commit(context);
         }
 
-        KeyExpression key3 = GROUP_EXPRESSION;
+        KeyExpression key3 = field("num_value_3_indexed");
         countMetaDataHook.metaDataVersion++;
         countMetaDataHook.baseHook = countKeyHook(key3, useIndex, countMetaDataHook.metaDataVersion);
 
@@ -341,7 +335,7 @@ public class FDBRecordStoreCountRecordsTest extends FDBRecordStoreTestBase {
                 assertThat(recordStore.isIndexReadable(index), is(true));
             }
 
-            assertUngroupedCount(132);
+            assertEquals(132, recordStore.getSnapshotRecordCount().join().longValue());
             for (int i = 0; i < 100; i++) {
                 assertEquals(1, recordStore.getSnapshotRecordCount(pkey, Key.Evaluated.scalar(i + startingPoint)).join().longValue(), "Incorrect when i is " + i);
             }
@@ -369,7 +363,7 @@ public class FDBRecordStoreCountRecordsTest extends FDBRecordStoreTestBase {
             assertThat(e.getMessage(), containsString("requires appropriate index"));
         }
 
-        RecordMetaDataHook hook = countKeyHook(GROUP_EXPRESSION, true, 10);
+        RecordMetaDataHook hook = countKeyHook(field("num_value_3_indexed"), true, 10);
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, hook);
@@ -421,7 +415,7 @@ public class FDBRecordStoreCountRecordsTest extends FDBRecordStoreTestBase {
 
         AtomicInteger versionCounter = new AtomicInteger(recordStore.getRecordMetaData().getVersion());
         RecordMetaDataHook hook = md -> {
-            md.setRecordCountKey(GROUP_EXPRESSION);
+            md.setRecordCountKey(field("num_value_3_indexed"));
             md.setVersion(md.getVersion() + versionCounter.incrementAndGet());
         };
 
@@ -530,7 +524,7 @@ public class FDBRecordStoreCountRecordsTest extends FDBRecordStoreTestBase {
 
     @Test
     public void countRecordUpdates() {
-        final KeyExpression key = GROUP_EXPRESSION;
+        final KeyExpression key = field("num_value_3_indexed");
         final RecordMetaDataHook hook = countUpdatesKeyHook(key, 0);
         HashMap<Integer, Integer> expectedCountBuckets = new HashMap<>();
 
@@ -550,8 +544,15 @@ public class FDBRecordStoreCountRecordsTest extends FDBRecordStoreTestBase {
 
         checkRecordUpdateCounts(expectedCountBuckets, hook, key);
 
-        // Delete 5 records, this shouldn't change the counts
-        deleteRecords(simpleMetaData(hook), 95, 100);
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, hook);
+
+            // Delete 5 records, this shouldn't change the counts
+            for (int i = 95; i < 100; i++) {
+                recordStore.deleteRecord(Tuple.from(i));
+            }
+            commit(context);
+        }
 
         checkRecordUpdateCounts(expectedCountBuckets, hook, key);
 
@@ -650,441 +651,12 @@ public class FDBRecordStoreCountRecordsTest extends FDBRecordStoreTestBase {
         }
     }
 
-    static Stream<Arguments> disableRecordCountKey() {
-        return Stream.of(true, false)
-                .flatMap(fromWriteOnly -> Stream.of(true, false)
-                        .flatMap(hasFallBack -> Stream.of(true, false)
-                                .map(grouped -> Arguments.of(fromWriteOnly, hasFallBack, grouped))));
-    }
-
-    @ParameterizedTest
-    @MethodSource
-    void disableRecordCountKey(boolean fromWriteOnly, boolean hasFallback, boolean grouped) {
-        final RecordMetaDataBuilder metaDataBuilder = simpleMetaDataBuilder();
-        addRecordCountKey(metaDataBuilder, grouped ? GROUP_EXPRESSION : EmptyKeyExpression.EMPTY);
-        if (hasFallback) {
-            addCountIndex(metaDataBuilder, grouped ? GROUP_EXPRESSION : EmptyKeyExpression.EMPTY);
-        }
-        IntConsumer assertCount = expected -> {
-            if (grouped) {
-                for (int groupingValue = 0; groupingValue < 5; groupingValue++) {
-                    assertGroupedCount(expected / 5, groupingValue);
-                }
-            } else {
-                assertUngroupedCount(expected);
-            }
-        };
-        final RecordMetaData metaData = metaDataBuilder.build();
-        saveRecords(metaData, 0, 100,
-                () -> assertCount.accept(0),
-                () -> assertCount.accept(100));
-
-        try (FDBRecordContext context = openContext()) {
-            createOrOpenRecordStore(context, metaData);
-            assertCount.accept(100);
-        }
-
-        rawAssertHasRecordCount(metaData, true);
-        if (fromWriteOnly) {
-            updateRecordCountState(metaData, RecordMetaDataProto.DataStoreInfo.RecordCountState.WRITE_ONLY);
-        }
-
-        updateRecordCountState(metaData, RecordMetaDataProto.DataStoreInfo.RecordCountState.DISABLED);
-
-        rawAssertHasRecordCount(metaData, false);
-
-        // We should be able to save new records without issue
-        saveRecords(metaData, 100, 110, () -> { }, () -> { });
-
-        // We should be able to delete some records without issue
-        deleteRecords(metaData, 95, 100);
-
-        // We cannot get the record count because there is no index, or recordCountKey
-        if (hasFallback) {
-            try (FDBRecordContext context = openContext()) {
-                createOrOpenRecordStore(context, metaData);
-                assertCount.accept(105);
-            }
-        } else {
-            assertCannotGetUngroupedRecordCount(metaData);
-        }
-
-        // ensure that the updates did not write anything to the RecordCountKey space
-        rawAssertHasRecordCount(metaData, false);
-    }
-
-    static Stream<Arguments> shouldNotRebuildIndexesWhenRecordCountIsNotReadable() {
-        return Stream.of(true, false)
-                .flatMap(startsWithCountKey -> Stream.of(true, false)
-                        .map(disabled -> Arguments.of(startsWithCountKey, disabled)));
-    }
-
-    @ParameterizedTest
-    @MethodSource
-    void shouldNotRebuildIndexesWhenRecordCountIsNotReadable(boolean startsWithCountKey, boolean disabled) {
-        // If disabled or WriteOnly, rebuilding indexes should behave the same as if the RecordCountKey didn't exist
-        final RecordMetaDataBuilder builder;
-        if (startsWithCountKey) {
-            builder = addRecordCountKey(simpleMetaDataBuilder(), EmptyKeyExpression.EMPTY);
-        } else {
-            builder = simpleMetaDataBuilder();
-        }
-        final RecordMetaData initialMetaData = builder.build();
-        saveRecords(initialMetaData, 0, 100,
-                () -> {
-                    if (startsWithCountKey) {
-                        assertUngroupedCount(0);
-                    }
-                },
-                () -> {
-                    if (startsWithCountKey) {
-                        assertUngroupedCount(100);
-                    }
-                });
-
-        if (startsWithCountKey) {
-            updateRecordCountState(initialMetaData, disabled ? RecordMetaDataProto.DataStoreInfo.RecordCountState.DISABLED :
-                    RecordMetaDataProto.DataStoreInfo.RecordCountState.WRITE_ONLY);
-        }
-
-        final Index index = new Index("OnNum", "num_value_2");
-        builder.addIndex("MySimpleRecord", index);
-        final RecordMetaData newMetaData = builder.build();
-
-        try (FDBRecordContext context = openContext()) {
-            createOrOpenRecordStore(context, newMetaData);
-            assertEquals(IndexState.DISABLED, recordStore.getAllIndexStates().get(index));
-            commit(context);
-        }
-    }
-
-    @Test
-    void recordCountStateWriteOnly() {
-        final RecordMetaData metaData = addRecordCountKey(simpleMetaDataBuilder(), EmptyKeyExpression.EMPTY).build();
-        saveRecords(metaData, 0, 100,
-                () -> assertUngroupedCount(0),
-                () -> assertUngroupedCount(100));
-
-        try (FDBRecordContext context = openContext()) {
-            createOrOpenRecordStore(context, metaData);
-            assertUngroupedCount(100);
-        }
-
-        updateRecordCountState(metaData, RecordMetaDataProto.DataStoreInfo.RecordCountState.WRITE_ONLY);
-
-        // We should be able to save new records without issue
-        saveRecords(metaData, 100, 110, () -> { }, () -> { });
-
-        // We should be able to delete some records without issue
-        deleteRecords(metaData, 95, 100);
-
-        // We cannot get the record count because there is no index, or recordCountKey
-        assertCannotGetUngroupedRecordCount(metaData);
-
-        updateRecordCountState(metaData, RecordMetaDataProto.DataStoreInfo.RecordCountState.READABLE);
-
-        try (FDBRecordContext context = openContext()) {
-            createOrOpenRecordStore(context, metaData);
-            assertUngroupedCount(105); // we added 10 and deleted 5
-        }
-    }
-
-    @Test
-    void recordCountStatefromDisabledShouldFail() {
-        final RecordMetaData metaData = addRecordCountKey(simpleMetaDataBuilder(), EmptyKeyExpression.EMPTY).build();
-        saveRecords(metaData, 0, 100,
-                () -> assertUngroupedCount(0),
-                () -> assertUngroupedCount(100));
-
-        try (FDBRecordContext context = openContext()) {
-            createOrOpenRecordStore(context, metaData);
-            assertUngroupedCount(100);
-        }
-
-        updateRecordCountState(metaData, RecordMetaDataProto.DataStoreInfo.RecordCountState.DISABLED);
-
-        // Once disabled we cannot change it to not disabled
-        // We could implement something to rebuild the data, but it's deprecated, and that's a fair amount of work
-        try (FDBRecordContext context1 = openContext()) {
-            createOrOpenRecordStore(context1, metaData);
-            assertThrows(RecordCoreException.class, this::markRecordCountWriteOnly);
-            context1.commit();
-        }
-
-        try (FDBRecordContext context1 = openContext()) {
-            createOrOpenRecordStore(context1, metaData);
-            assertThrows(RecordCoreException.class, this::markRecordCountReadable);
-            context1.commit();
-        }
-    }
-
-    @Test
-    void updateRecordCountStateShouldFailOnOldVersion() {
-        final RecordMetaData metaData = addRecordCountKey(simpleMetaDataBuilder(), EmptyKeyExpression.EMPTY).build();
-        final FormatVersion formatVersion = FormatVersionTestUtils.previous(FormatVersion.RECORD_COUNT_STATE);
-        saveRecords(metaData, 0, 100,
-                () -> assertUngroupedCount(0),
-                () -> assertUngroupedCount(100),
-                formatVersion);
-
-        try (FDBRecordContext context = openContext()) {
-            recordStore = createOrOpenRecordStore(context, metaData, path, formatVersion);
-            assertUngroupedCount(100);
-        }
-
-        for (final RecordMetaDataProto.DataStoreInfo.RecordCountState newState : RecordMetaDataProto.DataStoreInfo.RecordCountState.values()) {
-            try (FDBRecordContext context1 = openContext()) {
-                recordStore = createOrOpenRecordStore(context1, metaData, path, formatVersion);
-                assertThrows(RecordCoreException.class, () -> recordStore.updateRecordCountStateAsync(newState).join(),
-                        () -> "Should not allow updating to " + newState);
-            }
-        }
-    }
-
-    @ParameterizedTest
-    @EnumSource(RecordMetaDataProto.DataStoreInfo.RecordCountState.class)
-    @SuppressWarnings("deprecation")
-    void deleteWhereSuccessfully(RecordMetaDataProto.DataStoreInfo.RecordCountState newState) {
-        // deleteWhere should work regardless of the state
-        final RecordMetaDataBuilder recordMetaDataBuilder = simpleMetaDataBuilder();
-        recordMetaDataBuilder.setRecordCountKey(GROUP_EXPRESSION);
-        allowDeleteWhereByGroupingField(recordMetaDataBuilder);
-        final RecordMetaData metaData = recordMetaDataBuilder.build();
-        saveRecords(metaData, 0, 100,
-                () -> assertGroupedCount(0, 1),
-                () -> {
-                    assertGroupedCount(20, 1);
-                    assertGroupedCount(20, 2);
-                    assertGroupedCount(20, 3);
-                });
-
-        updateRecordCountState(metaData, newState);
-
-        try (FDBRecordContext context = openContext()) {
-            createOrOpenRecordStore(context, metaData);
-            recordStore.deleteRecordsWhere(Query.field(GROUPING_FIELD).equalsValue(2));
-            commit(context);
-        }
-
-        if (newState != RecordMetaDataProto.DataStoreInfo.RecordCountState.READABLE) {
-            try (FDBRecordContext context = openContext()) {
-                createOrOpenRecordStore(context, metaData);
-                final Key.Evaluated value = Key.Evaluated.concatenate(1);
-                final RecordCoreException recordCoreException = assertThrows(RecordCoreException.class,
-                        () -> recordStore.getSnapshotRecordCount(GROUP_EXPRESSION, value).join());
-                assertThat(recordCoreException.getMessage(), containsString("requires appropriate index"));
-            }
-        }
-        if (newState == RecordMetaDataProto.DataStoreInfo.RecordCountState.WRITE_ONLY) {
-            updateRecordCountState(metaData, RecordMetaDataProto.DataStoreInfo.RecordCountState.READABLE);
-        }
-
-        if (newState != RecordMetaDataProto.DataStoreInfo.RecordCountState.DISABLED) {
-            try (FDBRecordContext context = openContext()) {
-                createOrOpenRecordStore(context, metaData);
-                assertGroupedCount(20, 1);
-                assertGroupedCount(0, 2);
-                assertGroupedCount(20, 3);
-                commit(context);
-            }
-        }
-    }
-
-    @ParameterizedTest
-    @EnumSource(RecordMetaDataProto.DataStoreInfo.RecordCountState.class)
-    @SuppressWarnings("deprecation")
-    void deleteWhereNotCompatible(RecordMetaDataProto.DataStoreInfo.RecordCountState newState) {
-        // deleteWhere should fail if the count key is not grouped correctly, unless it is disabled
-        final RecordMetaDataBuilder recordMetaDataBuilder = simpleMetaDataBuilder();
-        recordMetaDataBuilder.setRecordCountKey(Key.Expressions.empty());
-        allowDeleteWhereByGroupingField(recordMetaDataBuilder);
-        final RecordMetaData metaData = recordMetaDataBuilder.build();
-        saveRecords(metaData, 0, 100,
-                () -> assertUngroupedCount(0),
-                () -> assertUngroupedCount(100));
-
-        updateRecordCountState(metaData, newState);
-
-        try (FDBRecordContext context = openContext()) {
-            createOrOpenRecordStore(context, metaData);
-            final QueryComponent deleteWhereQuery = Query.field(GROUPING_FIELD).equalsValue(2);
-            if (newState == RecordMetaDataProto.DataStoreInfo.RecordCountState.DISABLED) {
-                recordStore.deleteRecordsWhere(deleteWhereQuery);
-                commit(context);
-            } else {
-                assertThrows(Query.InvalidExpressionException.class,
-                        () -> recordStore.deleteRecordsWhere(deleteWhereQuery));
-            }
-        }
-
-        if (newState == RecordMetaDataProto.DataStoreInfo.RecordCountState.WRITE_ONLY) {
-            updateRecordCountState(metaData, RecordMetaDataProto.DataStoreInfo.RecordCountState.READABLE);
-        }
-
-        if (newState != RecordMetaDataProto.DataStoreInfo.RecordCountState.DISABLED) {
-            try (FDBRecordContext context = openContext()) {
-                createOrOpenRecordStore(context, metaData);
-                assertUngroupedCount(100);
-                commit(context);
-            }
-        } else {
-            rawAssertHasRecordCount(metaData,  false);
-        }
-    }
-
-    private static void allowDeleteWhereByGroupingField(final RecordMetaDataBuilder recordMetaDataBuilder) {
-        // update the primary keys to support deleteWhere
-        recordMetaDataBuilder.getRecordType("MySimpleRecord")
-                .setPrimaryKey(Key.Expressions.concatenateFields(GROUPING_FIELD, "rec_no"));
-        recordMetaDataBuilder.getRecordType("MyOtherRecord")
-                .setPrimaryKey(Key.Expressions.concatenateFields(GROUPING_FIELD, "rec_no"));
-        // these indexes have to be removed as they aren't grouped in a way that would allow deleteWhere
-        recordMetaDataBuilder.removeIndex("MySimpleRecord$num_value_unique");
-        recordMetaDataBuilder.removeIndex("MySimpleRecord$num_value_3_indexed");
-        recordMetaDataBuilder.removeIndex("MySimpleRecord$str_value_indexed");
-    }
-
-    @ParameterizedTest
-    @EnumSource(RecordMetaDataProto.DataStoreInfo.RecordCountState.class)
-    void rebuildRecordCountDuringCheckVersion(RecordMetaDataProto.DataStoreInfo.RecordCountState newState) {
-        // If the RecordCount is disabled it should not be rebuilt during checkVersion, otherwise it should
-        final RecordMetaDataBuilder builder;
-        builder = addRecordCountKey(simpleMetaDataBuilder(), EmptyKeyExpression.EMPTY);
-        final RecordMetaData initialMetaData = builder.build();
-        saveRecords(initialMetaData, 0, 100,
-                () -> assertUngroupedCount(0),
-                () -> assertUngroupedCount(100));
-
-        updateRecordCountState(initialMetaData, newState);
-
-        addRecordCountKey(builder, GROUP_EXPRESSION);
-        final RecordMetaData newMetaData = builder.build();
-
-        final boolean isDisabled = newState == RecordMetaDataProto.DataStoreInfo.RecordCountState.DISABLED;
-        try (FDBRecordContext context = openContext()) {
-            createOrOpenRecordStore(context, newMetaData);
-            assertEquals(isDisabled ? 0 : 1, timer.getCount(FDBStoreTimer.Events.RECOUNT_RECORDS));
-            commit(context);
-        }
-
-        if (isDisabled) {
-            rawAssertHasRecordCount(newMetaData, false);
-        } else {
-            rawAssertHasRecordCount(newMetaData, true);
-            // the following would be impossible if we didn't rebuild
-            try (FDBRecordContext context = openContext()) {
-                createOrOpenRecordStore(context, newMetaData);
-                markRecordCountReadable();
-                assertGroupedCount(20, 1);
-                assertGroupedCount(20, 2);
-            }
-        }
-
-    }
-
-    private void updateRecordCountState(final RecordMetaData metaData,
-                                        final RecordMetaDataProto.DataStoreInfo.RecordCountState newState) {
-        try (FDBRecordContext context = openContext()) {
-            createOrOpenRecordStore(context, metaData);
-            recordStore.updateRecordCountStateAsync(newState).join();
-            context.commit();
-        }
-    }
-
-    private Void markRecordCountWriteOnly() {
-        return recordStore.updateRecordCountStateAsync(RecordMetaDataProto.DataStoreInfo.RecordCountState.WRITE_ONLY).join();
-    }
-
-    private Void markRecordCountReadable() {
-        return recordStore.updateRecordCountStateAsync(RecordMetaDataProto.DataStoreInfo.RecordCountState.READABLE).join();
-    }
-
-    private void rawAssertHasRecordCount(final RecordMetaData metaData, final boolean hasRecordCounts) {
-        try (FDBRecordContext context = openContext()) {
-            createOrOpenRecordStore(context, metaData);
-            final Tuple tuple = Tuple.from(FDBRecordStoreKeyspace.RECORD_COUNT.key());
-            final List<KeyValue> counts = context.ensureActive()
-                    .getRange(Range.startsWith(recordStore.getSubspace().pack(tuple)))
-                    .asList().join();
-
-            assertEquals(counts.isEmpty(), !hasRecordCounts, counts.toString());
-        }
-    }
-
-    private void assertCannotGetUngroupedRecordCount(final RecordMetaData metaData) {
-        try (FDBRecordContext context = openContext()) {
-            createOrOpenRecordStore(context, metaData);
-            final RecordCoreException recordCoreException = assertThrows(RecordCoreException.class,
-                    () -> recordStore.getSnapshotRecordCount().get());
-            assertThat(recordCoreException.getMessage(), containsString("requires appropriate index"));
-        }
-    }
-
-    private void assertUngroupedCount(final int expected) {
-        assertEquals(expected, recordStore.getSnapshotRecordCount().join().longValue());
-    }
-
-    private void assertGroupedCount(final int expected, final int groupingValue) {
-        final Key.Evaluated value = Key.Evaluated.concatenate(groupingValue);
-        assertEquals(expected, recordStore.getSnapshotRecordCount(GROUP_EXPRESSION, value).join().longValue());
-    }
-
-    private void saveRecords(final RecordMetaData metaData, final int start, final int end,
-                             final Runnable beforeHook, final Runnable afterHook) {
-        saveRecords(metaData, start, end, beforeHook, afterHook, FormatVersion.getMaximumSupportedVersion());
-    }
-
-    private void saveRecords(final RecordMetaData metaData, final int start, final int end,
-                             final Runnable beforeHook, final Runnable afterHook, final FormatVersion formatVersion) {
-        try (FDBRecordContext context = openContext()) {
-            this.recordStore = createOrOpenRecordStore(context, metaData, path, formatVersion);
-
-            beforeHook.run();
-
-            for (int i = start; i < end; i++) {
-                int numBucket = i % 5;
-                recordStore.saveRecord(makeRecord(i, 0, numBucket));
-            }
-
-            afterHook.run();
-            commit(context);
-        }
-    }
-
-    private void deleteRecords(final RecordMetaData metaData, final int start, final int end) {
-        try (FDBRecordContext context = openContext()) {
-            createOrOpenRecordStore(context, metaData);
-
-            for (int i = start; i < end; i++) {
-                recordStore.deleteRecord(Tuple.from(i));
-            }
-            commit(context);
-        }
-    }
-
     private TestRecords1Proto.MySimpleRecord makeRecord(long recordNo, int numValue2, int numValue3Indexed) {
         TestRecords1Proto.MySimpleRecord.Builder recBuilder = TestRecords1Proto.MySimpleRecord.newBuilder();
         recBuilder.setRecNo(recordNo);
         recBuilder.setNumValue2(numValue2);
         recBuilder.setNumValue3Indexed(numValue3Indexed);
         return recBuilder.build();
-    }
-
-    private static void addCountIndex(@Nonnull final RecordMetaDataBuilder recordMetaDataBuilder,
-                                      @Nonnull final KeyExpression keyExpression) {
-        addCountIndex(keyExpression, -1, recordMetaDataBuilder);
-    }
-
-    @SuppressWarnings("deprecation")
-    private static RecordMetaDataBuilder addRecordCountKey(@Nonnull final RecordMetaDataBuilder recordMetaDataBuilder,
-                                                           @Nonnull final KeyExpression keyExpression) {
-        recordMetaDataBuilder.setRecordCountKey(keyExpression);
-        return recordMetaDataBuilder;
-    }
-
-    @Nonnull
-    private static RecordMetaDataBuilder simpleMetaDataBuilder() {
-        return RecordMetaData.newBuilder().setRecords(TestRecords1Proto.getDescriptor());
     }
 
     // Get a new metadata version every time we change the count key definition.
@@ -1104,7 +676,9 @@ public class FDBRecordStoreCountRecordsTest extends FDBRecordStoreTestBase {
     private static RecordMetaDataHook countUpdatesKeyHook(KeyExpression key, int indexVersion) {
         return md -> {
             md.removeIndex(COUNT_UPDATES_INDEX_NAME);
-            addIndex("record_update_count", key, IndexTypes.COUNT_UPDATES, indexVersion, md);
+            Index index = new Index("record_update_count", new GroupingKeyExpression(key, 0), IndexTypes.COUNT_UPDATES);
+            index.setLastModifiedVersion(indexVersion);
+            md.addUniversalIndex(index);
         };
     }
 
@@ -1113,23 +687,13 @@ public class FDBRecordStoreCountRecordsTest extends FDBRecordStoreTestBase {
         if (useIndex) {
             return md -> {
                 md.removeIndex(COUNT_INDEX_NAME);
-                addCountIndex(key, indexVersion, md);
+                Index index = new Index("record_count", new GroupingKeyExpression(key, 0), IndexTypes.COUNT);
+                index.setLastModifiedVersion(indexVersion);
+                md.addUniversalIndex(index);
             };
         } else {
             return md -> md.setRecordCountKey(key);
         }
-    }
-
-    private static void addCountIndex(final KeyExpression key, final int indexVersion,
-                                      final RecordMetaDataBuilder metaData) {
-        addIndex("record_count", key, IndexTypes.COUNT, indexVersion, metaData);
-    }
-
-    private static void addIndex(final String record_update_count, final KeyExpression key, final String countUpdates,
-                                 final int indexVersion, final RecordMetaDataBuilder metaData) {
-        Index index = new Index(record_update_count, new GroupingKeyExpression(key, 0), countUpdates);
-        index.setLastModifiedVersion(indexVersion);
-        metaData.addUniversalIndex(index);
     }
 
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FormatVersionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FormatVersionTest.java
@@ -59,7 +59,7 @@ class FormatVersionTest {
 
         assertEquals(IntStream.rangeClosed(1, 10).boxed().collect(Collectors.toList()),
                 versions);
-        assertEquals(FDBRecordStore.MAX_SUPPORTED_FORMAT_VERSION, FormatVersion.getMaximumSupportedVersion().getValueForSerialization());
+        assertEquals(FDBRecordStore.MAX_SUPPORTED_FORMAT_VERSION, versions.get(versions.size() - 1));
     }
 
     @Test

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/recordrepair/RecordValidationTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/recordrepair/RecordValidationTest.java
@@ -73,7 +73,7 @@ public class RecordValidationTest extends FDBRecordStoreTestBase {
      */
     @Test
     void monitorFormatVersion() {
-        assertEquals(FormatVersion.RECORD_COUNT_STATE, FormatVersion.getMaximumSupportedVersion(),
+        assertEquals(FormatVersion.CHECK_INDEX_BUILD_TYPE_DURING_UPDATE, FormatVersion.getMaximumSupportedVersion(),
                 "New format version found. Please review the validators to ensure they still catch corruptions");
     }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/recordrepair/ScanRecordKeysTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/recordrepair/ScanRecordKeysTest.java
@@ -90,7 +90,7 @@ public class ScanRecordKeysTest extends FDBRecordStoreTestBase {
      */
     @Test
     void monitorFormatVersion() {
-        assertEquals(FormatVersion.RECORD_COUNT_STATE, FormatVersion.getMaximumSupportedVersion(),
+        assertEquals(FormatVersion.CHECK_INDEX_BUILD_TYPE_DURING_UPDATE, FormatVersion.getMaximumSupportedVersion(),
                 "New format version found. Please review the key scanner to ensure they still catch corruptions");
     }
 


### PR DESCRIPTION
This reverts #3334. Issues were found with the record store state's lifecycle that would result in begin/end read/write store state calls not lining up. This removes the change in order to give us time to sort out that issue.

This reverts commit dcb0f30efe4bd784eaee44bde52498ca690b6620.