### PR TITLE
Remove deprecated KeySpacePath methods related to caching the resolved value, and associated list methods on KeySpace

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/DirectoryLayerDirectory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/DirectoryLayerDirectory.java
@@ -258,8 +258,7 @@ public class DirectoryLayerDirectory extends KeySpaceDirectory {
 
                         // Make sure that the path is constructed with the text-name from the directory layer.
                         ResolvedKeySpacePath myPath = new ResolvedKeySpacePath(parent,
-                                KeySpacePathImpl.newPath(parentPath, this, directoryString,
-                                        true, pathValue, remainder),
+                                KeySpacePathImpl.newPath(parentPath, this, directoryString),
                                 pathValue, remainder);
 
                         // We are finished if there are no more subdirectories or no more tuple to consume

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpace.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpace.java
@@ -180,55 +180,14 @@ public class KeySpace {
     @Nonnull
     public KeySpacePath path(@Nonnull String name, @Nullable Object value) {
         KeySpaceDirectory dir = root.getSubdirectory(name);
-        return KeySpacePathImpl.newPath(null, dir, value, false, null, null);
-    }
-
-    /**
-     * Given a tuple from an FDB key, attempts to determine what path through this directory the tuple
-     * represents, returning a <code>KeySpacePath</code> representing the leaf-most directory in the path.
-     * If entries remained in the tuple beyond the leaf directory, then
-     *   {@link KeySpacePath#getRemainder()} can be used to fetch the remaining portion.
-     *
-     * @param context context used, if needed, for any database operations
-     * @param key the tuple to be decoded
-     * @return a path entry representing the leaf directory entry that corresponds to a value in the
-     * provided tuple
-     * @throws RecordCoreArgumentException if the tuple provided does not correspond to any path through
-     *   the directory structure at this point
-     *
-     * @deprecated use {@link #resolveFromKeyAsync(FDBRecordContext, Tuple)} instead
-     */
-    @Deprecated
-    @API(API.Status.DEPRECATED)
-    @Nonnull
-    public CompletableFuture<KeySpacePath> pathFromKeyAsync(@Nonnull FDBRecordContext context, @Nonnull Tuple key) {
-        return root.findChildForKey(context, null, key, key.size(), 0).thenApply(ResolvedKeySpacePath::toPath);
-    }
-
-    /**
-     * Synchronous/blocking version of <code>pathFromKeyAsync</code>.
-     *
-     * @param context context used, if needed, for any database operations
-     * @param key the tuple to be decoded
-     * @return a path entry representing the leaf directory entry that corresponds to a value in the
-     * provided tuple
-     * @throws RecordCoreArgumentException if the tuple provided does not correspond to any path through
-     *   the directory structure at this point
-     *
-     * @deprecated use {@link #resolveFromKey(FDBRecordContext, Tuple)} instead
-     */
-    @Deprecated
-    @API(API.Status.DEPRECATED)
-    @Nonnull
-    public KeySpacePath pathFromKey(@Nonnull FDBRecordContext context, @Nonnull Tuple key) {
-        return context.asyncToSync(FDBStoreTimer.Waits.WAIT_KEYSPACE_PATH_RESOLVE, pathFromKeyAsync(context, key));
+        return KeySpacePathImpl.newPath(null, dir, value);
     }
 
     /**
      * Given a tuple from an FDB key, attempts to determine what path through this directory the tuple
      * represents, returning a <code>ResolvedKeySpacePath</code> representing the leaf-most directory in the path.
      * <p>
-     *     If entries remained in the tuple beyond the leaf directory, then {@link KeySpacePath#getRemainder()} can be
+     *     If entries remained in the tuple beyond the leaf directory, then {@link ResolvedKeySpacePath#getRemainder()} can be
      *     used to fetch the remaining portion.
      *     See also {@link KeySpacePath#toResolvedPathAsync(FDBRecordContext, byte[])} if you need to resolve and you
      *     know that it is part of a given path.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpaceDirectory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpaceDirectory.java
@@ -103,7 +103,7 @@ public class KeySpaceDirectory {
      * type may be stored in the directory, otherwise specifies a constant value that represents the
      * directory
      * @param wrapper if non-null, specifies a function that may be used to wrap any <code>KeySpacePath</code>
-     * objects return from {@link KeySpace#pathFromKey(FDBRecordContext, Tuple)}
+     * objects return from {@link KeySpace#resolveFromKeyAsync(FDBRecordContext, Tuple)}.
      *
      * @throws RecordCoreArgumentException if the provided value constant value is not valid for the
      * type of directory being created
@@ -130,7 +130,7 @@ public class KeySpaceDirectory {
      * @param name the name of the directory
      * @param keyType the data type of the values that may be contained within the directory
      * @param wrapper if non-null, specifies a function that may be used to wrap any <code>KeySpacePath</code>
-     * objects returned from {@link KeySpace#pathFromKey(FDBRecordContext, Tuple)}
+     * objects returned from {@link KeySpace#resolveFromKeyAsync(FDBRecordContext, Tuple)}
      */
     public KeySpaceDirectory(@Nonnull String name, @Nonnull KeyType keyType, @Nullable Function<KeySpacePath, KeySpacePath> wrapper) {
         this(name, keyType, keyType.getAnyValue(), wrapper);
@@ -213,14 +213,12 @@ public class KeySpaceDirectory {
             // Have we hit the leaf of the tree or run out of tuple to process?
             if (subdirs.isEmpty() || keyIndex + 1 == keySize) {
                 final Tuple remainder = (keyIndex + 1 == key.size()) ? null : TupleHelpers.subTuple(key, keyIndex + 1, key.size());
-                final KeySpacePath path = KeySpacePathImpl.newPath(parentPath, this, tupleValue,
-                        true, resolvedValue, remainder);
+                final KeySpacePath path = KeySpacePathImpl.newPath(parentPath, this, tupleValue);
 
                 return CompletableFuture.completedFuture(
                         Optional.of(new ResolvedKeySpacePath(parent, path, new PathValue(tupleValue), remainder)));
             } else {
-                final KeySpacePath path = KeySpacePathImpl.newPath(parentPath, this, tupleValue,
-                        true, resolvedValue, null);
+                final KeySpacePath path = KeySpacePathImpl.newPath(parentPath, this, tupleValue);
                 return findChildForKey(context,
                         new ResolvedKeySpacePath(parent, path, pathValue, null),
                         key, keySize, keyIndex + 1).thenApply(Optional::of);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpacePathImpl.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpacePathImpl.java
@@ -54,13 +54,6 @@ class KeySpacePathImpl implements KeySpacePath {
     @Nullable
     private final Object value;
 
-    // The following variables are only available with a path has been reconstructed from a tuple
-    private final boolean wasFromTuple;
-    @Nullable
-    private final PathValue resolvedPathValue;
-    @Nullable
-    protected final Tuple remainder;
-
     /**
      * Create a path element.
      *
@@ -68,47 +61,26 @@ class KeySpacePathImpl implements KeySpacePath {
      * @param directory the directory in which this path element resides
      * @param value the value to be used for this directory. This may not be the actual value that will be used
      *    in the tuple produced from the path
-     * @param wasFromTuple this will be true if this path was produced using {@link KeySpace#pathFromKey(FDBRecordContext, Tuple)}
-     * @param resolvedPathValue if <code>wasFromTuple</code> is true, this is the future that will be resolved when the
-     *    path is resolved
-     * @param remainder if <code>wasFromTuple</code> is true, this is any remainder of the euple that fell off the
-     *    end of the path
      */
     private KeySpacePathImpl(@Nullable KeySpacePath parent,
                              @Nonnull KeySpaceDirectory directory,
-                             @Nullable Object value,
-                             boolean wasFromTuple,
-                             @Nullable PathValue resolvedPathValue,
-                             @Nullable Tuple remainder) {
-        // Run-time assertion.
-        if (!wasFromTuple && (resolvedPathValue != null || remainder != null)) {
-            throw new IllegalArgumentException("Paths that weren't resolved from a tuple cannot provide storage information!");
-        }
-
+                             @Nullable Object value) {
         this.directory = directory;
         this.value = value;
         this.parent = parent;
-        this.wasFromTuple = wasFromTuple;
-        this.resolvedPathValue = resolvedPathValue;
-        this.remainder = remainder;
     }
 
     @Nonnull
     static KeySpacePath newPath(@Nullable KeySpacePath parent,
                                 @Nonnull KeySpaceDirectory directory,
-                                @Nullable Object value,
-                                boolean wasFromTuple,
-                                @Nullable PathValue resolvedPathValue,
-                                @Nullable Tuple remainder) {
-        return directory.wrap(new KeySpacePathImpl(parent, directory, value, wasFromTuple,
-                resolvedPathValue, remainder));
+                                @Nullable Object value) {
+        return directory.wrap(new KeySpacePathImpl(parent, directory, value));
     }
 
     @Nonnull
     static KeySpacePath newPath(@Nullable KeySpacePath parent,
                                 @Nonnull KeySpaceDirectory directory) {
-        return directory.wrap(new KeySpacePathImpl(parent, directory, directory.getValue(),
-                false, null, null));
+        return directory.wrap(new KeySpacePathImpl(parent, directory, directory.getValue()));
     }
 
     @Nonnull
@@ -128,33 +100,13 @@ class KeySpacePathImpl implements KeySpacePath {
     @Override
     public KeySpacePath add(@Nonnull String dirName, @Nullable Object value) {
         KeySpaceDirectory subdir = directory.getSubdirectory(dirName);
-        return subdir.wrap(new KeySpacePathImpl(self(), subdir, value,
-                false, null, null));
-    }
-
-    @Deprecated
-    @Nonnull
-    @Override
-    public RecordCursor<KeySpacePath> listAsync(@Nonnull FDBRecordContext context, 
-                                                @Nonnull String subdirName, 
-                                                @Nullable ValueRange<?> range,
-                                                @Nullable byte[] continuation,
-                                                @Nonnull ScanProperties scanProperties) {
-        return directory.listSubdirectoryAsync(self(), context, subdirName, range, continuation, scanProperties)
-                .map(ResolvedKeySpacePath::toPath);
+        return subdir.wrap(new KeySpacePathImpl(self(), subdir, value));
     }
 
     @Nonnull
     @Override
     public RecordCursor<ResolvedKeySpacePath> listSubdirectoryAsync(@Nonnull FDBRecordContext context, @Nonnull String subdirName, @Nullable ValueRange<?> range, @Nullable byte[] continuation, @Nonnull ScanProperties scanProperties) {
         return directory.listSubdirectoryAsync(self(), context, subdirName, range, continuation, scanProperties);
-    }
-
-    @Deprecated
-    @Nullable
-    @Override
-    public Tuple getRemainder() {
-        return remainder;
     }
 
     @Nullable
@@ -181,30 +133,10 @@ class KeySpacePathImpl implements KeySpacePath {
         return value;
     }
 
-    @Deprecated
-    @Nonnull
-    @Override
-    public PathValue getStoredValue() {
-        if (!wasFromTuple) {
-            throw new IllegalStateException("Path must be produced using pathFromKey() or list()");
-        }
-        return resolvedPathValue;
-    }
-
-    @Deprecated
-    @Override
-    public boolean hasStoredValue() {
-        return wasFromTuple;
-    }
-
     @Nonnull
     @Override
     public CompletableFuture<PathValue> resolveAsync(@Nonnull FDBRecordContext context) {
-        if (wasFromTuple) {
-            return CompletableFuture.completedFuture(resolvedPathValue);
-        } else {
-            return getDirectory().toTupleValueAsync(context, getValue());
-        }
+        return getDirectory().toTupleValueAsync(context, getValue());
     }
 
     @Nonnull
@@ -334,7 +266,6 @@ class KeySpacePathImpl implements KeySpacePath {
                 parent);
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public String toString(@Nullable Tuple t) {
         Iterator<Object> it = null;
@@ -349,18 +280,12 @@ class KeySpacePathImpl implements KeySpacePath {
             Object storedValue = null;
             if (it != null && it.hasNext()) {
                 storedValue = it.next();
-            } else if (entry.hasStoredValue()) {
-                storedValue = entry.getStoredValue().getResolvedValue();
             }
             if (storedValue != null && !Objects.equals(dirValue, storedValue)) {
                 ResolvedKeySpacePath.appendValue(sb, storedValue);
                 sb.append("->");
             }
             ResolvedKeySpacePath.appendValue(sb, dirValue);
-        }
-
-        if (getRemainder() != null) {
-            sb.append('+').append(getRemainder());
         }
 
         return sb.toString();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpacePathWrapper.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpacePathWrapper.java
@@ -106,13 +106,6 @@ public class KeySpacePathWrapper implements KeySpacePath {
         return inner.add(dirName, value);
     }
 
-    @Deprecated
-    @Override
-    @Nullable
-    public Tuple getRemainder() {
-        return inner.getRemainder();
-    }
-
     @Override
     @Nullable
     public KeySpacePath getParent() {
@@ -134,19 +127,6 @@ public class KeySpacePathWrapper implements KeySpacePath {
     @Override
     public Object getValue() {
         return inner.getValue();
-    }
-
-    @Deprecated
-    @Override
-    @Nonnull
-    public PathValue getStoredValue() {
-        return inner.getStoredValue();
-    }
-
-    @Deprecated
-    @Override
-    public boolean hasStoredValue() {
-        return inner.hasStoredValue();
     }
 
     @Override
@@ -177,17 +157,6 @@ public class KeySpacePathWrapper implements KeySpacePath {
     @Nonnull
     public CompletableFuture<Void> deleteAllDataAsync(@Nonnull FDBRecordContext context) {
         return inner.deleteAllDataAsync(context);
-    }
-
-    @Deprecated
-    @Override
-    @Nonnull
-    public RecordCursor<KeySpacePath> listAsync(@Nonnull FDBRecordContext context,
-                                                @Nonnull String subdirName,
-                                                @Nullable ValueRange<?> range,
-                                                @Nullable byte[] continuation,
-                                                @Nonnull ScanProperties scanProperties) {
-        return inner.listAsync(context, subdirName, range, continuation, scanProperties);
     }
 
     @Nonnull


### PR DESCRIPTION
Shortly before ResolvedKeySpacePath was introduced, `KeySpacePathImpl` would store the resolved tuple and remainder in itself.
The methods around this have been deprecated for years.
More pressingly, what having this value means is that if you have a KeySpacePath that is generated from `KeySpaceDirectory`s and call toTuple or toSubspace it will resolve in the context that you provide, but if that `KeySpacePath` came from resolving a key then toTuple / toSubspace will contain the original directory-layer mappings, which could be problematic if the provided context is not on the same cluster.

Resolves: #432