### PR TITLE
Omit portions of stack trace that are just junit in test summary

### DIFF
--- a/gradle/testing.gradle
+++ b/gradle/testing.gradle
@@ -1,4 +1,5 @@
 import java.util.regex.Matcher
+import java.util.regex.Pattern
 
 /*
  * testing.gradle
@@ -210,6 +211,19 @@ def configureTestTask = { propertyPrefix, task ->
     }
 }
 
+ext.skippedStackTraceEntries = Pattern.compile(/(?s)/ +
+                                               /\s+at java\.base\/jdk\.internal\.reflect\.NativeMethodAccessorImpl\.invoke0\(Native Method\)/ +
+                                               /\s+at java\.base\/jdk\.internal\.reflect\.NativeMethodAccessorImpl\.invoke\(NativeMethodAccessorImpl\.java:\d+\)/ +
+                                               /\s+at java\.base\/jdk\.internal\.reflect\.DelegatingMethodAccessorImpl\.invoke\(DelegatingMethodAccessorImpl\.java:\d+\)/ +
+                                               /\s+at java\.base\/java\.lang\.reflect\.Method\.invoke\(Method\.java:\d+\)/ +
+                                               /\s+at org\.junit\.platform\.commons\.util\.ReflectionUtils\.invokeMethod\(ReflectionUtils\.java:\d+\).*?/ +
+                                               /(?=\s+Suppressed:|\s+Caused by:|$)/)
+
+
+def betterException(String exception) {
+    return skippedStackTraceEntries.matcher(exception).replaceAll("\n...")
+}
+
 tasks.withType(Test) { theTask ->
     configureTestTask('allTest', theTask)
     configureTestTask(theTask.name, theTask)
@@ -247,7 +261,7 @@ tasks.withType(Test) { theTask ->
                 "<details>\n" +
                     "<summary> ❌ ${getFullDisplayName(descriptor)}</summary>\n" +
                     "(${duration}ms)\n\n" + // blank line is required for ``` to work
-                    "```\n${result.getException().asString()}\n```\n" +
+                    "```\n${betterException(result.getException().asString())}\n```\n" +
                 "</details>\n")
         }
     }

--- a/gradle/testing.gradle
+++ b/gradle/testing.gradle
@@ -212,7 +212,7 @@ def configureTestTask = { propertyPrefix, task ->
 }
 
 ext.skippedStackTraceEntries = Pattern.compile(/(?s)/ +
-                                               /\s+at java\.base\/jdk\.internal\.reflect\.NativeMethodAccessorImpl\.invoke0\(Native Method\)/ +
+                                               /(?<indent>\s+)at java\.base\/jdk\.internal\.reflect\.NativeMethodAccessorImpl\.invoke0\(Native Method\)/ +
                                                /\s+at java\.base\/jdk\.internal\.reflect\.NativeMethodAccessorImpl\.invoke\(NativeMethodAccessorImpl\.java:\d+\)/ +
                                                /\s+at java\.base\/jdk\.internal\.reflect\.DelegatingMethodAccessorImpl\.invoke\(DelegatingMethodAccessorImpl\.java:\d+\)/ +
                                                /\s+at java\.base\/java\.lang\.reflect\.Method\.invoke\(Method\.java:\d+\)/ +
@@ -221,7 +221,7 @@ ext.skippedStackTraceEntries = Pattern.compile(/(?s)/ +
 
 
 def betterException(String exception) {
-    return skippedStackTraceEntries.matcher(exception).replaceAll("\n...")
+    return skippedStackTraceEntries.matcher(exception).replaceAll("\n\${indent}... junit stack ...")
 }
 
 tasks.withType(Test) { theTask ->


### PR DESCRIPTION
I ran two tests that had exceptions deep in lucene code, with suppressions and causes, and this omission reduced the 768 lines / 76,114 bytes to 183 lines / 16,946 bytes.
GitHub has a limit of 1024k for the summary, so this should help keep us below the limit, and make it easier for developers to diagnose why a test failed.

There are probably some other situations that it won't catch, and maybe the formatting could be a little cleaner, but I think this gets the job done, and don't feel like it's worth spending a bunch of dedicated time on it right now.

Here is a sample after it is cleaned up:
<details>
<summary> ❌ FDBLuceneIndexFailureTest > basicGroupedPartitionedTest(boolean) > [2] true</summary>
(23ms)

```
java.lang.RuntimeException
	at com.apple.foundationdb.record.lucene.directory.FDBDirectoryWrapper.<init>(FDBDirectoryWrapper.java:93)
	at com.apple.foundationdb.record.lucene.directory.MockedFDBDirectoryWrapper.<init>(MockedFDBDirectoryWrapper.java:38)
	at com.apple.foundationdb.record.lucene.directory.MockedFDBDirectoryManager.createNewDirectoryWrapper(MockedFDBDirectoryManager.java:41)
	at com.apple.foundationdb.record.lucene.directory.FDBDirectoryManager.lambda$getDirectoryWrapper$12(FDBDirectoryManager.java:306)
	at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1705)
	at com.apple.foundationdb.record.lucene.directory.FDBDirectoryManager.getDirectoryWrapper(FDBDirectoryManager.java:306)
	at com.apple.foundationdb.record.lucene.directory.FDBDirectoryManager.getDirectoryWrapper(FDBDirectoryManager.java:301)
	at com.apple.foundationdb.record.lucene.directory.FDBDirectoryManager.getIndexWriter(FDBDirectoryManager.java:370)
	at com.apple.foundationdb.record.lucene.LuceneIndexMaintainer.writeDocument(LuceneIndexMaintainer.java:256)
	at com.apple.foundationdb.record.lucene.LuceneIndexMaintainer.lambda$update$8(LuceneIndexMaintainer.java:489)
	at java.base/java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:642)
	at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506)
	at java.base/java.util.concurrent.CompletableFuture.postFire(CompletableFuture.java:610)
	at java.base/java.util.concurrent.CompletableFuture$UniCompose.tryFire(CompletableFuture.java:1085)
	at java.base/java.util.concurrent.CompletableFuture$Completion.run(CompletableFuture.java:478)
	at com.apple.foundationdb.async.TaskNotifyingExecutor$Notifier.run(TaskNotifyingExecutor.java:77)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
	Suppressed: java.util.concurrent.ExecutionException: java.lang.RuntimeException
		at java.base/java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:395)
		at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2005)
		at com.apple.foundationdb.record.provider.foundationdb.FDBDatabase.asyncToSync(FDBDatabase.java:1121)
		at com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext.asyncToSync(FDBRecordContext.java:1182)
		at com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase.saveRecord(FDBRecordStoreBase.java:617)
		at com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase.saveRecord(FDBRecordStoreBase.java:599)
		at com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase.saveRecord(FDBRecordStoreBase.java:583)
		at com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase.saveRecord(FDBRecordStoreBase.java:559)
		at com.apple.foundationdb.record.lucene.FDBLuceneIndexFailureTest.basicGroupedPartitionedTest(FDBLuceneIndexFailureTest.java:107)

		... junit stack ...
	Caused by: java.lang.RuntimeException
		at com.apple.foundationdb.record.lucene.directory.FDBDirectoryWrapper.<init>(FDBDirectoryWrapper.java:93)
		at com.apple.foundationdb.record.lucene.directory.MockedFDBDirectoryWrapper.<init>(MockedFDBDirectoryWrapper.java:38)
		at com.apple.foundationdb.record.lucene.directory.MockedFDBDirectoryManager.createNewDirectoryWrapper(MockedFDBDirectoryManager.java:41)
		at com.apple.foundationdb.record.lucene.directory.FDBDirectoryManager.lambda$getDirectoryWrapper$12(FDBDirectoryManager.java:306)
		at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1705)
		at com.apple.foundationdb.record.lucene.directory.FDBDirectoryManager.getDirectoryWrapper(FDBDirectoryManager.java:306)
		at com.apple.foundationdb.record.lucene.directory.FDBDirectoryManager.getDirectoryWrapper(FDBDirectoryManager.java:301)
		at com.apple.foundationdb.record.lucene.directory.FDBDirectoryManager.getIndexWriter(FDBDirectoryManager.java:370)
		at com.apple.foundationdb.record.lucene.LuceneIndexMaintainer.writeDocument(LuceneIndexMaintainer.java:256)
		at com.apple.foundationdb.record.lucene.LuceneIndexMaintainer.lambda$update$8(LuceneIndexMaintainer.java:489)
		at java.base/java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:642)
		at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506)
		at java.base/java.util.concurrent.CompletableFuture.postFire(CompletableFuture.java:610)
		at java.base/java.util.concurrent.CompletableFuture$UniCompose.tryFire(CompletableFuture.java:1085)
		at java.base/java.util.concurrent.CompletableFuture$Completion.run(CompletableFuture.java:478)
		at com.apple.foundationdb.async.TaskNotifyingExecutor$Notifier.run(TaskNotifyingExecutor.java:77)
		at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
		at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
		at java.base/java.lang.Thread.run(Thread.java:829)
		Suppressed: java.util.concurrent.ExecutionException: java.lang.RuntimeException
			at java.base/java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:395)
			at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2005)
			at com.apple.foundationdb.record.provider.foundationdb.FDBDatabase.asyncToSync(FDBDatabase.java:1121)
			at com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext.asyncToSync(FDBRecordContext.java:1182)
			at com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase.saveRecord(FDBRecordStoreBase.java:617)
			at com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase.saveRecord(FDBRecordStoreBase.java:599)
			at com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase.saveRecord(FDBRecordStoreBase.java:583)
			at com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase.saveRecord(FDBRecordStoreBase.java:559)
			at com.apple.foundationdb.record.lucene.FDBLuceneIndexFailureTest.basicGroupedPartitionedTest(FDBLuceneIndexFailureTest.java:107)

			... junit stack ...
		Caused by: [CIRCULAR REFERENCE: java.lang.RuntimeException]

```
</details>