### PR TITLE
Upload coverage data to teamscale

### DIFF
--- a/.github/workflows/teamscale_upload.yml
+++ b/.github/workflows/teamscale_upload.yml
@@ -48,8 +48,8 @@ jobs:
         # create a new instance and use that
         with: # https://github.com/cqse/teamscale-upload/releases/tag/v2.9.6
           script: |
-            import { Octokit } from "octokit";
-            const unauthenticated = new Octokit({ });
+            const octokit = require('octokit')
+            const unauthenticated = new octokit.Octokit({ });
             let release = await unauthenticated.rest.repos.getReleaseByTag({
               owner: 'cqse',
               repo: 'teamscale-upload',

--- a/.github/workflows/teamscale_upload.yml
+++ b/.github/workflows/teamscale_upload.yml
@@ -1,8 +1,6 @@
 name: Upload Coverage to Teamscale
 
 on:
-  pull_request: # will fail, but good for testing
-    types: [opened, reopened, synchronize]
   workflow_run:
     workflows: [Pull Request]
     types:

--- a/.github/workflows/teamscale_upload.yml
+++ b/.github/workflows/teamscale_upload.yml
@@ -40,7 +40,7 @@ jobs:
             fs.writeFileSync(path.join(temp, 'coverage-report.zip'), Buffer.from(download.data));
 
       - name: 'Unzip artifact'
-        run: unzip coverage-report.zip -d "${{ runner.temp }}/artifacts"
+        run: unzip "${{ runner.temp }}/artifacts/coverage-report.zip" -d "${{ runner.temp }}/artifacts"
       - name: 'Download release'
         uses: actions/github-script@v7
         with: # https://github.com/cqse/teamscale-upload/releases/tag/v2.9.6
@@ -68,7 +68,7 @@ jobs:
             fs.writeFileSync(path.join(temp, 'teamscale-upload.zip'), Buffer.from(asset.data));
 
       - name: 'Unzip teamscale'
-        run: unzip teamscale-upload.zip -d "${{ runner.temp }}/teamscale"
+        run: unzip "${{ runner.temp }}/teamscale/teamscale-upload.zip" -d "${{ runner.temp }}/teamscale"
 
       - name: 'Upload coverage'
         run: |

--- a/.github/workflows/teamscale_upload.yml
+++ b/.github/workflows/teamscale_upload.yml
@@ -1,0 +1,80 @@
+name: Upload Coverage to Teamscale
+
+on:
+  pull_request: # will fail, but good for testing
+    types: [opened, reopened, synchronize]
+  workflow_run:
+    workflows: [Pull Request]
+    types:
+      - completed
+
+jobs:
+  download:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Download artifact'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "coverage-report"
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            const fs = require('fs');
+            const path = require('path');
+            const temp = '${{ runner.temp }}/artifacts';
+            if (!fs.existsSync(temp)){
+              fs.mkdirSync(temp);
+            }
+            fs.writeFileSync(path.join(temp, 'coverage-report.zip'), Buffer.from(download.data));
+
+      - name: 'Unzip artifact'
+        run: unzip coverage-report.zip -d "${{ runner.temp }}/artifacts"
+      - name: 'Download release'
+        uses: actions/github-script@v7
+        with: # https://github.com/cqse/teamscale-upload/releases/tag/v2.9.6
+          script: |
+            let release = await github.rest.repos.getReleaseByTag({
+              owner: 'cqse',
+              repo: 'teamscale-upload',
+              tag: 'v2.9.6'
+            });
+            let reference = release.assets.filter((asset) => {
+              return asset.name == "teamscale-upload-jlink-linux-x86_64.zip"
+            })[0];
+            let asset = await octokit.rest.repos.getReleaseAsset({
+              owner: 'cqse',
+              repo: 'teamscale-upload',
+              asset_id: reference.id
+            });
+            
+            const fs = require('fs');
+            const path = require('path');
+            const temp = '${{ runner.temp }}/teamscale;
+            if (!fs.existsSync(temp)){
+              fs.mkdirSync(temp);
+            }
+            fs.writeFileSync(path.join(temp, 'teamscale-upload.zip'), Buffer.from(asset.data));
+
+      - name: 'Unzip teamscale'
+        run: unzip teamscale-upload.zip -d "${{ runner.temp }}/teamscale"
+
+      - name: 'Upload coverage'
+        run: |
+          "${{ runner.temp }}/teamscale/teamscale-upload/bin/teamscale-upload" --server https://fdb.teamscale.io \
+          --project foundationdb-fdb-record-layer \
+          --user fdb-record-layer-build \
+          --accesskey ${{ secrets.TEAMSCALE_ACCESS_KEY }} \
+          --partition 'CI Tests' \
+          --commit ${{ context.payload.workflow_run.head_sha }} \
+          --format jacoco ${{ runner.temp}}/artifacts/codeCoverageReport.xml

--- a/.github/workflows/teamscale_upload.yml
+++ b/.github/workflows/teamscale_upload.yml
@@ -10,7 +10,7 @@ on:
       - completed
 
 jobs:
-  download:
+  upload_coverage:
     runs-on: ubuntu-latest
     steps:
       - name: 'Download artifact'

--- a/.github/workflows/teamscale_upload.yml
+++ b/.github/workflows/teamscale_upload.yml
@@ -41,45 +41,14 @@ jobs:
 
       - name: 'Unzip artifact'
         run: unzip "${{ runner.temp }}/artifacts/coverage-report.zip" -d "${{ runner.temp }}/artifacts"
-      - name: 'Download release'
-        uses: actions/github-script@v7
-        # The provided octokit in `github` as used above is already authenticated with a token that only allows
-        # access to our repository, but we want to access a public release. This doesn't require a token, so
-        # create a new instance and use that
-        with: # https://github.com/cqse/teamscale-upload/releases/tag/v2.9.6
-          script: |
-            const unauthenticated = new Octokit({ });
-            let release = await unauthenticated.rest.repos.getReleaseByTag({
-              owner: 'cqse',
-              repo: 'teamscale-upload',
-              tag: 'v2.9.6'
-            });
-            let reference = release.assets.filter((asset) => {
-              return asset.name == "teamscale-upload-jlink-linux-x86_64.zip"
-            })[0];
-            let asset = await unauthenticated.rest.repos.getReleaseAsset({
-              owner: 'cqse',
-              repo: 'teamscale-upload',
-              asset_id: reference.id
-            });
-            
-            const fs = require('fs');
-            const path = require('path');
-            const temp = '${{ runner.temp }}/teamscale;
-            if (!fs.existsSync(temp)){
-              fs.mkdirSync(temp);
-            }
-            fs.writeFileSync(path.join(temp, 'teamscale-upload.zip'), Buffer.from(asset.data));
-
-      - name: 'Unzip teamscale'
-        run: unzip "${{ runner.temp }}/teamscale/teamscale-upload.zip" -d "${{ runner.temp }}/teamscale"
-
       - name: 'Upload coverage'
-        run: |
-          "${{ runner.temp }}/teamscale/teamscale-upload/bin/teamscale-upload" --server https://fdb.teamscale.io \
-          --project foundationdb-fdb-record-layer \
-          --user fdb-record-layer-build \
-          --accesskey ${{ secrets.TEAMSCALE_ACCESS_KEY }} \
-          --partition 'CI Tests' \
-          --commit ${{ github.event.workflow_run.head_sha }} \
-          --format jacoco ${{ runner.temp}}/artifacts/codeCoverageReport.xml
+        uses: 'cqse/teamscale-upload-action@v2.9.6'
+        with:
+          server: 'https://fdb.teamscale.io'
+          project: 'foundationdb-fdb-record-layer'
+          user: 'foundationdb-fdb-record-layer'
+          partition: 'CI Tests'
+          accesskey: ${{ secrets.TEAMSCALE_ACCESS_KEY }}
+          format: 'JACOCO'
+          revision: ${{ github.event.workflow_run.head_sha }}
+          files: "${{ runner.temp}}/artifacts/codeCoverageReport.xml"

--- a/.github/workflows/teamscale_upload.yml
+++ b/.github/workflows/teamscale_upload.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           server: 'https://fdb.teamscale.io'
           project: 'foundationdb-fdb-record-layer'
-          user: 'foundationdb-fdb-record-layer'
+          user: 'fdb-record-layer-build'
           partition: 'CI Tests'
           accesskey: ${{ secrets.TEAMSCALE_ACCESS_KEY }}
           format: 'JACOCO'

--- a/.github/workflows/teamscale_upload.yml
+++ b/.github/workflows/teamscale_upload.yml
@@ -1,5 +1,8 @@
 name: Upload Coverage to Teamscale
 
+permissions:
+  actions: read
+
 on:
   workflow_run:
     workflows: [Pull Request]

--- a/.github/workflows/teamscale_upload.yml
+++ b/.github/workflows/teamscale_upload.yml
@@ -74,5 +74,5 @@ jobs:
           --user fdb-record-layer-build \
           --accesskey ${{ secrets.TEAMSCALE_ACCESS_KEY }} \
           --partition 'CI Tests' \
-          --commit ${{ context.payload.workflow_run.head_sha }} \
+          --commit ${{ github.event.workflow_run.head_sha }} \
           --format jacoco ${{ runner.temp}}/artifacts/codeCoverageReport.xml

--- a/.github/workflows/teamscale_upload.yml
+++ b/.github/workflows/teamscale_upload.yml
@@ -43,9 +43,14 @@ jobs:
         run: unzip "${{ runner.temp }}/artifacts/coverage-report.zip" -d "${{ runner.temp }}/artifacts"
       - name: 'Download release'
         uses: actions/github-script@v7
+        # The provided octokit in `github` as used above is already authenticated with a token that only allows
+        # access to our repository, but we want to access a public release. This doesn't require a token, so
+        # create a new instance and use that
         with: # https://github.com/cqse/teamscale-upload/releases/tag/v2.9.6
           script: |
-            let release = await github.rest.repos.getReleaseByTag({
+            import { Octokit } from "octokit";
+            const unauthenticated = new Octokit({ });
+            let release = await unauthenticated.rest.repos.getReleaseByTag({
               owner: 'cqse',
               repo: 'teamscale-upload',
               tag: 'v2.9.6'
@@ -53,7 +58,7 @@ jobs:
             let reference = release.assets.filter((asset) => {
               return asset.name == "teamscale-upload-jlink-linux-x86_64.zip"
             })[0];
-            let asset = await octokit.rest.repos.getReleaseAsset({
+            let asset = await unauthenticated.rest.repos.getReleaseAsset({
               owner: 'cqse',
               repo: 'teamscale-upload',
               asset_id: reference.id

--- a/.github/workflows/teamscale_upload.yml
+++ b/.github/workflows/teamscale_upload.yml
@@ -48,8 +48,7 @@ jobs:
         # create a new instance and use that
         with: # https://github.com/cqse/teamscale-upload/releases/tag/v2.9.6
           script: |
-            const octokit = require('octokit')
-            const unauthenticated = new octokit.Octokit({ });
+            const unauthenticated = new Octokit({ });
             let release = await unauthenticated.rest.repos.getReleaseByTag({
               owner: 'cqse',
               repo: 'teamscale-upload',


### PR DESCRIPTION
After a Pull Request workflow, this will be queued to download the coverage data, and upload it to teamscale.

This does take advantage of this action: https://github.com/cqse/teamscale-upload-action

Right now, if the `Pull Request` workflow fails, so will this, which is probably not what we want longterm. 