### PR TITLE
Allow MaintainYamlTestConfig with quickTest

### DIFF
--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlTestExtension.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlTestExtension.java
@@ -87,9 +87,14 @@ public class YamlTestExtension implements TestTemplateInvocationContextProvider,
 
     @Override
     public void beforeAll(final ExtensionContext context) throws Exception {
+        maintainConfigs = List.of(
+                new CorrectExplains(new EmbeddedConfig(clusterFile)),
+                new CorrectMetrics(new EmbeddedConfig(clusterFile)),
+                new CorrectExplainsAndMetrics(new EmbeddedConfig(clusterFile)),
+                new ShowPlanOnDiff(new EmbeddedConfig(clusterFile))
+        );
         if (Boolean.parseBoolean(System.getProperty("tests.runQuick", "false"))) {
             testConfigs = List.of(new EmbeddedConfig(clusterFile));
-            maintainConfigs = List.of();
         } else {
             AtomicInteger serverPort = new AtomicInteger(1111);
             List<File> jars = ExternalServer.getAvailableServers();
@@ -115,12 +120,6 @@ public class YamlTestExtension implements TestTemplateInvocationContextProvider,
                     // The configs for multi-server testing
                     externalServerConfigs).collect(Collectors.toList());
 
-            maintainConfigs = List.of(
-                    new CorrectExplains(new EmbeddedConfig(clusterFile)),
-                    new CorrectMetrics(new EmbeddedConfig(clusterFile)),
-                    new CorrectExplainsAndMetrics(new EmbeddedConfig(clusterFile)),
-                    new ShowPlanOnDiff(new EmbeddedConfig(clusterFile))
-            );
         }
         for (final YamlTestConfig testConfig : Iterables.concat(testConfigs, maintainConfigs)) {
             testConfig.beforeAll();


### PR DESCRIPTION
If you have a MaintainYamlTestConfig set, that should work correctly when running with quickTest, i.e. it should run the maintenance.

Previously it would fail because it would have an empty stream, and this should result in a better developer experience.