### PR TITLE
Add validation/verification to the planner to avoid alias ambiguities and unresolved aliases

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ConstraintsMap.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ConstraintsMap.java
@@ -97,6 +97,18 @@ public class ConstraintsMap {
         this.attributeToConstraintMap = Maps.newLinkedHashMap();
     }
 
+    public long getCurrentTick() {
+        return currentTick;
+    }
+
+    public long getWatermarkGoalTick() {
+        return watermarkGoalTick;
+    }
+
+    public long getWatermarkCommittedTick() {
+        return watermarkCommittedTick;
+    }
+
     /**
      * Method to return if a particular attribute is contained in the map.
      * @param attribute the attribute key to check

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PartialMatch.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PartialMatch.java
@@ -100,7 +100,7 @@ public class PartialMatch {
     private final Supplier<Map<CorrelationIdentifier, ComparisonRange>> boundParameterPrefixMapSupplier;
 
     @Nonnull
-    private final Supplier<Set<QueryPredicate>> boundPlaceholdersSupplier;
+    private final Supplier<Set<Placeholder>> boundPlaceholdersSupplier;
 
     @Nonnull
     private final Supplier<Set<Quantifier>> matchedQuantifiersSupplier;
@@ -217,14 +217,14 @@ public class PartialMatch {
     }
 
     @Nonnull
-    public final Set<QueryPredicate> getBoundPlaceholders() {
+    public final Set<Placeholder> getBoundPlaceholders() {
         return boundPlaceholdersSupplier.get();
     }
 
     @Nonnull
-    private Set<QueryPredicate> computeBoundPlaceholders() {
+    private Set<Placeholder> computeBoundPlaceholders() {
         final var boundParameterPrefixMap = getBoundParameterPrefixMap();
-        final var boundPlaceholders = Sets.<QueryPredicate>newIdentityHashSet();
+        final var boundPlaceholders = Sets.<Placeholder>newIdentityHashSet();
 
         //
         // Go through all accumulated parameter bindings -- find the query predicates binding the parameters. Those
@@ -246,7 +246,7 @@ public class PartialMatch {
 
             final var placeholder = (Placeholder)candidatePredicate;
             if (boundParameterPrefixMap.containsKey(placeholder.getParameterAlias())) {
-                boundPlaceholders.add(predicateMapping.getCandidatePredicate());
+                boundPlaceholders.add(placeholder);
             }
         }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/Reference.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/Reference.java
@@ -717,6 +717,11 @@ public class Reference implements Correlated<Reference>, Typed {
         return PlannerGraphVisitor.show(renderSingleGroups, this);
     }
 
+    @Nonnull
+    public String showExploratory() {
+        return PlannerGraphVisitor.show(PlannerGraphVisitor.REMOVE_FINAL_EXPRESSIONS | PlannerGraphVisitor.RENDER_SINGLE_GROUPS, this);
+    }
+
     @SuppressWarnings("PMD.CompareObjectsWithEquals")
     private static boolean isMemoizedExpression(@Nonnull final RelationalExpression member,
                                                 @Nonnull final RelationalExpression otherExpression,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/RelationalExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/RelationalExpression.java
@@ -853,4 +853,9 @@ public interface RelationalExpression extends Correlated<RelationalExpression>, 
     default String show(final boolean renderSingleGroups) {
         return PlannerGraphVisitor.show(renderSingleGroups, this);
     }
+
+    @Nonnull
+    default String showExploratory() {
+        return PlannerGraphVisitor.show(PlannerGraphVisitor.REMOVE_FINAL_EXPRESSIONS | PlannerGraphVisitor.RENDER_SINGLE_GROUPS, this);
+    }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/structure/ExpressionsPartitionMatchers.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/structure/ExpressionsPartitionMatchers.java
@@ -48,7 +48,7 @@ public class ExpressionsPartitionMatchers {
     @Nonnull
     @SuppressWarnings("unchecked")
     public static BindingMatcher<Reference> expressionPartitions(@Nonnull final BindingMatcher<? extends Iterable<? extends ExpressionPartition<? extends RelationalExpression>>> downstream) {
-        return TypedMatcherWithExtractAndDownstream.typedWithDownstream((Class<Reference>)(Class<?>)Reference.class,
+        return TypedMatcherWithExtractAndDownstream.typedWithDownstream(Reference.class,
                 Extractor.of(Reference::toExpressionPartitions, name -> "expressionPartitions(" + name + ")"),
                 downstream);
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/structure/PlanPartitionMatchers.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/structure/PlanPartitionMatchers.java
@@ -41,8 +41,8 @@ public class PlanPartitionMatchers {
 
     @Nonnull
     @SuppressWarnings("unchecked")
-    public static <R extends Reference> BindingMatcher<R> planPartitions(@Nonnull final BindingMatcher<? extends Iterable<PlanPartition>> downstream) {
-        return TypedMatcherWithExtractAndDownstream.typedWithDownstream((Class<R>)(Class<?>)Reference.class,
+    public static BindingMatcher<Reference> planPartitions(@Nonnull final BindingMatcher<? extends Iterable<PlanPartition>> downstream) {
+        return TypedMatcherWithExtractAndDownstream.typedWithDownstream(Reference.class,
                 Extractor.of(Reference::toPlanPartitions, name -> "planPartitions(" + name + ")"),
                 downstream);
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/structure/RecordQueryPlanMatchers.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/structure/RecordQueryPlanMatchers.java
@@ -511,8 +511,8 @@ public class RecordQueryPlanMatchers {
     
     @SuppressWarnings("unchecked")
     @Nonnull
-    public static <C extends RecordQueryPlanWithComparisonKeyValues> BindingMatcher<C> comparisonKeyValues(@Nonnull CollectionMatcher<? extends Value> comparisonKeyMatcher) {
-        return typedWithDownstream((Class<C>)(Class<?>)RecordQueryPlanWithComparisonKeyValues.class,
+    public static BindingMatcher<RecordQueryPlanWithComparisonKeyValues> comparisonKeyValues(@Nonnull CollectionMatcher<? extends Value> comparisonKeyMatcher) {
+        return typedWithDownstream(RecordQueryPlanWithComparisonKeyValues.class,
                 Extractor.of(RecordQueryPlanWithComparisonKeyValues::getComparisonKeyValues, name -> "comparisonKeyValues(" + name + ")"),
                 comparisonKeyMatcher);
     }
@@ -775,8 +775,8 @@ public class RecordQueryPlanMatchers {
 
     @Nonnull
     @SuppressWarnings("unchecked")
-    public static <M extends RecordQueryExplodePlan> BindingMatcher<M> collectionValue(@Nonnull BindingMatcher<? extends Value> downstream) {
-        return typedWithDownstream((Class<M>)(Class<?>)RecordQueryExplodePlan.class,
+    public static BindingMatcher<RecordQueryExplodePlan> collectionValue(@Nonnull BindingMatcher<? extends Value> downstream) {
+        return typedWithDownstream(RecordQueryExplodePlan.class,
                 Extractor.of(RecordQueryExplodePlan::getCollectionValue, name -> "collectionValue(" + name + ")"),
                 downstream);
     }
@@ -803,8 +803,8 @@ public class RecordQueryPlanMatchers {
 
     @Nonnull
     @SuppressWarnings("unchecked")
-    public static <M extends RecordQueryAbstractDataModificationPlan> BindingMatcher<M> target(@Nonnull BindingMatcher<? extends String> downstream) {
-        return typedWithDownstream((Class<M>)(Class<?>)RecordQueryAbstractDataModificationPlan.class,
+    public static BindingMatcher<RecordQueryAbstractDataModificationPlan> target(@Nonnull BindingMatcher<? extends String> downstream) {
+        return typedWithDownstream(RecordQueryAbstractDataModificationPlan.class,
                 Extractor.of(RecordQueryAbstractDataModificationPlan::getTargetRecordType, name -> "target(" + name + ")"),
                 downstream);
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/structure/ReferenceMatchers.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/structure/ReferenceMatchers.java
@@ -58,33 +58,32 @@ public class ReferenceMatchers {
 
     @Nonnull
     @SuppressWarnings("unchecked")
-    public static <R extends Reference> BindingMatcher<R> anyRef() {
-        return typed((Class<R>)(Class<?>)Reference.class);
+    public static BindingMatcher<Reference> anyRef() {
+        return typed(Reference.class);
     }
 
     @Nonnull
-    public static BindingMatcher<? extends Reference> anyRefOverOnlyPlans() {
+    public static BindingMatcher<Reference> anyRefOverOnlyPlans() {
         return members(all(RelationalExpressionMatchers.ofType(RecordQueryPlan.class)));
     }
 
     @Nonnull
     @SuppressWarnings("unchecked")
-    public static <R extends Reference, E extends RelationalExpression> BindingMatcher<R> members(@Nonnull final CollectionMatcher<E> downstream) {
-        return TypedMatcherWithExtractAndDownstream.typedWithDownstream((Class<R>)(Class<?>)Reference.class,
+    public static <E extends RelationalExpression> BindingMatcher<Reference> members(@Nonnull final CollectionMatcher<E> downstream) {
+        return TypedMatcherWithExtractAndDownstream.typedWithDownstream(Reference.class,
                 Extractor.of(Reference::getAllMemberExpressions, name -> "allMembers(" + name + ")"),
                 downstream);
     }
 
     @Nonnull
     @SuppressWarnings("unchecked")
-    public static <R extends Reference, E extends RelationalExpression> BindingMatcher<R> exploratoryMembers(@Nonnull final CollectionMatcher<E> downstream) {
-        return TypedMatcherWithExtractAndDownstream.typedWithDownstream((Class<R>)Reference.class,
+    public static <E extends RelationalExpression> BindingMatcher<Reference> exploratoryMembers(@Nonnull final CollectionMatcher<E> downstream) {
+        return TypedMatcherWithExtractAndDownstream.typedWithDownstream(Reference.class,
                 Extractor.of(Reference::getExploratoryExpressions, name -> "allMembers(" + name + ")"),
                 downstream);
     }
 
     @Nonnull
-    @SuppressWarnings("unchecked")
     public static <E extends RelationalExpression> BindingMatcher<Reference> exploratoryMember(@Nonnull final BindingMatcher<E> downstream) {
         return TypedMatcherWithExtractAndDownstream.typedWithDownstream(Reference.class,
                 Extractor.of(Reference::getExploratoryExpressions, name -> "exploratoryMember(" + name + ")"),

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/structure/RelationalExpressionMatchers.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/matching/structure/RelationalExpressionMatchers.java
@@ -94,11 +94,6 @@ public class RelationalExpressionMatchers {
                 downstream);
     }
 
-    @SuppressWarnings("unchecked")
-    public static <R extends RelationalExpression, C extends Collection<? extends Quantifier>> BindingMatcher<R> owning(@Nonnull final BindingMatcher<C> downstream) {
-        return ofTypeOwning((Class<R>)(Class<?>)RelationalExpression.class, downstream);
-    }
-
     public static <R extends RelationalExpression> BindingMatcher<R> canBeImplemented() {
         return PrimitiveMatchers.satisfies(relationalExpression ->
                 relationalExpression.getQuantifiers()
@@ -132,6 +127,11 @@ public class RelationalExpressionMatchers {
                                 typedWithDownstream(RelationalExpression.class,
                                         Extractor.of(RelationalExpression::getQuantifiers, name -> "quantifiers(" + name + ")"),
                                         downstreamQuantifiers))));
+    }
+
+    public static <E extends RelationalExpression> BindingMatcher<E> isExploratoryExpression() {
+        return PrimitiveMatchers.satisfiesWithOuterBinding(ReferenceMatchers.getCurrentReferenceMatcher(),
+                (expression, currentReference) -> !currentReference.isFinal(expression));
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/DecorrelateValuesRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/DecorrelateValuesRule.java
@@ -61,6 +61,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.MultiMatcher.some;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.QuantifierMatchers.forEachQuantifierWithoutDefaultOnEmptyOverRef;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.ReferenceMatchers.exploratoryMember;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RelationalExpressionMatchers.isExploratoryExpression;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RelationalExpressionMatchers.selectExpression;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.TypedMatcherWithPredicate.typedMatcherWithPredicate;
 
@@ -172,7 +173,7 @@ public class DecorrelateValuesRule extends ExplorationCascadesRule<SelectExpress
     // we don't match any that have references out to sibling quantifiers in the SelectExpression's root. However,
     // that's difficult to express with quantifiers, so in onMatch, we'll only select the subset without such correlations
     @Nonnull
-    private static final BindingMatcher<SelectExpression> root = selectExpression(some(valuesQunMatcher));
+    private static final BindingMatcher<SelectExpression> root = selectExpression(some(valuesQunMatcher)).where(isExploratoryExpression());
 
     public DecorrelateValuesRule() {
         super(root);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PredicatePushDownRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PredicatePushDownRule.java
@@ -57,6 +57,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.QuantifierMatchers.forEachQuantifierWithoutDefaultOnEmptyOverRef;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.ReferenceMatchers.exploratoryMembers;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RelationalExpressionMatchers.anyExpression;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RelationalExpressionMatchers.isExploratoryExpression;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RelationalExpressionMatchers.selectExpression;
 
 /**
@@ -182,7 +183,7 @@ public class PredicatePushDownRule extends ExplorationCascadesRule<SelectExpress
     private static final BindingMatcher<Quantifier.ForEach> forEachQuantifierMatcher =
             forEachQuantifierWithoutDefaultOnEmptyOverRef(belowReferenceMatcher);
     private static final BindingMatcher<SelectExpression> root =
-            selectExpression(forEachQuantifierMatcher);
+            selectExpression(forEachQuantifierMatcher).where(isExploratoryExpression());
 
     public PredicatePushDownRule() {
         super(root);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/QueryPredicateSimplificationRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/QueryPredicateSimplificationRule.java
@@ -40,6 +40,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.MultiMatcher.atLeastOne;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.QuantifierMatchers.anyQuantifier;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.QueryPredicateMatchers.anyPredicate;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RelationalExpressionMatchers.isExploratoryExpression;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RelationalExpressionMatchers.selectExpression;
 
 /**
@@ -88,11 +89,10 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  */
 @SuppressWarnings({"PMD.TooManyStaticImports", "PMD.CompareObjectsWithEquals"})
 public class QueryPredicateSimplificationRule extends ExplorationCascadesRule<SelectExpression> {
-
     @Nonnull
     private static final CollectionMatcher<QueryPredicate> predicateMatcher = atLeastOne(anyPredicate());
     @Nonnull
-    private static final BindingMatcher<SelectExpression> rootMatcher = selectExpression(predicateMatcher, all(anyQuantifier()));
+    private static final BindingMatcher<SelectExpression> rootMatcher = selectExpression(predicateMatcher, all(anyQuantifier())).where(isExploratoryExpression());
 
     public QueryPredicateSimplificationRule() {
         super(rootMatcher);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/SelectMergeRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/SelectMergeRule.java
@@ -58,6 +58,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.ExpressionsPartitionMatchers.rollUpPartitions;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.MultiMatcher.some;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.QuantifierMatchers.forEachQuantifierWithoutDefaultOnEmptyOverRef;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RelationalExpressionMatchers.isExploratoryExpression;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RelationalExpressionMatchers.selectExpression;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RelationalExpressionMatchers.withPredicatesExpression;
 
@@ -93,7 +94,7 @@ public class SelectMergeRule extends ImplementationCascadesRule<SelectExpression
             some(forEachQuantifierWithoutDefaultOnEmptyOverRef(childReferenceMatcher));
 
     @Nonnull
-    private static final BindingMatcher<SelectExpression> root = selectExpression(quantifiersMatcher);
+    private static final BindingMatcher<SelectExpression> root = selectExpression(quantifiersMatcher).where(isExploratoryExpression());
 
     public SelectMergeRule() {
         super(root);

--- a/fdb-record-layer-debugger/src/test/java/com/apple/foundationdb/record/query/plan/cascades/debug/ReplRunner.java
+++ b/fdb-record-layer-debugger/src/test/java/com/apple/foundationdb/record/query/plan/cascades/debug/ReplRunner.java
@@ -53,7 +53,8 @@ public class ReplRunner {
         try {
             LauncherDiscoveryRequestBuilder requestBuilder = LauncherDiscoveryRequestBuilder.request();
             if (className != null) {
-                requestBuilder.selectors(DiscoverySelectors.selectClass(className));
+                requestBuilder.selectors(DiscoverySelectors.selectClass(className))
+                        .filters(TagFilter.includeTags("debug"));
             } else {
                 requestBuilder.selectors(selectClasspathRoots(classpathRoots))
                         .filters(TagFilter.includeTags("debug"));


### PR DESCRIPTION
This PR adds logic to
1. validate a query graph handed in to the `CascadesPlanner`
2. validate every expression yielded during `REWRITING` and `PLANNING`.

This validation logic is implemented in `Reference.verifyCorrelationsRecursive` and `Reference.verifyCorrelationsForNewExpression`.

I ran extensive verification tests with these checks enabled, but as coded up in the PR it will only be run if an insane `Debugger` is installed. That is currently the case for `:fdb-record-layer-core:test` but not for `:fdb-relational-layer-core:test`.

Upon running these tests the following problems surfaced:
1. There were quite a few tests using `RecordQuery` that caused `InComparisonToExplodeRule` to yield an incorrect `ExplodeExpression` of a `QOV(parameter)` where `parameter` is a bound parameter marker. Since `QOV(...)` is only properly defined over correlations, `QOV(parameter)` is an illegal alias reference as `parameter` is not a correlation. This was fixed by introducing `ParameterValue` that can dereference an actual parameter. Other rules such as `ImplementInJoinRule` and `ImplementInUnionRule` had to be adapted to create the proper `InSource` flavors.
2. `RecursiveUnionExpression` (and `RecordQueryRecursiveUnionPlan`) can correlate AND descendants can refer to the temp aliases. Logic was added to allow the alias resolution to understand that these temp table aliases are valid aliases to be used in subgraphs underneath `RecursiveUnionExpression` (and `RecordQueryRecursiveUnionPlan`).
3. We created illegal plans when `QueryPlan.strictlySorted(...)` was called (we incorrectly did not inherit the right quantifier alias). The fix is a one-liner in `RecordQueryPredicatesFilterPlan`.
4. Some test cases were written in a way that they handed only incomplete fragments to the planner. I sometimes changed the test case if that was easy. The more general fix is to allow an `EvaluationContext` to be passed in that the verification logic can use to identify additionally visible aliases.
5. Tons of adaptations in `RuleTestHelper` as
  a. some query graphs were incomplete (dangling unresolved aliases)
  b. the `Traversal` that is used inside of `CascadesRuleCall` to validate new expressions was incorrectly maintained in `RuleTestHelper`