### PR TITLE
Reduce test load to reduce flakiness

### DIFF
--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
@@ -1108,11 +1108,6 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
             explicitMergeIndex(dataModel.index, contextProps, dataModel.schemaSetup);
         }
 
-        final Map<Tuple, Map<Tuple, Tuple>> initial = dataModel.groupingKeyToPrimaryKeyToPartitionKey.entrySet().stream().collect(Collectors.toMap(
-                Map.Entry::getKey,
-                entry -> Map.copyOf(entry.getValue())
-        ));
-
         dataModel.validate(() -> openContext(contextProps));
 
         try (FDBRecordContext context = openContext(contextProps)) {
@@ -1125,10 +1120,6 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
             commit(context);
         }
 
-        System.out.println("=== initial ===");
-        System.out.println(initial);
-        System.out.println("=== updated ===");
-        System.out.println(dataModel.groupingKeyToPrimaryKeyToPartitionKey);
         assertDataModelCount.accept(recordsPerIteration * loopCount,
                 dataModel.groupingKeyToPrimaryKeyToPartitionKey.values().stream().mapToInt(Map::size).sum());
 


### PR DESCRIPTION
Reduce test load: Save fewer records, use fewer threads and adjust tests to account for the different counts.
Resolves #3711



