### PR TITLE
Allow enabling autocommit without an active transaction

### DIFF
--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/RelationalConnection.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/RelationalConnection.java
@@ -158,6 +158,13 @@ public interface RelationalConnection extends java.sql.Connection {
     }
 
     @Override
+    default void commit() throws SQLException {
+        commit(false);
+    }
+
+    void commit(boolean onlyIfActive) throws SQLException;
+
+    @Override
     @ExcludeFromJacocoGeneratedReport
     default String nativeSQL(String sql) throws SQLException {
         throw new SQLFeatureNotSupportedException("Not implemented in the relational layer", ErrorCode.UNSUPPORTED_OPERATION.getErrorCode());

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/EmbeddedRelationalConnection.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/EmbeddedRelationalConnection.java
@@ -191,13 +191,17 @@ public class EmbeddedRelationalConnection implements RelationalConnection {
     }
 
     @Override
-    public void commit() throws SQLException {
+    public void commit(boolean onlyIfActive) throws SQLException {
         checkOpen();
         if (getAutoCommit()) {
             throw new RelationalException("commit called when the Connection is in auto-commit mode!", ErrorCode.CANNOT_COMMIT_ROLLBACK_WITH_AUTOCOMMIT).toSqlException();
         }
         if (!inActiveTransaction()) {
-            throw new RelationalException("No transaction to commit", ErrorCode.TRANSACTION_INACTIVE).toSqlException();
+            if (onlyIfActive) {
+                return;
+            } else {
+                throw new RelationalException("No transaction to commit", ErrorCode.TRANSACTION_INACTIVE).toSqlException();
+            }
         }
         commitInternal();
     }

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/memory/InMemoryRelationalConnection.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/memory/InMemoryRelationalConnection.java
@@ -78,7 +78,7 @@ public class InMemoryRelationalConnection implements RelationalConnection {
     }
 
     @Override
-    public void commit() throws SQLException {
+    public void commit(final boolean onlyIfActive) throws SQLException {
 
     }
 

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/AutoCommitTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/AutoCommitTests.java
@@ -520,7 +520,7 @@ public class AutoCommitTests {
             // since the resultSet is closed but autoCommit is off, transaction will remain open.
             Assertions.assertTrue(conn.inActiveTransaction());
         }
-        Assertions.assertDoesNotThrow(conn::commit);
+        Assertions.assertDoesNotThrow(() -> conn.commit());
     }
 
     @Test
@@ -670,7 +670,7 @@ public class AutoCommitTests {
         } else {
             Assertions.assertFalse(connection.getAutoCommit());
             if (transactionType == TransactionType.AUTO_COMMIT_OFF_WITH_EXPLICIT_COMMIT) {
-                Assertions.assertDoesNotThrow(connection::commit);
+                Assertions.assertDoesNotThrow(() -> connection.commit());
             }
         }
     }

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/RelationalConnectionRule.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/RelationalConnectionRule.java
@@ -102,6 +102,11 @@ public class RelationalConnectionRule implements BeforeEachCallback, AfterEachCa
     }
 
     @Override
+    public void commit(final boolean onlyIfActive) throws SQLException {
+        connection.commit(onlyIfActive);
+    }
+
+    @Override
     public void rollback() throws SQLException {
         connection.rollback();
     }

--- a/fdb-relational-grpc/src/main/proto/grpc/relational/jdbc/v1/jdbc.proto
+++ b/fdb-relational-grpc/src/main/proto/grpc/relational/jdbc/v1/jdbc.proto
@@ -151,6 +151,8 @@ message StatementResponse {
 }
 
 message CommitRequest {
+  // If true, this will only commit if there is an active transaction
+  bool only_if_active = 1;
 }
 
 message CommitResponse {

--- a/fdb-relational-jdbc/src/main/java/com/apple/foundationdb/relational/jdbc/JDBCRelationalConnection.java
+++ b/fdb-relational-jdbc/src/main/java/com/apple/foundationdb/relational/jdbc/JDBCRelationalConnection.java
@@ -257,15 +257,15 @@ class JDBCRelationalConnection implements RelationalConnection {
     }
 
     @Override
-    @ExcludeFromJacocoGeneratedReport
-    public void commit() throws SQLException {
+    public void commit(final boolean onlyIfActive) throws SQLException {
         try {
             if (getAutoCommit()) {
                 throw new SQLException("Commit cannot be called when auto commit is ON");
             } else {
                 TransactionalRequest.Builder transactionRequest = TransactionalRequest.newBuilder()
-                        .setCommitRequest(CommitRequest.newBuilder().build());
-                // wait here for response
+                        .setCommitRequest(CommitRequest.newBuilder()
+                                .setOnlyIfActive(onlyIfActive).build());
+                // wait here for responsea
                 final TransactionalResponse response = serverConnection.sendRequest(transactionRequest.build());
                 checkForResponseError(response);
                 if (!response.hasCommitResponse()) {
@@ -345,7 +345,7 @@ class JDBCRelationalConnection implements RelationalConnection {
             this.autoCommit = false;
         } else {
             // commit any remaining work
-            commit();
+            commit(true);
             this.autoCommit = true;
             serverConnection.close();
             serverConnection = null;

--- a/fdb-relational-server/src/main/java/com/apple/foundationdb/relational/server/FRL.java
+++ b/fdb-relational-server/src/main/java/com/apple/foundationdb/relational/server/FRL.java
@@ -361,9 +361,11 @@ public class FRL implements AutoCloseable {
         }
     }
 
-    public void transactionalCommit(TransactionalToken token) throws SQLException {
-        assertValidToken(token);
-        token.getConnection().commit();
+    public void transactionalCommit(TransactionalToken token, final boolean onlyIfActive) throws SQLException {
+        if (!(onlyIfActive && token == null)) {
+            assertValidToken(token);
+            token.getConnection().commit(onlyIfActive);
+        }
     }
 
     public void transactionalRollback(TransactionalToken token) throws SQLException {

--- a/fdb-relational-server/src/main/java/com/apple/foundationdb/relational/server/jdbc/v1/TransactionRequestHandler.java
+++ b/fdb-relational-server/src/main/java/com/apple/foundationdb/relational/server/jdbc/v1/TransactionRequestHandler.java
@@ -103,7 +103,8 @@ public class TransactionRequestHandler implements StreamObserver<TransactionalRe
             } else if (transactionRequest.hasCommitRequest()) {
                 // handle commit
                 logger.info("Handling commit request");
-                frl.transactionalCommit(transactionalToken);
+                frl.transactionalCommit(transactionalToken,
+                        transactionRequest.getCommitRequest().getOnlyIfActive());
                 responseBuilder.setCommitResponse(CommitResponse.newBuilder().build());
             } else if (transactionRequest.hasRollbackRequest()) {
                 // handle rollback


### PR DESCRIPTION
This allows the jdbc client to commit only if there is an active transaction, which is then used when disabling autoCommit to avoid throwing an error if there is no active transaction.


Resolves: #3473