### PR TITLE
Run Jupiter tests in relational-core, not just auto-test

### DIFF
--- a/fdb-relational-core/fdb-relational-core.gradle
+++ b/fdb-relational-core/fdb-relational-core.gradle
@@ -67,6 +67,7 @@ dependencies {
 // task should be moved to testing.gradle
 tasks.withType(Test).configureEach { theTask ->
     theTask.testFramework.options.includeEngines.add('auto-test')
+    theTask.testFramework.options.includeEngines.add('junit-jupiter')
 }
 
 publishing {


### PR DESCRIPTION
Apparently adding one engine to `includeEngines` causes `junit-jupiter` to be dropped. This adds it back so that we run all the tests.