### PR TITLE
Parallelize the PR jobs for fdb-extensions and yaml-tests

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -5,13 +5,15 @@ on:
     types: [opened, reopened, synchronize]
 
 jobs:
-  # Three parallel jobs:
+  # Multiple parallel jobs:
   #  1. style: Runs all checks on the build (including compilation static analysis) except the tests
   #     This allows us to catch anything related to build and style faster, as we don't have to wait
   #     on tests to complete. It also allows the test jobs to continue even if there's a style failure.
-  #  2. core-tests: Runs the fdb-record-layer-core tests. This is the longest test suite of the
-  #     various subprojects, so separating it out allows us to speed up the PRB time.
-  #  3. other-tests: Runs the rest of the tests. This tests everything else
+  #  2. (extensions, core, lucene, etc.)-tests: Runs the tests for one subproject each. These are the
+  #     more intensive subprojects, so separating them out allows us to run those parts of the build in
+  #     parallel, and it also allows us to ensure they get run even if there are failures in other
+  #     subprojects giving us more insight into the types of failures we're seeing.
+  #  3. other-tests: Runs the rest of the tests. This tests all the remaining subprojects.
   #  4. coverage: Merges the JaCoCo output of 2 and 3 and generates reports.
 
   style:
@@ -30,6 +32,42 @@ jobs:
         uses: ./actions/run-gradle
         with:
           gradle_command: build -x test -x destructiveTest -PreleaseBuild=false -PpublishBuild=false -PspotbugsEnableHtmlReport
+
+  extensions-tests:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
+      pull-requests: write
+    timeout-minutes: 40
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4.2.2
+      - name: Setup Base Environment
+        uses: ./actions/setup-base-env
+      - name: Setup FDB
+        uses: ./actions/setup-fdb
+      - name: Run Gradle Test
+        uses: ./actions/gradle-test
+        with:
+          gradle_command: :fdb-extensions:jar :fdb-extensions:test :fdb-extensions:destructiveTest
+          gradle_args: -PreleaseBuild=false -PpublishBuild=false
+      - name: Publish Test Reports
+        if: always()
+        uses: actions/upload-artifact@v4.6.0
+        with:
+          name: extensions-test-reports
+          path: |
+            test-reports/fdb-extensions/
+      - name: Publish Coverage Data
+        uses: actions/upload-artifact@v4.6.0
+        with:
+          name: extensions-coverage-data
+          path: |
+            **/.out/jacoco/*.exec
+            **/.out/libs/*.jar
+          include-hidden-files: true
+          retention-days: 1
 
   core-tests:
     runs-on: ubuntu-latest
@@ -103,6 +141,42 @@ jobs:
           include-hidden-files: true
           retention-days: 1
 
+  yaml-tests:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
+      pull-requests: write
+    timeout-minutes: 40
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4.2.2
+      - name: Setup Base Environment
+        uses: ./actions/setup-base-env
+      - name: Setup FDB
+        uses: ./actions/setup-fdb
+      - name: Run Gradle Test
+        uses: ./actions/gradle-test
+        with:
+          gradle_command: :yaml-tests:jar :yaml-tests:test :yaml-tests:destructiveTest
+          gradle_args: -PreleaseBuild=false -PpublishBuild=false
+      - name: Publish Test Reports
+        if: always()
+        uses: actions/upload-artifact@v4.6.0
+        with:
+          name: yaml-test-reports
+          path: |
+            test-reports/yaml-tests/
+      - name: Publish Coverage Data
+        uses: actions/upload-artifact@v4.6.0
+        with:
+          name: yaml-coverage-data
+          path: |
+            **/.out/jacoco/*.exec
+            **/.out/libs/*.jar
+          include-hidden-files: true
+          retention-days: 1
+
   other-tests:
     runs-on: ubuntu-latest
     permissions:
@@ -123,11 +197,15 @@ jobs:
           gradle_command: >-
             jar
             test
+            -x :fdb-extensions:test
             -x :fdb-record-layer-core:test
             -x :fdb-record-layer-lucene:test
+            -x :yaml-tests:test
             destructiveTest
+            -x :fdb-extensions:destructiveTest
             -x :fdb-record-layer-core:destructiveTest
             -x :fdb-record-layer-lucene:destructiveTest
+            -x :yaml-tests:destructiveTest
           gradle_args: -PreleaseBuild=false -PpublishBuild=false
       - name: Publish Test Reports
         if: always()
@@ -136,7 +214,6 @@ jobs:
           name: other-test-reports
           path: |
             test-reports/fdb-java-annotations/
-            test-reports/fdb-extensions/
             test-reports/fdb-record-layer-icu/
             test-reports/fdb-record-layer-spatial/
             test-reports/fdb-record-layer-jmh/
@@ -147,7 +224,6 @@ jobs:
             test-reports/fdb-relational-grpc/
             test-reports/fdb-relational-jdbc/
             test-reports/fdb-relational-server/
-            test-reports/yaml-tests/
       - name: Publish Coverage Data
         uses: actions/upload-artifact@v4.6.0
         with:
@@ -159,7 +235,7 @@ jobs:
           retention-days: 1
 
   coverage:
-    needs: [core-tests, lucene-tests, other-tests]
+    needs: [extensions-tests, core-tests, lucene-tests, yaml-tests, other-tests]
     runs-on: ubuntu-latest
     permissions:
       checks: read
@@ -176,10 +252,18 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: lucene-coverage-data
+      - name: 'Download extensions'
+        uses: actions/download-artifact@v4
+        with:
+          name: extensions-coverage-data
       - name: 'Download core'
         uses: actions/download-artifact@v4
         with:
           name: core-coverage-data
+      - name: 'Download yaml'
+        uses: actions/download-artifact@v4
+        with:
+          name: yaml-coverage-data
       - name: 'Download other'
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
Those are each approaching the 20 minute mark in some recent PR runs. Separating those out should help with total PRB run time.