### PR TITLE
Update minor version to 4.8

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@
 #
 
 rootProject.name=fdb-record-layer
-version=4.7.3.0
+version=4.8.0.0
 releaseBuild=false
 
 # this should be false for release branches (i.e. if there is no -SNAPSHOT on the above version)


### PR DESCRIPTION
Update minor version to `4.8` in response to #3659 and #3671.

These two changes activate features that are only intended to work with version 4.7 and newer, so running in mixed mode with older versions is not advised.