### PR TITLE
Use reference name "pull/PR_NUMBER/head" to get PR head reference

### DIFF
--- a/.github/workflows/metrics_analysis.yml
+++ b/.github/workflows/metrics_analysis.yml
@@ -27,7 +27,7 @@ jobs:
       run: |
         # Make sure we have the PR head fetched. Note that we only download the code for comparison,
         # we do not run any code from the pull request's version
-        git fetch origin pulls/${{ github.event.number }}/head
+        git fetch origin pull/${{ github.event.number }}/head
 
         # Run the analysis. Compare against the base hash of this PR
         ./gradlew :yaml-tests:analyzeMetrics \


### PR DESCRIPTION
This should be `pull`, singular, instead of `pulls`, plural. This is actually another thing I had correct in my test repo but that got copied over incorrectly in my haste.

I want to say that this is it, but of course, I thought that the last time as well.