### PR TITLE
Fix insertion of Struct with Enum

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/MessageHelpers.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/MessageHelpers.java
@@ -529,13 +529,21 @@ public class MessageHelpers {
                 final var currentField = currentRecordType.getField(index);
                 final var currentFieldType = Verify.verifyNotNull(currentField).getFieldType();
 
+                Descriptors.GenericDescriptor nestedTargetDescriptor;
+                if (targetFieldDescriptor.getJavaType() == Descriptors.FieldDescriptor.JavaType.MESSAGE) {
+                    nestedTargetDescriptor = targetFieldDescriptor.getMessageType();
+                } else if (targetFieldDescriptor.getJavaType() == Descriptors.FieldDescriptor.JavaType.ENUM) {
+                    nestedTargetDescriptor = targetFieldDescriptor.getEnumType();
+                } else {
+                    nestedTargetDescriptor = null;
+                }
                 // coerced object can only be NULL if passed-in object is NULL which cannot happen here
                 final var coercedObject =
                         Verify.verifyNotNull(
                                 coerceObject(
                                         promotionsChildrenMap == null ? null : promotionsChildrenMap.get(index),
                                         targetFieldType,
-                                        targetFieldDescriptor.getJavaType() == Descriptors.FieldDescriptor.JavaType.MESSAGE ? targetFieldDescriptor.getMessageType() : null,
+                                        nestedTargetDescriptor,
                                         currentFieldType,
                                         currentMessage.getField(messageFieldDescriptor)));
                 resultMessageBuilder.setField(targetFieldDescriptor, coercedObject);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/PromoteValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/PromoteValue.java
@@ -451,10 +451,13 @@ public class PromoteValue extends AbstractValue implements CreatesDynamicTypesVa
             final List<Type> inTypeElements = Objects.requireNonNull(((Type.Record) inType).getElementTypes());
             final List<Type> promoteToTypeElements = Objects.requireNonNull(((Type.Record) promoteToType).getElementTypes());
             SemanticException.check(inTypeElements.size() == promoteToTypeElements.size(), SemanticException.ErrorCode.INCOMPATIBLE_TYPE);
+            var promotionNeeded = false;
             for (int i = 0; i < inTypeElements.size(); i++) {
-                SemanticException.check(!isPromotionNeeded(inTypeElements.get(i), promoteToTypeElements.get(i)), SemanticException.ErrorCode.INCOMPATIBLE_TYPE);
+                if (isPromotionNeeded(inTypeElements.get(i), promoteToTypeElements.get(i))) {
+                    promotionNeeded = true;
+                }
             }
-            return false;
+            return promotionNeeded;
         }
         SemanticException.check((inType.isPrimitive() || inType.isEnum() || inType.isUuid()) &&
                 (promoteToType.isPrimitive() || promoteToType.isEnum() || promoteToType.isUuid()), SemanticException.ErrorCode.INCOMPATIBLE_TYPE);

--- a/fdb-relational-core/src/testFixtures/java/com/apple/foundationdb/relational/utils/ResultSetAssert.java
+++ b/fdb-relational-core/src/testFixtures/java/com/apple/foundationdb/relational/utils/ResultSetAssert.java
@@ -237,7 +237,7 @@ public class ResultSetAssert extends AbstractAssert<ResultSetAssert, RelationalR
                     RelationalStructAssert.assertThat((RelationalStruct) o).isEqualTo((RelationalStruct) expected);
                 } else if (expected instanceof Array) {
                     Assertions.assertThat(o).isInstanceOf(Array.class);
-                    ArrayAssert.assertThat((Array) o).isEqualTo((Array) expected);
+                    ArrayAssert.assertThat((Array) o).isEqualTo(expected);
                 } else if (expected instanceof Descriptors.EnumValueDescriptor) {
                     Assertions.assertThat(o).isInstanceOf(Descriptors.EnumValueDescriptor.class);
                     Assertions.assertThat(((Descriptors.EnumValueDescriptor) expected).getName()).isEqualTo(((Descriptors.EnumValueDescriptor) o).getName());

--- a/fdb-relational-core/src/testFixtures/java/com/apple/foundationdb/relational/utils/TestSchemas.java
+++ b/fdb-relational-core/src/testFixtures/java/com/apple/foundationdb/relational/utils/TestSchemas.java
@@ -61,7 +61,10 @@ public final class TestSchemas {
     @Nonnull
     private static final String PLAYING_CARD =
             "CREATE TYPE AS ENUM suit ('SPADES', 'HEARTS', 'DIAMONDS', 'CLUBS') " +
+                    "CREATE TYPE AS STRUCT SuitAndRank (suit suit, rank bigint)" +
                     "CREATE TABLE Card (id bigint, suit suit, rank bigint, PRIMARY KEY(id))" +
+                    "CREATE TABLE Card_Nested (id bigint, info SuitAndRank, PRIMARY KEY(id))" +
+                    "CREATE TABLE Card_Array (id bigint, collection SuitAndRank array, PRIMARY KEY(id))" +
                     "CREATE INDEX suit_idx AS SELECT suit FROM Card ORDER BY suit";
 
     @Nonnull


### PR DESCRIPTION
This PR fixes a minor bug that prevented the insertion of 

1. `struct with enum`: This was because of the fact that target `enum` descriptor was not getting propagated rightly during the message coercion.   
2. `array of struct with enum`: This was because of the fact that the array of structs was restricted to do promotion of struct, if needed.

