### PR TITLE
Prune duplicate intersections

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/AggregateDataAccessRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/AggregateDataAccessRule.java
@@ -53,6 +53,7 @@ import com.google.common.collect.ImmutableSet;
 
 import javax.annotation.Nonnull;
 import java.util.BitSet;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -170,6 +171,7 @@ public class AggregateDataAccessRule extends AbstractDataAccessRule {
 
         boolean hasCommonOrdering = false;
         final var expressionsBuilder = ImmutableList.<RelationalExpression>builder();
+        final var seenComparisonOrderingParts = new HashSet<List<OrderingPart.ProvidedOrderingPart>>();
         for (final var requestedOrdering : requestedOrderings) {
             final var translatedRequestedOrdering =
                     requestedOrdering.translateCorrelations(topToTopTranslationMap, true);
@@ -203,6 +205,11 @@ public class AggregateDataAccessRule extends AbstractDataAccessRule {
                     final var comparisonIsReverse =
                             RecordQuerySetPlan.resolveComparisonDirection(comparisonOrderingParts);
                     comparisonOrderingParts = RecordQuerySetPlan.adjustFixedBindings(comparisonOrderingParts, comparisonIsReverse);
+
+                    if (seenComparisonOrderingParts.contains(comparisonOrderingParts)) {
+                        continue;
+                    }
+                    seenComparisonOrderingParts.add(comparisonOrderingParts);
 
                     final var newQuantifiersBuilder = ImmutableList.<Quantifier.Physical>builder();
                     final var candidateTopAliasesBuilder = ImmutableList.<CorrelationIdentifier>builder();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/WithPrimaryKeyDataAccessRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/WithPrimaryKeyDataAccessRule.java
@@ -48,6 +48,7 @@ import com.google.common.collect.Iterables;
 
 import javax.annotation.Nonnull;
 import java.util.BitSet;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -148,6 +149,7 @@ public class WithPrimaryKeyDataAccessRule extends AbstractDataAccessRule {
 
         boolean hasCommonOrdering = false;
         final var expressionsBuilder = ImmutableList.<RelationalExpression>builder();
+        final var seenComparisonOrderingParts = new HashSet<List<OrderingPart.ProvidedOrderingPart>>();
         for (final var requestedOrdering : requestedOrderings) {
             final var translatedRequestedOrdering =
                     requestedOrdering.translateCorrelations(topToTopTranslationMap, true);
@@ -168,6 +170,11 @@ public class WithPrimaryKeyDataAccessRule extends AbstractDataAccessRule {
                     final var comparisonIsReverse =
                             RecordQuerySetPlan.resolveComparisonDirection(comparisonOrderingParts);
                     comparisonOrderingParts = RecordQuerySetPlan.adjustFixedBindings(comparisonOrderingParts, comparisonIsReverse);
+
+                    if (seenComparisonOrderingParts.contains(comparisonOrderingParts)) {
+                        continue;
+                    }
+                    seenComparisonOrderingParts.add(comparisonOrderingParts);
 
                     final var newQuantifiers =
                             partition


### PR DESCRIPTION
When the planner generates intersections of access paths, it might end up generating identical intersections unnecessarily.

This happens when the intersection ordering produces the same comparison parts when derived from multiple requested
orderings, which can happen if the intersection ordering, for example, has all of its ordering parts bound except one.

Example:
Given a partition or two access paths `X` and `Y` whose intersection ordering is with `bindings: {a=[=∅],b=[↑],e=[='bar'],d=[=42],c=[='foo']}` and `orderingSet: {a, b, e, d, c}` (note how all of the ordering parts are bound except one).

With the following requested ordering: `a↕, b↑, c↕, d↕, e↕` we end up generating an intersection `X ∩ Y | comparison=[b↑]`.
With a slightly different requested ordering `a↕, c↕, e↕, d↕, b↑` we end up generating the _same_ intersection `X ∩ Y | comparison=[b↑]`.
...

This can happen hundreds of times depending on how many requested orderings are there. Since these intersections are identical, they will be pruned away _anyway_ when we attempted to memoize them in the traversal structure, but this wasted effort puts unnecessary churn on the memoizer.

This fixes #3609.