### PR TITLE
Update code version before running tests in release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
   #   a) all the tests
   #   b) the mixed-mode tests
   test:
+    needs: [get-update-type]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -50,6 +51,12 @@ jobs:
         uses: ./actions/setup-base-env
       - name: Setup FDB
         uses: ./actions/setup-fdb
+      # Increment the version here so that the version used in tests matches the eventually published version.
+      # This is actually important in order to correctly choose appropriate external server versions during
+      # mixed mode tests (see: https://github.com/FoundationDB/fdb-record-layer/issues/3449)
+      - name: Increment version
+        shell: bash
+        run: python build/versionutils.py gradle.properties --increment -u ${{ needs.get-update-type.outputs.update-type }}
       - name: Run Gradle Test
         uses: ./actions/gradle-test
         with:


### PR DESCRIPTION
This modifies the release build workflow so that we increment the version of local code before we go to run the tests. This makes it so that we correctly distinguish between the latest external version (which should have a version less than `!current_version`) and the current code version. This is necessary to unblock the release build, which is failing currently due to certain tests failing when run in mixed mode against the lateset published version due to expected differences.

Overall, I think this is a better set-up for our tests, as the version that will actually run the tests is now closer to version that we will actually end up publishing. The only difference should be the release number, which _shouldn't_ matter, but it's good to be sure.

This fixes #3449.