### PR TITLE
Handle metrics for the same query but with different setups

### DIFF
--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlExecutionContext.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlExecutionContext.java
@@ -435,7 +435,7 @@ public final class YamlExecutionContext {
             infoMap.put("insert_time_ms", TimeUnit.NANOSECONDS.toMillis(countersAndTimers.getInsertTimeNs()));
             infoMap.put("insert_new_count", countersAndTimers.getInsertNewCount());
             infoMap.put("insert_reused_count", countersAndTimers.getInsertReusedCount());
-            mmap.put(identifier.getBlockName(), infoMap); // TODO fixme
+            mmap.put(identifier.getBlockName(), infoMap);
         }
 
         try (var fos = new FileOutputStream(fileName)) {

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryExecutor.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryExecutor.java
@@ -169,7 +169,7 @@ public class QueryExecutor {
                 continuationAfter = executeWithSetup(connection, singleConnection -> {
                     try (var s = singleConnection.createStatement()) {
                         final var queryResult = executeStatementAndCheckCacheIfNeeded(s, false, singleConnection, currentQuery, checkCache, maxRows);
-                        config.checkResult(currentQuery, queryResult, this.toString(), singleConnection);
+                        config.checkResult(currentQuery, queryResult, this.toString(), singleConnection, setup);
                         if (queryResult instanceof RelationalResultSet) {
                             return ((RelationalResultSet) queryResult).getContinuation();
                         }
@@ -182,7 +182,7 @@ public class QueryExecutor {
                     try (var s = singleConnection.prepareStatement(currentQuery)) {
                         setParametersInPreparedStatement(s);
                         final var queryResult = executeStatementAndCheckCacheIfNeeded(s, true, singleConnection, currentQuery, checkCache, maxRows);
-                        config.checkResult(currentQuery, queryResult, this.toString(), singleConnection);
+                        config.checkResult(currentQuery, queryResult, this.toString(), singleConnection, setup);
                         if (queryResult instanceof RelationalResultSet) {
                             return ((RelationalResultSet)queryResult).getContinuation();
                         }
@@ -224,7 +224,7 @@ public class QueryExecutor {
                 // We bypass checking for cache since the "EXECUTE CONTINUATION ..." statement does not need to be checked
                 // for caching.
                 final var queryResult = executeStatement(s, true, currentQuery);
-                config.checkResult(executeContinuationQuery, queryResult, this.toString(), connection);
+                config.checkResult(executeContinuationQuery, queryResult, this.toString(), connection, setup);
                 if (queryResult instanceof RelationalResultSet) {
                     continuationAfter = ((RelationalResultSet) queryResult).getContinuation();
                 }

--- a/yaml-tests/src/main/proto/planner_metrics.proto
+++ b/yaml-tests/src/main/proto/planner_metrics.proto
@@ -32,6 +32,7 @@ message Entry {
 message Identifier {
   optional string blockName = 1;
   optional string query = 2;
+  repeated string setups = 3;
 }
 
 message Info {

--- a/yaml-tests/src/test/java/TransactionSetupTest.java
+++ b/yaml-tests/src/test/java/TransactionSetupTest.java
@@ -24,6 +24,7 @@ import com.apple.foundationdb.relational.yamltests.YamlConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
 import com.apple.foundationdb.relational.yamltests.YamlRunner;
 import com.apple.foundationdb.relational.yamltests.configs.EmbeddedConfig;
+import com.apple.foundationdb.relational.yamltests.configs.YamlTestConfig;
 import com.apple.foundationdb.relational.yamltests.server.SemanticVersion;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -45,7 +46,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class TransactionSetupTest {
 
     private static final SemanticVersion VERSION = SemanticVersion.parse("4.4.8.0");
-    private static final EmbeddedConfig config = new EmbeddedConfig(null);
+    private static final YamlTestConfig config = new EmbeddedConfig(null);
+    private static final boolean CORRECT_METRICS = false;
 
     @BeforeAll
     static void beforeAll() throws Exception {
@@ -58,7 +60,13 @@ public class TransactionSetupTest {
     }
 
     private void doRun(String fileName) throws Exception {
-        new YamlRunner(fileName, createConnectionFactory(), YamlExecutionContext.ContextOptions.EMPTY_OPTIONS).run();
+        final YamlExecutionContext.ContextOptions options;
+        if (CORRECT_METRICS) {
+            options = YamlExecutionContext.ContextOptions.of(YamlExecutionContext.OPTION_CORRECT_METRICS, true);
+        } else {
+            options = YamlExecutionContext.ContextOptions.EMPTY_OPTIONS;
+        }
+        new YamlRunner(fileName, createConnectionFactory(), options).run();
     }
 
     YamlConnectionFactory createConnectionFactory() {
@@ -100,6 +108,7 @@ public class TransactionSetupTest {
 
     static Stream<String> shouldPass() {
         return Stream.of(
+                "double-query-metrics",
                 "double-reference",
                 "double-setup",
                 "duplicate-setup-reference-name",

--- a/yaml-tests/src/test/resources/transaction-setup/shouldPass/double-query-metrics.metrics.binpb
+++ b/yaml-tests/src/test/resources/transaction-setup/shouldPass/double-query-metrics.metrics.binpb
@@ -1,0 +1,25 @@
+Õ
+{
+transactions-testsEXPLAIN select * from t2Kcreate temporary function t2() on commit drop function AS SELECT * FROM t1;Õ
+¦ž«Æ-* ãÏº!(0»é¡8@	SCAN(<,>)«digraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=polyline;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Scan</td></tr><tr><td align="left">range: &lt;-âˆž, âˆž&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, )" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Primary Storage</td></tr><tr><td align="left">record types: [T1]</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, )" ];
+  2 -> 1 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}ÿ
+‰
+transactions-testsEXPLAIN select * from t2Ycreate temporary function t2() on commit drop function AS SELECT * FROM t1 where id < 50;ð
+
+½’Ü§:. Éµý/(0†¢8@9SCAN(<,>) | FILTER _.ID LESS_THAN promote(@cT218 AS LONG)–
+digraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=polyline;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE q14.ID LESS_THAN promote(@cT218 AS LONG)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, )" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Scan</td></tr><tr><td align="left">range: &lt;-âˆž, âˆž&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, )" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Primary Storage</td></tr><tr><td align="left">record types: [T1]</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, )" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q14> label="q14" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}

--- a/yaml-tests/src/test/resources/transaction-setup/shouldPass/double-query-metrics.metrics.yaml
+++ b/yaml-tests/src/test/resources/transaction-setup/shouldPass/double-query-metrics.metrics.yaml
@@ -1,0 +1,26 @@
+transactions-tests:
+-   query: EXPLAIN select * from t2
+    setup:
+    - create temporary function t2() on commit drop function AS SELECT * FROM t1;
+    explain: SCAN(<,>)
+    task_count: 166
+    task_total_time_ms: 95
+    transform_count: 42
+    transform_time_ms: 70
+    transform_yield_count: 15
+    insert_time_ms: 6
+    insert_new_count: 14
+    insert_reused_count: 2
+-   query: EXPLAIN select * from t2
+    setup:
+    - create temporary function t2() on commit drop function AS SELECT * FROM t1 where
+        id < 50;
+    explain: SCAN(<,>) | FILTER _.ID LESS_THAN promote(@cT218 AS LONG)
+    task_count: 189
+    task_total_time_ms: 122
+    transform_count: 46
+    transform_time_ms: 100
+    transform_yield_count: 16
+    insert_time_ms: 2
+    insert_new_count: 18
+    insert_reused_count: 2

--- a/yaml-tests/src/test/resources/transaction-setup/shouldPass/double-query-metrics.yamsql
+++ b/yaml-tests/src/test/resources/transaction-setup/shouldPass/double-query-metrics.yamsql
@@ -1,0 +1,48 @@
+#
+# double-query-metrics.yamsql
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2021-2025 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This test should pass
+---
+schema_template:
+    create table t1(id bigint, col1 bigint, primary key(id))
+---
+setup:
+  connect: 1
+  steps:
+    - query: INSERT INTO t1 VALUES (10, 20), (30, 40), (50, 60), (70, 80)
+---
+test_block:
+  name: transactions-tests
+  tests:
+    -
+      - query: select * from t2
+      - setup: create temporary function t2() on commit drop function AS
+               SELECT * FROM t1;
+      - explain: "SCAN(<,>)"
+      - result: [
+          {id: 10, col1: 20},
+          {id: 30, col1: 40},
+          {id: 50, col1: 60},
+          {id: 70, col1: 80}]
+    -
+      - query: select * from t2
+      - setup: create temporary function t2() on commit drop function AS
+               SELECT * FROM t1 where id < 50;
+      - explain: "SCAN(<,>) | FILTER _.ID LESS_THAN promote(@cT218 AS LONG)"
+...


### PR DESCRIPTION
Planner metrics previously assumed that it was only reasonable to have a query once within a single block. Having setup can make this more complicated, so this changes the keys for the metrics to have the setup too.

There were a couple unrelated cleanups along the way:
1. `markDirty()` was annotated `@Nullable`, but is `void`
2. `putMetrics` took `isDirectyMetrics`, but that parameter was never used, so I removed it.