### PR TITLE
Checkout main during teamscale upload workflow

### DIFF
--- a/.github/workflows/teamscale_upload.yml
+++ b/.github/workflows/teamscale_upload.yml
@@ -16,6 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
+      # This checks out the latest commit on main, not teh PRs head
+      # This is needed to get the teamscale-upload action
+      - name: Checkout sources
+        uses: actions/checkout@v4.2.2
       - name: 'Download artifact'
         uses: actions/github-script@v7
         with:


### PR DESCRIPTION
We need to checkout main in order to get the action for uploading to teamscale.