### PR TITLE
Disallow insertion of vectors of different precision and dimensions.

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/PromoteValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/PromoteValue.java
@@ -460,6 +460,12 @@ public class PromoteValue extends AbstractValue implements CreatesDynamicTypesVa
             }
             return promotionNeeded;
         }
+        if (inType.isVector() && promoteToType.isVector()) {
+            final var inVectorType = (Type.Vector)inType;
+            final var promoteToVectorType = (Type.Vector)promoteToType;
+            SemanticException.check(inVectorType.nullable().equals(promoteToVectorType.nullable()), SemanticException.ErrorCode.INCOMPATIBLE_TYPE);
+            return false;
+        }
         SemanticException.check((inType.isPrimitive() || inType.isEnum() || inType.isUuid()) &&
                 (promoteToType.isPrimitive() || promoteToType.isEnum() || promoteToType.isUuid()), SemanticException.ErrorCode.INCOMPATIBLE_TYPE);
         return inType.getTypeCode() != promoteToType.getTypeCode();

--- a/yaml-tests/src/test/resources/vector.yamsql
+++ b/yaml-tests/src/test/resources/vector.yamsql
@@ -363,6 +363,67 @@ test_block:
     -
       - query: select cast([1.0, 2.0] as VECTOR(3, DOUBLE)) from tDoubleVector where a = 100
       - error: "22F3H"
+    # Tests for attempting to insert vectors of different precision / size
+    # Wrong number of dimensions - HALF vector with 2 dimensions into table expecting 3
+    -
+      - query: insert into tHalfVector values (400, !! !v16 [1.1, 2.2] !!)
+      - error: "22000"
+    # Wrong number of dimensions - HALF vector with 4 dimensions into table expecting 3
+    -
+      - query: insert into tHalfVector values (401, !! !v16 [1.1, 2.2, 3.3, 4.4] !!)
+      - error: "22000"
+    # Wrong number of dimensions - FLOAT vector with 2 dimensions into table expecting 3
+    -
+      - query: insert into tFloatVector values (402, !! !v32 [1.1, 2.2] !!)
+      - error: "22000"
+    # Wrong number of dimensions - FLOAT vector with 4 dimensions into table expecting 3
+    -
+      - query: insert into tFloatVector values (403, !! !v32 [1.1, 2.2, 3.3, 4.4] !!)
+      - error: "22000"
+    # Wrong number of dimensions - DOUBLE vector with 2 dimensions into table expecting 3
+    -
+      - query: insert into tDoubleVector values (404, !! !v64 [1.1, 2.2] !!)
+      - error: "22000"
+    # Wrong number of dimensions - DOUBLE vector with 4 dimensions into table expecting 3
+    -
+      - query: insert into tDoubleVector values (405, !! !v64 [1.1, 2.2, 3.3, 4.4] !!)
+      - error: "22000"
+    # Wrong precision - FLOAT vector into HALF table
+    -
+      - query: insert into tHalfVector values (406, !! !v32 [1.1, 2.2, 3.3] !!)
+      - error: "22000"
+    # Wrong precision - DOUBLE vector into HALF table
+    -
+      - query: insert into tHalfVector values (407, !! !v64 [1.1, 2.2, 3.3] !!)
+      - error: "22000"
+    # Wrong precision - HALF vector into FLOAT table
+    -
+      - query: insert into tFloatVector values (408, !! !v16 [1.1, 2.2, 3.3] !!)
+      - error: "22000"
+    # Wrong precision - DOUBLE vector into FLOAT table
+    -
+      - query: insert into tFloatVector values (409, !! !v64 [1.1, 2.2, 3.3] !!)
+      - error: "22000"
+    # Wrong precision - HALF vector into DOUBLE table
+    -
+      - query: insert into tDoubleVector values (410, !! !v16 [1.1, 2.2, 3.3] !!)
+      - error: "22000"
+    # Wrong precision - FLOAT vector into DOUBLE table
+    -
+      - query: insert into tDoubleVector values (411, !! !v32 [1.1, 2.2, 3.3] !!)
+      - error: "22000"
+    # Wrong number of dimensions - HALF vector with 1 dimension into table expecting 3
+    -
+      - query: insert into tHalfVector values (412, !! !v16 [1.1] !!)
+      - error: "22000"
+    # Wrong number of dimensions - FLOAT vector with 5 dimensions into table expecting 3
+    -
+      - query: insert into tFloatVector values (413, !! !v32 [1.1, 2.2, 3.3, 4.4, 5.5] !!)
+      - error: "22000"
+    # Wrong number of dimensions - DOUBLE vector with 0 dimensions into table expecting 3
+    -
+      - query: insert into tDoubleVector values (414, !! !v64 [] !!)
+      - error: "22000"
     # Tests for tWithStruct (struct with HALF vector field)
     # Insert struct with vector
     -


### PR DESCRIPTION
It is possible to `INSERT` a vector with a different precision and dimensions than the ones defined in the schema. This is fixed by doing exact check of precision and dimensions in `PromoteValue.isPromotionNeeded` which does, besides checking promotion feasibility, type (in)compatibilities, which we may want to move to somewhere else later on.

This fixes #3729.