### PR TITLE
Remove redundant codeCoverageReport in nightly tests

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -103,12 +103,6 @@ jobs:
         with:
           gradle_command: jar test destructiveTest codeCoverageReport
           gradle_args: "-PreleaseBuild=false -PpublishBuild=false -PspotbugsEnableHtmlReport -Ptests.includeRandom -Ptests.iterations=2 -Ptests.nightly"
-      # If you run this command as part of the above it complains about imlplicit dependencies, but running separately
-      # is fine. We need to run it separately in pull_request, because we're combining different jobs
-      - name: Run JaCoCo Report
-        uses: ./actions/run-gradle
-        with:
-          gradle_command: codeCoverageReport
       - name: Publish Test Reports
         if: always()
         uses: actions/upload-artifact@v4.6.0


### PR DESCRIPTION
I forgot to remove this when I combined the commands in #3613