### PR TITLE
Upload the jreleaser trace logs & config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,6 +193,13 @@ jobs:
           JRELEASER_MAVENCENTRAL_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           JRELEASER_MAVENCENTRAL_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload jreleaser trace logs
+        if: always()
+        uses: actions/upload-artifact@v4.6.0
+        with:
+          name: jrelease-trace
+          path: .out/jreleaser/*
+          retention-days: 1
   
       # Post release: Update various files which reference version
       # Updating the yaml files has to be done after the tests complete, or it will mark tests as failing that aren't


### PR DESCRIPTION
We got an OutOfMemory with 4g of heap, and 211m of artifacts. This will upload the logs and config to the artifacts for investigation, in the hops it gives us something useful. I checked locally and neither appear to have any of the passwords.