### PR TITLE
Escape the ' character in the loggable method to help with log parser frameworks.

### DIFF
--- a/fdb-extensions/src/main/java/com/apple/foundationdb/tuple/ByteArrayUtil2.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/tuple/ByteArrayUtil2.java
@@ -129,6 +129,8 @@ public class ByteArrayUtil2 {
                 c = loggedBytes.charAt(i);
                 if (c == '\\') {
                     bytes.add((byte)'\\');
+                } else if (c == '\'') {
+                    bytes.add((byte)'\'');
                 } else if (c == 'x') {
                     i++;
                     bytes.add((byte)Integer.parseInt(loggedBytes.substring(i, i + 2), 16));

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/tuple/ByteArrayUtil2.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/tuple/ByteArrayUtil2.java
@@ -35,6 +35,7 @@ public class ByteArrayUtil2 {
 
     private static final byte EQUALS_CHARACTER = (byte)'=';
     private static final byte DOUBLE_QUOTE_CHARACTER = (byte)'"';
+    private static final byte SINGLE_QUOTE_CHARACTER = (byte)'\'';
     private static final byte BACKSLASH_CHARACTER = (byte)'\\';
     private static final byte MINIMUM_PRINTABLE_CHARACTER = 32;
     private static final int MAXIMUM_PRINTABLE_CHARACTER = 127;
@@ -71,7 +72,7 @@ public class ByteArrayUtil2 {
      * Creates a human-readable representation of {@code bytes} for logging purposes.
      * This differs from {@link ByteArrayUtil#printable(byte[])} in tha it excludes the
      * {@code =} and {@code "} characters, which can cause trouble when included as a
-     * key or value in log messages with keys and values.
+     * key or value in log messages with keys and values. For the same purpose, {@code '} is escaped as well.
      *
      * @param bytes a {@code byte} array
      * @return a hex representation of {@code bytes}
@@ -88,10 +89,12 @@ public class ByteArrayUtil2 {
             for (byte b : bytes) {
                 // remove '=' and '"' because they confuse parsing of key=value log messages
                 if (b >= MINIMUM_PRINTABLE_CHARACTER && b < MAXIMUM_PRINTABLE_CHARACTER &&
-                        b != BACKSLASH_CHARACTER && b != EQUALS_CHARACTER && b != DOUBLE_QUOTE_CHARACTER) {
+                        b != BACKSLASH_CHARACTER && b != EQUALS_CHARACTER && b != DOUBLE_QUOTE_CHARACTER && b != SINGLE_QUOTE_CHARACTER) {
                     sb.append((char)b);
                 } else if (b == BACKSLASH_CHARACTER) {
                     sb.append("\\\\");
+                } else if (b == SINGLE_QUOTE_CHARACTER) {
+                    sb.append("\\'");
                 } else {
                     sb.append("\\x").append(LOWER_CASE_HEX_CHARS[(b >>> 4) & 0x0F]).append(LOWER_CASE_HEX_CHARS[b & 0x0F]);
                 }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/tuple/ByteArrayUtil2.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/tuple/ByteArrayUtil2.java
@@ -93,8 +93,6 @@ public class ByteArrayUtil2 {
                     sb.append((char)b);
                 } else if (b == BACKSLASH_CHARACTER) {
                     sb.append("\\\\");
-                } else if (b == SINGLE_QUOTE_CHARACTER) {
-                    sb.append("\\'");
                 } else {
                     sb.append("\\x").append(LOWER_CASE_HEX_CHARS[(b >>> 4) & 0x0F]).append(LOWER_CASE_HEX_CHARS[b & 0x0F]);
                 }
@@ -129,8 +127,6 @@ public class ByteArrayUtil2 {
                 c = loggedBytes.charAt(i);
                 if (c == '\\') {
                     bytes.add((byte)'\\');
-                } else if (c == '\'') {
-                    bytes.add((byte)'\'');
                 } else if (c == 'x') {
                     i++;
                     bytes.add((byte)Integer.parseInt(loggedBytes.substring(i, i + 2), 16));

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/tuple/ByteArrayUtil2Test.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/tuple/ByteArrayUtil2Test.java
@@ -51,7 +51,7 @@ public class ByteArrayUtil2Test {
         for (int i = (byte)'"' + 1; i < (byte)'\''; i++) {
             assertEquals(Character.toString((char) i), ByteArrayUtil2.loggable(new byte[]{(byte)i}));
         }
-        assertEquals("\\'", ByteArrayUtil2.loggable(new byte[]{(byte)'\''}));
+        assertEquals("\\x27", ByteArrayUtil2.loggable(new byte[]{(byte)'\''}));
         for (int i = (byte)'\'' + 1; i < (byte)'='; i++) {
             assertEquals(Character.toString((char) i), ByteArrayUtil2.loggable(new byte[]{(byte)i}));
         }

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/tuple/ByteArrayUtil2Test.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/tuple/ByteArrayUtil2Test.java
@@ -44,8 +44,7 @@ public class ByteArrayUtil2Test {
             assertTrue(l.matches(hexRegex), l + " matches /" + hexRegex + "/");
         }
         for (int i = (byte)' '; i < (byte)'"'; i++) {
-            final String loggable = ByteArrayUtil2.loggable(new byte[] {(byte)i});
-            assertEquals(Character.toString((char) i), loggable);
+            assertEquals(Character.toString((char) i), ByteArrayUtil2.loggable(new byte[] {(byte)i}));
         }
         assertEquals("\\x22", ByteArrayUtil2.loggable(new byte[]{(byte)'"'}));
         for (int i = (byte)'"' + 1; i < (byte)'\''; i++) {

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/tuple/ByteArrayUtil2Test.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/tuple/ByteArrayUtil2Test.java
@@ -97,7 +97,7 @@ public class ByteArrayUtil2Test {
         assertFalse(loggable.contains("="), "loggable string should not contain equals sign");
         assertFalse(loggable.contains("\""), "loggable string should not contain quote");
 
-        if (!printable.contains("=") && !printable.contains("\"")) {
+        if (!printable.contains("=") && !printable.contains("\"") && !printable.contains("\'")) {
             assertEquals(printable, loggable);
         }
     }

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/tuple/ByteArrayUtil2Test.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/tuple/ByteArrayUtil2Test.java
@@ -95,6 +95,7 @@ public class ByteArrayUtil2Test {
         assertArrayEquals(bytes, unlogged, "Unprinting loggable bytes should reconstruct original array");
         assertFalse(loggable.contains("="), "loggable string should not contain equals sign");
         assertFalse(loggable.contains("\""), "loggable string should not contain quote");
+        assertFalse(loggable.contains("\'"), "loggable string should not contain single quote");
 
         if (!printable.contains("=") && !printable.contains("\"") && !printable.contains("\'")) {
             assertEquals(printable, loggable);

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/tuple/ByteArrayUtil2Test.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/tuple/ByteArrayUtil2Test.java
@@ -44,10 +44,15 @@ public class ByteArrayUtil2Test {
             assertTrue(l.matches(hexRegex), l + " matches /" + hexRegex + "/");
         }
         for (int i = (byte)' '; i < (byte)'"'; i++) {
-            assertEquals(Character.toString((char) i), ByteArrayUtil2.loggable(new byte[]{(byte)i}));
+            final String loggable = ByteArrayUtil2.loggable(new byte[] {(byte)i});
+            assertEquals(Character.toString((char) i), loggable);
         }
         assertEquals("\\x22", ByteArrayUtil2.loggable(new byte[]{(byte)'"'}));
-        for (int i = (byte)'"' + 1; i < (byte)'='; i++) {
+        for (int i = (byte)'"' + 1; i < (byte)'\''; i++) {
+            assertEquals(Character.toString((char) i), ByteArrayUtil2.loggable(new byte[]{(byte)i}));
+        }
+        assertEquals("\\'", ByteArrayUtil2.loggable(new byte[]{(byte)'\''}));
+        for (int i = (byte)'\'' + 1; i < (byte)'='; i++) {
             assertEquals(Character.toString((char) i), ByteArrayUtil2.loggable(new byte[]{(byte)i}));
         }
         assertEquals("\\x3d", ByteArrayUtil2.loggable(new byte[]{(byte)'='}));

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/tuple/TupleTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/tuple/TupleTest.java
@@ -89,7 +89,7 @@ public class TupleTest {
             .add(new ExpectedTupleEncoding<>(Double.MIN_NORMAL, "!\\x80\\x10\\x00\\x00\\x00\\x00\\x00\\x00"))
             .add(new ExpectedTupleEncoding<>(0.11577446748173348d, "!\\xbf\\xbd\\xa3e?\\x8b\\xbd\\x88"))
             // TODO: Add tests for Tuple encoding of BigIntegers (https://github.com/FoundationDB/fdb-record-layer/issues/18)
-            .add(new ExpectedTupleEncoding<>(true, "'"))
+            .add(new ExpectedTupleEncoding<>(true, "\\'"))
             .add(new ExpectedTupleEncoding<>(false, "&"))
             .add(new ExpectedTupleEncoding<>(Versionstamp.complete(
                     ByteArrayUtil2.unprint("\\x93\\x82\\x8db\\x97;\\xc5\\xfbt\\x9a"), 5180),
@@ -99,11 +99,11 @@ public class TupleTest {
             .add(new ExpectedTupleEncoding<>(new ArrayList<>(0), "\\x05\\x00"))
             .add(new ExpectedTupleEncoding<>(
                     Arrays.asList(0, 1, "String " + zeroByteCharacter + " andZero", true, null, new byte[] {0, 0x03}),
-                    "\\x05\\x14\\x15\\x01\\x02String \\x00\\xff andZero\\x00'\\x00\\xff\\x01\\x00\\xff\\x03\\x00\\x00"))
+                    "\\x05\\x14\\x15\\x01\\x02String \\x00\\xff andZero\\x00\\'\\x00\\xff\\x01\\x00\\xff\\x03\\x00\\x00"))
             .add(new ExpectedTupleEncoding<>(Tuple.from(), "\\x05\\x00"))
             .add(new ExpectedTupleEncoding<>(
                     Tuple.fromList(Arrays.asList(0, 1, "String " + zeroByteCharacter + " andZero", true, null, new byte[] {0, 0x03})),
-                    "\\x05\\x14\\x15\\x01\\x02String \\x00\\xff andZero\\x00'\\x00\\xff\\x01\\x00\\xff\\x03\\x00\\x00"))
+                    "\\x05\\x14\\x15\\x01\\x02String \\x00\\xff andZero\\x00\\'\\x00\\xff\\x01\\x00\\xff\\x03\\x00\\x00"))
             .add()
             .build();
 

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/tuple/TupleTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/tuple/TupleTest.java
@@ -89,7 +89,7 @@ public class TupleTest {
             .add(new ExpectedTupleEncoding<>(Double.MIN_NORMAL, "!\\x80\\x10\\x00\\x00\\x00\\x00\\x00\\x00"))
             .add(new ExpectedTupleEncoding<>(0.11577446748173348d, "!\\xbf\\xbd\\xa3e?\\x8b\\xbd\\x88"))
             // TODO: Add tests for Tuple encoding of BigIntegers (https://github.com/FoundationDB/fdb-record-layer/issues/18)
-            .add(new ExpectedTupleEncoding<>(true, "\\'"))
+            .add(new ExpectedTupleEncoding<>(true, "\\x27"))
             .add(new ExpectedTupleEncoding<>(false, "&"))
             .add(new ExpectedTupleEncoding<>(Versionstamp.complete(
                     ByteArrayUtil2.unprint("\\x93\\x82\\x8db\\x97;\\xc5\\xfbt\\x9a"), 5180),
@@ -99,11 +99,11 @@ public class TupleTest {
             .add(new ExpectedTupleEncoding<>(new ArrayList<>(0), "\\x05\\x00"))
             .add(new ExpectedTupleEncoding<>(
                     Arrays.asList(0, 1, "String " + zeroByteCharacter + " andZero", true, null, new byte[] {0, 0x03}),
-                    "\\x05\\x14\\x15\\x01\\x02String \\x00\\xff andZero\\x00\\'\\x00\\xff\\x01\\x00\\xff\\x03\\x00\\x00"))
+                    "\\x05\\x14\\x15\\x01\\x02String \\x00\\xff andZero\\x00\\x27\\x00\\xff\\x01\\x00\\xff\\x03\\x00\\x00"))
             .add(new ExpectedTupleEncoding<>(Tuple.from(), "\\x05\\x00"))
             .add(new ExpectedTupleEncoding<>(
                     Tuple.fromList(Arrays.asList(0, 1, "String " + zeroByteCharacter + " andZero", true, null, new byte[] {0, 0x03})),
-                    "\\x05\\x14\\x15\\x01\\x02String \\x00\\xff andZero\\x00\\'\\x00\\xff\\x01\\x00\\xff\\x03\\x00\\x00"))
+                    "\\x05\\x14\\x15\\x01\\x02String \\x00\\xff andZero\\x00\\x27\\x00\\xff\\x01\\x00\\xff\\x03\\x00\\x00"))
             .add()
             .build();
 


### PR DESCRIPTION
The ' (single quote) character can confuse log parsers. This PR escapes this character when used within a log message.
This change alters the serialized representation of the byte array as a string. Any usage of this representation would be therefore modified. Searching the codebase showed usage within Exception messages and logging, which is likely OK, but care should be taken to verify that no ill impact is exposed.
Resolves #3461
