### PR TITLE
Deprecate SQL type codes in JDBC

### DIFF
--- a/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/RelationalArrayFacade.java
+++ b/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/RelationalArrayFacade.java
@@ -181,7 +181,7 @@ class RelationalArrayFacade implements RelationalArray {
 
         final var columnMetadata = delegateMetadata.toBuilder().setName("VALUE").build();
         resultSetBuilder.setMetadata(ResultSetMetadata.newBuilder().setColumnMetadata(ListColumnMetadata.newBuilder()
-                .addColumnMetadata(ColumnMetadata.newBuilder().setName("INDEX").setType(Type.INTEGER).setJavaSqlTypesCode(Types.INTEGER).build())
+                .addColumnMetadata(ColumnMetadata.newBuilder().setName("INDEX").setType(Type.INTEGER).build())
                 .addColumnMetadata(columnMetadata).build()).build());
         for (int i = index; i < count; i++) {
             final var listColumnBuilder = ListColumn.newBuilder();
@@ -257,7 +257,7 @@ class RelationalArrayFacade implements RelationalArray {
 
         private void initOrCheckMetadata(ListColumnMetadata innerMetadata) {
             if (metadata == null) {
-                final var builder = ColumnMetadata.newBuilder().setName("ARRAY").setJavaSqlTypesCode(Types.STRUCT).setType(Type.STRUCT);
+                final var builder = ColumnMetadata.newBuilder().setName("ARRAY").setType(Type.STRUCT);
                 builder.setStructMetadata(innerMetadata);
                 metadata = builder.build();
             } else {

--- a/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/RelationalStructFacade.java
+++ b/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/RelationalStructFacade.java
@@ -455,7 +455,7 @@ class RelationalStructFacade implements RelationalStruct {
         public RelationalStructBuilder addBoolean(String fieldName, boolean b) {
             // Add the metadata and get offset at where to insert data.
             int offset = addMetadata(ColumnMetadata.newBuilder()
-                    .setName(fieldName).setJavaSqlTypesCode(Types.BOOLEAN).setType(Type.BOOLEAN).build());
+                    .setName(fieldName).setType(Type.BOOLEAN).build());
             // Add field data.
             this.listColumnBuilder.addColumn(offset, Column.newBuilder().setBoolean(b).build());
             return this;
@@ -464,7 +464,7 @@ class RelationalStructFacade implements RelationalStruct {
         @Override
         public RelationalStructBuilder addLong(String fieldName, long l) {
             int offset = addMetadata(ColumnMetadata.newBuilder()
-                    .setName(fieldName).setJavaSqlTypesCode(Types.BIGINT).setType(Type.LONG).build());
+                    .setName(fieldName).setType(Type.LONG).build());
             this.listColumnBuilder.addColumn(offset, Column.newBuilder().setLong(l).build());
             return this;
         }
@@ -477,7 +477,7 @@ class RelationalStructFacade implements RelationalStruct {
         @Override
         public RelationalStructBuilder addDouble(String fieldName, double d) {
             int offset = addMetadata(ColumnMetadata.newBuilder()
-                    .setName(fieldName).setJavaSqlTypesCode(Types.DOUBLE).setType(Type.DOUBLE).build());
+                    .setName(fieldName).setType(Type.DOUBLE).build());
             this.listColumnBuilder.addColumn(offset, Column.newBuilder().setDouble(d).build());
             return this;
         }
@@ -485,7 +485,7 @@ class RelationalStructFacade implements RelationalStruct {
         @Override
         public RelationalStructBuilder addBytes(String fieldName, byte[] bytes) {
             int offset = addMetadata(ColumnMetadata.newBuilder()
-                    .setName(fieldName).setJavaSqlTypesCode(Types.BINARY).setType(Type.BYTES).build());
+                    .setName(fieldName).setType(Type.BYTES).build());
             this.listColumnBuilder.addColumn(offset, Column.newBuilder().setBinary(ByteString.copyFrom(bytes)).build());
             return this;
         }
@@ -494,7 +494,7 @@ class RelationalStructFacade implements RelationalStruct {
         @SpotBugsSuppressWarnings("NP")
         public RelationalStructBuilder addString(String fieldName, @Nullable String s) {
             int offset = addMetadata(ColumnMetadata.newBuilder()
-                    .setName(fieldName).setJavaSqlTypesCode(Types.VARCHAR).setType(Type.STRING).build());
+                    .setName(fieldName).setType(Type.STRING).build());
             // TODO: setString requires a non-null string, but this method takes a nullable string
             this.listColumnBuilder.addColumn(offset, Column.newBuilder().setString(s).build());
             return this;
@@ -503,7 +503,7 @@ class RelationalStructFacade implements RelationalStruct {
         @Override
         public RelationalStructBuilder addUuid(final String fieldName, @Nullable final UUID uuid) {
             int offset = addMetadata(ColumnMetadata.newBuilder()
-                    .setName(fieldName).setJavaSqlTypesCode(Types.OTHER).setType(Type.UUID).build());
+                    .setName(fieldName).setType(Type.UUID).build());
             if (uuid == null) {
                 this.listColumnBuilder.addColumn(offset, Column.newBuilder().build());
             } else {
@@ -525,7 +525,7 @@ class RelationalStructFacade implements RelationalStruct {
             // Insert the data portion of RelationalStruct here.
             RelationalStructFacade relationalStructFacade = struct.unwrap(RelationalStructFacade.class);
             int offset = addMetadata(ColumnMetadata.newBuilder().setName(fieldName)
-                    .setJavaSqlTypesCode(Types.STRUCT).setType(Type.STRUCT).setStructMetadata(relationalStructFacade.getDelegateMetadata()).build());
+                    .setType(Type.STRUCT).setStructMetadata(relationalStructFacade.getDelegateMetadata()).build());
             this.listColumnBuilder
                     .addColumn(offset, Column.newBuilder().setStruct(relationalStructFacade.delegate).build());
             return this;
@@ -538,7 +538,7 @@ class RelationalStructFacade implements RelationalStruct {
             // Insert the data portion of RelationalStruct here.
             RelationalArrayFacade relationalArrayFacade = array.unwrap(RelationalArrayFacade.class);
             int offset = addMetadata(ColumnMetadata.newBuilder()
-                    .setName(fieldName).setJavaSqlTypesCode(Types.ARRAY).setType(Type.ARRAY)
+                    .setName(fieldName).setType(Type.ARRAY)
                     .setArrayMetadata(relationalArrayFacade.getDelegateMetadata())
                     .build());
             this.listColumnBuilder.addColumn(offset,

--- a/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/TypeConversion.java
+++ b/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/TypeConversion.java
@@ -176,7 +176,6 @@ public class TypeConversion {
         final var protobufType = toProtobufType(type);
         var columnMetadataBuilder = ColumnMetadata.newBuilder()
                 .setName(metadata.getColumnName(oneBasedIndex))
-                .setJavaSqlTypesCode(metadata.getColumnType(oneBasedIndex))
                 .setNullable(metadata.isNullable(oneBasedIndex) == DatabaseMetaData.columnNullable)
                 .setType(protobufType);
         // TODO phantom.
@@ -255,7 +254,6 @@ public class TypeConversion {
             throws SQLException {
         var columnMetadataBuilder = ColumnMetadata.newBuilder()
                 .setName(metadata.getElementName())
-                .setJavaSqlTypesCode(metadata.getElementType())
                 .setType(toProtobufType(metadata.asRelationalType().getElementType()))
                 .setNullable(metadata.isElementNullable() == DatabaseMetaData.columnNullable);
         final var elementRelationalType = metadata.asRelationalType().getElementType();

--- a/fdb-relational-grpc/src/main/proto/grpc/relational/jdbc/v1/column.proto
+++ b/fdb-relational-grpc/src/main/proto/grpc/relational/jdbc/v1/column.proto
@@ -48,7 +48,7 @@ message ColumnMetadata {
   string name = 1;
   string label = 2;
   //taken from java.sql.Types
-  int32 java_sql_types_code = 3;
+  int32 java_sql_types_code = 3 [deprecated = true];
   bool nullable = 4;
   // Indicates a column that isn't part of the DDL for a query, but is part of the returned
   // tuple (and therefore necessary to keep so that our positional ordering is intact)

--- a/fdb-relational-grpc/src/main/proto/grpc/relational/jdbc/v1/jdbc.proto
+++ b/fdb-relational-grpc/src/main/proto/grpc/relational/jdbc/v1/jdbc.proto
@@ -108,16 +108,16 @@ message Parameters {
 
 // A parameter has java sql type as well as actual parameter.
 message Parameter {
-  int32 java_sql_types_code = 1; // deprecated
+  int32 java_sql_types_code = 1 [deprecated = true];
   // Reuse the column type here. It has much of what we need carrying
   // across parameters as well as null support, etc.
   Column parameter = 2;
-  Type type = 3; // deprecated
+  Type type = 3 [deprecated = true]; // deprecated
   ParameterMetadata metadata = 4;
 }
 
 message ParameterMetadata {
-  int32 java_sql_types_code = 1;
+  int32 java_sql_types_code = 1 [deprecated = true];
   Type type = 2;
   oneof metadata {
     ListColumnMetadata structMetadata = 3;

--- a/fdb-relational-jdbc/src/main/java/com/apple/foundationdb/relational/jdbc/ParameterHelper.java
+++ b/fdb-relational-jdbc/src/main/java/com/apple/foundationdb/relational/jdbc/ParameterHelper.java
@@ -37,7 +37,6 @@ import com.google.protobuf.ByteString;
 import javax.annotation.Nonnull;
 import java.sql.Array;
 import java.sql.SQLException;
-import java.sql.Types;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -46,77 +45,56 @@ public class ParameterHelper {
 
     public static Parameter ofBoolean(boolean b) {
         return Parameter.newBuilder()
-                .setType(Type.BOOLEAN) // deprecated
-                .setJavaSqlTypesCode(Types.BOOLEAN) // deprecated
                 .setMetadata(ParameterMetadata.newBuilder()
-                        .setType(Type.BOOLEAN)
-                        .setJavaSqlTypesCode(Types.BOOLEAN))
+                        .setType(Type.BOOLEAN))
                 .setParameter(Column.newBuilder().setBoolean(b))
                 .build();
     }
 
     public static Parameter ofInt(int i) {
         return Parameter.newBuilder()
-                .setType(Type.INTEGER) // deprecated
-                .setJavaSqlTypesCode(Types.INTEGER) // deprecated
                 .setMetadata(ParameterMetadata.newBuilder()
-                        .setType(Type.INTEGER)
-                        .setJavaSqlTypesCode(Types.INTEGER))
+                        .setType(Type.INTEGER))
                 .setParameter(Column.newBuilder().setInteger(i))
                 .build();
     }
 
     public static Parameter ofLong(long l) {
         return Parameter.newBuilder()
-                .setType(Type.LONG) // deprecated
-                .setJavaSqlTypesCode(Types.BIGINT) // deprecated
                 .setMetadata(ParameterMetadata.newBuilder()
-                        .setType(Type.LONG)
-                        .setJavaSqlTypesCode(Types.BIGINT))
+                        .setType(Type.LONG))
                 .setParameter(Column.newBuilder().setLong(l))
                 .build();
     }
 
     public static Parameter ofFloat(float f) {
         return Parameter.newBuilder()
-                .setType(Type.FLOAT) // deprecated
-                .setJavaSqlTypesCode(Types.FLOAT) // deprecated
                 .setMetadata(ParameterMetadata.newBuilder()
-                        .setType(Type.FLOAT)
-                        .setJavaSqlTypesCode(Types.FLOAT))
+                        .setType(Type.FLOAT))
                 .setParameter(Column.newBuilder().setFloat(f))
                 .build();
     }
 
     public static Parameter ofDouble(double d) {
         return Parameter.newBuilder()
-                .setType(Type.DOUBLE) // deprecated
-                .setJavaSqlTypesCode(Types.DOUBLE) // deprecated
                 .setMetadata(ParameterMetadata.newBuilder()
-                        .setType(Type.DOUBLE)
-                        .setJavaSqlTypesCode(Types.DOUBLE))
+                        .setType(Type.DOUBLE))
                 .setParameter(Column.newBuilder().setDouble(d))
                 .build();
     }
 
     public static Parameter ofString(String s) {
         return Parameter.newBuilder()
-                .setType(Type.STRING) // deprecated
-                .setJavaSqlTypesCode(Types.VARCHAR) // deprecated
                 .setMetadata(ParameterMetadata.newBuilder()
-                        .setType(Type.STRING)
-                        .setJavaSqlTypesCode(Types.VARCHAR))
+                        .setType(Type.STRING))
                 .setParameter(Column.newBuilder().setString(s))
                 .build();
     }
 
     public static Parameter ofUUID(UUID id) {
         return Parameter.newBuilder()
-                .setType(Type.UUID) // deprecated
-                .setJavaSqlTypesCode(Types.OTHER) // deprecated
                 .setMetadata(ParameterMetadata.newBuilder()
-                        .setType(Type.UUID)
-                        .setJavaSqlTypesCode(Types.OTHER))
+                        .setType(Type.UUID))
                 .setParameter(Column.newBuilder().setUuid(Uuid.newBuilder()
                         .setMostSignificantBits(id.getMostSignificantBits())
                         .setLeastSignificantBits(id.getLeastSignificantBits())
@@ -130,8 +108,7 @@ public class ParameterHelper {
                         .setType(Type.VECTOR)
                         .setVectorMetadata(VectorMetadata.newBuilder()
                                 .setDimensions(vector.getNumDimensions())
-                                .setPrecision(getVectorPrecision(vector)).build())
-                        .setJavaSqlTypesCode(Types.OTHER))
+                                .setPrecision(getVectorPrecision(vector)).build()))
                 // TODO use PB ZeroCopyByteString.
                 .setParameter(Column.newBuilder().setBinary(ByteString.copyFrom(vector.getRawData())))
                 .build();
@@ -152,22 +129,16 @@ public class ParameterHelper {
 
     public static Parameter ofBytes(byte[] bytes) {
         return Parameter.newBuilder()
-                .setType(Type.BYTES) // deprecated
-                .setJavaSqlTypesCode(Types.BINARY) // deprecated
                 .setMetadata(ParameterMetadata.newBuilder()
-                        .setType(Type.BYTES)
-                        .setJavaSqlTypesCode(Types.BINARY))
+                        .setType(Type.BYTES))
                 .setParameter(Column.newBuilder().setBinary(ByteString.copyFrom(bytes)))
                 .build();
     }
 
     public static Parameter ofNull(int sqlType) {
         return Parameter.newBuilder()
-                .setType(Type.NULL) // deprecated
-                .setJavaSqlTypesCode(Types.NULL) // deprecated
                 .setMetadata(ParameterMetadata.newBuilder()
-                        .setType(Type.NULL)
-                        .setJavaSqlTypesCode(Types.NULL))
+                        .setType(Type.NULL))
                 .setParameter(Column.newBuilder().setNullType(sqlType))
                 .build();
     }
@@ -182,11 +153,8 @@ public class ParameterHelper {
             throw new SQLException("Array type not supported: " + a.getClass().getName(), ErrorCode.INVALID_PARAMETER.getErrorCode());
         }
         return Parameter.newBuilder()
-                .setType(Type.ARRAY)  // deprecated
-                .setJavaSqlTypesCode(Types.ARRAY) // deprecated
                 .setMetadata(ParameterMetadata.newBuilder()
-                        .setType(Type.ARRAY)
-                        .setJavaSqlTypesCode(Types.ARRAY))
+                        .setType(Type.ARRAY))
                 .setParameter(Column.newBuilder()
                         .setArray(com.apple.foundationdb.relational.jdbc.grpc.v1.column.Array.newBuilder()
                                 .setElementType(a.getBaseType())


### PR DESCRIPTION
With the `java_sql_types_code` field usages being removed in #3651 (in favour of richer Type in JDBC), we are now in a position to deprecate it. It also cleans redundant type infos that were present in `Parameter` proto object. The latter had `java_sql_types_code` and new `type` fields, and yet newer `ParameterMetadata` which itself has the `java_sql_types_code` and `type` fields. To declutter, this PR deprecate all except `type` in metadata. Note any of the type info is not being used currently and hence it is safe to deprecate all in a single step

 This PR does the following changes: 

1. removes the setting of `java_sql_types_code` in ColumnMetadata, Parameter and ParameterMetadata. Marks them as deprecated.
2. removes the setting of `type` in Parameter. Mark it as deprecated.