### PR TITLE
Allow index maintainer implementors to specify their own index match candidate

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/MetaDataEvolutionValidator.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/MetaDataEvolutionValidator.java
@@ -23,6 +23,7 @@ package com.apple.foundationdb.record.metadata;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.logging.LogMessageKeys;
+import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerFactoryRegistry;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerRegistry;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerRegistryImpl;
 import com.apple.foundationdb.record.util.pair.NonnullPair;
@@ -90,7 +91,7 @@ public class MetaDataEvolutionValidator {
     private static final MetaDataEvolutionValidator DEFAULT_INSTANCE = new MetaDataEvolutionValidator();
 
     @Nonnull
-    private final IndexMaintainerRegistry indexMaintainerRegistry;
+    private final IndexValidatorRegistry indexValidatorRegistry;
     private final boolean allowNoVersionChange;
     private final boolean allowNoSinceVersion;
     private final boolean allowIndexRebuilds;
@@ -100,7 +101,7 @@ public class MetaDataEvolutionValidator {
     private final boolean disallowTypeRenames;
 
     private MetaDataEvolutionValidator() {
-        this.indexMaintainerRegistry = IndexMaintainerRegistryImpl.instance();
+        this.indexValidatorRegistry = IndexMaintainerRegistryImpl.instance();
         this.allowNoVersionChange = false;
         this.allowNoSinceVersion = false;
         this.allowIndexRebuilds = false;
@@ -111,7 +112,7 @@ public class MetaDataEvolutionValidator {
     }
 
     private MetaDataEvolutionValidator(@Nonnull Builder builder) {
-        this.indexMaintainerRegistry = builder.indexMaintainerRegistry;
+        this.indexValidatorRegistry = builder.indexValidatorRegistry;
         this.allowNoVersionChange = builder.allowNoVersionChange;
         this.allowNoSinceVersion = builder.allowNoSinceVersion;
         this.allowIndexRebuilds = builder.allowIndexRebuilds;
@@ -668,7 +669,7 @@ public class MetaDataEvolutionValidator {
         // If there have been any changes to the index options, ask the index validator for that type
         // to validate the changed options.
         if (!oldIndex.getOptions().equals(newIndex.getOptions())) {
-            IndexValidator validatorForIndex = indexMaintainerRegistry.getIndexValidator(newIndex);
+            IndexValidator validatorForIndex = indexValidatorRegistry.getIndexValidator(newIndex);
             validatorForIndex.validateChangedOptions(oldIndex);
         }
     }
@@ -679,11 +680,11 @@ public class MetaDataEvolutionValidator {
      * the meta-data. By default, this uses the default {@link IndexMaintainerRegistryImpl} instance.
      *
      * @return the index maintainer registry used to validate indexes
-     * @see com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase.BaseBuilder#setIndexMaintainerRegistry(IndexMaintainerRegistry)
+     * @see com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase.BaseBuilder#setIndexMaintainerRegistry(IndexMaintainerFactoryRegistry)
      */
     @Nonnull
-    public IndexMaintainerRegistry getIndexMaintainerRegistry() {
-        return indexMaintainerRegistry;
+    public IndexValidatorRegistry getIndexValidatorRegistry() {
+        return indexValidatorRegistry;
     }
 
     /**
@@ -823,7 +824,7 @@ public class MetaDataEvolutionValidator {
      */
     public static class Builder {
         @Nonnull
-        private IndexMaintainerRegistry indexMaintainerRegistry;
+        private IndexValidatorRegistry indexValidatorRegistry;
         private boolean allowNoVersionChange;
         private boolean allowNoSinceVersion;
         private boolean allowIndexRebuilds;
@@ -833,7 +834,7 @@ public class MetaDataEvolutionValidator {
         private boolean disallowTypeRenames;
 
         private Builder(@Nonnull MetaDataEvolutionValidator validator) {
-            this.indexMaintainerRegistry = validator.indexMaintainerRegistry;
+            this.indexValidatorRegistry = validator.indexValidatorRegistry;
             this.allowNoVersionChange = validator.allowNoVersionChange;
             this.allowNoSinceVersion = validator.allowNoSinceVersion;
             this.allowIndexRebuilds = validator.allowIndexRebuilds;
@@ -844,29 +845,29 @@ public class MetaDataEvolutionValidator {
         }
 
         /**
-         * Set the registry of index maintainers used to validate indexes.
+         * Set the registry of index validators used to validate indexes.
          *
-         * @param indexMaintainerRegistry the index maintainer registry used to validate indexes
+         * @param indexValidatorRegistry the index validator registry used to validate indexes
          * @return this builder
-         * @see com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase.BaseBuilder#setIndexMaintainerRegistry(IndexMaintainerRegistry)
-         * @see MetaDataEvolutionValidator#getIndexMaintainerRegistry()
+         * @see com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase.BaseBuilder#setIndexMaintainerRegistry(IndexMaintainerFactoryRegistry)
+         * @see MetaDataEvolutionValidator#getIndexValidatorRegistry()
          */
         @Nonnull
-        public Builder setIndexMaintainerRegistry(@Nonnull IndexMaintainerRegistry indexMaintainerRegistry) {
-            this.indexMaintainerRegistry = indexMaintainerRegistry;
+        public Builder setIndexValidatorRegistry(@Nonnull IndexMaintainerRegistry indexValidatorRegistry) {
+            this.indexValidatorRegistry = indexValidatorRegistry;
             return this;
         }
 
         /**
-         * Get the registry of index maintainers used to validate indexes.
+         * Get the registry of index validators used to validate indexes.
          *
          * @return the index maintainer registry used to validate indexes
-         * @see com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase.BaseBuilder#setIndexMaintainerRegistry(IndexMaintainerRegistry)
-         * @see MetaDataEvolutionValidator#getIndexMaintainerRegistry()
+         * @see com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase.BaseBuilder#setIndexMaintainerRegistry(IndexMaintainerFactoryRegistry)
+         * @see MetaDataEvolutionValidator#getIndexValidatorRegistry()
          */
         @Nonnull
-        public IndexMaintainerRegistry getIndexMaintainerRegistry() {
-            return indexMaintainerRegistry;
+        public IndexValidatorRegistry getIndexValidatorRegistry() {
+            return indexValidatorRegistry;
         }
 
         /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -282,7 +282,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     protected final RecordSerializer<Message> serializer;
 
     @Nonnull
-    protected final IndexMaintainerRegistry indexMaintainerRegistry;
+    protected final IndexMaintainerFactoryRegistry indexMaintainerRegistry;
 
     @Nonnull
     protected final IndexMaintenanceFilter indexMaintenanceFilter;
@@ -322,7 +322,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
                              @Nonnull FormatVersion formatVersion,
                              @Nonnull RecordMetaDataProvider metaDataProvider,
                              @Nonnull RecordSerializer<Message> serializer,
-                             @Nonnull IndexMaintainerRegistry indexMaintainerRegistry,
+                             @Nonnull IndexMaintainerFactoryRegistry indexMaintainerRegistry,
                              @Nonnull IndexMaintenanceFilter indexMaintenanceFilter,
                              @Nonnull PipelineSizer pipelineSizer,
                              @Nullable FDBRecordStoreStateCache storeStateCache,
@@ -463,8 +463,9 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
         return serializer;
     }
 
+    @Override
     @Nonnull
-    public IndexMaintainerRegistry getIndexMaintainerRegistry() {
+    public IndexMaintainerFactoryRegistry getIndexMaintainerRegistry() {
         return indexMaintainerRegistry;
     }
 
@@ -5326,7 +5327,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
         private FDBRecordStoreBase.UserVersionChecker userVersionChecker;
 
         @Nonnull
-        private IndexMaintainerRegistry indexMaintainerRegistry = IndexMaintainerRegistryImpl.instance();
+        private IndexMaintainerFactoryRegistry indexMaintainerRegistry = IndexMaintainerRegistryImpl.instance();
 
         @Nonnull
         private IndexMaintenanceFilter indexMaintenanceFilter = IndexMaintenanceFilter.NORMAL;
@@ -5523,13 +5524,13 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
 
         @Override
         @Nonnull
-        public IndexMaintainerRegistry getIndexMaintainerRegistry() {
+        public IndexMaintainerFactoryRegistry getIndexMaintainerRegistry() {
             return indexMaintainerRegistry;
         }
 
         @Override
         @Nonnull
-        public Builder setIndexMaintainerRegistry(@Nonnull IndexMaintainerRegistry indexMaintainerRegistry) {
+        public Builder setIndexMaintainerRegistry(@Nonnull IndexMaintainerFactoryRegistry indexMaintainerRegistry) {
             this.indexMaintainerRegistry = indexMaintainerRegistry;
             return this;
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreBase.java
@@ -186,6 +186,8 @@ public interface FDBRecordStoreBase<M extends Message> extends RecordMetaDataPro
     @Nonnull
     RecordSerializer<M> getSerializer();
 
+    @Nonnull
+    IndexMaintainerFactoryRegistry getIndexMaintainerRegistry();
 
     /**
      * Returns the index maintainer for a given index.
@@ -2328,7 +2330,7 @@ public interface FDBRecordStoreBase<M extends Message> extends RecordMetaDataPro
          * @return the index registry to use
          */
         @Nonnull
-        IndexMaintainerRegistry getIndexMaintainerRegistry();
+        IndexMaintainerFactoryRegistry getIndexMaintainerRegistry();
 
         /**
          * Set the registry of index maintainers to be used by the record store.
@@ -2338,7 +2340,7 @@ public interface FDBRecordStoreBase<M extends Message> extends RecordMetaDataPro
          * @see RecordMetaDataBuilder#setIndexMaintainerRegistry
          */
         @Nonnull
-        BaseBuilder<M, R> setIndexMaintainerRegistry(@Nonnull IndexMaintainerRegistry indexMaintainerRegistry);
+        BaseBuilder<M, R> setIndexMaintainerRegistry(@Nonnull IndexMaintainerFactoryRegistry indexMaintainerRegistry);
 
         /**
          * Get the {@link IndexMaintenanceFilter index filter} to be used by the record store.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBTypedRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBTypedRecordStore.java
@@ -125,6 +125,13 @@ public class FDBTypedRecordStore<M extends Message> implements FDBRecordStoreBas
         return typedSerializer;
     }
 
+
+    @Nonnull
+    @Override
+    public IndexMaintainerFactoryRegistry getIndexMaintainerRegistry() {
+        return untypedStore.getIndexMaintainerRegistry();
+    }
+
     @Nonnull
     @Override
     public IndexMaintainer getIndexMaintainer(@Nonnull final Index index) {
@@ -497,13 +504,13 @@ public class FDBTypedRecordStore<M extends Message> implements FDBRecordStoreBas
 
         @Nonnull
         @Override
-        public IndexMaintainerRegistry getIndexMaintainerRegistry() {
+        public IndexMaintainerFactoryRegistry getIndexMaintainerRegistry() {
             return untypedStoreBuilder.getIndexMaintainerRegistry();
         }
 
         @Nonnull
         @Override
-        public Builder<M> setIndexMaintainerRegistry(@Nonnull IndexMaintainerRegistry indexMaintainerRegistry) {
+        public Builder<M> setIndexMaintainerRegistry(@Nonnull IndexMaintainerFactoryRegistry indexMaintainerRegistry) {
             untypedStoreBuilder.setIndexMaintainerRegistry(indexMaintainerRegistry);
             return this;
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexMaintainerFactory.java
@@ -21,10 +21,13 @@
 package com.apple.foundationdb.record.provider.foundationdb;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.IndexValidator;
+import com.apple.foundationdb.record.query.plan.cascades.MatchCandidate;
 
 import javax.annotation.Nonnull;
+import java.util.Collections;
 
 /**
  * A factory for {@link IndexMaintainer}.
@@ -68,4 +71,45 @@ public interface IndexMaintainerFactory {
      */
     @Nonnull
     IndexMaintainer getIndexMaintainer(@Nonnull IndexMaintainerState state);
+
+    /**
+     * Create {@link MatchCandidate}s to use for the given {@link Index}.
+     * Implementors can assume that the index is one of this factory's
+     * {@linkplain #getIndexTypes() supported types}. Note that this is
+     * structured as a method on the maintainer factory so that indexes
+     * defined outside the core repository can define the structure
+     * used by the planner to match them. However, use cases should be
+     * aware that the planner
+     *
+     * <p>
+     * By default, this returns an empty collection. This means that the
+     * index will not be matchable by the {@link com.apple.foundationdb.record.query.plan.cascades.CascadesPlanner}.
+     * Index types that want to be used in plans should implement this
+     * method. Utility methods in {@link MatchCandidate} can be used to
+     * create, for example, canonical expansions of indexes that behave like
+     * indexes defined in the core repository (e.g., {@link com.apple.foundationdb.record.metadata.IndexTypes#VALUE}
+     * indexes).
+     * </p>
+     *
+     * <p>
+     * Indexes may return more than one {@link MatchCandidate}. This can be
+     * useful for index types that have more than one way of being scanned.
+     * For example, the {@link com.apple.foundationdb.record.metadata.IndexTypes#RANK}
+     * index can be scanned {@link com.apple.foundationdb.record.IndexScanType#BY_VALUE},
+     * at which point it behaves just like a {@link com.apple.foundationdb.record.metadata.IndexTypes#VALUE}
+     * index, or it can be scanned {@link com.apple.foundationdb.record.IndexScanType#BY_RANK},
+     * at which point it behaves very differently. The different scan types are reflected
+     * in different {@link MatchCandidate} which encode different information about
+     * the index and how it should be scanned.
+     * </p>
+     *
+     * @param metaData the meta-data in which the index is defined
+     * @param index the index to expend
+     * @param reverse whether the index is to be scanned in reverse
+     * @return a collection of {@link MatchCandidate}s to match the index against
+     */
+    @Nonnull
+    default Iterable<MatchCandidate> createMatchCandidates(@Nonnull RecordMetaData metaData, @Nonnull Index index, boolean reverse) {
+        return Collections.emptyList();
+    }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexMaintainerFactoryRegistry.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexMaintainerFactoryRegistry.java
@@ -1,0 +1,72 @@
+/*
+ * IndexMaintainerFactoryRegistry.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.RecordMetaData;
+import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.metadata.IndexValidator;
+import com.apple.foundationdb.record.query.plan.cascades.MatchCandidate;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Registry of {@link IndexMaintainerFactory} objects. Each index type has an associated
+ * implementation of {@link IndexMaintainerFactory} that can generate {@link IndexMaintainer}s
+ * and {@link IndexValidator}s for indexes of that type. This registry stores the mapping of
+ * the index type to one of those factory classes.
+ */
+@API(API.Status.UNSTABLE)
+public interface IndexMaintainerFactoryRegistry extends IndexMaintainerRegistry, IndexMatchCandidateRegistry {
+    /**
+     * Get the {@link IndexMaintainerFactory} for the given index.
+     * This should look at the index's {@linkplain Index#getType() type}
+     * in order to identify the correct one.
+     *
+     * @param index the index to retrieve the maintainer factory for
+     * @return an {@link IndexMaintainerFactory}
+     * @throws com.apple.foundationdb.record.metadata.MetaDataException if the
+     *     {@link IndexMaintainerFactory} cannot be retrieved (e.g., if the index type
+     *     is unknown)
+     */
+    @Nonnull
+    IndexMaintainerFactory getIndexMaintainerFactory(@Nonnull Index index);
+
+    @Nonnull
+    @Override
+    default IndexValidator getIndexValidator(@Nonnull Index index) {
+        final IndexMaintainerFactory factory = getIndexMaintainerFactory(index);
+        return factory.getIndexValidator(index);
+    }
+
+    @Nonnull
+    @Override
+    default IndexMaintainer getIndexMaintainer(@Nonnull IndexMaintainerState state) {
+        final IndexMaintainerFactory factory = getIndexMaintainerFactory(state.index);
+        return factory.getIndexMaintainer(state);
+    }
+
+    @Override
+    default Iterable<MatchCandidate> createMatchCandidates(@Nonnull RecordMetaData metaData, @Nonnull Index index, boolean reverse) {
+        final IndexMaintainerFactory factory = getIndexMaintainerFactory(index);
+        return factory.createMatchCandidates(metaData, index, reverse);
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexMaintainerRegistryImpl.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexMaintainerRegistryImpl.java
@@ -24,7 +24,6 @@ import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.logging.KeyValueLogMessage;
 import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.metadata.Index;
-import com.apple.foundationdb.record.metadata.IndexValidator;
 import com.apple.foundationdb.record.metadata.MetaDataException;
 import com.apple.foundationdb.record.util.ServiceLoaderProvider;
 import org.slf4j.Logger;
@@ -38,7 +37,7 @@ import java.util.Map;
  * A singleton {@link IndexMaintainerRegistry} that finds {@link IndexMaintainerFactory} classes in the classpath.
  */
 @API(API.Status.INTERNAL)
-public class IndexMaintainerRegistryImpl implements IndexMaintainerRegistry {
+public class IndexMaintainerRegistryImpl implements IndexMaintainerFactoryRegistry {
     @Nonnull
     private static final Logger LOGGER = LoggerFactory.getLogger(IndexMaintainerRegistryImpl.class);
     @Nonnull
@@ -75,21 +74,11 @@ public class IndexMaintainerRegistryImpl implements IndexMaintainerRegistry {
 
     @Nonnull
     @Override
-    public IndexValidator getIndexValidator(@Nonnull Index index) {
+    public IndexMaintainerFactory getIndexMaintainerFactory(@Nonnull final Index index) {
         final IndexMaintainerFactory factory = registry.get(index.getType());
         if (factory == null) {
             throw new MetaDataException("Unknown index type for " + index);
         }
-        return factory.getIndexValidator(index);
-    }
-
-    @Nonnull
-    @Override
-    public IndexMaintainer getIndexMaintainer(@Nonnull IndexMaintainerState state) {
-        final IndexMaintainerFactory factory = registry.get(state.index.getType());
-        if (factory == null) {
-            throw new MetaDataException("Unknown index type for " + state.index);
-        }
-        return factory.getIndexMaintainer(state);
+        return factory;
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexMaintainerRegistryImpl.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexMaintainerRegistryImpl.java
@@ -47,7 +47,7 @@ public class IndexMaintainerRegistryImpl implements IndexMaintainerFactoryRegist
     private final Map<String, IndexMaintainerFactory> registry;
 
     @Nonnull
-    public static IndexMaintainerRegistry instance() {
+    public static IndexMaintainerFactoryRegistry instance() {
         return INSTANCE;
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexMatchCandidateRegistry.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexMatchCandidateRegistry.java
@@ -1,0 +1,53 @@
+/*
+ * IndexMatchCandidateRegistry.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb;
+
+import com.apple.foundationdb.record.RecordMetaData;
+import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.query.plan.cascades.MatchCandidate;
+
+import javax.annotation.Nonnull;
+
+/**
+ * A registry for mapping indexes to {@link MatchCandidate}s that can be used during
+ * planning by the {@link com.apple.foundationdb.record.query.plan.cascades.CascadesPlanner}.
+ * This is structured as a registry so that new index types can define the match candidate
+ * without needing to be defined in the core Record Layer repository.
+ *
+ * @see IndexMaintainerFactory#createMatchCandidates(RecordMetaData, Index, boolean)
+ * @see IndexMaintainerFactoryRegistry for a sub-interface that delegates to the {@link IndexMaintainerFactory}
+ * @see IndexMaintainerRegistryImpl for the default implementation
+ */
+public interface IndexMatchCandidateRegistry {
+
+    /**
+     * Create match candidates for the given {@link Index}.
+     *
+     * @param metaData the meta-data in which the index sits
+     * @param index the index to expand into {@link MatchCandidate}s
+     * @param reverse whether the query calls for the candidate to be reversed
+     * @return a collection of {@link MatchCandidate}s representing this index
+     * @see IndexMaintainerFactory#createMatchCandidates(RecordMetaData, Index, boolean)
+     */
+    Iterable<MatchCandidate> createMatchCandidates(@Nonnull RecordMetaData metaData,
+                                                   @Nonnull Index index,
+                                                   boolean reverse);
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/AtomicMutationIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/AtomicMutationIndexMaintainerFactory.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.provider.foundationdb.indexes;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.IndexTypes;
@@ -33,6 +34,8 @@ import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainer;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerFactory;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerState;
+import com.apple.foundationdb.record.query.plan.cascades.MatchCandidate;
+import com.apple.foundationdb.record.query.plan.cascades.MatchCandidateExpansion;
 import com.google.auto.service.AutoService;
 import com.google.protobuf.Descriptors;
 
@@ -151,4 +154,9 @@ public class AtomicMutationIndexMaintainerFactory implements IndexMaintainerFact
         return new AtomicMutationIndexMaintainer(state);
     }
 
+    @Nonnull
+    @Override
+    public Iterable<MatchCandidate> createMatchCandidates(@Nonnull final RecordMetaData metaData, @Nonnull final Index index, final boolean reverse) {
+        return MatchCandidateExpansion.expandAggregateIndexMatchCandidate(metaData, index, reverse);
+    }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/BitmapValueIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/BitmapValueIndexMaintainerFactory.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.provider.foundationdb.indexes;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.IndexTypes;
@@ -32,6 +33,8 @@ import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainer;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerFactory;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerState;
+import com.apple.foundationdb.record.query.plan.cascades.MatchCandidate;
+import com.apple.foundationdb.record.query.plan.cascades.MatchCandidateExpansion;
 import com.google.auto.service.AutoService;
 import com.google.protobuf.Descriptors;
 
@@ -103,5 +106,11 @@ public class BitmapValueIndexMaintainerFactory implements IndexMaintainerFactory
     @Nonnull
     public IndexMaintainer getIndexMaintainer(@Nonnull IndexMaintainerState state) {
         return new BitmapValueIndexMaintainer(state);
+    }
+
+    @Nonnull
+    @Override
+    public Iterable<MatchCandidate> createMatchCandidates(@Nonnull final RecordMetaData metaData, @Nonnull final Index index, final boolean reverse) {
+        return MatchCandidateExpansion.expandAggregateIndexMatchCandidate(metaData, index, reverse);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/PermutedMinMaxIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/PermutedMinMaxIndexMaintainerFactory.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.provider.foundationdb.indexes;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.IndexOptions;
@@ -32,7 +33,10 @@ import com.apple.foundationdb.record.metadata.expressions.GroupingKeyExpression;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainer;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerFactory;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerState;
+import com.apple.foundationdb.record.query.plan.cascades.MatchCandidate;
+import com.apple.foundationdb.record.query.plan.cascades.MatchCandidateExpansion;
 import com.google.auto.service.AutoService;
+import com.google.common.collect.ImmutableList;
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
@@ -88,4 +92,19 @@ public class PermutedMinMaxIndexMaintainerFactory implements IndexMaintainerFact
         return new PermutedMinMaxIndexMaintainer(state);
     }
 
+    @Nonnull
+    @Override
+    public Iterable<MatchCandidate> createMatchCandidates(@Nonnull final RecordMetaData metaData, @Nonnull final Index index, final boolean reverse) {
+        final MatchCandidateExpansion.IndexExpansionInfo info = MatchCandidateExpansion.createInfo(metaData, index, reverse);
+        final ImmutableList.Builder<MatchCandidate> resultBuilder = ImmutableList.builderWithExpectedSize(2);
+
+        // For permuted min and max, we use the value index expansion for BY_VALUE scans and we use
+        // the aggregate index expansion for BY_GROUP scans
+        MatchCandidateExpansion.expandValueIndexMatchCandidate(info)
+                .ifPresent(resultBuilder::add);
+        MatchCandidateExpansion.expandAggregateIndexMatchCandidate(info)
+                .ifPresent(resultBuilder::add);
+
+        return resultBuilder.build();
+    }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankIndexMaintainerFactory.java
@@ -22,6 +22,7 @@ package com.apple.foundationdb.record.provider.foundationdb.indexes;
 
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.async.RankedSet;
+import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.IndexOptions;
@@ -32,7 +33,11 @@ import com.apple.foundationdb.record.metadata.MetaDataValidator;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainer;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerFactory;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerState;
+import com.apple.foundationdb.record.query.plan.cascades.MatchCandidate;
+import com.apple.foundationdb.record.query.plan.cascades.MatchCandidateExpansion;
+import com.apple.foundationdb.record.query.plan.cascades.WindowedIndexExpansionVisitor;
 import com.google.auto.service.AutoService;
+import com.google.common.collect.ImmutableList;
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
@@ -102,4 +107,18 @@ public class RankIndexMaintainerFactory implements IndexMaintainerFactory {
         return new RankIndexMaintainer(state);
     }
 
+    @Nonnull
+    @Override
+    public Iterable<MatchCandidate> createMatchCandidates(@Nonnull final RecordMetaData metaData, @Nonnull final Index index, final boolean reverse) {
+        final MatchCandidateExpansion.IndexExpansionInfo info = MatchCandidateExpansion.createInfo(metaData, index, reverse);
+        final ImmutableList.Builder<MatchCandidate> resultBuilder = ImmutableList.builder();
+
+        // For rank() we need to create at two candidates. One for BY_RANK scans and one for BY_VALUE scans.
+        MatchCandidateExpansion.expandValueIndexMatchCandidate(info)
+                        .ifPresent(resultBuilder::add);
+        MatchCandidateExpansion.expandIndexMatchCandidate(info, info.getCommonPrimaryKeyForTypes(), new WindowedIndexExpansionVisitor(index, info.getIndexedRecordTypes()))
+                .ifPresent(resultBuilder::add);
+
+        return resultBuilder.build();
+    }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/ValueIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/ValueIndexMaintainerFactory.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.provider.foundationdb.indexes;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.IndexTypes;
 import com.apple.foundationdb.record.metadata.IndexValidator;
@@ -28,6 +29,8 @@ import com.apple.foundationdb.record.metadata.MetaDataValidator;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainer;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerFactory;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerState;
+import com.apple.foundationdb.record.query.plan.cascades.MatchCandidate;
+import com.apple.foundationdb.record.query.plan.cascades.MatchCandidateExpansion;
 import com.google.auto.service.AutoService;
 
 import javax.annotation.Nonnull;
@@ -64,5 +67,11 @@ public class ValueIndexMaintainerFactory implements IndexMaintainerFactory {
     @Nonnull
     public IndexMaintainer getIndexMaintainer(@Nonnull IndexMaintainerState state) {
         return new ValueIndexMaintainer(state);
+    }
+
+    @Nonnull
+    @Override
+    public Iterable<MatchCandidate> createMatchCandidates(@Nonnull final RecordMetaData metaData, @Nonnull final Index index, final boolean reverse) {
+        return MatchCandidateExpansion.expandValueIndexMatchCandidate(metaData, index, reverse);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VersionIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VersionIndexMaintainerFactory.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.provider.foundationdb.indexes;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.IndexTypes;
 import com.apple.foundationdb.record.metadata.IndexValidator;
@@ -28,6 +29,8 @@ import com.apple.foundationdb.record.metadata.MetaDataValidator;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainer;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerFactory;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerState;
+import com.apple.foundationdb.record.query.plan.cascades.MatchCandidate;
+import com.apple.foundationdb.record.query.plan.cascades.MatchCandidateExpansion;
 import com.google.auto.service.AutoService;
 
 import javax.annotation.Nonnull;
@@ -66,5 +69,11 @@ public class VersionIndexMaintainerFactory implements IndexMaintainerFactory {
     @Nonnull
     public IndexMaintainer getIndexMaintainer(@Nonnull IndexMaintainerState state) {
         return new VersionIndexMaintainer(state);
+    }
+
+    @Nonnull
+    @Override
+    public Iterable<MatchCandidate> createMatchCandidates(@Nonnull final RecordMetaData metaData, @Nonnull final Index index, final boolean reverse) {
+        return MatchCandidateExpansion.expandValueIndexMatchCandidate(metaData, index, reverse);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CascadesPlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CascadesPlanner.java
@@ -26,6 +26,8 @@ import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.RecordStoreState;
 import com.apple.foundationdb.record.logging.KeyValueLogMessage;
 import com.apple.foundationdb.record.logging.LogMessageKeys;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
+import com.apple.foundationdb.record.provider.foundationdb.IndexMatchCandidateRegistry;
 import com.apple.foundationdb.record.query.IndexQueryabilityFilter;
 import com.apple.foundationdb.record.query.ParameterRelationshipGraph;
 import com.apple.foundationdb.record.query.RecordQuery;
@@ -213,6 +215,8 @@ public class CascadesPlanner implements QueryPlanner {
     @Nonnull
     private final RecordStoreState recordStoreState;
     @Nonnull
+    private final IndexMatchCandidateRegistry matchCandidateRegistry;
+    @Nonnull
     private Reference currentRoot;
     @Nonnull
     private PlanContext planContext;
@@ -227,16 +231,21 @@ public class CascadesPlanner implements QueryPlanner {
     // max size of the task queue encountered during the planning
     private int maxQueueSize;
 
-    public CascadesPlanner(@Nonnull RecordMetaData metaData, @Nonnull RecordStoreState recordStoreState) {
+    public CascadesPlanner(@Nonnull RecordMetaData metaData, @Nonnull RecordStoreState recordStoreState, @Nonnull IndexMatchCandidateRegistry matchCandidateRegistry) {
         this.configuration = RecordQueryPlannerConfiguration.builder().build();
         this.metaData = metaData;
         this.recordStoreState = recordStoreState;
+        this.matchCandidateRegistry = matchCandidateRegistry;
         // Placeholders until we get a query.
         this.currentRoot = Reference.empty();
         this.planContext = PlanContext.emptyContext();
         this.evaluationContext = EvaluationContext.empty();
         this.traversal = Traversal.withRoot(currentRoot);
         this.taskStack = new ArrayDeque<>();
+    }
+
+    public static CascadesPlanner forStore(@Nonnull FDBRecordStoreBase<?> recordStore) {
+        return new CascadesPlanner(recordStore.getRecordMetaData(), recordStore.getRecordStoreState(), recordStore.getIndexMaintainerRegistry());
     }
 
     @Nonnull
@@ -344,7 +353,7 @@ public class CascadesPlanner implements QueryPlanner {
                                 @Nonnull final ParameterRelationshipGraph parameterRelationshipGraph) {
         try {
             planPartial(() -> Reference.initialOf(RelationalExpression.fromRecordQuery(metaData, query)),
-                    rootReference -> MetaDataPlanContext.forRecordQuery(configuration, metaData, recordStoreState, query),
+                    rootReference -> MetaDataPlanContext.forRecordQuery(configuration, metaData, recordStoreState, matchCandidateRegistry, query),
                     EvaluationContext.empty());
             return resultOrFail();
         } finally {
@@ -364,6 +373,7 @@ public class CascadesPlanner implements QueryPlanner {
                             MetaDataPlanContext.forRootReference(configuration,
                                     metaData,
                                     recordStoreState,
+                                    matchCandidateRegistry,
                                     rootReference,
                                     allowedIndexesOptional,
                                     indexQueryabilityFilter

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchCandidate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchCandidate.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.query.plan.cascades;
 
+import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.EvaluationContext;
 import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.logging.KeyValueLogMessage;
@@ -53,6 +54,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -274,61 +276,132 @@ public interface MatchCandidate {
                 .collect(ImmutableSet.toImmutableSet());
     }
 
+    /**
+     * Class encapsulating the information necessary to create a {@link MatchCandidate}
+     * for an {@link Index}. This exists as a convenience class that allows certain
+     * information to be computed once and referenced during match candidate creation.
+     */
+    @API(API.Status.INTERNAL)
+    class IndexExpansionInfo {
+        @Nonnull
+        private final RecordMetaData metaData;
+        @Nonnull
+        private final Index index;
+        private final boolean reverse;
+        @Nullable
+        private final KeyExpression commonPrimaryKeyForTypes;
+        @Nonnull
+        private final Collection<RecordType> indexedRecordTypes;
+        @Nonnull
+        private final Set<String> indexedRecordTypeNames;
+
+        private IndexExpansionInfo(@Nonnull RecordMetaData metaData,
+                                   @Nonnull Index index,
+                                   boolean reverse,
+                                   @Nonnull Collection<RecordType> indexedRecordTypes,
+                                   @Nonnull Set<String> indexedRecordTypeNames,
+                                   @Nullable KeyExpression commonPrimaryKeyForTypes) {
+            this.metaData = metaData;
+            this.index = index;
+            this.reverse = reverse;
+            this.indexedRecordTypes = indexedRecordTypes;
+            this.indexedRecordTypeNames = indexedRecordTypeNames;
+            this.commonPrimaryKeyForTypes = commonPrimaryKeyForTypes;
+        }
+
+        @Nonnull
+        public RecordMetaData getMetaData() {
+            return metaData;
+        }
+
+        @Nonnull
+        public Index getIndex() {
+            return index;
+        }
+
+        @Nonnull
+        public String getIndexName() {
+            return index.getName();
+        }
+
+        @Nonnull
+        public String getIndexType() {
+            return index.getType();
+        }
+
+        public boolean isReverse() {
+            return reverse;
+        }
+
+        @Nonnull
+        public Collection<RecordType> getIndexedRecordTypes() {
+            return indexedRecordTypes;
+        }
+
+        @Nonnull
+        public Set<String> getIndexedRecordTypeNames() {
+            return indexedRecordTypeNames;
+        }
+
+        @Nullable
+        public KeyExpression getCommonPrimaryKeyForTypes() {
+            return commonPrimaryKeyForTypes;
+        }
+
+        @Nonnull
+        public Set<String> getAvailableRecordTypeNames() {
+            return metaData.getRecordTypes().keySet();
+        }
+
+        /**
+         * Create an {@link IndexExpansionInfo} for a given index.
+         * This wraps the given parameters into a single object, as well
+         * as enriching the given parameters with pre-calculated items that
+         * can then be used during index expansion.
+         *
+         * @param metaData the meta-data that is the source of the index
+         * @param index the index that we are expanding
+         * @param reverse whether the query requires this scan be in reverse
+         * @return an object encapsulating information about the index
+         */
+        @Nonnull
+        public static IndexExpansionInfo forIndex(@Nonnull RecordMetaData metaData,
+                                                  @Nonnull Index index,
+                                                  boolean reverse) {
+            @Nonnull
+            final Collection<RecordType> indexedRecordTypes = Collections.unmodifiableCollection(metaData.recordTypesForIndex(index));
+            @Nonnull
+            final Set<String> indexedRecordTypeNames = indexedRecordTypes.stream()
+                    .map(RecordType::getName)
+                    .collect(ImmutableSet.toImmutableSet());
+            @Nullable
+            final KeyExpression commonPrimaryKeyForTypes = RecordMetaData.commonPrimaryKey(indexedRecordTypes);
+
+            return new IndexExpansionInfo(metaData, index, reverse, indexedRecordTypes, indexedRecordTypeNames, commonPrimaryKeyForTypes);
+        }
+
+    }
+
     @Nonnull
     static Iterable<MatchCandidate> fromIndexDefinition(@Nonnull final RecordMetaData metaData,
                                                         @Nonnull final Index index,
                                                         final boolean isReverse) {
-        final var resultBuilder = ImmutableList.<MatchCandidate>builder();
-        final var queriedRecordTypes = metaData.recordTypesForIndex(index);
-        final var commonPrimaryKeyForIndex = RecordMetaData.commonPrimaryKey(queriedRecordTypes);
+        final IndexExpansionInfo info = IndexExpansionInfo.forIndex(metaData, index, isReverse);
+        final ImmutableList.Builder<MatchCandidate> resultBuilder = ImmutableList.builder();
 
-        final var queriedRecordTypeNames =
-                queriedRecordTypes
-                        .stream()
-                        .map(RecordType::getName)
-                        .collect(ImmutableSet.toImmutableSet());
-
-        final var recordTypeMap = metaData.getRecordTypes();
-        final var availableRecordTypeNames = recordTypeMap.keySet();
-        final var availableRecordTypes = recordTypeMap.values();
-
-        final var indexType = index.getType();
-
-        switch (indexType) {
+        switch (info.getIndexType()) {
             case IndexTypes.VALUE:
             case IndexTypes.VERSION:
-                expandValueIndexMatchCandidate(
-                        index,
-                        availableRecordTypeNames,
-                        availableRecordTypes,
-                        queriedRecordTypeNames,
-                        queriedRecordTypes,
-                        isReverse,
-                        commonPrimaryKeyForIndex
-                ).ifPresent(resultBuilder::add);
+                expandValueIndexMatchCandidate(info)
+                        .ifPresent(resultBuilder::add);
                 break;
             case IndexTypes.RANK:
                 // For rank() we need to create at least two candidates. One for BY_RANK scans and one for BY_VALUE scans.
-                expandValueIndexMatchCandidate(
-                        index,
-                        availableRecordTypeNames,
-                        availableRecordTypes,
-                        queriedRecordTypeNames,
-                        queriedRecordTypes,
-                        isReverse,
-                        commonPrimaryKeyForIndex
-                ).ifPresent(resultBuilder::add);
+                expandValueIndexMatchCandidate(info)
+                        .ifPresent(resultBuilder::add);
 
-                expandIndexMatchCandidate(
-                        index,
-                        availableRecordTypeNames,
-                        availableRecordTypes,
-                        queriedRecordTypeNames,
-                        queriedRecordTypes,
-                        isReverse,
-                        commonPrimaryKeyForIndex,
-                        new WindowedIndexExpansionVisitor(index, queriedRecordTypes)
-                ).ifPresent(resultBuilder::add);
+                expandIndexMatchCandidate(info, info.getCommonPrimaryKeyForTypes(), new WindowedIndexExpansionVisitor(index, info.getIndexedRecordTypes()))
+                        .ifPresent(resultBuilder::add);
                 break;
             case IndexTypes.MIN_EVER_TUPLE: // fallthrough
             case IndexTypes.MAX_EVER_TUPLE: // fallthrough
@@ -338,36 +411,17 @@ public interface MatchCandidate {
             case IndexTypes.SUM: // fallthrough
             case IndexTypes.COUNT: // fallthrough
             case IndexTypes.COUNT_NOT_NULL:
-                expandAggregateIndexMatchCandidate(
-                        index,
-                        availableRecordTypeNames,
-                        availableRecordTypes,
-                        queriedRecordTypeNames,
-                        queriedRecordTypes,
-                        isReverse
-                ).ifPresent(resultBuilder::add);
+                expandAggregateIndexMatchCandidate(info)
+                        .ifPresent(resultBuilder::add);
                 break;
             case IndexTypes.PERMUTED_MAX: // fallthrough
             case IndexTypes.PERMUTED_MIN:
                 // For permuted min and max, we use the value index expansion for BY_VALUE scans and we use
                 // the aggregate index expansion for BY_GROUP scans
-                expandValueIndexMatchCandidate(
-                        index,
-                        availableRecordTypeNames,
-                        availableRecordTypes,
-                        queriedRecordTypeNames,
-                        queriedRecordTypes,
-                        isReverse,
-                        commonPrimaryKeyForIndex
-                ).ifPresent(resultBuilder::add);
-                expandAggregateIndexMatchCandidate(
-                        index,
-                        availableRecordTypeNames,
-                        availableRecordTypes,
-                        queriedRecordTypeNames,
-                        queriedRecordTypes,
-                        isReverse
-                ).ifPresent(resultBuilder::add);
+                expandValueIndexMatchCandidate(info)
+                        .ifPresent(resultBuilder::add);
+                expandAggregateIndexMatchCandidate(info)
+                        .ifPresent(resultBuilder::add);
                 break;
             default:
                 break;
@@ -375,63 +429,33 @@ public interface MatchCandidate {
         return resultBuilder.build();
     }
 
-    private static Optional<MatchCandidate> expandValueIndexMatchCandidate(@Nonnull final Index index,
-                                                                           @Nonnull final Set<String> availableRecordTypeNames,
-                                                                           @Nonnull final Collection<RecordType> availableRecordTypes,
-                                                                           @Nonnull final Set<String> queriedRecordTypeNames,
-                                                                           @Nonnull final Collection<RecordType> queriedRecordTypes,
-                                                                           final boolean isReverse,
-                                                                           @Nullable final KeyExpression commonPrimaryKeyForIndex) {
-        return expandIndexMatchCandidate(index,
-                availableRecordTypeNames,
-                availableRecordTypes,
-                queriedRecordTypeNames,
-                queriedRecordTypes,
-                isReverse,
-                commonPrimaryKeyForIndex,
-                new ValueIndexExpansionVisitor(index, queriedRecordTypes)
-        );
+    private static Optional<MatchCandidate> expandValueIndexMatchCandidate(@Nonnull IndexExpansionInfo info) {
+        return expandIndexMatchCandidate(info, info.getCommonPrimaryKeyForTypes(), new ValueIndexExpansionVisitor(info.getIndex(), info.getIndexedRecordTypes()));
     }
 
-    private static Optional<MatchCandidate> expandAggregateIndexMatchCandidate(@Nonnull final Index index,
-                                                                               @Nonnull final Set<String> availableRecordTypeNames,
-                                                                               @Nonnull final Collection<RecordType> availableRecordTypes,
-                                                                               @Nonnull final Set<String> queriedRecordTypeNames,
-                                                                               @Nonnull final Collection<RecordType> queriedRecordTypes,
-                                                                               final boolean isReverse) {
-        final var aggregateIndexExpansionVisitor = IndexTypes.BITMAP_VALUE.equals(index.getType())
-                ? new BitmapAggregateIndexExpansionVisitor(index, queriedRecordTypes)
-                : new AggregateIndexExpansionVisitor(index, queriedRecordTypes);
-        return expandIndexMatchCandidate(index,
-                availableRecordTypeNames,
-                availableRecordTypes,
-                queriedRecordTypeNames,
-                queriedRecordTypes,
-                isReverse,
-                null,
-                aggregateIndexExpansionVisitor
-        );
+    private static Optional<MatchCandidate> expandAggregateIndexMatchCandidate(@Nonnull IndexExpansionInfo info) {
+        final var aggregateIndexExpansionVisitor = IndexTypes.BITMAP_VALUE.equals(info.getIndexType())
+                ? new BitmapAggregateIndexExpansionVisitor(info.getIndex(), info.getIndexedRecordTypes())
+                : new AggregateIndexExpansionVisitor(info.getIndex(), info.getIndexedRecordTypes());
+        // Override the common primary key here. We always want it to be null because the primary key is not
+        // included in the expanded aggregate index
+        return expandIndexMatchCandidate(info, null, aggregateIndexExpansionVisitor);
     }
 
     @Nonnull
-    private static Optional<MatchCandidate> expandIndexMatchCandidate(@Nonnull final Index index,
-                                                                      @Nonnull final Set<String> availableRecordTypeNames,
-                                                                      @Nonnull final Collection<RecordType> availableRecordTypes,
-                                                                      @Nonnull final Set<String> queriedRecordTypeNames,
-                                                                      @Nonnull final Collection<RecordType> queriedRecordTypes,
-                                                                      final boolean isReverse,
-                                                                      @Nullable final KeyExpression commonPrimaryKeyForIndex,
+    private static Optional<MatchCandidate> expandIndexMatchCandidate(@Nonnull IndexExpansionInfo info,
+                                                                      @Nullable KeyExpression commonPrimaryKey,
                                                                       @Nonnull final ExpansionVisitor<?> expansionVisitor) {
-        final var baseRef = createBaseRef(availableRecordTypeNames, availableRecordTypes, queriedRecordTypeNames, queriedRecordTypes, new IndexAccessHint(index.getName()));
+        final var baseRef = createBaseRef(info, new IndexAccessHint(info.getIndexName()));
         try {
-            return Optional.of(expansionVisitor.expand(() -> Quantifier.forEach(baseRef), commonPrimaryKeyForIndex, isReverse));
+            return Optional.of(expansionVisitor.expand(() -> Quantifier.forEach(baseRef), commonPrimaryKey, info.isReverse()));
         } catch (final UnsupportedOperationException uOE) {
             // just log and return empty
             if (LOGGER.isDebugEnabled()) {
                 final String message =
                         KeyValueLogMessage.of("unsupported index",
                                 "reason", uOE.getMessage(),
-                                "indexName", index.getName());
+                                "indexName", info.getIndexName());
                 LOGGER.debug(message, uOE);
             }
         }
@@ -450,7 +474,7 @@ public interface MatchCandidate {
                             .filter(recordType -> queriedRecordTypeNames.contains(recordType.getName()))
                             .collect(ImmutableList.toImmutableList());
 
-            final var baseRef = createBaseRef(metaData.getRecordTypes().keySet(), availableRecordTypes, queriedRecordTypeNames, queriedRecordTypes, new PrimaryAccessHint());
+            final var baseRef = createBaseRef(metaData.getRecordTypes().keySet(), queriedRecordTypeNames, queriedRecordTypes, new PrimaryAccessHint());
             final var expansionVisitor = new PrimaryAccessExpansionVisitor(availableRecordTypes, queriedRecordTypes);
             return Optional.of(expansionVisitor.expand(() -> Quantifier.forEach(baseRef), primaryKey, isReverse));
         }
@@ -459,8 +483,13 @@ public interface MatchCandidate {
     }
 
     @Nonnull
+    static Reference createBaseRef(@Nonnull IndexExpansionInfo info,
+                                   @Nonnull AccessHint accessHint) {
+        return createBaseRef(info.getAvailableRecordTypeNames(), info.getIndexedRecordTypeNames(), info.getIndexedRecordTypes(), accessHint);
+    }
+
+    @Nonnull
     static Reference createBaseRef(@Nonnull final Set<String> availableRecordTypeNames,
-                                   @Nonnull final Collection<RecordType> availableRecordTypes,
                                    @Nonnull final Set<String> queriedRecordTypeNames,
                                    @Nonnull final Collection<RecordType> queriedRecordTypes,
                                    @Nonnull AccessHint accessHint) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchCandidateExpansion.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchCandidateExpansion.java
@@ -1,0 +1,278 @@
+/*
+ * MatchCandidateExpansion.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.cascades;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.RecordMetaData;
+import com.apple.foundationdb.record.logging.KeyValueLogMessage;
+import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.metadata.IndexTypes;
+import com.apple.foundationdb.record.metadata.RecordType;
+import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.FullUnorderedScanExpression;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.LogicalTypeFilterExpression;
+import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+
+public class MatchCandidateExpansion {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MatchCandidateExpansion.class);
+
+    private MatchCandidateExpansion() {
+    }
+
+    @Nonnull
+    public static Iterable<MatchCandidate> fromIndexDefinition(@Nonnull final RecordMetaData metaData,
+                                                               @Nonnull final Index index,
+                                                               final boolean isReverse) {
+        final IndexExpansionInfo info = IndexExpansionInfo.forIndex(metaData, index, isReverse);
+        final ImmutableList.Builder<MatchCandidate> resultBuilder = ImmutableList.builder();
+
+        switch (info.getIndexType()) {
+            case IndexTypes.VALUE:
+            case IndexTypes.VERSION:
+                expandValueIndexMatchCandidate(info)
+                        .ifPresent(resultBuilder::add);
+                break;
+            case IndexTypes.RANK:
+                // For rank() we need to create at least two candidates. One for BY_RANK scans and one for BY_VALUE scans.
+                expandValueIndexMatchCandidate(info)
+                        .ifPresent(resultBuilder::add);
+
+                expandIndexMatchCandidate(info, info.getCommonPrimaryKeyForTypes(), new WindowedIndexExpansionVisitor(index, info.getIndexedRecordTypes()))
+                        .ifPresent(resultBuilder::add);
+                break;
+            case IndexTypes.MIN_EVER_TUPLE: // fallthrough
+            case IndexTypes.MAX_EVER_TUPLE: // fallthrough
+            case IndexTypes.MAX_EVER_LONG: // fallthrough
+            case IndexTypes.MIN_EVER_LONG: // fallthrough
+            case IndexTypes.BITMAP_VALUE: // fallthrough
+            case IndexTypes.SUM: // fallthrough
+            case IndexTypes.COUNT: // fallthrough
+            case IndexTypes.COUNT_NOT_NULL:
+                expandAggregateIndexMatchCandidate(info)
+                        .ifPresent(resultBuilder::add);
+                break;
+            case IndexTypes.PERMUTED_MAX: // fallthrough
+            case IndexTypes.PERMUTED_MIN:
+                // For permuted min and max, we use the value index expansion for BY_VALUE scans and we use
+                // the aggregate index expansion for BY_GROUP scans
+                expandValueIndexMatchCandidate(info)
+                        .ifPresent(resultBuilder::add);
+                expandAggregateIndexMatchCandidate(info)
+                        .ifPresent(resultBuilder::add);
+                break;
+            default:
+                break;
+        }
+        return resultBuilder.build();
+    }
+
+    public static Optional<MatchCandidate> expandValueIndexMatchCandidate(@Nonnull IndexExpansionInfo info) {
+        return expandIndexMatchCandidate(info, info.getCommonPrimaryKeyForTypes(), new ValueIndexExpansionVisitor(info.getIndex(), info.getIndexedRecordTypes()));
+    }
+
+    public static Optional<MatchCandidate> expandAggregateIndexMatchCandidate(@Nonnull IndexExpansionInfo info) {
+        final var aggregateIndexExpansionVisitor = IndexTypes.BITMAP_VALUE.equals(info.getIndexType())
+                ? new BitmapAggregateIndexExpansionVisitor(info.getIndex(), info.getIndexedRecordTypes())
+                : new AggregateIndexExpansionVisitor(info.getIndex(), info.getIndexedRecordTypes());
+        // Override the common primary key here. We always want it to be null because the primary key is not
+        // included in the expanded aggregate index
+        return expandIndexMatchCandidate(info, null, aggregateIndexExpansionVisitor);
+    }
+
+    @Nonnull
+    private static Optional<MatchCandidate> expandIndexMatchCandidate(@Nonnull IndexExpansionInfo info,
+                                                                      @Nullable KeyExpression commonPrimaryKey,
+                                                                      @Nonnull final ExpansionVisitor<?> expansionVisitor) {
+        final var baseRef = createBaseRef(info, new IndexAccessHint(info.getIndexName()));
+        try {
+            return Optional.of(expansionVisitor.expand(() -> Quantifier.forEach(baseRef), commonPrimaryKey, info.isReverse()));
+        } catch (final UnsupportedOperationException uOE) {
+            // just log and return empty
+            if (LOGGER.isDebugEnabled()) {
+                final String message =
+                        KeyValueLogMessage.of("unsupported index",
+                                "reason", uOE.getMessage(),
+                                "indexName", info.getIndexName());
+                LOGGER.debug(message, uOE);
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Nonnull
+    public static Optional<MatchCandidate> fromPrimaryDefinition(@Nonnull final RecordMetaData metaData,
+                                                                 @Nonnull final Set<String> queriedRecordTypeNames,
+                                                                 @Nullable KeyExpression primaryKey,
+                                                                 final boolean isReverse) {
+        if (primaryKey != null) {
+            final var availableRecordTypes = metaData.getRecordTypes().values();
+            final var queriedRecordTypes =
+                    availableRecordTypes.stream()
+                            .filter(recordType -> queriedRecordTypeNames.contains(recordType.getName()))
+                            .collect(ImmutableList.toImmutableList());
+
+            final var baseRef = createBaseRef(metaData.getRecordTypes().keySet(), queriedRecordTypeNames, queriedRecordTypes, new PrimaryAccessHint());
+            final var expansionVisitor = new PrimaryAccessExpansionVisitor(availableRecordTypes, queriedRecordTypes);
+            return Optional.of(expansionVisitor.expand(() -> Quantifier.forEach(baseRef), primaryKey, isReverse));
+        }
+
+        return Optional.empty();
+    }
+
+    @Nonnull
+    private static Reference createBaseRef(@Nonnull IndexExpansionInfo info,
+                                          @Nonnull AccessHint accessHint) {
+        return createBaseRef(info.getAvailableRecordTypeNames(), info.getIndexedRecordTypeNames(), info.getIndexedRecordTypes(), accessHint);
+    }
+
+    @Nonnull
+    private static Reference createBaseRef(@Nonnull final Set<String> availableRecordTypeNames,
+                                          @Nonnull final Set<String> queriedRecordTypeNames,
+                                          @Nonnull final Collection<RecordType> queriedRecordTypes,
+                                          @Nonnull AccessHint accessHint) {
+        final var quantifier =
+                Quantifier.forEach(
+                        Reference.initialOf(
+                                new FullUnorderedScanExpression(availableRecordTypeNames,
+                                        new Type.AnyRecord(false),
+                                        new AccessHints(accessHint))));
+        return Reference.initialOf(
+                new LogicalTypeFilterExpression(queriedRecordTypeNames,
+                        quantifier,
+                        Type.Record.fromFieldDescriptorsMap(RecordMetaData.getFieldDescriptorMapFromTypes(queriedRecordTypes))));
+    }
+
+    /**
+     * Class encapsulating the information necessary to create a {@link MatchCandidate}
+     * for an {@link Index}. This exists as a convenience class that allows certain
+     * information to be computed once and referenced during match candidate creation.
+     */
+    @API(API.Status.INTERNAL)
+    public static class IndexExpansionInfo {
+        @Nonnull
+        private final RecordMetaData metaData;
+        @Nonnull
+        private final Index index;
+        private final boolean reverse;
+        @Nullable
+        private final KeyExpression commonPrimaryKeyForTypes;
+        @Nonnull
+        private final Collection<RecordType> indexedRecordTypes;
+        @Nonnull
+        private final Set<String> indexedRecordTypeNames;
+
+        private IndexExpansionInfo(@Nonnull RecordMetaData metaData,
+                                   @Nonnull Index index,
+                                   boolean reverse,
+                                   @Nonnull Collection<RecordType> indexedRecordTypes,
+                                   @Nonnull Set<String> indexedRecordTypeNames,
+                                   @Nullable KeyExpression commonPrimaryKeyForTypes) {
+            this.metaData = metaData;
+            this.index = index;
+            this.reverse = reverse;
+            this.indexedRecordTypes = indexedRecordTypes;
+            this.indexedRecordTypeNames = indexedRecordTypeNames;
+            this.commonPrimaryKeyForTypes = commonPrimaryKeyForTypes;
+        }
+
+        @Nonnull
+        public RecordMetaData getMetaData() {
+            return metaData;
+        }
+
+        @Nonnull
+        public Index getIndex() {
+            return index;
+        }
+
+        @Nonnull
+        public String getIndexName() {
+            return index.getName();
+        }
+
+        @Nonnull
+        public String getIndexType() {
+            return index.getType();
+        }
+
+        public boolean isReverse() {
+            return reverse;
+        }
+
+        @Nonnull
+        public Collection<RecordType> getIndexedRecordTypes() {
+            return indexedRecordTypes;
+        }
+
+        @Nonnull
+        public Set<String> getIndexedRecordTypeNames() {
+            return indexedRecordTypeNames;
+        }
+
+        @Nullable
+        public KeyExpression getCommonPrimaryKeyForTypes() {
+            return commonPrimaryKeyForTypes;
+        }
+
+        @Nonnull
+        public Set<String> getAvailableRecordTypeNames() {
+            return metaData.getRecordTypes().keySet();
+        }
+
+        /**
+         * Create an {@link IndexExpansionInfo} for a given index.
+         * This wraps the given parameters into a single object, as well
+         * as enriching the given parameters with pre-calculated items that
+         * can then be used during index expansion.
+         *
+         * @param metaData the meta-data that is the source of the index
+         * @param index the index that we are expanding
+         * @param reverse whether the query requires this scan be in reverse
+         * @return an object encapsulating information about the index
+         */
+        @Nonnull
+        public static IndexExpansionInfo forIndex(@Nonnull RecordMetaData metaData,
+                                                  @Nonnull Index index,
+                                                  boolean reverse) {
+            @Nonnull
+            final Collection<RecordType> indexedRecordTypes = Collections.unmodifiableCollection(metaData.recordTypesForIndex(index));
+            @Nonnull
+            final Set<String> indexedRecordTypeNames = indexedRecordTypes.stream()
+                    .map(RecordType::getName)
+                    .collect(ImmutableSet.toImmutableSet());
+            @Nullable
+            final KeyExpression commonPrimaryKeyForTypes = RecordMetaData.commonPrimaryKey(indexedRecordTypes);
+
+            return new IndexExpansionInfo(metaData, index, reverse, indexedRecordTypes, indexedRecordTypeNames, commonPrimaryKeyForTypes);
+        }
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MetaDataPlanContext.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MetaDataPlanContext.java
@@ -155,11 +155,11 @@ public class MetaDataPlanContext implements PlanContext {
         final ImmutableSet.Builder<MatchCandidate> matchCandidatesBuilder = ImmutableSet.builder();
         for (Index index : indexList) {
             final Iterable<MatchCandidate> candidatesForIndex =
-                    MatchCandidate.fromIndexDefinition(metaData, index, isSortReverse);
+                    MatchCandidateExpansion.fromIndexDefinition(metaData, index, isSortReverse);
             matchCandidatesBuilder.addAll(candidatesForIndex);
         }
 
-        MatchCandidate.fromPrimaryDefinition(metaData, queriedRecordTypeNames, commonPrimaryKey, isSortReverse)
+        MatchCandidateExpansion.fromPrimaryDefinition(metaData, queriedRecordTypeNames, commonPrimaryKey, isSortReverse)
                 .ifPresent(matchCandidatesBuilder::add);
 
         return new MetaDataPlanContext(plannerConfiguration, matchCandidatesBuilder.build());
@@ -199,12 +199,12 @@ public class MetaDataPlanContext implements PlanContext {
         final ImmutableSet.Builder<MatchCandidate> matchCandidatesBuilder = ImmutableSet.builder();
         for (final var index : indexList) {
             final Iterable<MatchCandidate> candidatesForIndex =
-                    MatchCandidate.fromIndexDefinition(metaData, index, false);
+                    MatchCandidateExpansion.fromIndexDefinition(metaData, index, false);
             matchCandidatesBuilder.addAll(candidatesForIndex);
         }
 
         for (final var recordType : queriedRecordTypes) {
-            MatchCandidate.fromPrimaryDefinition(metaData,
+            MatchCandidateExpansion.fromPrimaryDefinition(metaData,
                             ImmutableSet.of(recordType.getName()),
                             recordType.getPrimaryKey(),
                             false)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ValueIndexExpansionVisitor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ValueIndexExpansionVisitor.java
@@ -32,7 +32,6 @@ import com.apple.foundationdb.record.query.plan.cascades.expressions.MatchableSo
 import com.apple.foundationdb.record.query.plan.cascades.predicates.Placeholder;
 import com.apple.foundationdb.record.query.plan.cascades.predicates.PredicateWithValueAndRanges;
 import com.apple.foundationdb.record.query.plan.cascades.values.Value;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
@@ -75,7 +74,6 @@ public class ValueIndexExpansionVisitor extends KeyExpressionExpansionVisitor im
     private final List<RecordType> queriedRecordTypes;
 
     public ValueIndexExpansionVisitor(@Nonnull Index index, @Nonnull Collection<RecordType> queriedRecordTypes) {
-        Preconditions.checkArgument(SUPPORTED_INDEX_TYPES.contains(index.getType()));
         this.index = index;
         this.queriedRecordTypes = ImmutableList.copyOf(queriedRecordTypes);
     }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreConcurrentTestBase.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreConcurrentTestBase.java
@@ -101,7 +101,7 @@ public class FDBRecordStoreConcurrentTestBase {
     public QueryPlanner setupPlanner(@Nonnull FDBRecordStore recordStore, @Nullable PlannableIndexTypes indexTypes) {
         final QueryPlanner planner;
         if (useCascadesPlanner) {
-            planner = new CascadesPlanner(recordStore.getRecordMetaData(), recordStore.getRecordStoreState());
+            planner = CascadesPlanner.forStore(recordStore);
             if (Debugger.getDebugger() == null) {
                 Debugger.setDebugger(DebuggerWithSymbolTables.withSanityChecks());
             }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/QueryPlanFullySortedTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/QueryPlanFullySortedTest.java
@@ -28,6 +28,7 @@ import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.IndexOptions;
 import com.apple.foundationdb.record.metadata.IndexTypes;
 import com.apple.foundationdb.record.metadata.Key;
+import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerRegistryImpl;
 import com.apple.foundationdb.record.query.RecordQuery;
 import com.apple.foundationdb.record.query.expressions.Query;
 import com.apple.foundationdb.record.query.plan.QueryPlanner;
@@ -58,7 +59,7 @@ public class QueryPlanFullySortedTest extends FDBRecordStoreQueryTestBase {
         }
         metaData = builder.getRecordMetaData();
         planner = isUseCascadesPlanner() ?
-                  new CascadesPlanner(metaData, new RecordStoreState(null, null)) :
+                  new CascadesPlanner(metaData, new RecordStoreState(null, null), IndexMaintainerRegistryImpl.instance()) :
                   new RecordQueryPlanner(metaData, new RecordStoreState(null, null));
     }
 

--- a/fdb-record-layer-jmh/src/jmh/java/com/apple/foundationdb/record/benchmark/BenchmarkRecordStore.java
+++ b/fdb-record-layer-jmh/src/jmh/java/com/apple/foundationdb/record/benchmark/BenchmarkRecordStore.java
@@ -168,7 +168,7 @@ public class BenchmarkRecordStore {
         final RecordMetaData recordMetaData = recordStoreBuilder.getMetaDataProvider().getRecordMetaData();
         final RecordStoreState recordStoreState = new RecordStoreState(null, null);
         if (cascades) {
-            return new CascadesPlanner(recordMetaData, recordStoreState);
+            return new CascadesPlanner(recordMetaData, recordStoreState, recordStoreBuilder.getIndexMaintainerRegistry());
         } else {
             return new RecordQueryPlanner(recordMetaData, recordStoreState, timer.getTimer());
         }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneQueryTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneQueryTest.java
@@ -213,7 +213,7 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
     @Override
     public void setupPlanner(@Nullable PlannableIndexTypes indexTypes) {
         if (isUseCascadesPlanner()) {
-            planner = new CascadesPlanner(recordStore.getRecordMetaData(), recordStore.getRecordStoreState());
+            planner = CascadesPlanner.forStore(recordStore);
         } else {
             if (indexTypes == null) {
                 indexTypes = new PlannableIndexTypes(

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTestUtils.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTestUtils.java
@@ -37,7 +37,7 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStore;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreTestBase;
 import com.apple.foundationdb.record.provider.foundationdb.FormatVersion;
-import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerRegistry;
+import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerFactoryRegistry;
 import com.apple.foundationdb.record.provider.foundationdb.OnlineIndexer;
 import com.apple.foundationdb.record.provider.foundationdb.indexes.TextIndexTestUtils;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpacePath;
@@ -566,7 +566,7 @@ public class LuceneIndexTestUtils {
                                                                           final String document,
                                                                           final Index index,
                                                                           boolean useCascadesPlanner,
-                                                                          @Nullable IndexMaintainerRegistry indexMaintainerRegistry) {
+                                                                          @Nullable IndexMaintainerFactoryRegistry indexMaintainerRegistry) {
         FDBRecordStore store = openRecordStore(context,
                 path,
                 metaDataBuilder -> {
@@ -588,7 +588,7 @@ public class LuceneIndexTestUtils {
     static FDBRecordStore openRecordStore(FDBRecordContext context,
                                           @Nonnull KeySpacePath path,
                                           FDBRecordStoreTestBase.RecordMetaDataHook hook,
-                                          @Nullable IndexMaintainerRegistry indexMaintainerRegistry) {
+                                          @Nullable IndexMaintainerFactoryRegistry indexMaintainerRegistry) {
         RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder().setRecords(TestRecordsTextProto.getDescriptor());
         metaDataBuilder.getRecordType(COMPLEX_DOC).setPrimaryKey(concatenateFields("group", "doc_id"));
         hook.apply(metaDataBuilder);
@@ -601,7 +601,7 @@ public class LuceneIndexTestUtils {
     private static FDBRecordStore.Builder getStoreBuilder(@Nonnull FDBRecordContext context,
                                                           @Nonnull KeySpacePath path,
                                                           @Nonnull RecordMetaData metaData,
-                                                          @Nullable IndexMaintainerRegistry indexMaintainerRegistry) {
+                                                          @Nullable IndexMaintainerFactoryRegistry indexMaintainerRegistry) {
         final FDBRecordStore.Builder builder = FDBRecordStore.newBuilder()
                 .setFormatVersion(FormatVersion.getMaximumSupportedVersion()) // set to max to test newest features (unsafe for real deployments)
                 .setKeySpacePath(path)
@@ -617,7 +617,7 @@ public class LuceneIndexTestUtils {
                                      @Nullable PlannableIndexTypes indexTypes, boolean useRewritePlanner) {
         QueryPlanner planner;
         if (useRewritePlanner) {
-            planner = new CascadesPlanner(recordStore.getRecordMetaData(), recordStore.getRecordStoreState());
+            planner = new CascadesPlanner(recordStore.getRecordMetaData(), recordStore.getRecordStoreState(), recordStore.getIndexMaintainerRegistry());
             if (Debugger.getDebugger() == null) {
                 Debugger.setDebugger(DebuggerWithSymbolTables.withSanityChecks());
             }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneQueryIntegrationTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneQueryIntegrationTest.java
@@ -78,7 +78,7 @@ public class LuceneQueryIntegrationTest extends FDBRecordStoreQueryTestBase {
     @Override
     public void setupPlanner(@Nullable PlannableIndexTypes indexTypes) {
         if (isUseCascadesPlanner()) {
-            planner = new CascadesPlanner(recordStore.getRecordMetaData(), recordStore.getRecordStoreState());
+            planner = CascadesPlanner.forStore(recordStore);
         } else {
             if (indexTypes == null) {
                 indexTypes = new PlannableIndexTypes(

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/TestingIndexMaintainerRegistry.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/TestingIndexMaintainerRegistry.java
@@ -23,12 +23,10 @@ package com.apple.foundationdb.record.lucene.directory;
 import com.apple.foundationdb.record.logging.KeyValueLogMessage;
 import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.metadata.Index;
-import com.apple.foundationdb.record.metadata.IndexValidator;
 import com.apple.foundationdb.record.metadata.MetaDataException;
-import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainer;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerFactory;
+import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerFactoryRegistry;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerRegistry;
-import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerState;
 import com.apple.foundationdb.record.util.ServiceLoaderProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,7 +39,7 @@ import java.util.Map;
  * A testing-oriented version of {@link IndexMaintainerRegistry} that allows overriding a registry.
  * This can be used in place of the production registry
  */
-public class TestingIndexMaintainerRegistry implements IndexMaintainerRegistry {
+public class TestingIndexMaintainerRegistry implements IndexMaintainerFactoryRegistry {
     @Nonnull
     private static final Logger LOGGER = LoggerFactory.getLogger(TestingIndexMaintainerRegistry.class);
 
@@ -54,22 +52,12 @@ public class TestingIndexMaintainerRegistry implements IndexMaintainerRegistry {
 
     @Nonnull
     @Override
-    public IndexValidator getIndexValidator(@Nonnull Index index) {
+    public IndexMaintainerFactory getIndexMaintainerFactory(@Nonnull final Index index) {
         final IndexMaintainerFactory factory = registry.get(index.getType());
         if (factory == null) {
             throw new MetaDataException("Unknown index type for " + index);
         }
-        return factory.getIndexValidator(index);
-    }
-
-    @Nonnull
-    @Override
-    public IndexMaintainer getIndexMaintainer(@Nonnull IndexMaintainerState state) {
-        final IndexMaintainerFactory factory = registry.get(state.index.getType());
-        if (factory == null) {
-            throw new MetaDataException("Unknown index type for " + state.index);
-        }
-        return factory.getIndexMaintainer(state);
+        return factory;
     }
 
     /**

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/highlight/LuceneScaleTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/highlight/LuceneScaleTest.java
@@ -254,7 +254,7 @@ public class LuceneScaleTest extends FDBRecordStoreTestBase {
     @Override
     public void setupPlanner(@Nullable PlannableIndexTypes indexTypes) {
         if (isUseCascadesPlanner()) {
-            planner = new CascadesPlanner(recordStore.getRecordMetaData(), recordStore.getRecordStoreState());
+            planner = CascadesPlanner.forStore(recordStore);
         } else {
             if (indexTypes == null) {
                 indexTypes = new PlannableIndexTypes(

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/AbstractEmbeddedStatement.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/AbstractEmbeddedStatement.java
@@ -84,8 +84,8 @@ public abstract class AbstractEmbeddedStatement implements java.sql.Statement {
                     final var store = schema.loadStore().unwrap(FDBRecordStoreBase.class);
                     final var planGenerator = PlanGenerator.create(planCacheMaybe,
                             createPlanContext(store, options),
-                            store.getRecordMetaData(),
-                            store.getRecordStoreState(), this.options);
+                            store,
+                            this.options);
                     final Plan<?> plan = planGenerator.getPlan(sql);
                     final var executionContext = Plan.ExecutionContext.of(conn.getTransaction(), planGenerator.getOptions(), conn, metricCollector);
                     if (plan instanceof QueryPlan) {

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/api/ddl/DdlTestUtil.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/api/ddl/DdlTestUtil.java
@@ -24,6 +24,7 @@ import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.RecordMetaDataOptionsProto;
 import com.apple.foundationdb.record.RecordMetaDataProto;
 import com.apple.foundationdb.record.RecordStoreState;
+import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerRegistryImpl;
 import com.apple.foundationdb.relational.api.Options;
 import com.apple.foundationdb.relational.api.exceptions.RelationalException;
 import com.apple.foundationdb.relational.recordlayer.EmbeddedRelationalConnection;
@@ -85,7 +86,7 @@ public class DdlTestUtil {
         final var storeState = new RecordStoreState(null, Map.of());
         try (var schema = embeddedConnection.getRecordLayerDatabase().loadSchema(embeddedConnection.getSchema())) {
             final var metadata = schema.loadStore().getRecordMetaData();
-            return PlanGenerator.create(Optional.empty(), planContext, metadata, storeState, Options.NONE);
+            return PlanGenerator.create(Optional.empty(), planContext, metadata, storeState, IndexMaintainerRegistryImpl.instance(), Options.NONE);
         }
     }
 
@@ -108,7 +109,7 @@ public class DdlTestUtil {
         final var storeState = new RecordStoreState(null, Map.of());
         try (var schema = embeddedConnection.getRecordLayerDatabase().loadSchema(embeddedConnection.getSchema())) {
             final var metadata = schema.loadStore().getRecordMetaData();
-            return PlanGenerator.create(Optional.empty(), planContext, metadata, storeState, Options.NONE);
+            return PlanGenerator.create(Optional.empty(), planContext, metadata, storeState, IndexMaintainerRegistryImpl.instance(), Options.NONE);
         }
     }
 
@@ -122,7 +123,7 @@ public class DdlTestUtil {
         final var storeState = new RecordStoreState(null, Map.of());
         try (var schema = embeddedConnection.getRecordLayerDatabase().loadSchema(embeddedConnection.getSchema())) {
             final var metadata = schema.loadStore().getRecordMetaData();
-            return PlanGenerator.create(Optional.empty(), planContext, metadata, storeState, Options.NONE);
+            return PlanGenerator.create(Optional.empty(), planContext, metadata, storeState, IndexMaintainerRegistryImpl.instance(), Options.NONE);
         }
     }
 

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/memory/InMemoryRelationalStatement.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/memory/InMemoryRelationalStatement.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.relational.memory;
 
 import com.apple.foundationdb.record.RecordStoreState;
+import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerRegistryImpl;
 import com.apple.foundationdb.relational.api.KeySet;
 import com.apple.foundationdb.relational.api.Options;
 import com.apple.foundationdb.relational.api.Row;
@@ -115,7 +116,7 @@ public class InMemoryRelationalStatement implements RelationalStatement {
                     .withUserVersion(0)
                     .build();
 
-            final var planGenerator = PlanGenerator.create(Optional.empty(), ctx, ctx.getMetaData(), new RecordStoreState(null, Map.of()), Options.NONE);
+            final var planGenerator = PlanGenerator.create(Optional.empty(), ctx, ctx.getMetaData(), new RecordStoreState(null, Map.of()), IndexMaintainerRegistryImpl.instance(), Options.NONE);
             final Plan<?> plan = planGenerator.getPlan(sql);
             if (plan instanceof QueryPlan) {
                 throw new SQLFeatureNotSupportedException("Cannot execute queries in the InMemory Relational version, it's only good for Direct Access API");

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/PlanGenerationStackTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/PlanGenerationStackTest.java
@@ -185,10 +185,10 @@ public class PlanGenerationStackTest {
                 .withMetricsCollector(embeddedConnection.getMetricCollector())
                 .build();
         if (error == null) {
-            PlanGenerator planGenerator = PlanGenerator.create(Optional.empty(), planContext, store.getRecordMetaData(), store.getRecordStoreState(), Options.NONE);
+            PlanGenerator planGenerator = PlanGenerator.create(Optional.empty(), planContext, store, Options.NONE);
             final Plan<?> generatedPlan1 = planGenerator.getPlan(query);
             final var queryHash1 = ((QueryPlan.PhysicalQueryPlan) generatedPlan1).getRecordQueryPlan().semanticHashCode();
-            planGenerator = PlanGenerator.create(Optional.empty(), planContext, store.getRecordMetaData(), store.getRecordStoreState(), Options.NONE);
+            planGenerator = PlanGenerator.create(Optional.empty(), planContext, store, Options.NONE);
             final Plan<?> generatedPlan2 = planGenerator.getPlan(query);
             final var queryHash2 = ((QueryPlan.PhysicalQueryPlan) generatedPlan2).getRecordQueryPlan().semanticHashCode();
             embeddedConnection.rollback();
@@ -196,7 +196,7 @@ public class PlanGenerationStackTest {
             Assertions.assertEquals(queryHash1, queryHash2);
         } else {
             try {
-                PlanGenerator planGenerator = PlanGenerator.create(Optional.empty(), planContext, store.getRecordMetaData(), store.getRecordStoreState(), Options.NONE);
+                PlanGenerator planGenerator = PlanGenerator.create(Optional.empty(), planContext, store, Options.NONE);
                 planGenerator.getPlan(query);
                 Assertions.fail("expected an exception to be thrown");
             } catch (RelationalException e) {

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/metadata/SchemaTemplateSerDeTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/metadata/SchemaTemplateSerDeTests.java
@@ -25,6 +25,7 @@ import com.apple.foundationdb.record.RecordStoreState;
 import com.apple.foundationdb.record.metadata.IndexTypes;
 import com.apple.foundationdb.record.metadata.Key;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
+import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerRegistryImpl;
 import com.apple.foundationdb.record.query.plan.cascades.RawSqlFunction;
 import com.apple.foundationdb.record.util.pair.NonnullPair;
 import com.apple.foundationdb.relational.api.Options;
@@ -610,7 +611,7 @@ public class SchemaTemplateSerDeTests {
                     .withPlannerConfiguration(PlannerConfiguration.ofAllAvailableIndexes())
                     .withUserVersion(0)
                     .build();
-            return PlanGenerator.create(Optional.empty(), ctx, ctx.getMetaData(), new RecordStoreState(null, Map.of()), Options.NONE);
+            return PlanGenerator.create(Optional.empty(), ctx, ctx.getMetaData(), new RecordStoreState(null, Map.of()), IndexMaintainerRegistryImpl.instance(), Options.NONE);
         }
     }
 }

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/cache/ConstraintValidityTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/cache/ConstraintValidityTests.java
@@ -119,7 +119,7 @@ public class ConstraintValidityTests {
                 .withMetricsCollector(embeddedConnection.getMetricCollector())
                 .withUserVersion(44)
                 .build();
-        return PlanGenerator.create(Optional.of(cache), planContext, store.getRecordMetaData(), storeState, Options.builder().build());
+        return PlanGenerator.create(Optional.of(cache), planContext, store.getRecordMetaData(), storeState, store.getIndexMaintainerRegistry(), Options.builder().build());
     }
 
     private void planQuery(@Nonnull final RelationalPlanCache cache,

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/cache/RelationalPlanCacheTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/cache/RelationalPlanCacheTests.java
@@ -371,7 +371,7 @@ public class RelationalPlanCacheTests {
                 .withPlannerConfiguration(PlannerConfiguration.of(Optional.of(readableIndexes), options))
                 .withUserVersion(userVersion)
                 .build();
-        return PlanGenerator.create(Optional.of(cache), planContext, store.getRecordMetaData(), storeState, options);
+        return PlanGenerator.create(Optional.of(cache), planContext, store.getRecordMetaData(), storeState, store.getIndexMaintainerRegistry(), options);
     }
 
     @Nonnull

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/structuredsql/SqlVisitorTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/structuredsql/SqlVisitorTests.java
@@ -176,7 +176,7 @@ public class SqlVisitorTests {
                 .withSchemaTemplate(embeddedConnection.getSchemaTemplate())
                 .withMetricsCollector(embeddedConnection.getMetricCollector())
                 .build();
-        final PlanGenerator planGenerator = PlanGenerator.create(Optional.empty(), planContext, store.getRecordMetaData(), store.getRecordStoreState(), Options.NONE);
+        final PlanGenerator planGenerator = PlanGenerator.create(Optional.empty(), planContext, store, Options.NONE);
         Assertions.assertDoesNotThrow(() -> planGenerator.getPlan(query));
     }
 }


### PR DESCRIPTION
This refactors the way that index match candidates are generated so that individual index maintainer factory implementations can override how this is done for the index types they manage. This includes plumbing through the store's `IndexMaintainerRegistry` to the `CascadesPlanner` so that it can ask the right logic for the match candidate, as well as some refactoring done to the `MatchCandidate` logic so that, if all goes well, index implementors can rely on library code as much as possible.