### PR TITLE
remove CONTINUATION_CONTAINS_COMPILED_STATEMENT usage

### DIFF
--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/Options.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/Options.java
@@ -215,12 +215,6 @@ public final class Options {
         VALID_PLAN_HASH_MODES,
 
         /**
-         * Boolean indicator if continuations generated for query responses may contain serialized compiled statements
-         * that can be used in EXECUTE CONTINUATION statements.
-         */
-        CONTINUATIONS_CONTAIN_COMPILED_STATEMENTS,
-
-        /**
          * Timeout for asynchronous operations in milliseconds, this is usually used to set an upperbound time limit for
          * operations interacting with FDB.
          * Scope: Engine
@@ -294,7 +288,6 @@ public final class Options {
         builder.put(Name.EXECUTION_SCANNED_ROWS_LIMIT, Integer.MAX_VALUE);
         builder.put(Name.DRY_RUN, false);
         builder.put(Name.CASE_SENSITIVE_IDENTIFIERS, false);
-        builder.put(Name.CONTINUATIONS_CONTAIN_COMPILED_STATEMENTS, true);
         builder.put(Name.ASYNC_OPERATIONS_TIMEOUT_MILLIS, 10_000L);
         builder.put(Name.ENCRYPT_WHEN_SERIALIZING, false);
         builder.put(Name.ENCRYPTION_KEY_PASSWORD, "");
@@ -551,7 +544,6 @@ public final class Options {
         data.put(Name.CASE_SENSITIVE_IDENTIFIERS, List.of(TypeContract.booleanType()));
         data.put(Name.CURRENT_PLAN_HASH_MODE, List.of(TypeContract.stringType()));
         data.put(Name.VALID_PLAN_HASH_MODES, List.of(TypeContract.stringType()));
-        data.put(Name.CONTINUATIONS_CONTAIN_COMPILED_STATEMENTS, List.of(TypeContract.booleanType()));
         data.put(Name.ASYNC_OPERATIONS_TIMEOUT_MILLIS, List.of(TypeContract.longType(), RangeContract.of(0L, Long.MAX_VALUE)));
         data.put(Name.ENCRYPT_WHEN_SERIALIZING, List.of(TypeContract.booleanType()));
         data.put(Name.ENCRYPTION_KEY_STORE, List.of(TypeContract.nullableStringType()));

--- a/fdb-relational-api/src/testFixtures/java/com/apple/foundationdb/relational/utils/OptionsTestHelper.java
+++ b/fdb-relational-api/src/testFixtures/java/com/apple/foundationdb/relational/utils/OptionsTestHelper.java
@@ -57,7 +57,6 @@ public class OptionsTestHelper {
         builder = builder.withOption(Options.Name.CASE_SENSITIVE_IDENTIFIERS, true);
         builder = builder.withOption(Options.Name.CURRENT_PLAN_HASH_MODE, "m1");
         builder = builder.withOption(Options.Name.VALID_PLAN_HASH_MODES, "m1,m2");
-        builder = builder.withOption(Options.Name.CONTINUATIONS_CONTAIN_COMPILED_STATEMENTS, false);
         builder = builder.withOption(Options.Name.ASYNC_OPERATIONS_TIMEOUT_MILLIS, 5000L);
         builder = builder.withOption(Options.Name.ENCRYPT_WHEN_SERIALIZING, true);
         builder = builder.withOption(Options.Name.ENCRYPTION_KEY_STORE, "secrets.ks");

--- a/fdb-relational-core/src/main/antlr/RelationalParser.g4
+++ b/fdb-relational-core/src/main/antlr/RelationalParser.g4
@@ -517,7 +517,6 @@ queryOption
     : NOCACHE
     | LOG QUERY
     | DRY RUN
-    | CONTINUATION CONTAINS COMPILED STATEMENT
     ;
 
 // Transaction's Statements

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/AstNormalizer.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/AstNormalizer.java
@@ -301,9 +301,6 @@ public final class AstNormalizer extends RelationalParserBaseVisitor<Object> {
             if (ctx.DRY() != null) {
                 queryOptions.withOption(Options.Name.DRY_RUN, true);
             }
-            if (ctx.CONTINUATION() != null) {
-                queryOptions.withOption(Options.Name.CONTINUATIONS_CONTAIN_COMPILED_STATEMENTS, true);
-            }
             return null;
         } catch (SQLException e) {
             throw ExceptionUtil.toRelationalException(e).toUncheckedWrappedException();

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/OptionsUtils.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/OptionsUtils.java
@@ -30,7 +30,6 @@ import com.google.common.collect.ImmutableSet;
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
-import java.util.Objects;
 import java.util.Set;
 
 @API(API.Status.INTERNAL)
@@ -54,10 +53,6 @@ public final class OptionsUtils {
         return Arrays.stream(planHashModesAsString.split(","))
                 .map(planHashModeAsString -> PlanHashable.PlanHashMode.valueOf(planHashModeAsString.trim()))
                 .collect(ImmutableSet.toImmutableSet());
-    }
-
-    public static boolean getContinuationsContainsCompiledStatements(@Nonnull final Options options) {
-        return Objects.requireNonNull(options.getOption(Options.Name.CONTINUATIONS_CONTAIN_COMPILED_STATEMENTS));
     }
 
     @Nonnull

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/JoinWithLimitTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/JoinWithLimitTest.java
@@ -21,10 +21,8 @@
 package com.apple.foundationdb.relational.recordlayer;
 
 import com.apple.foundationdb.relational.api.Continuation;
-import com.apple.foundationdb.relational.api.Options;
 import com.apple.foundationdb.relational.utils.ResultSetAssert;
 import com.apple.foundationdb.relational.utils.SimpleDatabaseRule;
-
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -54,7 +52,6 @@ public class JoinWithLimitTest {
     @RegisterExtension
     @Order(2)
     public final RelationalConnectionRule connection = new RelationalConnectionRule(db::getConnectionUri)
-            .withOptions(Options.builder().withOption(Options.Name.CONTINUATIONS_CONTAIN_COMPILED_STATEMENTS, true).build())
             .withSchema(db.getSchemaName());
 
     @RegisterExtension

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/ExplainTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/ExplainTests.java
@@ -21,17 +21,14 @@
 package com.apple.foundationdb.relational.recordlayer.query;
 
 import com.apple.foundationdb.relational.api.Continuation;
-import com.apple.foundationdb.relational.api.Options;
-import com.apple.foundationdb.relational.api.RelationalConnection;
 import com.apple.foundationdb.relational.api.RelationalPreparedStatement;
 import com.apple.foundationdb.relational.api.RelationalResultSet;
 import com.apple.foundationdb.relational.api.RelationalStatement;
 import com.apple.foundationdb.relational.recordlayer.EmbeddedRelationalExtension;
 import com.apple.foundationdb.relational.recordlayer.Utils;
 import com.apple.foundationdb.relational.utils.Ddl;
-import com.apple.foundationdb.relational.utils.ResultSetAssert;
 import com.apple.foundationdb.relational.utils.RelationalStructAssert;
-
+import com.apple.foundationdb.relational.utils.ResultSetAssert;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -118,46 +115,11 @@ public class ExplainTests {
     }
 
     @Test
-    void explainWithContinuationNoSerializedPlanTest() throws Exception {
-        try (var ddl = Ddl.builder().database(URI.create("/TEST/QT")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
-            executeInsert(ddl);
-            Continuation continuation;
-            try (RelationalConnection conn = ddl.setSchemaAndGetConnection()) {
-                conn.setOption(Options.Name.CONTINUATIONS_CONTAIN_COMPILED_STATEMENTS, false);
-                try (RelationalPreparedStatement ps = conn.prepareStatement("SELECT * FROM RestaurantComplexRecord")) {
-                    ps.setMaxRows(2);
-                    continuation = consumeResultAndGetContinuation(ps, 2);
-                }
-                try (RelationalPreparedStatement ps = conn.prepareStatement("EXPLAIN SELECT * FROM RestaurantComplexRecord WITH CONTINUATION ?cont")) {
-                    ps.setMaxRows(2);
-                    ps.setObject("cont", continuation.serialize());
-                    try (final RelationalResultSet resultSet = ps.executeQuery()) {
-                        final var assertResult = ResultSetAssert.assertThat(resultSet);
-
-                        assertResult.hasNextRow()
-                                .hasColumn("PLAN", "ISCAN(RECORD_NAME_IDX <,>)")
-                                .hasColumn("PLAN_HASH", -1635569052);
-                        final var continuationInfo = resultSet.getStruct(5);
-                        org.junit.jupiter.api.Assertions.assertNotNull(continuationInfo);
-                        final var assertStruct = RelationalStructAssert.assertThat(continuationInfo);
-                        assertStruct.hasValue("EXECUTION_STATE", new byte[]{0, 21, 1, 21, 11});
-                        assertStruct.hasValue("VERSION", 1);
-                        assertStruct.hasValue("PLAN_HASH_MODE", null);
-                        assertStruct.hasValue("PLAN_HASH", -1635569052);
-                        assertStruct.hasValue("SERIALIZED_PLAN_COMPLEXITY", null);
-                    }
-                }
-            }
-        }
-    }
-
-    @Test
     void explainWithContinuationSerializedPlanTest() throws Exception {
         try (var ddl = Ddl.builder().database(URI.create("/TEST/QT")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
             executeInsert(ddl);
             Continuation continuation;
             try (final var connection = ddl.setSchemaAndGetConnection()) {
-                connection.setOption(Options.Name.CONTINUATIONS_CONTAIN_COMPILED_STATEMENTS, true);
                 try (RelationalPreparedStatement ps = ddl.setSchemaAndGetConnection().prepareStatement("SELECT * FROM RestaurantComplexRecord")) {
                     ps.setMaxRows(2);
                     continuation = consumeResultAndGetContinuation(ps, 2);
@@ -190,7 +152,6 @@ public class ExplainTests {
             executeInsert(ddl);
             Continuation continuation;
             try (final var connection = ddl.setSchemaAndGetConnection()) {
-                connection.setOption(Options.Name.CONTINUATIONS_CONTAIN_COMPILED_STATEMENTS, true);
                 try (RelationalPreparedStatement ps = ddl.setSchemaAndGetConnection().prepareStatement("SELECT * FROM RestaurantComplexRecord")) {
                     ps.setMaxRows(2);
                     continuation = consumeResultAndGetContinuation(ps, 2);
@@ -223,7 +184,6 @@ public class ExplainTests {
             executeInsert(ddl);
             Continuation continuation;
             try (final var connection = ddl.setSchemaAndGetConnection()) {
-                connection.setOption(Options.Name.CONTINUATIONS_CONTAIN_COMPILED_STATEMENTS, true);
                 try (RelationalPreparedStatement ps = ddl.setSchemaAndGetConnection().prepareStatement("SELECT * FROM RestaurantComplexRecord")) {
                     ps.setMaxRows(2);
                     continuation = consumeResultAndGetContinuation(ps, 2);

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/ForceContinuationQueryTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/ForceContinuationQueryTests.java
@@ -21,7 +21,6 @@
 package com.apple.foundationdb.relational.recordlayer.query;
 
 import com.apple.foundationdb.relational.api.Continuation;
-import com.apple.foundationdb.relational.api.Options;
 import com.apple.foundationdb.relational.api.exceptions.ContextualSQLException;
 import com.apple.foundationdb.relational.recordlayer.EmbeddedRelationalExtension;
 import com.apple.foundationdb.relational.recordlayer.RelationalConnectionRule;
@@ -29,7 +28,6 @@ import com.apple.foundationdb.relational.recordlayer.RelationalStatementRule;
 import com.apple.foundationdb.relational.recordlayer.UniqueIndexTests;
 import com.apple.foundationdb.relational.recordlayer.Utils;
 import com.apple.foundationdb.relational.utils.SimpleDatabaseRule;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -40,7 +38,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.sql.SQLException;
 import java.util.stream.Stream;
 
 public class ForceContinuationQueryTests {
@@ -75,14 +72,13 @@ public class ForceContinuationQueryTests {
     @RegisterExtension
     @Order(2)
     public final RelationalConnectionRule connection = new RelationalConnectionRule(db::getConnectionUri)
-            .withOptions(Options.builder().withOption(Options.Name.CONTINUATIONS_CONTAIN_COMPILED_STATEMENTS, true).build())
             .withSchema(db.getSchemaName());
 
     @RegisterExtension
     @Order(3)
     public final RelationalStatementRule statement = new RelationalStatementRule(connection);
 
-    public ForceContinuationQueryTests() throws SQLException {
+    public ForceContinuationQueryTests() {
     }
 
     @BeforeAll

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/GroupByQueryTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/GroupByQueryTests.java
@@ -59,7 +59,6 @@ public class GroupByQueryTests {
             try (var conn = ddl.setSchemaAndGetConnection()) {
                 Continuation continuation = null;
                 conn.setOption(Options.Name.EXECUTION_SCANNED_ROWS_LIMIT, 2);
-                conn.setOption(Options.Name.CONTINUATIONS_CONTAIN_COMPILED_STATEMENTS, true);
                 try (var statement = conn.createStatement()) {
                     insertT1Record(statement, 2, 1, 1, 20);
                     insertT1Record(statement, 3, 1, 2, 5);
@@ -82,7 +81,6 @@ public class GroupByQueryTests {
                 }
                 try (var preparedStatement = conn.prepareStatement("EXECUTE CONTINUATION ?param")) {
                     conn.setOption(Options.Name.EXECUTION_SCANNED_ROWS_LIMIT, 2);
-                    conn.setOption(Options.Name.CONTINUATIONS_CONTAIN_COMPILED_STATEMENTS, true);
                     // scan pk = 5 and pk = 4 rows, hit SCAN_LIMIT_REACHED
                     preparedStatement.setBytes("param", continuation.serialize());
                     try (final RelationalResultSet resultSet = preparedStatement.executeQuery()) {

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/QueryWithContinuationTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/QueryWithContinuationTest.java
@@ -99,13 +99,11 @@ public class QueryWithContinuationTest {
             executeInsert(ddl);
             Continuation continuation;
             try (final var connection = ddl.setSchemaAndGetConnection()) {
-                connection.setOption(Options.Name.CONTINUATIONS_CONTAIN_COMPILED_STATEMENTS, true);
                 try (var statement = connection.prepareStatement("SELECT * FROM RestaurantComplexRecord")) {
                     statement.setMaxRows(2);
                     continuation = assertResult(statement, 10L, 11L);
                     assertContinuation(continuation, false, false);
                 }
-                connection.setOption(Options.Name.CONTINUATIONS_CONTAIN_COMPILED_STATEMENTS, true);
                 try (var statement = connection.prepareStatement("EXECUTE CONTINUATION ?continuation")) {
                     statement.setMaxRows(2);
                     statement.setBytes("continuation", continuation.serialize());

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/QueryWithContinuationTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/QueryWithContinuationTest.java
@@ -119,35 +119,6 @@ public class QueryWithContinuationTest {
     }
 
     @Test
-    void preparedStatementWithExecuteContinuationWithOption() throws Exception {
-        try (var ddl = Ddl.builder().database(URI.create("/TEST/QT")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
-            executeInsert(ddl);
-            Continuation continuation;
-            try (final var connection = ddl.setSchemaAndGetConnection()) {
-                try (var statement =
-                        connection.prepareStatement("SELECT * FROM RestaurantComplexRecord OPTIONS(CONTINUATION CONTAINS COMPILED STATEMENT)")) {
-                    statement.setMaxRows(2);
-                    continuation = assertResult(statement, 10L, 11L);
-                    assertContinuation(continuation, false, false);
-                }
-
-                try (var statement =
-                        connection.prepareStatement("EXECUTE CONTINUATION ?continuation OPTIONS(CONTINUATION CONTAINS COMPILED STATEMENT)")) {
-                    statement.setMaxRows(2);
-                    statement.setBytes("continuation", continuation.serialize());
-                    continuation = assertResult(statement, 12L, 13L);
-                    assertContinuation(continuation, false, false);
-
-                    statement.setBytes("continuation", continuation.serialize());
-                    continuation = assertResult(statement, 14L);
-                    assertContinuation(continuation, false, true);
-                }
-
-            }
-        }
-    }
-
-    @Test
     void preparedStatementWithLimit() throws Exception {
         try (var ddl = Ddl.builder().database(URI.create("/TEST/QT")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
             executeInsert(ddl);

--- a/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/TypeConversion.java
+++ b/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/TypeConversion.java
@@ -802,8 +802,8 @@ public class TypeConversion {
         if (protoOptions.hasValidPlanHashModes()) {
             builder.withOption(Options.Name.VALID_PLAN_HASH_MODES, protoOptions.getValidPlanHashModes());
         }
-        if (!protoOptions.hasContinuationsContainCompiledStatements() || !protoOptions.getContinuationsContainCompiledStatements()) {
-            throw new RelationalException("Option CONTINUATIONS_CONTAIN_COMPILED_STATEMENTS not supported anymore!", ErrorCode.UNSUPPORTED_OPERATION).toUncheckedWrappedException();
+        if (protoOptions.hasContinuationsContainCompiledStatements() && !protoOptions.getContinuationsContainCompiledStatements()) {
+            throw new RelationalException("Option CONTINUATIONS_CONTAIN_COMPILED_STATEMENTS=false not supported anymore!", ErrorCode.UNSUPPORTED_OPERATION).toUncheckedWrappedException();
         }
         if (protoOptions.hasAsyncOperationsTimeoutMillis()) {
             builder.withOption(Options.Name.ASYNC_OPERATIONS_TIMEOUT_MILLIS, protoOptions.getAsyncOperationsTimeoutMillis());

--- a/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/TypeConversion.java
+++ b/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/TypeConversion.java
@@ -581,6 +581,8 @@ public class TypeConversion {
     @SuppressWarnings("unchecked")
     static com.apple.foundationdb.relational.jdbc.grpc.v1.Options.Builder toProtobuf(@Nonnull Options options) throws SQLException {
         final var builder = com.apple.foundationdb.relational.jdbc.grpc.v1.Options.newBuilder();
+        // Switched-on by default on JDBC driver until the option is deprecated and removed.
+        builder.setContinuationsContainCompiledStatements(true);
         for (Map.Entry<Options.Name, ?> entry : options.entries()) {
             switch (entry.getKey()) {
                 case MAX_ROWS:
@@ -668,9 +670,6 @@ public class TypeConversion {
                     break;
                 case VALID_PLAN_HASH_MODES:
                     builder.setValidPlanHashModes((String)entry.getValue());
-                    break;
-                case CONTINUATIONS_CONTAIN_COMPILED_STATEMENTS:
-                    builder.setContinuationsContainCompiledStatements((Boolean)entry.getValue());
                     break;
                 case ASYNC_OPERATIONS_TIMEOUT_MILLIS:
                     builder.setAsyncOperationsTimeoutMillis((Long)entry.getValue());
@@ -803,8 +802,8 @@ public class TypeConversion {
         if (protoOptions.hasValidPlanHashModes()) {
             builder.withOption(Options.Name.VALID_PLAN_HASH_MODES, protoOptions.getValidPlanHashModes());
         }
-        if (protoOptions.hasContinuationsContainCompiledStatements()) {
-            builder.withOption(Options.Name.CONTINUATIONS_CONTAIN_COMPILED_STATEMENTS, protoOptions.getContinuationsContainCompiledStatements());
+        if (!protoOptions.hasContinuationsContainCompiledStatements() || !protoOptions.getContinuationsContainCompiledStatements()) {
+            throw new RelationalException("Option CONTINUATIONS_CONTAIN_COMPILED_STATEMENTS not supported anymore!", ErrorCode.UNSUPPORTED_OPERATION).toUncheckedWrappedException();
         }
         if (protoOptions.hasAsyncOperationsTimeoutMillis()) {
             builder.withOption(Options.Name.ASYNC_OPERATIONS_TIMEOUT_MILLIS, protoOptions.getAsyncOperationsTimeoutMillis());


### PR DESCRIPTION
This PR does a couple of things:
- removes the usage of `CONTINUATION_CONTAINS_COMPILED_STATEMENT` option in Connection and as a query option. 
- The option was, by default, set to true and is now true for all the requests to the engine.
- We still support `SELECT ... WITH CONTINUATION ...`, which could be removed separately after this work. Hence, it could happen that a query started with a non-serialized continuation, but has now on serialised continuation.
- JDBC driver still supports the option, for backward compatilibility. However, the current change always sets that to `TRUE` and rejects connections that have it set to `FALSE`. Once this is rolled out, we should probably stop failing on false and mark the option as deprecated in proto. Finally, we can stop setting the option and remove the option altogether. 
- Removes a few tests around testing this option with False.