### PR TITLE
Setup teamscale toml file to support IDE plugin

### DIFF
--- a/.teamscale.toml
+++ b/.teamscale.toml
@@ -1,0 +1,14 @@
+# Configuration for project foundationdb-fdb-record-layer, connector github-fdb-record-layer
+
+# Learn more about the Teamscale IDE Configuration File Format at
+# <https://docs.teamscale.com/reference/teamscale-toml/>.
+
+version = "1.0"
+
+root = true
+
+[server]
+url = "https://fdb.teamscale.io/"
+
+[project]
+id = "foundationdb-fdb-record-layer"


### PR DESCRIPTION
This adds the required configuration to the repository to configure the teamscale plugin. 
See: https://docs.teamscale.com/reference/teamscale-toml/