### PR TITLE
Support nested not-repeated fields in SQL index definition.

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/FieldKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/FieldKeyExpression.java
@@ -54,7 +54,7 @@ import java.util.List;
  * <code>Key.Evaluated</code> containing the empty list.
  */
 @API(API.Status.UNSTABLE)
-public class FieldKeyExpression extends BaseKeyExpression implements AtomKeyExpression, KeyExpressionWithoutChildren {
+public class FieldKeyExpression extends BaseKeyExpression implements AtomKeyExpression, KeyExpressionWithoutChildren, GroupableKeyExpression {
     private static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("Field-Key-Expression");
 
     @Nonnull
@@ -290,16 +290,14 @@ public class FieldKeyExpression extends BaseKeyExpression implements AtomKeyExpr
         return new NestingKeyExpression(this, child);
     }
 
-    /**
-     * Get this field as a group without any grouping keys.
-     * @return this field without any grouping keys
-     */
     @Nonnull
+    @Override
     public GroupingKeyExpression ungrouped() {
         return new GroupingKeyExpression(this, 1);
     }
 
     @Nonnull
+    @Override
     public GroupingKeyExpression groupBy(@Nonnull KeyExpression groupByFirst, @Nonnull KeyExpression... groupByRest) {
         return GroupingKeyExpression.of(this, groupByFirst, groupByRest);
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/GroupableKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/GroupableKeyExpression.java
@@ -1,0 +1,42 @@
+/*
+ * GroupableKeyExpression.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.metadata.expressions;
+
+import com.apple.foundationdb.annotation.API;
+
+import javax.annotation.Nonnull;
+
+/**
+ * A {@link KeyExpression} that can be grouped by another {@link KeyExpression}.
+ */
+@API(API.Status.EXPERIMENTAL)
+public interface GroupableKeyExpression extends KeyExpression {
+
+    @Nonnull
+    GroupingKeyExpression groupBy(@Nonnull KeyExpression groupByFirst, @Nonnull KeyExpression... groupByRest);
+
+    /**
+     * Get {@code this} nesting as a group without any grouping keys.
+     *
+     * @return this nesting without any grouping keys
+     */
+    GroupingKeyExpression ungrouped();
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/NestingKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/NestingKeyExpression.java
@@ -46,7 +46,7 @@ import java.util.stream.Collectors;
  * record, then it will evaluate the same as if the parent field is unset or empty (depending on the fan type).
  */
 @API(API.Status.UNSTABLE)
-public class NestingKeyExpression extends BaseKeyExpression implements KeyExpressionWithChild, AtomKeyExpression {
+public class NestingKeyExpression extends BaseKeyExpression implements KeyExpressionWithChild, AtomKeyExpression, GroupableKeyExpression {
     private static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("Nesting-Key-Expression");
 
     @Nonnull
@@ -167,16 +167,14 @@ public class NestingKeyExpression extends BaseKeyExpression implements KeyExpres
         return child;
     }
 
-    /**
-     * Get this nesting as a group without any grouping keys.
-     * @return this nesting without any grouping keys
-     */
     @Nonnull
+    @Override
     public GroupingKeyExpression ungrouped() {
         return new GroupingKeyExpression(this, getColumnSize());
     }
 
     @Nonnull
+    @Override
     public GroupingKeyExpression groupBy(@Nonnull KeyExpression groupByFirst, @Nonnull KeyExpression... groupByRest) {
         return GroupingKeyExpression.of(this, groupByFirst, groupByRest);
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/ThenKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/ThenKeyExpression.java
@@ -45,7 +45,7 @@ import java.util.stream.Collectors;
  * against the <code>null</code> record.
  */
 @API(API.Status.UNSTABLE)
-public class ThenKeyExpression extends BaseKeyExpression implements KeyExpressionWithChildren {
+public class ThenKeyExpression extends BaseKeyExpression implements KeyExpressionWithChildren, GroupableKeyExpression {
     private static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("Then-Key-Expression");
 
     @Nonnull
@@ -146,16 +146,14 @@ public class ThenKeyExpression extends BaseKeyExpression implements KeyExpressio
         return columnSize;
     }
 
-    /**
-     * Get this entire concatenation as a group without any grouping keys.
-     * @return this concatenation without any grouping keys
-     */
     @Nonnull
+    @Override
     public GroupingKeyExpression ungrouped() {
         return new GroupingKeyExpression(this, getColumnSize());
     }
 
     @Nonnull
+    @Override
     public GroupingKeyExpression groupBy(@Nonnull KeyExpression groupByFirst, @Nonnull KeyExpression... groupByRest) {
         return GroupingKeyExpression.of(this, groupByFirst, groupByRest);
     }

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/IndexGenerator.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/IndexGenerator.java
@@ -30,6 +30,7 @@ import com.apple.foundationdb.record.metadata.Key;
 import com.apple.foundationdb.record.metadata.expressions.EmptyKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.FieldKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.FunctionKeyExpression;
+import com.apple.foundationdb.record.metadata.expressions.GroupableKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.GroupingKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.ThenKeyExpression;
@@ -391,7 +392,6 @@ public final class IndexGenerator {
         final var indexableAggregateValue = (IndexableAggregateValue) aggregateValue;
         final var child = Iterables.getOnlyElement(aggregateValue.getChildren());
         var indexTypeName = indexableAggregateValue.getIndexTypeName();
-        final KeyExpression groupedValue;
         final GroupingKeyExpression keyExpression;
         // COUNT(*) is a special case.
         if (aggregateValue instanceof CountValue && IndexTypes.COUNT.equals(indexTypeName)) {
@@ -402,7 +402,7 @@ public final class IndexGenerator {
             }
         } else if (aggregateValue instanceof NumericAggregationValue.BitmapConstructAgg && IndexTypes.BITMAP_VALUE.equals(indexTypeName)) {
             Assert.thatUnchecked(child instanceof FieldValue || child instanceof ArithmeticValue, "Unsupported index definition, expecting a column argument in aggregation function");
-            groupedValue = generate(List.of(child), Collections.emptyMap());
+            final var groupedValue = generate(List.of(child), Collections.emptyMap());
             // only support bitmap_construct_agg(bitmap_bit_position(column))
             // doesn't support bitmap_construct_agg(column)
             Assert.thatUnchecked(groupedValue instanceof FunctionKeyExpression, "Unsupported index definition, expecting a bitmap_bit_position function in bitmap_construct_agg function");
@@ -422,16 +422,11 @@ public final class IndexGenerator {
             }
         } else {
             Assert.thatUnchecked(child instanceof FieldValue, "Unsupported index definition, expecting a column argument in aggregation function");
-            groupedValue = generate(List.of(child), Collections.emptyMap());
-            Assert.thatUnchecked(groupedValue instanceof FieldKeyExpression || groupedValue instanceof ThenKeyExpression);
+            final var groupedValue = Assert.castUnchecked(generate(List.of(child), Collections.emptyMap()), GroupableKeyExpression.class);
             if (maybeGroupingExpression.isPresent()) {
-                keyExpression = (groupedValue instanceof FieldKeyExpression) ?
-                        ((FieldKeyExpression) groupedValue).groupBy(maybeGroupingExpression.get()) :
-                        ((ThenKeyExpression) groupedValue).groupBy(maybeGroupingExpression.get());
+                keyExpression = groupedValue.groupBy(maybeGroupingExpression.get());
             } else {
-                keyExpression = (groupedValue instanceof FieldKeyExpression) ?
-                        ((FieldKeyExpression) groupedValue).ungrouped() :
-                        ((ThenKeyExpression) groupedValue).ungrouped();
+                keyExpression = groupedValue.ungrouped();
             }
         }
         // special handling of min_ever and max_ever, depending on index attributes we either create the


### PR DESCRIPTION
This enables having nested, non-repeated fields in SQL index definition while introducing a common interface in the `KeyExpression` API called `GroupableKeyExpression` that declares grouping and ungrouping functions. The interface is implemented by existing `KeyExpression` implementations that already provide these methods, making dispatching on `KeyExpression` instances that support grouping more streamlined when creating in the SQL index generator.

This fixes #3546.