### PR TITLE
Revert "Updating release notes for 4.5.14.0"

### DIFF
--- a/docs/sphinx/source/ReleaseNotes.md
+++ b/docs/sphinx/source/ReleaseNotes.md
@@ -7,25 +7,6 @@ As the [versioning guide](Versioning.md) details, it cannot always be determined
 
 ## 4.5
 
-### 4.5.14.0
-
-<h4> New Features </h4>
-
-* Make YAML tests (and SQL more generally) able to encrypt records at rest - [PR #3557](https://github.com/FoundationDB/fdb-record-layer/pull/3557)
-
-
-**[Full Changelog (4.5.13.0...4.5.14.0)](https://github.com/FoundationDB/fdb-record-layer/compare/4.5.13.0...4.5.14.0)**
-
-#### Mixed Mode Test Results
-
-Mixed mode testing run against the following previous versions:
-
-❌`4.5.3.0`, ❌`4.5.4.0`, ❌`4.5.5.0`, ❌`4.5.6.0`, ❌`4.5.7.0`, ❌`4.5.8.0`, ❌`4.5.9.0`, ❌`4.5.10.0`, ✅`4.5.12.0`, ✅`4.5.13.0`
-
-[See full test run](https://github.com/FoundationDB/fdb-record-layer/actions/runs/17773912236)
-
-
-
 ### 4.5.13.0
 
 <h4> New Features </h4>


### PR DESCRIPTION
This reverts commit c660050ad0114eadd336f71ee819e8140fd60bc2.

The publish job failed for this release (see https://github.com/FoundationDB/fdb-record-layer/actions/runs/17773912236/job/50522129560), so the artifacts do not really exist.