### PR TITLE
Ignore test failures in nightly runs

### DIFF
--- a/gradle/testing.gradle
+++ b/gradle/testing.gradle
@@ -303,6 +303,9 @@ tasks.withType(Test).configureEach { task ->
         } else {
             task.testFramework.options.excludeTags.add('SuperSlow')
         }
+        if (project.hasProperty('tests.nightly')) {
+            task.ignoreFailures = true
+        }
         if (!project.hasProperty('tests.includeRandom')) {
             task.testFramework.options.excludeTags.add('Random')
         } else {


### PR DESCRIPTION
There have been a variety of flaky tests in our nightly runs recently. When this happens, we don't run the nightly tests for other submodules.

This change sets us to ignore test failures in the `nightly` run, causing it to proceed to other submodules.
This does mean that if a test fails in the nightly part of the nightly action, we will mark the overall nightly run as successful. This means that tracking the failures will require more clicks. I created #3821 to track improving the surfacing of nightly test failures.

I tested this locally by adding a failing test to `fdb-extensions` and running:
```
./gradlew :fdb-extensions:test :fdb-record-layer-core:test '--tests=*String*' -Ptests.nightly=true
```
and
```
./gradlew :fdb-extensions:test :fdb-record-layer-core:test '--tests=*String*'
```

The former noted the test failure, but proceeded to the core tests, and the overall gradle command exited with success.
The latter noted the test failure, did not proceed to the core tests, and the overall gradle command exited with failure.

Both displayed the failure in the markdown files used in the actions.

Documentation: https://docs.gradle.org/current/userguide/java_testing.html#sec:test_execution