### PR TITLE
Update to minor version 4.5 in recognition of incompatibility with older 4.3 versions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@
 #
 
 rootProject.name=fdb-record-layer
-version=4.4.15.0
+version=4.5.0.0
 releaseBuild=false
 
 # this should be false for release branches (i.e. if there is no -SNAPSHOT on the above version)


### PR DESCRIPTION
With #3495, we are no longer compatible in mixed modes with versions that do not have #3254, which was introduced in version 4.3.4.0. To highlight that this version can be safely upgraded from 4.4 but requires more care when upgrading from 4.3, this updates the minor version to 4.5.