### PR TITLE
Support classic index definitions

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/IndexKeyValueToPartialRecord.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/IndexKeyValueToPartialRecord.java
@@ -463,6 +463,9 @@ public class IndexKeyValueToPartialRecord implements PlanHashable, PlanSerializa
                 return !fieldDescriptor.isRequired();
             }
             switch (fieldDescriptor.getType()) {
+                case INT32:
+                    value = ((Number)value).intValue();
+                    break;
                 case MESSAGE:
                     value = TupleFieldsHelper.toProto(value, fieldDescriptor.getMessageType());
                     break;

--- a/fdb-relational-core/src/jmh/java/com/apple/foundationdb/relational/recordlayer/EmbeddedRelationalBenchmark.java
+++ b/fdb-relational-core/src/jmh/java/com/apple/foundationdb/relational/recordlayer/EmbeddedRelationalBenchmark.java
@@ -63,8 +63,8 @@ public abstract class EmbeddedRelationalBenchmark {
                     "CREATE TABLE \"RestaurantRecord\" (\"rest_no\" bigint, \"name\" string, \"location\" \"Location\", \"reviews\" \"RestaurantReview\" ARRAY, \"tags\" \"RestaurantTag\" ARRAY, \"customer\" string ARRAY, PRIMARY KEY(\"rest_no\")) " +
                     "CREATE TABLE \"RestaurantReviewer\" (\"id\" bigint, \"name\" string, \"email\" string, \"stats\" \"ReviewerStats\", PRIMARY KEY(\"id\")) " +
 
-                    "CREATE INDEX \"record_name_idx\" as select \"name\" from \"RestaurantRecord\" " +
-                    "CREATE INDEX \"reviewer_name_idx\" as select \"name\" from \"RestaurantReviewer\" ";
+                    "CREATE INDEX \"record_name_idx\" ON \"RestaurantRecord\"(\"name\") " +
+                    "CREATE INDEX \"reviewer_name_idx\" ON \"RestaurantReviewer\"(\"name\") ";
 
     static final String restaurantRecordTable = "RestaurantRecord";
 

--- a/fdb-relational-core/src/main/antlr/RelationalLexer.g4
+++ b/fdb-relational-core/src/main/antlr/RelationalLexer.g4
@@ -224,6 +224,7 @@ USAGE:                               'USAGE';
 USE:                                 'USE';
 USING:                               'USING';
 VALUES:                              'VALUES';
+VECTOR:                              'VECTOR';
 WHEN:                                'WHEN';
 WHERE:                               'WHERE';
 WHILE:                               'WHILE';

--- a/fdb-relational-core/src/main/antlr/RelationalParser.g4
+++ b/fdb-relational-core/src/main/antlr/RelationalParser.g4
@@ -158,7 +158,24 @@ enumDefinition
     ;
 
 indexDefinition
-    : (UNIQUE)? INDEX indexName=uid AS queryTerm indexAttributes?
+    : (UNIQUE)? INDEX indexName=uid AS queryTerm indexAttributes?                                                                       #indexAsSelectDefinition
+    | (UNIQUE)? INDEX indexName=uid ON tableName indexColumnList includeClause? partitionClause? indexAttributes?                       #indexOnSourceDefinition
+    ;
+
+indexColumnList
+    : '(' indexColumnSpec (',' indexColumnSpec)* ')'
+    ;
+
+indexColumnSpec
+    : columnName=uid orderClause?
+    ;
+
+includeClause
+    : INCLUDE '(' uidList ')'
+    ;
+
+indexType
+    : UNIQUE | VECTOR
     ;
 
 indexAttributes
@@ -406,7 +423,12 @@ orderByClause
     ;
 
 orderByExpression
-    : expression order=(ASC | DESC)? (NULLS nulls=(FIRST | LAST))?
+    : expression orderClause?
+    ;
+
+orderClause
+    : order=(ASC | DESC) (NULLS nulls=(FIRST | LAST))?
+    | NULLS nulls=(FIRST | LAST)
     ;
 
 tableSources // done
@@ -1107,10 +1129,11 @@ frameRange
     | expression (PRECEDING | FOLLOWING)
     ;
 
+*/
+
 partitionClause
     : PARTITION BY expression (',' expression)*
     ;
-*/
 
 scalarFunctionName
     : functionNameBase

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/AbstractEmbeddedStatement.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/AbstractEmbeddedStatement.java
@@ -215,10 +215,15 @@ public abstract class AbstractEmbeddedStatement implements java.sql.Statement {
             }
             return count;
         } catch (SQLException | RuntimeException ex) {
-            if (conn.canCommit()) {
-                conn.rollbackInternal();
+            SQLException finalException = ExceptionUtil.toRelationalException(ex).toSqlException();
+            try {
+                if (conn.canCommit()) {
+                    conn.rollbackInternal();
+                }
+            } catch (SQLException | RuntimeException rollbackError) {
+                finalException.addSuppressed(rollbackError);
             }
-            throw ExceptionUtil.toRelationalException(ex).toSqlException();
+            throw finalException;
         }
     }
 

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/ParseHelpers.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/ParseHelpers.java
@@ -39,6 +39,7 @@ import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.ParseTree;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.Base64;
 import java.util.Locale;
 import java.util.function.Supplier;
@@ -159,13 +160,18 @@ public final class ParseHelpers {
         }
     }
 
-    public static boolean isDescending(@Nonnull RelationalParser.OrderByExpressionContext orderByExpressionContext) {
-        return (orderByExpressionContext.ASC() == null) && (orderByExpressionContext.DESC() != null);
+    public static boolean isNullsLast(@Nullable RelationalParser.OrderClauseContext orderClause, boolean isDescending) {
+        if (orderClause == null || orderClause.nulls == null) {
+            return isDescending; // Default behavior: ASC NULLS FIRST, DESC NULLS LAST
+        }
+        return orderClause.LAST() != null;
     }
 
-    public static boolean isNullsLast(@Nonnull RelationalParser.OrderByExpressionContext orderByExpressionContext, boolean isDescending) {
-        return orderByExpressionContext.nulls == null ? isDescending :
-                (orderByExpressionContext.FIRST() == null) && (orderByExpressionContext.LAST() != null);
+    public static boolean isDescending(@Nullable RelationalParser.OrderClauseContext orderClause) {
+        if (orderClause == null) {
+            return false; // Default is ASC
+        }
+        return orderClause.DESC() != null;
     }
 
     public static class ParseTreeLikeAdapter implements TreeLike<ParseTreeLikeAdapter> {

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/BaseVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/BaseVisitor.java
@@ -403,8 +403,32 @@ public class BaseVisitor extends RelationalParserBaseVisitor<Object> implements 
 
     @Nonnull
     @Override
-    public RecordLayerIndex visitIndexDefinition(@Nonnull RelationalParser.IndexDefinitionContext ctx) {
-        return ddlVisitor.visitIndexDefinition(ctx);
+    public RecordLayerIndex visitIndexAsSelectDefinition(@Nonnull RelationalParser.IndexAsSelectDefinitionContext ctx) {
+        return ddlVisitor.visitIndexAsSelectDefinition(ctx);
+    }
+
+    @Nonnull
+    @Override
+    public RecordLayerIndex visitIndexOnSourceDefinition(@Nonnull RelationalParser.IndexOnSourceDefinitionContext ctx) {
+        return ddlVisitor.visitIndexOnSourceDefinition(ctx);
+    }
+
+    @Nonnull
+    @Override
+    public Object visitIndexColumnList(@Nonnull RelationalParser.IndexColumnListContext ctx) {
+        return ddlVisitor.visitIndexColumnList(ctx);
+    }
+
+    @Nonnull
+    @Override
+    public Object visitIndexColumnSpec(@Nonnull RelationalParser.IndexColumnSpecContext ctx) {
+        return ddlVisitor.visitIndexColumnSpec(ctx);
+    }
+
+    @Nonnull
+    @Override
+    public Object visitIncludeClause(@Nonnull RelationalParser.IncludeClauseContext ctx) {
+        return ddlVisitor.visitIncludeClause(ctx);
     }
 
     @Override
@@ -1695,5 +1719,10 @@ public class BaseVisitor extends RelationalParserBaseVisitor<Object> implements 
     @Nonnull
     public URI getDbUri() {
         return dbUri;
+    }
+
+    @Override
+    public Object visitOrderClause(@Nonnull RelationalParser.OrderClauseContext ctx) {
+        return visitChildren(ctx);
     }
 }

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DelegatingVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DelegatingVisitor.java
@@ -230,10 +230,9 @@ public class DelegatingVisitor<D extends TypedVisitor> implements TypedVisitor {
         return getDelegate().visitEnumDefinition(ctx);
     }
 
-    @Nonnull
     @Override
-    public RecordLayerIndex visitIndexDefinition(@Nonnull RelationalParser.IndexDefinitionContext ctx) {
-        return getDelegate().visitIndexDefinition(ctx);
+    public Object visitIndexType(final RelationalParser.IndexTypeContext ctx) {
+        return getDelegate().visitIndexType(ctx);
     }
 
     @Nonnull
@@ -533,6 +532,36 @@ public class DelegatingVisitor<D extends TypedVisitor> implements TypedVisitor {
     @Override
     public OrderByExpression visitOrderByExpression(@Nonnull RelationalParser.OrderByExpressionContext ctx) {
         return getDelegate().visitOrderByExpression(ctx);
+    }
+
+    @Nonnull
+    @Override
+    public RecordLayerIndex visitIndexAsSelectDefinition(@Nonnull RelationalParser.IndexAsSelectDefinitionContext ctx) {
+        return getDelegate().visitIndexAsSelectDefinition(ctx);
+    }
+
+    @Nonnull
+    @Override
+    public RecordLayerIndex visitIndexOnSourceDefinition(@Nonnull RelationalParser.IndexOnSourceDefinitionContext ctx) {
+        return getDelegate().visitIndexOnSourceDefinition(ctx);
+    }
+
+    @Nonnull
+    @Override
+    public Object visitIndexColumnList(@Nonnull RelationalParser.IndexColumnListContext ctx) {
+        return getDelegate().visitIndexColumnList(ctx);
+    }
+
+    @Nonnull
+    @Override
+    public Object visitIndexColumnSpec(@Nonnull RelationalParser.IndexColumnSpecContext ctx) {
+        return getDelegate().visitIndexColumnSpec(ctx);
+    }
+
+    @Nonnull
+    @Override
+    public Object visitIncludeClause(@Nonnull RelationalParser.IncludeClauseContext ctx) {
+        return getDelegate().visitIncludeClause(ctx);
     }
 
     @Override
@@ -1351,6 +1380,11 @@ public class DelegatingVisitor<D extends TypedVisitor> implements TypedVisitor {
         return getDelegate().visitWindowName(ctx);
     }
 
+    @Override
+    public Object visitPartitionClause(final RelationalParser.PartitionClauseContext ctx) {
+        return null;
+    }
+
     @Nonnull
     @Override
     public Object visitScalarFunctionName(@Nonnull RelationalParser.ScalarFunctionNameContext ctx) {
@@ -1557,6 +1591,11 @@ public class DelegatingVisitor<D extends TypedVisitor> implements TypedVisitor {
     @Override
     public Object visitChildren(RuleNode node) {
         return getDelegate().visitChildren(node);
+    }
+
+    @Override
+    public Object visitOrderClause(@Nonnull RelationalParser.OrderClauseContext ctx) {
+        return getDelegate().visitOrderClause(ctx);
     }
 
     @Override

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/ExpressionVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/ExpressionVisitor.java
@@ -199,8 +199,8 @@ public final class ExpressionVisitor extends DelegatingVisitor<BaseVisitor> {
     @Override
     public OrderByExpression visitOrderByExpression(@Nonnull RelationalParser.OrderByExpressionContext orderByExpressionContext) {
         final var expression = Assert.castUnchecked(orderByExpressionContext.expression().accept(this), Expression.class);
-        final var descending = ParseHelpers.isDescending(orderByExpressionContext);
-        final var nullsLast = ParseHelpers.isNullsLast(orderByExpressionContext, descending);
+        final var descending = ParseHelpers.isDescending(orderByExpressionContext.orderClause());
+        final var nullsLast = ParseHelpers.isNullsLast(orderByExpressionContext.orderClause(), descending);
         return OrderByExpression.of(expression, descending, nullsLast);
     }
 

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/QueryVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/QueryVisitor.java
@@ -595,8 +595,8 @@ public final class QueryVisitor extends DelegatingVisitor<BaseVisitor> {
             final var matchingExpressionMaybe = isAliasMaybe.flatMap(alias -> semanticAnalyzer.lookupAlias(visitFullId(alias), validSelectAliases));
             matchingExpressionMaybe.ifPresentOrElse(
                     matchingExpression -> {
-                        final var descending = ParseHelpers.isDescending(orderByExpression);
-                        final var nullsLast = ParseHelpers.isNullsLast(orderByExpression, descending);
+                        final var descending = ParseHelpers.isDescending(orderByExpression.orderClause());
+                        final var nullsLast = ParseHelpers.isNullsLast(orderByExpression.orderClause(), descending);
                         orderBysBuilder.add(OrderByExpression.of(matchingExpression, descending, nullsLast));
                     },
                     () -> orderBysBuilder.add(visitOrderByExpression(orderByExpression))

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/TypedVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/TypedVisitor.java
@@ -168,7 +168,23 @@ public interface TypedVisitor extends RelationalParserVisitor<Object> {
 
     @Nonnull
     @Override
-    RecordLayerIndex visitIndexDefinition(@Nonnull RelationalParser.IndexDefinitionContext ctx);
+    RecordLayerIndex visitIndexAsSelectDefinition(@Nonnull RelationalParser.IndexAsSelectDefinitionContext ctx);
+
+    @Nonnull
+    @Override
+    RecordLayerIndex visitIndexOnSourceDefinition(@Nonnull RelationalParser.IndexOnSourceDefinitionContext ctx);
+
+    @Nonnull
+    @Override
+    Object visitIndexColumnList(@Nonnull RelationalParser.IndexColumnListContext ctx);
+
+    @Nonnull
+    @Override
+    Object visitIndexColumnSpec(@Nonnull RelationalParser.IndexColumnSpecContext ctx);
+
+    @Nonnull
+    @Override
+    Object visitIncludeClause(@Nonnull RelationalParser.IncludeClauseContext ctx);
 
     @Override
     Object visitIndexAttributes(RelationalParser.IndexAttributesContext ctx);

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/util/ExceptionUtil.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/util/ExceptionUtil.java
@@ -22,6 +22,7 @@ package com.apple.foundationdb.relational.recordlayer.util;
 
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.RecordIndexUniquenessViolation;
 import com.apple.foundationdb.record.metadata.MetaDataException;
 import com.apple.foundationdb.record.provider.foundationdb.FDBExceptions;
 import com.apple.foundationdb.record.provider.foundationdb.RecordAlreadyExistsException;
@@ -67,7 +68,7 @@ public final class ExceptionUtil {
             code = ErrorCode.TRANSACTION_INACTIVE;
         } else if (re instanceof RecordDeserializationException || re.getCause() instanceof RecordDeserializationException) {
             code = ErrorCode.DESERIALIZATION_FAILURE;
-        } else if (re instanceof RecordAlreadyExistsException || re.getCause() instanceof RecordAlreadyExistsException) {
+        } else if (re instanceof RecordAlreadyExistsException || re.getCause() instanceof RecordAlreadyExistsException || re instanceof RecordIndexUniquenessViolation) {
             code = ErrorCode.UNIQUE_CONSTRAINT_VIOLATION;
         } else if (re instanceof MetaDataException) {
             //TODO(bfines) map this to specific error codes based on the violation

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/DeleteRangeNoMetadataKeyTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/DeleteRangeNoMetadataKeyTest.java
@@ -295,8 +295,8 @@ public class DeleteRangeNoMetadataKeyTest {
 
     @Test
     void testDeleteWithIndexWithSamePrefix() throws Exception {
-        final String schemaTemplateSuffix = " CREATE INDEX idx1 as select id, a from t1 order by id, a " +
-                "CREATE INDEX idx2 AS SELECT id, a, e, f FROM t2 ORDER BY id, a, e";
+        final String schemaTemplateSuffix = " CREATE INDEX idx1 ON t1(id, a) " +
+                "CREATE INDEX idx2 ON t2(id, a, e) INCLUDE(f)";
         try (var ddl = getDdl(schemaTemplateSuffix)) {
             try (var stmt = ddl.setSchemaAndGetConnection().createStatement()) {
                 insertData(stmt);

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/DeleteRangeTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/DeleteRangeTest.java
@@ -220,7 +220,7 @@ public class DeleteRangeTest {
 
     @Test
     void testDeleteWithIndexWithSamePrefix() throws Exception {
-        final String schemaTemplate = SCHEMA_TEMPLATE + " CREATE INDEX idx1 as select id, a from t1 order by id, a";
+        final String schemaTemplate = SCHEMA_TEMPLATE + " CREATE INDEX idx1 ON t1(id, a)";
         try (var ddl = Ddl.builder().database(URI.create("/TEST/QT")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
             try (var stmt = ddl.setSchemaAndGetConnection().createStatement()) {
                 insertData(stmt);
@@ -250,7 +250,7 @@ public class DeleteRangeTest {
 
     @Test
     void testDeleteWithIndexSamePrefixButDeleteGoesBeyondIndex() throws Exception {
-        final String schemaTemplate = SCHEMA_TEMPLATE + " CREATE INDEX idx1 as select id from t1";
+        final String schemaTemplate = SCHEMA_TEMPLATE + " CREATE INDEX idx1 ON t1(id)";
         try (var ddl = Ddl.builder().database(URI.create("/TEST/QT")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
             try (var stmt = ddl.setSchemaAndGetConnection().createStatement()) {
                 insertData(stmt);

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/UniqueIndexTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/UniqueIndexTests.java
@@ -24,6 +24,7 @@ import com.apple.foundationdb.relational.api.EmbeddedRelationalArray;
 import com.apple.foundationdb.relational.api.EmbeddedRelationalStruct;
 import com.apple.foundationdb.relational.api.Options;
 import com.apple.foundationdb.relational.api.RelationalStruct;
+import com.apple.foundationdb.relational.api.exceptions.ErrorCode;
 import com.apple.foundationdb.relational.utils.SimpleDatabaseRule;
 
 import org.junit.jupiter.api.Assertions;
@@ -86,6 +87,7 @@ public class UniqueIndexTests {
             final var count = statement.executeInsert(tableName, toInsert);
             Assertions.assertEquals(count, toInsert.size());
         } catch (SQLException e) {
+            Assertions.assertEquals(e.getSQLState(), ErrorCode.UNIQUE_CONSTRAINT_VIOLATION.getErrorCode());
             Assertions.assertTrue(e.getMessage().contains("Duplicate entry for unique index"));
             foundError = true;
         } catch (Exception e) {

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/CountQueryTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/CountQueryTest.java
@@ -43,7 +43,7 @@ import java.sql.SQLException;
 public class CountQueryTest {
     private static final String SCHEMA_TEMPLATE =
             "CREATE TABLE t1 (id bigint, a string, b bigint, primary key (id)) " +
-                    "CREATE INDEX i1 AS SELECT a FROM t1 " +
+                    "CREATE INDEX i1 ON t1(a) " +
                     "CREATE INDEX i2 AS SELECT count(*) FROM t1 GROUP BY a " +
                     "CREATE INDEX i3 AS SELECT count(a) FROM t1 GROUP BY b";
 

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/ExplainTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/ExplainTests.java
@@ -49,8 +49,8 @@ public class ExplainTests {
                     " CREATE TYPE AS STRUCT ReviewerStats (start_date bigint, school_name string, hometown string)" +
                     " CREATE TABLE RestaurantComplexRecord (rest_no bigint, name string, location Location, reviews RestaurantComplexReview ARRAY, tags RestaurantTag array, customer string array, encoded_bytes bytes, PRIMARY KEY(rest_no))" +
                     " CREATE TABLE RestaurantReviewer (id bigint, name string, email string, stats ReviewerStats, PRIMARY KEY(id))" +
-                    " CREATE INDEX record_name_idx as select name from RestaurantComplexRecord" +
-                    " CREATE INDEX reviewer_name_idx as select name from RestaurantReviewer" +
+                    " CREATE INDEX record_name_idx ON RestaurantComplexRecord(name)" +
+                    " CREATE INDEX reviewer_name_idx ON RestaurantReviewer(name)" +
                     " CREATE INDEX mv1 AS SELECT R.rating from RestaurantComplexRecord AS Rec, (select rating from Rec.reviews) R" +
                     " CREATE INDEX mv2 AS SELECT endo.\"endorsementText\" FROM RestaurantComplexRecord rec, (SELECT X.\"endorsementText\" FROM rec.reviews rev, (SELECT \"endorsementText\" from rev.endorsements) X) endo";
 

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/GroupByQueryTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/GroupByQueryTests.java
@@ -54,7 +54,7 @@ public class GroupByQueryTests {
     void groupByWithScanLimit() throws Exception {
         final String schemaTemplate =
                 "CREATE TABLE T1(pk bigint, a bigint, b bigint, c bigint, PRIMARY KEY(pk))" +
-                        "CREATE INDEX idx1 as select a, b, c from t1 order by a, b, c";
+                        "CREATE INDEX idx1 ON t1(a, b, c)";
         try (var ddl = Ddl.builder().database(URI.create("/TEST/QT")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
             try (var conn = ddl.setSchemaAndGetConnection()) {
                 Continuation continuation = null;
@@ -120,7 +120,7 @@ public class GroupByQueryTests {
     void groupByWithRowLimit() throws Exception {
         final String schemaTemplate =
                 "create table t1(pk bigint, a bigint, b bigint, c bigint, primary key(pk))\n" +
-                        "create index i1 as select a from t1";
+                        "create index i1 ON t1(a)";
         try (var ddl = Ddl.builder().database(URI.create("/TEST/QT")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
             try (var conn = ddl.setSchemaAndGetConnection()) {
                 conn.setOption(Options.Name.MAX_ROWS, 1);
@@ -198,7 +198,7 @@ public class GroupByQueryTests {
     void groupByClauseWithPredicateWorks() throws Exception {
         final String schemaTemplate =
                 "CREATE TABLE T1(pk bigint, a bigint, b bigint, c bigint, PRIMARY KEY(pk))" +
-                        "CREATE INDEX idx1 as select a, b, c from t1 order by a, b, c";
+                        "CREATE INDEX idx1 ON t1(a, b, c)";
         try (var ddl = Ddl.builder().database(URI.create("/TEST/QT")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
             try (var statement = ddl.setSchemaAndGetConnection().createStatement()) {
                 insertT1Record(statement, 2, 1, 1, 20);
@@ -248,7 +248,7 @@ public class GroupByQueryTests {
     void groupByClauseWorks() throws Exception {
         final String schemaTemplate =
                 "CREATE TABLE T1(pk bigint, a bigint, b bigint, c bigint, PRIMARY KEY(pk))" +
-                        "CREATE INDEX idx1 as select a, b from T1 order by a, b";
+                        "CREATE INDEX idx1 ON T1(a, b)";
         try (var ddl = Ddl.builder().database(URI.create("/TEST/QT")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
             try (var statement = ddl.setSchemaAndGetConnection().createStatement()) {
                 insertT1Record(statement, 2, 1, 1, 20);
@@ -277,7 +277,7 @@ public class GroupByQueryTests {
     void groupByClauseWorksWithSubquery() throws Exception {
         final String schemaTemplate =
                 "CREATE TABLE T1(pk bigint, a bigint, b bigint, c bigint, PRIMARY KEY(pk))" +
-                        "CREATE INDEX idx1 as select a, b from T1 order by a, b";
+                        "CREATE INDEX idx1 ON T1(a, b)";
         try (var ddl = Ddl.builder().database(URI.create("/TEST/QT")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
             try (var statement = ddl.setSchemaAndGetConnection().createStatement()) {
                 insertT1Record(statement, 2, 1, 1, 20);
@@ -306,7 +306,7 @@ public class GroupByQueryTests {
     void groupByClauseWorksWithSubqueryAliases() throws Exception {
         final String schemaTemplate =
                 "CREATE TABLE T1(pk bigint, a bigint, b bigint, c bigint, PRIMARY KEY(pk))" +
-                        "CREATE INDEX idx1 as select a, b from T1 order by a, b";
+                        "CREATE INDEX idx1 ON T1(a, b)";
         try (var ddl = Ddl.builder().database(URI.create("/TEST/QT")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
             try (var statement = ddl.setSchemaAndGetConnection().createStatement()) {
                 insertT1Record(statement, 2, 1, 1, 20);
@@ -335,7 +335,7 @@ public class GroupByQueryTests {
     void groupByClauseWorksWithSubqueryAliasesComplex() throws Exception {
         final String schemaTemplate =
                 "CREATE TABLE T1(pk bigint, a bigint, b bigint, c bigint, PRIMARY KEY(pk))" +
-                        "CREATE INDEX idx1 as select a, b from t1 order by a, b";
+                        "CREATE INDEX idx1 ON t1(a, b)";
         try (var ddl = Ddl.builder().database(URI.create("/TEST/QT")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
             try (var statement = ddl.setSchemaAndGetConnection().createStatement()) {
                 insertT1Record(statement, 2, 1, 1, 20);
@@ -364,7 +364,7 @@ public class GroupByQueryTests {
     void groupByClauseWorksDifferentAggregations() throws Exception {
         final String schemaTemplate =
                 "CREATE TABLE T1(pk bigint, a bigint, b bigint, c bigint, PRIMARY KEY(pk))" +
-                        "CREATE INDEX idx1 as select a, b from t1 order by a, b";
+                        "CREATE INDEX idx1 ON t1(a, b)";
         try (var ddl = Ddl.builder().database(URI.create("/TEST/QT")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
             try (var statement = ddl.setSchemaAndGetConnection().createStatement()) {
                 insertT1Record(statement, 2, 1, 1, 20);
@@ -393,7 +393,7 @@ public class GroupByQueryTests {
     void groupByClauseWorksComplexGrouping() throws Exception {
         final String schemaTemplate =
                 "CREATE TABLE T1(pk bigint, a bigint, b bigint, c bigint, PRIMARY KEY(pk))" +
-                        "CREATE INDEX idx1 as select a, b from t1 order by a, b";
+                        "CREATE INDEX idx1 ON t1(a, b)";
         try (var ddl = Ddl.builder().database(URI.create("/TEST/QT")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
             try (var statement = ddl.setSchemaAndGetConnection().createStatement()) {
                 insertT1Record(statement, 2, 1, 1, 20);
@@ -422,7 +422,7 @@ public class GroupByQueryTests {
     void groupByClauseSingleGroup() throws Exception {
         final String schemaTemplate =
                 "CREATE TABLE T1(pk bigint, a bigint, b bigint, c bigint, PRIMARY KEY(pk))" +
-                        "CREATE INDEX idx1 as select a, b from t1 order by a, b";
+                        "CREATE INDEX idx1 ON t1(a, b)";
         try (var ddl = Ddl.builder().database(URI.create("/TEST/QT")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
             try (var statement = ddl.setSchemaAndGetConnection().createStatement()) {
                 insertT1Record(statement, 2, 1, 1, 2000);
@@ -443,7 +443,7 @@ public class GroupByQueryTests {
     void groupByClauseWithoutGroupingColumnsInProjectionList() throws Exception {
         final String schemaTemplate =
                 "CREATE TABLE T1(pk bigint, a bigint, b bigint, c bigint, PRIMARY KEY(pk))" +
-                        "CREATE INDEX idx1 as select a, b from t1 order by a, b";
+                        "CREATE INDEX idx1 ON t1(a, b)";
         try (var ddl = Ddl.builder().database(URI.create("/TEST/QT")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
             try (var statement = ddl.setSchemaAndGetConnection().createStatement()) {
                 insertT1Record(statement, 2, 1, 1, 2000);
@@ -464,7 +464,7 @@ public class GroupByQueryTests {
     void groupByClauseWithoutAggregationsInProjectionList() throws Exception {
         final String schemaTemplate =
                 "CREATE TABLE T1(pk bigint, a bigint, b bigint, c bigint, PRIMARY KEY(pk))" +
-                        "CREATE INDEX idx1 as select a, b from t1 order by a, b";
+                        "CREATE INDEX idx1 ON t1(a, b)";
         try (var ddl = Ddl.builder().database(URI.create("/TEST/QT")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
             try (var statement = ddl.setSchemaAndGetConnection().createStatement()) {
                 insertT1Record(statement, 2, 1, 1, 2000);
@@ -485,7 +485,7 @@ public class GroupByQueryTests {
     void groupByInSubSelectWorks() throws Exception {
         final String schemaTemplate =
                 "CREATE TABLE T1(pk bigint, a bigint, b bigint, c bigint, PRIMARY KEY(pk))" +
-                        "CREATE INDEX idx1 as select a, b from t1 order by a, b";
+                        "CREATE INDEX idx1 ON t1(a, b)";
         try (var ddl = Ddl.builder().database(URI.create("/TEST/QT")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
             try (var statement = ddl.setSchemaAndGetConnection().createStatement()) {
                 insertT1Record(statement, 2, 1, 1, 2000);
@@ -506,7 +506,7 @@ public class GroupByQueryTests {
     void groupByConstantColumn() throws Exception {
         final String schemaTemplate =
                 "CREATE TABLE T1(pk bigint, a bigint, b bigint, c bigint, PRIMARY KEY(pk))" +
-                        "CREATE INDEX idx1 as select a, b from t1 order by a, b";
+                        "CREATE INDEX idx1 ON t1(a, b)";
         try (var ddl = Ddl.builder().database(URI.create("/TEST/QT")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
             try (var statement = ddl.setSchemaAndGetConnection().createStatement()) {
                 insertT1Record(statement, 2, 1, 1, 2000);
@@ -527,7 +527,7 @@ public class GroupByQueryTests {
     void aggregationWithoutGroupBy() throws Exception {
         final String schemaTemplate =
                 "CREATE TABLE T1(pk bigint, a bigint, b bigint, c bigint, PRIMARY KEY(pk))" +
-                        "CREATE INDEX idx1 as select a, b from t1 order by a, b";
+                        "CREATE INDEX idx1 ON t1(a, b)";
         try (var ddl = Ddl.builder().database(URI.create("/TEST/QT")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
             try (var statement = ddl.setSchemaAndGetConnection().createStatement()) {
                 insertT1Record(statement, 2, 1, 1, 2000);
@@ -548,7 +548,7 @@ public class GroupByQueryTests {
     void nestedGroupByStatements() throws Exception {
         final String schemaTemplate =
                 "CREATE TABLE T1(pk bigint, a bigint, b bigint, c bigint, PRIMARY KEY(pk))" +
-                        "CREATE INDEX idx1 as select a, b from t1 order by a, b";
+                        "CREATE INDEX idx1 ON t1(a, b)";
         try (var ddl = Ddl.builder().database(URI.create("/TEST/QT")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
             try (var statement = ddl.setSchemaAndGetConnection().createStatement()) {
                 insertT1Record(statement, 2, 1, 1, 2000);
@@ -569,7 +569,7 @@ public class GroupByQueryTests {
     void groupByClauseWorksComplexAggregations() throws Exception {
         final String schemaTemplate =
                 "CREATE TABLE T1(pk bigint, a bigint, b bigint, c bigint, PRIMARY KEY(pk))" +
-                        "CREATE INDEX idx1 as select a, b, c from t1 order by a, b, c";
+                        "CREATE INDEX idx1 ON t1(a, b, c)";
         try (var ddl = Ddl.builder().database(URI.create("/TEST/QT")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
             try (var statement = ddl.setSchemaAndGetConnection().createStatement()) {
                 insertT1Record(statement, 2, 1, 1, 20);
@@ -598,7 +598,7 @@ public class GroupByQueryTests {
     void groupByClauseWithNestedAggregationsIsSupported() throws Exception {
         final String schemaTemplate =
                 "CREATE TABLE T1(pk bigint, a bigint, b bigint, c bigint, PRIMARY KEY(pk))" +
-                        "CREATE INDEX idx1 as select a, b, c from t1 order by a, b, c";
+                        "CREATE INDEX idx1 ON t1(a, b, c)";
         try (var ddl = Ddl.builder().database(URI.create("/TEST/QT")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
             try (var statement = ddl.setSchemaAndGetConnection().createStatement()) {
                 insertT1Record(statement, 2, 1, 1, 20);
@@ -627,7 +627,7 @@ public class GroupByQueryTests {
     void expansionOfStarWorks() throws Exception {
         final String schemaTemplate =
                 "CREATE TABLE T1(pk bigint, a bigint, b bigint, c bigint, PRIMARY KEY(pk))" +
-                        "CREATE INDEX idx1 as select a from t1";
+                        "CREATE INDEX idx1 ON t1(a)";
         try (var ddl = Ddl.builder().database(URI.create("/TEST/QT")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
             try (var statement = ddl.setSchemaAndGetConnection().createStatement()) {
                 insertT1Record(statement, 2, 1, 1, 20);
@@ -654,7 +654,7 @@ public class GroupByQueryTests {
     void groupByClauseWithNamedGroupingColumns() throws Exception {
         final String schemaTemplate =
                 "CREATE TABLE T1(pk bigint, a bigint, b bigint, c bigint, PRIMARY KEY(pk))" +
-                        "CREATE INDEX idx1 as select a, b, c from t1 order by a, b, c";
+                        "CREATE INDEX idx1 ON t1(a, b, c)";
         try (var ddl = Ddl.builder().database(URI.create("/TEST/QT")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
             try (var statement = ddl.setSchemaAndGetConnection().createStatement()) {
                 insertT1Record(statement, 2, 1, 1, 20);
@@ -684,7 +684,7 @@ public class GroupByQueryTests {
         final String schemaTemplate =
                 "CREATE TABLE T1(pk bigint, a bigint, b bigint, c bigint, PRIMARY KEY(pk))" +
                         "CREATE TABLE T2(pk bigint, x bigint, y bigint, z bigint, primary key(pk))" +
-                        "CREATE INDEX idx1 AS SELECT B FROM T1";
+                        "CREATE INDEX idx1 ON T1(B)";
         try (var ddl = Ddl.builder().database(URI.create("/TEST/QT")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
             try (var statement = ddl.setSchemaAndGetConnection().createStatement()) {
                 insertT1Record(statement, 2, 1, 1, 20);
@@ -711,7 +711,7 @@ public class GroupByQueryTests {
     void groupByWithNamedGroups() throws Exception {
         final String schemaTemplate =
                 "CREATE TABLE T1(pk bigint, a bigint, b bigint, c bigint, PRIMARY KEY(pk))" +
-                        "CREATE INDEX idx1 as select a, b, c from t1 order by a, b, c";
+                        "CREATE INDEX idx1 ON t1(a, b, c)";
         try (var ddl = Ddl.builder().database(URI.create("/TEST/QT")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
             try (var statement = ddl.setSchemaAndGetConnection().createStatement()) {
                 insertT1Record(statement, 2, 1, 1, 20);

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/PreparedStatementTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/PreparedStatementTests.java
@@ -72,8 +72,8 @@ public class PreparedStatementTests {
                     " CREATE TYPE AS STRUCT ReviewerStats (start_date bigint, school_name string, hometown string)" +
                     " CREATE TABLE RestaurantComplexRecord (rest_no bigint, name string, location Location, reviews RestaurantComplexReview ARRAY, tags RestaurantTag array, customer string array, encoded_bytes bytes, key bytes, PRIMARY KEY(rest_no))" +
                     " CREATE TABLE RestaurantReviewer (id bigint, name string, email string, stats ReviewerStats, secrets bytes array, PRIMARY KEY(id))" +
-                    " CREATE INDEX record_name_idx as select name from RestaurantComplexRecord" +
-                    " CREATE INDEX reviewer_name_idx as select name from RestaurantReviewer" +
+                    " CREATE INDEX record_name_idx ON RestaurantComplexRecord(name)" +
+                    " CREATE INDEX reviewer_name_idx ON RestaurantReviewer(name)" +
                     " CREATE INDEX mv1 AS SELECT R.rating from RestaurantComplexRecord AS Rec, (select rating from Rec.reviews) R" +
                     " CREATE INDEX mv2 AS SELECT endo.\"endorsementText\" FROM RestaurantComplexRecord rec, (SELECT X.\"endorsementText\" FROM rec.reviews rev, (SELECT \"endorsementText\" from rev.endorsements) X) endo";
 

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/QueryWithContinuationTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/QueryWithContinuationTest.java
@@ -57,8 +57,8 @@ public class QueryWithContinuationTest {
                     " CREATE TYPE AS STRUCT ReviewerStats (start_date bigint, school_name string, hometown string)" +
                     " CREATE TABLE RestaurantComplexRecord (rest_no bigint, name string, location Location, reviews RestaurantComplexReview ARRAY, tags RestaurantTag array, customer string array, encoded_bytes bytes, PRIMARY KEY(rest_no))" +
                     " CREATE TABLE RestaurantReviewer (id bigint, name string, email string, stats ReviewerStats, PRIMARY KEY(id))" +
-                    " CREATE INDEX record_name_idx as select name from RestaurantComplexRecord" +
-                    " CREATE INDEX reviewer_name_idx as select name from RestaurantReviewer" +
+                    " CREATE INDEX record_name_idx ON RestaurantComplexRecord(name)" +
+                    " CREATE INDEX reviewer_name_idx ON RestaurantReviewer(name)" +
                     " CREATE INDEX mv1 AS SELECT R.rating from RestaurantComplexRecord AS Rec, (select rating from Rec.reviews) R" +
                     " CREATE INDEX mv2 AS SELECT endo.\"endorsementText\" FROM RestaurantComplexRecord rec, (SELECT X.\"endorsementText\" FROM rec.reviews rev, (SELECT \"endorsementText\" from rev.endorsements) X) endo";
 

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/StandardQueryTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/StandardQueryTests.java
@@ -78,8 +78,8 @@ public class StandardQueryTests {
                     " CREATE TYPE AS STRUCT ReviewerStats (start_date bigint, school_name string, hometown string)" +
                     " CREATE TABLE RestaurantComplexRecord (rest_no bigint, name string, location Location, reviews RestaurantComplexReview ARRAY, tags RestaurantTag array, customer string array, encoded_bytes bytes, PRIMARY KEY(rest_no))" +
                     " CREATE TABLE RestaurantReviewer (id bigint, name string, email string, stats ReviewerStats, PRIMARY KEY(id))" +
-                    " CREATE INDEX record_name_idx as select name from RestaurantComplexRecord" +
-                    " CREATE INDEX reviewer_name_idx as select name from RestaurantReviewer" +
+                    " CREATE INDEX record_name_idx ON RestaurantComplexRecord(name)" +
+                    " CREATE INDEX reviewer_name_idx ON RestaurantReviewer(name)" +
                     " CREATE INDEX mv1 AS SELECT R.rating from RestaurantComplexRecord AS Rec, (select rating from Rec.reviews) R" +
                     " CREATE INDEX mv2 AS SELECT endo.\"endorsementText\" FROM RestaurantComplexRecord rec, (SELECT X.\"endorsementText\" FROM rec.reviews rev, (SELECT \"endorsementText\" from rev.endorsements) X) endo";
 
@@ -91,8 +91,8 @@ public class StandardQueryTests {
                     " CREATE TYPE AS STRUCT ReviewerStats (start_date bigint, school_name string, hometown string)" +
                     " CREATE TABLE RestaurantComplexRecord (rest_no bigint, name string, location Location, reviews RestaurantComplexReview ARRAY NOT NULL, tags RestaurantTag array NOT NULL, customer string array NOT NULL, encoded_bytes bytes, PRIMARY KEY(rest_no))" +
                     " CREATE TABLE RestaurantReviewer (id bigint, name string, email string, stats ReviewerStats, PRIMARY KEY(id))" +
-                    " CREATE INDEX record_name_idx as select name from RestaurantComplexRecord" +
-                    " CREATE INDEX reviewer_name_idx as select name from RestaurantReviewer" +
+                    " CREATE INDEX record_name_idx ON RestaurantComplexRecord(name)" +
+                    " CREATE INDEX reviewer_name_idx ON RestaurantReviewer(name)" +
                     " CREATE INDEX mv1 AS SELECT R.rating from RestaurantComplexRecord AS Rec, (select rating from Rec.reviews) R" +
                     " CREATE INDEX mv2 AS SELECT endo.\"endorsementText\" FROM RestaurantComplexRecord rec, (SELECT X.\"endorsementText\" FROM rec.reviews rev, (SELECT \"endorsementText\" from rev.endorsements) X) endo";
 

--- a/fdb-relational-core/src/testFixtures/java/com/apple/foundationdb/relational/utils/TestSchemas.java
+++ b/fdb-relational-core/src/testFixtures/java/com/apple/foundationdb/relational/utils/TestSchemas.java
@@ -65,7 +65,7 @@ public final class TestSchemas {
                     "CREATE TABLE Card (id bigint, suit suit, rank bigint, PRIMARY KEY(id))" +
                     "CREATE TABLE Card_Nested (id bigint, info SuitAndRank, PRIMARY KEY(id))" +
                     "CREATE TABLE Card_Array (id bigint, collection SuitAndRank array, PRIMARY KEY(id))" +
-                    "CREATE INDEX suit_idx AS SELECT suit FROM Card ORDER BY suit";
+                    "CREATE INDEX suit_idx ON Card(suit)";
 
     @Nonnull
     public static String playingCard() {

--- a/yaml-tests/src/test/java/YamlIntegrationTests.java
+++ b/yaml-tests/src/test/java/YamlIntegrationTests.java
@@ -336,4 +336,14 @@ public class YamlIntegrationTests {
     public void castTests(YamlTest.Runner runner) throws Exception {
         runner.runYamsql("cast-tests.yamsql");
     }
+
+    @TestTemplate
+    public void alternateIndexSyntax(YamlTest.Runner runner) throws Exception {
+        runner.runYamsql("alternate-index-syntax.yamsql");
+    }
+
+    @TestTemplate
+    public void castTests(YamlTest.Runner runner) throws Exception {
+        runner.runYamsql("cast-tests.yamsql");
+    }
 }

--- a/yaml-tests/src/test/resources/alternate-index-syntax.metrics.binpb
+++ b/yaml-tests/src/test/resources/alternate-index-syntax.metrics.binpb
@@ -1,0 +1,266 @@
+Ú
+X
+basic_indexIEXPLAIN select name from customers_materialized_view where name = 'Alice'ï
+±áïûR≈ Èπ∞(ù0ı£ 8€@ëCOVERING(IDX_MV_INCLUDE [EQUALS promote(@c8 AS STRING)] -> [COUNTRY: VALUE[1], EMAIL: VALUE[0], ID: KEY[2], NAME: KEY[0]]) | MAP (_.NAME AS NAME)ﬂdigraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=polyline;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q307.NAME AS NAME)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(STRING AS NAME)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Covering Index Scan</td></tr><tr><td align="left">comparisons: [EQUALS promote(@c8 AS STRING)]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS ID, STRING AS NAME, STRING AS EMAIL, INT AS AGE, STRING AS CITY, STRING AS COUNTRY, STRING AS PROFESSION)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">IDX_MV_INCLUDE</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS ID, STRING AS NAME, STRING AS EMAIL, INT AS AGE, STRING AS CITY, STRING AS COUNTRY, STRING AS PROFESSION)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q307> label="q307" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}∆
+U
+basic_indexFEXPLAIN select name from customers_index_on_table where name = 'Alice'Ï
+–‘‡ùP  óı« (ü0Ä∑´	8ﬂ@kCOVERING(IDX_IOT_NAME [EQUALS promote(@c8 AS STRING)] -> [ID: KEY[2], NAME: KEY[0]]) | MAP (_.NAME AS NAME)›digraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=polyline;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q313.NAME AS NAME)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(STRING AS NAME)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Covering Index Scan</td></tr><tr><td align="left">comparisons: [EQUALS promote(@c8 AS STRING)]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS ID, STRING AS NAME, STRING AS EMAIL, INT AS AGE, STRING AS CITY, STRING AS COUNTRY, STRING AS PROFESSION)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">IDX_IOT_NAME</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS ID, STRING AS NAME, STRING AS EMAIL, INT AS AGE, STRING AS CITY, STRING AS COUNTRY, STRING AS PROFESSION)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q313> label="q313" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}ø
+X
+basic_indexIEXPLAIN select email from customers_materialized_view order by email desc‚
+æÒßÉMY …ïû>(L0ƒ˘ú8@xCOVERING(IDX_MV_EMAIL <,> -> [EMAIL: from_ordered_bytes(KEY:[0], DESC_NULLS_LAST), ID: KEY[2]]) | MAP (_.EMAIL AS EMAIL)…digraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=polyline;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q86.EMAIL AS EMAIL)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(STRING AS EMAIL)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Covering Index Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS ID, STRING AS NAME, STRING AS EMAIL, INT AS AGE, STRING AS CITY, STRING AS COUNTRY, STRING AS PROFESSION)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">IDX_MV_EMAIL</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS ID, STRING AS NAME, STRING AS EMAIL, INT AS AGE, STRING AS CITY, STRING AS COUNTRY, STRING AS PROFESSION)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q86> label="q86" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}æ
+U
+basic_indexFEXPLAIN select email from customers_index_on_table order by email desc‰
+æÅ§ÛLY ﬁ∂«=(L0‡ø±8@yCOVERING(IDX_IOT_EMAIL <,> -> [EMAIL: from_ordered_bytes(KEY:[0], DESC_NULLS_LAST), ID: KEY[2]]) | MAP (_.EMAIL AS EMAIL) digraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=polyline;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q86.EMAIL AS EMAIL)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(STRING AS EMAIL)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Covering Index Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS ID, STRING AS NAME, STRING AS EMAIL, INT AS AGE, STRING AS CITY, STRING AS COUNTRY, STRING AS PROFESSION)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">IDX_IOT_EMAIL</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS ID, STRING AS NAME, STRING AS EMAIL, INT AS AGE, STRING AS CITY, STRING AS COUNTRY, STRING AS PROFESSION)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q86> label="q86" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}ù
+j
+basic_index[EXPLAIN select age, city from customers_materialized_view where age > 25 order by age, cityÆ
+ÿ¿àÕO} ±äÈ:(U0¨∞—8&@åCOVERING(IDX_MV_MULTI [[GREATER_THAN promote(@c10 AS INT)]] -> [AGE: KEY[0], CITY: KEY[1], ID: KEY[3]]) | MAP (_.AGE AS AGE, _.CITY AS CITY)Ädigraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=polyline;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q101.AGE AS AGE, q101.CITY AS CITY)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS AGE, STRING AS CITY)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Covering Index Scan</td></tr><tr><td align="left">comparisons: [[GREATER_THAN promote(@c10 AS INT)]]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS ID, STRING AS NAME, STRING AS EMAIL, INT AS AGE, STRING AS CITY, STRING AS COUNTRY, STRING AS PROFESSION)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">IDX_MV_MULTI</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS ID, STRING AS NAME, STRING AS EMAIL, INT AS AGE, STRING AS CITY, STRING AS COUNTRY, STRING AS PROFESSION)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q101> label="q101" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}ú
+g
+basic_indexXEXPLAIN select age, city from customers_index_on_table where age > 25 order by age, city∞
+ÿÓ√ëP} „Å»;(U0û”¬8&@çCOVERING(IDX_IOT_MULTI [[GREATER_THAN promote(@c10 AS INT)]] -> [AGE: KEY[0], CITY: KEY[1], ID: KEY[3]]) | MAP (_.AGE AS AGE, _.CITY AS CITY)Ådigraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=polyline;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q101.AGE AS AGE, q101.CITY AS CITY)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS AGE, STRING AS CITY)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Covering Index Scan</td></tr><tr><td align="left">comparisons: [[GREATER_THAN promote(@c10 AS INT)]]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS ID, STRING AS NAME, STRING AS EMAIL, INT AS AGE, STRING AS CITY, STRING AS COUNTRY, STRING AS PROFESSION)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">IDX_IOT_MULTI</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS ID, STRING AS NAME, STRING AS EMAIL, INT AS AGE, STRING AS CITY, STRING AS COUNTRY, STRING AS PROFESSION)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q101> label="q101" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}Å
+k
+include_clauseYEXPLAIN select name, email, country from customers_materialized_view where name = 'Alice'ë
+ˆîÁ…P¡ ´Ï∆$(ô0íè∫8’@∫COVERING(IDX_MV_INCLUDE [EQUALS promote(@c12 AS STRING)] -> [COUNTRY: VALUE[1], EMAIL: VALUE[0], ID: KEY[2], NAME: KEY[0]]) | MAP (_.NAME AS NAME, _.EMAIL AS EMAIL, _.COUNTRY AS COUNTRY)≤digraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=polyline;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q306.NAME AS NAME, q306.EMAIL AS EMAIL, q306.COUNTRY AS COUNTRY)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(STRING AS NAME, STRING AS EMAIL, STRING AS COUNTRY)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Covering Index Scan</td></tr><tr><td align="left">comparisons: [EQUALS promote(@c12 AS STRING)]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS ID, STRING AS NAME, STRING AS EMAIL, INT AS AGE, STRING AS CITY, STRING AS COUNTRY, STRING AS PROFESSION)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">IDX_MV_INCLUDE</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS ID, STRING AS NAME, STRING AS EMAIL, INT AS AGE, STRING AS CITY, STRING AS COUNTRY, STRING AS PROFESSION)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q306> label="q306" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}¸
+h
+include_clauseVEXPLAIN select name, email, country from customers_index_on_table where name = 'Alice'è
+ï–úóR« ¬∂¿#(õ0ÆÛÕ8ÿ@∑COVERING(IDX_IOT_INCLUDE [EQUALS promote(@c12 AS STRING)] -> [COUNTRY: KEY[2], EMAIL: KEY[1], ID: KEY[4], NAME: KEY[0]]) | MAP (_.NAME AS NAME, _.EMAIL AS EMAIL, _.COUNTRY AS COUNTRY)≥digraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=polyline;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q309.NAME AS NAME, q309.EMAIL AS EMAIL, q309.COUNTRY AS COUNTRY)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(STRING AS NAME, STRING AS EMAIL, STRING AS COUNTRY)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Covering Index Scan</td></tr><tr><td align="left">comparisons: [EQUALS promote(@c12 AS STRING)]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS ID, STRING AS NAME, STRING AS EMAIL, INT AS AGE, STRING AS CITY, STRING AS COUNTRY, STRING AS PROFESSION)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">IDX_IOT_INCLUDE</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS ID, STRING AS NAME, STRING AS EMAIL, INT AS AGE, STRING AS CITY, STRING AS COUNTRY, STRING AS PROFESSION)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q309> label="q309" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}‘
+v
+mixed_asc_descdEXPLAIN select age, city from customers_materialized_view where age > 30 order by age asc, city descŸ
+ÿ§—Á} œèπ(U0æﬂ-8&@µCOVERING(IDX_MV_ASC_DESC [[GREATER_THAN promote(@c10 AS INT)]] -> [AGE: KEY[0], CITY: from_ordered_bytes(KEY:[1], DESC_NULLS_LAST), ID: KEY[3]]) | MAP (_.AGE AS AGE, _.CITY AS CITY)Édigraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=polyline;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q101.AGE AS AGE, q101.CITY AS CITY)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS AGE, STRING AS CITY)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Covering Index Scan</td></tr><tr><td align="left">comparisons: [[GREATER_THAN promote(@c10 AS INT)]]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS ID, STRING AS NAME, STRING AS EMAIL, INT AS AGE, STRING AS CITY, STRING AS COUNTRY, STRING AS PROFESSION)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">IDX_MV_ASC_DESC</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS ID, STRING AS NAME, STRING AS EMAIL, INT AS AGE, STRING AS CITY, STRING AS COUNTRY, STRING AS PROFESSION)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q101> label="q101" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}”
+s
+mixed_asc_descaEXPLAIN select age, city from customers_index_on_table where age > 30 order by age asc, city desc€
+ÿπ‘ } ÂñΩ(U0ê˝(8&@∂COVERING(IDX_IOT_ASC_DESC [[GREATER_THAN promote(@c10 AS INT)]] -> [AGE: KEY[0], CITY: from_ordered_bytes(KEY:[1], DESC_NULLS_LAST), ID: KEY[3]]) | MAP (_.AGE AS AGE, _.CITY AS CITY)Ñdigraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=polyline;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q101.AGE AS AGE, q101.CITY AS CITY)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS AGE, STRING AS CITY)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Covering Index Scan</td></tr><tr><td align="left">comparisons: [[GREATER_THAN promote(@c10 AS INT)]]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS ID, STRING AS NAME, STRING AS EMAIL, INT AS AGE, STRING AS CITY, STRING AS COUNTRY, STRING AS PROFESSION)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">IDX_IOT_ASC_DESC</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS ID, STRING AS NAME, STRING AS EMAIL, INT AS AGE, STRING AS CITY, STRING AS COUNTRY, STRING AS PROFESSION)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q101> label="q101" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}›
+w
+mixed_asc_desceEXPLAIN select age, city from customers_materialized_view where age < 40 order by age desc, city desc·
+ÿﬂ©´} ∆çö(U0»≈+8&@ëCOVERING(IDX_MV_MULTI [[LESS_THAN promote(@c10 AS INT)]] REVERSE -> [AGE: KEY[0], CITY: KEY[1], ID: KEY[3]]) | MAP (_.AGE AS AGE, _.CITY AS CITY)Ødigraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=polyline;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q101.AGE AS AGE, q101.CITY AS CITY)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS AGE, STRING AS CITY)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Covering Index Scan</td></tr><tr><td align="left">comparisons: [[LESS_THAN promote(@c10 AS INT)]]</td></tr><tr><td align="left">direction: reversed</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS ID, STRING AS NAME, STRING AS EMAIL, INT AS AGE, STRING AS CITY, STRING AS COUNTRY, STRING AS PROFESSION)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">IDX_MV_MULTI</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS ID, STRING AS NAME, STRING AS EMAIL, INT AS AGE, STRING AS CITY, STRING AS COUNTRY, STRING AS PROFESSION)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q101> label="q101" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}‹
+t
+mixed_asc_descbEXPLAIN select age, city from customers_index_on_table where age < 40 order by age desc, city desc„
+ÿˇ‚∂} Ω’™(U0Áı/8&@íCOVERING(IDX_IOT_MULTI [[LESS_THAN promote(@c10 AS INT)]] REVERSE -> [AGE: KEY[0], CITY: KEY[1], ID: KEY[3]]) | MAP (_.AGE AS AGE, _.CITY AS CITY)∞digraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=polyline;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q101.AGE AS AGE, q101.CITY AS CITY)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS AGE, STRING AS CITY)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Covering Index Scan</td></tr><tr><td align="left">comparisons: [[LESS_THAN promote(@c10 AS INT)]]</td></tr><tr><td align="left">direction: reversed</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS ID, STRING AS NAME, STRING AS EMAIL, INT AS AGE, STRING AS CITY, STRING AS COUNTRY, STRING AS PROFESSION)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">IDX_IOT_MULTI</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS ID, STRING AS NAME, STRING AS EMAIL, INT AS AGE, STRING AS CITY, STRING AS COUNTRY, STRING AS PROFESSION)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q101> label="q101" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}à
+v
+mixed_asc_descdEXPLAIN select age, city from customers_materialized_view where age < 50 order by age desc, city ascç
+ÿÔ«≈} †ΩÄ(U0ù∞@8&@∫COVERING(IDX_MV_ASC_DESC [[LESS_THAN promote(@c10 AS INT)]] REVERSE -> [AGE: KEY[0], CITY: from_ordered_bytes(KEY:[1], DESC_NULLS_LAST), ID: KEY[3]]) | MAP (_.AGE AS AGE, _.CITY AS CITY)≤digraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=polyline;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q101.AGE AS AGE, q101.CITY AS CITY)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS AGE, STRING AS CITY)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Covering Index Scan</td></tr><tr><td align="left">comparisons: [[LESS_THAN promote(@c10 AS INT)]]</td></tr><tr><td align="left">direction: reversed</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS ID, STRING AS NAME, STRING AS EMAIL, INT AS AGE, STRING AS CITY, STRING AS COUNTRY, STRING AS PROFESSION)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">IDX_MV_ASC_DESC</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS ID, STRING AS NAME, STRING AS EMAIL, INT AS AGE, STRING AS CITY, STRING AS COUNTRY, STRING AS PROFESSION)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q101> label="q101" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}á
+s
+mixed_asc_descaEXPLAIN select age, city from customers_index_on_table where age < 50 order by age desc, city ascè
+ÿ≈¥º} º‘†(U0Õ….8&@ªCOVERING(IDX_IOT_ASC_DESC [[LESS_THAN promote(@c10 AS INT)]] REVERSE -> [AGE: KEY[0], CITY: from_ordered_bytes(KEY:[1], DESC_NULLS_LAST), ID: KEY[3]]) | MAP (_.AGE AS AGE, _.CITY AS CITY)≥digraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=polyline;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q101.AGE AS AGE, q101.CITY AS CITY)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS AGE, STRING AS CITY)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Covering Index Scan</td></tr><tr><td align="left">comparisons: [[LESS_THAN promote(@c10 AS INT)]]</td></tr><tr><td align="left">direction: reversed</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS ID, STRING AS NAME, STRING AS EMAIL, INT AS AGE, STRING AS CITY, STRING AS COUNTRY, STRING AS PROFESSION)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">IDX_IOT_ASC_DESC</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS ID, STRING AS NAME, STRING AS EMAIL, INT AS AGE, STRING AS CITY, STRING AS COUNTRY, STRING AS PROFESSION)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q101> label="q101" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}ƒ
+l
+nulls_first_lastXEXPLAIN SELECT country FROM customers_materialized_view ORDER BY country ASC NULLS FIRST”
+æôÜÇY áı∏(L0‘–8@^COVERING(IDX_MV_NULLS_FIRST <,> -> [COUNTRY: KEY[0], ID: KEY[2]]) | MAP (_.COUNTRY AS COUNTRY)’digraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=polyline;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q86.COUNTRY AS COUNTRY)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(STRING AS COUNTRY)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Covering Index Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS ID, STRING AS NAME, STRING AS EMAIL, INT AS AGE, STRING AS CITY, STRING AS COUNTRY, STRING AS PROFESSION)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">IDX_MV_NULLS_FIRST</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS ID, STRING AS NAME, STRING AS EMAIL, INT AS AGE, STRING AS CITY, STRING AS COUNTRY, STRING AS PROFESSION)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q86> label="q86" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}√
+i
+nulls_first_lastUEXPLAIN SELECT country FROM customers_index_on_table ORDER BY country ASC NULLS FIRST’
+æ˚± Y öÈú	(L0óÌ8@_COVERING(IDX_IOT_NULLS_FIRST <,> -> [COUNTRY: KEY[0], ID: KEY[2]]) | MAP (_.COUNTRY AS COUNTRY)÷digraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=polyline;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q86.COUNTRY AS COUNTRY)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(STRING AS COUNTRY)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Covering Index Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS ID, STRING AS NAME, STRING AS EMAIL, INT AS AGE, STRING AS CITY, STRING AS COUNTRY, STRING AS PROFESSION)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">IDX_IOT_NULLS_FIRST</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS ID, STRING AS NAME, STRING AS EMAIL, INT AS AGE, STRING AS CITY, STRING AS COUNTRY, STRING AS PROFESSION)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q86> label="q86" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}Á
+k
+nulls_first_lastWEXPLAIN SELECT country FROM customers_materialized_view ORDER BY country ASC NULLS LAST˜
+æÔªßY ΩÙà(L0ﬂ†8@ÇCOVERING(IDX_MV_NULLS_LAST <,> -> [COUNTRY: from_ordered_bytes(KEY:[0], ASC_NULLS_LAST), ID: KEY[2]]) | MAP (_.COUNTRY AS COUNTRY)‘digraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=polyline;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q86.COUNTRY AS COUNTRY)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(STRING AS COUNTRY)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Covering Index Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS ID, STRING AS NAME, STRING AS EMAIL, INT AS AGE, STRING AS CITY, STRING AS COUNTRY, STRING AS PROFESSION)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">IDX_MV_NULLS_LAST</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS ID, STRING AS NAME, STRING AS EMAIL, INT AS AGE, STRING AS CITY, STRING AS COUNTRY, STRING AS PROFESSION)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q86> label="q86" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}Ê
+h
+nulls_first_lastTEXPLAIN SELECT country FROM customers_index_on_table ORDER BY country ASC NULLS LAST˘
+æˇæ◊Y ıÅΩ(L0öû8@ÉCOVERING(IDX_IOT_NULLS_LAST <,> -> [COUNTRY: from_ordered_bytes(KEY:[0], ASC_NULLS_LAST), ID: KEY[2]]) | MAP (_.COUNTRY AS COUNTRY)’digraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=polyline;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q86.COUNTRY AS COUNTRY)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(STRING AS COUNTRY)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Covering Index Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS ID, STRING AS NAME, STRING AS EMAIL, INT AS AGE, STRING AS CITY, STRING AS COUNTRY, STRING AS PROFESSION)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">IDX_IOT_NULLS_LAST</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS ID, STRING AS NAME, STRING AS EMAIL, INT AS AGE, STRING AS CITY, STRING AS COUNTRY, STRING AS PROFESSION)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q86> label="q86" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}”
+e
+nulls_first_lastQEXPLAIN SELECT age FROM customers_materialized_view ORDER BY age DESC NULLS FIRSTÈ
+æØÛëY Íﬁ˝(L0‡‡8@~COVERING(IDX_MV_DESC_NULLS_FIRST <,> -> [AGE: from_ordered_bytes(KEY:[0], DESC_NULLS_FIRST), ID: KEY[2]]) | MAP (_.AGE AS AGE)Àdigraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=polyline;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q86.AGE AS AGE)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS AGE)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Covering Index Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS ID, STRING AS NAME, STRING AS EMAIL, INT AS AGE, STRING AS CITY, STRING AS COUNTRY, STRING AS PROFESSION)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">IDX_MV_DESC_NULLS_FIRST</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS ID, STRING AS NAME, STRING AS EMAIL, INT AS AGE, STRING AS CITY, STRING AS COUNTRY, STRING AS PROFESSION)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q86> label="q86" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}“
+b
+nulls_first_lastNEXPLAIN SELECT age FROM customers_index_on_table ORDER BY age DESC NULLS FIRSTÎ
+æ¥‹âY ”‡ô(L0Ò¥8@COVERING(IDX_IOT_DESC_NULLS_FIRST <,> -> [AGE: from_ordered_bytes(KEY:[0], DESC_NULLS_FIRST), ID: KEY[2]]) | MAP (_.AGE AS AGE)Ãdigraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=polyline;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q86.AGE AS AGE)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS AGE)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Covering Index Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS ID, STRING AS NAME, STRING AS EMAIL, INT AS AGE, STRING AS CITY, STRING AS COUNTRY, STRING AS PROFESSION)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">IDX_IOT_DESC_NULLS_FIRST</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS ID, STRING AS NAME, STRING AS EMAIL, INT AS AGE, STRING AS CITY, STRING AS COUNTRY, STRING AS PROFESSION)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q86> label="q86" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}“
+d
+nulls_first_lastPEXPLAIN SELECT age FROM customers_materialized_view ORDER BY age DESC NULLS LASTÈ
+‰è»•u ≈§¢
+(X0ª—28.@|COVERING(IDX_MV_DESC_NULLS_LAST <,> -> [AGE: from_ordered_bytes(KEY:[0], DESC_NULLS_LAST), ID: KEY[2]]) | MAP (_.AGE AS AGE)Õdigraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=polyline;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q106.AGE AS AGE)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS AGE)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Covering Index Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS ID, STRING AS NAME, STRING AS EMAIL, INT AS AGE, STRING AS CITY, STRING AS COUNTRY, STRING AS PROFESSION)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">IDX_MV_DESC_NULLS_LAST</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS ID, STRING AS NAME, STRING AS EMAIL, INT AS AGE, STRING AS CITY, STRING AS COUNTRY, STRING AS PROFESSION)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q106> label="q106" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}—
+a
+nulls_first_lastMEXPLAIN SELECT age FROM customers_index_on_table ORDER BY age DESC NULLS LASTÎ
+‰≠Ôµu û±‹	(X0≈¸L8.@}COVERING(IDX_IOT_DESC_NULLS_LAST <,> -> [AGE: from_ordered_bytes(KEY:[0], DESC_NULLS_LAST), ID: KEY[2]]) | MAP (_.AGE AS AGE)Œdigraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=polyline;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q106.AGE AS AGE)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS AGE)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Covering Index Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS ID, STRING AS NAME, STRING AS EMAIL, INT AS AGE, STRING AS CITY, STRING AS COUNTRY, STRING AS PROFESSION)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">IDX_IOT_DESC_NULLS_LAST</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS ID, STRING AS NAME, STRING AS EMAIL, INT AS AGE, STRING AS CITY, STRING AS COUNTRY, STRING AS PROFESSION)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q106> label="q106" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}

--- a/yaml-tests/src/test/resources/alternate-index-syntax.metrics.yaml
+++ b/yaml-tests/src/test/resources/alternate-index-syntax.metrics.yaml
@@ -1,0 +1,270 @@
+basic_index:
+-   query: EXPLAIN select name from customers_materialized_view where name = 'Alice'
+    explain: 'COVERING(IDX_MV_INCLUDE [EQUALS promote(@c8 AS STRING)] -> [COUNTRY:
+        VALUE[1], EMAIL: VALUE[0], ID: KEY[2], NAME: KEY[0]]) | MAP (_.NAME AS NAME)'
+    task_count: 1841
+    task_total_time_ms: 172
+    transform_count: 453
+    transform_time_ms: 65
+    transform_yield_count: 157
+    insert_time_ms: 32
+    insert_new_count: 219
+    insert_reused_count: 21
+-   query: EXPLAIN select name from customers_index_on_table where name = 'Alice'
+    explain: 'COVERING(IDX_IOT_NAME [EQUALS promote(@c8 AS STRING)] -> [ID: KEY[2],
+        NAME: KEY[0]]) | MAP (_.NAME AS NAME)'
+    task_count: 1872
+    task_total_time_ms: 168
+    transform_count: 458
+    transform_time_ms: 68
+    transform_yield_count: 159
+    insert_time_ms: 19
+    insert_new_count: 223
+    insert_reused_count: 22
+-   query: EXPLAIN select email from customers_materialized_view order by email desc
+    explain: 'COVERING(IDX_MV_EMAIL <,> -> [EMAIL: from_ordered_bytes(KEY:[0], DESC_NULLS_LAST),
+        ID: KEY[2]]) | MAP (_.EMAIL AS EMAIL)'
+    task_count: 318
+    task_total_time_ms: 161
+    transform_count: 89
+    transform_time_ms: 130
+    transform_yield_count: 76
+    insert_time_ms: 2
+    insert_new_count: 20
+    insert_reused_count: 2
+-   query: EXPLAIN select email from customers_index_on_table order by email desc
+    explain: 'COVERING(IDX_IOT_EMAIL <,> -> [EMAIL: from_ordered_bytes(KEY:[0], DESC_NULLS_LAST),
+        ID: KEY[2]]) | MAP (_.EMAIL AS EMAIL)'
+    task_count: 318
+    task_total_time_ms: 161
+    transform_count: 89
+    transform_time_ms: 129
+    transform_yield_count: 76
+    insert_time_ms: 2
+    insert_new_count: 20
+    insert_reused_count: 2
+-   query: EXPLAIN select age, city from customers_materialized_view where age > 25
+        order by age, city
+    explain: 'COVERING(IDX_MV_MULTI [[GREATER_THAN promote(@c10 AS INT)]] -> [AGE:
+        KEY[0], CITY: KEY[1], ID: KEY[3]]) | MAP (_.AGE AS AGE, _.CITY AS CITY)'
+    task_count: 472
+    task_total_time_ms: 166
+    transform_count: 125
+    transform_time_ms: 123
+    transform_yield_count: 85
+    insert_time_ms: 7
+    insert_new_count: 38
+    insert_reused_count: 2
+-   query: EXPLAIN select age, city from customers_index_on_table where age > 25 order
+        by age, city
+    explain: 'COVERING(IDX_IOT_MULTI [[GREATER_THAN promote(@c10 AS INT)]] -> [AGE:
+        KEY[0], CITY: KEY[1], ID: KEY[3]]) | MAP (_.AGE AS AGE, _.CITY AS CITY)'
+    task_count: 472
+    task_total_time_ms: 168
+    transform_count: 125
+    transform_time_ms: 124
+    transform_yield_count: 85
+    insert_time_ms: 7
+    insert_new_count: 38
+    insert_reused_count: 2
+include_clause:
+-   query: EXPLAIN select name, email, country from customers_materialized_view where
+        name = 'Alice'
+    explain: 'COVERING(IDX_MV_INCLUDE [EQUALS promote(@c12 AS STRING)] -> [COUNTRY:
+        VALUE[1], EMAIL: VALUE[0], ID: KEY[2], NAME: KEY[0]]) | MAP (_.NAME AS NAME,
+        _.EMAIL AS EMAIL, _.COUNTRY AS COUNTRY)'
+    task_count: 1782
+    task_total_time_ms: 168
+    transform_count: 449
+    transform_time_ms: 76
+    transform_yield_count: 153
+    insert_time_ms: 13
+    insert_new_count: 213
+    insert_reused_count: 21
+-   query: EXPLAIN select name, email, country from customers_index_on_table where
+        name = 'Alice'
+    explain: 'COVERING(IDX_IOT_INCLUDE [EQUALS promote(@c12 AS STRING)] -> [COUNTRY:
+        KEY[2], EMAIL: KEY[1], ID: KEY[4], NAME: KEY[0]]) | MAP (_.NAME AS NAME, _.EMAIL
+        AS EMAIL, _.COUNTRY AS COUNTRY)'
+    task_count: 1813
+    task_total_time_ms: 172
+    transform_count: 455
+    transform_time_ms: 74
+    transform_yield_count: 155
+    insert_time_ms: 13
+    insert_new_count: 216
+    insert_reused_count: 21
+mixed_asc_desc:
+-   query: EXPLAIN select age, city from customers_materialized_view where age > 30
+        order by age asc, city desc
+    explain: 'COVERING(IDX_MV_ASC_DESC [[GREATER_THAN promote(@c10 AS INT)]] -> [AGE:
+        KEY[0], CITY: from_ordered_bytes(KEY:[1], DESC_NULLS_LAST), ID: KEY[3]]) |
+        MAP (_.AGE AS AGE, _.CITY AS CITY)'
+    task_count: 472
+    task_total_time_ms: 47
+    transform_count: 125
+    transform_time_ms: 26
+    transform_yield_count: 85
+    insert_time_ms: 0
+    insert_new_count: 38
+    insert_reused_count: 2
+-   query: EXPLAIN select age, city from customers_index_on_table where age > 30 order
+        by age asc, city desc
+    explain: 'COVERING(IDX_IOT_ASC_DESC [[GREATER_THAN promote(@c10 AS INT)]] -> [AGE:
+        KEY[0], CITY: from_ordered_bytes(KEY:[1], DESC_NULLS_LAST), ID: KEY[3]]) |
+        MAP (_.AGE AS AGE, _.CITY AS CITY)'
+    task_count: 472
+    task_total_time_ms: 45
+    transform_count: 125
+    transform_time_ms: 26
+    transform_yield_count: 85
+    insert_time_ms: 0
+    insert_new_count: 38
+    insert_reused_count: 2
+-   query: EXPLAIN select age, city from customers_materialized_view where age < 40
+        order by age desc, city desc
+    explain: 'COVERING(IDX_MV_MULTI [[LESS_THAN promote(@c10 AS INT)]] REVERSE ->
+        [AGE: KEY[0], CITY: KEY[1], ID: KEY[3]]) | MAP (_.AGE AS AGE, _.CITY AS CITY)'
+    task_count: 472
+    task_total_time_ms: 44
+    transform_count: 125
+    transform_time_ms: 25
+    transform_yield_count: 85
+    insert_time_ms: 0
+    insert_new_count: 38
+    insert_reused_count: 2
+-   query: EXPLAIN select age, city from customers_index_on_table where age < 40 order
+        by age desc, city desc
+    explain: 'COVERING(IDX_IOT_MULTI [[LESS_THAN promote(@c10 AS INT)]] REVERSE ->
+        [AGE: KEY[0], CITY: KEY[1], ID: KEY[3]]) | MAP (_.AGE AS AGE, _.CITY AS CITY)'
+    task_count: 472
+    task_total_time_ms: 47
+    transform_count: 125
+    transform_time_ms: 27
+    transform_yield_count: 85
+    insert_time_ms: 0
+    insert_new_count: 38
+    insert_reused_count: 2
+-   query: EXPLAIN select age, city from customers_materialized_view where age < 50
+        order by age desc, city asc
+    explain: 'COVERING(IDX_MV_ASC_DESC [[LESS_THAN promote(@c10 AS INT)]] REVERSE
+        -> [AGE: KEY[0], CITY: from_ordered_bytes(KEY:[1], DESC_NULLS_LAST), ID: KEY[3]])
+        | MAP (_.AGE AS AGE, _.CITY AS CITY)'
+    task_count: 472
+    task_total_time_ms: 45
+    transform_count: 125
+    transform_time_ms: 25
+    transform_yield_count: 85
+    insert_time_ms: 1
+    insert_new_count: 38
+    insert_reused_count: 2
+-   query: EXPLAIN select age, city from customers_index_on_table where age < 50 order
+        by age desc, city asc
+    explain: 'COVERING(IDX_IOT_ASC_DESC [[LESS_THAN promote(@c10 AS INT)]] REVERSE
+        -> [AGE: KEY[0], CITY: from_ordered_bytes(KEY:[1], DESC_NULLS_LAST), ID: KEY[3]])
+        | MAP (_.AGE AS AGE, _.CITY AS CITY)'
+    task_count: 472
+    task_total_time_ms: 45
+    transform_count: 125
+    transform_time_ms: 25
+    transform_yield_count: 85
+    insert_time_ms: 0
+    insert_new_count: 38
+    insert_reused_count: 2
+nulls_first_last:
+-   query: EXPLAIN SELECT country FROM customers_materialized_view ORDER BY country
+        ASC NULLS FIRST
+    explain: 'COVERING(IDX_MV_NULLS_FIRST <,> -> [COUNTRY: KEY[0], ID: KEY[2]]) |
+        MAP (_.COUNTRY AS COUNTRY)'
+    task_count: 318
+    task_total_time_ms: 27
+    transform_count: 89
+    transform_time_ms: 17
+    transform_yield_count: 76
+    insert_time_ms: 0
+    insert_new_count: 20
+    insert_reused_count: 2
+-   query: EXPLAIN SELECT country FROM customers_index_on_table ORDER BY country ASC
+        NULLS FIRST
+    explain: 'COVERING(IDX_IOT_NULLS_FIRST <,> -> [COUNTRY: KEY[0], ID: KEY[2]]) |
+        MAP (_.COUNTRY AS COUNTRY)'
+    task_count: 318
+    task_total_time_ms: 28
+    transform_count: 89
+    transform_time_ms: 19
+    transform_yield_count: 76
+    insert_time_ms: 0
+    insert_new_count: 20
+    insert_reused_count: 2
+-   query: EXPLAIN SELECT country FROM customers_materialized_view ORDER BY country
+        ASC NULLS LAST
+    explain: 'COVERING(IDX_MV_NULLS_LAST <,> -> [COUNTRY: from_ordered_bytes(KEY:[0],
+        ASC_NULLS_LAST), ID: KEY[2]]) | MAP (_.COUNTRY AS COUNTRY)'
+    task_count: 318
+    task_total_time_ms: 25
+    transform_count: 89
+    transform_time_ms: 14
+    transform_yield_count: 76
+    insert_time_ms: 0
+    insert_new_count: 20
+    insert_reused_count: 2
+-   query: EXPLAIN SELECT country FROM customers_index_on_table ORDER BY country ASC
+        NULLS LAST
+    explain: 'COVERING(IDX_IOT_NULLS_LAST <,> -> [COUNTRY: from_ordered_bytes(KEY:[0],
+        ASC_NULLS_LAST), ID: KEY[2]]) | MAP (_.COUNTRY AS COUNTRY)'
+    task_count: 318
+    task_total_time_ms: 24
+    transform_count: 89
+    transform_time_ms: 13
+    transform_yield_count: 76
+    insert_time_ms: 0
+    insert_new_count: 20
+    insert_reused_count: 2
+-   query: EXPLAIN SELECT age FROM customers_materialized_view ORDER BY age DESC NULLS
+        FIRST
+    explain: 'COVERING(IDX_MV_DESC_NULLS_FIRST <,> -> [AGE: from_ordered_bytes(KEY:[0],
+        DESC_NULLS_FIRST), ID: KEY[2]]) | MAP (_.AGE AS AGE)'
+    task_count: 318
+    task_total_time_ms: 6
+    transform_count: 89
+    transform_time_ms: 4
+    transform_yield_count: 76
+    insert_time_ms: 0
+    insert_new_count: 20
+    insert_reused_count: 2
+-   query: EXPLAIN SELECT age FROM customers_index_on_table ORDER BY age DESC NULLS
+        FIRST
+    explain: 'COVERING(IDX_IOT_DESC_NULLS_FIRST <,> -> [AGE: from_ordered_bytes(KEY:[0],
+        DESC_NULLS_FIRST), ID: KEY[2]]) | MAP (_.AGE AS AGE)'
+    task_count: 318
+    task_total_time_ms: 23
+    transform_count: 89
+    transform_time_ms: 13
+    transform_yield_count: 76
+    insert_time_ms: 0
+    insert_new_count: 20
+    insert_reused_count: 2
+-   query: EXPLAIN SELECT age FROM customers_materialized_view ORDER BY age DESC NULLS
+        LAST
+    explain: 'COVERING(IDX_MV_DESC_NULLS_LAST <,> -> [AGE: from_ordered_bytes(KEY:[0],
+        DESC_NULLS_LAST), ID: KEY[2]]) | MAP (_.AGE AS AGE)'
+    task_count: 484
+    task_total_time_ms: 34
+    transform_count: 117
+    transform_time_ms: 21
+    transform_yield_count: 88
+    insert_time_ms: 0
+    insert_new_count: 46
+    insert_reused_count: 6
+-   query: EXPLAIN SELECT age FROM customers_index_on_table ORDER BY age DESC NULLS
+        LAST
+    explain: 'COVERING(IDX_IOT_DESC_NULLS_LAST <,> -> [AGE: from_ordered_bytes(KEY:[0],
+        DESC_NULLS_LAST), ID: KEY[2]]) | MAP (_.AGE AS AGE)'
+    task_count: 484
+    task_total_time_ms: 34
+    transform_count: 117
+    transform_time_ms: 20
+    transform_yield_count: 88
+    insert_time_ms: 1
+    insert_new_count: 46
+    insert_reused_count: 6

--- a/yaml-tests/src/test/resources/alternate-index-syntax.yamsql
+++ b/yaml-tests/src/test/resources/alternate-index-syntax.yamsql
@@ -1,0 +1,245 @@
+#
+# alternate-index-syntax.yamsql
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2021-2025 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Test alternate CREATE INDEX ON syntax vs traditional CREATE INDEX AS SELECT
+# Both syntaxes should produce equivalent query plans
+---
+options:
+    supported_version: !current_version
+---
+schema_template: |
+    # Table with indexes defined via materialized view
+    create table customers_materialized_view(
+        id integer,
+        name string,
+        email string,
+        age integer,
+        city string,
+        country string,
+        profession string,
+        primary key(id)
+    )
+
+    create index idx_mv_name as select name from customers_materialized_view order by name
+    create index idx_mv_email as select email from customers_materialized_view order by email desc
+    create index idx_mv_multi as select age, city from customers_materialized_view order by age asc, city asc
+    create index idx_mv_asc_desc as select age, city from customers_materialized_view order by age asc, city desc
+    create index idx_mv_include as select name, email, country from customers_materialized_view order by name
+
+    # NULLS FIRST/LAST ordering
+    create index idx_mv_nulls_first as select country from customers_materialized_view order by country asc nulls first
+    create index idx_mv_nulls_last as select country from customers_materialized_view order by country asc nulls last
+    create index idx_mv_desc_nulls_first as select age from customers_materialized_view order by age desc nulls first
+    create index idx_mv_desc_nulls_last as select age from customers_materialized_view order by age desc nulls last
+
+    # Identical table with CREATE INDEX ON syntax (index on table style)
+    create table customers_index_on_table(
+        id integer,
+        name string,
+        email string,
+        age integer,
+        city string,
+        country string,
+        profession string,
+        primary key(id)
+    )
+
+    # CREATE INDEX ON syntax (index on table style)
+    create index idx_iot_name on customers_index_on_table(name)
+    create index idx_iot_email on customers_index_on_table(email desc)
+    create index idx_iot_multi on customers_index_on_table(age, city)
+    create index idx_iot_asc_desc on customers_index_on_table(age, city desc)
+    create index idx_iot_include on customers_index_on_table(name) include(email, country)
+
+    # Test NULLS FIRST/LAST ordering
+    create index idx_iot_nulls_first on customers_index_on_table(country asc nulls first)
+    create index idx_iot_nulls_last on customers_index_on_table(country asc nulls last)
+    create index idx_iot_desc_nulls_first on customers_index_on_table(age desc nulls first)
+    create index idx_iot_desc_nulls_last on customers_index_on_table(age desc nulls last)
+
+    # Test UNIQUE indexes on profession column
+    create unique index idx_mv_unique_profession as select profession from customers_materialized_view order by profession
+    create unique index idx_iot_unique_profession on customers_index_on_table(profession)
+
+---
+setup:
+  steps:
+    # Insert test data including NULL values to test NULLS ordering
+    # Each table gets different profession values to test UNIQUE constraints independently
+    - query: INSERT INTO customers_materialized_view VALUES
+             (1, 'Alice', 'alice@example.com', 25, 'New York', 'USA', 'Engineer'),
+             (2, 'Bob', 'bob@example.com', NULL, 'London', NULL, 'Designer'),
+             (3, 'Charlie', NULL, 35, 'Paris', 'France', 'Manager'),
+             (4, NULL, 'null@example.com', 30, NULL, 'Canada', 'Analyst')
+
+    - query: INSERT INTO customers_index_on_table VALUES
+             (1, 'Alice', 'alice@example.com', 25, 'New York', 'USA', 'Engineer'),
+             (2, 'Bob', 'bob@example.com', NULL, 'London', NULL, 'Designer'),
+             (3, 'Charlie', NULL, 35, 'Paris', 'France', 'Manager'),
+             (4, NULL, 'null@example.com', 30, NULL, 'Canada', 'Analyst')
+
+---
+test_block:
+  name: basic_index
+  tests:
+    # Test basic name index - plans should use respective indexes
+    -
+      - query: select name from customers_materialized_view where name = 'Alice'
+      - explain: "COVERING(IDX_MV_INCLUDE [EQUALS promote(@c8 AS STRING)] -> [COUNTRY: VALUE[1], EMAIL: VALUE[0], ID: KEY[2], NAME: KEY[0]]) | MAP (_.NAME AS NAME)"
+      - result: [{ Alice }]
+    -
+      - query: select name from customers_index_on_table where name = 'Alice'
+      - explain: "COVERING(IDX_IOT_NAME [EQUALS promote(@c8 AS STRING)] -> [ID: KEY[2], NAME: KEY[0]]) | MAP (_.NAME AS NAME)"
+      - result: [{ Alice }]
+
+    # Test descending email index
+    -
+      - query: select email from customers_materialized_view order by email desc
+      - explain: "COVERING(IDX_MV_EMAIL <,> -> [EMAIL: from_ordered_bytes(KEY:[0], DESC_NULLS_LAST), ID: KEY[2]]) | MAP (_.EMAIL AS EMAIL)"
+      - result: [{ null@example.com }, { bob@example.com }, { alice@example.com }, { !null }]
+    -
+      - query: select email from customers_index_on_table order by email desc
+      - explain: "COVERING(IDX_IOT_EMAIL <,> -> [EMAIL: from_ordered_bytes(KEY:[0], DESC_NULLS_LAST), ID: KEY[2]]) | MAP (_.EMAIL AS EMAIL)"
+      - result: [{ null@example.com }, { bob@example.com }, { alice@example.com }, { !null }]
+
+    # Test multi-column index - should use correct indexes now
+    -
+      - query: select age, city from customers_materialized_view where age > 25 order by age, city
+      - explain: "COVERING(IDX_MV_MULTI [[GREATER_THAN promote(@c10 AS INT)]] -> [AGE: KEY[0], CITY: KEY[1], ID: KEY[3]]) | MAP (_.AGE AS AGE, _.CITY AS CITY)"
+      - result: [{ 30, !null }, { 35, Paris }]
+    -
+      - query: select age, city from customers_index_on_table where age > 25 order by age, city
+      - explain: "COVERING(IDX_IOT_MULTI [[GREATER_THAN promote(@c10 AS INT)]] -> [AGE: KEY[0], CITY: KEY[1], ID: KEY[3]]) | MAP (_.AGE AS AGE, _.CITY AS CITY)"
+      - result: [{ 30, !null }, { 35, Paris }]
+
+---
+test_block:
+  name: include_clause
+  tests:
+    -
+      - query: select name, email, country from customers_materialized_view where name = 'Alice'
+      - explain: "COVERING(IDX_MV_INCLUDE [EQUALS promote(@c12 AS STRING)] -> [COUNTRY: VALUE[1], EMAIL: VALUE[0], ID: KEY[2], NAME: KEY[0]]) | MAP (_.NAME AS NAME, _.EMAIL AS EMAIL, _.COUNTRY AS COUNTRY)"
+      - result: [{ Alice, alice@example.com, USA }]
+    -
+      - query: select name, email, country from customers_index_on_table where name = 'Alice'
+      - explain: "COVERING(IDX_IOT_INCLUDE [EQUALS promote(@c12 AS STRING)] -> [COUNTRY: KEY[2], EMAIL: KEY[1], ID: KEY[4], NAME: KEY[0]]) | MAP (_.NAME AS NAME, _.EMAIL AS EMAIL, _.COUNTRY AS COUNTRY)"
+      - result: [{ Alice, alice@example.com, USA }]
+
+---
+test_block:
+  name: mixed_asc_desc
+  tests:
+    # Test mixed ASC/DESC ordering (age ASC, city DESC)
+    -
+      - query: select age, city from customers_materialized_view where age > 30 order by age asc, city desc
+      - explain: "COVERING(IDX_MV_ASC_DESC [[GREATER_THAN promote(@c10 AS INT)]] -> [AGE: KEY[0], CITY: from_ordered_bytes(KEY:[1], DESC_NULLS_LAST), ID: KEY[3]]) | MAP (_.AGE AS AGE, _.CITY AS CITY)"
+      - result: [{ 35, Paris }]
+    -
+      - query: select age, city from customers_index_on_table where age > 30 order by age asc, city desc
+      - explain: "COVERING(IDX_IOT_ASC_DESC [[GREATER_THAN promote(@c10 AS INT)]] -> [AGE: KEY[0], CITY: from_ordered_bytes(KEY:[1], DESC_NULLS_LAST), ID: KEY[3]]) | MAP (_.AGE AS AGE, _.CITY AS CITY)"
+      - result: [{ 35, Paris }]
+
+    # Test DESC DESC ordering (should use REVERSE on ASC ASC index)
+    -
+      - query: select age, city from customers_materialized_view where age < 40 order by age desc, city desc
+      - explain: "COVERING(IDX_MV_MULTI [[LESS_THAN promote(@c10 AS INT)]] REVERSE -> [AGE: KEY[0], CITY: KEY[1], ID: KEY[3]]) | MAP (_.AGE AS AGE, _.CITY AS CITY)"
+      - result: [{ 35, Paris }, { 30, !null }, { 25, New York }]
+    -
+      - query: select age, city from customers_index_on_table where age < 40 order by age desc, city desc
+      - explain: "COVERING(IDX_IOT_MULTI [[LESS_THAN promote(@c10 AS INT)]] REVERSE -> [AGE: KEY[0], CITY: KEY[1], ID: KEY[3]]) | MAP (_.AGE AS AGE, _.CITY AS CITY)"
+      - result: [{ 35, Paris }, { 30, !null }, { 25, New York }]
+
+    # Test DESC ASC ordering (should use REVERSE on ASC DESC index)
+    -
+      - query: select age, city from customers_materialized_view where age < 50 order by age desc, city asc
+      - explain: "COVERING(IDX_MV_ASC_DESC [[LESS_THAN promote(@c10 AS INT)]] REVERSE -> [AGE: KEY[0], CITY: from_ordered_bytes(KEY:[1], DESC_NULLS_LAST), ID: KEY[3]]) | MAP (_.AGE AS AGE, _.CITY AS CITY)"
+      - result: [{ 35, Paris }, { 30, !null }, { 25, New York }]
+    -
+      - query: select age, city from customers_index_on_table where age < 50 order by age desc, city asc
+      - explain: "COVERING(IDX_IOT_ASC_DESC [[LESS_THAN promote(@c10 AS INT)]] REVERSE -> [AGE: KEY[0], CITY: from_ordered_bytes(KEY:[1], DESC_NULLS_LAST), ID: KEY[3]]) | MAP (_.AGE AS AGE, _.CITY AS CITY)"
+      - result: [{ 35, Paris }, { 30, !null }, { 25, New York }]
+
+---
+test_block:
+  name: nulls_first_last
+  tests:
+    # Test NULLS FIRST/LAST ordering with actual results and index usage
+    -
+      - query: SELECT country FROM customers_materialized_view ORDER BY country ASC NULLS FIRST
+      - explain: "COVERING(IDX_MV_NULLS_FIRST <,> -> [COUNTRY: KEY[0], ID: KEY[2]]) | MAP (_.COUNTRY AS COUNTRY)"
+      - result: [{ !null }, { Canada }, { France }, { USA }]
+
+    -
+      - query: SELECT country FROM customers_index_on_table ORDER BY country ASC NULLS FIRST
+      - explain: "COVERING(IDX_IOT_NULLS_FIRST <,> -> [COUNTRY: KEY[0], ID: KEY[2]]) | MAP (_.COUNTRY AS COUNTRY)"
+      - result: [{ !null }, { Canada }, { France }, { USA }]
+
+    -
+      - query: SELECT country FROM customers_materialized_view ORDER BY country ASC NULLS LAST
+      - explain: "COVERING(IDX_MV_NULLS_LAST <,> -> [COUNTRY: from_ordered_bytes(KEY:[0], ASC_NULLS_LAST), ID: KEY[2]]) | MAP (_.COUNTRY AS COUNTRY)"
+      - result: [{ Canada }, { France }, { USA }, { !null }]
+
+    -
+      - query: SELECT country FROM customers_index_on_table ORDER BY country ASC NULLS LAST
+      - explain: "COVERING(IDX_IOT_NULLS_LAST <,> -> [COUNTRY: from_ordered_bytes(KEY:[0], ASC_NULLS_LAST), ID: KEY[2]]) | MAP (_.COUNTRY AS COUNTRY)"
+      - result: [{ Canada }, { France }, { USA }, { !null }]
+
+    -
+      - query: SELECT age FROM customers_materialized_view ORDER BY age DESC NULLS FIRST
+      - explain: "COVERING(IDX_MV_DESC_NULLS_FIRST <,> -> [AGE: from_ordered_bytes(KEY:[0], DESC_NULLS_FIRST), ID: KEY[2]]) | MAP (_.AGE AS AGE)"
+      - result: [{ !null }, { 35 }, { 30 }, { 25 }]
+
+    -
+      - query: SELECT age FROM customers_index_on_table ORDER BY age DESC NULLS FIRST
+      - explain: "COVERING(IDX_IOT_DESC_NULLS_FIRST <,> -> [AGE: from_ordered_bytes(KEY:[0], DESC_NULLS_FIRST), ID: KEY[2]]) | MAP (_.AGE AS AGE)"
+      - result: [{ !null }, { 35 }, { 30 }, { 25 }]
+
+    -
+      - query: SELECT age FROM customers_materialized_view ORDER BY age DESC NULLS LAST
+      - explain: "COVERING(IDX_MV_DESC_NULLS_LAST <,> -> [AGE: from_ordered_bytes(KEY:[0], DESC_NULLS_LAST), ID: KEY[2]]) | MAP (_.AGE AS AGE)"
+      - result: [{ 35 }, { 30 }, { 25 }, { !null }]
+
+    -
+      - query: SELECT age FROM customers_index_on_table ORDER BY age DESC NULLS LAST
+      - explain: "COVERING(IDX_IOT_DESC_NULLS_LAST <,> -> [AGE: from_ordered_bytes(KEY:[0], DESC_NULLS_LAST), ID: KEY[2]]) | MAP (_.AGE AS AGE)"
+      - result: [{ 35 }, { 30 }, { 25 }, { !null }]
+
+---
+test_block:
+  name: unique_constraint
+  preset: single_repetition_ordered
+  tests:
+    # Test UNIQUE constraint violations on profession column - should fail when attempting to insert duplicate professions
+    -
+      - query: INSERT INTO customers_materialized_view VALUES (5, 'David', 'david@example.com', 28, 'Boston', 'USA', 'Engineer')
+      - error: "23505"
+
+    -
+      - query: INSERT INTO customers_index_on_table VALUES (5, 'Eve', 'eve@example.com', 32, 'Seattle', 'USA', 'Engineer')
+      - error: "23505"
+
+    # Test that different professions still work
+    -
+      - query: INSERT INTO customers_materialized_view VALUES (5, 'David', 'david@example.com', 28, 'Boston', 'USA', 'Scientist')
+      - count: 1
+
+    -
+      - query: INSERT INTO customers_index_on_table VALUES (5, 'Eve', 'eve@example.com', 32, 'Seattle', 'USA', 'Architect')
+      - count: 1
+...


### PR DESCRIPTION
This PR adds support for defining Index using the classic Index definitions.

To add support for Filtered Indexes and other indexes, like Aggregate Indexes, and Bitmap Indexes, the classic Index definition also support defining indexes over views.