### PR TITLE
Remove release notes for unpublished builds

### DIFF
--- a/docs/sphinx/source/ReleaseNotes.md
+++ b/docs/sphinx/source/ReleaseNotes.md
@@ -7,58 +7,6 @@ As the [versioning guide](Versioning.md) details, it cannot always be determined
 
 ## 4.4
 
-### 4.4.6.0
-
-<h4> New Features </h4>
-
-* Include planner configuration in the `QueryCacheKey` - [PR #3463](https://github.com/FoundationDB/fdb-record-layer/pull/3463)
-
-
-**[Full Changelog (4.4.5.0...4.4.6.0)](https://github.com/FoundationDB/fdb-record-layer/compare/4.4.5.0...4.4.6.0)**
-
-#### Mixed Mode Test Results
-
-Mixed mode testing run against the following previous versions:
-
-✅`4.2.5.0`, ✅`4.2.6.0`, ✅`4.2.8.0`, ✅`4.3.2.0`, ✅`4.3.3.0`, ✅`4.3.3.1`, ✅`4.3.5.0`, ✅`4.3.6.0`, ✅`4.4.3.0`, ✅`4.4.4.0`
-
-[See full test run](https://github.com/FoundationDB/fdb-record-layer/actions/runs/16176108904)
-
-
-
-### 4.4.5.0
-
-<h4> New Features </h4>
-
-* revive and move `PlannerRepl` into its own component - [PR #3466](https://github.com/FoundationDB/fdb-record-layer/pull/3466)
-<h4> Bug Fixes </h4>
-
-* Fix transactional insert throwing No Value Present in server - [PR #3476](https://github.com/FoundationDB/fdb-record-layer/pull/3476)
-
-<details>
-<summary>
-
-<h4> Build/Test/Documentation/Style Improvements (click to expand) </h4>
-
-</summary>
-
-* Re-enable force continuation tests in Yaml - [PR #3393](https://github.com/FoundationDB/fdb-record-layer/pull/3393)
-
-</details>
-
-
-**[Full Changelog (4.4.4.0...4.4.5.0)](https://github.com/FoundationDB/fdb-record-layer/compare/4.4.4.0...4.4.5.0)**
-
-#### Mixed Mode Test Results
-
-Mixed mode testing run against the following previous versions:
-
-✅`4.2.5.0`, ✅`4.2.6.0`, ✅`4.2.8.0`, ✅`4.3.2.0`, ✅`4.3.3.0`, ✅`4.3.3.1`, ✅`4.3.5.0`, ✅`4.3.6.0`, ✅`4.4.3.0`, ✅`4.4.4.0`
-
-[See full test run](https://github.com/FoundationDB/fdb-record-layer/actions/runs/16167136840)
-
-
-
 ### 4.4.4.0
 
 <h4> New Features </h4>


### PR DESCRIPTION
The release workflows for the 4.4.5.0 and 4.4.6.0 releases failed to publish due to an authentication issue with publishing to maven central. This removes the release notes so that we'll regenerate them appropriately (for 4.4.7.0, presumably).