### PR TITLE
Set timeout on PRB jobs

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,6 +20,7 @@ jobs:
       checks: write
       contents: read
       pull-requests: write
+    timeout-minutes: 30
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4.2.2
@@ -36,6 +37,7 @@ jobs:
       checks: write
       contents: read
       pull-requests: write
+    timeout-minutes: 40
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4.2.2
@@ -71,6 +73,7 @@ jobs:
       checks: write
       contents: read
       pull-requests: write
+    timeout-minutes: 40
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4.2.2
@@ -106,6 +109,7 @@ jobs:
       checks: write
       contents: read
       pull-requests: write
+    timeout-minutes: 60
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4.2.2
@@ -160,6 +164,7 @@ jobs:
     permissions:
       checks: read
       contents: read
+    timeout-minutes: 10
     steps:
       - name: Checkout HEAD sources
         uses: actions/checkout@v4.2.2


### PR DESCRIPTION
I saw a PRB take 4 hours due to an issue with a test. The default is 6 hours, but I think that is too long and would just be wasting resources if a test has a deadlock.
I looked at a couple recent PRBs and doubled their times to put in timeouts. Probably if we start to hit any of these timeouts we'll want to parallelize our tests more.
I saw:
core-tests: 18m
lucene-tests: 15m
other-tests: 32m
style: 13m
coverage: 1m