### PR TITLE
Remove log4j.properties from `fdb-record-layer-core` jar

### DIFF
--- a/fdb-record-layer-core/fdb-record-layer-core.gradle
+++ b/fdb-record-layer-core/fdb-record-layer-core.gradle
@@ -66,7 +66,6 @@ task testShadowJar(type: com.github.jengelman.gradle.plugins.shadow.tasks.Shadow
                    'Multi-Release': 'true' // https://github.com/johnrengelman/shadow/issues/449
     }
     mergeServiceFiles()
-    exclude 'log4j.properties'
 }
 
 publishing {

--- a/fdb-record-layer-core/src/main/resources/log4j.properties
+++ b/fdb-record-layer-core/src/main/resources/log4j.properties
@@ -1,5 +1,0 @@
-log4j.rootLogger=DEBUG, console
-
-log4j.appender.console=org.apache.log4j.ConsoleAppender
-log4j.appender.console.layout=org.apache.log4j.PatternLayout
-log4j.appender.console.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n


### PR DESCRIPTION
We were defining a `log4j.properties` file in `src/main/resources`. We were already overloading that definition in our various tests, which set up their own log4j properties file, as well as in the relational server jar (which has its own `log4j2.xml`), so it was unnecessary for our purposes. It could however cause trouble downstream as imported libraries are not expected to come with a log4j properties file like this.

This fixes #3840.