### PR TITLE
Fix code coverage for nightly when run with the tests

### DIFF
--- a/gradle/root.gradle
+++ b/gradle/root.gradle
@@ -105,7 +105,7 @@ tasks.register('codeCoverageReport', JacocoReport) {
     ]
 
     def compiledFiles = coverageSubprojects.collect { sp ->
-        new File(sp.buildDir, "libs/${sp.name}-${sp.version}.jar")
+        sp.layout.buildDirectory.file("libs/${sp.name}-${sp.version}.jar").get().asFile
     }.findAll { jf -> jf.exists() }
     classDirectories.setFrom(compiledFiles.collect { jf ->
         zipTree(jf).matching {

--- a/gradle/root.gradle
+++ b/gradle/root.gradle
@@ -104,12 +104,11 @@ tasks.register('codeCoverageReport', JacocoReport) {
         "**/generated/*", "**/grpc/v1/**/*"
     ]
 
-    def compiledFiles = coverageSubprojects.collect { sp ->
-        sp.layout.buildDirectory.file("libs/${sp.name}-${sp.version}.jar").get().asFile
-    }.findAll { jf -> jf.exists() }
-    classDirectories.setFrom(compiledFiles.collect { jf ->
-        zipTree(jf).matching {
-            exclude exclusions
+    classDirectories.setFrom(coverageSubprojects.collect { sp ->
+        sp.layout.buildDirectory.file("libs/${sp.name}-${sp.version}.jar").map { jf ->
+            zipTree(jf).matching {
+                exclude exclusions
+            }
         }
     })
 


### PR DESCRIPTION
It was looking at whether the jars exist at the time that the codeCoverageReport was being configured, rather than when it was being executed. This now looks at the information lazily when actually executing. 