### PR TITLE
Separate out Lucene tests so they run separately in PRB

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -64,6 +64,40 @@ jobs:
           include-hidden-files: true
           retention-days: 1
 
+  lucene-tests:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4.2.2
+      - name: Setup Base Environment
+        uses: ./actions/setup-base-env
+      - name: Setup FDB
+        uses: ./actions/setup-fdb
+      - name: Run Gradle Test
+        uses: ./actions/gradle-test
+        with:
+          gradle_command: :fdb-record-layer-lucene:test :fdb-record-layer-lucene:destructiveTest
+          gradle_args: -PreleaseBuild=false -PpublishBuild=false
+      - name: Publish Test Reports
+        if: always()
+        uses: actions/upload-artifact@v4.6.0
+        with:
+          name: lucene-test-reports
+          path: |
+            test-reports/fdb-record-layer-lucene/
+      - name: Publish Coverage Data
+        uses: actions/upload-artifact@v4.6.0
+        with:
+          name: lucene-coverage-data
+          path: |
+            **/.out/jacoco/*.exec
+          include-hidden-files: true
+          retention-days: 1
+
   other-tests:
     runs-on: ubuntu-latest
     permissions:
@@ -80,7 +114,7 @@ jobs:
       - name: Run Gradle Test
         uses: ./actions/gradle-test
         with:
-          gradle_command: test -x :fdb-record-layer-core:test destructiveTest -x :fdb-record-layer-core:destructiveTest
+          gradle_command: test -x :fdb-record-layer-core:test -x :fdb-record-layer-lucene:test destructiveTest -x :fdb-record-layer-core:destructiveTest -x :fdb-record-layer-lucene:destructiveTest 
           gradle_args: -PreleaseBuild=false -PpublishBuild=false
       - name: Publish Test Reports
         if: always()
@@ -92,7 +126,6 @@ jobs:
             test-reports/fdb-extensions/
             test-reports/fdb-record-layer-icu/
             test-reports/fdb-record-layer-spatial/
-            test-reports/fdb-record-layer-lucene/
             test-reports/fdb-record-layer-jmh/
             test-reports/examples/
             test-reports/fdb-relational-api/
@@ -113,7 +146,7 @@ jobs:
           retention-days: 1
 
   coverage:
-    needs: [core-tests, other-tests]
+    needs: [core-tests, lucene-tests, other-tests]
     runs-on: ubuntu-latest
     permissions:
       checks: read


### PR DESCRIPTION
I was looking through recent PRB runs, and it seemed like the time to run other-tests was now around twice the time to run the core-tests. Most of the time seemed to be coming from lucene-tests, so I wanted to experiment with separating those out. This hopefully should decrease our total PRB time