### PR TITLE
Fix 4.9 version for initial 4.9 release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@
 #
 
 rootProject.name=fdb-record-layer
-version=4.9
+version=4.9.0.0
 releaseBuild=false
 
 # this should be false for release branches (i.e. if there is no -SNAPSHOT on the above version)


### PR DESCRIPTION
Whoops, I apparently forgot the procedure here, and we need to set this to 4.9.0.0 instead of 4.9 for the first release in a minor version.