### PR TITLE
Allow version repair to operate while the store is locked

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -500,7 +500,23 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     @Nonnull
     public CompletableFuture<FDBStoredRecord<Message>> dryRunSaveRecordAsync(@Nonnull final Message rec, @Nonnull RecordExistenceCheck existenceCheck,
                                                                              @Nullable FDBRecordVersion version, @Nonnull VersionstampSaveBehavior behavior) {
-        return saveTypedRecord(serializer, rec, existenceCheck, null, VersionstampSaveBehavior.DEFAULT, true);
+        return saveTypedRecord(serializer, rec, existenceCheck, null, VersionstampSaveBehavior.DEFAULT, true, false);
+    }
+
+    /**
+     * Internal flavor of the {@link #saveRecordAsync} method that allows bypassing of the record update lock.
+     * This is used by internal repair processes to ensure we can repair records outside the normal data flow.
+     * @param rec the record to save
+     * @param existenceCheck whether to throw an exception if a record with the same primary key does or does not already exist
+     * @param version the associated record version
+     * @param behavior the save behavior w.r.t. the given <code>version</code>
+     * @return a future that completes with the stored record form of the saved record
+     */
+    @Nonnull
+    @API(API.Status.INTERNAL)
+    public CompletableFuture<FDBStoredRecord<Message>> overrideLockSaveRecordAsync(@Nonnull final Message rec, @Nonnull RecordExistenceCheck existenceCheck,
+                                                                                   @Nullable FDBRecordVersion version, @Nonnull final VersionstampSaveBehavior behavior) {
+        return saveTypedRecord(serializer, rec, existenceCheck, version, behavior, false, true);
     }
 
     @Nonnull
@@ -510,7 +526,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
                                                                                         @Nonnull RecordExistenceCheck existenceCheck,
                                                                                         @Nullable FDBRecordVersion version,
                                                                                         @Nonnull VersionstampSaveBehavior behavior) {
-        return saveTypedRecord(typedSerializer, rec, existenceCheck, version, behavior, false);
+        return saveTypedRecord(typedSerializer, rec, existenceCheck, version, behavior, false, false);
     }
 
     @Nonnull
@@ -520,7 +536,8 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
                                                                                         @Nonnull RecordExistenceCheck existenceCheck,
                                                                                         @Nullable FDBRecordVersion version,
                                                                                         @Nonnull VersionstampSaveBehavior behavior,
-                                                                                        boolean isDryRun) {
+                                                                                        boolean isDryRun,
+                                                                                        boolean overrideLock) {
         final RecordMetaData metaData = metaDataProvider.getRecordMetaData();
         final Descriptors.Descriptor recordDescriptor = rec.getDescriptorForType();
         final RecordType recordType = metaData.getRecordTypeForDescriptor(recordDescriptor);
@@ -555,7 +572,9 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
                 return CompletableFuture.completedFuture(newRecord);
             }
             return getRecordStoreStateAsync().thenCompose(recordStoreState -> {
-                validateRecordUpdateAllowed(recordStoreState);
+                if (!overrideLock) {
+                    validateRecordUpdateAllowed(recordStoreState);
+                }
                 final FDBStoredRecord<M> newRecord = serializeAndSaveRecord(typedSerializer, recordBuilder, metaData, oldRecord);
                 if (oldRecord == null) {
                     addRecordCount(metaData, newRecord, LITTLE_ENDIAN_INT64_ONE);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBTypedRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBTypedRecordStore.java
@@ -140,7 +140,7 @@ public class FDBTypedRecordStore<M extends Message> implements FDBRecordStoreBas
     @Nonnull
     @Override
     public CompletableFuture<FDBStoredRecord<M>> dryRunSaveRecordAsync(@Nonnull M rec, @Nonnull RecordExistenceCheck existenceCheck, @Nullable FDBRecordVersion version, @Nonnull VersionstampSaveBehavior behavior) {
-        return untypedStore.saveTypedRecord(typedSerializer, rec, existenceCheck, version, behavior, true);
+        return untypedStore.saveTypedRecord(typedSerializer, rec, existenceCheck, version, behavior, true, false);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/recordrepair/RecordVersionValidator.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/recordrepair/RecordVersionValidator.java
@@ -87,11 +87,12 @@ public class RecordVersionValidator implements RecordValidator {
                 }
                 // Create a new version
                 // Save the record with the existing data and the new version
-                // This uses the DEFAULT behavior to follow the metadata direction on whether to store the version
+                // Override the lock as it may happen that the store is locked under the repair protocol
+                // Use the DEFAULT behavior to follow the metadata direction on whether to store the version
                 final FDBRecordVersion newVersion = FDBRecordVersion.incomplete(store.getContext().claimLocalVersion());
                 return store.loadRecordAsync(validationResult.getPrimaryKey())
                         .thenCompose(rec ->
-                                store.saveRecordAsync(rec.getRecord(), newVersion, FDBRecordStoreBase.VersionstampSaveBehavior.DEFAULT))
+                                store.overrideLockSaveRecordAsync(rec.getRecord(), FDBRecordStoreBase.RecordExistenceCheck.NONE, newVersion, FDBRecordStoreBase.VersionstampSaveBehavior.DEFAULT))
                         .thenApply(ignore ->
                                 validationResult.withRepair(RecordRepairResult.REPAIR_VERSION_CREATED));
             default:

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RecordsUpdateLockTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RecordsUpdateLockTest.java
@@ -59,6 +59,9 @@ class RecordsUpdateLockTest extends OnlineIndexerTest {
 
                 // Dry run should always succeed
                 recordStore.dryRunSaveRecordAsync(record, FDBRecordStoreBase.RecordExistenceCheck.NONE).join();
+
+                // Override locks should always succeed
+                recordStore.overrideLockSaveRecordAsync(record, FDBRecordStoreBase.RecordExistenceCheck.NONE, null, FDBRecordStoreBase.VersionstampSaveBehavior.DEFAULT).join();
             }
             context.commit();
         }


### PR DESCRIPTION
Create a version of the `saveRecordAsync` that allows bypassing the new store update lock.
We could have made this more complicated by creating a framework for rules around when can a certain kind of lock be bypassed and for what "reason" (e.g. "repair"), but this seems like an overkill so I opted for the straightforward way of a single boolean and an `if (override)` in the base `saveRecordAsync` implementation.

Resolves #3391 