### PR TITLE
Add fdb metrics to the indexMerger log messages

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
@@ -510,6 +510,7 @@ public abstract class IndexingBase {
             StoreTimer metricsDiff = null;
             if (timer != null) {
                 metricsDiff = lastProgressSnapshot == null ? timer : StoreTimer.getDifference(timer, lastProgressSnapshot);
+                // Note: this fdb metrics represents all the fdb activity (including merges, heartbeats, etc.) since the previous log message.
                 lastProgressSnapshot = StoreTimerSnapshot.from(timer);
             }
             LOGGER.info(KeyValueLogMessage.build("Indexer: Built Range",


### PR DESCRIPTION
To get better visibility of the index merge process, add fdb metrics to the merger's log messages.

Resolves #3685