### PR TITLE
Allow enabling autoCommit without an active transaction

### DIFF
--- a/fdb-relational-grpc/src/main/proto/grpc/relational/jdbc/v1/jdbc.proto
+++ b/fdb-relational-grpc/src/main/proto/grpc/relational/jdbc/v1/jdbc.proto
@@ -121,6 +121,7 @@ message TransactionalRequest {
       InsertRequest insertRequest = 2;
       CommitRequest commitRequest = 3;
       RollbackRequest rollbackRequest = 4;
+      EnableAutoCommitRequest enableAutoCommitRequest = 5;
   }
 }
 
@@ -130,7 +131,10 @@ message TransactionalResponse {
       InsertResponse insertResponse = 2;
       CommitResponse commitResponse = 3;
       RollbackResponse rollbackResponse = 4;
+
       google.protobuf.Any errorResponse = 5;
+
+      EnableAutoCommitResponse enableAutoCommitResponse = 6;
   }
 }
 
@@ -160,6 +164,12 @@ message RollbackRequest {
 }
 
 message RollbackResponse {
+}
+
+message EnableAutoCommitRequest {
+}
+
+message EnableAutoCommitResponse {
 }
 
 message DatabaseMetaDataRequest {}

--- a/fdb-relational-jdbc/src/test/java/com/apple/foundationdb/relational/jdbc/JDBCAutoCommitTest.java
+++ b/fdb-relational-jdbc/src/test/java/com/apple/foundationdb/relational/jdbc/JDBCAutoCommitTest.java
@@ -207,7 +207,7 @@ public class JDBCAutoCommitTest {
 
             try (RelationalStatement statement = connection.createStatement()) {
                 insertOneRow(statement);
-                connection.setAutoCommit(true);
+                connection.setAutoCommit(true); // this should commit
 
                 RelationalResultSet resultSet = statement.executeQuery("SELECT * FROM test_table");
                 assertNextResult(resultSet, 100, "one hundred");

--- a/fdb-relational-server/src/main/java/com/apple/foundationdb/relational/server/FRL.java
+++ b/fdb-relational-server/src/main/java/com/apple/foundationdb/relational/server/FRL.java
@@ -371,6 +371,16 @@ public class FRL implements AutoCloseable {
         token.getConnection().rollback();
     }
 
+    public void enableAutoCommit(TransactionalToken token) throws SQLException {
+        // we don't actually call setAutoCommit(false) until an operation happens, so if there is no token
+        // there's no connection that needs updating
+        if (token == null) {
+            return;
+        }
+        assertValidToken(token);
+        token.getConnection().setAutoCommit(true);
+    }
+
     public void transactionalClose(TransactionalToken token) throws SQLException {
         if (token != null && !token.expired()) {
             token.close();

--- a/fdb-relational-server/src/main/java/com/apple/foundationdb/relational/server/jdbc/v1/TransactionRequestHandler.java
+++ b/fdb-relational-server/src/main/java/com/apple/foundationdb/relational/server/jdbc/v1/TransactionRequestHandler.java
@@ -26,6 +26,7 @@ import com.apple.foundationdb.relational.api.Options;
 import com.apple.foundationdb.relational.jdbc.TypeConversion;
 import com.apple.foundationdb.relational.jdbc.grpc.GrpcSQLExceptionUtil;
 import com.apple.foundationdb.relational.jdbc.grpc.v1.CommitResponse;
+import com.apple.foundationdb.relational.jdbc.grpc.v1.EnableAutoCommitResponse;
 import com.apple.foundationdb.relational.jdbc.grpc.v1.InsertRequest;
 import com.apple.foundationdb.relational.jdbc.grpc.v1.InsertResponse;
 import com.apple.foundationdb.relational.jdbc.grpc.v1.RollbackResponse;
@@ -110,8 +111,12 @@ public class TransactionRequestHandler implements StreamObserver<TransactionalRe
                 logger.info("Handling rollback request");
                 frl.transactionalRollback(transactionalToken);
                 responseBuilder.setRollbackResponse(RollbackResponse.newBuilder().build());
+            } else if (transactionRequest.hasEnableAutoCommitRequest()) {
+                logger.info("Enabling autoCommit");
+                frl.enableAutoCommit(transactionalToken);
+                responseBuilder.setEnableAutoCommitResponse(EnableAutoCommitResponse.newBuilder().build());
             } else {
-                throw new IllegalArgumentException("Unknown transactional request type in" + transactionRequest);
+                throw new IllegalArgumentException("Unknown transactional request type: " + transactionRequest);
             }
             responseObserver.onNext(responseBuilder.build());
         } catch (SQLException e) {


### PR DESCRIPTION
This changes the client so that it sends a request to enable autoCommit when it is enabled on the client, rather than calling `commit` directly. By doing so, the server can determine whether it wants to commit or not based on whether it has an active transaction.

Fixes: #3473