### PR TITLE
Add support for NULL type fields in ExecuteInsert

### DIFF
--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/RecordTypeTable.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/RecordTypeTable.java
@@ -250,6 +250,8 @@ public class RecordTypeTable extends RecordTypeScannable<FDBStoredRecord<Message
                             }
                         }
                         break;
+                    case NULL:
+                        break;
                     default:
                         Assert.failUnchecked(ErrorCode.INTERNAL_ERROR, (String.format(Locale.ROOT, "Unexpected Column type <%s> for column <%s>",
                                 struct.getMetaData().getColumnType(i), columnName)));


### PR DESCRIPTION
This PR adds support for inserting structs with NULL typed fields into the table via `ExecuteInsert` in the Direct Access API. Also adds a test for the same. 

This bug was introduced by https://github.com/FoundationDB/fdb-record-layer/pull/3484, which essentially shifts the Relational-layer from using Sql Type codes for internal operations to relying on Relational DataTypes for getting a richer information. 

Fixes: https://github.com/FoundationDB/fdb-record-layer/issues/3491