### PR TITLE
Introduce value-specific plan cache constraints

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/EvaluatesToValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/EvaluatesToValue.java
@@ -1,0 +1,262 @@
+/*
+ * EvaluatesToValue.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.cascades.values;
+
+import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
+import com.apple.foundationdb.record.EvaluationContext;
+import com.apple.foundationdb.record.ObjectPlanHash;
+import com.apple.foundationdb.record.PlanDeserializer;
+import com.apple.foundationdb.record.PlanHashable;
+import com.apple.foundationdb.record.PlanSerializationContext;
+import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.planprotos.PEvaluatesToValue;
+import com.apple.foundationdb.record.planprotos.PEvaluation;
+import com.apple.foundationdb.record.planprotos.PValue;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
+import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
+import com.apple.foundationdb.record.query.plan.cascades.BooleanWithConstraint;
+import com.apple.foundationdb.record.query.plan.explain.ExplainTokensWithPrecedence;
+import com.google.auto.service.AutoService;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.protobuf.Message;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+public class EvaluatesToValue extends AbstractValue implements Value.RangeMatchableValue, ValueWithChild {
+    private static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("Evaluates-To-Value");
+
+    public enum Evaluation {
+        IS_TRUE,
+        IS_FALSE,
+        IS_NULL,
+        IS_NOT_NULL
+    }
+
+    @Nonnull
+    private final Value child;
+    @Nonnull
+    private final Evaluation evaluation;
+
+    private EvaluatesToValue(@Nonnull final Value child, @Nonnull final Evaluation evaluation) {
+        this.child = child;
+        this.evaluation = evaluation;
+    }
+
+    @Override
+    public int planHash(@Nonnull final PlanHashMode mode) {
+        return PlanHashable.objectsPlanHash(mode, BASE_HASH, evaluation, child);
+    }
+
+    @Nonnull
+    @Override
+    public Value getChild() {
+        return child;
+    }
+
+    @Nonnull
+    public Evaluation getEvaluation() {
+        return evaluation;
+    }
+
+    @Nonnull
+    @Override
+    public ValueWithChild withNewChild(@Nonnull final Value rebasedChild) {
+        return of(rebasedChild, evaluation);
+    }
+
+    @Nullable
+    @Override
+    public <M extends Message> Boolean eval(@Nullable final FDBRecordStoreBase<M> store,
+                                            @Nonnull final EvaluationContext context) {
+        final var value = child.eval(store, context);
+        switch (evaluation) {
+            case IS_TRUE:
+                return value instanceof Boolean && ((Boolean)value);
+            case IS_FALSE:
+                return value instanceof Boolean && !((Boolean)value);
+            case IS_NULL:
+                return value == null;
+            case IS_NOT_NULL:
+                return value != null;
+            default:
+                throw new RecordCoreException("unexpected evaluation " + evaluation);
+        }
+    }
+
+    @Override
+    @SpotBugsSuppressWarnings("EQ_UNUSUAL")
+    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
+    public boolean equals(final Object o) {
+        return semanticEquals(o, AliasMap.emptyMap());
+    }
+
+    @Nonnull
+    @Override
+    public BooleanWithConstraint equalsWithoutChildren(@Nonnull final Value other) {
+        return super.equalsWithoutChildren(other)
+                .filter(ignored -> evaluation.equals(((EvaluatesToValue)other).getEvaluation()));
+    }
+
+    @Override
+    public int hashCode() {
+        return semanticHashCode();
+    }
+
+    @Override
+    public int hashCodeWithoutChildren() {
+        return PlanHashable.objectsPlanHash(PlanHashable.CURRENT_FOR_CONTINUATION, BASE_HASH, evaluation);
+    }
+
+    @Nonnull
+    @Override
+    public ExplainTokensWithPrecedence explain(@Nonnull final Iterable<Supplier<ExplainTokensWithPrecedence>> explainSuppliers) {
+        final var child = Iterables.getOnlyElement(explainSuppliers).get().getExplainTokens();
+        return ExplainTokensWithPrecedence.of(ExplainTokensWithPrecedence.Precedence.ALWAYS_PARENS,
+                child.addWhitespace().addIdentifier("EVALUATES").addWhitespace().addKeyword("TO")
+                        .addWhitespace().addIdentifier(evaluation.toString()));
+    }
+
+    @Nonnull
+    @Override
+    public PEvaluatesToValue toProto(@Nonnull final PlanSerializationContext serializationContext) {
+        final PEvaluation evaluationProto;
+        switch (evaluation) {
+            case IS_TRUE:
+                evaluationProto = PEvaluation.IS_TRUE;
+                break;
+            case IS_FALSE:
+                evaluationProto = PEvaluation.IS_FALSE;
+                break;
+            case IS_NULL:
+                evaluationProto = PEvaluation.IS_NULL;
+                break;
+            case IS_NOT_NULL:
+                evaluationProto = PEvaluation.IS_NOT_NULL;
+                break;
+            default:
+                throw new RecordCoreException("unexpected evaluation " + evaluation);
+        }
+
+        return PEvaluatesToValue.newBuilder()
+                .setChild(child.toValueProto(serializationContext))
+                .setEvaluation(evaluationProto)
+                .build();
+    }
+
+    @Nonnull
+    @Override
+    public PValue toValueProto(@Nonnull final PlanSerializationContext serializationContext) {
+        return PValue.newBuilder().setEvaluatesToValue(toProto(serializationContext)).build();
+    }
+
+    @Nonnull
+    public static EvaluatesToValue fromProto(@Nonnull final PlanSerializationContext serializationContext,
+                                             @Nonnull final PEvaluatesToValue ofTypeValueProto) {
+        final Evaluation evaluation;
+        final PEvaluation evaluationProto = ofTypeValueProto.getEvaluation();
+        switch (evaluationProto) {
+            case IS_TRUE:
+                evaluation = Evaluation.IS_TRUE;
+                break;
+            case IS_FALSE:
+                evaluation = Evaluation.IS_FALSE;
+                break;
+            case IS_NULL:
+                evaluation = Evaluation.IS_NULL;
+                break;
+            case IS_NOT_NULL:
+                evaluation = Evaluation.IS_NOT_NULL;
+                break;
+            default:
+                throw new RecordCoreException("unexpected evaluation " + evaluationProto);
+        }
+        return of(Value.fromValueProto(serializationContext, Objects.requireNonNull(ofTypeValueProto.getChild())), evaluation);
+    }
+
+    @Nonnull
+    private static EvaluatesToValue of(@Nonnull final Value value, @Nonnull final Evaluation evaluation) {
+        return new EvaluatesToValue(value, evaluation);
+    }
+
+    @Nonnull
+    public static EvaluatesToValue isTrue(@Nonnull final Value value) {
+        return of(value, Evaluation.IS_TRUE);
+    }
+
+    @Nonnull
+    public static EvaluatesToValue isFalse(@Nonnull final Value value) {
+        return of(value, Evaluation.IS_FALSE);
+    }
+
+    @Nonnull
+    public static EvaluatesToValue isNull(@Nonnull final Value value) {
+        return of(value, Evaluation.IS_NULL);
+    }
+
+    @Nonnull
+    public static EvaluatesToValue isNotNull(@Nonnull final Value value) {
+        return of(value, Evaluation.IS_NOT_NULL);
+    }
+
+    @Nonnull
+    public static EvaluatesToValue of(@Nonnull final ConstantObjectValue constantObjectValue,
+                                      @Nonnull final EvaluationContext evaluationContext) {
+        final var plainValue = constantObjectValue.evalWithoutStore(evaluationContext);
+        if (plainValue == null) {
+            return isNull(constantObjectValue);
+        }
+        if (plainValue instanceof Boolean) {
+            Boolean booleanPlainValue = (Boolean)plainValue;
+            return booleanPlainValue ? isTrue(constantObjectValue) : isFalse(constantObjectValue);
+        } else {
+            return isNotNull(constantObjectValue);
+        }
+    }
+
+    @Nonnull
+    @Override
+    protected Iterable<? extends Value> computeChildren() {
+        return ImmutableList.of(getChild());
+    }
+
+    /**
+     * Deserializer.
+     */
+    @AutoService(PlanDeserializer.class)
+    public static class Deserializer implements PlanDeserializer<PEvaluatesToValue, EvaluatesToValue> {
+        @Nonnull
+        @Override
+        public Class<PEvaluatesToValue> getProtoMessageClass() {
+            return PEvaluatesToValue.class;
+        }
+
+        @Nonnull
+        @Override
+        public EvaluatesToValue fromProto(@Nonnull final PlanSerializationContext serializationContext,
+                                     @Nonnull final PEvaluatesToValue ofTypeValueProto) {
+            return EvaluatesToValue.fromProto(serializationContext, ofTypeValueProto);
+        }
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/EvaluatesToValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/EvaluatesToValue.java
@@ -105,6 +105,12 @@ public class EvaluatesToValue extends AbstractValue implements Value.RangeMatcha
         }
     }
 
+    @Nullable
+    @Override
+    public Boolean evalWithoutStore(@Nonnull final EvaluationContext context) {
+        return eval(null, context);
+    }
+
     @Override
     @SpotBugsSuppressWarnings("EQ_UNUSUAL")
     @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/EvaluatesToValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/EvaluatesToValue.java
@@ -32,7 +32,7 @@ import com.apple.foundationdb.record.planprotos.PEvaluation;
 import com.apple.foundationdb.record.planprotos.PValue;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
-import com.apple.foundationdb.record.query.plan.cascades.BooleanWithConstraint;
+import com.apple.foundationdb.record.query.plan.cascades.ConstrainedBoolean;
 import com.apple.foundationdb.record.query.plan.explain.ExplainTokensWithPrecedence;
 import com.google.auto.service.AutoService;
 import com.google.common.collect.ImmutableList;
@@ -114,7 +114,7 @@ public class EvaluatesToValue extends AbstractValue implements Value.RangeMatcha
 
     @Nonnull
     @Override
-    public BooleanWithConstraint equalsWithoutChildren(@Nonnull final Value other) {
+    public ConstrainedBoolean equalsWithoutChildren(@Nonnull final Value other) {
         return super.equalsWithoutChildren(other)
                 .filter(ignored -> evaluation.equals(((EvaluatesToValue)other).getEvaluation()));
     }

--- a/fdb-record-layer-core/src/main/proto/record_query_plan.proto
+++ b/fdb-record-layer-core/src/main/proto/record_query_plan.proto
@@ -253,6 +253,7 @@ message PValue {
     PMacroFunctionValue macro_function_value = 47;
     PRangeValue range_value = 48;
     PFirstOrDefaultStreamingValue first_or_default_streaming_value = 49;
+    PEvaluatesToValue evaluates_to_value = 50;
   }
 }
 
@@ -441,6 +442,18 @@ message PEmptyValue {
 message PExistsValue {
   optional PQuantifiedObjectValue child = 1; // deprecated
   optional string alias = 2;
+}
+
+enum PEvaluation {
+  IS_TRUE = 1;
+  IS_FALSE = 2;
+  IS_NULL = 3;
+  IS_NOT_NULL = 4;
+}
+
+message PEvaluatesToValue {
+  optional PValue child = 1;
+  optional PEvaluation evaluation = 2;
 }
 
 message PFieldValue {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/ConstantFoldingTestUtils.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/ConstantFoldingTestUtils.java
@@ -124,7 +124,7 @@ public class ConstantFoldingTestUtils {
     }
 
     @Nonnull
-    private static ValueWrapper newCov(@Nonnull final Type type, @Nullable Object bindingValue) {
+    public static ValueWrapper newCov(@Nonnull final Type type, @Nullable Object bindingValue) {
         final var correlationId = CorrelationIdentifier.uniqueID();
         final var constantId = String.valueOf(counter++);
         final var bindingKey = Bindings.Internal.CONSTANT.bindingName(correlationId.getId());

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/values/EvaluatesToValueTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/values/EvaluatesToValueTest.java
@@ -1,0 +1,122 @@
+/*
+ * EvaluatesToValueTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.cascades.values;
+
+import com.apple.foundationdb.record.Bindings;
+import com.apple.foundationdb.record.EvaluationContext;
+import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
+import com.google.common.base.Verify;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.util.HashMap;
+
+import static com.apple.foundationdb.record.query.plan.cascades.ConstantFoldingTestUtils.newCov;
+
+
+public class EvaluatesToValueTest {
+
+    @Nonnull
+    private static EvaluationContext replaceBinding(@Nonnull final EvaluationContext evaluationContext,
+                                                    @Nonnull final String constantId,
+                                                    @Nullable Object newValue) {
+        final var list = evaluationContext.getBindings().asMappingList();
+        Verify.verify(list.size() == 1);
+        final var bindingValueMap = new HashMap<String, Object>();
+        bindingValueMap.put(constantId, newValue);
+        return EvaluationContext.forBindings(Bindings.newBuilder().set(list.get(0).getKey(), bindingValueMap).build());
+    }
+
+    @Test
+    void evaluatesToTrueWorksCorrectly() {
+        final var valueWrapper = newCov(Type.primitiveType(Type.TypeCode.BOOLEAN), true);
+        final var cov = (ConstantObjectValue)valueWrapper.value();
+        final var evaluationContext = valueWrapper.getEvaluationContext();
+        final var valueUnderTest = EvaluatesToValue.of(cov, evaluationContext);
+        Assertions.assertNotNull(valueUnderTest.evalWithoutStore(evaluationContext));
+        Assertions.assertTrue(Verify.verifyNotNull(valueUnderTest.evalWithoutStore(evaluationContext)));
+
+        var newEvaluationContext = replaceBinding(evaluationContext, cov.getConstantId(), false);
+        Assertions.assertNotNull(valueUnderTest.evalWithoutStore(newEvaluationContext));
+        Assertions.assertFalse(Verify.verifyNotNull(valueUnderTest.evalWithoutStore(newEvaluationContext)));
+
+        newEvaluationContext = replaceBinding(evaluationContext, cov.getConstantId(), null);
+        Assertions.assertNotNull(valueUnderTest.evalWithoutStore(newEvaluationContext));
+        Assertions.assertFalse(Verify.verifyNotNull(valueUnderTest.evalWithoutStore(newEvaluationContext)));
+    }
+
+    @Test
+    void evaluatesToFalseWorksCorrectly() {
+        final var valueWrapper = newCov(Type.primitiveType(Type.TypeCode.BOOLEAN), false);
+        final var cov = (ConstantObjectValue)valueWrapper.value();
+        final var evaluationContext = valueWrapper.getEvaluationContext();
+        final var valueUnderTest = EvaluatesToValue.of(cov, evaluationContext);
+        Assertions.assertNotNull(valueUnderTest.evalWithoutStore(evaluationContext));
+        Assertions.assertTrue(Verify.verifyNotNull(valueUnderTest.evalWithoutStore(evaluationContext)));
+
+        var newEvaluationContext = replaceBinding(evaluationContext, cov.getConstantId(), true);
+        Assertions.assertNotNull(valueUnderTest.evalWithoutStore(newEvaluationContext));
+        Assertions.assertFalse(Verify.verifyNotNull(valueUnderTest.evalWithoutStore(newEvaluationContext)));
+
+        newEvaluationContext = replaceBinding(evaluationContext, cov.getConstantId(), null);
+        Assertions.assertNotNull(valueUnderTest.evalWithoutStore(newEvaluationContext));
+        Assertions.assertFalse(Verify.verifyNotNull(valueUnderTest.evalWithoutStore(newEvaluationContext)));
+    }
+
+    @Test
+    void evaluatesToNullWorksCorrectly() {
+        final var valueWrapper = newCov(Type.primitiveType(Type.TypeCode.BOOLEAN), null);
+        final var cov = (ConstantObjectValue)valueWrapper.value();
+        final var evaluationContext = valueWrapper.getEvaluationContext();
+        final var valueUnderTest = EvaluatesToValue.of(cov, evaluationContext);
+        Assertions.assertNotNull(valueUnderTest.evalWithoutStore(evaluationContext));
+        Assertions.assertTrue(Verify.verifyNotNull(valueUnderTest.evalWithoutStore(evaluationContext)));
+
+        var newEvaluationContext = replaceBinding(evaluationContext, cov.getConstantId(), true);
+        Assertions.assertNotNull(valueUnderTest.evalWithoutStore(newEvaluationContext));
+        Assertions.assertFalse(Verify.verifyNotNull(valueUnderTest.evalWithoutStore(newEvaluationContext)));
+
+        newEvaluationContext = replaceBinding(evaluationContext, cov.getConstantId(), false);
+        Assertions.assertNotNull(valueUnderTest.evalWithoutStore(newEvaluationContext));
+        Assertions.assertFalse(Verify.verifyNotNull(valueUnderTest.evalWithoutStore(newEvaluationContext)));
+    }
+
+    @Test
+    void evaluatesToNotNullWorksCorrectly() {
+        final var valueWrapper = newCov(Type.primitiveType(Type.TypeCode.INT), 42);
+        final var cov = (ConstantObjectValue)valueWrapper.value();
+        final var evaluationContext = valueWrapper.getEvaluationContext();
+        final var valueUnderTest = EvaluatesToValue.of(cov, evaluationContext);
+        Assertions.assertNotNull(valueUnderTest.evalWithoutStore(evaluationContext));
+        Assertions.assertTrue(Verify.verifyNotNull(valueUnderTest.evalWithoutStore(evaluationContext)));
+
+        var newEvaluationContext = replaceBinding(evaluationContext, cov.getConstantId(), 43);
+        Assertions.assertNotNull(valueUnderTest.evalWithoutStore(newEvaluationContext));
+        Assertions.assertTrue(Verify.verifyNotNull(valueUnderTest.evalWithoutStore(newEvaluationContext)));
+
+        newEvaluationContext = replaceBinding(evaluationContext, cov.getConstantId(), null);
+        Assertions.assertNotNull(valueUnderTest.evalWithoutStore(newEvaluationContext));
+        Assertions.assertFalse(Verify.verifyNotNull(valueUnderTest.evalWithoutStore(newEvaluationContext)));
+    }
+}

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/QueryPlan.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/QueryPlan.java
@@ -601,7 +601,7 @@ public abstract class QueryPlan extends Plan<RelationalResultSet> implements Typ
         @Nonnull
         @Override
         public QueryPlanConstraint getConstraint() {
-            return context.getPlanConstraintsForLiterals();
+            return context.getPlanConstraintsForLiteralReferences();
         }
 
         @Nonnull

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/cache/ConstraintValidityTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/cache/ConstraintValidityTests.java
@@ -31,6 +31,7 @@ import com.apple.foundationdb.record.query.plan.cascades.predicates.QueryPredica
 import com.apple.foundationdb.record.query.plan.cascades.predicates.ValuePredicate;
 import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
 import com.apple.foundationdb.record.query.plan.cascades.values.ConstantObjectValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.EvaluatesToValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.OfTypeValue;
 import com.apple.foundationdb.relational.api.Options;
 import com.apple.foundationdb.relational.recordlayer.AbstractDatabase;
@@ -175,6 +176,19 @@ public class ConstraintValidityTests {
                 new Comparisons.SimpleComparison(Comparisons.Type.EQUALS, true));
     }
 
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    @Nonnull
+    private static QueryPredicate isNotNull(final int tokenIndex, final Optional<String> scope, Type type) {
+        return new ValuePredicate(EvaluatesToValue.isNotNull(
+                ConstantObjectValue.of(Quantifier.constant(), constantId(tokenIndex, scope), type)),
+                new Comparisons.SimpleComparison(Comparisons.Type.EQUALS, true));
+    }
+
+    @Nonnull
+    private static QueryPredicate isNotNullInt(final int tokenIndex) {
+        return isNotNull(tokenIndex, Optional.empty(), Type.primitiveType(Type.TypeCode.INT));
+    }
+
     @Nonnull
     private static QueryPredicate and(@Nonnull final QueryPredicate... predicates) {
         return AndPredicate.and(Arrays.asList(predicates));
@@ -234,17 +248,19 @@ public class ConstraintValidityTests {
         final var c15Equals10 = equalsConstraint(15, 10);
         final var c15Int = ofTypeInt(15);
         final var c8Int = ofTypeInt(8);
+        final var c15IntNotNull = isNotNullInt(15);
+        final var c8IntNotNull = isNotNullInt(8);
         final var c8Equalsc15 = covsEqualsConstraints(8, 15);
         planQuery(cache, "SELECT MAX(score), game + 10 FROM score GROUP BY game + 10", MaxScoreByGame10);
         cacheShouldBe(cache, Map.of("SELECT MAX ( \"SCORE\" ) , \"GAME\" + ? FROM \"SCORE\" GROUP BY \"GAME\" + ? ",
-                Map.of(ppe(cons(and(and(c15Equals10, c15Equals10), and(c15Int, c8Int, c8Equalsc15)))), MaxScoreByGame10)));
+                Map.of(ppe(cons(and(and(c15Equals10, c15Equals10), and(c15Int, c8Int, c8Equalsc15, c15IntNotNull, c8IntNotNull)))), MaxScoreByGame10)));
 
         final var c15Equals20 = equalsConstraint(15, 20);
         planQuery(cache, "SELECT MAX(score), game + 20 FROM score GROUP BY game + 20", MaxScoreByGame20);
         cacheShouldBe(cache, Map.of("SELECT MAX ( \"SCORE\" ) , \"GAME\" + ? FROM \"SCORE\" GROUP BY \"GAME\" + ? ",
                 Map.of(
-                        ppe(cons(and(and(c15Equals10, c15Equals10), and(c15Int, c8Int, c8Equalsc15)))), MaxScoreByGame10,
-                        ppe(cons(and(and(c15Equals20, c15Equals20), and(c15Int, c8Int, c8Equalsc15)))), MaxScoreByGame20)));
+                        ppe(cons(and(and(c15Equals10, c15Equals10), and(c15Int, c8Int, c8Equalsc15, c15IntNotNull, c8IntNotNull)))), MaxScoreByGame10,
+                        ppe(cons(and(and(c15Equals20, c15Equals20), and(c15Int, c8Int, c8Equalsc15, c15IntNotNull, c8IntNotNull)))), MaxScoreByGame20)));
     }
 
     @Test
@@ -254,17 +270,19 @@ public class ConstraintValidityTests {
         final var c15Equals2 = equalsConstraint(15, 2);
         final var c15Int = ofTypeInt(15);
         final var c8Int = ofTypeInt(8);
+        final var c15IntNotNull = isNotNullInt(15);
+        final var c8IntNotNull = isNotNullInt(8);
         final var c8Equalsc15 = covsEqualsConstraints(8, 15);
         planQuery(cache, "SELECT MAX(score), game & 2 FROM score GROUP BY game & 2", BitAndScore2);
         cacheShouldBe(cache, Map.of("SELECT MAX ( \"SCORE\" ) , \"GAME\" & ? FROM \"SCORE\" GROUP BY \"GAME\" & ? ",
-                Map.of(ppe(cons(and(and(c15Equals2, c15Equals2), and(c15Int, c8Int, c8Equalsc15)))), BitAndScore2)));
+                Map.of(ppe(cons(and(and(c15Equals2, c15Equals2), and(c15Int, c8Int, c8Equalsc15, c15IntNotNull, c8IntNotNull)))), BitAndScore2)));
 
         final var c15Equals4 = equalsConstraint(15, 4);
         planQuery(cache, "SELECT MAX(score), game & 4 FROM score GROUP BY game & 4", BitAndScore4);
         cacheShouldBe(cache, Map.of("SELECT MAX ( \"SCORE\" ) , \"GAME\" & ? FROM \"SCORE\" GROUP BY \"GAME\" & ? ",
                 Map.of(
-                        ppe(cons(and(and(c15Equals2, c15Equals2), and(c15Int, c8Int, c8Equalsc15)))), BitAndScore2,
-                        ppe(cons(and(and(c15Equals4, c15Equals4), and(c15Int, c8Int, c8Equalsc15)))), BitAndScore4)));
+                        ppe(cons(and(and(c15Equals2, c15Equals2), and(c15Int, c8Int, c8Equalsc15, c15IntNotNull, c8IntNotNull)))), BitAndScore2,
+                        ppe(cons(and(and(c15Equals4, c15Equals4), and(c15Int, c8Int, c8Equalsc15, c15IntNotNull, c8IntNotNull)))), BitAndScore4)));
     }
 
     @Test
@@ -275,17 +293,20 @@ public class ConstraintValidityTests {
         final var c17Int = ofTypeInt(17);
         final var c10Int = ofTypeInt(10);
         final var c8Int = ofTypeInt(8);
+        final var c17IntNotNull = isNotNullInt(17);
+        final var c8IntNotNull = isNotNullInt(8);
+        final var c10IntNotNull = isNotNullInt(10);
         final var c8Equalsc17 = covsEqualsConstraints(8, 17);
         planQuery(cache, "SELECT MAX(score), game + 10 + 42 FROM score GROUP BY game + 10", MaxScoreByGame10);
         cacheShouldBe(cache, Map.of("SELECT MAX ( \"SCORE\" ) , \"GAME\" + ? + ? FROM \"SCORE\" GROUP BY \"GAME\" + ? ",
-                Map.of(ppe(cons(and(and(c17Equals10, c17Equals10), and(c17Int, c8Int, c10Int, c8Equalsc17)))), MaxScoreByGame10)));
+                Map.of(ppe(cons(and(and(c17Equals10, c17Equals10), and(c17Int, c8Int, c10Int, c8Equalsc17, c17IntNotNull, c8IntNotNull, c10IntNotNull)))), MaxScoreByGame10)));
 
         final var c17Equals20 = equalsConstraint(17, 20);
         planQuery(cache, "SELECT MAX(score), game + 20 + 42 FROM score GROUP BY game + 20", MaxScoreByGame20);
         cacheShouldBe(cache, Map.of("SELECT MAX ( \"SCORE\" ) , \"GAME\" + ? + ? FROM \"SCORE\" GROUP BY \"GAME\" + ? ",
                 Map.of(
-                        ppe(cons(and(and(c17Equals10, c17Equals10), and(c17Int, c8Int, c10Int, c8Equalsc17)))), MaxScoreByGame10,
-                        ppe(cons(and(and(c17Equals20, c17Equals20), and(c17Int, c8Int, c10Int, c8Equalsc17)))), MaxScoreByGame20)));
+                        ppe(cons(and(and(c17Equals10, c17Equals10), and(c17Int, c8Int, c10Int, c8Equalsc17, c17IntNotNull, c8IntNotNull, c10IntNotNull)))), MaxScoreByGame10,
+                        ppe(cons(and(and(c17Equals20, c17Equals20), and(c17Int, c8Int, c10Int, c8Equalsc17, c17IntNotNull, c8IntNotNull, c10IntNotNull)))), MaxScoreByGame20)));
     }
 
     @Test
@@ -296,16 +317,19 @@ public class ConstraintValidityTests {
         final var c17Int = ofTypeInt(17);
         final var c10Int = ofTypeInt(10);
         final var c8Int = ofTypeInt(8);
+        final var c17IntNotNull = isNotNullInt(17);
+        final var c8IntNotNull = isNotNullInt(8);
+        final var c10IntNotNull = isNotNullInt(10);
         final var c8Equalsc15 = covsEqualsConstraints(8, 17);
         planQuery(cache, "SELECT MAX(score), game & 2 + 10 FROM score GROUP BY game & 2", BitAndScore2);
         cacheShouldBe(cache, Map.of("SELECT MAX ( \"SCORE\" ) , \"GAME\" & ? + ? FROM \"SCORE\" GROUP BY \"GAME\" & ? ",
-                Map.of(ppe(cons(and(and(c17Equals2, c17Equals2), and(c17Int, c8Int, c10Int, c8Equalsc15)))), BitAndScore2)));
+                Map.of(ppe(cons(and(and(c17Equals2, c17Equals2), and(c17Int, c8Int, c10Int, c8Equalsc15, c17IntNotNull, c8IntNotNull, c10IntNotNull)))), BitAndScore2)));
 
         final var c17Equals4 = equalsConstraint(17, 4);
         planQuery(cache, "SELECT MAX(score), game & 4 + 10 FROM score GROUP BY game & 4", BitAndScore4);
         cacheShouldBe(cache, Map.of("SELECT MAX ( \"SCORE\" ) , \"GAME\" & ? + ? FROM \"SCORE\" GROUP BY \"GAME\" & ? ",
                 Map.of(
-                        ppe(cons(and(and(c17Equals2, c17Equals2), and(c17Int, c8Int, c10Int, c8Equalsc15)))), BitAndScore2,
-                        ppe(cons(and(and(c17Equals4, c17Equals4), and(c17Int, c8Int, c10Int, c8Equalsc15)))), BitAndScore4)));
+                        ppe(cons(and(and(c17Equals2, c17Equals2), and(c17Int, c8Int, c10Int, c8Equalsc15, c17IntNotNull, c8IntNotNull, c10IntNotNull)))), BitAndScore2,
+                        ppe(cons(and(and(c17Equals4, c17Equals4), and(c17Int, c8Int, c10Int, c8Equalsc15, c17IntNotNull, c8IntNotNull, c10IntNotNull)))), BitAndScore4)));
     }
 }

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/cache/ValueSpecificConstraintTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/cache/ValueSpecificConstraintTests.java
@@ -1,0 +1,264 @@
+/*
+ * ValueSpecificConstraintTests.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.relational.recordlayer.query.cache;
+
+import com.apple.foundationdb.relational.api.RelationalConnection;
+import com.apple.foundationdb.relational.recordlayer.EmbeddedRelationalExtension;
+import com.apple.foundationdb.relational.recordlayer.LogAppenderRule;
+import com.apple.foundationdb.relational.recordlayer.Utils;
+import com.apple.foundationdb.relational.recordlayer.query.PlanGenerator;
+import com.apple.foundationdb.relational.utils.Ddl;
+import com.google.common.collect.ImmutableMap;
+import org.apache.logging.log4j.Level;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import javax.annotation.Nonnull;
+import java.net.URI;
+import java.util.Map;
+import java.util.TreeMap;
+
+public class ValueSpecificConstraintTests {
+
+    @RegisterExtension
+    @Order(0)
+    public final EmbeddedRelationalExtension relationalExtension = new EmbeddedRelationalExtension();
+
+    @RegisterExtension
+    @Order(1)
+    public final LogAppenderRule logAppender = new LogAppenderRule("TemporaryFunctionTests", PlanGenerator.class, Level.INFO);
+
+    public ValueSpecificConstraintTests() {
+        Utils.enableCascadesDebugger();
+    }
+
+    private void queryShouldMissCache(@Nonnull final RelationalConnection connection, @Nonnull final String query) throws Exception {
+        final var queryWithCacheLoggingOption = query + " options (log query)";
+        connection.createStatement().executeQuery(queryWithCacheLoggingOption);
+        Assertions.assertTrue(logAppender.lastMessageIsCacheMiss());
+    }
+
+    private void queryShouldHitCache(@Nonnull final RelationalConnection connection, @Nonnull final String query) throws Exception {
+        final var queryWithCacheLoggingOption = query + " options (log query)";
+        connection.createStatement().executeQuery(queryWithCacheLoggingOption);
+        Assertions.assertTrue(logAppender.lastMessageIsCacheHit());
+    }
+
+    private void preparedQueryShouldMissCache(@Nonnull final RelationalConnection connection, @Nonnull final String query,
+                                              @Nonnull final Map<Integer, Object> preparedParams) throws Exception {
+        final var queryWithCacheLoggingOption = query + " options (log query)";
+        final var statement = connection.prepareStatement(queryWithCacheLoggingOption);
+        for (final var entry : preparedParams.entrySet()) {
+            statement.setObject(entry.getKey(), entry.getValue());
+        }
+        statement.execute();
+        Assertions.assertTrue(logAppender.lastMessageIsCacheMiss());
+    }
+
+    private void preparedQueryShouldHitCache(@Nonnull final RelationalConnection connection, @Nonnull final String query,
+                                             @Nonnull final Map<Integer, Object> preparedParams) throws Exception {
+        final var queryWithCacheLoggingOption = query + " options (log query)";
+        final var statement = connection.prepareStatement(queryWithCacheLoggingOption);
+        for (final var entry : preparedParams.entrySet()) {
+            statement.setObject(entry.getKey(), entry.getValue());
+        }
+        statement.execute();
+        Assertions.assertTrue(logAppender.lastMessageIsCacheHit());
+    }
+
+    @Test
+    void constrainingLiteralTrueBooleanWorks() throws Exception {
+        final String schemaTemplate = "create table t(pk bigint, a bigint, b boolean, primary key(pk))";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/QT")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            final var connection = ddl.setSchemaAndGetConnection();
+            queryShouldMissCache(ddl.getConnection(), "select a + 42 from t where b = true");
+            queryShouldHitCache(ddl.getConnection(), "select a + 42 from t where b = true");
+
+            // 'true' is included in the constraints, therefore, we must not pick the query from the cache when using 'false'
+            queryShouldMissCache(ddl.getConnection(), "select a + 42 from t where b = false");
+            queryShouldHitCache(ddl.getConnection(), "select a + 42 from t where b = false");
+
+            // 'true' and 'false' are included in the constraints, therefore, we must not pick the query from the cache when using 'null'
+            queryShouldMissCache(ddl.getConnection(), "select a + 42 from t where b = null");
+            queryShouldHitCache(ddl.getConnection(), "select a + 42 from t where b = null");
+        }
+    }
+
+    @Test
+    void constrainingPreparedTrueBooleanWorks() throws Exception {
+        final String schemaTemplate = "create table t(pk bigint, a bigint, b boolean, primary key(pk))";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/QT")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            final var connection = ddl.setSchemaAndGetConnection();
+            preparedQueryShouldMissCache(connection, "select a + 42 from t where b = ?", ImmutableMap.of(1, true));
+            preparedQueryShouldHitCache(connection, "select a + 42 from t where b = ?", ImmutableMap.of(1, true));
+
+            // 'true' is included in the constraints, therefore, we must not pick the query from the cache when using 'false'
+            preparedQueryShouldMissCache(connection, "select a + 42 from t where b = ?", ImmutableMap.of(1, false));
+            preparedQueryShouldHitCache(connection, "select a + 42 from t where b = ?", ImmutableMap.of(1, false));
+
+            // 'true' and 'false' are included in the constraints, therefore, we must not pick the query from the cache when using 'null'
+            final Map<Integer, Object> map = new TreeMap<>();
+            map.put(1, null);
+            preparedQueryShouldMissCache(connection, "select a + 42 from t where b = ?", map);
+            preparedQueryShouldHitCache(connection, "select a + 42 from t where b = ?", map);
+        }
+    }
+
+    @Test
+    void constrainingLiteralFalseBooleanWorks() throws Exception {
+        final String schemaTemplate = "create table t(pk bigint, a bigint, b boolean, primary key(pk))";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/QT")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            final var connection = ddl.setSchemaAndGetConnection();
+            queryShouldMissCache(connection, "select a + 42 from t where b = false");
+            queryShouldHitCache(connection, "select a + 42 from t where b = false");
+
+            // 'false' is included in the constraints, therefore, we must not pick the query from the cache when using 'true'
+            queryShouldMissCache(connection, "select a + 42 from t where b = true");
+            queryShouldHitCache(connection, "select a + 42 from t where b = true");
+
+
+            // 'false' and 'true' are included in the constraints, therefore, we must not pick the query from the cache when using 'null'
+            queryShouldMissCache(connection, "select a + 42 from t where b = null");
+            queryShouldHitCache(connection, "select a + 42 from t where b = null");
+        }
+    }
+
+    @Test
+    void constrainingPreparedFalseBooleanWorks() throws Exception {
+        final String schemaTemplate = "create table t(pk bigint, a bigint, b boolean, primary key(pk))";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/QT")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            final var connection = ddl.setSchemaAndGetConnection();
+            preparedQueryShouldMissCache(connection, "select a + 42 from t where b = ?", ImmutableMap.of(1, false));
+            preparedQueryShouldHitCache(connection, "select a + 42 from t where b = ?", ImmutableMap.of(1, false));
+
+            // 'false' is included in the constraints, therefore, we must not pick the query from the cache when using 'true'
+            preparedQueryShouldMissCache(connection, "select a + 42 from t where b = ?", ImmutableMap.of(1, true));
+            preparedQueryShouldHitCache(connection, "select a + 42 from t where b = ?", ImmutableMap.of(1, true));
+
+            // 'false' and 'true' are included in the constraints, therefore, we must not pick the query from the cache when using 'null'
+            final Map<Integer, Object> map = new TreeMap<>();
+            map.put(1, null);
+            preparedQueryShouldMissCache(connection, "select a + 42 from t where b = ?", map);
+            preparedQueryShouldHitCache(connection, "select a + 42 from t where b = ?", map);
+        }
+    }
+
+    @Test
+    void constrainingLiteralNullBooleanWorks() throws Exception {
+        final String schemaTemplate = "create table t(pk bigint, a bigint, b boolean, primary key(pk))";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/QT")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            final var connection = ddl.setSchemaAndGetConnection();
+            queryShouldMissCache(connection, "select a + 42 from t where b = null");
+            queryShouldHitCache(connection, "select a + 42 from t where b = null");
+
+            // 'null' is included in the constraints, therefore, we must not pick the query from the cache when using 'false'
+            queryShouldMissCache(connection, "select a + 42 from t where b = false");
+            queryShouldHitCache(connection, "select a + 42 from t where b = false");
+
+            // 'null' and 'false' are included in the constraints, therefore, we must not pick the query from the cache when using 'true'
+            queryShouldMissCache(connection, "select a + 42 from t where b = true");
+            queryShouldHitCache(connection, "select a + 42 from t where b = true");
+        }
+    }
+
+    @Test
+    void constrainingPreparedNullBooleanWorks() throws Exception {
+        final String schemaTemplate = "create table t(pk bigint, a bigint, b boolean, primary key(pk))";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/QT")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            final var connection = ddl.setSchemaAndGetConnection();
+            final Map<Integer, Object> map = new TreeMap<>();
+            map.put(1, null);
+            preparedQueryShouldMissCache(connection, "select a + 42 from t where b = ?", map);
+            preparedQueryShouldHitCache(connection, "select a + 42 from t where b = ?", map);
+
+            // 'null' is included in the constraints, therefore, we must not pick the query from the cache when using 'false'
+            preparedQueryShouldMissCache(connection, "select a + 42 from t where b = ?", ImmutableMap.of(1, false));
+            preparedQueryShouldHitCache(connection, "select a + 42 from t where b = ?", ImmutableMap.of(1, false));
+
+            // 'null' and 'false' are included in the constraints, therefore, we must not pick the query from the cache when using 'true'
+            preparedQueryShouldMissCache(connection, "select a + 42 from t where b = ?", ImmutableMap.of(1, true));
+            preparedQueryShouldHitCache(connection, "select a + 42 from t where b = ?", ImmutableMap.of(1, true));
+        }
+    }
+
+    @Test
+    void constrainingNonNullLiteralWorks() throws Exception {
+        final String schemaTemplate = "create table t(pk bigint, a bigint, b boolean, primary key(pk))";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/QT")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            final var connection = ddl.setSchemaAndGetConnection();
+            queryShouldMissCache(connection, "select a + 43 from t where a = 42");
+            queryShouldHitCache(connection, "select a + 43 from t where a = 45"); // different literals are ok here (no index filters)
+
+            // not-null is included in the constraints, therefore, we must not pick the query from the cache when using 'null'
+            queryShouldMissCache(connection, "select a + 43 from t where a = null");
+            queryShouldHitCache(connection, "select a + 43 from t where a = null");
+        }
+    }
+
+    @Test
+    void constrainingPreparedNotNullWorks() throws Exception {
+        final String schemaTemplate = "create table t(pk bigint, a bigint, b boolean, primary key(pk))";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/QT")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            final var connection = ddl.setSchemaAndGetConnection();
+            preparedQueryShouldMissCache(connection, "select a + 43 from t where a = ?", ImmutableMap.of(1, 42));
+            preparedQueryShouldHitCache(connection, "select a + 43 from t where a = ?", ImmutableMap.of(1, 45)); // different literals are ok here (no index filters)
+
+            // 'not-null' is included in the constraints, therefore, we must not pick the query from the cache when using 'null'
+            final Map<Integer, Object> map = new TreeMap<>();
+            map.put(1, null);
+            preparedQueryShouldMissCache(connection, "select a + 43 from t where a = ?", map);
+            preparedQueryShouldHitCache(connection, "select a + 43 from t where a = ?", map);
+        }
+    }
+
+    @Test
+    void constrainingNullLiteralWorks() throws Exception {
+        final String schemaTemplate = "create table t(pk bigint, a bigint, b boolean, primary key(pk))";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/QT")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            final var connection = ddl.setSchemaAndGetConnection();
+
+            queryShouldMissCache(connection, "select a + 43 from t where a = null");
+            queryShouldHitCache(connection, "select a + 43 from t where a = null");
+
+            // 'null' is included in the constraints, therefore, we must not pick the query from the cache when using 'not-null'
+            queryShouldMissCache(connection, "select a + 43 from t where a = 42");
+            queryShouldHitCache(connection, "select a + 43 from t where a = 45"); // different literals are ok here (no index filters)
+        }
+    }
+
+    @Test
+    void constrainingPreparedNullWorks() throws Exception {
+        final String schemaTemplate = "create table t(pk bigint, a bigint, b boolean, primary key(pk))";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/QT")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            final var connection = ddl.setSchemaAndGetConnection();
+            final Map<Integer, Object> map = new TreeMap<>();
+            map.put(1, null);
+            preparedQueryShouldMissCache(connection, "select a + 43 from t where a = ?", map);
+            preparedQueryShouldHitCache(connection, "select a + 43 from t where a = ?", map);
+
+            // 'null' is included in the constraints, therefore, we must not pick the query from the cache when using 'not-null'
+            preparedQueryShouldMissCache(connection, "select a + 43 from t where a = ?", ImmutableMap.of(1, 42));
+            preparedQueryShouldHitCache(connection, "select a + 43 from t where a = ?", ImmutableMap.of(1, 45)); // different literals are ok here (no index filters)
+        }
+    }
+}


### PR DESCRIPTION
This introduces new set of value-specific constraints to be added to the plan cache keys, the constraints are created for the following:

* Explicit boolean values (true, false).
* Explicit null values.
* Whether a literal is not null.

Implementing these constraints is crucial to prevent the use of physical plans generated based on assumptions about literal values that may not hold true during subsequent query executions. This can occur when the actual literal values differ from those initially assumed.

Therefore, the plan generator should analyze the literals and generate necessary constraints about their values according to the above rules to be used in the plan cache key.

This resolves #3412 