### PR TITLE
Do not mark gradle test as release or publish build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Run Gradle Test
         uses: ./actions/gradle-test
         with:
-          gradle_args: -PreleaseBuild=true -PpublishBuild=true
+          gradle_args: -PreleaseBuild=false -PpublishBuild=false
       - name: Upload coverage to teamscale
         # temporary until we validate that this is working correctly
         continue-on-error: true


### PR DESCRIPTION
I think this is the reason the last nightly build failed with:
```
2025-09-10T10:35:11.5880883Z * What went wrong:
2025-09-10T10:35:11.5881289Z Execution failed for task ':yaml-tests:serverJars'.
2025-09-10T10:35:11.5882938Z > Entry fdb-relational-server-4.5.10.0-all.jar is a duplicate but no duplicate handling
strategy has been set. Please refer to
https://docs.gradle.org/8.13/dsl/org.gradle.api.tasks.Copy.html#org.gradle.api.tasks.Copy:duplicatesStrategy for
details.
```