### PR TITLE
Run jar when calculating codeCoverageReport in nightly build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -33,14 +33,8 @@ jobs:
       - name: Run Gradle Test
         uses: ./actions/gradle-test
         with:
-          gradle_command: test destructiveTest
+          gradle_command: jar test destructiveTest codeCoverageReport
           gradle_args: -PreleaseBuild=false -PpublishBuild=false
-      # If you run this command as part of the above it complains about imlplicit dependencies, but running separately
-      # is fine. We need to run it separately in pull_request, because we're combining different jobs
-      - name: Run JaCoCo Report
-        uses: ./actions/run-gradle
-        with:
-          gradle_command: codeCoverageReport
       - name: Upload coverage to teamscale
         # temporary until we validate that this is working correctly
         continue-on-error: true
@@ -66,14 +60,8 @@ jobs:
       - name: Run Gradle Test
         uses: ./actions/gradle-test
         with:
-          gradle_command: mixedModeTest
+          gradle_command: jar mixedModeTest codeCoverageReport
           gradle_args: -PreleaseBuild=false -PpublishBuild=false
-      # If you run this command as part of the above it complains about imlplicit dependencies, but running separately
-      # is fine. We need to run it separately in pull_request, because we're combining different jobs
-      - name: Run JaCoCo Report
-        uses: ./actions/run-gradle
-        with:
-          gradle_command: codeCoverageReport
       # We don't commit the incremented version, but we use this to know the version when generating
       # the resulting markdown
       - name: Increment version
@@ -113,7 +101,7 @@ jobs:
       - name: Run Gradle Test
         uses: ./actions/gradle-test
         with:
-          gradle_command: test destructiveTest
+          gradle_command: jar test destructiveTest codeCoverageReport
           gradle_args: "-PreleaseBuild=false -PpublishBuild=false -PspotbugsEnableHtmlReport -Ptests.includeRandom -Ptests.iterations=2 -Ptests.nightly"
       # If you run this command as part of the above it complains about imlplicit dependencies, but running separately
       # is fine. We need to run it separately in pull_request, because we're combining different jobs


### PR DESCRIPTION
Some projects were showing up, incorrectly with 0% coverage. The resolution for this in PRB was to run `jar` and pass around the artifacts. We don't have to pass around the artifacts, so we can just run jar in the same command. I'm hoping that the change here also fixes the issue with the nightly build.

I validated locally running `jar test destructiveTest codeCoverageReport`, and the `mixedMode` version. It does not complain about implicit task dependencies.