### PR TITLE
Rename shouldCommit back to canCommit

### DIFF
--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/AbstractEmbeddedStatement.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/AbstractEmbeddedStatement.java
@@ -109,7 +109,7 @@ public abstract class AbstractEmbeddedStatement implements java.sql.Statement {
                         resultSetRetrieved = true;
                         //ddl statements are updates that don't return results, so they get 0 for row count
                         currentRowCount = 0;
-                        if (conn.shouldCommit()) {
+                        if (conn.canCommit()) {
                             conn.commitInternal();
                         }
                         return false;
@@ -117,7 +117,7 @@ public abstract class AbstractEmbeddedStatement implements java.sql.Statement {
                 }
             } catch (RelationalException | SQLException | RuntimeException ex) {
                 try {
-                    if (conn.inActiveTransaction() && conn.shouldCommit()) {
+                    if (conn.inActiveTransaction() && conn.canCommit()) {
                         conn.rollbackInternal();
                     }
                 } catch (SQLException e) {
@@ -170,7 +170,7 @@ public abstract class AbstractEmbeddedStatement implements java.sql.Statement {
             closeOpenResultSets();
             closed = true;
         } catch (RuntimeException ex) {
-            if (conn.shouldCommit()) {
+            if (conn.canCommit()) {
                 try {
                     conn.rollbackInternal();
                 } catch (SQLException e) {
@@ -209,12 +209,12 @@ public abstract class AbstractEmbeddedStatement implements java.sql.Statement {
             while (resultSet.next()) {
                 count++;
             }
-            if (conn.shouldCommit()) {
+            if (conn.canCommit()) {
                 conn.commitInternal();
             }
             return count;
         } catch (SQLException | RuntimeException ex) {
-            if (conn.shouldCommit()) {
+            if (conn.canCommit()) {
                 conn.rollbackInternal();
             }
             throw ExceptionUtil.toRelationalException(ex).toSqlException();

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/EmbeddedRelationalConnection.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/EmbeddedRelationalConnection.java
@@ -84,7 +84,7 @@ import java.util.stream.Collectors;
  *     to be used to execute all statements and procedure. For consumer perspective, this is equivalent to {@code autoCommit}
  *     being set to {@code true} since the {@link Connection#commit()} and {@link Connection#rollback()} wont be applicable.
  *     However, all statements run within the external transaction. For internal usage, the consumer should check
- *     {@link EmbeddedRelationalConnection#shouldCommit()} to see if they are allowed to manage a transaction.</li>
+ *     {@link EmbeddedRelationalConnection#canCommit()} to see if they are allowed to manage a transaction.</li>
  * </ul>
  */
 @API(API.Status.EXPERIMENTAL)
@@ -185,7 +185,7 @@ public class EmbeddedRelationalConnection implements RelationalConnection {
      * @return {@code true} if the transaction can be committed by internal stakeholders, else {@code false}.
      * @throws SQLException if the connection is closed.
      */
-    boolean shouldCommit() throws SQLException {
+    boolean canCommit() throws SQLException {
         checkOpen();
         return !usingAnExternalTransaction && this.autoCommit;
     }
@@ -492,7 +492,7 @@ public class EmbeddedRelationalConnection implements RelationalConnection {
      */
     boolean ensureTransactionActive() throws RelationalException, SQLException {
         if (inActiveTransaction()) {
-            if (shouldCommit()) {
+            if (canCommit()) {
                 // canCommit() = true means that there is no external transaction and autoCommit is enabled, meaning
                 // that the internal stakeholders can manage the transactions when required to.
                 // As this implies that autoCommit is enabled, if there is an existing transaction in such a case, that

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/EmbeddedRelationalStatement.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/EmbeddedRelationalStatement.java
@@ -335,7 +335,7 @@ public class EmbeddedRelationalStatement extends AbstractEmbeddedStatement imple
                 } catch (SQLException sqle) {
                     exception.addSuppressed(sqle);
                 }
-            } else if (conn.shouldCommit()) {
+            } else if (conn.canCommit()) {
                 conn.commitInternal();
             }
         }

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/RecordLayerResultSet.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/RecordLayerResultSet.java
@@ -94,7 +94,7 @@ public class RecordLayerResultSet extends AbstractRecordLayerResultSet {
         } catch (RelationalException e) {
             throw e.toSqlException();
         }
-        if (connection != null && connection.shouldCommit() && connection.inActiveTransaction()) {
+        if (connection != null && connection.canCommit() && connection.inActiveTransaction()) {
             connection.commitInternal();
         }
         this.closed = true;


### PR DESCRIPTION
As a follow up correction to https://github.com/FoundationDB/fdb-record-layer/pull/3429, rename this function back. 