### PR TITLE
Type specifier suffix for `long` and `int` literals

### DIFF
--- a/fdb-relational-core/src/main/antlr/RelationalLexer.g4
+++ b/fdb-relational-core/src/main/antlr/RelationalLexer.g4
@@ -1272,14 +1272,14 @@ FILESIZE_LITERAL:                    DEC_DIGIT+ ('K'|'M'|'G'|'T');
 
 START_NATIONAL_STRING_LITERAL:       'N' SQUOTA_STRING;
 STRING_LITERAL:                      SQUOTA_STRING;
-DECIMAL_LITERAL:                     DEC_DIGIT+;
+DECIMAL_LITERAL:                     DEC_DIGIT+ DECIMAL_TYPE_MODIFIER?;
 HEXADECIMAL_LITERAL:                 'X' STRING_LITERAL;
 BASE64_LITERAL:                      'B64' STRING_LITERAL;
 
-REAL_LITERAL:                        (DEC_DIGIT+)? '.' DEC_DIGIT+ TYPE_MODIFIER?
-                                     | DEC_DIGIT+ '.' EXPONENT_NUM_PART TYPE_MODIFIER?
-                                     | (DEC_DIGIT+)? '.' (DEC_DIGIT+ EXPONENT_NUM_PART) TYPE_MODIFIER?
-                                     | DEC_DIGIT+ EXPONENT_NUM_PART TYPE_MODIFIER?;
+REAL_LITERAL:                        (DEC_DIGIT+)? '.' DEC_DIGIT+ REAL_TYPE_MODIFIER?
+                                     | DEC_DIGIT+ '.' EXPONENT_NUM_PART REAL_TYPE_MODIFIER?
+                                     | (DEC_DIGIT+)? '.' (DEC_DIGIT+ EXPONENT_NUM_PART) REAL_TYPE_MODIFIER?
+                                     | DEC_DIGIT+ EXPONENT_NUM_PART REAL_TYPE_MODIFIER?;
 NULL_SPEC_LITERAL:                   '\\' 'N';
 BIT_STRING:                          BIT_STRING_L;
 STRING_CHARSET_NAME:                 '_' CHARSET_NAME;
@@ -1341,7 +1341,10 @@ fragment BIT_STRING_L:               'B' '\'' [01]+ '\'';
 
 fragment FLOAT_TYPE_MODIFIER:        ('F'|'f');
 fragment DOUBLE_TYPE_MODIFIER:       ('D'|'d');
-fragment TYPE_MODIFIER:              (FLOAT_TYPE_MODIFIER | DOUBLE_TYPE_MODIFIER);
+fragment REAL_TYPE_MODIFIER:         (FLOAT_TYPE_MODIFIER | DOUBLE_TYPE_MODIFIER);
+fragment INT_TYPE_MODIFIER:          ('I' | 'i');
+fragment LONG_TYPE_MODIFIER:         ('L' | 'l');
+fragment DECIMAL_TYPE_MODIFIER:      (INT_TYPE_MODIFIER | LONG_TYPE_MODIFIER);
 
 
 

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/ParseHelpers.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/ParseHelpers.java
@@ -30,6 +30,7 @@ import com.apple.foundationdb.relational.api.exceptions.RelationalException;
 import com.apple.foundationdb.relational.generated.RelationalParser;
 import com.apple.foundationdb.relational.recordlayer.util.Hex;
 
+import com.apple.foundationdb.relational.util.Assert;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import org.antlr.v4.runtime.CommonTokenStream;
@@ -63,24 +64,36 @@ public final class ParseHelpers {
      */
     @Nonnull
     public static Object parseDecimal(@Nonnull String valueAsString) {
+        final var lastCharIdx = valueAsString.length() - 1;
+        Assert.thatUnchecked(lastCharIdx >= 0);
         if (valueAsString.contains(".")) {
-            final var lastCharacter = valueAsString.charAt(valueAsString.length() - 1);
+            final var lastCharacter = valueAsString.charAt(lastCharIdx);
             switch (lastCharacter) {
-                case 'f':
+                case 'f': // fallthrough
                 case 'F':
-                    return Float.parseFloat(valueAsString.substring(0, valueAsString.length() - 1));
-                case 'd':
+                    return Float.parseFloat(valueAsString.substring(0, lastCharIdx));
+                case 'd': // fallthrough
                 case 'D':
-                    return Double.parseDouble(valueAsString.substring(0, valueAsString.length() - 1));
+                    return Double.parseDouble(valueAsString.substring(0, lastCharIdx));
                 default:
                     return Double.parseDouble(valueAsString);
             }
         } else {
-            long result = Long.parseLong(valueAsString);
-            if (Integer.MIN_VALUE <= result && result <= Integer.MAX_VALUE) {
-                return Math.toIntExact(result);
-            } else {
-                return result;
+            final var lastCharacter = valueAsString.charAt(lastCharIdx);
+            switch (lastCharacter) {
+                case 'l': // fallthrough
+                case 'L':
+                    return Long.parseLong(valueAsString.substring(0, lastCharIdx));
+                case 'i': // fallthrough
+                case 'I':
+                    return Integer.parseInt(valueAsString.substring(0, lastCharIdx));
+                default:
+                    long result = Long.parseLong(valueAsString);
+                    if (Integer.MIN_VALUE <= result && result <= Integer.MAX_VALUE) {
+                        return Math.toIntExact(result);
+                    } else {
+                        return result;
+                    }
             }
         }
     }

--- a/yaml-tests/src/test/java/YamlIntegrationTests.java
+++ b/yaml-tests/src/test/java/YamlIntegrationTests.java
@@ -273,4 +273,10 @@ public class YamlIntegrationTests {
     public void sqlFunctionsTest(YamlTest.Runner runner) throws Exception {
         runner.runYamsql("sql-functions.yamsql");
     }
+
+    @TestTemplate
+    @MaintainYamlTestConfig(YamlTestConfigFilters.CORRECT_EXPLAIN_AND_METRICS)
+    public void literalTests(YamlTest.Runner runner) throws Exception {
+        runner.runYamsql("literal-tests.yamsql");
+    }
 }

--- a/yaml-tests/src/test/resources/literal-tests.metrics.binpb
+++ b/yaml-tests/src/test/resources/literal-tests.metrics.binpb
@@ -1,0 +1,94 @@
+ß
+@
+	unnamed-33EXPLAIN select * from B where 6L = coalesce(5L, 6L)‚
+
+õ√¥‘#& ˜ÿ’(0¸≈◊8@6SCAN(<,>) | FILTER @c6 EQUALS coalesce_long(@c10, @c6)ã
+digraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=polyline;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE @c6 EQUALS coalesce_long(@c10, @c6)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS B1, )" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS B1, )" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Primary Storage</td></tr><tr><td align="left">record types: [B]</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS B1, )" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}…
+@
+	unnamed-33EXPLAIN select * from B where 6L = coalesce(5I, 6I)Ñ
+õ©≠‚#& ª•ü(0û›Ô8@GSCAN(<,>) | FILTER @c6 EQUALS promote(coalesce_int(@c10, @c12) AS LONG)ú
+digraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=polyline;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE @c6 EQUALS promote(coalesce_int(@c10, @c12) AS LONG)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS B1, )" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS B1, )" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Primary Storage</td></tr><tr><td align="left">record types: [B]</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS B1, )" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}«
+>
+	unnamed-31EXPLAIN select * from B where 6L = coalesce(5, 6)Ñ
+õØÓ’#& Ñ—¨(0·â˙8@GSCAN(<,>) | FILTER @c6 EQUALS promote(coalesce_int(@c10, @c12) AS LONG)ú
+digraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=polyline;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE @c6 EQUALS promote(coalesce_int(@c10, @c12) AS LONG)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS B1, )" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS B1, )" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Primary Storage</td></tr><tr><td align="left">record types: [B]</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS B1, )" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}È
+>
+	unnamed-31EXPLAIN select * from B where 6 = coalesce(5L, 6)¶
+õó¶Œ#& ⁄ëá(0Î˜Ì8@XSCAN(<,>) | FILTER promote(@c6 AS LONG) EQUALS coalesce_long(@c10, promote(@c6 AS LONG))≠
+digraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=polyline;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE promote(@c6 AS LONG) EQUALS coalesce_long(@c10, promote(@c6 AS LONG))</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS B1, )" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS B1, )" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Primary Storage</td></tr><tr><td align="left">record types: [B]</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS B1, )" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}Î
+@
+	unnamed-33EXPLAIN select * from B where 6I = coalesce(5L, 6I)¶
+õ‰ˇ…#& Ú«¯(0ûù˚8@XSCAN(<,>) | FILTER promote(@c6 AS LONG) EQUALS coalesce_long(@c10, promote(@c6 AS LONG))≠
+digraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=polyline;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE promote(@c6 AS LONG) EQUALS coalesce_long(@c10, promote(@c6 AS LONG))</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS B1, )" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS B1, )" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Primary Storage</td></tr><tr><td align="left">record types: [B]</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS B1, )" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}Î
+@
+	unnamed-33EXPLAIN select * from B where 6i = coalesce(5l, 6i)¶
+õÚ£ÿ#& ÅñØ(0¶∞Ê8@XSCAN(<,>) | FILTER promote(@c6 AS LONG) EQUALS coalesce_long(@c10, promote(@c6 AS LONG))≠
+digraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=polyline;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE promote(@c6 AS LONG) EQUALS coalesce_long(@c10, promote(@c6 AS LONG))</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS B1, )" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS B1, )" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Primary Storage</td></tr><tr><td align="left">record types: [B]</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS B1, )" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}¢
+=
+	unnamed-30EXPLAIN select * from B where 6 = coalesce(5, 6)‡
+
+õ¸≥Õ#& ∑Âè(0ÁÛ˚8@5SCAN(<,>) | FILTER @c6 EQUALS coalesce_int(@c10, @c6)ä
+digraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=polyline;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE @c6 EQUALS coalesce_int(@c10, @c6)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS B1, )" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS B1, )" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Primary Storage</td></tr><tr><td align="left">record types: [B]</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS B1, )" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}

--- a/yaml-tests/src/test/resources/literal-tests.metrics.yaml
+++ b/yaml-tests/src/test/resources/literal-tests.metrics.yaml
@@ -1,0 +1,74 @@
+unnamed-3:
+-   query: EXPLAIN select * from B where 6L = coalesce(5L, 6L)
+    explain: SCAN(<,>) | FILTER @c6 EQUALS coalesce_long(@c10, @c6)
+    task_count: 155
+    task_total_time_ms: 74
+    transform_count: 38
+    transform_time_ms: 51
+    transform_yield_count: 14
+    insert_time_ms: 5
+    insert_new_count: 14
+    insert_reused_count: 2
+-   query: EXPLAIN select * from B where 6L = coalesce(5I, 6I)
+    explain: SCAN(<,>) | FILTER @c6 EQUALS promote(coalesce_int(@c10, @c12) AS LONG)
+    task_count: 155
+    task_total_time_ms: 75
+    transform_count: 38
+    transform_time_ms: 52
+    transform_yield_count: 14
+    insert_time_ms: 3
+    insert_new_count: 14
+    insert_reused_count: 2
+-   query: EXPLAIN select * from B where 6L = coalesce(5, 6)
+    explain: SCAN(<,>) | FILTER @c6 EQUALS promote(coalesce_int(@c10, @c12) AS LONG)
+    task_count: 155
+    task_total_time_ms: 74
+    transform_count: 38
+    transform_time_ms: 51
+    transform_yield_count: 14
+    insert_time_ms: 4
+    insert_new_count: 14
+    insert_reused_count: 2
+-   query: EXPLAIN select * from B where 6 = coalesce(5L, 6)
+    explain: SCAN(<,>) | FILTER promote(@c6 AS LONG) EQUALS coalesce_long(@c10, promote(@c6
+        AS LONG))
+    task_count: 155
+    task_total_time_ms: 74
+    transform_count: 38
+    transform_time_ms: 52
+    transform_yield_count: 14
+    insert_time_ms: 5
+    insert_new_count: 14
+    insert_reused_count: 2
+-   query: EXPLAIN select * from B where 6I = coalesce(5L, 6I)
+    explain: SCAN(<,>) | FILTER promote(@c6 AS LONG) EQUALS coalesce_long(@c10, promote(@c6
+        AS LONG))
+    task_count: 155
+    task_total_time_ms: 74
+    transform_count: 38
+    transform_time_ms: 54
+    transform_yield_count: 14
+    insert_time_ms: 4
+    insert_new_count: 14
+    insert_reused_count: 2
+-   query: EXPLAIN select * from B where 6i = coalesce(5l, 6i)
+    explain: SCAN(<,>) | FILTER promote(@c6 AS LONG) EQUALS coalesce_long(@c10, promote(@c6
+        AS LONG))
+    task_count: 155
+    task_total_time_ms: 74
+    transform_count: 38
+    transform_time_ms: 53
+    transform_yield_count: 14
+    insert_time_ms: 3
+    insert_new_count: 14
+    insert_reused_count: 2
+-   query: EXPLAIN select * from B where 6 = coalesce(5, 6)
+    explain: SCAN(<,>) | FILTER @c6 EQUALS coalesce_int(@c10, @c6)
+    task_count: 155
+    task_total_time_ms: 74
+    transform_count: 38
+    transform_time_ms: 52
+    transform_yield_count: 14
+    insert_time_ms: 4
+    insert_new_count: 14
+    insert_reused_count: 2

--- a/yaml-tests/src/test/resources/literal-tests.yamsql
+++ b/yaml-tests/src/test/resources/literal-tests.yamsql
@@ -1,0 +1,70 @@
+#
+# literal-tests.yamsql
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+options:
+    supported_version: !current_version
+---
+schema_template:
+    create table B(b1 integer, b2 string, b3 bigint, primary key(b1))
+---
+setup:
+  steps:
+    - query: insert into B values
+        (1I, 'a', 2L),
+        (3i, 'b', 4l),
+        (5, 'c', 6)
+---
+test_block:
+  preset: single_repetition_parallelized
+  tests:
+    -
+      - query: select * from B;
+      - result: [{1, 'a', !l 2},
+                 {3, 'b', !l 4},
+                 {5, 'c', !l 6}]
+    -
+      - query: select * from B where 6L = coalesce(5L, 6L)
+      - explain: "SCAN(<,>) | FILTER @c6 EQUALS coalesce_long(@c10, @c6)"
+      - result: []
+    -
+      - query: select * from B where 6L = coalesce(5I, 6I)
+      - explain: "SCAN(<,>) | FILTER @c6 EQUALS promote(coalesce_int(@c10, @c12) AS LONG)"
+      - result: []
+    -
+      - query: select * from B where 6L = coalesce(5, 6)
+      - explain: "SCAN(<,>) | FILTER @c6 EQUALS promote(coalesce_int(@c10, @c12) AS LONG)"
+      - result: []
+    -
+      - query: select * from B where 6 = coalesce(5L, 6)
+      - explain: "SCAN(<,>) | FILTER promote(@c6 AS LONG) EQUALS coalesce_long(@c10, promote(@c6 AS LONG))"
+      - result: []
+    -
+      - query: select * from B where 6I = coalesce(5L, 6I)
+      - explain: "SCAN(<,>) | FILTER promote(@c6 AS LONG) EQUALS coalesce_long(@c10, promote(@c6 AS LONG))"
+      - result: []
+    -
+      - query: select * from B where 6i = coalesce(5l, 6i)
+      - explain: "SCAN(<,>) | FILTER promote(@c6 AS LONG) EQUALS coalesce_long(@c10, promote(@c6 AS LONG))"
+      - result: []
+    -
+      - query: select * from B where 6 = coalesce(5, 6)
+      - explain: "SCAN(<,>) | FILTER @c6 EQUALS coalesce_int(@c10, @c6)"
+      - result: []
+...


### PR DESCRIPTION
This adds two new type specifiers: `i` (or `I`) for `int` and `l` or (`L`) for `long`/`bigint`, consistent with the existing `float` and `double` specifiers.

The primary advantage is enhanced precision when specifying literal types for functions, predicates, and especially SQL testing. This improved precision allows for more accurate testing with literals, closely mirroring the behavior of prepared parameters.

This fixes #3433 .