### PR TITLE
Add new `Option`s to disable planner rules through the Relational API

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlannerConfiguration.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlannerConfiguration.java
@@ -27,12 +27,14 @@ import com.apple.foundationdb.record.query.RecordQuery;
 import com.apple.foundationdb.record.query.plan.cascades.CascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.PlannerRule;
 import com.apple.foundationdb.record.query.plan.cascades.PlanningRuleSet;
+import com.apple.foundationdb.record.query.plan.cascades.RewritingRuleSet;
 import com.apple.foundationdb.record.query.plan.cascades.rules.PredicateToLogicalUnionRule;
 import com.apple.foundationdb.record.query.plan.plans.QueryPlan;
 import com.apple.foundationdb.record.query.plan.serialization.PlanSerialization;
 import com.apple.foundationdb.record.query.plan.sorting.RecordQueryPlannerSortConfiguration;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -434,6 +436,7 @@ public class RecordQueryPlannerConfiguration {
             this.protoBuilder = RecordPlannerConfigurationProto.PlannerConfiguration.newBuilder();
         }
 
+        @CanIgnoreReturnValue
         @Nonnull
         public Builder setIndexScanPreference(@Nonnull QueryPlanner.IndexScanPreference indexScanPreference) {
             protoBuilder.setIndexScanPreference(SCAN_PREFERENCE_BI_MAP.get(indexScanPreference));
@@ -444,54 +447,63 @@ public class RecordQueryPlannerConfiguration {
             flags = value ? (flags | mask) : (flags & ~mask);
         }
 
+        @CanIgnoreReturnValue
         @Nonnull
         public Builder setAttemptFailedInJoinAsOr(boolean attemptFailedInJoinAsOr) {
             updateFlags(attemptFailedInJoinAsOr, ATTEMPT_FAILED_IN_JOIN_AS_OR_MASK);
             return this;
         }
 
+        @CanIgnoreReturnValue
         @Nonnull
         public Builder setAttemptFailedInJoinAsUnionMaxSize(int attemptFailedInJoinAsUnionMaxSize) {
             protoBuilder.setAttemptFailedInJoinAsUnionMaxSize(attemptFailedInJoinAsUnionMaxSize);
             return this;
         }
 
+        @CanIgnoreReturnValue
         @Nonnull
         public Builder setComplexityThreshold(final int complexityThreshold) {
             protoBuilder.setComplexityThreshold(complexityThreshold);
             return this;
         }
 
+        @CanIgnoreReturnValue
         @Nonnull
         public Builder setCheckForDuplicateConditions(final boolean checkForDuplicateConditions) {
             updateFlags(checkForDuplicateConditions, CHECK_FOR_DUPLICATE_CONDITIONS_MASK);
             return this;
         }
 
+        @CanIgnoreReturnValue
         @Nonnull
         public Builder setDeferFetchAfterUnionAndIntersection(boolean deferFetchAfterUnionAndIntersection) {
             updateFlags(deferFetchAfterUnionAndIntersection, DEFER_FETCH_AFTER_UNION_AND_INTERSECTION_MASK);
             return this;
         }
 
+        @CanIgnoreReturnValue
         @Nonnull
         public Builder setDeferFetchAfterInJoinAndInUnion(boolean deferFetchAfterInJoinAndInUnion) {
             updateFlags(deferFetchAfterInJoinAndInUnion, DEFER_FETCH_AFTER_IN_JOIN_AND_IN_UNION_MASK);
             return this;
         }
 
+        @CanIgnoreReturnValue
         @Nonnull
         public Builder setOmitPrimaryKeyInUnionOrderingKey(boolean omitPrimaryKeyInUnionOrderingKey) {
             updateFlags(omitPrimaryKeyInUnionOrderingKey, OMIT_PRIMARY_KEY_IN_UNION_ORDERING_KEY_MASK);
             return this;
         }
 
+        @CanIgnoreReturnValue
         @Nonnull
         public Builder setOmitPrimaryKeyInOrderingKeyForInUnion(boolean omitPrimaryKeyInOrderingKeyForInUnion) {
             updateFlags(omitPrimaryKeyInOrderingKeyForInUnion, OMIT_PRIMARY_KEY_IN_ORDERING_KEY_FOR_IN_UNION_MASK);
             return this;
         }
 
+        @CanIgnoreReturnValue
         @Nonnull
         public Builder setOptimizeForIndexFilters(final boolean optimizeForIndexFilters) {
             updateFlags(optimizeForIndexFilters, OPTIMIZE_FOR_INDEX_FILTERS_MASK);
@@ -505,6 +517,7 @@ public class RecordQueryPlannerConfiguration {
          * @param optimizeForRequiredResults set the optimizeForRequiredResults parameter
          * @return this builder
          */
+        @CanIgnoreReturnValue
         @Nonnull
         public Builder setOptimizeForRequiredResults(final boolean optimizeForRequiredResults) {
             updateFlags(optimizeForRequiredResults, OPTIMIZE_FOR_REQUIRED_RESULTS_MASK);
@@ -518,6 +531,7 @@ public class RecordQueryPlannerConfiguration {
          * @param maxTaskQueueSize the maximum size of the queue.
          * @return this builder
          */
+        @CanIgnoreReturnValue
         @Nonnull
         public Builder setMaxTaskQueueSize(final int maxTaskQueueSize) {
             protoBuilder.setMaxTaskQueueSize(maxTaskQueueSize);
@@ -531,6 +545,7 @@ public class RecordQueryPlannerConfiguration {
          * @param maxTotalTaskCount the maximum number of tasks.
          * @return this builder
          */
+        @CanIgnoreReturnValue
         @Nonnull
         public Builder setMaxTotalTaskCount(final int maxTotalTaskCount) {
             protoBuilder.setMaxTotalTaskCount(maxTotalTaskCount);
@@ -542,6 +557,7 @@ public class RecordQueryPlannerConfiguration {
          * @param useFullKeyForValueIndex whether to include primary key in planning
          * @return this builder
          */
+        @CanIgnoreReturnValue
         @Nonnull
         public Builder setUseFullKeyForValueIndex(final boolean useFullKeyForValueIndex) {
             updateFlags(!useFullKeyForValueIndex, DONT_USE_FULL_KEY_FOR_VALUE_INDEX_MASK);
@@ -554,6 +570,7 @@ public class RecordQueryPlannerConfiguration {
          * @param maxNumMatchesPerRuleCall the desired maximum number of matches that are permitted per rule call
          * @return {@code this}
          */
+        @CanIgnoreReturnValue
         @Nonnull
         public Builder setMaxNumMatchesPerRuleCall(final int maxNumMatchesPerRuleCall) {
             protoBuilder.setMaxNumMatchesPerRuleCall(maxNumMatchesPerRuleCall);
@@ -565,6 +582,7 @@ public class RecordQueryPlannerConfiguration {
          * @param sortConfiguration configuration to use for planning non-index sorting, or {@code null} to never allow it
          * @return this builder
          */
+        @CanIgnoreReturnValue
         @Nonnull
         public Builder setSortConfiguration(@Nullable final RecordQueryPlannerSortConfiguration sortConfiguration) {
             if (sortConfiguration == null) {
@@ -581,6 +599,7 @@ public class RecordQueryPlannerConfiguration {
          * @param allowNonIndexSort whether to allow non-index sorting
          * @return this builder
          */
+        @CanIgnoreReturnValue
         @Nonnull
         public Builder setAllowNonIndexSort(final boolean allowNonIndexSort) {
             setSortConfiguration(allowNonIndexSort ? RecordQueryPlannerSortConfiguration.getDefaultInstance() : null);
@@ -592,6 +611,7 @@ public class RecordQueryPlannerConfiguration {
          * @param disabledTransformationRules a set of disabled rules.
          * @return this builder
          */
+        @CanIgnoreReturnValue
         @Nonnull
         public Builder setDisabledTransformationRules(@Nonnull final Set<Class<? extends CascadesRule<?>>> disabledTransformationRules) {
             protoBuilder.clearDisabledTransformationRules();
@@ -609,6 +629,7 @@ public class RecordQueryPlannerConfiguration {
          * @param planningRuleSet a {@link PlanningRuleSet} that is used to resolve the rule name to a rule class
          * @return this builder
          */
+        @CanIgnoreReturnValue
         @Nonnull
         public Builder setDisabledTransformationRuleNames(@Nonnull final Set<String> disabledTransformationRuleNames, @Nonnull PlanningRuleSet planningRuleSet) {
             protoBuilder.clearDisabledTransformationRules()
@@ -617,10 +638,34 @@ public class RecordQueryPlannerConfiguration {
         }
 
         /**
+         * Helper method that disables all rewriting rules. These are the rules that
+         * are applied to the logical query and are designed to produce a canonical
+         * version of the original query. However, these rules can add to the planning
+         * time if the process of rewriting the query ends up over-enumerating.
+         * If a query encounters problems during this stage of planning, this can
+         * be used as a stop-gap to disable all rewrites and proceed directly to
+         * the planning stage.
+         *
+         * @return this builder
+         * @see RewritingRuleSet
+         */
+        @API(API.Status.EXPERIMENTAL)
+        @SuppressWarnings("unchecked")
+        @CanIgnoreReturnValue
+        @Nonnull
+        public Builder disableRewritingRules() {
+            for (CascadesRule<?> rule : RewritingRuleSet.OPTIONAL_RULES) {
+                disableTransformationRule((Class<? extends CascadesRule<?>>) rule.getClass());
+            }
+            return this;
+        }
+
+        /**
          * Helper method to disable the planner transformation rule class passed in.
          * @param ruleClass a rule class that should be disabled
          * @return this builder
          */
+        @CanIgnoreReturnValue
         @Nonnull
         public Builder disableTransformationRule(@Nonnull Class<? extends CascadesRule<?>> ruleClass) {
             protoBuilder.addDisabledTransformationRules(ruleClass.getSimpleName());
@@ -641,6 +686,7 @@ public class RecordQueryPlannerConfiguration {
          * @param deferCrossProducts indicator if the planner should defer cross products
          * @return this builder
          */
+        @CanIgnoreReturnValue
         @Nonnull
         public Builder setDeferCrossProducts(final boolean deferCrossProducts) {
             updateFlags(!deferCrossProducts, DONT_DEFER_CROSS_PRODUCTS_MASK);
@@ -655,6 +701,7 @@ public class RecordQueryPlannerConfiguration {
          * @return this builder
          */
         @API(API.Status.EXPERIMENTAL)
+        @CanIgnoreReturnValue
         @Nonnull
         public Builder setIndexFetchMethod(@Nonnull final IndexFetchMethod indexFetchMethod) {
             protoBuilder.setIndexFetchMethod(FETCH_METHOD_BI_MAP.get(indexFetchMethod));
@@ -662,6 +709,7 @@ public class RecordQueryPlannerConfiguration {
         }
 
         @API(API.Status.EXPERIMENTAL)
+        @CanIgnoreReturnValue
         @Nonnull
         public Builder addValueIndexOverScanNeeded(@Nonnull final String indexName) {
             protoBuilder.addValueIndexesOverScanNeeded(indexName);
@@ -674,6 +722,7 @@ public class RecordQueryPlannerConfiguration {
          * @return this builder
          */
         @API(API.Status.EXPERIMENTAL)
+        @CanIgnoreReturnValue
         @Nonnull
         public Builder setPlanOtherAttemptWholeFilter(final boolean planOtherAttemptWholeFilter) {
             updateFlags(planOtherAttemptWholeFilter, PLAN_OTHER_ATTEMPT_FULL_FILTER_MASK);
@@ -688,6 +737,7 @@ public class RecordQueryPlannerConfiguration {
          * @return this builder
          * @see #getMaxNumReplansForInToJoin()
          */
+        @CanIgnoreReturnValue
         @Nonnull
         public Builder setMaxNumReplansForInToJoin(final int maxNumReplansForInToJoin) {
             protoBuilder.setMaxNumReplansForInToJoin(maxNumReplansForInToJoin);
@@ -702,6 +752,7 @@ public class RecordQueryPlannerConfiguration {
          * @return this builder
          * @see #getMaxNumReplansForInUnion()
          */
+        @CanIgnoreReturnValue
         @Nonnull
         public Builder setMaxNumReplansForInUnion(final int maxNumReplansForInUnion) {
             protoBuilder.setMaxNumReplansForInUnion(maxNumReplansForInUnion);
@@ -714,12 +765,14 @@ public class RecordQueryPlannerConfiguration {
          * @param orToUnionMaxNumConjuncts the maximum number of conjuncts
          * @return this builder
          */
+        @CanIgnoreReturnValue
         @Nonnull
         public Builder setOrToUnionMaxNumConjuncts(final int orToUnionMaxNumConjuncts) {
             protoBuilder.setOrToUnionMaxNumConjuncts(orToUnionMaxNumConjuncts);
             return this;
         }
 
+        @CanIgnoreReturnValue
         @Nonnull
         public Builder setNormalizeNestedFields(boolean normalizeNestedFields) {
             updateFlags(normalizeNestedFields, NORMALIZE_NESTED_FIELDS_MASK);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/RewritingRuleSet.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/RewritingRuleSet.java
@@ -47,6 +47,7 @@ public class RewritingRuleSet extends CascadesRuleSet {
             new FinalizeExpressionsRule()
     );
 
+    @Nonnull
     private static final Set<CascadesRule<? extends RelationalExpression>> ALL_EXPRESSION_RULES =
             ImmutableSet.<CascadesRule<? extends RelationalExpression>>builder()
                     .addAll(PREORDER_RULES)
@@ -54,6 +55,13 @@ public class RewritingRuleSet extends CascadesRuleSet {
                     .addAll(IMPLEMENTATION_RULES)
                     .build();
 
+    @Nonnull
+    public static final Set<CascadesRule<? extends RelationalExpression>> OPTIONAL_RULES =
+            ALL_EXPRESSION_RULES.stream()
+                    .filter(rule -> !(rule instanceof FinalizeExpressionsRule))
+                    .collect(ImmutableSet.toImmutableSet());
+
+    @Nonnull
     public static final RewritingRuleSet DEFAULT = new RewritingRuleSet();
 
     @VisibleForTesting

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/options/CollectionContract.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/options/CollectionContract.java
@@ -1,0 +1,59 @@
+/*
+ * CollectionTypeContract.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.relational.api.options;
+
+import com.apple.foundationdb.relational.api.Options;
+import com.apple.foundationdb.relational.api.exceptions.ErrorCode;
+
+import javax.annotation.Nonnull;
+import java.sql.SQLException;
+import java.util.Collection;
+
+/**
+ * Option contract that ensures that all elements of a collection match some contract.
+ * The contract is only valid if the elements of the given option are (1) some kind
+ * of collection type and (2) every element in the collection satisfies the "element
+ * contract" over which the contract is defined. For example, the child contract
+ * may be that each element is of a given type or within a particular range.
+ */
+public class CollectionContract implements OptionContract {
+    @Nonnull
+    private final OptionContract elementContract;
+
+    public CollectionContract(@Nonnull OptionContract elementContract) {
+        this.elementContract = elementContract;
+    }
+
+    @Override
+    public void validate(final Options.Name name, final Object value) throws SQLException {
+        if (!(value instanceof Collection<?>)) {
+            throw new SQLException("Option " + name + " should be of a collection type instead of " + value.getClass().getName(), ErrorCode.INVALID_PARAMETER.getErrorCode());
+        }
+        try {
+            Collection<?> collectionValue = (Collection<?>)value;
+            for (Object element : collectionValue) {
+                elementContract.validate(name, element);
+            }
+        } catch (SQLException err) {
+            throw new SQLException("Element of collection option " + name + " violated contract: " + err.getMessage(), err.getSQLState(), err);
+        }
+    }
+}

--- a/fdb-relational-api/src/test/java/com/apple/foundationdb/relational/api/OptionsTest.java
+++ b/fdb-relational-api/src/test/java/com/apple/foundationdb/relational/api/OptionsTest.java
@@ -23,6 +23,7 @@ package com.apple.foundationdb.relational.api;
 import com.apple.foundationdb.relational.api.exceptions.ErrorCode;
 import com.apple.foundationdb.relational.utils.RelationalAssertions;
 
+import com.google.common.collect.ImmutableSet;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -129,6 +130,13 @@ class OptionsTest {
                 .hasErrorCode(ErrorCode.INVALID_PARAMETER)
                 .hasMessage("Option CONTINUATION should be of type interface com.apple.foundationdb.relational.api.Continuation but is class java.lang.Object");
 
+        RelationalAssertions.assertThrowsSqlException(() -> Options.builder().withOption(Options.Name.DISABLED_PLANNER_RULES, "foo"))
+                .hasErrorCode(ErrorCode.INVALID_PARAMETER)
+                .hasMessage("Option DISABLED_PLANNER_RULES should be of a collection type instead of java.lang.String");
+
+        RelationalAssertions.assertThrowsSqlException(() -> Options.builder().withOption(Options.Name.DISABLED_PLANNER_RULES, ImmutableSet.of(-1)))
+                .hasErrorCode(ErrorCode.INVALID_PARAMETER)
+                .hasMessage("Element of collection option DISABLED_PLANNER_RULES violated contract: Option DISABLED_PLANNER_RULES should be of type class java.lang.String but is class java.lang.Integer");
     }
 
     @Test


### PR DESCRIPTION
This exposes the existing methods on the `RecordQueryPlanConfiguration` to allow us to disable planner rules through the Relational API. It also adds a new helper method that allows us to turn off all of the planner rewrite rules at once, which can be useful as a stop-gap as we work to integrate them further.

This resolves #3420.