### PR TITLE
Index maintainer factory API may require some users to respond in 4.7

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@
 #
 
 rootProject.name=fdb-record-layer
-version=4.6.5.0
+version=4.7.0.0
 releaseBuild=false
 
 # this should be false for release branches (i.e. if there is no -SNAPSHOT on the above version)


### PR DESCRIPTION
This updates the minor version to 4.7 to account for the API changes introduced by #3640. Users who override the index maintainer registry in some way will need to respond to those changes. This updates the minor version to 4.7 to signal that to our consumers.