### PR TITLE
Fix for Lucene block leaks on file deletion

### DIFF
--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
@@ -122,7 +122,8 @@ public class FDBDirectory extends Directory  {
     public static final int DEFAULT_INITIAL_CAPACITY = 128;
     private static final int SEQUENCE_SUBSPACE = 0;
     private static final int META_SUBSPACE = 1;
-    private static final int DATA_SUBSPACE = 2;
+    @VisibleForTesting
+    public static final int DATA_SUBSPACE = 2;
     @SuppressWarnings({"Unused", "PMD.UnusedPrivateField"}) // preserved to document that this is reserved
     private static final int SCHEMA_SUBSPACE = 3;
     private static final int PRIMARY_KEY_SUBSPACE = 4;
@@ -657,7 +658,7 @@ public class FDBDirectory extends Directory  {
 
     @Nonnull
     @VisibleForTesting
-    protected CompletableFuture<Map<String, FDBLuceneFileReference>> getFileReferenceCacheAsync() {
+    public CompletableFuture<Map<String, FDBLuceneFileReference>> getFileReferenceCacheAsync() {
         if (fileReferenceCache.get() != null) {
             return CompletableFuture.completedFuture(fileReferenceCache.get());
         }
@@ -741,8 +742,8 @@ public class FDBDirectory extends Directory  {
         if (fieldInfosStorage.delete(id)) {
             agilityContext.clear(fieldInfosSubspace.pack(id));
         }
-        // Nothing stored here currently.
-        agilityContext.clear(dataSubspace.subspace(Tuple.from(id)).range());
+        // Clear all data blocks for the file
+        agilityContext.clear(dataSubspace.subspace(Tuple.from(value.getId())).range());
 
         // Delete K/V data: If the deferredDelete flag is on then delete all content from K/V subspace for the segment
         // (this is to support CFS deletion, that will be disjoint from the actual file deletion).

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
@@ -734,16 +734,16 @@ public class FDBDirectory extends Directory  {
     @VisibleForTesting
     protected boolean deleteFileInternal(@Nonnull Map<String, FDBLuceneFileReference> cache, @Nonnull String name) throws IOException {
         // TODO make this transactional or ensure that it is deleted in the right order
-        FDBLuceneFileReference value = cache.remove(name);
-        if (value == null) {
+        FDBLuceneFileReference fileReference = cache.remove(name);
+        if (fileReference == null) {
             return false;
         }
-        final long id = value.getFieldInfosId();
+        final long id = fileReference.getFieldInfosId();
         if (fieldInfosStorage.delete(id)) {
             agilityContext.clear(fieldInfosSubspace.pack(id));
         }
         // Clear all data blocks for the file
-        agilityContext.clear(dataSubspace.subspace(Tuple.from(value.getId())).range());
+        agilityContext.clear(dataSubspace.subspace(Tuple.from(fileReference.getId())).range());
 
         // Delete K/V data: If the deferredDelete flag is on then delete all content from K/V subspace for the segment
         // (this is to support CFS deletion, that will be disjoint from the actual file deletion).

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryTest.java
@@ -164,7 +164,7 @@ public class FDBDirectoryTest extends FDBDirectoryBaseTest {
 
     @Test
     public void testListAll() throws IOException {
-        assertEquals(directory.listAll().length, x0);
+        assertEquals(directory.listAll().length, 0);
         directory.writeFDBLuceneFileReference("test1", new FDBLuceneFileReference(1, 1, 1, 1));
         directory.writeFDBLuceneFileReference("test2", new FDBLuceneFileReference(2, 1, 1, 1));
         directory.writeFDBLuceneFileReference("test3", new FDBLuceneFileReference(3, 1, 1, 1));

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryTest.java
@@ -255,7 +255,7 @@ public class FDBDirectoryTest extends FDBDirectoryBaseTest {
     }
 
     @Test
-    public void testDataBlocksProperlyCleared() throws Exception {
+    void testDataBlocksProperlyCleared() throws Exception {
         // Create a file with data blocks
         long fileId = 1L;
         FDBLuceneFileReference reference = new FDBLuceneFileReference(fileId, 100, 100, 1024);
@@ -287,7 +287,7 @@ public class FDBDirectoryTest extends FDBDirectoryBaseTest {
     }
 
     @Test
-    public void testNoBlockLeaksWithMultipleFiles() throws Exception {
+    void testNoBlockLeaksWithMultipleFiles() throws Exception {
         // Create multiple files with data blocks
         long fileId1 = 100L;
         long fileId2 = 200L;

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryTest.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.lucene.directory;
 
+import com.apple.foundationdb.KeyValue;
 import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.record.RecordCoreArgumentException;
 import com.apple.foundationdb.record.lucene.LuceneConcurrency;
@@ -28,6 +29,7 @@ import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.test.Tags;
+import org.assertj.core.api.Assertions;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -162,7 +164,7 @@ public class FDBDirectoryTest extends FDBDirectoryBaseTest {
 
     @Test
     public void testListAll() throws IOException {
-        assertEquals(directory.listAll().length, 0);
+        assertEquals(directory.listAll().length, x0);
         directory.writeFDBLuceneFileReference("test1", new FDBLuceneFileReference(1, 1, 1, 1));
         directory.writeFDBLuceneFileReference("test2", new FDBLuceneFileReference(2, 1, 1, 1));
         directory.writeFDBLuceneFileReference("test3", new FDBLuceneFileReference(3, 1, 1, 1));
@@ -250,5 +252,76 @@ public class FDBDirectoryTest extends FDBDirectoryBaseTest {
     private void assertMetricCountAtMost(StoreTimer.Event metric, int maximumValue) {
         assertThat("Metric " + metric + " should be called at most " + maximumValue + " times",
                 timer.getCount(metric), lessThanOrEqualTo(maximumValue));
+    }
+
+    @Test
+    public void testDataBlocksProperlyCleared() throws Exception {
+        // Create a file with data blocks
+        long fileId = 1L;
+        FDBLuceneFileReference reference = new FDBLuceneFileReference(fileId, 100, 100, 1024);
+        String fileName = "test_file.dat";
+        // Write file reference and data blocks
+        directory.writeFDBLuceneFileReference(fileName, reference);
+        // Write data to blocks
+        byte[] testData1 = "test data block 1".getBytes();
+        byte[] testData2 = "test data block 2".getBytes();
+        directory.writeData(fileId, 1, testData1);
+        directory.writeData(fileId, 2, testData2);
+        
+        // Verify data blocks exist
+        final EmptyIndexInput emptyInput = new EmptyIndexInput("Test");
+        final byte[] block1 = directory.readBlock(emptyInput, fileName, directory.getFDBLuceneFileReferenceAsync(fileName), 1).join();
+        final byte[] block2 = directory.readBlock(emptyInput, fileName, directory.getFDBLuceneFileReferenceAsync(fileName), 2).join();
+        Assertions.assertThat(block1).isNotEmpty();
+        Assertions.assertThat(block2).isNotEmpty();
+
+        // Delete the file
+        directory.deleteFile(fileName);
+        
+        // Verify file is gone from directory listing
+        assertEquals(0, directory.listAll().length);
+        
+        // Shortcut to ensure the index is empty: No file references, no data blocks
+        final List<KeyValue> subspaceKeys = context.ensureActive().getRange(directory.getSubspace().range()).asList().join();
+        Assertions.assertThat(subspaceKeys).isEmpty();
+    }
+
+    @Test
+    public void testNoBlockLeaksWithMultipleFiles() throws Exception {
+        // Create multiple files with data blocks
+        long fileId1 = 100L;
+        long fileId2 = 200L;
+        FDBLuceneFileReference ref1 = new FDBLuceneFileReference(fileId1, 50, 50, 512);
+        FDBLuceneFileReference ref2 = new FDBLuceneFileReference(fileId2, 75, 75, 1024);
+        String fileName1 = "file1.dat";
+        String fileName2 = "file2.dat";
+        // Write file references and data
+        directory.writeFDBLuceneFileReference(fileName1, ref1);
+        directory.writeFDBLuceneFileReference(fileName2, ref2);
+        // Write data to blocks
+        byte[] data1 = "data for file 1".getBytes();
+        byte[] data2 = "data for file 2".getBytes();
+        directory.writeData(fileId1, 1, data1);
+        directory.writeData(fileId2, 1, data2);
+
+        // There should be one key for the file reference and one for the data block
+        final int keysPerFile = 2;
+        // Get initial data subspace size
+        final List<KeyValue> initialKeys = context.ensureActive().getRange(directory.getSubspace().range()).asList().join();
+        Assertions.assertThat(initialKeys).hasSize(2 * keysPerFile);
+
+        // Delete first file
+        directory.deleteFile(fileName1);
+        
+        // Check that data subspace size reduced appropriately
+        final List<KeyValue> afterDeleteKeys = context.ensureActive().getRange(directory.getSubspace().range()).asList().join();
+        Assertions.assertThat(afterDeleteKeys).hasSize(1 * keysPerFile);
+        
+        // Delete second file
+        directory.deleteFile(fileName2);
+        
+        // Check that data subspace is now empty
+        final List<KeyValue> finalKeys = context.ensureActive().getRange(directory.getSubspace().range()).asList().join();
+        Assertions.assertThat(finalKeys).isEmpty();
     }
 }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/MockedFDBDirectory.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/MockedFDBDirectory.java
@@ -94,7 +94,7 @@ public class MockedFDBDirectory extends FDBDirectory {
 
     @Nonnull
     @Override
-    protected CompletableFuture<Map<String, FDBLuceneFileReference>> getFileReferenceCacheAsync() {
+    public CompletableFuture<Map<String, FDBLuceneFileReference>> getFileReferenceCacheAsync() {
         return super.getFileReferenceCacheAsync()
                 .thenApply(cache -> {
                     injectedFailures.checkFailureForCoreException(LUCENE_GET_FILE_REFERENCE_CACHE_ASYNC);


### PR DESCRIPTION
The source of the leaking data blocks has been found and fixed.
Added more tests to verify the leakage was fixed directly as well as an addition to the `LuceneIndexTestValidator` to get some additional coverage "for free" whenever we use it in other tests.


Resolves #3550
