### PR TITLE
Specify repo when fetching PR head in metrics build

### DIFF
--- a/.github/workflows/metrics_analysis.yml
+++ b/.github/workflows/metrics_analysis.yml
@@ -27,7 +27,7 @@ jobs:
       run: |
         # Make sure we have the PR head fetched. Note that we only download the code for comparison,
         # we do not run any code from the pull request's version
-        git fetch pulls/${{ github.event.number }}/head
+        git fetch origin pulls/${{ github.event.number }}/head
 
         # Run the analysis. Compare against the base hash of this PR
         ./gradlew :yaml-tests:analyzeMetrics \


### PR DESCRIPTION
I missed the word "origin" in the fetch command, leading to another job failure: https://github.com/FoundationDB/fdb-record-layer/actions/runs/17983041897/job/51153993870?pr=3626

I actually had this right in a test repo I was using to validate this stuff, but I messed it up when I copied things over. 🤦