### PR TITLE
Resolves FoundationDB#1076: Incorrect continuation when scanning by EndpointType.PREFIX_STRING

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursorBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursorBase.java
@@ -40,6 +40,7 @@ import com.apple.foundationdb.record.cursors.AsyncIteratorCursor;
 import com.apple.foundationdb.record.cursors.BaseCursor;
 import com.apple.foundationdb.record.cursors.CursorLimitManager;
 import com.apple.foundationdb.subspace.Subspace;
+import com.apple.foundationdb.tuple.ByteArrayUtil;
 import com.apple.foundationdb.tuple.Tuple;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.ZeroCopyByteString;
@@ -245,6 +246,11 @@ public abstract class KeyValueCursorBase<K extends KeyValue> extends AsyncIterat
             // Handle the continuation and then turn the endpoints into one byte array on the
             // left (inclusive) and another on the right (exclusive).
             prefixLength = calculatePrefixLength();
+
+            // When both endpoints are prefix strings, we should strip off the last byte \x00 from Tuple
+            if (lowEndpoint == EndpointType.PREFIX_STRING && highEndpoint == EndpointType.PREFIX_STRING) {
+                prefixLength--;
+            }
 
             reverse = scanProperties.isReverse();
             if (continuation != null) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/KeyValueCursorTest.java
@@ -199,6 +199,81 @@ public class KeyValueCursorTest {
     }
 
     @Test
+    public void prefixString() {
+        fdb.run(context -> {
+            fdb.database().run(tr -> {
+                for (int i = 0; i < 5; i++) {
+                    tr.set(subspace.pack(Tuple.from("apple", i)), Tuple.from("apple", i).pack());
+                }
+                return null;
+            });
+            TupleRange range = new TupleRange(
+                    Tuple.from("a"),
+                    Tuple.from("a"),
+                    EndpointType.PREFIX_STRING,
+                    EndpointType.PREFIX_STRING
+            );
+
+            KeyValueCursor cursor = KeyValueCursor.Builder.withSubspace(subspace)
+                    .setContext(context)
+                    .setRange(range)
+                    .setContinuation(null)
+                    .setScanProperties(ScanProperties.FORWARD_SCAN)
+                    .build();
+            for (int j = 0; j < 5; j++) {
+                KeyValue kv = cursor.getNext().get();
+                System.out.println(kv);
+                assertArrayEquals(subspace.pack(Tuple.from("apple", j)), kv.getKey());
+                assertArrayEquals(Tuple.from("apple", j).pack(), kv.getValue());
+            }
+            assertThat(cursor.getNext().hasNext(), is(false));
+
+            cursor = KeyValueCursor.Builder.withSubspace(subspace)
+                    .setContext(context)
+                    .setRange(range)
+                    .setContinuation(null)
+                    .setScanProperties(new ScanProperties(ExecuteProperties.newBuilder().setReturnedRowLimit(2).build()))
+                    .build();
+            for (int j = 0; j < 2; j++) {
+                KeyValue kv = cursor.getNext().get();
+                System.out.println(kv);
+                assertArrayEquals(subspace.pack(Tuple.from("apple", j)), kv.getKey());
+                assertArrayEquals(Tuple.from("apple", j).pack(), kv.getValue());
+            }
+
+            cursor = KeyValueCursor.Builder.withSubspace(subspace)
+                    .setContext(context)
+                    .setRange(range)
+                    .setContinuation(cursor.getNext().getContinuation().toBytes())
+                    .setScanProperties(new ScanProperties(ExecuteProperties.newBuilder().setReturnedRowLimit(2).build()))
+                    .build();
+
+            for (int j = 2; j < 4; j++) {
+                KeyValue kv = cursor.getNext().get();
+                System.out.println(kv);
+                assertArrayEquals(subspace.pack(Tuple.from("apple", j)), kv.getKey());
+                assertArrayEquals(Tuple.from("apple", j).pack(), kv.getValue());
+            }
+
+            cursor = KeyValueCursor.Builder.withSubspace(subspace)
+                    .setContext(context)
+                    .setRange(range)
+                    .setContinuation(cursor.getNext().getContinuation().toBytes())
+                    .setScanProperties(new ScanProperties(ExecuteProperties.newBuilder().setReturnedRowLimit(1).build()))
+                    .build();
+
+            for (int j = 4; j < 5; j++) {
+                KeyValue kv = cursor.getNext().get();
+                System.out.println(kv);
+                assertArrayEquals(subspace.pack(Tuple.from("apple", j)), kv.getKey());
+                assertArrayEquals(Tuple.from("apple", j).pack(), kv.getValue());
+            }
+
+            return null;
+        });
+    }
+
+    @Test
     public void exclusiveRange() {
         fdb.run(context -> {
             KeyValueCursor cursor = KeyValueCursor.Builder.withSubspace(subspace)


### PR DESCRIPTION
`KeyValueCursor` is including null terminator `\x00` when both endpoints are PREFIX_STRING, which causes continuation missing one byte from last key. 

In `prefixString` unit test I populated 5 records `("apple", 0)` -> `("apple", 4)` and scanned with "a" prefix, the continuation after scanning the first two records is `ple\x00...` instead of `pple\x00` and calculated `continuationBytes` in `KeyValueCursorBase` is `...a\x00ple\x00...` instead of `...apple\x00...`.