### PR TITLE
Upload coverage from nightly builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -113,6 +113,7 @@ jobs:
           test-reports/fdb-relational-jdbc/
           test-reports/fdb-relational-server/
           test-reports/yaml-tests/
+
     - name: Upload coverage to teamscale
         # temporary until we validate that this is working correctly
         continue-on-error: true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -42,6 +42,7 @@ jobs:
           partition: 'CI Tests'
           revision: ${{ github.sha }}
           files: "${{ github.workspace }}/.out/reports/jacoco/codeCoverageReport/codeCoverageReport.xml"
+          teamscaleKey: ${{ secrets.TEAMSCALE_ACCESS_KEY }}
 
   mixed-mode-test:
     if: github.repository == 'FoundationDB/fdb-record-layer'
@@ -84,6 +85,7 @@ jobs:
           partition: 'Mixed Mode Tests'
           revision: ${{ github.sha }}
           files: "${{ github.workspace }}/.out/reports/jacoco/codeCoverageReport/codeCoverageReport.xml"
+          teamscaleKey: ${{ secrets.TEAMSCALE_ACCESS_KEY }}
 
   nightly_test:
     if: github.repository == 'FoundationDB/fdb-record-layer'
@@ -129,6 +131,7 @@ jobs:
         partition: 'Nightly Tests'
         revision: ${{ github.sha }}
         files: "${{ github.workspace }}/.out/reports/jacoco/codeCoverageReport/codeCoverageReport.xml"
+        teamscaleKey: ${{ secrets.TEAMSCALE_ACCESS_KEY }}
 
 
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,7 +10,9 @@ jobs:
   #   a) all the tests
   #   b) the mixed-mode tests
   #   c) the nightly tests
-  # At the moment the nightly tests include the regular tests, but we do both to get valuable coverage in teamscale.
+  # The nightly tests (currently) include all the regular tests, but we want to publish to teamscale the coverage
+  # statistics we're getting from PRB/before release. We want to be able to differentiate those two types of coverage
+  # in teamscale for a better understanding of what might escape in PRB.
   # It's possible that we could change the nightly tests to just be the new tests, and not the regular tests in the future.
   test:
     if: github.repository == 'FoundationDB/fdb-record-layer'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -91,47 +91,47 @@ jobs:
     if: github.repository == 'FoundationDB/fdb-record-layer'
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout sources
-      uses: actions/checkout@v4.2.2
-    - name: Setup Base Environment
-      uses: ./actions/setup-base-env
-    - name: Setup FDB
-      uses: ./actions/setup-fdb
-    - name: Run Gradle Test
-      uses: ./actions/gradle-test
-      with:
-        gradle_args: "-PreleaseBuild=false -PpublishBuild=false -PspotbugsEnableHtmlReport -Ptests.includeRandom -Ptests.iterations=2 -Ptests.nightly"
-    - name: Publish Test Reports
-      if: always()
-      uses: actions/upload-artifact@v4.6.0
-      with:
-        name: test-reports
-        path: |
-          test-reports/fdb-java-annotations/
-          test-reports/fdb-extensions/
-          test-reports/fdb-record-layer-core/
-          test-reports/fdb-record-layer-icu/
-          test-reports/fdb-record-layer-spatial/
-          test-reports/fdb-record-layer-lucene/
-          test-reports/fdb-record-layer-jmh/
-          test-reports/examples/
-          test-reports/fdb-relational-api/
-          test-reports/fdb-relational-core/
-          test-reports/fdb-relational-cli/
-          test-reports/fdb-relational-grpc/
-          test-reports/fdb-relational-jdbc/
-          test-reports/fdb-relational-server/
-          test-reports/yaml-tests/
-
-    - name: Upload coverage to teamscale
-      # temporary until we validate that this is working correctly
-      continue-on-error: true
-      uses: ./actions/teamscale-upload
-      with:
-        partition: 'Nightly Tests'
-        revision: ${{ github.sha }}
-        files: "${{ github.workspace }}/.out/reports/jacoco/codeCoverageReport/codeCoverageReport.xml"
-        teamscaleKey: ${{ secrets.TEAMSCALE_ACCESS_KEY }}
+      - name: Checkout sources
+        uses: actions/checkout@v4.2.2
+      - name: Setup Base Environment
+        uses: ./actions/setup-base-env
+      - name: Setup FDB
+        uses: ./actions/setup-fdb
+      - name: Run Gradle Test
+        uses: ./actions/gradle-test
+        with:
+          gradle_args: "-PreleaseBuild=false -PpublishBuild=false -PspotbugsEnableHtmlReport -Ptests.includeRandom -Ptests.iterations=2 -Ptests.nightly"
+      - name: Publish Test Reports
+        if: always()
+        uses: actions/upload-artifact@v4.6.0
+        with:
+          name: test-reports
+          path: |
+            test-reports/fdb-java-annotations/
+            test-reports/fdb-extensions/
+            test-reports/fdb-record-layer-core/
+            test-reports/fdb-record-layer-icu/
+            test-reports/fdb-record-layer-spatial/
+            test-reports/fdb-record-layer-lucene/
+            test-reports/fdb-record-layer-jmh/
+            test-reports/examples/
+            test-reports/fdb-relational-api/
+            test-reports/fdb-relational-core/
+            test-reports/fdb-relational-cli/
+            test-reports/fdb-relational-grpc/
+            test-reports/fdb-relational-jdbc/
+            test-reports/fdb-relational-server/
+            test-reports/yaml-tests/
+      
+      - name: Upload coverage to teamscale
+        # temporary until we validate that this is working correctly
+        continue-on-error: true
+        uses: ./actions/teamscale-upload
+        with:
+          partition: 'Nightly Tests'
+          revision: ${{ github.sha }}
+          files: "${{ github.workspace }}/.out/reports/jacoco/codeCoverageReport/codeCoverageReport.xml"
+          teamscaleKey: ${{ secrets.TEAMSCALE_ACCESS_KEY }}
 
 
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,7 +6,77 @@ on:
   workflow_dispatch:
 
 jobs:
-  gradle:
+  # In parallel, we run:
+  #   a) all the tests
+  #   b) the mixed-mode tests
+  #   c) the nightly tests
+  # At the moment the nightly tests include the regular tests, but we do both to get valuable coverage in teamscale.
+  # It's possible that we could change the nightly tests to just be the new tests, and not the regular tests in the future.
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4.2.2
+      - name: Setup Base Environment
+        id: setup-base
+        uses: ./actions/setup-base-env
+      - name: Setup FDB
+        uses: ./actions/setup-fdb
+      - name: Run Gradle Test
+        uses: ./actions/gradle-test
+        with:
+          gradle_args: -PreleaseBuild=true -PpublishBuild=true
+      - name: Upload coverage to teamscale
+        # temporary until we validate that this is working correctly
+        continue-on-error: true
+        uses: ./actions/teamscale-upload
+        with:
+          partition: 'CI Tests'
+          revision: ${{ github.sha }}
+
+  mixed-mode-test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4.2.2
+      - name: Setup Base Environment
+        uses: ./actions/setup-base-env
+      - name: Setup FDB
+        uses: ./actions/setup-fdb
+      - name: Run Gradle Test
+        uses: ./actions/gradle-test
+        with:
+          gradle_command: mixedModeTest
+          gradle_args: -PreleaseBuild=false -PpublishBuild=false
+      # We don't commit the incremented version, but we use this to know the version when generating
+      # the resulting markdown
+      - name: Increment version
+        shell: bash
+        run: python build/versionutils.py gradle.properties --increment -u PATCH
+      - name: Get new version
+        id: get_new_version
+        shell: bash
+        run: |
+          echo "version=$(python build/versionutils.py gradle.properties)" >> "$GITHUB_OUTPUT"
+      - name: Create markdown
+        shell: bash
+        run: python build/publish-mixed-mode-results.py ${{ steps.get_new_version.outputs.version }} --run-link ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} --output mixed-mode-results.md
+      - name: Preview results
+        shell: bash
+        run: cat mixed-mode-results.md >> $GITHUB_STEP_SUMMARY
+      - name: Upload coverage to teamscale
+        # temporary until we validate that this is working correctly
+        continue-on-error: true
+        uses: ./actions/teamscale-upload
+        with:
+          partition: 'Mixed Mode Tests'
+          revision: ${{ github.sha }}
+
+  nightly_test:
     if: github.repository == 'FoundationDB/fdb-record-layer'
     runs-on: ubuntu-latest
     steps:
@@ -42,18 +112,12 @@ jobs:
           test-reports/fdb-relational-server/
           test-reports/yaml-tests/
     - name: Upload coverage to teamscale
-      # temporary continue-on-error until we validate that this is working correctly
-      continue-on-error: true
-      uses: 'cqse/teamscale-upload-action@8d10b6693b9242420ef2062dbefc36af6e88d587'
+        # temporary until we validate that this is working correctly
+        continue-on-error: true
+        uses: ./actions/teamscale-upload
         with:
-          server: 'https://fdb.teamscale.io'
-          project: 'foundationdb-fdb-record-layer'
-          user: 'fdb-record-layer-build'
           partition: 'Nightly Tests'
-          accesskey: ${{ secrets.TEAMSCALE_ACCESS_KEY }}
-          format: 'JACOCO'
-          revision: ${{ github.event.workflow_run.head_sha }}
-          files: |
-            ${{ github.workspace }}/.out/reports/jacoco/codeCoverageReport/codeCoverageReport.xml
+          revision: ${{ github.sha }}
+
 
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,6 +13,7 @@ jobs:
   # At the moment the nightly tests include the regular tests, but we do both to get valuable coverage in teamscale.
   # It's possible that we could change the nightly tests to just be the new tests, and not the regular tests in the future.
   test:
+    if: github.repository == 'FoundationDB/fdb-record-layer'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -38,6 +39,7 @@ jobs:
           files: "${{ github.workspace }}/.out/reports/jacoco/codeCoverageReport/codeCoverageReport.xml"
 
   mixed-mode-test:
+    if: github.repository == 'FoundationDB/fdb-record-layer'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           partition: 'CI Tests'
           revision: ${{ github.sha }}
+          files: "${{ github.workspace }}/.out/reports/jacoco/codeCoverageReport/codeCoverageReport.xml"
 
   mixed-mode-test:
     runs-on: ubuntu-latest
@@ -75,6 +76,7 @@ jobs:
         with:
           partition: 'Mixed Mode Tests'
           revision: ${{ github.sha }}
+          files: "${{ github.workspace }}/.out/reports/jacoco/codeCoverageReport/codeCoverageReport.xml"
 
   nightly_test:
     if: github.repository == 'FoundationDB/fdb-record-layer'
@@ -118,6 +120,7 @@ jobs:
         with:
           partition: 'Nightly Tests'
           revision: ${{ github.sha }}
+          files: "${{ github.workspace }}/.out/reports/jacoco/codeCoverageReport/codeCoverageReport.xml"
 
 
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -41,4 +41,19 @@ jobs:
           test-reports/fdb-relational-jdbc/
           test-reports/fdb-relational-server/
           test-reports/yaml-tests/
+    - name: Upload coverage to teamscale
+      # temporary continue-on-error until we validate that this is working correctly
+      continue-on-error: true
+      uses: 'cqse/teamscale-upload-action@8d10b6693b9242420ef2062dbefc36af6e88d587'
+        with:
+          server: 'https://fdb.teamscale.io'
+          project: 'foundationdb-fdb-record-layer'
+          user: 'fdb-record-layer-build'
+          partition: 'Nightly Tests'
+          accesskey: ${{ secrets.TEAMSCALE_ACCESS_KEY }}
+          format: 'JACOCO'
+          revision: ${{ github.event.workflow_run.head_sha }}
+          files: |
+            ${{ github.workspace }}/.out/reports/jacoco/codeCoverageReport/codeCoverageReport.xml
+
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,8 +11,11 @@ jobs:
   #   b) the mixed-mode tests
   #   c) the nightly tests
   # The nightly tests (currently) include all the regular tests, but we want to publish to teamscale the coverage
-  # statistics we're getting from PRB/before release. We want to be able to differentiate those two types of coverage
-  # in teamscale for a better understanding of what might escape in PRB.
+  # statistics we're getting from PRB separately. We want to be able to differentiate those two types of coverage
+  # in teamscale for a better understanding of what might escape in PRB (or in our pre-release test run).
+  # The mixed-mode coverage is a little different, we want to see explicitly what code is being covered in mixed-mode
+  # so that we can find potential uncovered code that could expose bugs when multiple versions are running at the same
+  # time.
   # It's possible that we could change the nightly tests to just be the new tests, and not the regular tests in the future.
   test:
     if: github.repository == 'FoundationDB/fdb-record-layer'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -115,13 +115,13 @@ jobs:
           test-reports/yaml-tests/
 
     - name: Upload coverage to teamscale
-        # temporary until we validate that this is working correctly
-        continue-on-error: true
-        uses: ./actions/teamscale-upload
-        with:
-          partition: 'Nightly Tests'
-          revision: ${{ github.sha }}
-          files: "${{ github.workspace }}/.out/reports/jacoco/codeCoverageReport/codeCoverageReport.xml"
+      # temporary until we validate that this is working correctly
+      continue-on-error: true
+      uses: ./actions/teamscale-upload
+      with:
+        partition: 'Nightly Tests'
+        revision: ${{ github.sha }}
+        files: "${{ github.workspace }}/.out/reports/jacoco/codeCoverageReport/codeCoverageReport.xml"
 
 
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,21 @@ jobs:
         uses: ./actions/gradle-test
         with:
           gradle_args: -PreleaseBuild=true -PpublishBuild=true
+      - name: Upload coverage to teamscale
+        # temporary until we validate that this is working correctly
+        continue-on-error: true
+        uses: 'cqse/teamscale-upload-action@8d10b6693b9242420ef2062dbefc36af6e88d587'
+          with:
+            server: 'https://fdb.teamscale.io'
+            project: 'foundationdb-fdb-record-layer'
+            user: 'fdb-record-layer-build'
+            # Use the same partition as teamscale_upload.yml for PRs
+            partition: 'CI Tests'
+            accesskey: ${{ secrets.TEAMSCALE_ACCESS_KEY }}
+            format: 'JACOCO'
+            revision: ${{ github.event.workflow_run.head_sha }}
+            files: |
+              ${{ github.workspace }}/.out/reports/jacoco/codeCoverageReport/codeCoverageReport.xml
 
   # 2. b) We run the mixed mode tests
   mixed-mode-test:
@@ -104,6 +119,20 @@ jobs:
         with:
           name: mixed-mode-results
           path: mixed-mode-results.md
+      - name: Upload coverage to teamscale
+        # temporary continue-on-error until we validate that this is working correctly
+        continue-on-error: true
+        uses: 'cqse/teamscale-upload-action@8d10b6693b9242420ef2062dbefc36af6e88d587'
+          with:
+            server: 'https://fdb.teamscale.io'
+            project: 'foundationdb-fdb-record-layer'
+            user: 'fdb-record-layer-build'
+            partition: 'Mixed Mode Tests'
+            accesskey: ${{ secrets.TEAMSCALE_ACCESS_KEY }}
+            format: 'JACOCO'
+            revision: ${{ github.event.workflow_run.head_sha }}
+            files: |
+              ${{ github.workspace }}/.out/reports/jacoco/codeCoverageReport/codeCoverageReport.xml
 
   # 3. Update the version in the repo, update the release notes, tag the commit
   #    and publish the artifacts, and if this is a BUILD release generate the documentation

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,21 +61,6 @@ jobs:
         uses: ./actions/gradle-test
         with:
           gradle_args: -PreleaseBuild=true -PpublishBuild=true
-      - name: Upload coverage to teamscale
-        # temporary until we validate that this is working correctly
-        continue-on-error: true
-        uses: 'cqse/teamscale-upload-action@8d10b6693b9242420ef2062dbefc36af6e88d587'
-          with:
-            server: 'https://fdb.teamscale.io'
-            project: 'foundationdb-fdb-record-layer'
-            user: 'fdb-record-layer-build'
-            # Use the same partition as teamscale_upload.yml for PRs
-            partition: 'CI Tests'
-            accesskey: ${{ secrets.TEAMSCALE_ACCESS_KEY }}
-            format: 'JACOCO'
-            revision: ${{ github.event.workflow_run.head_sha }}
-            files: |
-              ${{ github.workspace }}/.out/reports/jacoco/codeCoverageReport/codeCoverageReport.xml
 
   # 2. b) We run the mixed mode tests
   mixed-mode-test:
@@ -119,20 +104,6 @@ jobs:
         with:
           name: mixed-mode-results
           path: mixed-mode-results.md
-      - name: Upload coverage to teamscale
-        # temporary continue-on-error until we validate that this is working correctly
-        continue-on-error: true
-        uses: 'cqse/teamscale-upload-action@8d10b6693b9242420ef2062dbefc36af6e88d587'
-          with:
-            server: 'https://fdb.teamscale.io'
-            project: 'foundationdb-fdb-record-layer'
-            user: 'fdb-record-layer-build'
-            partition: 'Mixed Mode Tests'
-            accesskey: ${{ secrets.TEAMSCALE_ACCESS_KEY }}
-            format: 'JACOCO'
-            revision: ${{ github.event.workflow_run.head_sha }}
-            files: |
-              ${{ github.workspace }}/.out/reports/jacoco/codeCoverageReport/codeCoverageReport.xml
 
   # 3. Update the version in the repo, update the release notes, tag the commit
   #    and publish the artifacts, and if this is a BUILD release generate the documentation

--- a/.github/workflows/teamscale_upload.yml
+++ b/.github/workflows/teamscale_upload.yml
@@ -50,3 +50,4 @@ jobs:
           partition: 'CI Tests'
           revision: ${{ github.event.workflow_run.head_sha }}
           files: "${{ runner.temp}}/artifacts/codeCoverageReport.xml"
+          teamscaleKey: ${{ secrets.TEAMSCALE_ACCESS_KEY }}

--- a/.github/workflows/teamscale_upload.yml
+++ b/.github/workflows/teamscale_upload.yml
@@ -45,14 +45,8 @@ jobs:
       - name: 'Unzip artifact'
         run: unzip "${{ runner.temp }}/artifacts/coverage-report.zip" -d "${{ runner.temp }}/artifacts"
       - name: 'Upload coverage'
-        uses: 'cqse/teamscale-upload-action@8d10b6693b9242420ef2062dbefc36af6e88d587'
+        uses: ./actions/teamscale-upload
         with:
-          server: 'https://fdb.teamscale.io'
-          project: 'foundationdb-fdb-record-layer'
-          user: 'fdb-record-layer-build'
-          # Use the same partition as we do for non-mixed-mode tests in release
           partition: 'CI Tests'
-          accesskey: ${{ secrets.TEAMSCALE_ACCESS_KEY }}
-          format: 'JACOCO'
           revision: ${{ github.event.workflow_run.head_sha }}
           files: "${{ runner.temp}}/artifacts/codeCoverageReport.xml"

--- a/.github/workflows/teamscale_upload.yml
+++ b/.github/workflows/teamscale_upload.yml
@@ -3,6 +3,8 @@ name: Upload Coverage to Teamscale
 permissions:
   actions: read
 
+# This is a separate workflow from pull_request.yml because it needs to run with access
+# to the secrets
 on:
   workflow_run:
     workflows: [Pull Request]
@@ -48,6 +50,7 @@ jobs:
           server: 'https://fdb.teamscale.io'
           project: 'foundationdb-fdb-record-layer'
           user: 'fdb-record-layer-build'
+          # Use the same partition as we do for non-mixed-mode tests in release
           partition: 'CI Tests'
           accesskey: ${{ secrets.TEAMSCALE_ACCESS_KEY }}
           format: 'JACOCO'

--- a/actions/teamscale-upload/action.yml
+++ b/actions/teamscale-upload/action.yml
@@ -10,6 +10,9 @@ inputs:
   files:
     description: 'Path to coverage xml file from jacoco'
     required: true
+  teamscaleKey:
+    description: 'Access key to teamscale'
+    required: true
 
 runs:
   using: "composite"
@@ -23,7 +26,7 @@ runs:
         project: 'foundationdb-fdb-record-layer'
         user: 'fdb-record-layer-build'
         partition: inputs.partition
-        accesskey: ${{ secrets.TEAMSCALE_ACCESS_KEY }}
+        accesskey: ${{ inputs.teamscaleKey }}
         format: 'JACOCO'
         revision: ${{ inputs.revision }}
         files: ${{ inputs.files }}

--- a/actions/teamscale-upload/action.yml
+++ b/actions/teamscale-upload/action.yml
@@ -7,6 +7,9 @@ inputs:
   revision:
     description: 'Git sha'
     required: true
+  files:
+    description: 'Path to coverage xml file from jacoco'
+    required: true
 
 runs:
   using: "composite"
@@ -19,10 +22,8 @@ runs:
         server: 'https://fdb.teamscale.io'
         project: 'foundationdb-fdb-record-layer'
         user: 'fdb-record-layer-build'
-        # Use the same partition as teamscale_upload.yml for PRs
         partition: inputs.partition
         accesskey: ${{ secrets.TEAMSCALE_ACCESS_KEY }}
         format: 'JACOCO'
         revision: ${{ inputs.revision }}
-        files: |
-          ${{ github.workspace }}/.out/reports/jacoco/codeCoverageReport/codeCoverageReport.xml
+        files: ${{ inputs.files }}

--- a/actions/teamscale-upload/action.yml
+++ b/actions/teamscale-upload/action.yml
@@ -1,0 +1,28 @@
+name: Upload Teamscale Coverage
+
+inputs:
+  partition:
+    description: 'Partition for the test coverage'
+    required: true
+  revision:
+    description: 'Git sha'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+  - name: Upload coverage to teamscale
+    # temporary until we validate that this is working correctly
+    continue-on-error: true
+    uses: 'cqse/teamscale-upload-action@8d10b6693b9242420ef2062dbefc36af6e88d587'
+      with:
+        server: 'https://fdb.teamscale.io'
+        project: 'foundationdb-fdb-record-layer'
+        user: 'fdb-record-layer-build'
+        # Use the same partition as teamscale_upload.yml for PRs
+        partition: inputs.partition
+        accesskey: ${{ secrets.TEAMSCALE_ACCESS_KEY }}
+        format: 'JACOCO'
+        revision: ${{ inputs.revision }}
+        files: |
+          ${{ github.workspace }}/.out/reports/jacoco/codeCoverageReport/codeCoverageReport.xml


### PR DESCRIPTION
Add new jobs to the nightly flow to run standard tests and mixed-mode tests. This is primarily there so that we can upload coverage to teamscale. 
These new teamscale steps are set to continue-on-error, to make sure they are working correctly before impacting the nightly build.

I also extracted the teamscale upload into a separate action to decrease repetition, this is the biggest risk; if I messed this up, it could impact the post-pr teamscale upload.