### PR TITLE
Use merge control to indicate an explicit merge path

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexDeferredMaintenanceControl.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexDeferredMaintenanceControl.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.provider.foundationdb;
 
+import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.metadata.Index;
 
 import java.util.HashSet;
@@ -29,6 +30,7 @@ import java.util.Set;
  * Some store's indexes may need merging on some occasions. This helper module should allow the caller
  * to set and probe the merge policy and merge requests.
  */
+@API(API.Status.EXPERIMENTAL)
 public class IndexDeferredMaintenanceControl {
     private Set<Index> mergeRequiredIndexes = null;
     private boolean autoMergeDuringCommit = false;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMerger.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMerger.java
@@ -94,7 +94,6 @@ public class IndexingMerger {
                                     mergeControl.setRepartitionDocumentCount(repartitionDocumentCount);
                                     mergeControl.setLastStep(IndexDeferredMaintenanceControl.LastStep.NONE);
                                     mergeControl.setRepartitionCapped(false);
-                                    mergeControl.setExplicitMergePath(true);
                                     return store.getIndexMaintainer(index).mergeIndex();
                                 })
                                 .thenApply(ignore -> false)

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
@@ -390,7 +390,9 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
     public CompletableFuture<Void> mergeIndex() {
         return rebalancePartitions()
                 .thenCompose(ignored -> {
-                    state.store.getIndexDeferredMaintenanceControl().setLastStep(IndexDeferredMaintenanceControl.LastStep.MERGE);
+                    final IndexDeferredMaintenanceControl mergeControl = state.store.getIndexDeferredMaintenanceControl();
+                    mergeControl.setExplicitMergePath(true);
+                    mergeControl.setLastStep(IndexDeferredMaintenanceControl.LastStep.MERGE);
                     return directoryManager.mergeIndex(partitioner);
                 });
     }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LucenePrimaryKeySegmentIndexTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LucenePrimaryKeySegmentIndexTest.java
@@ -318,7 +318,6 @@ public class LucenePrimaryKeySegmentIndexTest extends FDBRecordStoreTestBase {
         try (FDBRecordContext context = openContext()) {
             rebuildIndexMetaData(context, SIMPLE_DOC, index);
             final LuceneIndexMaintainer indexMaintainer = (LuceneIndexMaintainer)recordStore.getIndexMaintainer(index);
-            recordStore.getIndexDeferredMaintenanceControl().setExplicitMergePath(true);
             indexMaintainer.mergeIndex();
         }
         try (FDBRecordContext context = openContext()) {


### PR DESCRIPTION
  Instead of guessing whether or not merge was called automatically during commit, use the merge control to indicate an explicit merge path. This should reduce the vulnerability to unpredicted behavior of 3rd party code.

Resolve #3834