### PR TITLE
Add logging for failure to open record store

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMerger.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMerger.java
@@ -92,7 +92,14 @@ public class IndexingMerger {
                                     mergeControl.setLastStep(IndexDeferredMaintenanceControl.LastStep.NONE);
                                     mergeControl.setRepartitionCapped(false);
                                     return store.getIndexMaintainer(index).mergeIndex();
-                                }).thenApply(ignore -> false),
+                                })
+                                .thenApply(ignore -> false)
+                                .whenComplete((value, ex) -> {
+                                    if (ex != null) {
+                                        // failed to open the store
+                                        LOGGER.warn("Failed to open record store", ex);
+                                    }
+                                }),
                         Result::of,
                         common.indexLogMessageKeyValues()
                 ).handle((ignore, e) -> {


### PR DESCRIPTION
When the system is under load there may be cases where the RecordStore will fail to open. In these cases it may be hard to figure out when is going wrong. In order to help troubleshoot the issue, this PR adds a log message to that effect.

Resolves #3758
