### PR TITLE
Explicitly fetch PR head in metrics diff job

### DIFF
--- a/.github/workflows/metrics_analysis.yml
+++ b/.github/workflows/metrics_analysis.yml
@@ -9,6 +9,7 @@ jobs:
   metrics-analysis:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       issues: write
       pull-requests: write
 
@@ -24,6 +25,10 @@ jobs:
     - name: Run metrics diff analysis
       id: metrics-diff
       run: |
+        # Make sure we have the PR head fetched. Note that we only download the code for comparison,
+        # we do not run any code from the pull request's version
+        git fetch pulls/${{ github.event.number }}/head
+
         # Run the analysis. Compare against the base hash of this PR
         ./gradlew :yaml-tests:analyzeMetrics \
           -PmetricsAnalysis.baseRef="${{ github.sha }}" \


### PR DESCRIPTION
The metrics diff job failed when trying to compare two hashes: https://github.com/FoundationDB/fdb-record-layer/actions/runs/17979075422

This is because we are using the `pull_request_target` job type, and that only fetches the target's branch's state (so, `main` in this case), but we need to fetch both the PR head and the target head in order to compute the diff. We have to be a little careful, because the `pull_request_target` runs at heightened permissions (that is, including writes), so it is important it does not run any outside code. So in this fix, we fetch the PR head, but we do not check it out. We will continue to run the analysis tool from the target branch.

Hopefully, this unblocks the broken metrics diff job.