### PR TITLE
Deprecate synchronized indexing controls

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexOperationBaseBuilder.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexOperationBaseBuilder.java
@@ -709,6 +709,7 @@ public abstract class OnlineIndexOperationBaseBuilder<B extends OnlineIndexOpera
     }
 
     /**
+     * <em>Deprecated</em>. This will soon be determined by the indexing session type
      * Set the use of a synchronized session during the index operation. Synchronized sessions help performing
      * the multiple transactions operations in a resource efficient way.
      * Normally this should be {@code true}.
@@ -716,7 +717,6 @@ public abstract class OnlineIndexOperationBaseBuilder<B extends OnlineIndexOpera
      * @see SynchronizedSessionRunner
      * @param useSynchronizedSession use synchronize session if true, otherwise false
      * @return this builder
-     * Deprecated This will soon be determined by the indexing session type
      */
     @API(API.Status.DEPRECATED)
     public B setUseSynchronizedSession(boolean useSynchronizedSession) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexOperationBaseBuilder.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexOperationBaseBuilder.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.provider.foundationdb;
 
+import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.RecordMetaDataProvider;
@@ -715,7 +716,11 @@ public abstract class OnlineIndexOperationBaseBuilder<B extends OnlineIndexOpera
      * @see SynchronizedSessionRunner
      * @param useSynchronizedSession use synchronize session if true, otherwise false
      * @return this builder
+     * @deprecated This will soon be determined by the indexing session type
      */
+    @API(API.Status.DEPRECATED)
+    @SuppressWarnings("PMD.AvoidUsingHardCodedIP") // version is not IP
+    @Deprecated(since = "4.4.3.0", forRemoval = true)
     public B setUseSynchronizedSession(boolean useSynchronizedSession) {
         configBuilder.setUseSynchronizedSession(useSynchronizedSession);
         return self();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexOperationBaseBuilder.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexOperationBaseBuilder.java
@@ -716,7 +716,7 @@ public abstract class OnlineIndexOperationBaseBuilder<B extends OnlineIndexOpera
      * @see SynchronizedSessionRunner
      * @param useSynchronizedSession use synchronize session if true, otherwise false
      * @return this builder
-     * @deprecated This will soon be determined by the indexing session type
+     * Deprecated This will soon be determined by the indexing session type
      */
     @API(API.Status.DEPRECATED)
     public B setUseSynchronizedSession(boolean useSynchronizedSession) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexOperationBaseBuilder.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexOperationBaseBuilder.java
@@ -719,8 +719,6 @@ public abstract class OnlineIndexOperationBaseBuilder<B extends OnlineIndexOpera
      * @deprecated This will soon be determined by the indexing session type
      */
     @API(API.Status.DEPRECATED)
-    @SuppressWarnings("PMD.AvoidUsingHardCodedIP") // version is not IP
-    @Deprecated(since = "4.4.3.0", forRemoval = true)
     public B setUseSynchronizedSession(boolean useSynchronizedSession) {
         configBuilder.setUseSynchronizedSession(useSynchronizedSession);
         return self();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
@@ -318,8 +318,9 @@ public class OnlineIndexer implements AutoCloseable {
      * that explicitly state that they are building an unbuilt range, i.e., a range of keys
      * that contains no keys which have yet been processed by the {@link OnlineIndexer}
      * during an index build.
+     * <em>Deprecated</em> and unused.
      */
-    // TODO: remove unused exception
+    @API(API.Status.DEPRECATED)
     @SuppressWarnings("serial")
     public static class RecordBuiltRangeException extends RecordCoreException {
         public RecordBuiltRangeException(@Nullable Tuple start, @Nullable Tuple end) {
@@ -439,7 +440,7 @@ public class OnlineIndexer implements AutoCloseable {
      * the lock.
      * @return a future that will be ready when the lock is released
      * @see SynchronizedSession#endAnySession
-     * Deprecated. The functionality of this function can be done with {@link #blockIndexBuilds}
+     * <em>Deprecated</em>. The functionality of this function can be done with {@link #blockIndexBuilds}
      */
     @API(API.Status.DEPRECATED)
     public CompletableFuture<Void> stopOngoingOnlineIndexBuildsAsync() {
@@ -450,7 +451,7 @@ public class OnlineIndexer implements AutoCloseable {
 
     /**
      * Synchronous/blocking version of {@link #stopOngoingOnlineIndexBuildsAsync()}.
-     * Deprecated. The functionality of this function can be done with {@link #blockIndexBuilds}
+     * <em>Deprecated</em>. The functionality of this function can be done with {@link #blockIndexBuilds}
      */
     @API(API.Status.DEPRECATED)
     public void stopOngoingOnlineIndexBuilds() {
@@ -462,7 +463,7 @@ public class OnlineIndexer implements AutoCloseable {
      * the lock.
      * @param recordStore record store whose index builds need to be stopped
      * @param index the index whose builds need to be stopped
-     * Deprecated. The functionality of this function can be done with {@link #blockIndexBuilds}
+     * <em>Deprecated</em>. The functionality of this function can be done with {@link #blockIndexBuilds}
      */
     @API(API.Status.DEPRECATED)
     public static void stopOngoingOnlineIndexBuilds(@Nonnull FDBRecordStore recordStore, @Nonnull Index index) {
@@ -472,9 +473,7 @@ public class OnlineIndexer implements AutoCloseable {
     /**
      * Synchronous/blocking version of {@link #checkAnyOngoingOnlineIndexBuildsAsync()}.
      * @return <code>true</code> if the index is being built and <code>false</code> otherwise
-     * Deprecated. The functionality of this function will be replaced by shared heartbeats
      */
-    @API(API.Status.DEPRECATED)
     public boolean checkAnyOngoingOnlineIndexBuilds() {
         return runner.asyncToSync(FDBStoreTimer.Waits.WAIT_CHECK_ONGOING_ONLINE_INDEX_BUILD, checkAnyOngoingOnlineIndexBuildsAsync());
     }
@@ -483,9 +482,7 @@ public class OnlineIndexer implements AutoCloseable {
      * Check if the index is being built by any of the {@link OnlineIndexer}s (only if they use {@link SynchronizedSession}s),
      * including <i>this</i> {@link OnlineIndexer}.
      * @return a future that will complete to <code>true</code> if the index is being built and <code>false</code> otherwise
-     * Deprecated. The functionality of this function will be replaced by shared heartbeats
      */
-    @API(API.Status.DEPRECATED)
     public CompletableFuture<Boolean> checkAnyOngoingOnlineIndexBuildsAsync() {
         return runner.runAsync(context -> openRecordStore(context).thenCompose(recordStore ->
                 checkAnyOngoingOnlineIndexBuildsAsync(recordStore, index)),
@@ -497,9 +494,7 @@ public class OnlineIndexer implements AutoCloseable {
      * @param recordStore record store whose index builds need to be checked
      * @param index the index to check for ongoing index builds
      * @return a future that will complete to <code>true</code> if the index is being built and <code>false</code> otherwise
-     * Deprecated. The functionality of this function will be replaced by shared heartbeats
      */
-    @API(API.Status.DEPRECATED)
     public static CompletableFuture<Boolean> checkAnyOngoingOnlineIndexBuildsAsync(@Nonnull FDBRecordStore recordStore, @Nonnull Index index) {
         return SynchronizedSession.checkActiveSessionExists(recordStore.ensureContextActive(), IndexingSubspaces.indexBuildLockSubspace(recordStore, index));
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
@@ -436,11 +436,11 @@ public class OnlineIndexer implements AutoCloseable {
     }
 
     /**
+     * <em>Deprecated</em>. The functionality of this function can be done with {@link #blockIndexBuilds}
      * Stop any ongoing online index build (only if it uses {@link SynchronizedSession}s) by forcefully releasing
      * the lock.
      * @return a future that will be ready when the lock is released
      * @see SynchronizedSession#endAnySession
-     * <em>Deprecated</em>. The functionality of this function can be done with {@link #blockIndexBuilds}
      */
     @API(API.Status.DEPRECATED)
     public CompletableFuture<Void> stopOngoingOnlineIndexBuildsAsync() {
@@ -450,8 +450,8 @@ public class OnlineIndexer implements AutoCloseable {
     }
 
     /**
-     * Synchronous/blocking version of {@link #stopOngoingOnlineIndexBuildsAsync()}.
      * <em>Deprecated</em>. The functionality of this function can be done with {@link #blockIndexBuilds}
+     * Synchronous/blocking version of {@link #stopOngoingOnlineIndexBuildsAsync()}.
      */
     @API(API.Status.DEPRECATED)
     public void stopOngoingOnlineIndexBuilds() {
@@ -459,11 +459,11 @@ public class OnlineIndexer implements AutoCloseable {
     }
 
     /**
+     * <em>Deprecated</em>. The functionality of this function can be done with {@link #blockIndexBuilds}
      * Stop any ongoing online index build (only if it uses {@link SynchronizedSession}s) by forcefully releasing
      * the lock.
      * @param recordStore record store whose index builds need to be stopped
      * @param index the index whose builds need to be stopped
-     * <em>Deprecated</em>. The functionality of this function can be done with {@link #blockIndexBuilds}
      */
     @API(API.Status.DEPRECATED)
     public static void stopOngoingOnlineIndexBuilds(@Nonnull FDBRecordStore recordStore, @Nonnull Index index) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
@@ -319,6 +319,7 @@ public class OnlineIndexer implements AutoCloseable {
      * that contains no keys which have yet been processed by the {@link OnlineIndexer}
      * during an index build.
      */
+    // TODO: remove unused exception
     @SuppressWarnings("serial")
     public static class RecordBuiltRangeException extends RecordCoreException {
         public RecordBuiltRangeException(@Nullable Tuple start, @Nullable Tuple end) {
@@ -441,8 +442,6 @@ public class OnlineIndexer implements AutoCloseable {
      * @deprecated The functionality of this function can be done with {@link #blockIndexBuilds}
      */
     @API(API.Status.DEPRECATED)
-    @SuppressWarnings("PMD.AvoidUsingHardCodedIP") // version is not IP
-    @Deprecated(since = "4.4.3.0", forRemoval = true)
     public CompletableFuture<Void> stopOngoingOnlineIndexBuildsAsync() {
         return runner.runAsync(context -> openRecordStore(context).thenAccept(recordStore ->
                 stopOngoingOnlineIndexBuilds(recordStore, index)),
@@ -454,8 +453,6 @@ public class OnlineIndexer implements AutoCloseable {
      * @deprecated The functionality of this function can be done with {@link #blockIndexBuilds}
      */
     @API(API.Status.DEPRECATED)
-    @SuppressWarnings("PMD.AvoidUsingHardCodedIP") // version is not IP
-    @Deprecated(since = "4.4.3.0", forRemoval = true)
     public void stopOngoingOnlineIndexBuilds() {
         runner.asyncToSync(FDBStoreTimer.Waits.WAIT_STOP_ONLINE_INDEX_BUILD, stopOngoingOnlineIndexBuildsAsync());
     }
@@ -468,8 +465,6 @@ public class OnlineIndexer implements AutoCloseable {
      * @deprecated The functionality of this function can be done with {@link #blockIndexBuilds}
      */
     @API(API.Status.DEPRECATED)
-    @SuppressWarnings("PMD.AvoidUsingHardCodedIP") // version is not IP
-    @Deprecated(since = "4.4.3.0", forRemoval = true)
     public static void stopOngoingOnlineIndexBuilds(@Nonnull FDBRecordStore recordStore, @Nonnull Index index) {
         SynchronizedSession.endAnySession(recordStore.ensureContextActive(), IndexingSubspaces.indexBuildLockSubspace(recordStore, index));
     }
@@ -480,8 +475,6 @@ public class OnlineIndexer implements AutoCloseable {
      * @deprecated The functionality of this function will be replaced by shared heartbeats
      */
     @API(API.Status.DEPRECATED)
-    @SuppressWarnings("PMD.AvoidUsingHardCodedIP") // version is not IP
-    @Deprecated(since = "4.4.3.0", forRemoval = true)
     public boolean checkAnyOngoingOnlineIndexBuilds() {
         return runner.asyncToSync(FDBStoreTimer.Waits.WAIT_CHECK_ONGOING_ONLINE_INDEX_BUILD, checkAnyOngoingOnlineIndexBuildsAsync());
     }
@@ -493,8 +486,6 @@ public class OnlineIndexer implements AutoCloseable {
      * @deprecated The functionality of this function will be replaced by shared heartbeats
      */
     @API(API.Status.DEPRECATED)
-    @SuppressWarnings("PMD.AvoidUsingHardCodedIP") // version is not IP
-    @Deprecated(since = "4.4.3.0", forRemoval = true)
     public CompletableFuture<Boolean> checkAnyOngoingOnlineIndexBuildsAsync() {
         return runner.runAsync(context -> openRecordStore(context).thenCompose(recordStore ->
                 checkAnyOngoingOnlineIndexBuildsAsync(recordStore, index)),
@@ -509,8 +500,6 @@ public class OnlineIndexer implements AutoCloseable {
      * @deprecated The functionality of this function will be replaced by shared heartbeats
      */
     @API(API.Status.DEPRECATED)
-    @SuppressWarnings("PMD.AvoidUsingHardCodedIP") // version is not IP
-    @Deprecated(since = "4.4.3.0", forRemoval = true)
     public static CompletableFuture<Boolean> checkAnyOngoingOnlineIndexBuildsAsync(@Nonnull FDBRecordStore recordStore, @Nonnull Index index) {
         return SynchronizedSession.checkActiveSessionExists(recordStore.ensureContextActive(), IndexingSubspaces.indexBuildLockSubspace(recordStore, index));
     }
@@ -524,11 +513,6 @@ public class OnlineIndexer implements AutoCloseable {
      * multiple transactions honoring the rate-limiting parameters set in the constructor of this class. It also retries
      * any retriable errors that it encounters while it runs the build. At the end, it marks the index readable in the
      * store.
-     * </p>
-     * <p>
-     * One may consider to set the index state precondition to {@link IndexStatePrecondition#ERROR_IF_DISABLED_CONTINUE_IF_WRITE_ONLY}
-     * and {@link OnlineIndexer.Builder#setUseSynchronizedSession(boolean)} to {@code false}, which makes the indexer
-     * follow the same behavior as before version 2.8.90.0. But it is not recommended.
      * </p>
      * @return a future that will be ready when the build has completed
      * @throws com.apple.foundationdb.synchronizedsession.SynchronizedSessionLockedException the build is stopped
@@ -1468,7 +1452,6 @@ public class OnlineIndexer implements AutoCloseable {
              * by other threads/processes/systems with the exact same parameters, are attempting to concurrently build this
              * index. To allow that, the indexer will:
              * <ol>
-             *   <li> Avoid the indexing lock - i.e. assume that {@link OnlineIndexer.Builder#setUseSynchronizedSession(boolean)} was called with false</li>
              *   <li> Divide the records space to fragments, then iterate the fragments in a way that minimize the interference, while
              *      indexing each fragment independently.</li>
              *   <li> Handle indexing conflicts, when occurred.</li>

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
@@ -439,7 +439,7 @@ public class OnlineIndexer implements AutoCloseable {
      * the lock.
      * @return a future that will be ready when the lock is released
      * @see SynchronizedSession#endAnySession
-     * @deprecated The functionality of this function can be done with {@link #blockIndexBuilds}
+     * Deprecated. The functionality of this function can be done with {@link #blockIndexBuilds}
      */
     @API(API.Status.DEPRECATED)
     public CompletableFuture<Void> stopOngoingOnlineIndexBuildsAsync() {
@@ -450,7 +450,7 @@ public class OnlineIndexer implements AutoCloseable {
 
     /**
      * Synchronous/blocking version of {@link #stopOngoingOnlineIndexBuildsAsync()}.
-     * @deprecated The functionality of this function can be done with {@link #blockIndexBuilds}
+     * Deprecated. The functionality of this function can be done with {@link #blockIndexBuilds}
      */
     @API(API.Status.DEPRECATED)
     public void stopOngoingOnlineIndexBuilds() {
@@ -462,7 +462,7 @@ public class OnlineIndexer implements AutoCloseable {
      * the lock.
      * @param recordStore record store whose index builds need to be stopped
      * @param index the index whose builds need to be stopped
-     * @deprecated The functionality of this function can be done with {@link #blockIndexBuilds}
+     * Deprecated. The functionality of this function can be done with {@link #blockIndexBuilds}
      */
     @API(API.Status.DEPRECATED)
     public static void stopOngoingOnlineIndexBuilds(@Nonnull FDBRecordStore recordStore, @Nonnull Index index) {
@@ -472,7 +472,7 @@ public class OnlineIndexer implements AutoCloseable {
     /**
      * Synchronous/blocking version of {@link #checkAnyOngoingOnlineIndexBuildsAsync()}.
      * @return <code>true</code> if the index is being built and <code>false</code> otherwise
-     * @deprecated The functionality of this function will be replaced by shared heartbeats
+     * Deprecated. The functionality of this function will be replaced by shared heartbeats
      */
     @API(API.Status.DEPRECATED)
     public boolean checkAnyOngoingOnlineIndexBuilds() {
@@ -483,7 +483,7 @@ public class OnlineIndexer implements AutoCloseable {
      * Check if the index is being built by any of the {@link OnlineIndexer}s (only if they use {@link SynchronizedSession}s),
      * including <i>this</i> {@link OnlineIndexer}.
      * @return a future that will complete to <code>true</code> if the index is being built and <code>false</code> otherwise
-     * @deprecated The functionality of this function will be replaced by shared heartbeats
+     * Deprecated. The functionality of this function will be replaced by shared heartbeats
      */
     @API(API.Status.DEPRECATED)
     public CompletableFuture<Boolean> checkAnyOngoingOnlineIndexBuildsAsync() {
@@ -497,7 +497,7 @@ public class OnlineIndexer implements AutoCloseable {
      * @param recordStore record store whose index builds need to be checked
      * @param index the index to check for ongoing index builds
      * @return a future that will complete to <code>true</code> if the index is being built and <code>false</code> otherwise
-     * @deprecated The functionality of this function will be replaced by shared heartbeats
+     * Deprecated. The functionality of this function will be replaced by shared heartbeats
      */
     @API(API.Status.DEPRECATED)
     public static CompletableFuture<Boolean> checkAnyOngoingOnlineIndexBuildsAsync(@Nonnull FDBRecordStore recordStore, @Nonnull Index index) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
@@ -438,7 +438,11 @@ public class OnlineIndexer implements AutoCloseable {
      * the lock.
      * @return a future that will be ready when the lock is released
      * @see SynchronizedSession#endAnySession
+     * @deprecated The functionality of this function can be done with {@link #blockIndexBuilds}
      */
+    @API(API.Status.DEPRECATED)
+    @SuppressWarnings("PMD.AvoidUsingHardCodedIP") // version is not IP
+    @Deprecated(since = "4.4.3.0", forRemoval = true)
     public CompletableFuture<Void> stopOngoingOnlineIndexBuildsAsync() {
         return runner.runAsync(context -> openRecordStore(context).thenAccept(recordStore ->
                 stopOngoingOnlineIndexBuilds(recordStore, index)),
@@ -447,7 +451,11 @@ public class OnlineIndexer implements AutoCloseable {
 
     /**
      * Synchronous/blocking version of {@link #stopOngoingOnlineIndexBuildsAsync()}.
+     * @deprecated The functionality of this function can be done with {@link #blockIndexBuilds}
      */
+    @API(API.Status.DEPRECATED)
+    @SuppressWarnings("PMD.AvoidUsingHardCodedIP") // version is not IP
+    @Deprecated(since = "4.4.3.0", forRemoval = true)
     public void stopOngoingOnlineIndexBuilds() {
         runner.asyncToSync(FDBStoreTimer.Waits.WAIT_STOP_ONLINE_INDEX_BUILD, stopOngoingOnlineIndexBuildsAsync());
     }
@@ -457,7 +465,11 @@ public class OnlineIndexer implements AutoCloseable {
      * the lock.
      * @param recordStore record store whose index builds need to be stopped
      * @param index the index whose builds need to be stopped
+     * @deprecated The functionality of this function can be done with {@link #blockIndexBuilds}
      */
+    @API(API.Status.DEPRECATED)
+    @SuppressWarnings("PMD.AvoidUsingHardCodedIP") // version is not IP
+    @Deprecated(since = "4.4.3.0", forRemoval = true)
     public static void stopOngoingOnlineIndexBuilds(@Nonnull FDBRecordStore recordStore, @Nonnull Index index) {
         SynchronizedSession.endAnySession(recordStore.ensureContextActive(), IndexingSubspaces.indexBuildLockSubspace(recordStore, index));
     }
@@ -465,7 +477,11 @@ public class OnlineIndexer implements AutoCloseable {
     /**
      * Synchronous/blocking version of {@link #checkAnyOngoingOnlineIndexBuildsAsync()}.
      * @return <code>true</code> if the index is being built and <code>false</code> otherwise
+     * @deprecated The functionality of this function will be replaced by shared heartbeats
      */
+    @API(API.Status.DEPRECATED)
+    @SuppressWarnings("PMD.AvoidUsingHardCodedIP") // version is not IP
+    @Deprecated(since = "4.4.3.0", forRemoval = true)
     public boolean checkAnyOngoingOnlineIndexBuilds() {
         return runner.asyncToSync(FDBStoreTimer.Waits.WAIT_CHECK_ONGOING_ONLINE_INDEX_BUILD, checkAnyOngoingOnlineIndexBuildsAsync());
     }
@@ -474,7 +490,11 @@ public class OnlineIndexer implements AutoCloseable {
      * Check if the index is being built by any of the {@link OnlineIndexer}s (only if they use {@link SynchronizedSession}s),
      * including <i>this</i> {@link OnlineIndexer}.
      * @return a future that will complete to <code>true</code> if the index is being built and <code>false</code> otherwise
+     * @deprecated The functionality of this function will be replaced by shared heartbeats
      */
+    @API(API.Status.DEPRECATED)
+    @SuppressWarnings("PMD.AvoidUsingHardCodedIP") // version is not IP
+    @Deprecated(since = "4.4.3.0", forRemoval = true)
     public CompletableFuture<Boolean> checkAnyOngoingOnlineIndexBuildsAsync() {
         return runner.runAsync(context -> openRecordStore(context).thenCompose(recordStore ->
                 checkAnyOngoingOnlineIndexBuildsAsync(recordStore, index)),
@@ -486,7 +506,11 @@ public class OnlineIndexer implements AutoCloseable {
      * @param recordStore record store whose index builds need to be checked
      * @param index the index to check for ongoing index builds
      * @return a future that will complete to <code>true</code> if the index is being built and <code>false</code> otherwise
+     * @deprecated The functionality of this function will be replaced by shared heartbeats
      */
+    @API(API.Status.DEPRECATED)
+    @SuppressWarnings("PMD.AvoidUsingHardCodedIP") // version is not IP
+    @Deprecated(since = "4.4.3.0", forRemoval = true)
     public static CompletableFuture<Boolean> checkAnyOngoingOnlineIndexBuildsAsync(@Nonnull FDBRecordStore recordStore, @Nonnull Index index) {
         return SynchronizedSession.checkActiveSessionExists(recordStore.ensureContextActive(), IndexingSubspaces.indexBuildLockSubspace(recordStore, index));
     }
@@ -763,11 +787,6 @@ public class OnlineIndexer implements AutoCloseable {
          * Set how should {@link #buildIndexAsync()} (or its variations) build the index based on its state. Normally
          * this should be {@link IndexStatePrecondition#BUILD_IF_DISABLED_CONTINUE_BUILD_IF_WRITE_ONLY} if the index is
          * not corrupted.
-         * <p>
-         * One may consider setting it to {@link IndexStatePrecondition#ERROR_IF_DISABLED_CONTINUE_IF_WRITE_ONLY} and
-         * {@link #setUseSynchronizedSession(boolean)} to {@code false}, which makes the indexer follow the same behavior
-         * as before version 2.8.90.0. But it is not recommended.
-         * </p>
          * @see IndexStatePrecondition
          * @param indexStatePrecondition build option to use
          * @return this builder

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildIndexTest.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.provider.foundationdb;
 
 import com.apple.foundationdb.async.AsyncUtil;
+import com.apple.foundationdb.async.MoreAsyncUtil;
 import com.apple.foundationdb.async.RangeSet;
 import com.apple.foundationdb.record.IndexState;
 import com.apple.foundationdb.record.logging.KeyValueLogMessage;
@@ -33,6 +34,7 @@ import com.apple.foundationdb.synchronizedsession.SynchronizedSessionLockedExcep
 import com.apple.foundationdb.tuple.Tuple;
 import com.apple.test.RandomizedTestUtils;
 import com.google.protobuf.Message;
+import org.junit.jupiter.api.Assertions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -216,6 +218,11 @@ abstract class OnlineIndexerBuildIndexTest extends OnlineIndexerTest {
                     });
                 }
             }
+
+            buildFuture = MoreAsyncUtil.composeWhenComplete(
+                    buildFuture,
+                    (result, ex) -> indexBuilder.checkAnyOngoingOnlineIndexBuildsAsync().thenAccept(Assertions::assertFalse),
+                    fdb::mapAsyncToSyncException);
 
             if (recordsWhileBuilding != null && !recordsWhileBuilding.isEmpty()) {
                 int i = 0;

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildIndexTest.java
@@ -21,7 +21,6 @@
 package com.apple.foundationdb.record.provider.foundationdb;
 
 import com.apple.foundationdb.async.AsyncUtil;
-import com.apple.foundationdb.async.MoreAsyncUtil;
 import com.apple.foundationdb.async.RangeSet;
 import com.apple.foundationdb.record.IndexState;
 import com.apple.foundationdb.record.logging.KeyValueLogMessage;
@@ -34,7 +33,6 @@ import com.apple.foundationdb.synchronizedsession.SynchronizedSessionLockedExcep
 import com.apple.foundationdb.tuple.Tuple;
 import com.apple.test.RandomizedTestUtils;
 import com.google.protobuf.Message;
-import org.junit.jupiter.api.Assertions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -180,7 +178,6 @@ abstract class OnlineIndexerBuildIndexTest extends OnlineIndexerTest {
         if (!safeBuild) {
             indexingPolicy.setIfDisabled(OnlineIndexer.IndexingPolicy.DesiredAction.ERROR)
                     .setIfMismatchPrevious(OnlineIndexer.IndexingPolicy.DesiredAction.ERROR);
-            builder.setUseSynchronizedSession(false);
         }
         if (sourceIndex != null) {
             indexingPolicy.setSourceIndex(sourceIndex.getName())
@@ -238,13 +235,6 @@ abstract class OnlineIndexerBuildIndexTest extends OnlineIndexerTest {
                     });
                 }
             }
-            if (safeBuild) {
-                buildFuture = MoreAsyncUtil.composeWhenComplete(
-                        buildFuture,
-                        (result, ex) -> indexBuilder.checkAnyOngoingOnlineIndexBuildsAsync().thenAccept(Assertions::assertFalse),
-                        fdb::mapAsyncToSyncException);
-            }
-
             if (recordsWhileBuilding != null && !recordsWhileBuilding.isEmpty()) {
                 int i = 0;
                 while (i < recordsWhileBuilding.size()) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildIndexTest.java
@@ -76,6 +76,7 @@ abstract class OnlineIndexerBuildIndexTest extends OnlineIndexerTest {
         this.safeBuild = safeBuild;
     }
 
+    @SuppressWarnings("removal")
     <M extends Message> void singleRebuild(
             @Nonnull OnlineIndexerTestRecordHandler<M> recordHandler,
             @Nonnull List<M> records,
@@ -178,6 +179,7 @@ abstract class OnlineIndexerBuildIndexTest extends OnlineIndexerTest {
         if (!safeBuild) {
             indexingPolicy.setIfDisabled(OnlineIndexer.IndexingPolicy.DesiredAction.ERROR)
                     .setIfMismatchPrevious(OnlineIndexer.IndexingPolicy.DesiredAction.ERROR);
+            builder.setUseSynchronizedSession(false);
         }
         if (sourceIndex != null) {
             indexingPolicy.setSourceIndex(sourceIndex.getName())
@@ -235,6 +237,7 @@ abstract class OnlineIndexerBuildIndexTest extends OnlineIndexerTest {
                     });
                 }
             }
+
             if (recordsWhileBuilding != null && !recordsWhileBuilding.isEmpty()) {
                 int i = 0;
                 while (i < recordsWhileBuilding.size()) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildIndexTest.java
@@ -62,7 +62,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 /**
  * A base class for testing building indexes with {@link OnlineIndexer#buildIndex()} (or similar APIs).
@@ -70,13 +69,6 @@ import static org.junit.jupiter.api.Assumptions.assumeFalse;
 abstract class OnlineIndexerBuildIndexTest extends OnlineIndexerTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(OnlineIndexerBuildIndexTest.class);
 
-    private final boolean safeBuild;
-
-    OnlineIndexerBuildIndexTest(boolean safeBuild) {
-        this.safeBuild = safeBuild;
-    }
-
-    @SuppressWarnings("removal")
     <M extends Message> void singleRebuild(
             @Nonnull OnlineIndexerTestRecordHandler<M> recordHandler,
             @Nonnull List<M> records,
@@ -132,13 +124,7 @@ abstract class OnlineIndexerBuildIndexTest extends OnlineIndexerTest {
 
         final boolean isAlwaysReadable;
         try (FDBRecordContext context = openContext()) {
-            // If it is a safe build, it should work without setting the index state to write-only, which will be taken
-            // care of by OnlineIndexer.
-            if (!safeBuild) {
-                LOGGER.info(KeyValueLogMessage.of("marking write-only", TestLogMessageKeys.INDEX, index));
-                recordStore.clearAndMarkIndexWriteOnly(index).join();
-            }
-            isAlwaysReadable = safeBuild && recordStore.isIndexReadable(index);
+            isAlwaysReadable = recordStore.isIndexReadable(index);
             context.commit();
         }
 
@@ -176,11 +162,6 @@ abstract class OnlineIndexerBuildIndexTest extends OnlineIndexerTest {
         }
         OnlineIndexer.IndexingPolicy.Builder indexingPolicy = OnlineIndexer.IndexingPolicy.newBuilder();
 
-        if (!safeBuild) {
-            indexingPolicy.setIfDisabled(OnlineIndexer.IndexingPolicy.DesiredAction.ERROR)
-                    .setIfMismatchPrevious(OnlineIndexer.IndexingPolicy.DesiredAction.ERROR);
-            builder.setUseSynchronizedSession(false);
-        }
         if (sourceIndex != null) {
             indexingPolicy.setSourceIndex(sourceIndex.getName())
                     .setForbidRecordScan(true);
@@ -198,30 +179,28 @@ abstract class OnlineIndexerBuildIndexTest extends OnlineIndexerTest {
             if (agents == 1) {
                 buildFuture = indexBuilder.buildIndexAsync(false);
             } else {
+                // Multiple agents
                 if (overlap) {
                     CompletableFuture<?>[] futures = new CompletableFuture<?>[agents];
                     for (int i = 0; i < agents; i++) {
                         final int agent = i;
-                        futures[i] = safeBuild ?
-                                     indexBuilder.buildIndexAsync(false)
-                                               .exceptionally(exception -> {
-                                                   // (agents - 1) of the agents should stop with SynchronizedSessionLockedException
-                                                   // because the other one is already working on building the index.
-                                                   if (exception.getCause() instanceof SynchronizedSessionLockedException) {
-                                                       LOGGER.info(KeyValueLogMessage.of("Detected another worker processing this index",
-                                                               TestLogMessageKeys.INDEX, index,
-                                                               TestLogMessageKeys.AGENT, agent), exception);
-                                                       return null;
-                                                   } else {
-                                                       throw new CompletionException(exception);
-                                                   }
-                                               }) :
-                                     indexBuilder.buildIndexAsync(false);
+                        futures[i] = indexBuilder.buildIndexAsync(false)
+                                .exceptionally(exception -> {
+                                    // (agents - 1) of the agents should stop with SynchronizedSessionLockedException
+                                    // because the other one is already working on building the index.
+                                    if (exception.getCause() instanceof SynchronizedSessionLockedException) {
+                                        LOGGER.info(KeyValueLogMessage.of("Detected another worker processing this index",
+                                                TestLogMessageKeys.INDEX, index,
+                                                TestLogMessageKeys.AGENT, agent), exception);
+                                        return null;
+                                    } else {
+                                        throw new CompletionException(exception);
+                                    }
+                                });
                     }
                     buildFuture = CompletableFuture.allOf(futures);
                 } else {
-                    // Safe builds do not support building ranges yet.
-                    assumeFalse(safeBuild);
+                    // Mutual indexing is now replacing the assignment of different ranges to multiple agents
                     final List<Tuple> boundaries = getBoundariesList(records, records.size() / agents);
                     IntStream range = IntStream.rangeClosed(0, agents);
                     buildFuture = AsyncUtil.DONE;

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildJoinedIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildJoinedIndexTest.java
@@ -74,10 +74,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  * Tests for building indexes on {@link com.apple.foundationdb.record.metadata.JoinedRecordType}s.
  */
 @SuppressWarnings("try")
-abstract class OnlineIndexerBuildJoinedIndexTest extends OnlineIndexerBuildIndexTest {
-    OnlineIndexerBuildJoinedIndexTest(boolean safeBuild) {
-        super(safeBuild);
-    }
+class OnlineIndexerBuildJoinedIndexTest extends OnlineIndexerBuildIndexTest {
 
     static class OnlineIndexerJoinedRecordHandler implements OnlineIndexerTestRecordHandler<Message> {
         private static final OnlineIndexerJoinedRecordHandler INSTANCE = new OnlineIndexerJoinedRecordHandler();
@@ -522,17 +519,5 @@ abstract class OnlineIndexerBuildJoinedIndexTest extends OnlineIndexerBuildIndex
             addRandomUpdate(r, rec, recordsWhileBuilding, deleteWhileBuilding);
         }
         singleCountIndexRebuild(records, recordsWhileBuilding, deleteWhileBuilding);
-    }
-
-    static class Unsafe extends OnlineIndexerBuildJoinedIndexTest {
-        Unsafe() {
-            super(false);
-        }
-    }
-
-    static class Safe extends OnlineIndexerBuildJoinedIndexTest {
-        Safe() {
-            super(true);
-        }
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildRankIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildRankIndexTest.java
@@ -185,7 +185,7 @@ class OnlineIndexerBuildRankIndexTest extends OnlineIndexerBuildIndexTest {
     }
 
     @Test
-    public void emptyRangeRank() {
+    void emptyRangeRank() {
         rankRebuild(Collections.emptyList());
     }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildRankIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildRankIndexTest.java
@@ -61,11 +61,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  * Test building value indexes.
  */
 @SuppressWarnings("try")
-public abstract class OnlineIndexerBuildRankIndexTest extends OnlineIndexerBuildIndexTest {
-
-    private OnlineIndexerBuildRankIndexTest(boolean safeBuild) {
-        super(safeBuild);
-    }
+class OnlineIndexerBuildRankIndexTest extends OnlineIndexerBuildIndexTest {
 
     private void rankRebuild(@Nonnull List<TestRecords1Proto.MySimpleRecord> records, @Nullable List<TestRecords1Proto.MySimpleRecord> recordsWhileBuilding,
                              int agents, boolean overlap) {
@@ -309,23 +305,5 @@ public abstract class OnlineIndexerBuildRankIndexTest extends OnlineIndexerBuild
                 TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(r.nextInt(100)).setNumValue2(r.nextInt(20) + 20).build()
         ).limit(100).sorted(Comparator.comparingLong(TestRecords1Proto.MySimpleRecord::getRecNo)).collect(Collectors.toList());
         rankRebuild(records, recordsWhileBuilding, 5, false);
-    }
-
-    /**
-     * Build indexes with the unchecked index build interfaces.
-     */
-    public static class Unsafe extends OnlineIndexerBuildRankIndexTest {
-        Unsafe() {
-            super(false);
-        }
-    }
-
-    /**
-     * Build indexes with the safe index build interfaces.
-     */
-    public static class Safe extends OnlineIndexerBuildRankIndexTest {
-        Safe() {
-            super(true);
-        }
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildSumIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildSumIndexTest.java
@@ -61,7 +61,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * Test building sum indexes.
  */
-public abstract class OnlineIndexerBuildSumIndexTest extends OnlineIndexerBuildIndexTest {
+class OnlineIndexerBuildSumIndexTest extends OnlineIndexerBuildIndexTest {
     private static final Index REC_NO_INDEX = new Index("simple$rec_no", "rec_no");
     private static final Index NUM_VALUE_2_INDEX = new Index("simple$num_value_2", "num_value_2");
 
@@ -92,10 +92,6 @@ public abstract class OnlineIndexerBuildSumIndexTest extends OnlineIndexerBuildI
                 return IndexMaintenanceFilter.IndexValues.NONE;
             }
         };
-    }
-
-    private OnlineIndexerBuildSumIndexTest(boolean safeBuild) {
-        super(safeBuild);
     }
 
     @SuppressWarnings("try")
@@ -467,23 +463,5 @@ public abstract class OnlineIndexerBuildSumIndexTest extends OnlineIndexerBuildI
                 .map(TestRecords1Proto.MySimpleRecord::getRecNo)
                 .collect(Collectors.toList());
         sumRebuildFiltered(records, recordsWhileBuilding, deleteWhileBuilding, sourceIndex, filterSource);
-    }
-
-    /**
-     * Build indexes with the unchecked index build interfaces.
-     */
-    public static class Unsafe extends OnlineIndexerBuildSumIndexTest {
-        Unsafe() {
-            super(false);
-        }
-    }
-
-    /**
-     * Build indexes with the safe index build interfaces.
-     */
-    public static class Safe extends OnlineIndexerBuildSumIndexTest {
-        Safe() {
-            super(true);
-        }
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildUnnestedIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildUnnestedIndexTest.java
@@ -78,7 +78,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * Tests for building indexes on an unnested record type.
  */
-abstract class OnlineIndexerBuildUnnestedIndexTest extends OnlineIndexerBuildIndexTest {
+class OnlineIndexerBuildUnnestedIndexTest extends OnlineIndexerBuildIndexTest {
     @Nonnull
     public static final String UNNESTED = "UnnestedMapType";
     @Nonnull
@@ -97,10 +97,6 @@ abstract class OnlineIndexerBuildUnnestedIndexTest extends OnlineIndexerBuildInd
 
     @Nonnull
     private static final List<String> KEYS = List.of("foo", "bar", "baz", "qux", "zop", "zork");
-
-    OnlineIndexerBuildUnnestedIndexTest(boolean safeBuild) {
-        super(safeBuild);
-    }
 
     public static class OnlineIndexerTestUnnestedRecordHandler implements OnlineIndexerTestRecordHandler<Message> {
         @Nonnull
@@ -688,19 +684,6 @@ abstract class OnlineIndexerBuildUnnestedIndexTest extends OnlineIndexerBuildInd
                 )
                 .build()) {
             assertThrows(IndexingBase.ValidationException.class, indexer::buildIndex);
-        }
-    }
-
-    public static class Safe extends OnlineIndexerBuildUnnestedIndexTest {
-        Safe() {
-            super(true);
-        }
-
-    }
-
-    public static class Unsafe extends OnlineIndexerBuildUnnestedIndexTest {
-        Unsafe() {
-            super(false);
         }
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildValueIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildValueIndexTest.java
@@ -51,11 +51,7 @@ import static com.apple.foundationdb.record.metadata.Key.Expressions.field;
 /**
  * Test building value indexes.
  */
-public abstract class OnlineIndexerBuildValueIndexTest extends OnlineIndexerBuildIndexTest {
-
-    private OnlineIndexerBuildValueIndexTest(boolean safeBuild) {
-        super(safeBuild);
-    }
+class OnlineIndexerBuildValueIndexTest extends OnlineIndexerBuildIndexTest {
 
     private void valueRebuild(@Nonnull List<TestRecords1Proto.MySimpleRecord> records, @Nullable List<TestRecords1Proto.MySimpleRecord> recordsWhileBuilding,
                               int agents, boolean overlap, boolean splitLongRecords) {
@@ -398,23 +394,5 @@ public abstract class OnlineIndexerBuildValueIndexTest extends OnlineIndexerBuil
                 TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(r.nextInt(100)).setNumValue2(r.nextInt(20) + 20).build()
         ).limit(100).sorted(Comparator.comparingLong(TestRecords1Proto.MySimpleRecord::getRecNo)).collect(Collectors.toList());
         valueRebuild(records, recordsWhileBuilding, 5, false);
-    }
-
-    /**
-     * Build indexes with the unchecked index build interfaces.
-     */
-    public static class Unsafe extends OnlineIndexerBuildValueIndexTest {
-        Unsafe() {
-            super(false);
-        }
-    }
-
-    /**
-     * Build indexes with the safe index build interfaces.
-     */
-    public static class Safe extends OnlineIndexerBuildValueIndexTest {
-        Safe() {
-            super(true);
-        }
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildVersionIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildVersionIndexTest.java
@@ -63,11 +63,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  * Test building version indexes.
  */
 @SuppressWarnings("try")
-public abstract class OnlineIndexerBuildVersionIndexTest extends OnlineIndexerBuildIndexTest {
-
-    private OnlineIndexerBuildVersionIndexTest(boolean safeBuild) {
-        super(safeBuild);
-    }
+class OnlineIndexerBuildVersionIndexTest extends OnlineIndexerBuildIndexTest {
 
     private void versionRebuild(@Nonnull List<TestRecords1Proto.MySimpleRecord> records, @Nullable List<TestRecords1Proto.MySimpleRecord> recordsWhileBuilding,
                                 int agents, boolean overlap) {
@@ -414,23 +410,5 @@ public abstract class OnlineIndexerBuildVersionIndexTest extends OnlineIndexerBu
             context.commit();
         }
         versionRebuild(records, recordsWhileBuilding, 1, false);
-    }
-
-    /**
-     * Build indexes with the unchecked index build interfaces.
-     */
-    public static class Unsafe extends OnlineIndexerBuildVersionIndexTest {
-        Unsafe() {
-            super(false);
-        }
-    }
-
-    /**
-     * Build indexes with the safe index build interfaces.
-     */
-    public static class Safe extends OnlineIndexerBuildVersionIndexTest {
-        Safe() {
-            super(true);
-        }
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerIndexFromIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerIndexFromIndexTest.java
@@ -34,8 +34,6 @@ import com.google.common.collect.Comparators;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -55,8 +53,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Tests for building indexes from other indexes with {@link OnlineIndexer}.
  */
 class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
-    private static final Logger LOGGER = LoggerFactory.getLogger(OnlineIndexerIndexFromIndexTest.class);
-
 
     private void populateData(final long numRecords, final long numOtherRecords) {
         openSimpleMetaData();
@@ -366,6 +362,7 @@ class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
             try (FDBRecordContext context = openContext()) {
                 e = assertThrows(IndexingBase.ValidationException.class, () -> indexBuilder.rebuildIndex(recordStore));
                 assertTrue(e.getMessage().contains("source index is not a VALUE index"));
+                context.commit();
             }
         }
 
@@ -404,6 +401,7 @@ class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
             try (FDBRecordContext context = openContext()) {
                 e = assertThrows(IndexingBase.ValidationException.class, () -> indexBuilder.rebuildIndex(recordStore));
                 assertTrue(e.getMessage().contains("source index creates duplicates"));
+                context.commit();
             }
         }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMultiTargetTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMultiTargetTest.java
@@ -35,8 +35,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
@@ -52,6 +50,7 @@ import java.util.stream.LongStream;
 
 import static com.apple.foundationdb.record.metadata.Key.Expressions.field;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -60,7 +59,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 @Tag(Tags.Slow)
 class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
-    private static final Logger LOGGER = LoggerFactory.getLogger(OnlineIndexerMultiTargetTest.class);
 
     private void populateOtherData(final long numRecords) {
         List<TestRecords1Proto.MyOtherRecord> records = LongStream.range(0, numRecords).mapToObj(val ->
@@ -329,7 +327,7 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
 
             RecordCoreException e = assertThrows(RecordCoreException.class, indexBuilder::buildIndex);
             assertTrue(e.getMessage().contains("This index was partly built by another method"));
-            assertTrue(e instanceof IndexingBase.PartlyBuiltException);
+            assertInstanceOf(IndexingBase.PartlyBuiltException.class, e);
             final IndexBuildProto.IndexBuildIndexingStamp savedStamp = ((IndexingBase.PartlyBuiltException)e).getSavedStamp();
             assertEquals(IndexBuildProto.IndexBuildIndexingStamp.Method.BY_RECORDS, savedStamp.getMethod());
         }
@@ -371,7 +369,7 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
 
             RecordCoreException e = assertThrows(RecordCoreException.class, indexBuilder::buildIndex);
             assertTrue(e.getMessage().contains("This index was partly built by another method"));
-            assertTrue(e instanceof IndexingBase.PartlyBuiltException);
+            assertInstanceOf(IndexingBase.PartlyBuiltException.class, e);
             final IndexBuildProto.IndexBuildIndexingStamp savedStamp = ((IndexingBase.PartlyBuiltException)e).getSavedStamp();
             assertEquals(IndexBuildProto.IndexBuildIndexingStamp.Method.MULTI_TARGET_BY_RECORDS, savedStamp.getMethod());
             assertTrue(savedStamp.getTargetIndexList().containsAll(Arrays.asList("indexA", "indexB", "indexC", "indexD")));

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMultiTargetTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMultiTargetTest.java
@@ -23,8 +23,6 @@ package com.apple.foundationdb.record.provider.foundationdb;
 import com.apple.foundationdb.record.IndexBuildProto;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.TestRecords1Proto;
-import com.apple.foundationdb.record.logging.KeyValueLogMessage;
-import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.IndexOptions;
 import com.apple.foundationdb.record.metadata.IndexTypes;
@@ -50,7 +48,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 
 import static com.apple.foundationdb.record.metadata.Key.Expressions.field;
@@ -970,47 +967,4 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
         // happy indexes assertion
         assertReadable(indexes);
     }
-
-    @ParameterizedTest
-    @BooleanSource
-    void testMultiTargetIgnoringSyncLock(boolean reverseScan) {
-        // Simply build the index
-
-        final long numRecords = 180;
-
-        List<Index> indexes = new ArrayList<>();
-        indexes.add(new Index("indexA", field("num_value_2"), EmptyKeyExpression.EMPTY, IndexTypes.VALUE, IndexOptions.UNIQUE_OPTIONS));
-        indexes.add(new Index("indexB", field("num_value_3_indexed"), IndexTypes.VALUE));
-        indexes.add(new Index("indexC", field("num_value_unique"), EmptyKeyExpression.EMPTY, IndexTypes.VALUE, IndexOptions.UNIQUE_OPTIONS));
-        indexes.add(new Index("indexD", new GroupingKeyExpression(EmptyKeyExpression.EMPTY, 0), IndexTypes.COUNT));
-
-        populateData(numRecords);
-
-        FDBRecordStoreTestBase.RecordMetaDataHook hook = allIndexesHook(indexes);
-        openSimpleMetaData(hook);
-        disableAll(indexes);
-
-        IntStream.rangeClosed(0, 4).parallel().forEach(id -> {
-            snooze(100 - id);
-            try {
-                try (OnlineIndexer indexBuilder = newIndexerBuilder(indexes)
-                        .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
-                                .setReverseScanOrder(reverseScan))
-                        .setLimit(5)
-                        .setUseSynchronizedSession(id == 0)
-                        .setMaxRetries(100) // enough to avoid giving up
-                        .build()) {
-                    indexBuilder.buildIndex(true);
-                }
-            } catch (IndexingBase.UnexpectedReadableException ex) {
-                LOGGER.info(KeyValueLogMessage.of("Ignoring lock, got exception",
-                        LogMessageKeys.SESSION_ID, id,
-                        LogMessageKeys.ERROR, ex.getMessage()));
-            }
-        });
-
-        assertReadable(indexes);
-        scrubAndValidate(indexes);
-    }
-
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerSimpleTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerSimpleTest.java
@@ -406,7 +406,6 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
                 // once" may not hold true. With the two options, it is running doBuildIndexAsync effectively. Probably
                 // it would be better if this test can test the config loader with bare metal OnlineIndexer.runAsync
                 // instead.
-                .setUseSynchronizedSession(false)
                 .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
                         .setIfReadable(OnlineIndexer.IndexingPolicy.DesiredAction.ERROR)
                         .setIfWriteOnly(OnlineIndexer.IndexingPolicy.DesiredAction.CONTINUE)


### PR DESCRIPTION
Deprecate `OnlineIndexer.stopOngoingOnlineIndexBuilds` and variants in favor of `blockIndexBuilds`

Resolves #3548