### PR TITLE
Add serialized plan complexity and hash to the continuation info in EXPLAIN

### DIFF
--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/QueryPlan.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/QueryPlan.java
@@ -310,7 +310,8 @@ public abstract class QueryPlan extends Plan<RelationalResultSet> implements Typ
                             DataType.StructType.Field.from("EXECUTION_STATE", DataType.Primitives.BYTES.type(), 0),
                             DataType.StructType.Field.from("VERSION", DataType.Primitives.INTEGER.type(), 1),
                             DataType.StructType.Field.from("PLAN_HASH_MODE", DataType.Primitives.STRING.type(), 2),
-                            DataType.StructType.Field.from("SERIALIZED_PLAN_COMPLEXITY", DataType.Primitives.INTEGER.type(), 3)),
+                            DataType.StructType.Field.from("PLAN_HASH", DataType.Primitives.INTEGER.type(), 3),
+                            DataType.StructType.Field.from("SERIALIZED_PLAN_COMPLEXITY", DataType.Primitives.INTEGER.type(), 4)),
                     true);
             final var plannerMetricsStructType = DataType.StructType.from(
                     "PLANNER_METRICS", List.of(
@@ -338,6 +339,7 @@ public abstract class QueryPlan extends Plan<RelationalResultSet> implements Typ
                             parsedContinuation.getExecutionState(),
                             parsedContinuation.getVersion(),
                             parsedContinuation.getCompiledStatement() == null ? null : parsedContinuation.getCompiledStatement().getPlanSerializationMode(),
+                            parsedContinuation.getPlanHash(),
                             getPlanFromContinuation(parsedContinuation, executionContext).map(RecordQueryPlan::getComplexity).orElse(null)
                     ), RelationalStructMetaData.of(continuationStructType));
 
@@ -432,7 +434,7 @@ public abstract class QueryPlan extends Plan<RelationalResultSet> implements Typ
                 // 3. query constraints
                 //
 
-                final var serializationContext = new PlanSerializationContext(new DefaultPlanSerializationRegistry(), currentPlanHashMode);
+                final var serializationContext = new PlanSerializationContext(DefaultPlanSerializationRegistry.INSTANCE, currentPlanHashMode);
 
                 final var literals = queryExecutionContext.getLiterals();
                 final var compiledStatementBuilder = CompiledStatement.newBuilder()

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/ExplainTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/ExplainTests.java
@@ -73,9 +73,10 @@ public class ExplainTests {
                 "EXECUTION_STATE",
                 "VERSION",
                 "PLAN_HASH_MODE",
+                "PLAN_HASH",
                 "SERIALIZED_PLAN_COMPLEXITY"
         );
-        final var expectedContTypes = List.of(Types.BINARY, Types.INTEGER, Types.VARCHAR, Types.INTEGER);
+        final var expectedContTypes = List.of(Types.BINARY, Types.INTEGER, Types.VARCHAR, Types.INTEGER, Types.INTEGER);
         try (var ddl = Ddl.builder().database(URI.create("/TEST/QT")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
             executeInsert(ddl);
             try (RelationalPreparedStatement ps = ddl.setSchemaAndGetConnection().prepareStatement("EXPLAIN SELECT * FROM RestaurantComplexRecord")) {
@@ -108,7 +109,7 @@ public class ExplainTests {
                     final var assertResult = ResultSetAssert.assertThat(resultSet);
                     assertResult.hasNextRow()
                             .hasColumn("PLAN", "ISCAN(RECORD_NAME_IDX <,>)")
-                            .hasColumn("PLAN_HASH", -1635569052L)
+                            .hasColumn("PLAN_HASH", -1635569052)
                             .hasColumn("PLAN_CONTINUATION", null);
                     assertResult.hasNoNextRow();
                 }
@@ -132,15 +133,17 @@ public class ExplainTests {
                     ps.setObject("cont", continuation.serialize());
                     try (final RelationalResultSet resultSet = ps.executeQuery()) {
                         final var assertResult = ResultSetAssert.assertThat(resultSet);
+
                         assertResult.hasNextRow()
                                 .hasColumn("PLAN", "ISCAN(RECORD_NAME_IDX <,>)")
-                                .hasColumn("PLAN_HASH", -1635569052L);
+                                .hasColumn("PLAN_HASH", -1635569052);
                         final var continuationInfo = resultSet.getStruct(5);
                         org.junit.jupiter.api.Assertions.assertNotNull(continuationInfo);
                         final var assertStruct = RelationalStructAssert.assertThat(continuationInfo);
                         assertStruct.hasValue("EXECUTION_STATE", new byte[]{0, 21, 1, 21, 11});
                         assertStruct.hasValue("VERSION", 1);
                         assertStruct.hasValue("PLAN_HASH_MODE", null);
+                        assertStruct.hasValue("PLAN_HASH", -1635569052);
                         assertStruct.hasValue("SERIALIZED_PLAN_COMPLEXITY", null);
                     }
                 }
@@ -166,13 +169,14 @@ public class ExplainTests {
                         final var assertResult = ResultSetAssert.assertThat(resultSet);
                         assertResult.hasNextRow()
                                 .hasColumn("PLAN", "ISCAN(RECORD_NAME_IDX <,>)")
-                                .hasColumn("PLAN_HASH", -1635569052L);
+                                .hasColumn("PLAN_HASH", -1635569052);
                         final var continuationInfo = resultSet.getStruct(5);
                         org.junit.jupiter.api.Assertions.assertNotNull(continuationInfo);
                         final var assertStruct = RelationalStructAssert.assertThat(continuationInfo);
                         assertStruct.hasValue("EXECUTION_STATE", new byte[]{0, 21, 1, 21, 11});
                         assertStruct.hasValue("VERSION", 1);
                         assertStruct.hasValue("PLAN_HASH_MODE", "VC0");
+                        assertStruct.hasValue("PLAN_HASH", -1635569052);
                         assertStruct.hasValue("SERIALIZED_PLAN_COMPLEXITY", 1);
                     }
                 }
@@ -198,13 +202,14 @@ public class ExplainTests {
                         final var assertResult = ResultSetAssert.assertThat(resultSet);
                         assertResult.hasNextRow()
                                 .hasColumn("PLAN", "ISCAN(RECORD_NAME_IDX <,>)")
-                                .hasColumn("PLAN_HASH", -1635569052L);
+                                .hasColumn("PLAN_HASH", -1635569052);
                         final var continuationInfo = resultSet.getStruct(5);
                         org.junit.jupiter.api.Assertions.assertNotNull(continuationInfo);
                         final var assertStruct = RelationalStructAssert.assertThat(continuationInfo);
                         assertStruct.hasValue("EXECUTION_STATE", new byte[]{0, 21, 1, 21, 11});
                         assertStruct.hasValue("VERSION", 1);
                         assertStruct.hasValue("PLAN_HASH_MODE", "VC0");
+                        assertStruct.hasValue("PLAN_HASH", -1635569052);
                         assertStruct.hasValue("SERIALIZED_PLAN_COMPLEXITY", 1);
                     }
                 }

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/ExplainTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/ExplainTests.java
@@ -69,8 +69,13 @@ public class ExplainTests {
     void explainResultSetMetadataTest() throws Exception {
         final var expectedLabels = List.of("PLAN", "PLAN_HASH", "PLAN_DOT", "PLAN_GML", "PLAN_CONTINUATION", "PLANNER_METRICS");
         final var expectedTypes = List.of(Types.VARCHAR, Types.INTEGER, Types.VARCHAR, Types.VARCHAR, Types.STRUCT, Types.STRUCT);
-        final var expectedContLabels = List.of("EXECUTION_STATE", "VERSION", "PLAN_HASH_MODE");
-        final var expectedContTypes = List.of(Types.BINARY, Types.INTEGER, Types.VARCHAR);
+        final var expectedContLabels = List.of(
+                "EXECUTION_STATE",
+                "VERSION",
+                "PLAN_HASH_MODE",
+                "SERIALIZED_PLAN_COMPLEXITY"
+        );
+        final var expectedContTypes = List.of(Types.BINARY, Types.INTEGER, Types.VARCHAR, Types.INTEGER);
         try (var ddl = Ddl.builder().database(URI.create("/TEST/QT")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
             executeInsert(ddl);
             try (RelationalPreparedStatement ps = ddl.setSchemaAndGetConnection().prepareStatement("EXPLAIN SELECT * FROM RestaurantComplexRecord")) {
@@ -136,6 +141,7 @@ public class ExplainTests {
                         assertStruct.hasValue("EXECUTION_STATE", new byte[]{0, 21, 1, 21, 11});
                         assertStruct.hasValue("VERSION", 1);
                         assertStruct.hasValue("PLAN_HASH_MODE", null);
+                        assertStruct.hasValue("SERIALIZED_PLAN_COMPLEXITY", null);
                     }
                 }
             }
@@ -167,6 +173,7 @@ public class ExplainTests {
                         assertStruct.hasValue("EXECUTION_STATE", new byte[]{0, 21, 1, 21, 11});
                         assertStruct.hasValue("VERSION", 1);
                         assertStruct.hasValue("PLAN_HASH_MODE", "VC0");
+                        assertStruct.hasValue("SERIALIZED_PLAN_COMPLEXITY", 1);
                     }
                 }
             }
@@ -198,6 +205,7 @@ public class ExplainTests {
                         assertStruct.hasValue("EXECUTION_STATE", new byte[]{0, 21, 1, 21, 11});
                         assertStruct.hasValue("VERSION", 1);
                         assertStruct.hasValue("PLAN_HASH_MODE", "VC0");
+                        assertStruct.hasValue("SERIALIZED_PLAN_COMPLEXITY", 1);
                     }
                 }
 

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/storage/BackingLocatableResolverStoreTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/storage/BackingLocatableResolverStoreTest.java
@@ -416,33 +416,33 @@ public class BackingLocatableResolverStoreTest {
         try (RelationalConnection connection = db.connect(null)) {
             connection.setSchema("dl");
             try (RelationalStatement statement = connection.createStatement()) {
-                long version = interningLayer.getVersion(null).join();
+                int version = interningLayer.getVersion(null).join();
                 assertStateMatches(statement, version, "UNLOCKED");
 
                 interningLayer.incrementVersion().join();
-                assertStateMatches(statement, version + 1L, "UNLOCKED");
+                assertStateMatches(statement, version + 1, "UNLOCKED");
 
-                insertResolverState(statement, version + 2L, "UNLOCKED");
-                assertStateMatches(statement, version + 2L, "UNLOCKED");
+                insertResolverState(statement, version + 2, "UNLOCKED");
+                assertStateMatches(statement, version + 2, "UNLOCKED");
 
                 interningLayer.enableWriteLock().join();
-                assertStateMatches(statement, version + 2L, "WRITE_LOCKED");
+                assertStateMatches(statement, version + 2, "WRITE_LOCKED");
 
                 interningLayer.disableWriteLock().join();
-                assertStateMatches(statement, version + 2L, "UNLOCKED");
+                assertStateMatches(statement, version + 2, "UNLOCKED");
 
                 interningLayer.retireLayer().join();
-                assertStateMatches(statement, version + 2L, "RETIRED");
+                assertStateMatches(statement, version + 2, "RETIRED");
 
-                insertResolverState(statement, version + 3L, "RETIRED");
-                assertStateMatches(statement, version + 3L, "RETIRED");
+                insertResolverState(statement, version + 3, "RETIRED");
+                assertStateMatches(statement, version + 3, "RETIRED");
 
-                insertResolverState(statement, version + 3L, "UNLOCKED");
-                assertStateMatches(statement, version + 3L, "UNLOCKED");
+                insertResolverState(statement, version + 3, "UNLOCKED");
+                assertStateMatches(statement, version + 3, "UNLOCKED");
 
-                RelationalAssertions.assertThrowsSqlException(() -> insertResolverState(statement, version + 2L, "UNLOCKED"))
+                RelationalAssertions.assertThrowsSqlException(() -> insertResolverState(statement, version + 2, "UNLOCKED"))
                         .hasMessageContaining("resolver state version must monotonically increase");
-                assertStateMatches(statement, version + 3L, "UNLOCKED");
+                assertStateMatches(statement, version + 3, "UNLOCKED");
             }
         }
     }
@@ -455,7 +455,7 @@ public class BackingLocatableResolverStoreTest {
         try (RelationalConnection connection = db.connect(null)) {
             connection.setSchema("dl");
             try (RelationalStatement statement = connection.createStatement()) {
-                long version = interningLayer.getVersion(null).join();
+                int version = interningLayer.getVersion(null).join();
 
                 try (RelationalResultSet resultSet = scanResolverStates(statement)) {
                     ResultSetAssert.assertThat(resultSet)
@@ -482,7 +482,7 @@ public class BackingLocatableResolverStoreTest {
         try (RelationalConnection connection = db.connect(null)) {
             connection.setSchema("dl");
             try (RelationalStatement statement = connection.createStatement()) {
-                long version = interningLayer.getVersion(null).join();
+                int version = interningLayer.getVersion(null).join();
 
                 Continuation continuation;
                 try (RelationalResultSet resultSet = scanResolverStates(statement, 1, ContinuationImpl.BEGIN)) {
@@ -635,7 +635,7 @@ public class BackingLocatableResolverStoreTest {
         }
     }
 
-    private void assertStateMatches(RelationalStatement statement, long version, String lock) throws SQLException {
+    private void assertStateMatches(RelationalStatement statement, int version, String lock) throws SQLException {
         try (RelationalResultSet resultSet = statement.executeGet(LocatableResolverMetaDataProvider.RESOLVER_STATE_TYPE_NAME, new KeySet(), Options.NONE)) {
             ResultSetAssert.assertThat(resultSet)
                     .hasNextRow()
@@ -657,9 +657,9 @@ public class BackingLocatableResolverStoreTest {
         }
     }
 
-    private void insertResolverState(RelationalStatement statement, long version, String lock) throws SQLException {
+    private void insertResolverState(RelationalStatement statement, int version, String lock) throws SQLException {
         final var struct = EmbeddedRelationalStruct.newBuilder()
-                .addInt(LocatableResolverMetaDataProvider.VERSION_FIELD_NAME, (int) version)
+                .addInt(LocatableResolverMetaDataProvider.VERSION_FIELD_NAME, version)
                 .addObject(LocatableResolverMetaDataProvider.LOCK_FIELD_NAME, lock)
                 .build();
         Options options = Options.builder()

--- a/fdb-relational-core/src/testFixtures/java/com/apple/foundationdb/relational/utils/ResultSetAssert.java
+++ b/fdb-relational-core/src/testFixtures/java/com/apple/foundationdb/relational/utils/ResultSetAssert.java
@@ -155,6 +155,7 @@ public class ResultSetAssert extends AbstractAssert<ResultSetAssert, RelationalR
                 return rs.getBoolean(position);
             case Types.SMALLINT:
             case Types.INTEGER:
+                return rs.getInt(position);
             case Types.BIGINT:
                 return rs.getLong(position);
             case Types.FLOAT:


### PR DESCRIPTION
This PR adds two new columns, `PLAN_HASH` and `SERIALIZED_PLAN_COMPLEXITY`, to the `PLAN_CONTINUATION` struct in the result from EXPLAIN which contain the plan hash stored in the continuation and the complexity of the plan serialized within the continuation (if the continuation contains a compiled statement )respectively . 

The new columns are populated for EXPLAINs on an `EXECUTE CONTINUATION` statement and a regular SELECT statement that uses the `WITH CONTINUATION` clause.