### PR TITLE
Online Indexer: replace the synchronized runner with a heartbeat

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/logging/LogMessageKeys.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/logging/LogMessageKeys.java
@@ -58,6 +58,7 @@ public enum LogMessageKeys {
     TRANSACTION_ID,
     TRANSACTION_NAME,
     AGE_SECONDS,
+    AGE_MILLISECONDS,
     CONSTITUENT,
     TOTAL_MICROS,
     // record splitting/unsplitting
@@ -162,7 +163,7 @@ public enum LogMessageKeys {
     RECORDS_PER_SECOND,
     DOCUMENT,
     SESSION_ID,
-    INDEXER_SESSION_ID,
+    EXISTING_INDEXER_ID,
     INDEXER_ID,
     INDEX_STATE_PRECONDITION,
     INITIAL_INDEX_STATE,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -83,6 +83,7 @@ import com.apple.foundationdb.record.metadata.expressions.EmptyKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.provider.common.DynamicMessageRecordSerializer;
 import com.apple.foundationdb.record.provider.common.RecordSerializer;
+import com.apple.foundationdb.record.provider.foundationdb.indexing.IndexingHeartbeat;
 import com.apple.foundationdb.record.provider.foundationdb.indexing.IndexingRangeSet;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpacePath;
 import com.apple.foundationdb.record.provider.foundationdb.storestate.FDBRecordStoreStateCache;
@@ -4965,7 +4966,9 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     }
 
     private void clearReadableIndexBuildData(Index index) {
+        // Clear index maintenance data that is unneeded once the index becomes readable
         IndexingRangeSet.forIndexBuild(this, index).clear();
+        IndexingHeartbeat.clearAllHeartbeats(this, index);
     }
 
     @SuppressWarnings("PMD.CloseResource")

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
@@ -413,6 +413,10 @@ public class FDBStoreTimer extends StoreTimer {
         WAIT_INDEX_OPERATION("wait for index operation"),
         /** Wait for indexing type stamp operation. */
         WAIT_INDEX_TYPESTAMP_OPERATION("wait for indexing type stamp operation"),
+        /** Wait for clearing indexing heartbeats. */
+        WAIT_INDEX_CLEAR_HEARTBEATS("Wait for clearing indexing heartbeats"),
+        /** Wait for reading indexing heartbeats. */
+        WAIT_INDEX_READ_HEARTBEATS("Wait for reading indexing heartbeats"),
         /** Wait for adding an index. */
         WAIT_ADD_INDEX("wait for adding an index"),
         /** Wait for dropping an index. */

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingByIndex.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingByIndex.java
@@ -103,7 +103,7 @@ public class IndexingByIndex extends IndexingBase {
         throw new ValidationException("no source index",
                 LogMessageKeys.INDEX_NAME, common.getIndex().getName(),
                 LogMessageKeys.SOURCE_INDEX, policy.getSourceIndex(),
-                LogMessageKeys.INDEXER_ID, common.getUuid());
+                LogMessageKeys.INDEXER_ID, common.getIndexerId());
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingCommon.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingCommon.java
@@ -27,7 +27,6 @@ import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.MetaDataException;
 import com.apple.foundationdb.record.metadata.RecordType;
-import com.apple.foundationdb.record.provider.foundationdb.synchronizedsession.SynchronizedSessionRunner;
 import com.apple.foundationdb.record.query.plan.synthetic.SyntheticRecordPlanner;
 import com.apple.foundationdb.tuple.Tuple;
 
@@ -50,10 +49,9 @@ import java.util.stream.Collectors;
 
 @API(API.Status.INTERNAL)
 public class IndexingCommon {
-    private final UUID uuid = UUID.randomUUID();
+    private final UUID indexerId = UUID.randomUUID();
 
     @Nonnull private final FDBDatabaseRunner runner;
-    @Nullable private SynchronizedSessionRunner synchronizedSessionRunner = null;
 
     @Nonnull private final FDBRecordStore.Builder recordStoreBuilder;
     @Nonnull private final AtomicLong totalRecordsScanned;
@@ -137,8 +135,8 @@ public class IndexingCommon {
         }
     }
 
-    public UUID getUuid() {
-        return uuid;
+    public UUID getIndexerId() {
+        return indexerId;
     }
 
     public List<Object> indexLogMessageKeyValues() {
@@ -158,7 +156,7 @@ public class IndexingCommon {
         logIf(true, keyValues,
                 LogMessageKeys.TARGET_INDEX_NAME, getTargetIndexesNames(),
                 LogMessageKeys.RECORDS_SCANNED, totalRecordsScanned.get(),
-                LogMessageKeys.INDEXER_ID, uuid);
+                LogMessageKeys.INDEXER_ID, indexerId);
 
         if (moreKeyValues != null && !moreKeyValues.isEmpty()) {
             keyValues.addAll(moreKeyValues);
@@ -176,11 +174,6 @@ public class IndexingCommon {
 
     @Nonnull
     public FDBDatabaseRunner getRunner() {
-        return synchronizedSessionRunner == null ? runner : synchronizedSessionRunner;
-    }
-
-    @Nonnull
-    public FDBDatabaseRunner getNonSynchronizedRunner() {
         return runner;
     }
 
@@ -258,15 +251,6 @@ public class IndexingCommon {
         return recordStoreBuilder;
     }
 
-    @Nullable
-    public SynchronizedSessionRunner getSynchronizedSessionRunner() {
-        return synchronizedSessionRunner;
-    }
-
-    public void setSynchronizedSessionRunner(@Nullable final SynchronizedSessionRunner synchronizedSessionRunner) {
-        this.synchronizedSessionRunner = synchronizedSessionRunner;
-    }
-
     @Nonnull
     public AtomicLong getTotalRecordsScanned() {
         return totalRecordsScanned;
@@ -287,8 +271,5 @@ public class IndexingCommon {
 
     public void close() {
         runner.close();
-        if (synchronizedSessionRunner != null) {
-            synchronizedSessionRunner.close();
-        }
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMerger.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMerger.java
@@ -77,7 +77,7 @@ public class IndexingMerger {
                 // Merge operation may take a long time, hence the runner's context must be a read-only. Ensure that it
                 // isn't a synchronized one, which may attempt a heartbeat write
                 // Note: this runAsync will retry according to the runner's "maxAttempts" setting
-                common.getNonSynchronizedRunner().runAsync(context -> openRecordStore(context)
+                common.getRunner().runAsync(context -> openRecordStore(context)
                                 .thenCompose(store -> {
                                     mergeStartTime.set(System.nanoTime());
                                     final IndexDeferredMaintenanceControl mergeControl = store.getIndexDeferredMaintenanceControl();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexScrubber.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexScrubber.java
@@ -75,7 +75,7 @@ public class OnlineIndexScrubber implements AutoCloseable {
     @Nonnull
     private CompletableFuture<Void> scrubIndexAsync(IndexScrubbingTools.ScrubbingType type, AtomicLong count) {
         return AsyncUtil.composeHandle(
-                getScrubber(type, count).buildIndexAsync(false, common.config.shouldUseSynchronizedSession()),
+                getScrubber(type, count).buildIndexAsync(false),
                 (ignore, ex) -> {
                     if (ex != null) {
                         throw FDBExceptions.wrapException(ex);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexing/IndexingHeartbeat.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexing/IndexingHeartbeat.java
@@ -1,0 +1,208 @@
+/*
+ * IndexingHeartbeat.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb.indexing;
+
+import com.apple.foundationdb.KeyValue;
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.async.AsyncIterator;
+import com.apple.foundationdb.async.AsyncUtil;
+import com.apple.foundationdb.record.IndexBuildProto;
+import com.apple.foundationdb.record.logging.KeyValueLogMessage;
+import com.apple.foundationdb.record.logging.LogMessageKeys;
+import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStore;
+import com.apple.foundationdb.record.provider.foundationdb.IndexingSubspaces;
+import com.apple.foundationdb.synchronizedsession.SynchronizedSessionLockedException;
+import com.google.protobuf.InvalidProtocolBufferException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Indexing Shared Heartbeats can be used to define and handle "active" indexing processes.
+ * Every indexer should update its unique heartbeat during its indexing iteration. If the indexing session is optimized for
+ * non-mutual (as defined by the indexing type, see {@link IndexBuildProto.IndexBuildIndexingStamp}), detecting an existing
+ * active heartbeat will help preventing concurrent, conflicting, indexing attempts.
+ * In addition, the heartbeats can be used by users to query activity status of ongoing indexing sessions.
+ */
+@API(API.Status.INTERNAL)
+public class IndexingHeartbeat {
+    // [prefix, indexerId] -> [creator info, create time, heartbeat time]
+    @Nonnull
+    private static final Logger logger = LoggerFactory.getLogger(IndexingHeartbeat.class);
+    public static final String INVALID_HEARTBEAT_INFO = "<< Invalid Heartbeat >>";
+
+    final UUID indexerId;
+    final String info;
+    final long createTimeMilliseconds;
+    final long leaseLength;
+    final boolean allowMutual;
+
+    public IndexingHeartbeat(final UUID indexerId, String info, long leaseLength, boolean allowMutual) {
+        this.indexerId = indexerId;
+        this.info = info;
+        this.leaseLength = leaseLength;
+        this.allowMutual = allowMutual;
+        this.createTimeMilliseconds = nowMilliseconds();
+    }
+
+    public UUID getIndexerId() {
+        return indexerId;
+    }
+
+    public void updateHeartbeat(@Nonnull FDBRecordStore store, @Nonnull Index index) {
+        byte[] key = IndexingSubspaces.indexHeartbeatSubspaceBytes(store, index, indexerId);
+        byte[] value = IndexBuildProto.IndexBuildHeartbeat.newBuilder()
+                .setInfo(info)
+                .setCreateTimeMilliseconds(createTimeMilliseconds)
+                .setHeartbeatTimeMilliseconds(nowMilliseconds())
+                .build().toByteArray();
+        store.ensureContextActive().set(key, value);
+    }
+
+    public CompletableFuture<Void> checkAndUpdateHeartbeat(@Nonnull FDBRecordStore store, @Nonnull Index index) {
+        // complete exceptionally if non-mutual, other exists
+        if (allowMutual) {
+            updateHeartbeat(store, index);
+            return AsyncUtil.DONE;
+        }
+
+        final AsyncIterator<KeyValue> iterator = heartbeatsIterator(store, index);
+        final long now = nowMilliseconds();
+        return AsyncUtil.forEachRemaining(iterator, kv -> checkSingleHeartbeat(store, index, kv, now), store.getExecutor())
+                .thenRun(() -> updateHeartbeat(store, index));
+    }
+
+    private void checkSingleHeartbeat(final @Nonnull FDBRecordStore store, final @Nonnull Index index, final KeyValue kv, final long now) {
+        try {
+            final UUID otherIndexerId = heartbeatKeyToIndexerId(store, index, kv.getKey());
+            if (!otherIndexerId.equals(this.indexerId)) {
+                final IndexBuildProto.IndexBuildHeartbeat otherHeartbeat = IndexBuildProto.IndexBuildHeartbeat.parseFrom(kv.getValue());
+                final long age = now - otherHeartbeat.getHeartbeatTimeMilliseconds();
+                if (age > TimeUnit.DAYS.toMillis(-1) && age < leaseLength) {
+                    // Note that if this heartbeat's age is more than a day in the future, it is considered as bad data. A day seems to be
+                    // long enough to tolerate reasonable clock skews between nodes.
+                    // For practical reasons, this exception is backward compatible to the Synchronized Lock one
+                    throw new SynchronizedSessionLockedException("Failed to initialize the session because of an existing session in progress")
+                            .addLogInfo(LogMessageKeys.INDEXER_ID, indexerId)
+                            .addLogInfo(LogMessageKeys.EXISTING_INDEXER_ID, otherIndexerId)
+                            .addLogInfo(LogMessageKeys.AGE_MILLISECONDS, age)
+                            .addLogInfo(LogMessageKeys.TIME_LIMIT_MILLIS, leaseLength);
+                }
+            }
+        } catch (InvalidProtocolBufferException e) {
+            if (logger.isWarnEnabled()) {
+                logger.warn(KeyValueLogMessage.of("Bad indexing heartbeat item",
+                        LogMessageKeys.KEY, kv.getKey(),
+                        LogMessageKeys.VALUE, kv.getValue()));
+            }
+        }
+    }
+
+    public void clearHeartbeat(@Nonnull FDBRecordStore store, @Nonnull Index index) {
+        store.ensureContextActive().clear(IndexingSubspaces.indexHeartbeatSubspaceBytes(store, index, indexerId));
+    }
+
+    public static void clearAllHeartbeats(@Nonnull FDBRecordStore store, @Nonnull Index index) {
+        store.ensureContextActive().clear(IndexingSubspaces.indexHeartbeatSubspace(store, index).range());
+    }
+
+    public static CompletableFuture<Map<UUID, IndexBuildProto.IndexBuildHeartbeat>> getIndexingHeartbeats(FDBRecordStore store, Index index, int maxCount) {
+        final Map<UUID, IndexBuildProto.IndexBuildHeartbeat> ret = new HashMap<>();
+        final AsyncIterator<KeyValue> iterator = heartbeatsIterator(store, index);
+        final AtomicInteger iterationCount = new AtomicInteger(0);
+        return AsyncUtil.whileTrue(() -> iterator.onHasNext()
+                        .thenApply(hasNext -> {
+                            if (!hasNext) {
+                                return false;
+                            }
+                            if (maxCount > 0 && maxCount < iterationCount.incrementAndGet()) {
+                                return false;
+                            }
+                            final KeyValue kv = iterator.next();
+                            final UUID otherIndexerId = heartbeatKeyToIndexerId(store, index, kv.getKey());
+                            try {
+                                final IndexBuildProto.IndexBuildHeartbeat otherHeartbeat = IndexBuildProto.IndexBuildHeartbeat.parseFrom(kv.getValue());
+                                ret.put(otherIndexerId, otherHeartbeat);
+                            } catch (InvalidProtocolBufferException e) {
+                                // Let the caller know about this invalid heartbeat.
+                                ret.put(otherIndexerId, IndexBuildProto.IndexBuildHeartbeat.newBuilder()
+                                        .setInfo(INVALID_HEARTBEAT_INFO)
+                                                .setCreateTimeMilliseconds(0)
+                                                .setHeartbeatTimeMilliseconds(0)
+                                        .build());
+                            }
+                            return true;
+                        }), store.getExecutor())
+                .thenApply(ignore -> ret);
+    }
+
+    public static CompletableFuture<Integer> clearIndexingHeartbeats(@Nonnull FDBRecordStore store, @Nonnull Index index, long minAgeMilliseconds, int maxIteration) {
+        final AsyncIterator<KeyValue> iterator = heartbeatsIterator(store, index);
+        final AtomicInteger deleteCount = new AtomicInteger(0);
+        final AtomicInteger iterationCount = new AtomicInteger(0);
+        final long now = nowMilliseconds();
+        return AsyncUtil.whileTrue(() -> iterator.onHasNext()
+                        .thenApply(hasNext -> {
+                            if (!hasNext) {
+                                return false;
+                            }
+                            if (maxIteration > 0 && maxIteration < iterationCount.incrementAndGet()) {
+                                return false;
+                            }
+                            final KeyValue kv = iterator.next();
+                            boolean shouldRemove;
+                            try {
+                                final IndexBuildProto.IndexBuildHeartbeat otherHeartbeat = IndexBuildProto.IndexBuildHeartbeat.parseFrom(kv.getValue());
+                                // remove heartbeat if too old
+                                shouldRemove = now >= otherHeartbeat.getHeartbeatTimeMilliseconds() +  minAgeMilliseconds;
+                            } catch (InvalidProtocolBufferException e) {
+                                // remove heartbeat if invalid
+                                shouldRemove = true;
+                            }
+                            if (shouldRemove) {
+                                store.ensureContextActive().clear(kv.getKey());
+                                deleteCount.incrementAndGet();
+                            }
+                            return true;
+                        }), store.getExecutor())
+                .thenApply(ignore -> deleteCount.get());
+    }
+
+    private static AsyncIterator<KeyValue> heartbeatsIterator(FDBRecordStore store, Index index) {
+        return store.getContext().ensureActive().getRange(IndexingSubspaces.indexHeartbeatSubspace(store, index).range()).iterator();
+    }
+
+    private static UUID heartbeatKeyToIndexerId(FDBRecordStore store, Index index, byte[] key) {
+        return IndexingSubspaces.indexHeartbeatSubspace(store, index).unpack(key).getUUID(0);
+    }
+
+    private static long nowMilliseconds() {
+        return System.currentTimeMillis();
+    }
+}

--- a/fdb-record-layer-core/src/main/proto/index_build.proto
+++ b/fdb-record-layer-core/src/main/proto/index_build.proto
@@ -46,4 +46,12 @@ message IndexBuildIndexingStamp {
   optional string blockID = 7; // optional, a short string that describes the reason for the block.
  }
 
+// An heartbeat is maintained by an OnlineIndexer at every transaction during the indexing iteration, to ensure there
+// aren't too many concurrent processes trying to build an index
+message IndexBuildHeartbeat {
+    optional string info = 1; // general information about the indexing session. This can be useful when querying the heartbeats.
+    optional int64 createTimeMilliseconds = 2; // indexer's creation time (since epoch)
+    optional int64 heartbeatTimeMilliseconds = 3; // last heartbeat's time (since epoch). This is the only heartbeat value that changes during online indexing.
+ }
+
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMultiTargetTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMultiTargetTest.java
@@ -313,7 +313,6 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
         buildIndexAndCrashHalfway(chunkSize, 2, timer, newIndexerBuilder(indexAhead)
                 .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
                         .setReverseScanOrder(reverse2)
-                        .checkIndexingStampFrequencyMilliseconds(0)
                         .allowTakeoverContinue()));
 
         // 3. assert mismatch type stamp
@@ -864,21 +863,7 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
             try (OnlineIndexer indexBuilder = newIndexerBuilder(indexes)
                     .setLeaseLengthMillis(TimeUnit.SECONDS.toMillis(20))
                     .setLimit(4)
-                    .setConfigLoader(old -> {
-                        if (passed.get()) {
-                            try {
-                                startBuildingSemaphore.release();
-                                pauseMutualBuildSemaphore.acquire(); // pause to try building indexes
-                            } catch (InterruptedException e) {
-                                throw new RuntimeException(e);
-                            } finally {
-                                pauseMutualBuildSemaphore.release();
-                            }
-                        } else {
-                            passed.set(true);
-                        }
-                        return old;
-                    })
+                    .setConfigLoader(old -> pauseAfterOnePass(old, passed, startBuildingSemaphore, pauseMutualBuildSemaphore))
                     .build()) {
                 indexBuilder.buildIndex();
             }
@@ -930,21 +915,7 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
             try (OnlineIndexer indexBuilder = newIndexerBuilder(indexes)
                     .setLeaseLengthMillis(TimeUnit.SECONDS.toMillis(20))
                     .setLimit(4)
-                    .setConfigLoader(old -> {
-                        if (passed.get()) {
-                            try {
-                                startBuildingSemaphore.release();
-                                pauseMutualBuildSemaphore.acquire(); // pause to try building indexes
-                            } catch (InterruptedException e) {
-                                throw new RuntimeException(e);
-                            } finally {
-                                pauseMutualBuildSemaphore.release();
-                            }
-                        } else {
-                            passed.set(true);
-                        }
-                        return old;
-                    })
+                    .setConfigLoader(old -> pauseAfterOnePass(old, passed, startBuildingSemaphore, pauseMutualBuildSemaphore))
                     .build()) {
                 indexBuilder.buildIndex();
             }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerSimpleTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerSimpleTest.java
@@ -32,12 +32,15 @@ import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.IndexTypes;
 import com.apple.foundationdb.record.metadata.MetaDataException;
 import com.apple.foundationdb.record.util.pair.Pair;
+import com.apple.foundationdb.synchronizedsession.SynchronizedSessionLockedException;
+import com.apple.test.BooleanSource;
 import com.apple.test.Tags;
 import com.google.common.collect.ImmutableMap;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -48,6 +51,9 @@ import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
@@ -886,5 +892,89 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
             fdb.setTrackLastSeenVersionOnRead(dbTracksReadVersionOnRead);
             fdb.setTrackLastSeenVersionOnRead(dbTracksReadVersionOnCommit);
         }
+    }
+
+    @ParameterizedTest
+    @BooleanSource
+    @SuppressWarnings("removal")
+    void testExclusiveBuildRegardlessOfSettingDeprecatedSynchronizedSession(boolean useSynchronizedSession) throws InterruptedException {
+        // regardless of useSynchronizedSession's value, the build should be exclusive
+        Index index = new Index("simple$value_2", field("num_value_2").ungrouped(), IndexTypes.SUM);
+        FDBRecordStoreTestBase.RecordMetaDataHook hook = metaDataBuilder -> metaDataBuilder.addIndex("MySimpleRecord", index);
+        populateData(21);
+        openSimpleMetaData(hook);
+        disableAll(List.of(index));
+
+        // ensure exclusive build
+        Semaphore pauseMutualBuildSemaphore = new Semaphore(1);
+        Semaphore startBuildingSemaphore =  new Semaphore(1);
+        pauseMutualBuildSemaphore.acquire();
+        startBuildingSemaphore.acquire();
+        AtomicBoolean passed = new AtomicBoolean(false);
+        Thread t1 = new Thread(() -> {
+            // build index and pause halfway, allowing an active session test
+            try (OnlineIndexer indexBuilder = newIndexerBuilder(index)
+                    .setUseSynchronizedSession(useSynchronizedSession)
+                    .setLeaseLengthMillis(TimeUnit.SECONDS.toMillis(20))
+                    .setLimit(4)
+                    .setConfigLoader(old -> pauseAfterOnePass(old, passed, startBuildingSemaphore, pauseMutualBuildSemaphore))
+                    .build()) {
+                indexBuilder.buildIndex();
+            }
+        });
+        t1.start();
+        startBuildingSemaphore.acquire();
+        startBuildingSemaphore.release();
+
+        // Fail to start another indexer
+        try (FDBRecordContext context = openContext()) {
+            try (OnlineIndexer indexBuilder = newIndexerBuilder(index)
+                    .build()) {
+                assertTrue(OnlineIndexer.checkAnyOngoingOnlineIndexBuildsAsync(recordStore, index).join());
+                assertThrows(SynchronizedSessionLockedException.class, indexBuilder::buildIndex);
+            }
+            context.commit();
+        }
+
+        // Successfully convert to a mutual indexer
+        try (OnlineIndexer indexBuilder = newIndexerBuilder(index)
+                .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
+                        .setMutualIndexing()
+                        .allowTakeoverContinue()
+                        .build())
+                .build()) {
+            assertTrue(indexBuilder.checkAnyOngoingOnlineIndexBuildsAsync().join());
+            indexBuilder.buildIndex();
+        }
+        // let the other thread finish indexing
+        pauseMutualBuildSemaphore.release();
+        t1.join();
+        // happy indexes assertion
+        assertReadable(index);
+    }
+
+    @ParameterizedTest
+    @BooleanSource
+    @SuppressWarnings("removal")
+    void testSuccessfullyBuildWithDeprecatedApiFunctions(final boolean useSynchronizedSession) {
+        Index index = new Index("simple$value_2", field("num_value_2").ungrouped(), IndexTypes.SUM);
+        FDBRecordStoreTestBase.RecordMetaDataHook hook = metaDataBuilder -> metaDataBuilder.addIndex("MySimpleRecord", index);
+        populateData(20);
+
+        openSimpleMetaData(hook);
+        disableAll(List.of(index));
+        try (OnlineIndexer indexBuilder = newIndexerBuilder(index)
+                .setLimit(3)
+                .setUseSynchronizedSession(useSynchronizedSession) // ignored value
+                .setConfigLoader(old -> {
+                    assertTrue(old.shouldUseSynchronizedSession());
+                    return old.toBuilder().setUseSynchronizedSession(useSynchronizedSession).build(); // ignored value
+                })
+                .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
+                        .checkIndexingStampFrequencyMilliseconds(useSynchronizedSession ? 5_000 : 0)) // ignored value
+                .build()) {
+            indexBuilder.buildIndex();
+        }
+        assertReadable(index);
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
@@ -40,6 +40,7 @@ import com.apple.foundationdb.tuple.Tuple;
 import com.apple.test.Tags;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -48,7 +49,9 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 
@@ -369,12 +372,23 @@ public abstract class OnlineIndexerTest {
         return boundaries;
     }
 
-    protected void snooze(int millis) {
+    protected static void snooze(int millis) {
         try {
             Thread.sleep(millis);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();  //set the flag back to true
             throw new RuntimeException(e);
         }
+    }
+
+    protected static OnlineIndexOperationConfig pauseAfterOnePass(final OnlineIndexOperationConfig oldConfig, final AtomicBoolean passed, final Semaphore inPauseSemaphore, final Semaphore pauseSemaphore) {
+        if (passed.get()) {
+            inPauseSemaphore.release();
+            Assertions.assertDoesNotThrow(() -> pauseSemaphore.acquire());
+            pauseSemaphore.release();
+        } else {
+            passed.set(true);
+        }
+        return oldConfig;
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexingHeartbeatTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexingHeartbeatTest.java
@@ -1,0 +1,356 @@
+/*
+ * OnlineIndexingHeartbeatTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb;
+
+import com.apple.foundationdb.record.IndexBuildProto;
+import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.metadata.IndexOptions;
+import com.apple.foundationdb.record.metadata.IndexTypes;
+import com.apple.foundationdb.record.metadata.expressions.EmptyKeyExpression;
+import com.apple.foundationdb.record.provider.foundationdb.indexing.IndexingHeartbeat;
+import com.apple.foundationdb.tuple.Tuple;
+import com.apple.test.BooleanSource;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static com.apple.foundationdb.record.metadata.Key.Expressions.field;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verify indexing heartbeat activity (query & clear).
+ */
+class OnlineIndexingHeartbeatTest extends OnlineIndexerTest {
+
+    @Test
+    void testHeartbeatLowLevel() {
+        List<Index> indexes = new ArrayList<>();
+        indexes.add(new Index("indexA", field("num_value_2"), EmptyKeyExpression.EMPTY, IndexTypes.VALUE, IndexOptions.UNIQUE_OPTIONS));
+        indexes.add(new Index("indexB", field("num_value_3_indexed"), IndexTypes.VALUE));
+        FDBRecordStoreTestBase.RecordMetaDataHook hook = allIndexesHook(indexes);
+
+        final int count = 10;
+        IndexingHeartbeat[] heartbeats = new IndexingHeartbeat[count];
+        for (int i = 0; i < count; i++) {
+            heartbeats[i] = new IndexingHeartbeat(UUID.randomUUID(), "Test", 100 + i, true);
+        }
+
+        openSimpleMetaData(hook);
+        try (FDBRecordContext context = openContext()) {
+            for (var heartbeat : heartbeats) {
+                heartbeat.updateHeartbeat(recordStore, indexes.get(0));
+                heartbeat.updateHeartbeat(recordStore, indexes.get(1));
+            }
+            context.commit();
+        }
+
+        // Verify query/clear operation
+        try (OnlineIndexer indexer = newIndexerBuilder(indexes.get(0)).build()) {
+            // Query, unlimited
+            Map<UUID, IndexBuildProto.IndexBuildHeartbeat> queried = indexer.getIndexingHeartbeats(0);
+            assertThat(queried).hasSize(count);
+            assertThat(queried.keySet())
+                    .containsExactlyInAnyOrderElementsOf(Arrays.stream(heartbeats).map(heartbeat -> heartbeat.getIndexerId()).collect(Collectors.toList()));
+
+            // Query, partial
+            queried = indexer.getIndexingHeartbeats(5);
+            assertThat(queried).hasSize(5);
+
+            // clear, partial
+            int countDeleted = indexer.clearIndexingHeartbeats(0, 7);
+            assertThat(countDeleted).isEqualTo(7);
+            queried = indexer.getIndexingHeartbeats(5);
+            assertThat(queried).hasSize(3);
+        }
+
+        // Verify that the previous clear does not affect other index
+        try (OnlineIndexer indexer = newIndexerBuilder(indexes.get(1)).build()) {
+            Map<UUID, IndexBuildProto.IndexBuildHeartbeat> queried = indexer.getIndexingHeartbeats(100);
+            assertThat(queried).hasSize(count);
+            assertThat(queried.keySet())
+                    .containsExactlyInAnyOrderElementsOf(Arrays.stream(heartbeats).map(IndexingHeartbeat::getIndexerId).collect(Collectors.toList()));
+
+            // clear all
+            int countDeleted = indexer.clearIndexingHeartbeats(0, 0);
+            assertThat(countDeleted).isEqualTo(count);
+
+            // verify empty
+            queried = indexer.getIndexingHeartbeats(0);
+            assertThat(queried).isEmpty();
+        }
+    }
+
+    @ParameterizedTest
+    @BooleanSource
+    void testIndexersHeartbeatsClearAfterBuild(boolean mutualIndexing) {
+        // Assert that the heartbeats are cleared after building
+        List<Index> indexes = new ArrayList<>();
+        indexes.add(new Index("indexA", field("num_value_2"), EmptyKeyExpression.EMPTY, IndexTypes.VALUE, IndexOptions.UNIQUE_OPTIONS));
+        indexes.add(new Index("indexC", field("num_value_unique"), EmptyKeyExpression.EMPTY, IndexTypes.VALUE, IndexOptions.UNIQUE_OPTIONS));
+        int numRecords = 77;
+        populateData(numRecords);
+        FDBRecordStoreTestBase.RecordMetaDataHook hook = allIndexesHook(indexes);
+        openSimpleMetaData(hook);
+        disableAll(indexes);
+
+        if (mutualIndexing) {
+            int boundarySize = 23;
+            final List<Tuple> boundariesList = getBoundariesList(numRecords, boundarySize);
+            IntStream.rangeClosed(1, 5).parallel().forEach(i -> {
+                try (OnlineIndexer indexer = newIndexerBuilder(indexes)
+                        .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
+                                .setMutualIndexingBoundaries(boundariesList))
+                        .build()) {
+                    indexer.buildIndex();
+                }
+            });
+        } else {
+            try (OnlineIndexer indexer = newIndexerBuilder(indexes)
+                    .build()) {
+                indexer.buildIndex();
+            }
+        }
+
+        for (Index index : indexes) {
+            try (OnlineIndexer indexer = newIndexerBuilder(index).build()) {
+                assertThat(indexer.getIndexingHeartbeats(0)).isEmpty();
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @BooleanSource
+    void testIndexersHeartbeatsClearAfterCrash(boolean mutualIndexing) {
+        // Assert that the heartbeats are cleared after crash
+        List<Index> indexes = new ArrayList<>();
+        indexes.add(new Index("indexA", field("num_value_2"), EmptyKeyExpression.EMPTY, IndexTypes.VALUE, IndexOptions.UNIQUE_OPTIONS));
+        indexes.add(new Index("indexC", field("num_value_unique"), EmptyKeyExpression.EMPTY, IndexTypes.VALUE, IndexOptions.UNIQUE_OPTIONS));
+        int numRecords = 98;
+        populateData(numRecords);
+        FDBRecordStoreTestBase.RecordMetaDataHook hook = allIndexesHook(indexes);
+        openSimpleMetaData(hook);
+        disableAll(indexes);
+
+        final String testThrowMsg = "Intentionally crash during test";
+        final AtomicLong counter = new AtomicLong(0);
+        if (mutualIndexing) {
+            int boundarySize = 20;
+            final List<Tuple> boundariesList = getBoundariesList(numRecords, boundarySize);
+            IntStream.rangeClosed(1, 9).parallel().forEach(i -> {
+                try (OnlineIndexer indexer = newIndexerBuilder(indexes)
+                        .setLimit(10)
+                        .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
+                                .setMutualIndexingBoundaries(boundariesList))
+                        .setConfigLoader(old -> {
+                            // Unfortunately, we cannot verify that at least one heartbeat exists from this
+                            // block, as it would have been nesting "asyncToSync" functions. But there are other tests
+                            // that verify the "sync lock" functionality.
+                            if (counter.incrementAndGet() > 2) {
+                                throw new RecordCoreException(testThrowMsg);
+                            }
+                            return old;
+                        })
+                        .build()) {
+                    RecordCoreException e = assertThrows(RecordCoreException.class, indexer::buildIndex);
+                    assertTrue(e.getMessage().contains(testThrowMsg));
+                }
+            });
+        } else {
+            try (OnlineIndexer indexer = newIndexerBuilder(indexes)
+                    .setLimit(10)
+                    .setConfigLoader(old -> {
+                        // Unfortunately, we cannot verify that at least one heartbeat exists from this
+                        // block, as it would have been nesting "asyncToSync" functions. But there are other tests
+                        // that verify the "sync lock" functionality.
+                        if (counter.incrementAndGet() > 2) {
+                            throw new RecordCoreException(testThrowMsg);
+                        }
+                        return old;
+                    })
+                    .build()) {
+                RecordCoreException e = assertThrows(RecordCoreException.class, indexer::buildIndex);
+                assertTrue(e.getMessage().contains(testThrowMsg));
+            }
+        }
+
+        for (Index index : indexes) {
+            try (OnlineIndexer indexer = newIndexerBuilder(index).build()) {
+                assertThat(indexer.getIndexingHeartbeats(0)).isEmpty();
+            }
+        }
+    }
+
+    @Test
+    void testMutualIndexersHeartbeatsClearAfterBuild() throws InterruptedException {
+        // Check heartbeats count during mutual indexing
+        List<Index> indexes = new ArrayList<>();
+        indexes.add(new Index("indexA", field("num_value_2"), EmptyKeyExpression.EMPTY, IndexTypes.VALUE, IndexOptions.UNIQUE_OPTIONS));
+        indexes.add(new Index("indexC", field("num_value_unique"), EmptyKeyExpression.EMPTY, IndexTypes.VALUE, IndexOptions.UNIQUE_OPTIONS));
+        int numRecords = 77;
+        populateData(numRecords);
+        int boundarySize = 5;
+        final List<Tuple> boundariesList = getBoundariesList(numRecords, boundarySize);
+        FDBRecordStoreTestBase.RecordMetaDataHook hook = allIndexesHook(indexes);
+        openSimpleMetaData(hook);
+        disableAll(indexes);
+
+        Semaphore pauseSemaphore = new Semaphore(1);
+        Semaphore startSemaphore = new Semaphore(1);
+        final AtomicInteger count = new AtomicInteger(0);
+        pauseSemaphore.acquire();
+        startSemaphore.acquire();
+        AtomicReference<Map<UUID, IndexBuildProto.IndexBuildHeartbeat>> heartbeats = new AtomicReference<>();
+        IntStream.rangeClosed(1, 4).parallel().forEach(i -> {
+            if (i == 4) {
+                Assertions.assertDoesNotThrow(() -> {
+                    startSemaphore.acquire();
+                    Thread.sleep(100);
+                });
+                try (OnlineIndexer indexer = newIndexerBuilder(indexes).build()) {
+                    heartbeats.set(indexer.getIndexingHeartbeats(0));
+                }
+                startSemaphore.release();
+                pauseSemaphore.release();
+            } else {
+                buildIndexWithPause(indexes, boundariesList, count, startSemaphore, pauseSemaphore);
+            }
+        });
+        // While building, heartbeats count should have been 3
+        assertThat(heartbeats.get()).hasSize(3);
+
+        // After building, heartbeats count should be 0
+        try (OnlineIndexer indexer = newIndexerBuilder(indexes).build()) {
+            heartbeats.set(indexer.getIndexingHeartbeats(0));
+        }
+    }
+
+    private void buildIndexWithPause(final List<Index> indexes, final List<Tuple> boundariesList, final AtomicInteger count, final Semaphore startSemaphore, final Semaphore pauseSemaphore) {
+        AtomicInteger counter = new AtomicInteger(0);
+        try (OnlineIndexer indexer = newIndexerBuilder(indexes)
+                .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
+                        .setMutualIndexingBoundaries(boundariesList))
+                .setConfigLoader(old -> {
+                    if (counter.incrementAndGet() > 0) {
+                        if (count.incrementAndGet() == 2) {
+                            startSemaphore.release();
+                        }
+                        Assertions.assertDoesNotThrow(() -> pauseSemaphore.acquire());
+                        pauseSemaphore.release();
+                    }
+                    return old;
+                })
+                .build()) {
+            indexer.buildIndex();
+        }
+    }
+
+    @Test
+    void testHeartbeatsRenewal() throws InterruptedException {
+        // make sure that the heartbeats behave as expected during indexing:
+        // single item
+        // same indexerId, genesis time
+        // monotonically increasing heartbeats
+        List<Index> indexes = new ArrayList<>();
+        indexes.add(new Index("indexA", field("num_value_2"), EmptyKeyExpression.EMPTY, IndexTypes.VALUE, IndexOptions.UNIQUE_OPTIONS));
+        int numRecords = 74;
+        populateData(numRecords);
+        FDBRecordStoreTestBase.RecordMetaDataHook hook = allIndexesHook(indexes);
+        openSimpleMetaData(hook);
+        disableAll(indexes);
+        final List<Map<UUID, IndexBuildProto.IndexBuildHeartbeat>> heartbeatsQueries = new ArrayList<>();
+
+        Semaphore indexerGo = new Semaphore(1);
+        Semaphore collectorGo = new Semaphore(1);
+        AtomicBoolean indexerDone = new AtomicBoolean(false);
+        collectorGo.acquire();
+        Thread indexerThread = buildIndexesThread(indexes, collectorGo, indexerGo, indexerDone);
+        Thread collectorThread = collectHeartbeatsThread(indexerDone, collectorGo, indexes, heartbeatsQueries, indexerGo);
+        indexerThread.start();
+        collectorThread.start();
+        collectorThread.join();
+        indexerThread.join();
+
+        assertThat(heartbeatsQueries).hasSizeGreaterThan(5);
+        assertThat(heartbeatsQueries.get(0)).hasSize(1);
+        final Map.Entry<UUID, IndexBuildProto.IndexBuildHeartbeat> first = heartbeatsQueries.get(0).entrySet().iterator().next();
+        Map.Entry<UUID, IndexBuildProto.IndexBuildHeartbeat> previous = first;
+        for (int i = 1; i < heartbeatsQueries.size() - 1; i++) {
+            assertThat(heartbeatsQueries.get(i)).hasSize(1);
+            final Map.Entry<UUID, IndexBuildProto.IndexBuildHeartbeat> item = heartbeatsQueries.get(i).entrySet().iterator().next();
+            assertThat(item.getKey()).isEqualTo(first.getKey());
+            assertThat(item.getValue().getCreateTimeMilliseconds()).isEqualTo(first.getValue().getCreateTimeMilliseconds());
+            assertThat(item.getValue().getInfo()).isEqualTo(first.getValue().getInfo());
+            assertThat(item.getValue().getHeartbeatTimeMilliseconds())
+                    .isGreaterThan(previous.getValue().getHeartbeatTimeMilliseconds());
+            previous = item;
+        }
+    }
+
+    @Nonnull
+    private Thread collectHeartbeatsThread(final AtomicBoolean indexerDone, final Semaphore colectorGo, final List<Index> indexes, final List<Map<UUID, IndexBuildProto.IndexBuildHeartbeat>> heartbeatsQueries, final Semaphore indexerGo) {
+        return new Thread(() -> {
+            while (!indexerDone.get()) {
+                Assertions.assertDoesNotThrow(() -> colectorGo.acquire());
+                try (FDBRecordContext context = openContext()) {
+                    final Map<UUID, IndexBuildProto.IndexBuildHeartbeat> heartbeats = IndexingHeartbeat.getIndexingHeartbeats(recordStore, indexes.get(0), 0).join();
+                    heartbeatsQueries.add(heartbeats);
+                    context.commit();
+                }
+                indexerGo.release();
+            }
+        });
+    }
+
+    @Nonnull
+    private Thread buildIndexesThread(final List<Index> indexes, final Semaphore colectorGo, final Semaphore indexerGo, final AtomicBoolean indexerDone) {
+        return new Thread(() -> {
+            try (OnlineIndexer indexer = newIndexerBuilder(indexes)
+                    .setLimit(10)
+                    .setConfigLoader(old -> {
+                        colectorGo.release();
+                        Assertions.assertDoesNotThrow(() -> indexerGo.acquire());
+                        return old;
+                    })
+                    .build()) {
+                indexer.buildIndex();
+            }
+            colectorGo.release();
+            indexerDone.set(true);
+        });
+    }
+}

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexing/IndexingHeartbeatLowLevelTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexing/IndexingHeartbeatLowLevelTest.java
@@ -1,0 +1,506 @@
+/*
+ * IndexingHeartbeatLowLevelTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb.indexing;
+
+import com.apple.foundationdb.record.IndexBuildProto;
+import com.apple.foundationdb.record.RecordMetaData;
+import com.apple.foundationdb.record.RecordMetaDataBuilder;
+import com.apple.foundationdb.record.TestRecords1Proto;
+import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.metadata.IndexOptions;
+import com.apple.foundationdb.record.metadata.IndexTypes;
+import com.apple.foundationdb.record.metadata.expressions.EmptyKeyExpression;
+import com.apple.foundationdb.record.metadata.expressions.GroupingKeyExpression;
+import com.apple.foundationdb.record.metadata.expressions.VersionKeyExpression;
+import com.apple.foundationdb.record.provider.foundationdb.FDBDatabase;
+import com.apple.foundationdb.record.provider.foundationdb.FDBDatabaseFactory;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStore;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreTestBase;
+import com.apple.foundationdb.record.provider.foundationdb.IndexingSubspaces;
+import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpacePath;
+import com.apple.foundationdb.record.test.FDBDatabaseExtension;
+import com.apple.foundationdb.record.test.TestKeySpace;
+import com.apple.foundationdb.record.test.TestKeySpacePathManagerExtension;
+import com.apple.foundationdb.synchronizedsession.SynchronizedSessionLockedException;
+import com.google.protobuf.Descriptors;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static com.apple.foundationdb.record.metadata.Key.Expressions.concat;
+import static com.apple.foundationdb.record.metadata.Key.Expressions.field;
+
+class IndexingHeartbeatLowLevelTest {
+    @RegisterExtension
+    final FDBDatabaseExtension dbExtension = new FDBDatabaseExtension();
+    @RegisterExtension
+    final TestKeySpacePathManagerExtension pathManager = new TestKeySpacePathManagerExtension(dbExtension);
+    FDBDatabase fdb;
+    KeySpacePath path;
+    FDBRecordStore recordStore;
+    RecordMetaData metaData;
+
+    @BeforeEach
+    void setUp() {
+        final FDBDatabaseFactory factory = dbExtension.getDatabaseFactory();
+        factory.setInitialDelayMillis(2L);
+        factory.setMaxDelayMillis(4L);
+        factory.setMaxAttempts(100);
+
+        fdb = dbExtension.getDatabase();
+        fdb.setAsyncToSyncTimeout(5, TimeUnit.MINUTES);
+        path = pathManager.createPath(TestKeySpace.RECORD_STORE);
+    }
+
+    FDBRecordContext openContext() {
+        FDBRecordContext context = fdb.openContext();
+        FDBRecordStore.Builder builder = createStoreBuilder()
+                .setContext(context);
+        recordStore = builder.createOrOpen(FDBRecordStoreBase.StoreExistenceCheck.NONE);
+        metaData = recordStore.getRecordMetaData();
+        return context;
+    }
+
+    @Nonnull
+    private FDBRecordStore.Builder createStoreBuilder() {
+        return FDBRecordStore.newBuilder()
+                .setMetaDataProvider(metaData)
+                .setKeySpacePath(path);
+    }
+
+    void openMetaData(@Nonnull Descriptors.FileDescriptor descriptor, @Nonnull FDBRecordStoreTestBase.RecordMetaDataHook hook) {
+        RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder().setRecords(descriptor);
+        hook.apply(metaDataBuilder);
+        metaData = metaDataBuilder.getRecordMetaData();
+    }
+
+    void openSimpleMetaData(@Nonnull FDBRecordStoreTestBase.RecordMetaDataHook hook) {
+        openMetaData(TestRecords1Proto.getDescriptor(), hook);
+    }
+
+    protected static FDBRecordStoreTestBase.RecordMetaDataHook allIndexesHook(List<Index> indexes) {
+        return metaDataBuilder -> {
+            for (Index index: indexes) {
+                metaDataBuilder.addIndex("MySimpleRecord", index);
+            }
+        } ;
+    }
+
+    @Test
+    void testHeartbeatQuery() {
+        List<Index> indexes = new ArrayList<>();
+        indexes.add(new Index("indexA", field("num_value_2"), EmptyKeyExpression.EMPTY, IndexTypes.VALUE, IndexOptions.UNIQUE_OPTIONS));
+        indexes.add(new Index("indexD", new GroupingKeyExpression(EmptyKeyExpression.EMPTY, 0), IndexTypes.COUNT));
+        FDBRecordStoreTestBase.RecordMetaDataHook hook = allIndexesHook(indexes);
+
+        final int count = 23;
+        IndexingHeartbeat[] heartbeats = new IndexingHeartbeat[count];
+        for (int i = 0; i < count; i++) {
+            heartbeats[i] = new IndexingHeartbeat(UUID.randomUUID(), "heartbeat" + i, 100 + i, false);
+        }
+
+        // populate heartbeats
+        openSimpleMetaData(hook);
+        try (FDBRecordContext context = openContext()) {
+            for (var heartbeat : heartbeats) {
+                heartbeat.updateHeartbeat(recordStore, indexes.get(0));
+                heartbeat.updateHeartbeat(recordStore, indexes.get(1));
+            }
+            context.commit();
+        }
+
+        // Verify query operation
+        for (Index index: indexes) {
+            try (FDBRecordContext context = openContext()) {
+                // Query, unlimited
+                Map<UUID, IndexBuildProto.IndexBuildHeartbeat> queried =
+                        IndexingHeartbeat.getIndexingHeartbeats(recordStore, index, 0).join();
+                Assertions.assertThat(queried).hasSize(count);
+                Assertions.assertThat(queried.keySet())
+                        .containsExactlyInAnyOrderElementsOf(Arrays.stream(heartbeats).map(heartbeat -> heartbeat.indexerId).collect(Collectors.toList()));
+                Assertions.assertThat(queried.values().stream().map(IndexBuildProto.IndexBuildHeartbeat::getInfo))
+                        .containsExactlyInAnyOrderElementsOf(Arrays.stream(heartbeats).map(heartbeat -> heartbeat.info).collect(Collectors.toList()));
+                Assertions.assertThat(queried.values().stream().map(IndexBuildProto.IndexBuildHeartbeat::getCreateTimeMilliseconds))
+                        .containsExactlyInAnyOrderElementsOf(Arrays.stream(heartbeats).map(heartbeat -> heartbeat.createTimeMilliseconds).collect(Collectors.toList()));
+
+                // Query, partial
+                queried =
+                        IndexingHeartbeat.getIndexingHeartbeats(recordStore, index, 5).join();
+                Assertions.assertThat(queried).hasSize(5);
+                context.commit();
+            }
+        }
+    }
+
+    @Test
+    void testHeartbeatClearing() {
+        List<Index> indexes = new ArrayList<>();
+        indexes.add(new Index("indexA", field("num_value_2"), EmptyKeyExpression.EMPTY, IndexTypes.VALUE, IndexOptions.UNIQUE_OPTIONS));
+        indexes.add(new Index("indexD", new GroupingKeyExpression(EmptyKeyExpression.EMPTY, 0), IndexTypes.COUNT));
+        FDBRecordStoreTestBase.RecordMetaDataHook hook = allIndexesHook(indexes);
+
+        final int count = 10;
+        IndexingHeartbeat[] heartbeats = new IndexingHeartbeat[count];
+        for (int i = 0; i < count; i++) {
+            heartbeats[i] = new IndexingHeartbeat(UUID.randomUUID(), "test", 100 + i, false);
+        }
+
+        // populate heartbeats
+        openSimpleMetaData(hook);
+        try (FDBRecordContext context = openContext()) {
+            for (var heartbeat : heartbeats) {
+                heartbeat.updateHeartbeat(recordStore, indexes.get(0));
+                heartbeat.updateHeartbeat(recordStore, indexes.get(1));
+            }
+            context.commit();
+        }
+
+        // Verify clear operation
+        Index index = indexes.get(0);
+        try (FDBRecordContext context = openContext()) {
+            Map<UUID, IndexBuildProto.IndexBuildHeartbeat> queried =
+                    IndexingHeartbeat.getIndexingHeartbeats(recordStore, index, 0).join();
+            Assertions.assertThat(queried).hasSize(count);
+
+            // clear, partial
+            int countDeleted =
+                    IndexingHeartbeat.clearIndexingHeartbeats(recordStore, index, 0, 7).join();
+            Assertions.assertThat(countDeleted).isEqualTo(7);
+            queried =
+                    IndexingHeartbeat.getIndexingHeartbeats(recordStore, index, 5).join();
+            Assertions.assertThat(queried).hasSize(3);
+            context.commit();
+        }
+
+        // Verify that the previous clear does not affect other index
+        index = indexes.get(1);
+        try (FDBRecordContext context = openContext()) {
+            Map<UUID, IndexBuildProto.IndexBuildHeartbeat> queried =
+                    IndexingHeartbeat.getIndexingHeartbeats(recordStore, index, 100).join();
+            Assertions.assertThat(queried).hasSize(count);
+
+            // clear all
+            int countDeleted =
+                    IndexingHeartbeat.clearIndexingHeartbeats(recordStore, index, 0, 0).join();
+            Assertions.assertThat(countDeleted).isEqualTo(count);
+
+            // verify empty
+            queried =
+                    IndexingHeartbeat.getIndexingHeartbeats(recordStore, index, 0).join();
+            Assertions.assertThat(queried).isEmpty();
+            context.commit();
+        }
+    }
+
+    @Test
+    void testCheckAndUpdateNonMutual() {
+        Index index = new Index("indexD", new GroupingKeyExpression(EmptyKeyExpression.EMPTY, 0), IndexTypes.COUNT);
+        FDBRecordStoreTestBase.RecordMetaDataHook hook = allIndexesHook(List.of(index));
+        IndexingHeartbeat heartbeat1 = new IndexingHeartbeat(UUID.randomUUID(), "Test", TimeUnit.SECONDS.toMillis(30), false);
+
+        // Successfully update heartbeat
+        openSimpleMetaData(hook);
+        try (FDBRecordContext context = openContext()) {
+            heartbeat1.checkAndUpdateHeartbeat(recordStore, index).join();
+            context.commit();
+        }
+
+        // Successfully update heartbeat
+        try (FDBRecordContext context = openContext()) {
+            final Map<UUID, IndexBuildProto.IndexBuildHeartbeat> existingHeartbeats = IndexingHeartbeat.getIndexingHeartbeats(recordStore, index, 0).join();
+            Assertions.assertThat(existingHeartbeats).hasSize(1);
+            heartbeat1.checkAndUpdateHeartbeat(recordStore, index).join();
+            context.commit();
+        }
+
+        IndexingHeartbeat heartbeat2 = new IndexingHeartbeat(UUID.randomUUID(), "Test", TimeUnit.SECONDS.toMillis(30), false);
+        Assertions.assertThat(heartbeat1.indexerId).isNotEqualTo(heartbeat2.indexerId);
+        // Fail to create another non-mutual heartbeat
+        try (FDBRecordContext context = openContext()) {
+            final Map<UUID, IndexBuildProto.IndexBuildHeartbeat> existingHeartbeats = IndexingHeartbeat.getIndexingHeartbeats(recordStore, index, 0).join();
+            Assertions.assertThat(existingHeartbeats).hasSize(1);
+            Assertions.assertThatThrownBy(() -> heartbeat2.checkAndUpdateHeartbeat(recordStore, index).join())
+                    .isInstanceOf(CompletionException.class)
+                    .hasCauseInstanceOf(SynchronizedSessionLockedException.class);
+            context.commit();
+        }
+
+        // Successfully clear heartbeat1
+        try (FDBRecordContext context = openContext()) {
+            final Map<UUID, IndexBuildProto.IndexBuildHeartbeat> existingHeartbeats = IndexingHeartbeat.getIndexingHeartbeats(recordStore, index, 0).join();
+            Assertions.assertThat(existingHeartbeats).hasSize(1);
+            heartbeat1.clearHeartbeat(recordStore, index);
+            context.commit();
+        }
+
+        // Successfully update heartbeat2
+        try (FDBRecordContext context = openContext()) {
+            heartbeat2.checkAndUpdateHeartbeat(recordStore, index).join();
+            context.commit();
+        }
+
+        // Successfully clear heartbeat2
+        try (FDBRecordContext context = openContext()) {
+            heartbeat2.clearHeartbeat(recordStore, index);
+            final Map<UUID, IndexBuildProto.IndexBuildHeartbeat> existingHeartbeats = IndexingHeartbeat.getIndexingHeartbeats(recordStore, index, 0).join();
+            Assertions.assertThat(existingHeartbeats).isEmpty();
+            context.commit();
+        }
+    }
+
+    @Test
+    void testCheckAndUpdateMutual() {
+        Index index = new Index("indexD", new GroupingKeyExpression(EmptyKeyExpression.EMPTY, 0), IndexTypes.COUNT);
+        FDBRecordStoreTestBase.RecordMetaDataHook hook = allIndexesHook(List.of(index));
+
+        final int count = 10;
+        IndexingHeartbeat[] heartbeats = new IndexingHeartbeat[count];
+        for (int i = 0; i < count; i++) {
+            heartbeats[i] = new IndexingHeartbeat(UUID.randomUUID(), "Mutual", TimeUnit.SECONDS.toMillis(100), true);
+        }
+
+        // Successfully check//update all heartbeats
+        openSimpleMetaData(hook);
+        try (FDBRecordContext context = openContext()) {
+            for (int i = 0; i < 3; i++) {
+                for (IndexingHeartbeat heartbeat: heartbeats) {
+                    heartbeat.checkAndUpdateHeartbeat(recordStore, index).join();
+                }
+            }
+            context.commit();
+        }
+
+        // Check count, clear all
+        try (FDBRecordContext context = openContext()) {
+            final Map<UUID, IndexBuildProto.IndexBuildHeartbeat> existingHeartbeats = IndexingHeartbeat.getIndexingHeartbeats(recordStore, index, 0).join();
+            Assertions.assertThat(existingHeartbeats).hasSize(count);
+
+            for (int i = 0; i < 3; i++) {
+                for (IndexingHeartbeat heartbeat: heartbeats) {
+                    heartbeat.clearHeartbeat(recordStore, index);
+                }
+            }
+            context.commit();
+        }
+
+        // verify cleared
+        try (FDBRecordContext context = openContext()) {
+            final Map<UUID, IndexBuildProto.IndexBuildHeartbeat> existingHeartbeats = IndexingHeartbeat.getIndexingHeartbeats(recordStore, index, 0).join();
+            Assertions.assertThat(existingHeartbeats).isEmpty();
+            context.commit();
+        }
+    }
+
+    @Test
+    void testSetHeartbeatAfterOtherHeartbeatExpiration() throws InterruptedException {
+        Index index = new Index("versionIndex1", concat(field("num_value_2"), VersionKeyExpression.VERSION), IndexTypes.VERSION);
+        FDBRecordStoreTestBase.RecordMetaDataHook hook = allIndexesHook(List.of(index));
+        IndexingHeartbeat heartbeat1 = new IndexingHeartbeat(UUID.randomUUID(), "Test", TimeUnit.SECONDS.toMillis(10), false);
+
+        // Successfully update heartbeat1
+        openSimpleMetaData(hook);
+        try (FDBRecordContext context = openContext()) {
+            heartbeat1.checkAndUpdateHeartbeat(recordStore, index).join();
+            context.commit();
+        }
+
+        // Delay 20, set heartbeat2's lease to 4
+        Thread.sleep(20);
+        IndexingHeartbeat heartbeat2 = new IndexingHeartbeat(UUID.randomUUID(), "Test", 4, false);
+        Assertions.assertThat(heartbeat1.indexerId).isNotEqualTo(heartbeat2.indexerId);
+
+        // heartbeat2 successfully takes over
+        try (FDBRecordContext context = openContext()) {
+            final Map<UUID, IndexBuildProto.IndexBuildHeartbeat> existingHeartbeats = IndexingHeartbeat.getIndexingHeartbeats(recordStore, index, 0).join();
+            Assertions.assertThat(existingHeartbeats).hasSize(1);
+            heartbeat2.checkAndUpdateHeartbeat(recordStore, index).join();
+            context.commit();
+        }
+    }
+
+    @Test
+    void testFailSetHeartbeatBeforeOtherHeartbeatExpiration() throws InterruptedException {
+        Index index = new Index("indexD", new GroupingKeyExpression(EmptyKeyExpression.EMPTY, 0), IndexTypes.COUNT);
+        FDBRecordStoreTestBase.RecordMetaDataHook hook = allIndexesHook(List.of(index));
+
+        final IndexingHeartbeat heartbeatA = new IndexingHeartbeat(UUID.randomUUID(), "a", 500, false);
+        final IndexingHeartbeat heartbeatB = new IndexingHeartbeat(UUID.randomUUID(), "b", 5, false);
+
+        // Set heartbeat A
+        openSimpleMetaData(hook);
+        try (FDBRecordContext context = openContext()) {
+            heartbeatA.checkAndUpdateHeartbeat(recordStore, index).join();
+            context.commit();
+        }
+
+        Thread.sleep(100);
+        // heartbeatB would have respected heartbeatA's lock for 5 milliseconds only. Now successfully set itself.
+        try (FDBRecordContext context = openContext()) {
+            heartbeatB.checkAndUpdateHeartbeat(recordStore, index).join();
+            context.commit();
+        }
+
+        // Expect heartbeatA to fail check/update
+        // Note: if become flakey, increase the least time of heartbeatA
+        try (FDBRecordContext context = openContext()) {
+            Assertions.assertThatThrownBy(() -> heartbeatA.checkAndUpdateHeartbeat(recordStore, index).join())
+                    .isInstanceOf(CompletionException.class)
+                    .hasCauseInstanceOf(SynchronizedSessionLockedException.class);
+            context.commit();
+        }
+    }
+
+    @Test
+    void testHeartbeatClearOldHeartbeats() throws InterruptedException {
+        Index index = new Index("versionIndex1", concat(field("num_value_2"), VersionKeyExpression.VERSION), IndexTypes.VERSION);
+        FDBRecordStoreTestBase.RecordMetaDataHook hook = allIndexesHook(List.of(index));
+        IndexingHeartbeat heartbeat1 = new IndexingHeartbeat(UUID.randomUUID(), "Test", TimeUnit.SECONDS.toMillis(10), true);
+        IndexingHeartbeat heartbeat2 = new IndexingHeartbeat(UUID.randomUUID(), "Test", TimeUnit.SECONDS.toMillis(10), true);
+        IndexingHeartbeat heartbeat3 = new IndexingHeartbeat(UUID.randomUUID(), "Test", TimeUnit.SECONDS.toMillis(10), true);
+
+        // Successfully create heartbeat1
+        openSimpleMetaData(hook);
+        try (FDBRecordContext context = openContext()) {
+            heartbeat1.checkAndUpdateHeartbeat(recordStore, index).join();
+            heartbeat2.checkAndUpdateHeartbeat(recordStore, index).join();
+            context.commit();
+        }
+
+        // Delay 20, clear anything older than 5 milliseconds
+        Thread.sleep(20);
+        try (FDBRecordContext context = openContext()) {
+            final Map<UUID, IndexBuildProto.IndexBuildHeartbeat> existingHeartbeats = IndexingHeartbeat.getIndexingHeartbeats(recordStore, index, 0).join();
+            Assertions.assertThat(existingHeartbeats).hasSize(2);
+            final Integer numDeleted = IndexingHeartbeat.clearIndexingHeartbeats(recordStore, index, 5, 0).join();
+            Assertions.assertThat(numDeleted).isEqualTo(2);
+            context.commit();
+        }
+
+        // Now make sure that clear indexing heartbeats does not remove when it should not
+        try (FDBRecordContext context = openContext()) {
+            heartbeat3.checkAndUpdateHeartbeat(recordStore, index).join();
+            final Map<UUID, IndexBuildProto.IndexBuildHeartbeat> existingHeartbeats = IndexingHeartbeat.getIndexingHeartbeats(recordStore, index, 0).join();
+            Assertions.assertThat(existingHeartbeats).hasSize(1);
+            final Integer numDeleted = IndexingHeartbeat.clearIndexingHeartbeats(recordStore, index, TimeUnit.SECONDS.toMillis(10), 0).join();
+            Assertions.assertThat(numDeleted).isZero();
+            context.commit();
+        }
+
+    }
+
+    @Test
+    void testMixedNonMutualThenMutualHeartbeats() {
+        // This scenario should never happen because of the indexing type-stamp protection. Testing it anyway...
+        Index index = new Index("versionIndex1", concat(field("num_value_2"), VersionKeyExpression.VERSION), IndexTypes.VERSION);
+        FDBRecordStoreTestBase.RecordMetaDataHook hook = allIndexesHook(List.of(index));
+        IndexingHeartbeat heartbeatMutual = new IndexingHeartbeat(UUID.randomUUID(), "Test", TimeUnit.SECONDS.toMillis(10), true);
+        IndexingHeartbeat heartbeatExclusive = new IndexingHeartbeat(UUID.randomUUID(), "Test", TimeUnit.SECONDS.toMillis(10), false);
+
+        // lock exclusive, then successfully lock mutual.
+        openSimpleMetaData(hook);
+        try (FDBRecordContext context = openContext()) {
+            heartbeatExclusive.checkAndUpdateHeartbeat(recordStore, index).join();
+            context.commit();
+        }
+
+        try (FDBRecordContext context = openContext()) {
+            // Mutual: Successfully updates
+            heartbeatMutual.checkAndUpdateHeartbeat(recordStore, index).join();
+            context.commit();
+        }
+    }
+
+    @Test
+    void testMixedMutualThenNonMutualHeartbeats() {
+        // This scenario should never happen because of the indexing typestamp protection. Testing it anyway...
+        Index index = new Index("versionIndex1", concat(field("num_value_2"), VersionKeyExpression.VERSION), IndexTypes.VERSION);
+        FDBRecordStoreTestBase.RecordMetaDataHook hook = allIndexesHook(List.of(index));
+        IndexingHeartbeat heartbeatMutual = new IndexingHeartbeat(UUID.randomUUID(), "Test", TimeUnit.SECONDS.toMillis(10), true);
+        IndexingHeartbeat heartbeatExclusive = new IndexingHeartbeat(UUID.randomUUID(), "Test", TimeUnit.SECONDS.toMillis(10), false);
+
+        // lock mutual, then fail to lock exclusive
+        openSimpleMetaData(hook);
+        try (FDBRecordContext context = openContext()) {
+            final Map<UUID, IndexBuildProto.IndexBuildHeartbeat> heartbeats = IndexingHeartbeat.getIndexingHeartbeats(recordStore, index, 0).join();
+            Assertions.assertThat(heartbeats).isEmpty();
+            heartbeatMutual.checkAndUpdateHeartbeat(recordStore, index).join();
+            context.commit();
+        }
+
+        try (FDBRecordContext context = openContext()) {
+            Assertions.assertThatThrownBy(() -> heartbeatExclusive.checkAndUpdateHeartbeat(recordStore, index).join())
+                    .isInstanceOf(CompletionException.class)
+                    .hasCauseInstanceOf(SynchronizedSessionLockedException.class);
+            // and clear
+            heartbeatMutual.clearHeartbeat(recordStore, index);
+            context.commit();
+        }
+    }
+
+    @Test
+    void testUnparseableHeartbeat() {
+        Index index = new Index("versionIndex1", concat(field("num_value_2"), VersionKeyExpression.VERSION), IndexTypes.VERSION);
+        FDBRecordStoreTestBase.RecordMetaDataHook hook = allIndexesHook(List.of(index));
+
+        // write unparseable data where a heartbeat should exist
+        openSimpleMetaData(hook);
+        try (FDBRecordContext context = openContext()) {
+            byte[] key = IndexingSubspaces.indexHeartbeatSubspaceBytes(recordStore, index, UUID.randomUUID());
+            byte[] value = "meaningless byte value".getBytes();
+            recordStore.ensureContextActive().set(key, value);
+            context.commit();
+        }
+
+        IndexingHeartbeat heartbeat = new IndexingHeartbeat(UUID.randomUUID(), "Test", TimeUnit.SECONDS.toMillis(30), false);
+        try (FDBRecordContext context = openContext()) {
+            final Map<UUID, IndexBuildProto.IndexBuildHeartbeat> existingHeartbeats = IndexingHeartbeat.getIndexingHeartbeats(recordStore, index, 0).join();
+            Assertions.assertThat(existingHeartbeats).hasSize(1);
+            heartbeat.checkAndUpdateHeartbeat(recordStore, index).join();
+            context.commit();
+        }
+
+        // Make sure that the unparsable heartbeat can be cleared
+        try (FDBRecordContext context = openContext()) {
+            heartbeat.checkAndUpdateHeartbeat(recordStore, index).join();
+            Map<UUID, IndexBuildProto.IndexBuildHeartbeat> existingHeartbeats = IndexingHeartbeat.getIndexingHeartbeats(recordStore, index, 0).join();
+            Assertions.assertThat(existingHeartbeats).hasSize(2);
+            final Integer numDeleted = IndexingHeartbeat.clearIndexingHeartbeats(recordStore, index, TimeUnit.SECONDS.toMillis(10), 0).join();
+            Assertions.assertThat(numDeleted).isEqualTo(1);
+            existingHeartbeats = IndexingHeartbeat.getIndexingHeartbeats(recordStore, index, 0).join();
+            Assertions.assertThat(existingHeartbeats).hasSize(1);
+            Assertions.assertThat(existingHeartbeats.get(heartbeat.indexerId)).isNotNull();
+            context.commit();
+        }
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@
 #
 
 rootProject.name=fdb-record-layer
-version=4.5.14.0
+version=4.6.0.0
 releaseBuild=false
 
 # this should be false for release branches (i.e. if there is no -SNAPSHOT on the above version)


### PR DESCRIPTION
   Each indexing session, for each index, will create a key-value heartbeat of the format:
```        [prefix, xid] -> [indexing-type, genesis time, heartbeat time] ```
   Indexing session that are expected to be exclusive will throw an exception if another, active, session exists.

   Motivation:
        1. Represent the heartbeat in every index during multi target indexing (currently - only the master index has a sync lock)
        2. Keep a heartbeat during mutual indexing, which can allow better automatic decision making
        3. Decide about exclusiveness according to the indexing method (currently - user input)

With this change, the equivalent of a sync lock will be determined by the indexing type and cannot be set by the users. The index configuration function `setUseSynchronizedSession` will have no effect on the indexing process. 

During graduate code upgrade on multiple servers, there may be a situation where one server is indexing with a synchronized session lock, while another server builds the same index with an exclusive heartbeat "lock". If that happens:
a) There will be no more than two concurrent active sessions
b) The indexing sessions will conflict each other until one of the indexers will give up. While this may be not optimal, the generated index will be valid.

Resolve #3529