### PR TITLE
Planner rewrite rule for simplifying `SelectExpression` predicates

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/simplification/ConstantFoldingMultiConstraintPredicateRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/simplification/ConstantFoldingMultiConstraintPredicateRule.java
@@ -1,0 +1,214 @@
+/*
+ * ConstantFoldingBooleanPredicateWithRangesRule.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.cascades.predicates.simplification;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.query.expressions.Comparisons;
+import com.apple.foundationdb.record.query.plan.cascades.matching.structure.BindingMatcher;
+import com.apple.foundationdb.record.query.plan.cascades.predicates.ConstantPredicate;
+import com.apple.foundationdb.record.query.plan.cascades.predicates.PredicateWithValueAndRanges;
+import com.apple.foundationdb.record.query.plan.cascades.predicates.RangeConstraints;
+import com.apple.foundationdb.record.query.plan.cascades.predicates.simplification.ConstantPredicateFoldingUtil.EffectiveConstant;
+import com.apple.foundationdb.record.query.plan.cascades.values.Value;
+import com.google.common.base.Verify;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+
+import javax.annotation.Nonnull;
+
+import java.util.Optional;
+
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.ListMatcher.exactly;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.MultiMatcher.atLeastTwo;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.QueryPredicateMatchers.anyComparison;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.QueryPredicateMatchers.predicateWithValueAndRanges;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.QueryPredicateMatchers.rangeConstraint;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.ValueMatchers.anyValue;
+
+/**
+ * This rule examines {@link PredicateWithValueAndRanges} comprising a single {@link RangeConstraints} with multiple
+ * constraints and attempts to fold to a simple {@link ConstantPredicate} if it is feasible to do so, i.e. if the
+ * range constraints correspond to certain types of constant comparisons.
+ * The following cases are handled:
+ * <ul>
+ *     <li>{@code FALSE, [NULL, NULL] (AND [NULL, NULL])+  → NULL}</li>
+ *     <li>{@code TRUE, [NULL, NULL] (AND [NULL, NULL])+  → NULL}</li>
+ *     <li>{@code TRUE = [TRUE, TRUE] (AND [TRUE, TRUE])+  → TRUE}</li>
+ *     <li>{@code TRUE = [FALSE, FALSE] (AND [FALSE, FALSE])+ → FALSE}</li>
+ *     <li>{@code FALSE = [TRUE, TRUE] (AND [TRUE, TRUE])+ → FALSE}</li>
+ *     <li>{@code FALSE = [FALSE, FALSE] (AND [FALSE, FALSE])+ → TRUE}</li>
+ *     <li>{@code NULL ≠ [NULL, NULL] (AND [NULL, NULL])+ → NULL}</li>
+ *     <li>{@code NULL ≠ [TRUE, TRUE] (AND [TRUE, TRUE])+ → NULL}</li>
+ *     <li>{@code NULL ≠ [FALSE, FALSE] (AND [FALSE, FALSE])+ → NULL}</li>
+ *     <li>{@code TRUE ≠ [NULL, NULL] (AND [NULL, NULL])+ → NULL}</li>
+ *     <li>{@code TRUE ≠ [TRUE, TRUE] (AND [TRUE, TRUE])+ → FALSE}</li>
+ *     <li>{@code TRUE ≠ [FALSE, FALSE] (AND [FALSE, FALSE])+ → TRUE}</li>
+ *     <li>{@code FALSE ≠ [NULL, NULL] (AND [NULL, NULL])+ → NULL}</li>
+ *     <li>{@code FALSE ≠ [TRUE, TRUE] (AND [TRUE, TRUE])+ → TRUE}</li>
+ *     <li>{@code FALSE ≠ [FALSE, FALSE] (AND [FALSE, FALSE])+ → FALSE}</li>
+ *     <li>{@code NULL, IS_NULL (AND IS_NULL)+ → TRUE}</li>
+ *     <li>{@code TRUE, IS_NULL (AND IS_NULL)+ → FALSE}</li>
+ *     <li>{@code FALSE, IS_NULL (AND IS_NULL)+ → FALSE}</li>
+ *     <li>{@code NOT_NULL, IS_NULL (AND IS_NULL)+  → FALSE}</li>
+ *     <li>{@code TRUE IS_NOT_NULL (AND IS_NOT_NULL)+ → TRUE}</li>
+ *     <li>{@code FALSE IS_NOT_NULL (AND IS_NOT_NULL)+ → TRUE}</li>
+ *     <li>{@code NULL IS_NOT_NULL (AND IS_NOT_NULL)+ → FALSE}</li>
+ *     <li>{@code FALSE = ... AND [TRUE, TRUE] AND ... → FALSE} (implied and annulment) </li>
+ *     <li>{@code TRUE = ... AND [TRUE, TRUE] AND [FALSE, FALSE] ... → FALSE} and other contradictions leading to disjoint ranges</li>
+ *     <li>{@code FALSE = ... AND [NULL, NULL] AND [FALSE, FALSE] ... → NULL} assuming all constraints are either {@code [FALSE, FALSE] } or {@code [NULL, NULL]}</li>
+ * </ul>
+ */
+@API(API.Status.EXPERIMENTAL)
+@SuppressWarnings("PMD.TooManyStaticImports")
+public class ConstantFoldingMultiConstraintPredicateRule extends QueryPredicateSimplificationRule<PredicateWithValueAndRanges> {
+
+    @Nonnull
+    private static final BindingMatcher<RangeConstraints> rangeMatcher = rangeConstraint(atLeastTwo(anyComparison()));
+
+    @Nonnull
+    private static final BindingMatcher<Value> comparandMatcher = anyValue();
+
+    @Nonnull
+    private static final BindingMatcher<PredicateWithValueAndRanges> rootMatcher = predicateWithValueAndRanges(comparandMatcher, exactly(rangeMatcher));
+
+    public ConstantFoldingMultiConstraintPredicateRule() {
+        super(rootMatcher);
+    }
+
+    @Override
+    public void onMatch(@Nonnull final QueryPredicateSimplificationRuleCall call) {
+        final var multiConstraintRange = call.getBindings().get(rangeMatcher);
+        final var lhs = call.getBindings().get(comparandMatcher);
+        foldConjunctionRangesMaybe(lhs, multiConstraintRange).ifPresent(call::yieldResult);
+    }
+
+    @Nonnull
+    private Optional<ConstantPredicate> foldConjunctionRangesMaybe(final Value lhs, @Nonnull final RangeConstraints rangeConstraints) {
+        final var rangeCategoriesBuilder = ImmutableSet.<RangeCategory>builder();
+        final var lhsOperand = EffectiveConstant.from(lhs);
+
+        // degenerate case, give up.
+        if (rangeConstraints.getComparisons().isEmpty()) {
+            return Optional.empty();
+        }
+
+        for (final var comparison : rangeConstraints.getComparisons()) {
+            if (comparison.getType().isUnary()) {
+                if (comparison.getType() == Comparisons.Type.IS_NULL) {
+                    switch (lhsOperand) {
+                        case NULL:
+                            rangeCategoriesBuilder.add(RangeCategory.SingletonTrue);
+                            break;
+                        case TRUE: // fallthrough
+                        case FALSE: // fallthrough
+                        case NOT_NULL:
+                            rangeCategoriesBuilder.add(RangeCategory.SingletonFalse);
+                            break;
+                        default:
+                            break;
+                    }
+                } else {
+                    rangeCategoriesBuilder.add(RangeCategory.UNKNOWN);
+                }
+            } else {
+                if (!(comparison instanceof Comparisons.ValueComparison)) {
+                    rangeCategoriesBuilder.add(RangeCategory.UNKNOWN);
+                    continue;
+                }
+                final var valueComparison = (Comparisons.ValueComparison)comparison;
+                final var rhsOperand = EffectiveConstant.from(valueComparison.getValue());
+                switch (comparison.getType()) {
+                    case EQUALS:
+                        if (lhsOperand == EffectiveConstant.NULL || rhsOperand == EffectiveConstant.NULL) {
+                            rangeCategoriesBuilder.add(RangeCategory.SingletonNull);
+                            break;
+                        } else if (lhsOperand.equals(rhsOperand)) {
+                            rangeCategoriesBuilder.add(RangeCategory.SingletonTrue);
+                            break;
+                        } else {
+                            rangeCategoriesBuilder.add(RangeCategory.SingletonFalse);
+                            break;
+                        }
+                    case NOT_EQUALS:
+                        if (lhsOperand == EffectiveConstant.NULL || rhsOperand == EffectiveConstant.NULL) {
+                            rangeCategoriesBuilder.add(RangeCategory.SingletonNull);
+                            break;
+                        } else if (!lhsOperand.equals(rhsOperand)) {
+                            rangeCategoriesBuilder.add(RangeCategory.SingletonTrue);
+                            break;
+                        } else {
+                            rangeCategoriesBuilder.add(RangeCategory.SingletonFalse);
+                            break;
+                        }
+                    default:
+                        rangeCategoriesBuilder.add(RangeCategory.UNKNOWN);
+                }
+            }
+        }
+        // if we have more than one distinct range then it is impossible to find a single value that satisfies all of them
+        final var rangeCategories = rangeCategoriesBuilder.build();
+
+        // if at least one range is FALSE, the returned result must be FALSE
+        if (rangeCategories.contains(RangeCategory.SingletonFalse)) {
+            return Optional.of(ConstantPredicate.FALSE);
+        }
+
+        // if at least one range is UNKNOWN, give up.
+        if (rangeCategories.contains(RangeCategory.UNKNOWN)) {
+            return Optional.empty();
+        }
+
+        if (rangeCategories.size() == 1) {
+            final var singleRangeCategory = Iterables.getOnlyElement(rangeCategories);
+            switch (singleRangeCategory) {
+                case SingletonTrue:
+                    return Optional.of(ConstantPredicate.TRUE);
+                case SingletonFalse:
+                    return Optional.of(ConstantPredicate.FALSE);
+                case SingletonNull:
+                    return Optional.of(ConstantPredicate.NULL);
+                default:
+                    return Optional.empty();
+            }
+        }
+
+        // we have multiple disjoint singleton ranges then it is impossible to find a single value satisfying all
+        // of them ...
+
+        // ... unless we have a combination of TRUE and NULL then the result is NULL
+        if (rangeCategories.stream().noneMatch(p -> p == RangeCategory.SingletonFalse)) {
+            // we must have TRUE and NULL
+            Verify.verify(rangeCategories.contains(RangeCategory.SingletonTrue));
+            Verify.verify(rangeCategories.contains(RangeCategory.SingletonNull));
+            return Optional.of(ConstantPredicate.NULL);
+        }
+
+        // ... ok range is impossible, bailout.
+        return Optional.of(ConstantPredicate.FALSE);
+    }
+
+    private enum RangeCategory {
+        SingletonNull,
+        SingletonTrue,
+        SingletonFalse,
+        UNKNOWN
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/simplification/ConstantFoldingMultiConstraintPredicateRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/simplification/ConstantFoldingMultiConstraintPredicateRule.java
@@ -115,12 +115,12 @@ public class ConstantFoldingMultiConstraintPredicateRule extends QueryPredicateS
                 if (comparison.getType() == Comparisons.Type.IS_NULL) {
                     switch (lhsOperand) {
                         case NULL:
-                            rangeCategoriesBuilder.add(RangeCategory.SingletonTrue);
+                            rangeCategoriesBuilder.add(RangeCategory.SINGLETON_TRUE);
                             break;
                         case TRUE: // fallthrough
                         case FALSE: // fallthrough
                         case NOT_NULL:
-                            rangeCategoriesBuilder.add(RangeCategory.SingletonFalse);
+                            rangeCategoriesBuilder.add(RangeCategory.SINGLETON_FALSE);
                             break;
                         default:
                             break;
@@ -138,24 +138,24 @@ public class ConstantFoldingMultiConstraintPredicateRule extends QueryPredicateS
                 switch (comparison.getType()) {
                     case EQUALS:
                         if (lhsOperand == EffectiveConstant.NULL || rhsOperand == EffectiveConstant.NULL) {
-                            rangeCategoriesBuilder.add(RangeCategory.SingletonNull);
+                            rangeCategoriesBuilder.add(RangeCategory.SINGLETON_NULL);
                             break;
                         } else if (lhsOperand.equals(rhsOperand)) {
-                            rangeCategoriesBuilder.add(RangeCategory.SingletonTrue);
+                            rangeCategoriesBuilder.add(RangeCategory.SINGLETON_TRUE);
                             break;
                         } else {
-                            rangeCategoriesBuilder.add(RangeCategory.SingletonFalse);
+                            rangeCategoriesBuilder.add(RangeCategory.SINGLETON_FALSE);
                             break;
                         }
                     case NOT_EQUALS:
                         if (lhsOperand == EffectiveConstant.NULL || rhsOperand == EffectiveConstant.NULL) {
-                            rangeCategoriesBuilder.add(RangeCategory.SingletonNull);
+                            rangeCategoriesBuilder.add(RangeCategory.SINGLETON_NULL);
                             break;
                         } else if (!lhsOperand.equals(rhsOperand)) {
-                            rangeCategoriesBuilder.add(RangeCategory.SingletonTrue);
+                            rangeCategoriesBuilder.add(RangeCategory.SINGLETON_TRUE);
                             break;
                         } else {
-                            rangeCategoriesBuilder.add(RangeCategory.SingletonFalse);
+                            rangeCategoriesBuilder.add(RangeCategory.SINGLETON_FALSE);
                             break;
                         }
                     default:
@@ -167,7 +167,7 @@ public class ConstantFoldingMultiConstraintPredicateRule extends QueryPredicateS
         final var rangeCategories = rangeCategoriesBuilder.build();
 
         // if at least one range is FALSE, the returned result must be FALSE
-        if (rangeCategories.contains(RangeCategory.SingletonFalse)) {
+        if (rangeCategories.contains(RangeCategory.SINGLETON_FALSE)) {
             return Optional.of(ConstantPredicate.FALSE);
         }
 
@@ -179,11 +179,11 @@ public class ConstantFoldingMultiConstraintPredicateRule extends QueryPredicateS
         if (rangeCategories.size() == 1) {
             final var singleRangeCategory = Iterables.getOnlyElement(rangeCategories);
             switch (singleRangeCategory) {
-                case SingletonTrue:
+                case SINGLETON_TRUE:
                     return Optional.of(ConstantPredicate.TRUE);
-                case SingletonFalse:
+                case SINGLETON_FALSE:
                     return Optional.of(ConstantPredicate.FALSE);
-                case SingletonNull:
+                case SINGLETON_NULL:
                     return Optional.of(ConstantPredicate.NULL);
                 default:
                     return Optional.empty();
@@ -194,10 +194,10 @@ public class ConstantFoldingMultiConstraintPredicateRule extends QueryPredicateS
         // of them ...
 
         // ... unless we have a combination of TRUE and NULL then the result is NULL
-        if (rangeCategories.stream().noneMatch(p -> p == RangeCategory.SingletonFalse)) {
+        if (rangeCategories.stream().noneMatch(p -> p == RangeCategory.SINGLETON_FALSE)) {
             // we must have TRUE and NULL
-            Verify.verify(rangeCategories.contains(RangeCategory.SingletonTrue));
-            Verify.verify(rangeCategories.contains(RangeCategory.SingletonNull));
+            Verify.verify(rangeCategories.contains(RangeCategory.SINGLETON_TRUE));
+            Verify.verify(rangeCategories.contains(RangeCategory.SINGLETON_NULL));
             return Optional.of(ConstantPredicate.NULL);
         }
 
@@ -206,9 +206,9 @@ public class ConstantFoldingMultiConstraintPredicateRule extends QueryPredicateS
     }
 
     private enum RangeCategory {
-        SingletonNull,
-        SingletonTrue,
-        SingletonFalse,
+        SINGLETON_NULL,
+        SINGLETON_TRUE,
+        SINGLETON_FALSE,
         UNKNOWN
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/simplification/ConstantFoldingRuleSet.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/simplification/ConstantFoldingRuleSet.java
@@ -38,6 +38,7 @@ public class ConstantFoldingRuleSet extends DefaultQueryPredicateRuleSet {
     protected static final QueryPredicateSimplificationRule<? extends QueryPredicate> valuePredicateSimplificationRule = new ValuePredicateSimplificationRule();
     protected static final QueryPredicateSimplificationRule<? extends QueryPredicate> constantFoldingBooleanLiteralsRule = new ConstantFoldingValuePredicateRule();
     protected static final QueryPredicateSimplificationRule<? extends QueryPredicate> constantFoldingBooleanPredicateWithRangesRule = new ConstantFoldingPredicateWithRangesRule();
+    protected static final QueryPredicateSimplificationRule<? extends QueryPredicate> constantFoldingImpossiblePredicateWithRangesRule = new ConstantFoldingMultiConstraintPredicateRule();
 
     protected static final Set<QueryPredicateSimplificationRule<? extends QueryPredicate>> SIMPLIFICATION_WITH_CONSTANT_FOLDING_RULES =
             ImmutableSet.<QueryPredicateSimplificationRule<? extends QueryPredicate>>builder()
@@ -45,6 +46,7 @@ public class ConstantFoldingRuleSet extends DefaultQueryPredicateRuleSet {
                     .add(valuePredicateSimplificationRule)
                     .add(constantFoldingBooleanLiteralsRule)
                     .add(constantFoldingBooleanPredicateWithRangesRule)
+                    .add(constantFoldingImpossiblePredicateWithRangesRule)
                     .build();
 
     protected static final SetMultimap<QueryPredicateSimplificationRule<? extends QueryPredicate>, QueryPredicateSimplificationRule<? extends QueryPredicate>> SIMPLIFICATION_WITH_CONSTANT_FOLDING_DEPENDS_ON;
@@ -57,6 +59,7 @@ public class ConstantFoldingRuleSet extends DefaultQueryPredicateRuleSet {
         SIMPLIFICATION_RULES.forEach(existingRule -> simplificationDependsOnBuilder.put(existingRule, valuePredicateSimplificationRule));
         SIMPLIFICATION_RULES.forEach(existingRule -> simplificationDependsOnBuilder.put(existingRule, constantFoldingBooleanLiteralsRule));
         SIMPLIFICATION_RULES.forEach(existingRule -> simplificationDependsOnBuilder.put(existingRule, constantFoldingBooleanPredicateWithRangesRule));
+        SIMPLIFICATION_RULES.forEach(existingRule -> simplificationDependsOnBuilder.put(existingRule, constantFoldingImpossiblePredicateWithRangesRule));
         SIMPLIFICATION_WITH_CONSTANT_FOLDING_DEPENDS_ON = simplificationDependsOnBuilder.build();
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/QueryPredicateSimplificationRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/QueryPredicateSimplificationRule.java
@@ -110,7 +110,7 @@ public class QueryPredicateSimplificationRule extends ExplorationCascadesRule<Se
         final var simplifiedConjunction = Simplification.optimize(conjunction, call.getEvaluationContext(), aliasMap,
                 constantAliases, ConstantFoldingRuleSet.ofSimplificationRules());
 
-        if (simplifiedConjunction.get() == conjunction) {
+        if (simplifiedConjunction.get().semanticEquals(conjunction, aliasMap)) {
             return;
         }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/QueryPredicateSimplificationRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/QueryPredicateSimplificationRule.java
@@ -1,0 +1,128 @@
+/*
+ * DecorrelateValuesRule.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.cascades.rules;
+
+import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
+import com.apple.foundationdb.record.query.plan.cascades.ExplorationCascadesRule;
+import com.apple.foundationdb.record.query.plan.cascades.ExplorationCascadesRuleCall;
+import com.apple.foundationdb.record.query.plan.cascades.Quantifiers;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.SelectExpression;
+import com.apple.foundationdb.record.query.plan.cascades.matching.structure.BindingMatcher;
+import com.apple.foundationdb.record.query.plan.cascades.matching.structure.CollectionMatcher;
+import com.apple.foundationdb.record.query.plan.cascades.predicates.AndPredicate;
+import com.apple.foundationdb.record.query.plan.cascades.predicates.QueryPredicate;
+import com.apple.foundationdb.record.query.plan.cascades.predicates.simplification.ConstantFoldingRuleSet;
+import com.apple.foundationdb.record.query.plan.cascades.values.simplification.Simplification;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Sets;
+
+import javax.annotation.Nonnull;
+
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.MultiMatcher.all;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.MultiMatcher.atLeastOne;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.QuantifierMatchers.anyQuantifier;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.QueryPredicateMatchers.anyPredicate;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RelationalExpressionMatchers.selectExpression;
+
+/**
+ * A rule that traverses the predicates in a {@link SelectExpression} and attempts to simplify their conjunction, if
+ * successful, it will create a new {@link SelectExpression} with the simplified predicate (or its simplified terms in
+ * case of {@link AndPredicate}).
+ * <br>
+ * The rule will delegate the simplification legwork to the {@link QueryPredicate} simplification engine.
+ * <br>
+ * <b>Example 1</b>
+ * <pre>{@code
+ *  SELECT a, b, c
+ *  FROM t
+ *  WHERE a = 3 AND false
+ *  }</pre>
+ * simplifies to:
+ * <pre>{@code
+ *  SELECT a, b, c
+ *  FROM t
+ *  WHERE false
+ *  }</pre>
+ * <b>Example 2</b>
+ * <pre>{@code
+ *  SELECT a, b, c
+ *  FROM t
+ *  WHERE a = 3 AND ?p = true | p→false
+ *  }</pre>
+ * simplifies to:
+ * <pre>{@code
+ *  SELECT a, b, c
+ *  FROM t
+ *  WHERE false
+ *  }</pre>
+ * <b>Example 3</b>
+ * <pre>{@code
+ *  SELECT a, b, c
+ *  FROM t
+ *  WHERE (a = 3 AND ?p = true) AND (?q = 42) | p→true, q→null
+ *  }</pre>
+ * simplifies to:
+ * <pre>{@code
+ *  SELECT a, b, c
+ *  FROM t
+ *  WHERE null
+ *  }</pre>
+ */
+@SuppressWarnings({"PMD.TooManyStaticImports", "PMD.CompareObjectsWithEquals"})
+public class QueryPredicateSimplificationRule extends ExplorationCascadesRule<SelectExpression> {
+
+    @Nonnull
+    private static final CollectionMatcher<QueryPredicate> predicateMatcher = atLeastOne(anyPredicate());
+    @Nonnull
+    private static final BindingMatcher<SelectExpression> rootMatcher = selectExpression(predicateMatcher, all(anyQuantifier()));
+
+    public QueryPredicateSimplificationRule() {
+        super(rootMatcher);
+    }
+
+    @Override
+    public void onMatch(@Nonnull final ExplorationCascadesRuleCall call) {
+        final var selectExpression = call.get(rootMatcher);
+        final var predicates = call.get(predicateMatcher);
+        final var conjunction = AndPredicate.and(predicates);
+        final var aliasMap = AliasMap.emptyMap();
+        final var constantAliases = Sets.difference(conjunction.getCorrelatedTo(),
+                Quantifiers.aliases(selectExpression.getQuantifiers()));
+
+        final var simplifiedConjunction = Simplification.optimize(conjunction, call.getEvaluationContext(), aliasMap,
+                constantAliases, ConstantFoldingRuleSet.ofSimplificationRules());
+
+        if (simplifiedConjunction.get() == conjunction) {
+            return;
+        }
+
+        final var resultValue = selectExpression.getResultValue();
+        final var quantifier = selectExpression.getQuantifiers();
+        final SelectExpression simplifiedSelectExpression;
+        if (simplifiedConjunction instanceof AndPredicate) {
+            simplifiedSelectExpression = new SelectExpression(resultValue, quantifier, ((AndPredicate)simplifiedConjunction).getChildren());
+        } else {
+            simplifiedSelectExpression = new SelectExpression(resultValue, quantifier, ImmutableList.of(simplifiedConjunction.get()));
+        }
+
+        call.yieldExploratoryExpression(simplifiedSelectExpression);
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/QueryPredicateSimplificationRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/QueryPredicateSimplificationRule.java
@@ -1,5 +1,5 @@
 /*
- * DecorrelateValuesRule.java
+ * QueryPredicateSimplificationRule.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/RuleTestHelper.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/RuleTestHelper.java
@@ -90,6 +90,15 @@ public class RuleTestHelper {
     ));
 
     @Nonnull
+    public static final Type.Record TYPE_BLAH = Type.Record.fromFieldsWithName("bla", true, ImmutableList.of(
+            Type.Record.Field.of(Type.primitiveType(Type.TypeCode.BOOLEAN, true), Optional.of("boolField")),
+            Type.Record.Field.of(Type.primitiveType(Type.TypeCode.STRING, true), Optional.of("intField")),
+            Type.Record.Field.of(Type.primitiveType(Type.TypeCode.INT, true), Optional.of("stringField")),
+            Type.Record.Field.of(TYPE_S, Optional.of("structField")),
+            Type.Record.Field.of(new Type.Array(true, TYPE_S), Optional.of("arrayOfStructField"))
+    ));
+
+    @Nonnull
     public static Quantifier fuseQun() {
         return forEach(new FullUnorderedScanExpression(ImmutableSet.of("T", "TAU"), Type.Record.fromFields(ImmutableList.of()), new AccessHints()));
     }
@@ -102,6 +111,11 @@ public class RuleTestHelper {
     @Nonnull
     public static Quantifier baseTau() {
         return forEach(new LogicalTypeFilterExpression(ImmutableSet.of("TAU"), fuseQun(), TYPE_TAU));
+    }
+
+    @Nonnull
+    public static Quantifier baseBlah() {
+        return forEach(new LogicalTypeFilterExpression(ImmutableSet.of("BLAH"), fuseQun(), TYPE_BLAH));
     }
 
     @Nonnull
@@ -144,7 +158,7 @@ public class RuleTestHelper {
     }
 
     @Nonnull
-    private TestRuleExecution run(RelationalExpression original) {
+    private TestRuleExecution run(RelationalExpression original, EvaluationContext evaluationContext) {
         // copy the graph handed in so the caller can modify it at will afterwards and won't see the effects of
         // rewriting and planning
         final var copiedOriginal =
@@ -166,7 +180,7 @@ public class RuleTestHelper {
         }
         Reference ref = Reference.ofExploratoryExpression(PlannerStage.CANONICAL, copiedOriginal);
         PlanContext planContext = new FakePlanContext();
-        return TestRuleExecution.applyRule(planContext, rule, ref, EvaluationContext.EMPTY);
+        return TestRuleExecution.applyRule(planContext, rule, ref, evaluationContext);
     }
 
     public void ensureStage(@Nonnull PlannerStage plannerStage, @Nonnull RelationalExpression expression) {
@@ -230,6 +244,13 @@ public class RuleTestHelper {
     @CanIgnoreReturnValue
     @Nonnull
     public TestRuleExecution assertYields(RelationalExpression original, RelationalExpression... expected) {
+        return assertYields(original, EvaluationContext.EMPTY, expected);
+    }
+
+    @CanIgnoreReturnValue
+    @Nonnull
+    public TestRuleExecution assertYields(RelationalExpression original, EvaluationContext evaluationContext,
+                                          RelationalExpression... expected) {
         final ImmutableList.Builder<RelationalExpression> expectedListBuilder = ImmutableList.builder();
         for (RelationalExpression expression : expected) {
             //
@@ -250,7 +271,7 @@ public class RuleTestHelper {
             }
         }
 
-        TestRuleExecution execution = run(original);
+        TestRuleExecution execution = run(original, evaluationContext);
         try (AutoCloseableSoftAssertions softly = new AutoCloseableSoftAssertions()) {
             softly.assertThat(execution.getResult().getAllMemberExpressions())
                     .hasSize(1 + expectedList.size())
@@ -262,7 +283,13 @@ public class RuleTestHelper {
     @CanIgnoreReturnValue
     @Nonnull
     public TestRuleExecution assertYieldsNothing(RelationalExpression original, boolean matched) {
-        TestRuleExecution execution = run(original);
+        return assertYieldsNothing(original, EvaluationContext.empty(), matched);
+    }
+
+    @CanIgnoreReturnValue
+    @Nonnull
+    public TestRuleExecution assertYieldsNothing(RelationalExpression original, EvaluationContext evaluationContext, boolean matched) {
+        TestRuleExecution execution = run(original, evaluationContext);
         try (AutoCloseableSoftAssertions softly = new AutoCloseableSoftAssertions()) {
             softly.assertThat(execution.hasYielded())
                     .as("rule should not have yielded new expressions")

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/RuleTestHelper.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/RuleTestHelper.java
@@ -90,15 +90,6 @@ public class RuleTestHelper {
     ));
 
     @Nonnull
-    public static final Type.Record TYPE_BLAH = Type.Record.fromFieldsWithName("bla", true, ImmutableList.of(
-            Type.Record.Field.of(Type.primitiveType(Type.TypeCode.BOOLEAN, true), Optional.of("boolField")),
-            Type.Record.Field.of(Type.primitiveType(Type.TypeCode.STRING, true), Optional.of("intField")),
-            Type.Record.Field.of(Type.primitiveType(Type.TypeCode.INT, true), Optional.of("stringField")),
-            Type.Record.Field.of(TYPE_S, Optional.of("structField")),
-            Type.Record.Field.of(new Type.Array(true, TYPE_S), Optional.of("arrayOfStructField"))
-    ));
-
-    @Nonnull
     public static Quantifier fuseQun() {
         return forEach(new FullUnorderedScanExpression(ImmutableSet.of("T", "TAU"), Type.Record.fromFields(ImmutableList.of()), new AccessHints()));
     }
@@ -111,11 +102,6 @@ public class RuleTestHelper {
     @Nonnull
     public static Quantifier baseTau() {
         return forEach(new LogicalTypeFilterExpression(ImmutableSet.of("TAU"), fuseQun(), TYPE_TAU));
-    }
-
-    @Nonnull
-    public static Quantifier baseBlah() {
-        return forEach(new LogicalTypeFilterExpression(ImmutableSet.of("BLAH"), fuseQun(), TYPE_BLAH));
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/rules/QueryPredicateSimplificationRuleTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/rules/QueryPredicateSimplificationRuleTest.java
@@ -64,7 +64,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.ConstantFoldingT
 import static com.apple.foundationdb.record.query.plan.cascades.ConstantFoldingTestUtils.litString;
 import static com.apple.foundationdb.record.query.plan.cascades.ConstantFoldingTestUtils.litTrue;
 import static com.apple.foundationdb.record.query.plan.cascades.ConstantFoldingTestUtils.notNullIntCov;
-import static com.apple.foundationdb.record.query.plan.cascades.RuleTestHelper.baseBlah;
+import static com.apple.foundationdb.record.query.plan.cascades.RuleTestHelper.baseT;
 
 /**
  * A test suite for predicate simplification. A key component is a random predicate tree generator which, for a given
@@ -111,17 +111,17 @@ public class QueryPredicateSimplificationRuleTest {
     @ParameterizedTest(name = "({1}) should be the simplified version of {0}")
     @MethodSource("randomPredicateProvider")
     void testPredicateSimplification(QueryPredicate actualPredicate, QueryPredicate expectedPredicate, EvaluationContext evaluationContext) {
-        final Quantifier baseQun = baseBlah();
+        final Quantifier baseQun = baseT();
 
         final SelectExpression selectExpression = GraphExpansion.builder()
                 .addQuantifier(baseQun)
-                .addResultColumn(projectColumn(baseQun, "intField"))
+                .addResultColumn(projectColumn(baseQun, "a"))
                 .addPredicate(actualPredicate)
                 .build().buildSelect();
 
         final SelectExpression expected = GraphExpansion.builder()
                 .addQuantifier(baseQun)
-                .addResultColumn(projectColumn(baseQun, "intField"))
+                .addResultColumn(projectColumn(baseQun, "a"))
                 .addPredicate(expectedPredicate)
                 .build().buildSelect();
         testHelper.assertYields(selectExpression, evaluationContext, expected);
@@ -130,11 +130,11 @@ public class QueryPredicateSimplificationRuleTest {
     @ParameterizedTest(name = "({1}) should be the simplified version of {0}")
     @MethodSource("randomPredicateProvider")
     void testPredicateSimplificationGeneratedConjunctionIsSplitCorrectly(QueryPredicate actualPredicate, QueryPredicate expectedPredicate, EvaluationContext evaluationContext) {
-        final Quantifier baseQun = baseBlah();
+        final Quantifier baseQun = baseT();
 
         final SelectExpression selectExpression = GraphExpansion.builder()
                 .addQuantifier(baseQun)
-                .addResultColumn(projectColumn(baseQun, "intField"))
+                .addResultColumn(projectColumn(baseQun, "a"))
                 .addPredicate(RandomPredicateGenerator.getNonConstantPredicates().get(1))
                 .addPredicate(actualPredicate)
                 .addPredicate(RandomPredicateGenerator.getNonConstantPredicates().get(2))
@@ -150,7 +150,7 @@ public class QueryPredicateSimplificationRuleTest {
             // P1 AND P2 AND P4, because after collapsing P3 to TRUE, it should be removed afterward.
             expected = GraphExpansion.builder()
                 .addQuantifier(baseQun)
-                .addResultColumn(projectColumn(baseQun, "intField"))
+                .addResultColumn(projectColumn(baseQun, "a"))
                 .addPredicate(RandomPredicateGenerator.getNonConstantPredicates().get(1))
                 .addPredicate(RandomPredicateGenerator.getNonConstantPredicates().get(2))
                 .addPredicate(RandomPredicateGenerator.getNonConstantPredicates().get(3))
@@ -163,7 +163,7 @@ public class QueryPredicateSimplificationRuleTest {
             // FALSE (the expected predicate)
             expected = GraphExpansion.builder()
                     .addQuantifier(baseQun)
-                    .addResultColumn(projectColumn(baseQun, "intField"))
+                    .addResultColumn(projectColumn(baseQun, "a"))
                     .addPredicate(expectedPredicate)
                     .build().buildSelect();
         } else {
@@ -176,7 +176,7 @@ public class QueryPredicateSimplificationRuleTest {
             // since P1, P2, P4 are not constant.
             expected = GraphExpansion.builder()
                     .addQuantifier(baseQun)
-                    .addResultColumn(projectColumn(baseQun, "intField"))
+                    .addResultColumn(projectColumn(baseQun, "a"))
                     .addPredicate(RandomPredicateGenerator.getNonConstantPredicates().get(1))
                     .addPredicate(expectedPredicate)
                     .addPredicate(RandomPredicateGenerator.getNonConstantPredicates().get(2))
@@ -238,11 +238,11 @@ public class QueryPredicateSimplificationRuleTest {
          */
         @Nonnull
         private static final List<QueryPredicate> nonConstantPredicates = ImmutableList.of(
-                fieldPredicate(baseBlah(), "intField", new Comparisons.NullComparison(Comparisons.Type.NOT_NULL)),
-                fieldPredicate(baseBlah(), "stringField", new Comparisons.ValueComparison(Comparisons.Type.EQUALS, litString("foo").value())),
-                LiteralValue.ofScalar("something").withComparison(new Comparisons.ValueComparison(Comparisons.Type.EQUALS, fieldValue(baseBlah(), "stringField"))),
-                fieldPredicate(baseBlah(), "intField", new Comparisons.ValueComparison(Comparisons.Type.GREATER_THAN, litInt(42).value())),
-                new NullValue(Type.primitiveType(Type.TypeCode.INT)).withComparison(new Comparisons.ValueComparison(Comparisons.Type.EQUALS, fieldValue(baseBlah(), "intField")))
+                fieldPredicate(baseT(), "a", new Comparisons.NullComparison(Comparisons.Type.NOT_NULL)),
+                fieldPredicate(baseT(), "b", new Comparisons.ValueComparison(Comparisons.Type.EQUALS, litString("foo").value())),
+                LiteralValue.ofScalar("something").withComparison(new Comparisons.ValueComparison(Comparisons.Type.EQUALS, fieldValue(baseT(), "b"))),
+                fieldPredicate(baseT(), "a", new Comparisons.ValueComparison(Comparisons.Type.GREATER_THAN, litInt(42).value())),
+                new NullValue(Type.primitiveType(Type.TypeCode.INT)).withComparison(new Comparisons.ValueComparison(Comparisons.Type.EQUALS, fieldValue(baseT(), "a")))
         );
 
         @Nonnull

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/rules/QueryPredicateSimplificationRuleTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/rules/QueryPredicateSimplificationRuleTest.java
@@ -1,0 +1,485 @@
+/*
+ * QueryPredicateSimplificationRuleTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.cascades.rules;
+
+import com.apple.foundationdb.record.EvaluationContext;
+import com.apple.foundationdb.record.query.expressions.Comparisons;
+import com.apple.foundationdb.record.query.plan.cascades.GraphExpansion;
+import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
+import com.apple.foundationdb.record.query.plan.cascades.RuleTestHelper;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.SelectExpression;
+import com.apple.foundationdb.record.query.plan.cascades.predicates.AndPredicate;
+import com.apple.foundationdb.record.query.plan.cascades.predicates.ConstantPredicate;
+import com.apple.foundationdb.record.query.plan.cascades.predicates.OrPredicate;
+import com.apple.foundationdb.record.query.plan.cascades.predicates.QueryPredicate;
+import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
+import com.apple.foundationdb.record.query.plan.cascades.values.LiteralValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.NullValue;
+import com.apple.foundationdb.record.util.pair.NonnullPair;
+import com.apple.test.RandomizedTestUtils;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Streams;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Stream;
+
+import static com.apple.foundationdb.record.provider.foundationdb.query.FDBQueryGraphTestHelpers.fieldPredicate;
+import static com.apple.foundationdb.record.provider.foundationdb.query.FDBQueryGraphTestHelpers.fieldValue;
+import static com.apple.foundationdb.record.provider.foundationdb.query.FDBQueryGraphTestHelpers.projectColumn;
+import static com.apple.foundationdb.record.query.plan.cascades.ConstantFoldingTestUtils.areEqual;
+import static com.apple.foundationdb.record.query.plan.cascades.ConstantFoldingTestUtils.areEqualAsRange;
+import static com.apple.foundationdb.record.query.plan.cascades.ConstantFoldingTestUtils.areNotEqual;
+import static com.apple.foundationdb.record.query.plan.cascades.ConstantFoldingTestUtils.covFalse;
+import static com.apple.foundationdb.record.query.plan.cascades.ConstantFoldingTestUtils.covNull;
+import static com.apple.foundationdb.record.query.plan.cascades.ConstantFoldingTestUtils.covTrue;
+import static com.apple.foundationdb.record.query.plan.cascades.ConstantFoldingTestUtils.isNotNull;
+import static com.apple.foundationdb.record.query.plan.cascades.ConstantFoldingTestUtils.isNull;
+import static com.apple.foundationdb.record.query.plan.cascades.ConstantFoldingTestUtils.litFalse;
+import static com.apple.foundationdb.record.query.plan.cascades.ConstantFoldingTestUtils.litInt;
+import static com.apple.foundationdb.record.query.plan.cascades.ConstantFoldingTestUtils.litNull;
+import static com.apple.foundationdb.record.query.plan.cascades.ConstantFoldingTestUtils.litString;
+import static com.apple.foundationdb.record.query.plan.cascades.ConstantFoldingTestUtils.litTrue;
+import static com.apple.foundationdb.record.query.plan.cascades.ConstantFoldingTestUtils.notNullIntCov;
+import static com.apple.foundationdb.record.query.plan.cascades.RuleTestHelper.baseBlah;
+
+/**
+ * A test suite for predicate simplification. A key component is a random predicate tree generator which, for a given
+ * predicate, constructs randomized AND/OR trees. This allows testing predicate simplification in the context of complex,
+ * production-like SQL statements. The generator creates a tree with the specified predicate embedded within it, providing
+ * a realistic environment for evaluating simplification logic.
+ * <br>
+ * For example: Given a predicate {@code P1} that evaluates to {@code FALSE}, the framework puts it in a tree of
+ * {@code AND} predicates and then carries on to make sure that the tree collapses to {@code FALSE}.
+ * <pre>{@code
+ *        AND
+ *       /   \
+ *     AND    C
+ *     /  \
+ *    A    AND
+ *        /   \
+ *       B     P1 <-- evaluates to false
+ * }</pre>
+ */
+public class QueryPredicateSimplificationRuleTest {
+
+    @Nonnull
+    private static final QueryPredicateSimplificationRule rule = new QueryPredicateSimplificationRule();
+    @Nonnull
+    private static final RuleTestHelper testHelper = new RuleTestHelper(rule);
+
+    @Nonnull
+    public static Stream<Arguments> randomPredicateProvider() {
+        final var firstStream = RandomizedTestUtils.randomSeeds(123943, 92789234, 3498204, 20374023, 787234234, 89712321,
+                        8971293, 87912321, 87123912, 789435, 98743534, 897432973, 879237492, 7197231, 871297831, 8781923)
+                .map(seed -> {
+                    final var randomPredicate = new RandomPredicateGenerator(new Random(seed));
+                    final var instance = randomPredicate.generate();
+                    return Arguments.arguments(instance.predicateUnderTest, instance.expectedPredicate, instance.evaluationContext);
+                });
+        final var secondStream = RandomizedTestUtils.randomArguments(random -> {
+            final var randomPredicate = new RandomPredicateGenerator(random);
+            final var instance = randomPredicate.generate();
+            return Arguments.arguments(instance.predicateUnderTest, instance.expectedPredicate, instance.evaluationContext);
+        });
+        return Streams.concat(firstStream, secondStream);
+    }
+
+    @ParameterizedTest(name = "({1}) should be the simplified version of {0}")
+    @MethodSource("randomPredicateProvider")
+    void testPredicateSimplification(QueryPredicate actualPredicate, QueryPredicate expectedPredicate, EvaluationContext evaluationContext) {
+        final Quantifier baseQun = baseBlah();
+
+        final SelectExpression selectExpression = GraphExpansion.builder()
+                .addQuantifier(baseQun)
+                .addResultColumn(projectColumn(baseQun, "intField"))
+                .addPredicate(actualPredicate)
+                .build().buildSelect();
+
+        final SelectExpression expected = GraphExpansion.builder()
+                .addQuantifier(baseQun)
+                .addResultColumn(projectColumn(baseQun, "intField"))
+                .addPredicate(expectedPredicate)
+                .build().buildSelect();
+        testHelper.assertYields(selectExpression, evaluationContext, expected);
+    }
+
+    public static class RandomPredicateGenerator {
+
+        public static class PredicateTest {
+            @Nonnull
+            private final QueryPredicate expectedPredicate;
+
+            @Nonnull
+            private final QueryPredicate predicateUnderTest;
+
+            @Nonnull
+            private final EvaluationContext evaluationContext;
+
+            PredicateTest(@Nonnull final QueryPredicate expectedPredicate, @Nonnull final QueryPredicate predicateUnderTest,
+                          @Nonnull final EvaluationContext evaluationContext) {
+                this.expectedPredicate = expectedPredicate;
+                this.predicateUnderTest = predicateUnderTest;
+                this.evaluationContext = evaluationContext;
+            }
+        }
+
+        @Nonnull
+        private final List<NonnullPair<QueryPredicate, EvaluationContext>> nullConstantPredicates;
+
+        @Nonnull
+        private final List<NonnullPair<QueryPredicate, EvaluationContext>> trueConstantPredicates;
+
+        @Nonnull
+        private final List<QueryPredicate> trueConstantLiteralPredicates;
+
+        @Nonnull
+        private final List<NonnullPair<QueryPredicate, EvaluationContext>> falseConstantPredicates;
+
+        @Nonnull
+        private final List<QueryPredicate> falseConstantLiteralPredicates;
+
+        @Nonnull
+        private final Random random;
+
+        public RandomPredicateGenerator(@Nonnull Random random) {
+            this.random = random;
+            this.nullConstantPredicates = generateNullConstantPredicates();
+            this.trueConstantPredicates = buildTrueConstantPredicates();
+            this.trueConstantLiteralPredicates = buildTrueConstantLiteralPredicates();
+            this.falseConstantPredicates = buildFalseConstantPredicates();
+            this.falseConstantLiteralPredicates = buildFalseConstantLiteralPredicates();
+        }
+
+        @Nonnull
+        public PredicateTest generate() {
+            final var isTrue = random.nextInt(3);
+            if (isTrue == 0) {
+                final var nullConstantPredicate = nullConstantPredicates.get(random.nextInt(nullConstantPredicates.size()));
+                return new PredicateTest(ConstantPredicate.NULL, randomTreeForNull(nullConstantPredicate.getLeft()), nullConstantPredicate.getRight());
+            } else if (isTrue == 1) {
+                final var trueConstantPredicate = trueConstantPredicates.get(random.nextInt(trueConstantPredicates.size()));
+                return new PredicateTest(ConstantPredicate.TRUE, randomOrTree(trueConstantPredicate.getLeft()), trueConstantPredicate.getRight());
+            } else {
+                final var falseConstantPredicate = falseConstantPredicates.get(random.nextInt(falseConstantPredicates.size()));
+                return new PredicateTest(ConstantPredicate.FALSE, randomAndTree(falseConstantPredicate.getLeft()), falseConstantPredicate.getRight());
+            }
+        }
+
+        /**
+         * List of predicates that can not be evaluated at query compile time.
+         */
+        @Nonnull
+        private final List<QueryPredicate> nonConstantPredicates = ImmutableList.of(
+                fieldPredicate(baseBlah(), "intField", new Comparisons.NullComparison(Comparisons.Type.NOT_NULL)),
+                fieldPredicate(baseBlah(), "stringField", new Comparisons.ValueComparison(Comparisons.Type.EQUALS, litString("foo").value())),
+                LiteralValue.ofScalar("something").withComparison(new Comparisons.ValueComparison(Comparisons.Type.EQUALS, fieldValue(baseBlah(), "stringField"))),
+                fieldPredicate(baseBlah(), "intField", new Comparisons.ValueComparison(Comparisons.Type.GREATER_THAN, litInt(42).value())),
+                new NullValue(Type.primitiveType(Type.TypeCode.INT)).withComparison(new Comparisons.ValueComparison(Comparisons.Type.EQUALS, fieldValue(baseBlah(), "intField")))
+        );
+
+        @Nonnull
+        private static List<NonnullPair<QueryPredicate, EvaluationContext>> generateNullConstantPredicates() {
+            final var nullConstantPredicatesBuilder = ImmutableList.<NonnullPair<QueryPredicate, EvaluationContext>>builder();
+            {
+                var op1 = covTrue();
+                var op2 = covNull();
+                nullConstantPredicatesBuilder.add(NonnullPair.of(areEqual(op1.value(), op2.value()), op1.mergeEvaluationContext(op2)));
+            }
+            {
+                var op1 = covFalse();
+                var op2 = covNull();
+                nullConstantPredicatesBuilder.add(NonnullPair.of(areNotEqual(op1.value(), op2.value()), op1.mergeEvaluationContext(op2)));
+            }
+            {
+                var op1 = litNull();
+                var op2 = litTrue();
+                nullConstantPredicatesBuilder.add(NonnullPair.of(areNotEqual(op1.value(), op2.value()), op1.mergeEvaluationContext(op2)));
+            }
+            {
+                var op1 = litFalse();
+                var op2 = litNull();
+                nullConstantPredicatesBuilder.add(NonnullPair.of(areNotEqual(op1.value(), op2.value()), op1.mergeEvaluationContext(op2)));
+            }
+
+            {
+                var op1 = litFalse();
+                var op2 = litNull();
+                nullConstantPredicatesBuilder.add(NonnullPair.of(areEqual(op1.value(), op2.value()), op1.mergeEvaluationContext(op2)));
+            }
+            {
+                var op1 = covFalse();
+                var op2 = covNull();
+                nullConstantPredicatesBuilder.add(NonnullPair.of(areEqual(op1.value(), op2.value()), op1.mergeEvaluationContext(op2)));
+            }
+            {
+                var op1 = litNull();
+                var op2 = litTrue();
+                nullConstantPredicatesBuilder.add(NonnullPair.of(areEqual(op1.value(), op2.value()), op1.mergeEvaluationContext(op2)));
+            }
+            {
+                var op1 = litFalse();
+                var op2 = litNull();
+                nullConstantPredicatesBuilder.add(NonnullPair.of(areEqual(op1.value(), op2.value()), op1.mergeEvaluationContext(op2)));
+            }
+            return nullConstantPredicatesBuilder.build();
+        }
+
+        @Nonnull
+        private static List<NonnullPair<QueryPredicate, EvaluationContext>> buildTrueConstantPredicates() {
+            final var nullConstantPredicatesBuilder = ImmutableList.<NonnullPair<QueryPredicate, EvaluationContext>>builder();
+            {
+                var op1 = covTrue();
+                var op2 = litTrue();
+                nullConstantPredicatesBuilder.add(NonnullPair.of(areEqual(op1.value(), op2.value()), op1.mergeEvaluationContext(op2)));
+            }
+            {
+                var op1 = litFalse();
+                var op2 = litFalse();
+                nullConstantPredicatesBuilder.add(NonnullPair.of(areEqual(op1.value(), op2.value()), op1.mergeEvaluationContext(op2)));
+            }
+            {
+                var op1 = litFalse();
+                var op2 = litTrue();
+                nullConstantPredicatesBuilder.add(NonnullPair.of(areNotEqual(op1.value(), op2.value()), op1.mergeEvaluationContext(op2)));
+            }
+            {
+                var op1 = notNullIntCov();
+                nullConstantPredicatesBuilder.add(NonnullPair.of(isNotNull(op1.value()), op1.getEvaluationContext()));
+            }
+            {
+                var op2 = litNull();
+                nullConstantPredicatesBuilder.add(NonnullPair.of(isNull(op2.value()), EvaluationContext.empty()));
+            }
+            {
+                var op1 = covFalse();
+                var op2 = litFalse();
+                nullConstantPredicatesBuilder.add(NonnullPair.of(areEqualAsRange(op1.value(), op2.value()), op1.mergeEvaluationContext(op2)));
+            }
+            {
+                var op1 = covTrue();
+                var op2 = covTrue();
+                nullConstantPredicatesBuilder.add(NonnullPair.of(areEqualAsRange(op1.value(), op2.value()), op1.mergeEvaluationContext(op2)));
+            }
+            return nullConstantPredicatesBuilder.build();
+        }
+
+        @Nonnull
+        private static List<QueryPredicate> buildTrueConstantLiteralPredicates() {
+            final var trueConstantLiteralPredicatesBuilder = ImmutableList.<QueryPredicate>builder();
+            {
+                var op1 = litTrue();
+                var op2 = litTrue();
+                trueConstantLiteralPredicatesBuilder.add(areEqual(op1.value(), op2.value()));
+            }
+            {
+                var op1 = litFalse();
+                var op2 = litFalse();
+                trueConstantLiteralPredicatesBuilder.add(areEqual(op1.value(), op2.value()));
+            }
+            {
+                var op1 = litFalse();
+                var op2 = litTrue();
+                trueConstantLiteralPredicatesBuilder.add(areNotEqual(op1.value(), op2.value()));
+            }
+            {
+                var op1 = litInt(42);
+                trueConstantLiteralPredicatesBuilder.add(isNotNull(op1.value()));
+            }
+            {
+                var op2 = litNull();
+                trueConstantLiteralPredicatesBuilder.add(isNull(op2.value()));
+            }
+            {
+                var op1 = litFalse();
+                var op2 = litFalse();
+                trueConstantLiteralPredicatesBuilder.add(areEqualAsRange(op1.value(), op2.value()));
+            }
+            {
+                var op1 = litTrue();
+                var op2 = litTrue();
+                trueConstantLiteralPredicatesBuilder.add(areEqualAsRange(op1.value(), op2.value()));
+            }
+            return trueConstantLiteralPredicatesBuilder.build();
+        }
+
+
+        private static List<NonnullPair<QueryPredicate, EvaluationContext>> buildFalseConstantPredicates() {
+            final var nullConstantPredicatesBuilder = ImmutableList.<NonnullPair<QueryPredicate, EvaluationContext>>builder();
+            {
+                var op1 = covTrue();
+                var op2 = litTrue();
+                nullConstantPredicatesBuilder.add(NonnullPair.of(areNotEqual(op1.value(), op2.value()), op1.mergeEvaluationContext(op2)));
+            }
+            {
+                var op1 = litFalse();
+                var op2 = litFalse();
+                nullConstantPredicatesBuilder.add(NonnullPair.of(areNotEqual(op1.value(), op2.value()), op1.mergeEvaluationContext(op2)));
+            }
+            {
+                var op1 = litFalse();
+                var op2 = litTrue();
+                nullConstantPredicatesBuilder.add(NonnullPair.of(areEqual(op1.value(), op2.value()), op1.mergeEvaluationContext(op2)));
+            }
+            {
+                var op1 = litFalse();
+                var op2 = litTrue();
+                nullConstantPredicatesBuilder.add(NonnullPair.of(areEqual(op1.value(), op2.value()), op1.mergeEvaluationContext(op2)));
+            }
+            {
+                var op1 = notNullIntCov();
+                nullConstantPredicatesBuilder.add(NonnullPair.of(isNull(op1.value()), op1.getEvaluationContext()));
+            }
+            {
+                var op2 = litNull();
+                nullConstantPredicatesBuilder.add(NonnullPair.of(isNotNull(op2.value()), EvaluationContext.empty()));
+            }
+            {
+                var op1 = covFalse();
+                var op2 = litFalse();
+                nullConstantPredicatesBuilder.add(NonnullPair.of(areNotEqual(op1.value(), op2.value()), op1.mergeEvaluationContext(op2)));
+            }
+            {
+                var op1 = covTrue();
+                var op2 = covTrue();
+                nullConstantPredicatesBuilder.add(NonnullPair.of(areNotEqual(op1.value(), op2.value()), op1.mergeEvaluationContext(op2)));
+            }
+            return nullConstantPredicatesBuilder.build();
+        }
+
+        private static List<QueryPredicate> buildFalseConstantLiteralPredicates() {
+            final var nullConstantPredicatesBuilder = ImmutableList.<QueryPredicate>builder();
+            {
+                var op1 = litTrue();
+                var op2 = litTrue();
+                nullConstantPredicatesBuilder.add(areNotEqual(op1.value(), op2.value()));
+            }
+            {
+                var op1 = litFalse();
+                var op2 = litFalse();
+                nullConstantPredicatesBuilder.add(areNotEqual(op1.value(), op2.value()));
+            }
+            {
+                var op1 = litFalse();
+                var op2 = litTrue();
+                nullConstantPredicatesBuilder.add(areEqual(op1.value(), op2.value()));
+            }
+            {
+                var op1 = litFalse();
+                var op2 = litTrue();
+                nullConstantPredicatesBuilder.add(areEqualAsRange(op1.value(), op2.value()));
+            }
+            {
+                var op1 = litInt(42);
+                nullConstantPredicatesBuilder.add(isNull(op1.value()));
+            }
+            {
+                var op2 = litNull();
+                nullConstantPredicatesBuilder.add(isNotNull(op2.value()));
+            }
+            {
+                var op1 = litFalse();
+                var op2 = litFalse();
+                nullConstantPredicatesBuilder.add(areNotEqual(op1.value(), op2.value()));
+            }
+            {
+                var op1 = litTrue();
+                var op2 = litTrue();
+                nullConstantPredicatesBuilder.add(areNotEqual(op1.value(), op2.value()));
+            }
+            return nullConstantPredicatesBuilder.build();
+        }
+
+        @Nonnull
+        private List<QueryPredicate> generateRandomPredicates(QueryPredicate needle, List<QueryPredicate> otherPredicates) {
+            final int listSize = 2 + random.nextInt(8);
+            final int needlePosition = random.nextInt(listSize);
+            final var predicateBuilder = ImmutableList.<QueryPredicate>builder();
+            for (int i = 0; i < listSize; i++) {
+                if (needlePosition == i) {
+                    predicateBuilder.add(needle);
+                } else {
+                    final int nonConstantPredicatePosition = random.nextInt(otherPredicates.size());
+                    predicateBuilder.add(otherPredicates.get(nonConstantPredicatePosition));
+                }
+            }
+            return predicateBuilder.build();
+        }
+
+        @Nonnull
+        private QueryPredicate generateRandomOrPredicate(QueryPredicate needle, List<QueryPredicate> otherPredicates) {
+            return OrPredicate.or(generateRandomPredicates(needle, otherPredicates));
+        }
+
+        @Nonnull
+        private QueryPredicate generateRandomAndPredicate(QueryPredicate constantPredicate, List<QueryPredicate> otherPredicates) {
+            return AndPredicate.and(generateRandomPredicates(constantPredicate, otherPredicates));
+        }
+
+        @Nonnull
+        private QueryPredicate randomOrTree(QueryPredicate needleAtLeaf, List<QueryPredicate> otherPredicates) {
+            final var depth = 2 + random.nextInt(4);
+            var currentLevel = generateRandomOrPredicate(needleAtLeaf, otherPredicates);
+            for (int i = 0; i < depth; i++) {
+                currentLevel = generateRandomOrPredicate(currentLevel, otherPredicates);
+            }
+            return currentLevel;
+        }
+
+        @Nonnull
+        private QueryPredicate randomOrTree(QueryPredicate needleAtLeaf) {
+            return randomOrTree(needleAtLeaf, nonConstantPredicates);
+        }
+
+        @Nonnull
+        private QueryPredicate randomAndTree(QueryPredicate needleAtLeaf, List<QueryPredicate> otherPredicates) {
+            final var depth = 2 + random.nextInt(4);
+            var currentLevel = generateRandomAndPredicate(needleAtLeaf, otherPredicates);
+            for (int i = 0; i < depth; i++) {
+                currentLevel = generateRandomAndPredicate(currentLevel, otherPredicates);
+            }
+            return currentLevel;
+        }
+
+        @Nonnull
+        private QueryPredicate randomAndTree(QueryPredicate needleAtLeaf) {
+            return randomAndTree(needleAtLeaf, nonConstantPredicates);
+        }
+
+        @Nonnull
+        public QueryPredicate randomTreeForNull(QueryPredicate needleAtLeaf) {
+            final var depth = 2 + random.nextInt(4);
+            var isAnd = random.nextBoolean();
+            var currentLevel = isAnd ? generateRandomAndPredicate(needleAtLeaf, trueConstantLiteralPredicates)
+                               : generateRandomOrPredicate(needleAtLeaf, falseConstantLiteralPredicates);
+            for (int i = 0; i < depth; i++) {
+                isAnd = random.nextBoolean();
+                currentLevel = isAnd ? generateRandomAndPredicate(currentLevel, trueConstantLiteralPredicates)
+                      : generateRandomOrPredicate(needleAtLeaf, falseConstantLiteralPredicates);
+            }
+            return currentLevel;
+        }
+    }
+}


### PR DESCRIPTION
This introduces a new planner rewrite rule called `QueryPredicateSimplificationRule`, it matches `SelectExpression`s with at least one predicate, and attempts to simplify the conjunction of the predicates through the `QueryPredicate` simplification engine and rules (which were introduced in #3404).

If the predicate was simplified, it proceeds to create a new `SelectExpression` with that simplified predicate, and if the predicate is a conjunction, it breaks it apart, and supply its terms to the `SelectExpression` to align with the way the `SelectExpression` is constructed where its predicates are heavily preprocessed.

This PR also introduces a new `QueryPredicate` simplification rule called `ConstantFoldingMultiConstraintPredicateRule` that, as the name suggests, attempt to simplify a `PredicateValueWithRangeAndConstraints` that has 1 `RangeConstraints` with _at least_ 2 constraints. There are some interesting cases where the resulting constraints are contradicting and result in disjoint singleton ranges that are impossible to satisfy (more about that explained #3407).

Finally, the PR introduced a new randomized predicate testing framework that is able to generate complex predicate trees and validate them. It integrates with the `RandomizedTestUtils` so it can also benefit from any nightly testing capabilities.

This resolves #3407 and #3410.