### PR TITLE
Update the Maven Central publishing URL to avoid sunset service

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,9 +189,9 @@ jobs:
         env:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.GPG_PRIVATE_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_PASSPHRASE }}
+          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
+          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MAVEN_USER: ${{ secrets.MAVEN_USER }}
-          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
   
       # Post release: Update various files which reference version
       # Updating the yaml files has to be done after the tests complete, or it will mark tests as failing that aren't

--- a/build.gradle
+++ b/build.gradle
@@ -310,8 +310,8 @@ if (Boolean.parseBoolean(centralPublish)) {
     nexusPublishing {
         repositories {
             sonatype {
-                username = System.getenv("MAVEN_USER")
-                password = System.getenv("MAVEN_PASSWORD")
+                // Update the URL now that the OSSRH service has been sunset: https://central.sonatype.org/news/20250326_ossrh_sunset/
+                nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
             }
         }
     }

--- a/docs/sphinx/source/ReleaseNotes.md
+++ b/docs/sphinx/source/ReleaseNotes.md
@@ -5,59 +5,6 @@ This document contains a log of changes to the FoundationDB Record Layer. It aim
 
 As the [versioning guide](Versioning.md) details, it cannot always be determined solely by looking at the version numbers whether one Record Layer version contains all changes included in another. In particular, bug fixes and backwards-compatible changes might be back-ported to or introduced as patches against older versions. To track when a patch version has been included in the main release train, some releases will say as a note that they contain all changes from a specific patch.
 
-## 4.4
-
-### 4.4.2.0
-
-
-
-**[Full Changelog (4.4.1.0...4.4.2.0)](https://github.com/FoundationDB/fdb-record-layer/compare/4.4.1.0...4.4.2.0)**
-
-#### Mixed Mode Test Results
-
-Mixed mode testing run against the following previous versions:
-
-❌`4.2.3.0`, ❌`4.2.4.0`, ✅`4.2.5.0`, ✅`4.2.6.0`, ✅`4.2.8.0`, ✅`4.3.2.0`, ✅`4.3.3.0`, ✅`4.3.3.1`, ✅`4.3.5.0`, ✅`4.3.6.0`
-
-[See full test run](https://github.com/FoundationDB/fdb-record-layer/actions/runs/16003773419)
-
-
-
-### 4.4.1.0
-
-<h4> New Features </h4>
-
-* Improve MetaDataProtoEditor handling of unqualified types and add support for renaming all the types - [PR #3402](https://github.com/FoundationDB/fdb-record-layer/pull/3402)
-* Enable the Planner Rewrite Rules - [PR #3401](https://github.com/FoundationDB/fdb-record-layer/pull/3401)
-<h4> Bug Fixes </h4>
-
-* add placeholders in all appropriate select expressions - [PR #3451](https://github.com/FoundationDB/fdb-record-layer/pull/3451)
-
-<details>
-<summary>
-
-<h4> Build/Test/Documentation/Style Improvements (click to expand) </h4>
-
-</summary>
-
-* Pick correct locally generated build for `!current_version` tests - [PR #3455](https://github.com/FoundationDB/fdb-record-layer/pull/3455)
-* Have ExternalServer dynamically find available ports - [PR #3398](https://github.com/FoundationDB/fdb-record-layer/pull/3398)
-
-</details>
-
-
-**[Full Changelog (4.3.6.0...4.4.1.0)](https://github.com/FoundationDB/fdb-record-layer/compare/4.3.6.0...4.4.1.0)**
-
-#### Mixed Mode Test Results
-
-Mixed mode testing run against the following previous versions:
-
-❌`4.2.3.0`, ❌`4.2.4.0`, ✅`4.2.5.0`, ✅`4.2.6.0`, ✅`4.2.8.0`, ✅`4.3.2.0`, ✅`4.3.3.0`, ✅`4.3.3.1`, ✅`4.3.5.0`, ✅`4.3.6.0`
-
-[See full test run](https://github.com/FoundationDB/fdb-record-layer/actions/runs/16002338481)
-
-
-
 ## 4.3
 
 ### 4.3.6.0


### PR DESCRIPTION
The service we were using to publish to Maven Central was sunset. There is a legacy API that allows us to continue to use our old publising gradle platform, and so I've updated the configuration so that it follows the advice available on their website: https://github.com/gradle-nexus/publish-plugin?tab=readme-ov-file#publishing-to-maven-central-via-sonatype-central

This is advertised to be pretty straightforward. The two main steps are (1) update the publishing URL to one that uses a bridge API and (2) modify the credentials to ones generated by the new portal. I've done that (and already updated the secrets on the repo with the new credentials). So we should be able to get a new build published through the new gateway once this is in.

I've also gone ahead and removed the release notes for the builds that never actually were published. That way, when we get a new build out, we'll get the correct set of release notes automatically without needing to tweaks those by hand later.

This fixes https://github.com/FoundationDB/fdb-record-layer/issues/3456.