### PR TITLE
Create test showcasing bug with enums and index scans

### DIFF
--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlTestExtension.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlTestExtension.java
@@ -134,7 +134,7 @@ public class YamlTestExtension implements TestTemplateInvocationContextProvider,
         if (mixedModeOnly || singleExternalVersionOnly) {
             return Stream.of();
         } else {
-            return Stream.of(new EmbeddedConfig(clusterFile), new ForceContinuations(new EmbeddedConfig(clusterFile)), new JDBCInProcessConfig(clusterFile));
+            return Stream.of(new EmbeddedConfig(clusterFile), new JDBCInProcessConfig(clusterFile));
         }
     }
 

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryExecutor.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryExecutor.java
@@ -148,15 +148,13 @@ public class QueryExecutor {
                 preMetricCollector.getCountsForCounter(RelationalMetric.RelationalCount.PLAN_CACHE_TERTIARY_HIT) : 0;
         final var toReturn = executeStatementAndCheckForceContinuations(s, statementHasQuery, queryString, connection, maxRows);
         final var postMetricCollector = connection.getMetricCollector();
-        if (postMetricCollector != null) {
-            final var postValue = postMetricCollector.hasCounter(RelationalMetric.RelationalCount.PLAN_CACHE_TERTIARY_HIT) ?
-                                  postMetricCollector.getCountsForCounter(RelationalMetric.RelationalCount.PLAN_CACHE_TERTIARY_HIT) : 0;
-            final var planFound = preMetricCollector != postMetricCollector ? postValue == 1 : postValue == preValue + 1;
-            if (!planFound) {
-                reportTestFailure("‼️ Expected to retrieve the plan from the cache at line " + lineNumber);
-            } else {
-                logger.debug("🎁 Retrieved the plan from the cache!");
-            }
+        final var postValue = postMetricCollector.hasCounter(RelationalMetric.RelationalCount.PLAN_CACHE_TERTIARY_HIT) ?
+                              postMetricCollector.getCountsForCounter(RelationalMetric.RelationalCount.PLAN_CACHE_TERTIARY_HIT) : 0;
+        final var planFound = preMetricCollector != postMetricCollector ? postValue == 1 : postValue == preValue + 1;
+        if (!planFound) {
+            reportTestFailure("‼️ Expected to retrieve the plan from the cache at line " + lineNumber);
+        } else {
+            logger.debug("🎁 Retrieved the plan from the cache!");
         }
         return toReturn;
     }

--- a/yaml-tests/src/test/resources/enum.yamsql
+++ b/yaml-tests/src/test/resources/enum.yamsql
@@ -156,14 +156,14 @@ test_block:
       - query: SELECT * From TABLE_B where "mood" = 'CONFUSED'
       - explain: "ISCAN(B$MOOD [EQUALS promote(@c8 AS ENUM<JOYFUL(0), HAPPY(1), RELAXED(2), INDIFFERENT(3), CONFUSED(4), SAD(5), ANXIOUS(6), ANGRY(7)>)])"
       # Disable force_continuations on this plan until we resolve: https://github.com/FoundationDB/fdb-record-layer/issues/3734
-      # - maxRows: 0
+      - maxRows: 0
       - unorderedResult: [{2, 'bar', 'CONFUSED'},
                           {11, 'plugh', 'CONFUSED'}]
     -
       - query: SELECT * From TABLE_B where "mood" > 'INDIFFERENT'
       - explain: "ISCAN(B$MOOD [[GREATER_THAN promote(@c8 AS ENUM<JOYFUL(0), HAPPY(1), RELAXED(2), INDIFFERENT(3), CONFUSED(4), SAD(5), ANXIOUS(6), ANGRY(7)>)]])"
       # Disable force_continuations on this plan until we resolve: https://github.com/FoundationDB/fdb-record-layer/issues/3734
-      # - maxRows: 0
+      - maxRows: 0
       - unorderedResult: [{2, 'bar', 'CONFUSED'},
                           {4, 'qux', 'ANGRY'},
                           {7, 'grault', 'ANXIOUS'},


### PR DESCRIPTION
This adds a test case to showcase the problem with https://github.com/FoundationDB/fdb-record-layer/issues/3734. It modifies `enum.yamsql` with a new test case analogous to the one in the issue. There are two new queries that are planned with an index scan over an index on an enum valued field, and both of them fail with the same `NullPointerException` that is alluded to in the bug report.