### PR TITLE
When correcting yamsql metrics, only update queries with differences

### DIFF
--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/CheckExplainConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/CheckExplainConfig.java
@@ -43,6 +43,16 @@ import java.util.Objects;
 
 import static com.apple.foundationdb.relational.yamltests.command.QueryCommand.reportTestFailure;
 
+/**
+ * QueryConfig associated with {@link QueryConfig#QUERY_CONFIG_EXPLAIN} and
+ * {@link QueryConfig#QUERY_CONFIG_EXPLAIN_CONTAINS}, that validates that the results of running {@code EXPLAIN} with
+ * the query under test matches the explain results. In addition, this gathers the planner metrics from the results of
+ * the explains and compares them to the ones committed. It doesn't compare raw timing, because that would, naturally
+ * change between runs, but those are stored to provide context. In the event that
+ * {@link com.apple.foundationdb.relational.yamltests.MaintainYamlTestConfig} is used to correct the explain and/or
+ * metrics, this will record the actual values via the {@link YamlExecutionContext}, which will save them when the
+ * test completes.
+ */
 class CheckExplainConfig extends QueryConfig {
 
     private static final Logger logger = LogManager.getLogger(CheckExplainConfig.class);

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/CheckExplainConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/CheckExplainConfig.java
@@ -1,0 +1,215 @@
+/*
+ * CheckExplainConfig.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.relational.yamltests.command;
+
+import com.apple.foundationdb.record.query.plan.cascades.debug.BrowserHelper;
+import com.apple.foundationdb.relational.api.RelationalResultSet;
+import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
+import com.apple.foundationdb.relational.yamltests.generated.stats.PlannerMetricsProto;
+import com.github.difflib.text.DiffRow;
+import com.github.difflib.text.DiffRowGenerator;
+import com.google.common.base.Verify;
+import com.google.common.collect.ImmutableMap;
+import com.google.protobuf.Descriptors;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import javax.annotation.Nonnull;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+import static com.apple.foundationdb.relational.yamltests.command.QueryCommand.reportTestFailure;
+
+class CheckExplainConfig extends QueryConfig {
+
+    private static final Logger logger = LogManager.getLogger(CheckExplainConfig.class);
+    private final int lineNumber;
+    private final YamlExecutionContext executionContext;
+    private final boolean isExact;
+    private final String blockName;
+
+    public CheckExplainConfig(final String configName,
+                              final Object value,
+                              final int lineNumber,
+                              final YamlExecutionContext executionContext,
+                              final boolean isExact,
+                              final String blockName) {
+        super(configName, value, lineNumber, executionContext);
+        this.lineNumber = lineNumber;
+        this.executionContext = executionContext;
+        this.isExact = isExact;
+        this.blockName = blockName;
+    }
+
+    @Override
+    String decorateQuery(@Nonnull String query) {
+        return "EXPLAIN " + query;
+    }
+
+    @SuppressWarnings({"PMD.CloseResource", "PMD.EmptyWhileStmt"})
+    // lifetime of autocloseable resource persists beyond method
+    @Override
+    void checkResultInternal(@Nonnull String currentQuery, @Nonnull Object actual,
+                             @Nonnull String queryDescription, @Nonnull List<String> setups) throws SQLException {
+        logger.debug("⛳️ Matching plan for query '{}'", queryDescription);
+        final var resultSet = (RelationalResultSet)actual;
+        resultSet.next();
+        final var actualPlan = resultSet.getString(1);
+        var success = isExact ? getVal().equals(actualPlan) : actualPlan.contains((String)getVal());
+        final var actualDot = resultSet.getString(3);
+        final var metricsMap = executionContext.getMetricsMap();
+        final var identifier = PlannerMetricsProto.Identifier.newBuilder()
+                .setBlockName(blockName)
+                .setQuery(currentQuery)
+                .addAllSetups(setups)
+                .build();
+        final var expectedPlannerMetricsInfo = metricsMap.get(identifier);
+
+        if (success) {
+            logger.debug("✅️ plan match!");
+        } else {
+            if (executionContext.shouldShowPlanOnDiff() &&
+                    actualDot != null && expectedPlannerMetricsInfo != null) {
+                BrowserHelper.browse("/showPlanDiff.html",
+                        ImmutableMap.of("$SQL", queryDescription,
+                                "$DOT_EXPECTED", expectedPlannerMetricsInfo.getDot(),
+                                "$DOT_ACTUAL", actualDot));
+            }
+
+            final var expectedPlan = getValueString();
+            final var diffGenerator = DiffRowGenerator.create()
+                    .showInlineDiffs(true)
+                    .inlineDiffByWord(true)
+                    .newTag(f -> f ? CommandUtil.Color.RED.toString() : CommandUtil.Color.RESET.toString())
+                    .oldTag(f -> f ? CommandUtil.Color.GREEN.toString() : CommandUtil.Color.RESET.toString())
+                    .build();
+            final List<DiffRow> diffRows = diffGenerator.generateDiffRows(
+                    Collections.singletonList(expectedPlan),
+                    Collections.singletonList(actualPlan));
+            final var planDiffs = new StringBuilder();
+            for (final var diffRow : diffRows) {
+                planDiffs.append(diffRow.getOldLine()).append('\n').append(diffRow.getNewLine()).append('\n');
+            }
+            if (isExact && executionContext.shouldCorrectExplains()) {
+                if (!executionContext.correctExplain(getLineNumber() - 1, actualPlan)) {
+                    reportTestFailure("‼️ Cannot correct explain plan at line " + getLineNumber());
+                } else {
+                    logger.debug("⭐️ Successfully replaced plan at line {}", getLineNumber());
+                }
+            } else {
+                final var diffMessage = String.format(Locale.ROOT, "‼️ plan mismatch at line %d:%n" +
+                                "⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤%n%s" +
+                                "⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤%n" +
+                                "↪ expected plan %s:%n%s%n" +
+                                "⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤%n" +
+                                "↩ actual plan:%n%s",
+                        getLineNumber(), planDiffs, (!isExact ? "fragment" : ""), getValueString(), actualPlan);
+                reportTestFailure(diffMessage);
+            }
+        }
+
+        final var actualPlannerMetrics = resultSet.getStruct(6);
+        if (isExact && actualPlannerMetrics != null) {
+            Objects.requireNonNull(actualDot);
+            final var taskCount = actualPlannerMetrics.getLong(1);
+            Verify.verify(taskCount > 0);
+            final var taskTotalTimeInNs = actualPlannerMetrics.getLong(2);
+            Verify.verify(taskTotalTimeInNs > 0);
+
+            if (expectedPlannerMetricsInfo == null && !executionContext.shouldCorrectMetrics()) {
+                reportTestFailure("‼️ No planner metrics for line " + getLineNumber());
+            }
+            final var actualInfo = PlannerMetricsProto.Info.newBuilder()
+                    .setExplain(actualPlan)
+                    .setDot(actualDot)
+                    .setCountersAndTimers(PlannerMetricsProto.CountersAndTimers.newBuilder()
+                            .setTaskCount(taskCount)
+                            .setTaskTotalTimeNs(taskTotalTimeInNs)
+                            .setTransformCount(actualPlannerMetrics.getLong(3))
+                            .setTransformTimeNs(actualPlannerMetrics.getLong(4))
+                            .setTransformYieldCount(actualPlannerMetrics.getLong(5))
+                            .setInsertTimeNs(actualPlannerMetrics.getLong(6))
+                            .setInsertNewCount(actualPlannerMetrics.getLong(7))
+                            .setInsertReusedCount(actualPlannerMetrics.getLong(8)))
+                    .build();
+            if (expectedPlannerMetricsInfo == null) {
+                executionContext.putMetrics(blockName, currentQuery, lineNumber, actualInfo, setups);
+                executionContext.markDirty();
+                logger.debug("⭐️ Successfully inserted new planner metrics at line {}", getLineNumber());
+            } else {
+                final var expectedCountersAndTimers = expectedPlannerMetricsInfo.getCountersAndTimers();
+                final var actualCountersAndTimers = actualInfo.getCountersAndTimers();
+                final var metricsDescriptor = expectedCountersAndTimers.getDescriptorForType();
+
+                boolean isDifferent =
+                        isMetricDifferent(expectedCountersAndTimers,
+                                actualCountersAndTimers,
+                                metricsDescriptor.findFieldByName("task_count"),
+                                lineNumber) |
+                                isMetricDifferent(expectedCountersAndTimers,
+                                        actualCountersAndTimers,
+                                        metricsDescriptor.findFieldByName("transform_count"),
+                                        lineNumber) |
+                                isMetricDifferent(expectedCountersAndTimers,
+                                        actualCountersAndTimers,
+                                        metricsDescriptor.findFieldByName("transform_yield_count"),
+                                        lineNumber) |
+                                isMetricDifferent(expectedCountersAndTimers,
+                                        actualCountersAndTimers,
+                                        metricsDescriptor.findFieldByName("insert_new_count"),
+                                        lineNumber) |
+                                isMetricDifferent(expectedCountersAndTimers,
+                                        actualCountersAndTimers,
+                                        metricsDescriptor.findFieldByName("insert_reused_count"),
+                                        lineNumber);
+                if (isDifferent) {
+                    executionContext.putMetrics(blockName, currentQuery, lineNumber, actualInfo, setups);
+                    if (executionContext.shouldCorrectMetrics()) {
+                        executionContext.markDirty();
+                        logger.debug("⭐️ Successfully updated planner metrics at line {}", getLineNumber());
+                    } else {
+                        reportTestFailure("‼️ Planner metrics have changed for line " + getLineNumber());
+                    }
+                } else {
+                    executionContext.putMetrics(blockName, currentQuery, lineNumber, expectedPlannerMetricsInfo, setups);
+                }
+            }
+        }
+    }
+
+
+    private static boolean isMetricDifferent(@Nonnull final PlannerMetricsProto.CountersAndTimers expected,
+                                             @Nonnull final PlannerMetricsProto.CountersAndTimers actual,
+                                             @Nonnull final Descriptors.FieldDescriptor fieldDescriptor,
+                                             int lineNumber) {
+        final long expectedMetric = (long)expected.getField(fieldDescriptor);
+        final long actualMetric = (long)actual.getField(fieldDescriptor);
+        if (expectedMetric != actualMetric) {
+            logger.warn("‼️ metric {} differs; lineNumber = {}; expected = {}; actual = {}",
+                    fieldDescriptor.getName(), lineNumber, expectedMetric, actualMetric);
+            return true;
+        }
+        return false;
+    }
+}

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryConfig.java
@@ -334,14 +334,16 @@ public abstract class QueryConfig {
                                                 actualCountersAndTimers,
                                                 metricsDescriptor.findFieldByName("insert_reused_count"),
                                                 lineNumber);
-                        executionContext.putMetrics(blockName, currentQuery, lineNumber, actualInfo, setups);
                         if (isDifferent) {
+                            executionContext.putMetrics(blockName, currentQuery, lineNumber, actualInfo, setups);
                             if (executionContext.shouldCorrectMetrics()) {
                                 executionContext.markDirty();
                                 logger.debug("⭐️ Successfully updated planner metrics at line {}", getLineNumber());
                             } else {
                                 reportTestFailure("‼️ Planner metrics have changed for line " + getLineNumber());
                             }
+                        } else {
+                            executionContext.putMetrics(blockName, currentQuery, lineNumber, expectedPlannerMetricsInfo, setups);
                         }
                     }
                 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryConfig.java
@@ -20,7 +20,6 @@
 
 package com.apple.foundationdb.relational.yamltests.command;
 
-import com.apple.foundationdb.record.query.plan.cascades.debug.BrowserHelper;
 import com.apple.foundationdb.relational.api.RelationalResultSet;
 import com.apple.foundationdb.relational.recordlayer.ErrorCapturingResultSet;
 import com.apple.foundationdb.relational.util.Assert;
@@ -29,19 +28,13 @@ import com.apple.foundationdb.relational.yamltests.Matchers;
 import com.apple.foundationdb.relational.yamltests.YamlConnection;
 import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
 import com.apple.foundationdb.relational.yamltests.block.PreambleBlock;
-import com.apple.foundationdb.relational.yamltests.generated.stats.PlannerMetricsProto;
 import com.apple.foundationdb.relational.yamltests.server.SemanticVersion;
 import com.apple.foundationdb.relational.yamltests.server.SupportedVersionCheck;
 import com.apple.foundationdb.tuple.ByteArrayUtil2;
-import com.github.difflib.text.DiffRow;
-import com.github.difflib.text.DiffRowGenerator;
-import com.google.common.base.Verify;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeSet;
 import com.google.common.collect.TreeRangeSet;
-import com.google.protobuf.Descriptors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
@@ -51,10 +44,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
-import java.util.Objects;
 import java.util.Set;
 
 import static com.apple.foundationdb.relational.yamltests.command.QueryCommand.reportTestFailure;
@@ -98,7 +89,7 @@ public abstract class QueryConfig {
     private final YamlExecutionContext executionContext;
     @Nullable private final String configName;
 
-    private QueryConfig(@Nullable String configName, @Nullable Object value, int lineNumber, @Nonnull YamlExecutionContext executionContext) {
+    protected QueryConfig(@Nullable String configName, @Nullable Object value, int lineNumber, @Nonnull YamlExecutionContext executionContext) {
         this.configName = configName;
         this.value = value;
         this.lineNumber = lineNumber;
@@ -213,156 +204,7 @@ public abstract class QueryConfig {
     private static QueryConfig getCheckExplainConfig(boolean isExact, @Nonnull String blockName,
                                                      @Nonnull String configName, @Nullable Object value,
                                                      int lineNumber, @Nonnull YamlExecutionContext executionContext) {
-        return new QueryConfig(configName, value, lineNumber, executionContext) {
-            @Override
-            String decorateQuery(@Nonnull String query) {
-                return "EXPLAIN " + query;
-            }
-
-            @SuppressWarnings({"PMD.CloseResource", "PMD.EmptyWhileStmt"}) // lifetime of autocloseable resource persists beyond method
-            @Override
-            void checkResultInternal(@Nonnull String currentQuery, @Nonnull Object actual,
-                                     @Nonnull String queryDescription, @Nonnull List<String> setups) throws SQLException {
-                logger.debug("⛳️ Matching plan for query '{}'", queryDescription);
-                final var resultSet = (RelationalResultSet) actual;
-                resultSet.next();
-                final var actualPlan = resultSet.getString(1);
-                var success = isExact ? getVal().equals(actualPlan) : actualPlan.contains((String) getVal());
-                final var actualDot = resultSet.getString(3);
-                final var metricsMap = executionContext.getMetricsMap();
-                final var identifier = PlannerMetricsProto.Identifier.newBuilder()
-                        .setBlockName(blockName)
-                        .setQuery(currentQuery)
-                        .addAllSetups(setups)
-                        .build();
-                final var expectedPlannerMetricsInfo = metricsMap.get(identifier);
-
-                if (success) {
-                    logger.debug("✅️ plan match!");
-                } else {
-                    if (executionContext.shouldShowPlanOnDiff() &&
-                            actualDot != null && expectedPlannerMetricsInfo != null) {
-                        BrowserHelper.browse("/showPlanDiff.html",
-                                ImmutableMap.of("$SQL", queryDescription,
-                                        "$DOT_EXPECTED", expectedPlannerMetricsInfo.getDot(),
-                                        "$DOT_ACTUAL", actualDot));
-                    }
-
-                    final var expectedPlan = getValueString();
-                    final var diffGenerator = DiffRowGenerator.create()
-                            .showInlineDiffs(true)
-                            .inlineDiffByWord(true)
-                            .newTag(f -> f ? CommandUtil.Color.RED.toString() : CommandUtil.Color.RESET.toString())
-                            .oldTag(f -> f ? CommandUtil.Color.GREEN.toString() : CommandUtil.Color.RESET.toString())
-                            .build();
-                    final List<DiffRow> diffRows = diffGenerator.generateDiffRows(
-                            Collections.singletonList(expectedPlan),
-                            Collections.singletonList(actualPlan));
-                    final var planDiffs = new StringBuilder();
-                    for (final var diffRow : diffRows) {
-                        planDiffs.append(diffRow.getOldLine()).append('\n').append(diffRow.getNewLine()).append('\n');
-                    }
-                    if (isExact && executionContext.shouldCorrectExplains()) {
-                        if (!executionContext.correctExplain(getLineNumber() - 1, actualPlan)) {
-                            reportTestFailure("‼️ Cannot correct explain plan at line " + getLineNumber());
-                        } else {
-                            logger.debug("⭐️ Successfully replaced plan at line {}", getLineNumber());
-                        }
-                    } else {
-                        final var diffMessage = String.format(Locale.ROOT, "‼️ plan mismatch at line %d:%n" +
-                                "⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤%n%s" +
-                                "⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤%n" +
-                                "↪ expected plan %s:%n%s%n" +
-                                "⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤%n" +
-                                "↩ actual plan:%n%s",
-                                getLineNumber(), planDiffs, (!isExact ? "fragment" : ""), getValueString(), actualPlan);
-                        reportTestFailure(diffMessage);
-                    }
-                }
-
-                final var actualPlannerMetrics = resultSet.getStruct(6);
-                if (isExact && actualPlannerMetrics != null) {
-                    Objects.requireNonNull(actualDot);
-                    final var taskCount = actualPlannerMetrics.getLong(1);
-                    Verify.verify(taskCount > 0);
-                    final var taskTotalTimeInNs = actualPlannerMetrics.getLong(2);
-                    Verify.verify(taskTotalTimeInNs > 0);
-
-                    if (expectedPlannerMetricsInfo == null && !executionContext.shouldCorrectMetrics()) {
-                        reportTestFailure("‼️ No planner metrics for line " + getLineNumber());
-                    }
-                    final var actualInfo = PlannerMetricsProto.Info.newBuilder()
-                            .setExplain(actualPlan)
-                            .setDot(actualDot)
-                            .setCountersAndTimers(PlannerMetricsProto.CountersAndTimers.newBuilder()
-                                            .setTaskCount(taskCount)
-                                            .setTaskTotalTimeNs(taskTotalTimeInNs)
-                                            .setTransformCount(actualPlannerMetrics.getLong(3))
-                                            .setTransformTimeNs(actualPlannerMetrics.getLong(4))
-                                            .setTransformYieldCount(actualPlannerMetrics.getLong(5))
-                                            .setInsertTimeNs(actualPlannerMetrics.getLong(6))
-                                            .setInsertNewCount(actualPlannerMetrics.getLong(7))
-                                            .setInsertReusedCount(actualPlannerMetrics.getLong(8)))
-                            .build();
-                    if (expectedPlannerMetricsInfo == null) {
-                        executionContext.putMetrics(blockName, currentQuery, lineNumber, actualInfo, setups);
-                        executionContext.markDirty();
-                        logger.debug("⭐️ Successfully inserted new planner metrics at line {}", getLineNumber());
-                    } else {
-                        final var expectedCountersAndTimers = expectedPlannerMetricsInfo.getCountersAndTimers();
-                        final var actualCountersAndTimers = actualInfo.getCountersAndTimers();
-                        final var metricsDescriptor = expectedCountersAndTimers.getDescriptorForType();
-
-                        boolean isDifferent =
-                                isMetricDifferent(expectedCountersAndTimers,
-                                        actualCountersAndTimers,
-                                        metricsDescriptor.findFieldByName("task_count"),
-                                        lineNumber) |
-                                        isMetricDifferent(expectedCountersAndTimers,
-                                                actualCountersAndTimers,
-                                                metricsDescriptor.findFieldByName("transform_count"),
-                                                lineNumber) |
-                                        isMetricDifferent(expectedCountersAndTimers,
-                                                actualCountersAndTimers,
-                                                metricsDescriptor.findFieldByName("transform_yield_count"),
-                                                lineNumber) |
-                                        isMetricDifferent(expectedCountersAndTimers,
-                                                actualCountersAndTimers,
-                                                metricsDescriptor.findFieldByName("insert_new_count"),
-                                                lineNumber) |
-                                        isMetricDifferent(expectedCountersAndTimers,
-                                                actualCountersAndTimers,
-                                                metricsDescriptor.findFieldByName("insert_reused_count"),
-                                                lineNumber);
-                        if (isDifferent) {
-                            executionContext.putMetrics(blockName, currentQuery, lineNumber, actualInfo, setups);
-                            if (executionContext.shouldCorrectMetrics()) {
-                                executionContext.markDirty();
-                                logger.debug("⭐️ Successfully updated planner metrics at line {}", getLineNumber());
-                            } else {
-                                reportTestFailure("‼️ Planner metrics have changed for line " + getLineNumber());
-                            }
-                        } else {
-                            executionContext.putMetrics(blockName, currentQuery, lineNumber, expectedPlannerMetricsInfo, setups);
-                        }
-                    }
-                }
-            }
-        };
-    }
-
-    private static boolean isMetricDifferent(@Nonnull final PlannerMetricsProto.CountersAndTimers expected,
-                                             @Nonnull final PlannerMetricsProto.CountersAndTimers actual,
-                                             @Nonnull final Descriptors.FieldDescriptor fieldDescriptor,
-                                             int lineNumber) {
-        final long expectedMetric = (long)expected.getField(fieldDescriptor);
-        final long actualMetric = (long)actual.getField(fieldDescriptor);
-        if (expectedMetric != actualMetric) {
-            logger.warn("‼️ metric {} differs; lineNumber = {}; expected = {}; actual = {}",
-                    fieldDescriptor.getName(), lineNumber, expectedMetric, actualMetric);
-            return true;
-        }
-        return false;
+        return new CheckExplainConfig(configName, value, lineNumber, executionContext, isExact, blockName);
     }
 
     private static QueryConfig getCheckErrorConfig(@Nullable Object value, int lineNumber, @Nonnull YamlExecutionContext executionContext) {


### PR DESCRIPTION
Without this change, if you add a new query and run the test with CORRECT_METRICS, it will update all the timings for all of the other queries. This is less important for the binp, but can make it hard to look at the metrics yaml diff, as there will be many lines to ignore.

With this change, it will keep the original info for every query that did not result in a diffence.

I tested this locally by adding a new query to standard-tests.yamsql and seeing that when I correct the metrics, only the one in question is modified, and the rest stay the same.

Here is an example diff without this change: https://github.com/ScottDugas/fdb-record-layer/commit/8f0778fd7bc4085a0836c09fbb4aee54043147b7
And here is an example diff with it: https://github.com/ScottDugas/fdb-record-layer/commit/025389276e7b5ed51f08e27e4ee5f0e54d2fa1e8