### PR TITLE
Interpret full-supported UUID type correctly in JDBC server 

### DIFF
--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/metadata/DataType.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/metadata/DataType.java
@@ -68,6 +68,7 @@ public abstract class DataType {
         typeCodeJdbcTypeMap.put(Code.DOUBLE, Types.DOUBLE);
         typeCodeJdbcTypeMap.put(Code.STRING, Types.VARCHAR);
         typeCodeJdbcTypeMap.put(Code.ENUM, Types.OTHER);
+        typeCodeJdbcTypeMap.put(Code.UUID, Types.OTHER);
         typeCodeJdbcTypeMap.put(Code.BYTES, Types.BINARY);
         typeCodeJdbcTypeMap.put(Code.VERSION, Types.BINARY);
         typeCodeJdbcTypeMap.put(Code.STRUCT, Types.STRUCT);

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/metadata/DataType.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/metadata/DataType.java
@@ -801,6 +801,79 @@ public abstract class DataType {
         }
     }
 
+    public static final class UuidType extends DataType {
+        @Nonnull
+        private static final UuidType NOT_NULLABLE_INSTANCE = new UuidType(false);
+
+        @Nonnull
+        private static final UuidType NULLABLE_INSTANCE = new UuidType(true);
+
+        @Nonnull
+        private final Supplier<Integer> hashCodeSupplier = Suppliers.memoize(this::computeHashCode);
+
+        private UuidType(boolean isNullable) {
+            super(isNullable, true, Code.UUID);
+        }
+
+        @Override
+        @Nonnull
+        public DataType withNullable(boolean isNullable) {
+            if (isNullable) {
+                return Primitives.NULLABLE_UUID.type();
+            } else {
+                return Primitives.UUID.type();
+            }
+        }
+
+        @Override
+        public boolean isResolved() {
+            return true;
+        }
+
+        @Nonnull
+        @Override
+        public DataType resolve(@Nonnull Map<String, Named> resolutionMap) {
+            return this;
+        }
+
+        @Nonnull
+        public static UuidType nullable() {
+            return NULLABLE_INSTANCE;
+        }
+
+        @Nonnull
+        public static UuidType notNullable() {
+            return NOT_NULLABLE_INSTANCE;
+        }
+
+        private int computeHashCode() {
+            return Objects.hash(getCode(), isNullable());
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCodeSupplier.get();
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            }
+
+            if (!(other instanceof UuidType)) {
+                return false;
+            }
+            final var otherUuidType = (UuidType) other;
+            return this.isNullable() == otherUuidType.isNullable();
+        }
+
+        @Override
+        public String toString() {
+            return "uuid" + (isNullable() ? " ∪ ∅" : "");
+        }
+    }
+
     public static final class NullType extends DataType {
 
         @Nonnull
@@ -1426,6 +1499,7 @@ public abstract class DataType {
         BYTES,
         VERSION,
         ENUM,
+        UUID,
         STRUCT,
         ARRAY,
         UNKNOWN,
@@ -1443,6 +1517,7 @@ public abstract class DataType {
         STRING(StringType.notNullable()),
         BYTES(BytesType.notNullable()),
         VERSION(VersionType.notNullable()),
+        UUID(UuidType.notNullable()),
         NULLABLE_BOOLEAN(BooleanType.nullable()),
         NULLABLE_LONG(LongType.nullable()),
         NULLABLE_INTEGER(IntegerType.nullable()),
@@ -1451,6 +1526,7 @@ public abstract class DataType {
         NULLABLE_STRING(StringType.nullable()),
         NULLABLE_BYTES(BytesType.nullable()),
         NULLABLE_VERSION(VersionType.nullable()),
+        NULLABLE_UUID(UuidType.nullable()),
         NULL(NullType.INSTANCE)
         ;
 

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/DataTypeUtils.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/DataTypeUtils.java
@@ -148,6 +148,7 @@ public class DataTypeUtils {
         primitivesMap.put(DataType.Primitives.BYTES.type(), Type.primitiveType(Type.TypeCode.BYTES, false));
         primitivesMap.put(DataType.Primitives.STRING.type(), Type.primitiveType(Type.TypeCode.STRING, false));
         primitivesMap.put(DataType.Primitives.VERSION.type(), Type.primitiveType(Type.TypeCode.VERSION, false));
+        primitivesMap.put(DataType.Primitives.UUID.type(), Type.uuidType(false));
 
         primitivesMap.put(DataType.Primitives.NULLABLE_BOOLEAN.type(), Type.primitiveType(Type.TypeCode.BOOLEAN, true));
         primitivesMap.put(DataType.Primitives.NULLABLE_INTEGER.type(), Type.primitiveType(Type.TypeCode.INT, true));
@@ -157,6 +158,8 @@ public class DataTypeUtils {
         primitivesMap.put(DataType.Primitives.NULLABLE_BYTES.type(), Type.primitiveType(Type.TypeCode.BYTES, true));
         primitivesMap.put(DataType.Primitives.NULLABLE_STRING.type(), Type.primitiveType(Type.TypeCode.STRING, true));
         primitivesMap.put(DataType.Primitives.NULLABLE_VERSION.type(), Type.primitiveType(Type.TypeCode.VERSION, true));
+        primitivesMap.put(DataType.Primitives.NULLABLE_UUID.type(), Type.uuidType(true));
+
         primitivesMap.put(DataType.Primitives.NULL.type(), Type.nullType());
     }
 }

--- a/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/TypeConversion.java
+++ b/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/TypeConversion.java
@@ -44,6 +44,7 @@ import com.apple.foundationdb.relational.jdbc.grpc.v1.column.ListColumn;
 import com.apple.foundationdb.relational.jdbc.grpc.v1.column.ListColumnMetadata;
 import com.apple.foundationdb.relational.jdbc.grpc.v1.column.Struct;
 import com.apple.foundationdb.relational.jdbc.grpc.v1.column.Type;
+import com.apple.foundationdb.relational.jdbc.grpc.v1.column.Uuid;
 import com.apple.foundationdb.relational.util.PositionalIndex;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.ByteString;
@@ -226,6 +227,8 @@ public class TypeConversion {
                 return Type.VERSION;
             case ENUM:
                 return Type.ENUM;
+            case UUID:
+                return Type.UUID;
             default:
                 throw new RelationalException("not supported in toProtobuf: " + type, ErrorCode.INTERNAL_ERROR).toUncheckedWrappedException();
         }
@@ -461,6 +464,13 @@ public class TypeConversion {
             case DOUBLE:
                 column = toColumn(wasNull ? null : (Double) value,
                         (a, b) -> a == null ? b.clearDouble() : b.setDouble(a));
+                break;
+            case UUID:
+                column = toColumn(wasNull ? null : (UUID) value,
+                        (a, b) -> a == null ? b.clearUuid() : b.setUuid(Uuid.newBuilder()
+                                .setMostSignificantBits(a.getMostSignificantBits())
+                                .setLeastSignificantBits(a.getLeastSignificantBits())
+                                .build()));
                 break;
             default:
                 throw new SQLException("DataType: " + field.getType() + " not supported",


### PR DESCRIPTION
This PR (1) adds the missing support in `DataType` and gRPC-related classes for the future UUID type. This is needed to maintain compatibility in mixed-mode testing with the future full-support version.

It is relatively difficult to test this on the `main` as we cannot bring in the support in the current PR. However, here is the PR for re-introducing the full support: https://github.com/FoundationDB/fdb-record-layer/pull/3510 (2). I have tested that (2) is backward compatible with fixes in (1). Hence, if (1) releases first, and then we bring in (2) we will maintain compatibility to "older" version JDBC servers.  