### PR TITLE
When correcting yamsql metrics, only update queries with differences

### DIFF
--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/queryconfigs/CheckExplainConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/queryconfigs/CheckExplainConfig.java
@@ -189,14 +189,16 @@ public class CheckExplainConfig extends QueryConfig {
             final var actualCountersAndTimers = actualInfo.getCountersAndTimers();
             final var metricsDescriptor = expectedCountersAndTimers.getDescriptorForType();
 
-            executionContext.putMetrics(blockName, currentQuery, lineNumber, actualInfo, setups);
             if (areMetricsDifferent(expectedCountersAndTimers, actualCountersAndTimers, metricsDescriptor)) {
+                executionContext.putMetrics(blockName, currentQuery, lineNumber, actualInfo, setups);
                 if (executionContext.shouldCorrectMetrics()) {
                     executionContext.markDirty();
                     logger.debug(() -> "⭐️ Successfully updated planner metrics at line " + getLineNumber());
                 } else {
                     QueryCommand.reportTestFailure("‼️ Planner metrics have changed for line " + getLineNumber());
                 }
+            } else {
+                executionContext.putMetrics(blockName, currentQuery, lineNumber, expectedPlannerMetricsInfo, setups);
             }
         }
     }


### PR DESCRIPTION
Without this change, if you add a new query and run the test with CORRECT_METRICS, it will update all the timings for all of the other queries. This is less important for the binp, but can make it hard to look at the metrics yaml diff, as there will be many lines to ignore.

With this change, it will keep the original info for every query that did not result in a diffence.