### PR TITLE
Pick correct locally generated build for `!current_version` tests

### DIFF
--- a/yaml-tests/yaml-tests.gradle
+++ b/yaml-tests/yaml-tests.gradle
@@ -179,7 +179,7 @@ task serverJars(type: Copy) {
     into project.layout.buildDirectory.dir('externalServer')
     from resolveOtherServer(["4.2.3.0", "4.2.4.0"].toSet())
     from (rootProject.project("fdb-relational-server").layout.files('.dist')) {
-        include("*-SNAPSHOT-all.jar")
+        include("fdb-relational-server-${rootProject.version}-all.jar")
     }
 }
 


### PR DESCRIPTION
The previous logic for choosing the locally generated build for `!current_version` required that there be the word `SNAPSHOT` in the jar name. This had the effect that during release builds, we wouldn't run tests with the current version as an external version. This resulted in test failures after `ExternalServerTest` was added.

This fixes #3454.