### PR TITLE
Integrate with Teamscale during pull request builds

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Run Gradle Test
         uses: ./actions/gradle-test
         with:
-          gradle_command: :fdb-record-layer-core:test :fdb-record-layer-core:destructiveTest
+          gradle_command: :fdb-record-layer-core:test :fdb-record-layer-core:destructiveTest teamscaleTestReportUpload
           gradle_args: -PreleaseBuild=false -PpublishBuild=false
         env:
           TEAMSCALE_ACCESS_KEY: ${{ secrets.TEAMSCALE_ACCESS_KEY }}
@@ -82,7 +82,7 @@ jobs:
       - name: Run Gradle Test
         uses: ./actions/gradle-test
         with:
-          gradle_command: :fdb-record-layer-lucene:test :fdb-record-layer-lucene:destructiveTest
+          gradle_command: :fdb-record-layer-lucene:test :fdb-record-layer-lucene:destructiveTest teamscaleTestReportUpload
           gradle_args: -PreleaseBuild=false -PpublishBuild=false
         env:
           TEAMSCALE_ACCESS_KEY: ${{ secrets.TEAMSCALE_ACCESS_KEY }}
@@ -118,7 +118,7 @@ jobs:
       - name: Run Gradle Test
         uses: ./actions/gradle-test
         with:
-          gradle_command: test -x :fdb-record-layer-core:test -x :fdb-record-layer-lucene:test destructiveTest -x :fdb-record-layer-core:destructiveTest -x :fdb-record-layer-lucene:destructiveTest 
+          gradle_command: test -x :fdb-record-layer-core:test -x :fdb-record-layer-lucene:test destructiveTest -x :fdb-record-layer-core:destructiveTest -x :fdb-record-layer-lucene:destructiveTest teamscaleTestReportUpload
           gradle_args: -PreleaseBuild=false -PpublishBuild=false
         env:
           TEAMSCALE_ACCESS_KEY: ${{ secrets.TEAMSCALE_ACCESS_KEY }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -48,6 +48,8 @@ jobs:
         with:
           gradle_command: :fdb-record-layer-core:test :fdb-record-layer-core:destructiveTest
           gradle_args: -PreleaseBuild=false -PpublishBuild=false
+        env:
+          TEAMSCALE_ACCESS_KEY: ${{ secrets.TEAMSCALE_ACCESS_KEY }}
       - name: Publish Test Reports
         if: always()
         uses: actions/upload-artifact@v4.6.0
@@ -82,6 +84,8 @@ jobs:
         with:
           gradle_command: :fdb-record-layer-lucene:test :fdb-record-layer-lucene:destructiveTest
           gradle_args: -PreleaseBuild=false -PpublishBuild=false
+        env:
+          TEAMSCALE_ACCESS_KEY: ${{ secrets.TEAMSCALE_ACCESS_KEY }}
       - name: Publish Test Reports
         if: always()
         uses: actions/upload-artifact@v4.6.0
@@ -116,6 +120,8 @@ jobs:
         with:
           gradle_command: test -x :fdb-record-layer-core:test -x :fdb-record-layer-lucene:test destructiveTest -x :fdb-record-layer-core:destructiveTest -x :fdb-record-layer-lucene:destructiveTest 
           gradle_args: -PreleaseBuild=false -PpublishBuild=false
+        env:
+          TEAMSCALE_ACCESS_KEY: ${{ secrets.TEAMSCALE_ACCESS_KEY }}
       - name: Publish Test Reports
         if: always()
         uses: actions/upload-artifact@v4.6.0

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,6 @@
+import com.teamscale.aggregation.compact.AggregateCompactCoverageReport
+import com.teamscale.TeamscaleUpload
+
 /*
  * build.gradle
  *
@@ -38,6 +41,8 @@ plugins {
     alias(libs.plugins.spotbugs)
     alias(libs.plugins.nexus)
     alias(libs.plugins.download)
+    alias(libs.plugins.teamscale.aggregation)
+    alias(libs.plugins.teamscale)
 }
 
 ext {
@@ -355,4 +360,46 @@ if (!ext.fdbEnvironment.isEmpty()) {
             task.environment(fdbenv)
         }
     }
+}
+
+teamscale {
+    server {
+        url = "https://fdb.teamscale.io"
+        project = "foundationdb-fdb-record-layer"
+        userName = "fdb-record-layer-build"
+        userAccessToken = isRunningInCI() ? System.getenv("TEAMSCALE_ACCESS_KEY") : "NO ACCESS"
+    }
+    commit {
+        revision = System.getenv("GIT_COMMIT")
+    }
+}
+
+dependencies {
+    reportAggregation(subprojects)
+}
+
+reporting {
+    reports {
+        testAggregateCompactCoverageReport(AggregateCompactCoverageReport) {
+            testSuiteName = JvmTestSuitePlugin.DEFAULT_TEST_SUITE_NAME
+        }
+    }
+}
+
+tasks.register("teamscaleTestReportUpload", TeamscaleUpload) {
+    partition = "CI Tests"
+    ignoreFailures = false
+    message = "Gradle Upload"
+
+    if (isRunningInCI()) {
+        from(tasks.testAggregateCompactCoverageReport)
+    }
+}
+
+static def isRunningInCI() {
+    return System.getenv().containsKey("GITHUB_ACTIONS")
+}
+
+tasks.named('check') {
+    finalizedBy tasks.named("teamscaleTestReportUpload")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -367,7 +367,7 @@ teamscale {
         url = "https://fdb.teamscale.io"
         project = "foundationdb-fdb-record-layer"
         userName = "fdb-record-layer-build"
-        userAccessToken = isRunningInCI() ? System.getenv("TEAMSCALE_ACCESS_KEY") : "NO ACCESS"
+        userAccessToken = hasTeamscaleAccess() ? System.getenv("TEAMSCALE_ACCESS_KEY") : "NO ACCESS"
     }
     commit {
         revision = System.getenv("GIT_COMMIT")
@@ -391,13 +391,13 @@ tasks.register("teamscaleTestReportUpload", TeamscaleUpload) {
     ignoreFailures = false
     message = "Gradle Upload"
 
-    if (isRunningInCI()) {
+    if (hasTeamscaleAccess()) {
         from(tasks.testAggregateCompactCoverageReport)
     }
 }
 
-static def isRunningInCI() {
-    return System.getenv().containsKey("GITHUB_ACTIONS")
+static def hasTeamscaleAccess() {
+    return System.getenv().containsKey("TEAMSCALE_ACCESS_KEY")
 }
 
 tasks.named('check') {

--- a/build.gradle
+++ b/build.gradle
@@ -399,7 +399,3 @@ tasks.register("teamscaleTestReportUpload", TeamscaleUpload) {
 static def hasTeamscaleAccess() {
     return System.getenv().containsKey("TEAMSCALE_ACCESS_KEY")
 }
-
-tasks.named('check') {
-    finalizedBy tasks.named("teamscaleTestReportUpload")
-}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -71,6 +71,7 @@ snakeyaml = "2.2"
 
 jacoco = "0.8.5"
 spotbugs = "4.9.0"
+teamscale = "35.2.0"
 
 [libraries]
 
@@ -159,3 +160,5 @@ serviceloader = { id = "com.github.harbby.gradle.serviceloader", version = "1.1.
 shadow = { id = "com.gradleup.shadow", version = "8.3.5" }
 spotbugs = { id = "com.github.spotbugs", version = "6.1.3" }
 versions = { id = "com.github.ben-manes.versions", version = "0.52.0" }
+teamscale-aggregation = { id = "com.teamscale.aggregation", version.ref = "teamscale" }
+teamscale = { id = "com.teamscale", version.ref = "teamscale" }


### PR DESCRIPTION
This enables uploading code coverage data to teamscale, primarily to allow teamscale to report on test gaps.