### PR TITLE
Implement a `closeAll` utility to close multiple closeables

### DIFF
--- a/fdb-extensions/src/main/java/com/apple/foundationdb/util/CloseException.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/util/CloseException.java
@@ -1,0 +1,33 @@
+/*
+ * CloseException.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.util;
+
+/**
+ * Exception thrown when the {@link CloseableUtils#closeAll} method catches an exception.
+ * This exception will have the {@code cause} set to the first exception thrown during {@code closeAll} and any further
+ * exception thrown will be added as {@code Suppressed}.
+ */
+@SuppressWarnings("serial")
+public class CloseException extends Exception {
+    public CloseException(final Throwable cause) {
+        super(cause);
+    }
+}

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/util/CloseableUtilsTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/util/CloseableUtilsTest.java
@@ -49,7 +49,7 @@ public class CloseableUtilsTest {
         SimpleCloseable c2 = new SimpleCloseable(true, "c2");
         SimpleCloseable c3 = new SimpleCloseable(true, "c3");
 
-        final CloseableUtils.CloseException exception = assertThrows(CloseableUtils.CloseException.class, () -> CloseableUtils.closeAll(c1, c2, c3));
+        final CloseException exception = assertThrows(CloseException.class, () -> CloseableUtils.closeAll(c1, c2, c3));
 
         Assertions.assertEquals("c1", exception.getCause().getMessage());
         final Throwable[] suppressed = exception.getSuppressed();
@@ -68,7 +68,7 @@ public class CloseableUtilsTest {
         SimpleCloseable c2 = new SimpleCloseable(false, null);
         SimpleCloseable c3 = new SimpleCloseable(true, "c3");
 
-        final CloseableUtils.CloseException exception = assertThrows(CloseableUtils.CloseException.class, () -> CloseableUtils.closeAll(c1, c2, c3));
+        final CloseException exception = assertThrows(CloseException.class, () -> CloseableUtils.closeAll(c1, c2, c3));
 
         Assertions.assertEquals("c1", exception.getCause().getMessage());
         final Throwable[] suppressed = exception.getSuppressed();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/recordrepair/RecordRepair.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/recordrepair/RecordRepair.java
@@ -30,6 +30,7 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStore;
 import com.apple.foundationdb.record.provider.foundationdb.runners.throttled.CursorFactory;
 import com.apple.foundationdb.record.provider.foundationdb.runners.throttled.ThrottledRetryingIterator;
 import com.apple.foundationdb.tuple.Tuple;
+import com.apple.foundationdb.util.CloseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -114,15 +115,8 @@ public abstract class RecordRepair implements AutoCloseable {
     }
 
     @Override
-    public void close() {
-        try {
-            throttledIterator.close();
-        } catch (Exception e) {
-            if (logger.isWarnEnabled()) {
-                logger.warn("Failed to close the throttled iterator", e);
-            }
-            // Do not rethrow. We are trying to close the runner and the exception should log all errors
-        }
+    public void close() throws CloseException {
+        throttledIterator.close();
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/runners/throttled/ThrottledRetryingIterator.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/runners/throttled/ThrottledRetryingIterator.java
@@ -33,6 +33,7 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContextConfi
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStore;
 import com.apple.foundationdb.record.provider.foundationdb.runners.FutureAutoClose;
 import com.apple.foundationdb.record.provider.foundationdb.runners.TransactionalRunner;
+import com.apple.foundationdb.util.CloseException;
 import com.apple.foundationdb.util.CloseableUtils;
 import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
@@ -150,7 +151,7 @@ public class ThrottledRetryingIterator<T> implements AutoCloseable {
     }
 
     @Override
-    public void close() throws CloseableUtils.CloseException {
+    public void close() throws CloseException {
         if (closed) {
             return;
         }


### PR DESCRIPTION
Tech debt from the ThrottlingIterator work. Close multiple closeables and capture all exceptions.
Resolve  #3465
