### PR TITLE
Run expensive `Traversal` verification sanity check less often

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CascadesPlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CascadesPlanner.java
@@ -437,11 +437,16 @@ public class CascadesPlanner implements QueryPlanner {
                     Debugger.withDebugger(debugger -> debugger.onEvent(nextTask.toTaskEvent(Location.BEGIN)));
                     try {
                         nextTask.execute();
-                        Debugger.sanityCheck(() ->
-                                // This is a fairly expensive check, but it makes sure that the traversal
-                                // is up to date with the query DAG. This is used during memoization, so
-                                // it's important that it has an accurate view of the state of the world.
-                                traversal.verifyIntegrity());
+                        Debugger.sanityCheck(() -> {
+                            // This is a fairly expensive check, but it makes sure that the traversal
+                            // is up to date with the query DAG. This is used during memoization, so
+                            // it's important that it has an accurate view of the state of the world.
+                            // If this catches something, it may aid debugging to run this with every
+                            // task execution
+                            if (taskCount % 20 == 0) {
+                                traversal.verifyIntegrity();
+                            }
+                        });
                     } finally {
                         Debugger.withDebugger(debugger -> debugger.onEvent(nextTask.toTaskEvent(Location.END)));
                     }


### PR DESCRIPTION
A sanity check to validate the traversal integrity was recently added in #3435. That check alone seems to almost double the total time it takes to run the `core-tests` during PRB from around 15 minutes to around 30 minutes. It's a useful check, but it is probably running too often. We should be able to get away with only running it occaisionally and then only enabling it more stringently if the need arises.