### PR TITLE
Push distinct-by-primary-key operators below map operators in plans

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PlanningRuleSet.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PlanningRuleSet.java
@@ -26,6 +26,7 @@ import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalE
 import com.apple.foundationdb.record.query.plan.cascades.rules.AdjustMatchRule;
 import com.apple.foundationdb.record.query.plan.cascades.rules.AggregateDataAccessRule;
 import com.apple.foundationdb.record.query.plan.cascades.rules.ImplementRecursiveDfsJoinRule;
+import com.apple.foundationdb.record.query.plan.cascades.rules.PushDistinctBelowMapRule;
 import com.apple.foundationdb.record.query.plan.cascades.rules.WithPrimaryKeyDataAccessRule;
 import com.apple.foundationdb.record.query.plan.cascades.rules.ImplementDeleteRule;
 import com.apple.foundationdb.record.query.plan.cascades.rules.ImplementDistinctRule;
@@ -148,6 +149,7 @@ public class PlanningRuleSet extends CascadesRuleSet {
             new ImplementUniqueRule(),
             new RemoveSortRule(),
             new PushDistinctBelowFilterRule(),
+            new PushDistinctBelowMapRule(),
             new MergeFetchIntoCoveringIndexRule(),
             new PushInJoinThroughFetchRule<>(RecordQueryInValuesJoinPlan.class),
             new PushInJoinThroughFetchRule<>(RecordQueryInParameterJoinPlan.class),

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushDistinctBelowMapRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushDistinctBelowMapRule.java
@@ -1,0 +1,112 @@
+/*
+ * PushDistinctBelowMapRule.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.cascades.rules;
+
+import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRule;
+import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRuleCall;
+import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
+import com.apple.foundationdb.record.query.plan.cascades.Quantifiers;
+import com.apple.foundationdb.record.query.plan.cascades.Reference;
+import com.apple.foundationdb.record.query.plan.cascades.matching.structure.BindingMatcher;
+import com.apple.foundationdb.record.query.plan.cascades.matching.structure.RecordQueryPlanMatchers;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryMapPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedPrimaryKeyDistinctPlan;
+
+import javax.annotation.Nonnull;
+
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.ListMatcher.exactly;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.QuantifierMatchers.physicalQuantifier;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.QuantifierMatchers.physicalQuantifierOverRef;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.ReferenceMatchers.anyRefOverOnlyPlans;
+
+/**
+ * A rule that pushes a {@link RecordQueryUnorderedPrimaryKeyDistinctPlan} below a {@link RecordQueryMapPlan}.
+ * This is a pinhole optimization, ensuring that we apply any distinct operations before applying any
+ * map-operations.
+ *
+ * <pre>
+ * {@code
+ *         +-----------------------------------+                          +---------------------------------+
+ *         |                                   |                          |                                 |
+ *         |  UnorderedPrimaryKeyDistinctPlan  |                          |             MapPlan             |
+ *         |                                   |                          |                                 |
+ *         +-----------------+-----------------+                          +----------------+----------------+
+ *                           |                                                             |
+ *                           |                                                             |
+ *                           |                    +------------------->                    |
+ *           +---------------+--------------+                            +-----------------+-----------------+
+ *           |                              |                            |                                   |
+ *           |            MapPlan           |                            |  UnorderedPrimaryKeyDistinctPlan  |
+ *           |                              |                            |                                   |
+ *           +---------------+--------------+                            +-----------------+-----------------+
+ *                           |                                                             |
+ *                           |                                                             |
+ *                           |                                                             |
+ *                    +------+------+                                                      |
+ *                    |             |                                                      |
+ *                    |  innerPlan  |   +--------------------------------------------------+
+ *                    |             |
+ *                    +-------------+
+ * }
+ * </pre>
+ *
+ * <p>
+ * Note that the {@link RecordQueryUnorderedPrimaryKeyDistinctPlan} uses the primary key that is baked
+ * into the {@link com.apple.foundationdb.record.query.plan.plans.QueryResult}s that are retuned by its
+ * underlying plan, and that that value is not modified by the map plan operator. One could imagine a different
+ * distinct operator that took a {@link com.apple.foundationdb.record.query.plan.cascades.values.Value} to
+ * generate some kind of distinctness key. If we wanted to apply this rule to such an operator, we'd have to
+ * be a little more careful. For one, we'd have to make sure to translate that value when pushing it down. But
+ * moreover, we'd need to make sure that the map value is one-to-one, or more precisely, that it does not change
+ * the number of distinct values.
+ * </p>
+ *
+ * @see PushDistinctBelowFilterRule for a similar rule operating on filter plans
+ * @see PushDistinctThroughFetchRule for a similar rule operating on fetch plans
+ */
+public class PushDistinctBelowMapRule extends ImplementationCascadesRule<RecordQueryUnorderedPrimaryKeyDistinctPlan> {
+    @Nonnull
+    private static final BindingMatcher<? extends Reference> innerRefMatcher = anyRefOverOnlyPlans();
+    @Nonnull
+    private static final BindingMatcher<Quantifier.Physical> innerQuantifierMatcher = physicalQuantifierOverRef(innerRefMatcher);
+    @Nonnull
+    private static final BindingMatcher<RecordQueryMapPlan> mapPlanMatcher = RecordQueryPlanMatchers.map(exactly(innerQuantifierMatcher));
+    @Nonnull
+    private static final BindingMatcher<RecordQueryUnorderedPrimaryKeyDistinctPlan> root =
+            RecordQueryPlanMatchers.unorderedPrimaryKeyDistinct(exactly(physicalQuantifier(mapPlanMatcher)));
+
+    public PushDistinctBelowMapRule() {
+        super(root);
+    }
+
+    @Override
+    public void onMatch(@Nonnull final ImplementationCascadesRuleCall call) {
+        final Reference inner = call.get(innerRefMatcher);
+        final Quantifier.Physical qun = call.get(innerQuantifierMatcher);
+        final RecordQueryMapPlan mapPlan = call.get(mapPlanMatcher);
+
+        // Reverse the order of the map and the unordered primary key distinct plan and yield
+        final RecordQueryUnorderedPrimaryKeyDistinctPlan newDistinctPlan =
+                new RecordQueryUnorderedPrimaryKeyDistinctPlan(Quantifier.physical(inner));
+        final Quantifier.Physical newQun = Quantifier.physical(call.memoizePlan(newDistinctPlan));
+        call.yieldPlan(new RecordQueryMapPlan(newQun, mapPlan.getResultValue().rebase(Quantifiers.translate(qun, newQun))));
+    }
+}

--- a/yaml-tests/src/test/java/YamlIntegrationTests.java
+++ b/yaml-tests/src/test/java/YamlIntegrationTests.java
@@ -363,6 +363,11 @@ public class YamlIntegrationTests {
     }
 
     @TestTemplate
+    public void updateWithVersions(YamlTest.Runner runner) throws Exception {
+        runner.runYamsql("update-with-versions.yamsql");
+    }
+
+    @TestTemplate
     public void userDefinedMacroFunctionTests(YamlTest.Runner runner) throws Exception {
         runner.runYamsql("user-defined-macro-function-tests.yamsql");
     }

--- a/yaml-tests/src/test/resources/null-extraction-tests.metrics.binpb
+++ b/yaml-tests/src/test/resources/null-extraction-tests.metrics.binpb
@@ -8,10 +8,10 @@ Y
   1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">comparisons: [EQUALS promote(@c8 AS LONG), EQUALS @c12]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS B1, STRING AS B2, LONG AS B3)" ];
   2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">I1</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS B1, STRING AS B2, LONG AS B3)" ];
   2 -> 1 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}‹
+}Ž
 e
-agg-index-tests-countLEXPLAIN select * from B where b3 = 4 and b2 = 'b' and (? is null or b1 < 20)¡
-’å”òŠ ¨˜è	(T0½ƒu8¯@·COVERING(I1 [EQUALS promote(@c8 AS LONG), EQUALS promote(@c12 AS STRING)] -> [B1: KEY[3], B2: KEY[1], B3: KEY[0]]) | FILTER @c15 IS_NULL OR _.B1 LESS_THAN promote(@c21 AS INT) | FETCHÇdigraph G {
+agg-index-tests-countLEXPLAIN select * from B where b3 = 4 and b2 = 'b' and (? is null or b1 < 20)¤
+˜ÓóƒŠ ŠöÈ	(T0ûÊn8¯@ºCOVERING(I1 [EQUALS promote(@c8 AS LONG), EQUALS promote(@c12 AS STRING)] -> [B1: KEY:[3], B2: KEY:[1], B3: KEY:[0]]) | FILTER @c15 IS_NULL OR _.B1 LESS_THAN promote(@c21 AS INT) | FETCHÇdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=polyline;

--- a/yaml-tests/src/test/resources/null-extraction-tests.metrics.yaml
+++ b/yaml-tests/src/test/resources/null-extraction-tests.metrics.yaml
@@ -14,10 +14,10 @@ agg-index-tests-count:
 -   query: EXPLAIN select * from B where b3 = 4 and b2 = 'b' and (? is null or b1
         < 20)
     explain: 'COVERING(I1 [EQUALS promote(@c8 AS LONG), EQUALS promote(@c12 AS STRING)]
-        -> [B1: KEY[3], B2: KEY[1], B3: KEY[0]]) | FILTER @c15 IS_NULL OR _.B1 LESS_THAN
-        promote(@c21 AS INT) | FETCH'
-    task_count: 1426
-    task_total_time_ms: 45
+        -> [B1: KEY:[3], B2: KEY:[1], B3: KEY:[0]]) | FILTER @c15 IS_NULL OR _.B1
+        LESS_THAN promote(@c21 AS INT) | FETCH'
+    task_count: 1432
+    task_total_time_ms: 56
     transform_count: 266
     transform_time_ms: 20
     transform_yield_count: 84

--- a/yaml-tests/src/test/resources/semantic-search.metrics.binpb
+++ b/yaml-tests/src/test/resources/semantic-search.metrics.binpb
@@ -142,10 +142,10 @@
   3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">DOCUMENTSEUCLIDEANINDEX</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(STRING AS ZONE, STRING AS DOCID, STRING AS BOOKSHELF, STRING AS TITLE, VECTOR(16, 3) AS EMBEDDING)" ];
   3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}è 
+}ç 
 À
-semantic-search-queries¤EXPLAIN select title from documents where zone = 'zone1' and bookshelf = 'fiction' qualify (row_number() over (partition by zone, bookshelf order by cosine_distance(embedding, ?) asc) <= 1 or row_number() over (partition by zone, bookshelf order by euclidean_distance(embedding, ?) asc) <= 1)¢
-å£¡¦: Ç§–&(10Ù•À8/@÷ISCAN(DOCUMENTSCOSINEINDEX [EQUALS promote(@c8 AS STRING), EQUALS promote(@c12 AS STRING)]:{DISTANCE_RANK_LESS_THAN_OR_EQUAL @c31: @c37}:[] BY_DISTANCE) âˆª ISCAN(DOCUMENTSEUCLIDEANINDEX [EQUALS promote(@c8 AS STRING), EQUALS promote(@c12 AS STRING)]:{DISTANCE_RANK_LESS_THAN_OR_EQUAL @c55: @c37}:[] BY_DISTANCE) COMPARE BY (recordType([_]), _.DOCID) | MAP (_.TITLE AS TITLE)ˆdigraph G {
+semantic-search-queries¤EXPLAIN select title from documents where zone = 'zone1' and bookshelf = 'fiction' qualify (row_number() over (partition by zone, bookshelf order by cosine_distance(embedding, ?) asc) <= 1 or row_number() over (partition by zone, bookshelf order by euclidean_distance(embedding, ?) asc) <= 1)¡
+æ”üÀ Ðê¹(10›ü'8/@÷ISCAN(DOCUMENTSCOSINEINDEX [EQUALS promote(@c8 AS STRING), EQUALS promote(@c12 AS STRING)]:{DISTANCE_RANK_LESS_THAN_OR_EQUAL @c31: @c37}:[] BY_DISTANCE) âˆª ISCAN(DOCUMENTSEUCLIDEANINDEX [EQUALS promote(@c8 AS STRING), EQUALS promote(@c12 AS STRING)]:{DISTANCE_RANK_LESS_THAN_OR_EQUAL @c55: @c37}:[] BY_DISTANCE) COMPARE BY (recordType([_]), _.DOCID) | MAP (_.TITLE AS TITLE)ˆdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;

--- a/yaml-tests/src/test/resources/semantic-search.metrics.yaml
+++ b/yaml-tests/src/test/resources/semantic-search.metrics.yaml
@@ -192,12 +192,12 @@ semantic-search-queries:
         ∪ ISCAN(DOCUMENTSEUCLIDEANINDEX [EQUALS promote(@c8 AS STRING), EQUALS promote(@c12
         AS STRING)]:{DISTANCE_RANK_LESS_THAN_OR_EQUAL @c55: @c37}:[] BY_DISTANCE)
         COMPARE BY (recordType([_]), _.DOCID) | MAP (_.TITLE AS TITLE)'
-    task_count: 485
-    task_total_time_ms: 122
+    task_count: 486
+    task_total_time_ms: 26
     transform_count: 143
-    transform_time_ms: 80
+    transform_time_ms: 17
     transform_yield_count: 49
-    insert_time_ms: 3
+    insert_time_ms: 0
     insert_new_count: 47
     insert_reused_count: 6
 -   query: EXPLAIN select r.reviewId, r.rating, d2.docId, d2.title from reviews r

--- a/yaml-tests/src/test/resources/standard-tests.metrics.binpb
+++ b/yaml-tests/src/test/resources/standard-tests.metrics.binpb
@@ -32,35 +32,35 @@ w
   1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">comparisons: [EQUALS promote(@c8 AS LONG)]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS COL1, LONG AS COL2)" ];
   2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">I1</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS COL1, LONG AS COL2)" ];
   2 -> 1 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}ª
+}ø
 I
-standard-tests7EXPLAIN select * from T1 where COL1 >= 10 OR COL1 <= 20Ì
-Ö
-¸ùá/Ñ ¡§¥(O0µçæ8ü@–COVERING(I1 [[GREATER_THAN_OR_EQUALS promote(@c9 AS LONG)]] -> [COL1: KEY[0], ID: KEY[2]]) ‚äé COVERING(I1 [[LESS_THAN_OR_EQUALS promote(@c14 AS LONG)]] -> [COL1: KEY[0], ID: KEY[2]]) | DISTINCT BY PK | FETCH˘digraph G {
+standard-tests7EXPLAIN select * from T1 where COL1 >= 10 OR COL1 <= 20Ò
+ã
+°°§>Ñ À≈´(O0≤ﬁœ8ü@‘COVERING(I1 [[GREATER_THAN_OR_EQUALS promote(@c9 AS LONG)]] -> [COL1: KEY:[0], ID: KEY:[2]]) ‚äé COVERING(I1 [[LESS_THAN_OR_EQUALS promote(@c14 AS LONG)]] -> [COL1: KEY:[0], ID: KEY:[2]]) | DISTINCT BY PK | FETCH˘digraph G {
   fontname=courier;
   rankdir=BT;
   splines=polyline;
   1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Fetch Records</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="12" tooltip="RELATION(LONG AS ID, LONG AS COL1, LONG AS COL2)" ];
   2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Unordered Primary Key Distinct</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="12" tooltip="RELATION(LONG AS ID, LONG AS COL1, LONG AS COL2)" ];
   3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Union All</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="12" tooltip="RELATION(LONG AS ID, LONG AS COL1, LONG AS COL2)" ];
-  4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Covering Index Scan</td></tr><tr><td align="left">comparisons: [[LESS_THAN_OR_EQUALS promote(@c14 AS LONG)]]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS COL1, LONG AS COL2)" ];
-  5 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Covering Index Scan</td></tr><tr><td align="left">comparisons: [[GREATER_THAN_OR_EQUALS promote(@c9 AS LONG)]]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS COL1, LONG AS COL2)" ];
+  4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Covering Index Scan</td></tr><tr><td align="left">comparisons: [[GREATER_THAN_OR_EQUALS promote(@c9 AS LONG)]]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS COL1, LONG AS COL2)" ];
+  5 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Covering Index Scan</td></tr><tr><td align="left">comparisons: [[LESS_THAN_OR_EQUALS promote(@c14 AS LONG)]]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS COL1, LONG AS COL2)" ];
   6 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">I1</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS COL1, LONG AS COL2)" ];
   7 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">I1</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS COL1, LONG AS COL2)" ];
   3 -> 2 [ label=<&nbsp;q137> label="q137" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  4 -> 3 [ label=<&nbsp;q119> label="q119" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  5 -> 3 [ label=<&nbsp;q117> label="q117" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  4 -> 3 [ label=<&nbsp;q117> label="q117" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  5 -> 3 [ label=<&nbsp;q119> label="q119" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   6 -> 4 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   7 -> 5 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q139> label="q139" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}Œ
+}“
 W
-standard-testsEEXPLAIN select * from T1 where COL1 >= 10 OR COL1 <= 20 ORDER BY COL1Ú
-∏ÏÕÍ‡ àÕÒ(>0®ÒÖ8}@ûISCAN(I1 [[GREATER_THAN_OR_EQUALS promote(@c9 AS LONG)]]) ‚à™ ISCAN(I1 [[LESS_THAN_OR_EQUALS promote(@c14 AS LONG)]]) COMPARE BY (_.COL1, recordType(_), _.ID)±digraph G {
+standard-testsEEXPLAIN select * from T1 where COL1 >= 10 OR COL1 <= 20 ORDER BY COL1ˆ
+Ω‰Ëˆ7‡ ÄÄ◊(>0óòæ8}@†ISCAN(I1 [[GREATER_THAN_OR_EQUALS promote(@c9 AS LONG)]]) ‚à™ ISCAN(I1 [[LESS_THAN_OR_EQUALS promote(@c14 AS LONG)]]) COMPARE BY (_.COL1, recordType([_]), _.ID)≥digraph G {
   fontname=courier;
   rankdir=BT;
   splines=polyline;
-  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Union Distinct</td></tr><tr><td align="left">COMPARE BY (_.COL1, recordType(_), _.ID)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS COL1, LONG AS COL2)" ];
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Union Distinct</td></tr><tr><td align="left">COMPARE BY (_.COL1, recordType([_]), _.ID)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS COL1, LONG AS COL2)" ];
   2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">comparisons: [[GREATER_THAN_OR_EQUALS promote(@c9 AS LONG)]]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS COL1, LONG AS COL2)" ];
   3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">I1</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS COL1, LONG AS COL2)" ];
   4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">comparisons: [[LESS_THAN_OR_EQUALS promote(@c14 AS LONG)]]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS COL1, LONG AS COL2)" ];
@@ -119,36 +119,35 @@ H
   1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">comparisons: [EQUALS promote(@c8 AS LONG)]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS COL1, LONG AS COL2)" ];
   2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">I1</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS COL1, LONG AS COL2)" ];
   2 -> 1 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}ñ
+}ö
 f
-standard-testsTEXPLAIN select * from T1 where (COL1 = 20 OR COL1 = 10) AND (COL1 = 20 OR COL1 = 10)´
-≠
-òΩÕé ◊±‚(S0çá∫8•@ØCOVERING(I1 [EQUALS promote(@c9 AS LONG)] -> [COL1: KEY[0], ID: KEY[2]]) ‚äé COVERING(I1 [EQUALS promote(@c13 AS LONG)] -> [COL1: KEY[0], ID: KEY[2]]) | DISTINCT BY PK | FETCHÿdigraph G {
+standard-testsTEXPLAIN select * from T1 where (COL1 = 20 OR COL1 = 10) AND (COL1 = 20 OR COL1 = 10)Ø
+≥
+≥Ä¬*é §ﬂæ(S0£ûà8•@≥COVERING(I1 [EQUALS promote(@c9 AS LONG)] -> [COL1: KEY:[0], ID: KEY:[2]]) ‚äé COVERING(I1 [EQUALS promote(@c13 AS LONG)] -> [COL1: KEY:[0], ID: KEY:[2]]) | DISTINCT BY PK | FETCHÿdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=polyline;
   1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Fetch Records</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="12" tooltip="RELATION(LONG AS ID, LONG AS COL1, LONG AS COL2)" ];
   2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Unordered Primary Key Distinct</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="12" tooltip="RELATION(LONG AS ID, LONG AS COL1, LONG AS COL2)" ];
   3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Union All</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="12" tooltip="RELATION(LONG AS ID, LONG AS COL1, LONG AS COL2)" ];
-  4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Covering Index Scan</td></tr><tr><td align="left">comparisons: [EQUALS promote(@c9 AS LONG)]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS COL1, LONG AS COL2)" ];
-  5 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Covering Index Scan</td></tr><tr><td align="left">comparisons: [EQUALS promote(@c13 AS LONG)]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS COL1, LONG AS COL2)" ];
+  4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Covering Index Scan</td></tr><tr><td align="left">comparisons: [EQUALS promote(@c13 AS LONG)]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS COL1, LONG AS COL2)" ];
+  5 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Covering Index Scan</td></tr><tr><td align="left">comparisons: [EQUALS promote(@c9 AS LONG)]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS COL1, LONG AS COL2)" ];
   6 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">I1</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS COL1, LONG AS COL2)" ];
   7 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">I1</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS COL1, LONG AS COL2)" ];
   3 -> 2 [ label=<&nbsp;q138> label="q138" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  4 -> 3 [ label=<&nbsp;q118> label="q118" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  5 -> 3 [ label=<&nbsp;q120> label="q120" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  4 -> 3 [ label=<&nbsp;q120> label="q120" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  5 -> 3 [ label=<&nbsp;q118> label="q118" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   6 -> 4 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   7 -> 5 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q140> label="q140" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}©
+}≠
 t
-standard-testsbEXPLAIN select * from T1 where (COL1 = 20 OR COL1 = 10) AND (COL1 = 20 OR COL1 = 10) ORDER BY COL1∞
-®	ù¯√Ò ç˘´
-(@0çÁ∂8Ñ@}ISCAN(I1 [EQUALS promote(@c9 AS LONG)]) ‚à™ ISCAN(I1 [EQUALS promote(@c13 AS LONG)]) COMPARE BY (_.COL1, recordType(_), _.ID)êdigraph G {
+standard-testsbEXPLAIN select * from T1 where (COL1 = 20 OR COL1 = 10) AND (COL1 = 20 OR COL1 = 10) ORDER BY COL1¥
+≠	öÀ¨:Ò ÍÑÜ(@0∫⁄§8Ñ@ISCAN(I1 [EQUALS promote(@c9 AS LONG)]) ‚à™ ISCAN(I1 [EQUALS promote(@c13 AS LONG)]) COMPARE BY (_.COL1, recordType([_]), _.ID)ídigraph G {
   fontname=courier;
   rankdir=BT;
   splines=polyline;
-  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Union Distinct</td></tr><tr><td align="left">COMPARE BY (_.COL1, recordType(_), _.ID)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS COL1, LONG AS COL2)" ];
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Union Distinct</td></tr><tr><td align="left">COMPARE BY (_.COL1, recordType([_]), _.ID)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS COL1, LONG AS COL2)" ];
   2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">comparisons: [EQUALS promote(@c9 AS LONG)]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS COL1, LONG AS COL2)" ];
   3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">I1</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS COL1, LONG AS COL2)" ];
   4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">comparisons: [EQUALS promote(@c13 AS LONG)]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS COL1, LONG AS COL2)" ];

--- a/yaml-tests/src/test/resources/standard-tests.metrics.yaml
+++ b/yaml-tests/src/test/resources/standard-tests.metrics.yaml
@@ -35,26 +35,26 @@ standard-tests:
     insert_reused_count: 4
 -   query: EXPLAIN select * from T1 where COL1 >= 10 OR COL1 <= 20
     explain: 'COVERING(I1 [[GREATER_THAN_OR_EQUALS promote(@c9 AS LONG)]] -> [COL1:
-        KEY[0], ID: KEY[2]]) ⊎ COVERING(I1 [[LESS_THAN_OR_EQUALS promote(@c14 AS LONG)]]
-        -> [COL1: KEY[0], ID: KEY[2]]) | DISTINCT BY PK | FETCH'
-    task_count: 1285
-    task_total_time_ms: 98
+        KEY:[0], ID: KEY:[2]]) ⊎ COVERING(I1 [[LESS_THAN_OR_EQUALS promote(@c14 AS
+        LONG)]] -> [COL1: KEY:[0], ID: KEY:[2]]) | DISTINCT BY PK | FETCH'
+    task_count: 1291
+    task_total_time_ms: 130
     transform_count: 260
-    transform_time_ms: 36
+    transform_time_ms: 48
     transform_yield_count: 79
-    insert_time_ms: 5
+    insert_time_ms: 7
     insert_new_count: 159
     insert_reused_count: 23
 -   query: EXPLAIN select * from T1 where COL1 >= 10 OR COL1 <= 20 ORDER BY COL1
     explain: ISCAN(I1 [[GREATER_THAN_OR_EQUALS promote(@c9 AS LONG)]]) ∪ ISCAN(I1
-        [[LESS_THAN_OR_EQUALS promote(@c14 AS LONG)]]) COMPARE BY (_.COL1, recordType(_),
+        [[LESS_THAN_OR_EQUALS promote(@c14 AS LONG)]]) COMPARE BY (_.COL1, recordType([_]),
         _.ID)
-    task_count: 1080
-    task_total_time_ms: 47
+    task_count: 1085
+    task_total_time_ms: 117
     transform_count: 224
-    transform_time_ms: 14
+    transform_time_ms: 43
     transform_yield_count: 62
-    insert_time_ms: 2
+    insert_time_ms: 5
     insert_new_count: 125
     insert_reused_count: 14
 -   query: EXPLAIN select * from T1 where COL1 >= 10 AND COL1 <= 20
@@ -111,27 +111,27 @@ standard-tests:
     insert_reused_count: 4
 -   query: EXPLAIN select * from T1 where (COL1 = 20 OR COL1 = 10) AND (COL1 = 20
         OR COL1 = 10)
-    explain: 'COVERING(I1 [EQUALS promote(@c9 AS LONG)] -> [COL1: KEY[0], ID: KEY[2]])
-        ⊎ COVERING(I1 [EQUALS promote(@c13 AS LONG)] -> [COL1: KEY[0], ID: KEY[2]])
+    explain: 'COVERING(I1 [EQUALS promote(@c9 AS LONG)] -> [COL1: KEY:[0], ID: KEY:[2]])
+        ⊎ COVERING(I1 [EQUALS promote(@c13 AS LONG)] -> [COL1: KEY:[0], ID: KEY:[2]])
         | DISTINCT BY PK | FETCH'
-    task_count: 1325
-    task_total_time_ms: 51
+    task_count: 1331
+    task_total_time_ms: 89
     transform_count: 270
-    transform_time_ms: 18
+    transform_time_ms: 30
     transform_yield_count: 83
-    insert_time_ms: 3
+    insert_time_ms: 4
     insert_new_count: 165
     insert_reused_count: 24
 -   query: EXPLAIN select * from T1 where (COL1 = 20 OR COL1 = 10) AND (COL1 = 20
         OR COL1 = 10) ORDER BY COL1
     explain: ISCAN(I1 [EQUALS promote(@c9 AS LONG)]) ∪ ISCAN(I1 [EQUALS promote(@c13
-        AS LONG)]) COMPARE BY (_.COL1, recordType(_), _.ID)
-    task_count: 1192
-    task_total_time_ms: 59
+        AS LONG)]) COMPARE BY (_.COL1, recordType([_]), _.ID)
+    task_count: 1197
+    task_total_time_ms: 122
     transform_count: 241
-    transform_time_ms: 21
+    transform_time_ms: 44
     transform_yield_count: 64
-    insert_time_ms: 2
+    insert_time_ms: 4
     insert_new_count: 132
     insert_reused_count: 21
 -   query: EXPLAIN select * from T1 where (COL1 >= 10 AND COL1 <= 20) OR (COL1 >=

--- a/yaml-tests/src/test/resources/update-delete-returning.metrics.binpb
+++ b/yaml-tests/src/test/resources/update-delete-returning.metrics.binpb
@@ -1,7 +1,7 @@
-›
+œ
 e
-	unnamed-1XEXPLAIN update A set A2 = 42, A3 = 44 where A1 <= 2 returning "new".A3 OPTIONS(DRY RUN);±
- º»~G ¬¥9(0Â’8@tSCAN(<,>) | DISTINCT BY PK | FILTER _.A1 LESS_THAN_OR_EQUALS promote(@c15 AS LONG) | UPDATE A | MAP (_.new.A3 AS A3)Ÿdigraph G {
+	unnamed-1XEXPLAIN update A set A2 = 42, A3 = 44 where A1 <= 2 returning "new".A3 OPTIONS(DRY RUN);²
+¢³×®G ´ºR(0òü8@tSCAN(<,>) | DISTINCT BY PK | FILTER _.A1 LESS_THAN_OR_EQUALS promote(@c15 AS LONG) | UPDATE A | MAP (_.new.A3 AS A3)Ÿdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=polyline;
@@ -23,35 +23,35 @@ e
     rankDir=LR;
     3 -> 4 [ color="red" style="invis" ];
   }
-}Š
+}‹
 T
-	unnamed-1GEXPLAIN update A set A2 = 42, A3 = 44 where A1 <= 2 returning "new".A3;±
- º»~G ¬¥9(0Â’8@tSCAN(<,>) | DISTINCT BY PK | FILTER _.A1 LESS_THAN_OR_EQUALS promote(@c15 AS LONG) | UPDATE A | MAP (_.new.A3 AS A3)Ÿdigraph G {
+	unnamed-1GEXPLAIN update A set A2 = 42, A3 = 44 where A1 <= 2 returning "new".A3;²
+¢³×®G ´ºR(0òü8@tSCAN(<,>) | DISTINCT BY PK | FILTER _.A1 LESS_THAN_OR_EQUALS promote(@c15 AS LONG) | UPDATE A | MAP (_.new.A3 AS A3)Ÿdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=polyline;
   1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q6.new.A3 AS A3)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS A3)" ];
   2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Modification</td></tr><tr><td align="left">UPDATE</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightcoral" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS A1, LONG AS A2, LONG AS A3 AS old, LONG AS A1, LONG AS A2, LONG AS A3 AS new)" ];
-  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE q37.A1 LESS_THAN_OR_EQUALS promote(@c15 AS LONG)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS A1, LONG AS A2, LONG AS A3)" ];
-  4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Primary Storage</td></tr><tr><td align="left">A</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS A1, LONG AS A2, LONG AS A3 AS old, LONG AS A1, LONG AS A2, LONG AS A3 AS new)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Primary Storage</td></tr><tr><td align="left">A</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS A1, LONG AS A2, LONG AS A3 AS old, LONG AS A1, LONG AS A2, LONG AS A3 AS new)" ];
+  4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE q37.A1 LESS_THAN_OR_EQUALS promote(@c15 AS LONG)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS A1, LONG AS A2, LONG AS A3)" ];
   5 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Unordered Primary Key Distinct</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="12" tooltip="RELATION(LONG AS A1, LONG AS A2, LONG AS A3)" ];
   6 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Scan</td></tr><tr><td align="left">range: &lt;-âˆž, âˆž&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS A1, LONG AS A2, LONG AS A3)" ];
   7 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Primary Storage</td></tr><tr><td align="left">record types: [A]</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS A1, LONG AS A2, LONG AS A3)" ];
-  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  4 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="none" arrowtail="normal" dir="both" ];
-  5 -> 3 [ label=<&nbsp;q37> label="q37" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="none" arrowtail="normal" dir="both" ];
+  4 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  5 -> 4 [ label=<&nbsp;q37> label="q37" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   6 -> 5 [ label=<&nbsp;q35> label="q35" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   7 -> 6 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   {
     rank=same;
     rankDir=LR;
-    3 -> 4 [ color="red" style="invis" ];
+    4 -> 3 [ color="red" style="invis" ];
   }
-}½
+}¾
 p
-	unnamed-1cEXPLAIN update A set A2 = 42, A3 = 44 where A1 <= 2 returning "new".A3 + "new".A3 OPTIONS(DRY RUN);È
- ‚ßsG ã¿3(0Î­8@SCAN(<,>) | DISTINCT BY PK | FILTER _.A1 LESS_THAN_OR_EQUALS promote(@c15 AS LONG) | UPDATE A | MAP (_.new.A3 + _.new.A3 AS _0)«digraph G {
+	unnamed-1cEXPLAIN update A set A2 = 42, A3 = 44 where A1 <= 2 returning "new".A3 + "new".A3 OPTIONS(DRY RUN);É
+¢’ÄÅG Â¯X(0Ûÿ8@SCAN(<,>) | DISTINCT BY PK | FILTER _.A1 LESS_THAN_OR_EQUALS promote(@c15 AS LONG) | UPDATE A | MAP (_.new.A3 + _.new.A3 AS _0)«digraph G {
   fontname=courier;
   rankdir=BT;
   splines=polyline;
@@ -73,35 +73,35 @@ p
     rankDir=LR;
     3 -> 4 [ color="red" style="invis" ];
   }
-}¬
+}­
 _
-	unnamed-1REXPLAIN update A set A2 = 42, A3 = 44 where A1 <= 2 returning "new".A3 + "new".A3;È
- ‚ßsG ã¿3(0Î­8@SCAN(<,>) | DISTINCT BY PK | FILTER _.A1 LESS_THAN_OR_EQUALS promote(@c15 AS LONG) | UPDATE A | MAP (_.new.A3 + _.new.A3 AS _0)«digraph G {
+	unnamed-1REXPLAIN update A set A2 = 42, A3 = 44 where A1 <= 2 returning "new".A3 + "new".A3;É
+¢’ÄÅG Â¯X(0Ûÿ8@SCAN(<,>) | DISTINCT BY PK | FILTER _.A1 LESS_THAN_OR_EQUALS promote(@c15 AS LONG) | UPDATE A | MAP (_.new.A3 + _.new.A3 AS _0)«digraph G {
   fontname=courier;
   rankdir=BT;
   splines=polyline;
   1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q6.new.A3 + q6.new.A3 AS _0)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS _0)" ];
   2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Modification</td></tr><tr><td align="left">UPDATE</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightcoral" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS A1, LONG AS A2, LONG AS A3 AS old, LONG AS A1, LONG AS A2, LONG AS A3 AS new)" ];
-  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE q37.A1 LESS_THAN_OR_EQUALS promote(@c15 AS LONG)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS A1, LONG AS A2, LONG AS A3)" ];
-  4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Primary Storage</td></tr><tr><td align="left">A</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS A1, LONG AS A2, LONG AS A3 AS old, LONG AS A1, LONG AS A2, LONG AS A3 AS new)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Primary Storage</td></tr><tr><td align="left">A</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS A1, LONG AS A2, LONG AS A3 AS old, LONG AS A1, LONG AS A2, LONG AS A3 AS new)" ];
+  4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE q37.A1 LESS_THAN_OR_EQUALS promote(@c15 AS LONG)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS A1, LONG AS A2, LONG AS A3)" ];
   5 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Unordered Primary Key Distinct</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="12" tooltip="RELATION(LONG AS A1, LONG AS A2, LONG AS A3)" ];
   6 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Scan</td></tr><tr><td align="left">range: &lt;-âˆž, âˆž&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS A1, LONG AS A2, LONG AS A3)" ];
   7 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Primary Storage</td></tr><tr><td align="left">record types: [A]</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS A1, LONG AS A2, LONG AS A3)" ];
-  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  4 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="none" arrowtail="normal" dir="both" ];
-  5 -> 3 [ label=<&nbsp;q37> label="q37" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="none" arrowtail="normal" dir="both" ];
+  4 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  5 -> 4 [ label=<&nbsp;q37> label="q37" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   6 -> 5 [ label=<&nbsp;q35> label="q35" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   7 -> 6 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   {
     rank=same;
     rankDir=LR;
-    3 -> 4 [ color="red" style="invis" ];
+    4 -> 3 [ color="red" style="invis" ];
   }
-}Œ
+}‹
 H
-	unnamed-1;EXPLAIN update A set A2 = 52 where A1 > 2 OPTIONS(DRY RUN);¿
-á¢ôâ7 ÒŸª(0®¨8@VSCAN(<,>) | DISTINCT BY PK | FILTER _.A1 GREATER_THAN promote(@c10 AS LONG) | UPDATE AÉdigraph G {
+	unnamed-1;EXPLAIN update A set A2 = 52 where A1 > 2 OPTIONS(DRY RUN);¾
+ã¶þ´7 Ñða(0âñ8@VSCAN(<,>) | DISTINCT BY PK | FILTER _.A1 GREATER_THAN promote(@c10 AS LONG) | UPDATE AÉdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=polyline;
@@ -121,10 +121,10 @@ H
     rankDir=LR;
     2 -> 6 [ color="red" style="invis" ];
   }
-}û
+}ú
 7
-	unnamed-1*EXPLAIN update A set A2 = 52 where A1 > 2;¿
-á¢ôâ7 ÒŸª(0®¨8@VSCAN(<,>) | DISTINCT BY PK | FILTER _.A1 GREATER_THAN promote(@c10 AS LONG) | UPDATE AÉdigraph G {
+	unnamed-1*EXPLAIN update A set A2 = 52 where A1 > 2;¾
+ã¶þ´7 Ñða(0âñ8@VSCAN(<,>) | DISTINCT BY PK | FILTER _.A1 GREATER_THAN promote(@c10 AS LONG) | UPDATE AÉdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=polyline;

--- a/yaml-tests/src/test/resources/update-delete-returning.metrics.yaml
+++ b/yaml-tests/src/test/resources/update-delete-returning.metrics.yaml
@@ -3,10 +3,10 @@ unnamed-1:
         OPTIONS(DRY RUN);
     explain: SCAN(<,>) | DISTINCT BY PK | FILTER _.A1 LESS_THAN_OR_EQUALS promote(@c15
         AS LONG) | UPDATE A | MAP (_.new.A3 AS A3)
-    task_count: 288
+    task_count: 290
     task_total_time_ms: 2
     transform_count: 71
-    transform_time_ms: 0
+    transform_time_ms: 1
     transform_yield_count: 19
     insert_time_ms: 0
     insert_new_count: 25
@@ -14,10 +14,10 @@ unnamed-1:
 -   query: EXPLAIN update A set A2 = 42, A3 = 44 where A1 <= 2 returning "new".A3;
     explain: SCAN(<,>) | DISTINCT BY PK | FILTER _.A1 LESS_THAN_OR_EQUALS promote(@c15
         AS LONG) | UPDATE A | MAP (_.new.A3 AS A3)
-    task_count: 288
+    task_count: 290
     task_total_time_ms: 2
     transform_count: 71
-    transform_time_ms: 0
+    transform_time_ms: 1
     transform_yield_count: 19
     insert_time_ms: 0
     insert_new_count: 25
@@ -26,10 +26,10 @@ unnamed-1:
         + "new".A3 OPTIONS(DRY RUN);
     explain: SCAN(<,>) | DISTINCT BY PK | FILTER _.A1 LESS_THAN_OR_EQUALS promote(@c15
         AS LONG) | UPDATE A | MAP (_.new.A3 + _.new.A3 AS _0)
-    task_count: 288
-    task_total_time_ms: 1
+    task_count: 290
+    task_total_time_ms: 3
     transform_count: 71
-    transform_time_ms: 0
+    transform_time_ms: 1
     transform_yield_count: 19
     insert_time_ms: 0
     insert_new_count: 25
@@ -38,10 +38,10 @@ unnamed-1:
         + "new".A3;
     explain: SCAN(<,>) | DISTINCT BY PK | FILTER _.A1 LESS_THAN_OR_EQUALS promote(@c15
         AS LONG) | UPDATE A | MAP (_.new.A3 + _.new.A3 AS _0)
-    task_count: 288
-    task_total_time_ms: 1
+    task_count: 290
+    task_total_time_ms: 3
     transform_count: 71
-    transform_time_ms: 0
+    transform_time_ms: 1
     transform_yield_count: 19
     insert_time_ms: 0
     insert_new_count: 25
@@ -49,10 +49,10 @@ unnamed-1:
 -   query: EXPLAIN update A set A2 = 52 where A1 > 2 OPTIONS(DRY RUN);
     explain: SCAN(<,>) | DISTINCT BY PK | FILTER _.A1 GREATER_THAN promote(@c10 AS
         LONG) | UPDATE A
-    task_count: 225
-    task_total_time_ms: 3
+    task_count: 227
+    task_total_time_ms: 2
     transform_count: 55
-    transform_time_ms: 2
+    transform_time_ms: 1
     transform_yield_count: 17
     insert_time_ms: 0
     insert_new_count: 21
@@ -60,10 +60,10 @@ unnamed-1:
 -   query: EXPLAIN update A set A2 = 52 where A1 > 2;
     explain: SCAN(<,>) | DISTINCT BY PK | FILTER _.A1 GREATER_THAN promote(@c10 AS
         LONG) | UPDATE A
-    task_count: 225
-    task_total_time_ms: 3
+    task_count: 227
+    task_total_time_ms: 2
     transform_count: 55
-    transform_time_ms: 2
+    transform_time_ms: 1
     transform_yield_count: 17
     insert_time_ms: 0
     insert_new_count: 21

--- a/yaml-tests/src/test/resources/update-with-versions.metrics.binpb
+++ b/yaml-tests/src/test/resources/update-with-versions.metrics.binpb
@@ -1,0 +1,171 @@
+›
+9
+update-queries-with-versionsEXPLAIN select * from T1;ü
+ü˛˜õ) ¡çV(0îñ	8@GSCAN(<,>) | TFILTER T1 | MAP (_.ID AS ID, _.A AS A, _.B AS B, _.C AS C)πdigraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=polyline;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q2.ID AS ID, q2.A AS A, q2.B AS B, q2.C AS C)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS A, STRING AS B, LONG AS C)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Type Filter</td></tr><tr><td align="left">WHERE record IS [T1]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS A, STRING AS B, LONG AS C, VERSION AS __ROW_VERSION)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(RECORD)" ];
+  4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Primary Storage</td></tr><tr><td align="left">record types: [T1, T2]</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(RECORD)" ];
+  3 -> 2 [ label=<&nbsp;q19> label="q19" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  4 -> 3 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+} 
+M
+update-queries-with-versions-EXPLAIN select "__ROW_VERSION", T1.* from T1;¯
+ü¬⁄ä) ØöO(0‰ü8@fSCAN(<,>) | TFILTER T1 | MAP (version([_]) AS __ROW_VERSION, _.ID AS ID, _.A AS A, _.B AS B, _.C AS C)Ûdigraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=polyline;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (version([q2]) AS __ROW_VERSION, q2.ID AS ID, q2.A AS A, q2.B AS B, q2.C AS C)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(VERSION AS __ROW_VERSION, LONG AS ID, LONG AS A, STRING AS B, LONG AS C)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Type Filter</td></tr><tr><td align="left">WHERE record IS [T1]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS A, STRING AS B, LONG AS C, VERSION AS __ROW_VERSION)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(RECORD)" ];
+  4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Primary Storage</td></tr><tr><td align="left">record types: [T1, T2]</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(RECORD)" ];
+  3 -> 2 [ label=<&nbsp;q19> label="q19" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  4 -> 3 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+} 
+9
+update-queries-with-versionsEXPLAIN select * from T2;å
+ËÜ©ñT ´Ë”(+0ı¿8-@GISCAN(T2$a_with_b <,>) | MAP (_.ID AS ID, _.A AS A, _.B AS B, _.C AS C)•digraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=polyline;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q2.ID AS ID, q2.A AS A, q2.B AS B, q2.C AS C)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS A, STRING AS B, LONG AS C)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS A, STRING AS B, LONG AS C, VERSION AS __ROW_VERSION)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">T2$a_with_b</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS A, STRING AS B, LONG AS C, VERSION AS __ROW_VERSION)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}’
+D
+update-queries-with-versions$EXPLAIN select * from T2 order by a;å
+ÖëﬂæC ñŸµ($0ØŒ8@GISCAN(T2$a_with_b <,>) | MAP (_.ID AS ID, _.A AS A, _.B AS B, _.C AS C)•digraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=polyline;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q2.ID AS ID, q2.A AS A, q2.B AS B, q2.C AS C)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS A, STRING AS B, LONG AS C)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS A, STRING AS B, LONG AS C, VERSION AS __ROW_VERSION)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">T2$a_with_b</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS A, STRING AS B, LONG AS C, VERSION AS __ROW_VERSION)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}Œ
+f
+update-queries-with-versionsFEXPLAIN select "__ROW_VERSION", T2.* from T2 order by "__ROW_VERSION";„
+ŒÊÚí9 ﬂåØ( 0‡‘8@eISCAN(T2$version <,>) | MAP (version([_]) AS __ROW_VERSION, _.ID AS ID, _.A AS A, _.B AS B, _.C AS C)ﬁdigraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=polyline;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (version([q2]) AS __ROW_VERSION, q2.ID AS ID, q2.A AS A, q2.B AS B, q2.C AS C)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(VERSION AS __ROW_VERSION, LONG AS ID, LONG AS A, STRING AS B, LONG AS C)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS A, STRING AS B, LONG AS C, VERSION AS __ROW_VERSION)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">T2$version</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS A, STRING AS B, LONG AS C, VERSION AS __ROW_VERSION)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}é
+s
+update-queries-with-versionsSEXPLAIN select "__ROW_VERSION", T2.* from T2 where a = 40 order by "__ROW_VERSION";ñ
+ﬂÚØ≥e ™ŸÔ('0Á¸8!@ÇISCAN(T2$a_version [EQUALS promote(@c12 AS LONG)]) | MAP (version([_]) AS __ROW_VERSION, _.ID AS ID, _.A AS A, _.B AS B, _.C AS C)Ûdigraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=polyline;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (version([q2]) AS __ROW_VERSION, q2.ID AS ID, q2.A AS A, q2.B AS B, q2.C AS C)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(VERSION AS __ROW_VERSION, LONG AS ID, LONG AS A, STRING AS B, LONG AS C)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">comparisons: [EQUALS promote(@c12 AS LONG)]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS A, STRING AS B, LONG AS C, VERSION AS __ROW_VERSION)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">T2$a_version</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS A, STRING AS B, LONG AS C, VERSION AS __ROW_VERSION)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}í
+S
+update-queries-with-versions3EXPLAIN select * from T1 where a = 10 and b = 'odd'∫
+ˆãÌ„B ¯ùk(0ÎÃ8@óSCAN(<,>) | TFILTER T1 | FILTER _.A EQUALS promote(@c8 AS LONG) AND _.B EQUALS promote(@c12 AS STRING) | MAP (_.ID AS ID, _.A AS A, _.B AS B, _.C AS C)Édigraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=polyline;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q27.ID AS ID, q27.A AS A, q27.B AS B, q27.C AS C)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS A, STRING AS B, LONG AS C)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE q2.A EQUALS promote(@c8 AS LONG) AND q2.B EQUALS promote(@c12 AS STRING)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS A, STRING AS B, LONG AS C, VERSION AS __ROW_VERSION)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Type Filter</td></tr><tr><td align="left">WHERE record IS [T1]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS A, STRING AS B, LONG AS C, VERSION AS __ROW_VERSION)" ];
+  4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(RECORD)" ];
+  5 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Primary Storage</td></tr><tr><td align="left">record types: [T1, T2]</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(RECORD)" ];
+  3 -> 2 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  4 -> 3 [ label=<&nbsp;q20> label="q20" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  5 -> 4 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q27> label="q27" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}ˇ!
+Z
+update-queries-with-versions:EXPLAIN update T1 set c = c + 1 where a = 10 and b = 'odd'†!
+Õ‹ÉèN ˆóm(0Àﬁ8"@µSCAN(<,>) | TFILTER T1 | DISTINCT BY PK | FILTER _.A EQUALS promote(@c12 AS LONG) AND _.B EQUALS promote(@c16 AS STRING) | MAP (_.ID AS ID, _.A AS A, _.B AS B, _.C AS C) | UPDATE T1Àdigraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=polyline;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Modification</td></tr><tr><td align="left">UPDATE</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightcoral" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS A, STRING AS B, LONG AS C AS old, LONG AS ID, LONG AS A, STRING AS B, LONG AS C AS new)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q45.ID AS ID, q45.A AS A, q45.B AS B, q45.C AS C)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS A, STRING AS B, LONG AS C)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE q49.A EQUALS promote(@c12 AS LONG) AND q49.B EQUALS promote(@c16 AS STRING)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS A, STRING AS B, LONG AS C, VERSION AS __ROW_VERSION)" ];
+  4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Unordered Primary Key Distinct</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="12" tooltip="RELATION(LONG AS ID, LONG AS A, STRING AS B, LONG AS C, VERSION AS __ROW_VERSION)" ];
+  5 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Type Filter</td></tr><tr><td align="left">WHERE record IS [T1]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS A, STRING AS B, LONG AS C, VERSION AS __ROW_VERSION)" ];
+  6 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(RECORD)" ];
+  7 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Primary Storage</td></tr><tr><td align="left">record types: [T1, T2]</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(RECORD)" ];
+  8 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Primary Storage</td></tr><tr><td align="left">T1</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS A, STRING AS B, LONG AS C AS old, LONG AS ID, LONG AS A, STRING AS B, LONG AS C AS new)" ];
+  3 -> 2 [ label=<&nbsp;q45> label="q45" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  4 -> 3 [ label=<&nbsp;q49> label="q49" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  5 -> 4 [ label=<&nbsp;q47> label="q47" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  6 -> 5 [ label=<&nbsp;q23> label="q23" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  7 -> 6 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  8 -> 1 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="none" arrowtail="normal" dir="both" ];
+  {
+    rank=same;
+    rankDir=LR;
+    2 -> 8 [ color="red" style="invis" ];
+  }
+}æ
+a
+update-queries-with-versionsAEXPLAIN select * from T2 where a = 30 and id < 100 and b = 'even'ÿ
+Àô»™⁄ √Øˇ(C0ï˘78o@∂ISCAN(T2$a_with_b [EQUALS promote(@c8 AS LONG)]) | FILTER _.ID LESS_THAN promote(@c12 AS LONG) AND _.B EQUALS promote(@c16 AS STRING) | MAP (_.ID AS ID, _.A AS A, _.B AS B, _.C AS C)Ädigraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=polyline;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q2.ID AS ID, q2.A AS A, q2.B AS B, q2.C AS C)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS A, STRING AS B, LONG AS C)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE q2.ID LESS_THAN promote(@c12 AS LONG) AND q2.B EQUALS promote(@c16 AS STRING)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS A, STRING AS B, LONG AS C, VERSION AS __ROW_VERSION)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">comparisons: [EQUALS promote(@c8 AS LONG)]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS A, STRING AS B, LONG AS C, VERSION AS __ROW_VERSION)" ];
+  4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">T2$a_with_b</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS A, STRING AS B, LONG AS C, VERSION AS __ROW_VERSION)" ];
+  3 -> 2 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  4 -> 3 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}æ
+h
+update-queries-with-versionsHEXPLAIN update T2 set c = c + 1 where a = 30 and id < 100 and b = 'even'—
+÷	‚‘üÄ ◊®í(L0¨«@8é@‘ISCAN(T2$a_with_b [EQUALS promote(@c12 AS LONG)]) | DISTINCT BY PK | FILTER _.ID LESS_THAN promote(@c16 AS LONG) AND _.B EQUALS promote(@c20 AS STRING) | MAP (_.ID AS ID, _.A AS A, _.B AS B, _.C AS C) | UPDATE T2⁄digraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=polyline;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Modification</td></tr><tr><td align="left">UPDATE</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightcoral" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS A, STRING AS B, LONG AS C AS old, LONG AS ID, LONG AS A, STRING AS B, LONG AS C AS new)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q186.ID AS ID, q186.A AS A, q186.B AS B, q186.C AS C)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS A, STRING AS B, LONG AS C)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE q190.ID LESS_THAN promote(@c16 AS LONG) AND q190.B EQUALS promote(@c20 AS STRING)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS A, STRING AS B, LONG AS C, VERSION AS __ROW_VERSION)" ];
+  4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Unordered Primary Key Distinct</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="12" tooltip="RELATION(LONG AS ID, LONG AS A, STRING AS B, LONG AS C, VERSION AS __ROW_VERSION)" ];
+  5 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">comparisons: [EQUALS promote(@c12 AS LONG)]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS A, STRING AS B, LONG AS C, VERSION AS __ROW_VERSION)" ];
+  6 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">T2$a_with_b</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS A, STRING AS B, LONG AS C, VERSION AS __ROW_VERSION)" ];
+  7 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Primary Storage</td></tr><tr><td align="left">T2</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS A, STRING AS B, LONG AS C AS old, LONG AS ID, LONG AS A, STRING AS B, LONG AS C AS new)" ];
+  3 -> 2 [ label=<&nbsp;q186> label="q186" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  4 -> 3 [ label=<&nbsp;q190> label="q190" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  5 -> 4 [ label=<&nbsp;q188> label="q188" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  6 -> 5 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  7 -> 1 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="none" arrowtail="normal" dir="both" ];
+  {
+    rank=same;
+    rankDir=LR;
+    2 -> 7 [ color="red" style="invis" ];
+  }
+}é
+s
+update-queries-with-versionsSEXPLAIN select "__ROW_VERSION", T2.* from T2 where a = 30 order by "__ROW_VERSION";ñ
+ﬂÚØ≥e ™ŸÔ('0Á¸8!@ÇISCAN(T2$a_version [EQUALS promote(@c12 AS LONG)]) | MAP (version([_]) AS __ROW_VERSION, _.ID AS ID, _.A AS A, _.B AS B, _.C AS C)Ûdigraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=polyline;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (version([q2]) AS __ROW_VERSION, q2.ID AS ID, q2.A AS A, q2.B AS B, q2.C AS C)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(VERSION AS __ROW_VERSION, LONG AS ID, LONG AS A, STRING AS B, LONG AS C)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">comparisons: [EQUALS promote(@c12 AS LONG)]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS A, STRING AS B, LONG AS C, VERSION AS __ROW_VERSION)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">T2$a_version</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS A, STRING AS B, LONG AS C, VERSION AS __ROW_VERSION)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}

--- a/yaml-tests/src/test/resources/update-with-versions.metrics.yaml
+++ b/yaml-tests/src/test/resources/update-with-versions.metrics.yaml
@@ -1,0 +1,170 @@
+update-queries-with-versions:
+-   query: EXPLAIN select * from T1;
+    explain: SCAN(<,>) | TFILTER T1 | MAP (_.ID AS ID, _.A AS A, _.B AS B, _.C AS
+        C)
+    task_count: 159
+    task_total_time_ms: 2
+    transform_count: 41
+    transform_time_ms: 1
+    transform_yield_count: 13
+    insert_time_ms: 0
+    insert_new_count: 15
+    insert_reused_count: 2
+-   query: EXPLAIN select "__ROW_VERSION", T1.* from T1;
+    explain: SCAN(<,>) | TFILTER T1 | MAP (version([_]) AS __ROW_VERSION, _.ID AS
+        ID, _.A AS A, _.B AS B, _.C AS C)
+    task_count: 159
+    task_total_time_ms: 2
+    transform_count: 41
+    transform_time_ms: 1
+    transform_yield_count: 13
+    insert_time_ms: 0
+    insert_new_count: 15
+    insert_reused_count: 2
+-   query: EXPLAIN select * from T2;
+    explain: ISCAN(T2$a_with_b <,>) | MAP (_.ID AS ID, _.A AS A, _.B AS B, _.C AS
+        C)
+    task_count: 360
+    task_total_time_ms: 6
+    transform_count: 84
+    transform_time_ms: 3
+    transform_yield_count: 43
+    insert_time_ms: 0
+    insert_new_count: 45
+    insert_reused_count: 8
+-   query: EXPLAIN select * from T2 order by a;
+    explain: ISCAN(T2$a_with_b <,>) | MAP (_.ID AS ID, _.A AS A, _.B AS B, _.C AS
+        C)
+    task_count: 261
+    task_total_time_ms: 5
+    transform_count: 67
+    transform_time_ms: 2
+    transform_yield_count: 36
+    insert_time_ms: 0
+    insert_new_count: 27
+    insert_reused_count: 4
+-   query: EXPLAIN select "__ROW_VERSION", T2.* from T2 order by "__ROW_VERSION";
+    explain: ISCAN(T2$version <,>) | MAP (version([_]) AS __ROW_VERSION, _.ID AS ID,
+        _.A AS A, _.B AS B, _.C AS C)
+    task_count: 206
+    task_total_time_ms: 4
+    transform_count: 57
+    transform_time_ms: 2
+    transform_yield_count: 32
+    insert_time_ms: 0
+    insert_new_count: 17
+    insert_reused_count: 2
+-   query: EXPLAIN select "__ROW_VERSION", T2.* from T2 where a = 40 order by "__ROW_VERSION";
+    explain: ISCAN(T2$a_version [EQUALS promote(@c12 AS LONG)]) | MAP (version([_])
+        AS __ROW_VERSION, _.ID AS ID, _.A AS A, _.B AS B, _.C AS C)
+    task_count: 351
+    task_total_time_ms: 7
+    transform_count: 101
+    transform_time_ms: 3
+    transform_yield_count: 39
+    insert_time_ms: 0
+    insert_new_count: 33
+    insert_reused_count: 2
+-   query: EXPLAIN select * from T1 where a = 10 and b = 'odd'
+    explain: SCAN(<,>) | TFILTER T1 | FILTER _.A EQUALS promote(@c8 AS LONG) AND _.B
+        EQUALS promote(@c12 AS STRING) | MAP (_.ID AS ID, _.A AS A, _.B AS B, _.C
+        AS C)
+    task_count: 246
+    task_total_time_ms: 3
+    transform_count: 66
+    transform_time_ms: 1
+    transform_yield_count: 17
+    insert_time_ms: 0
+    insert_new_count: 25
+    insert_reused_count: 2
+-   query: EXPLAIN update T1 set c = c + 1 where a = 10 and b = 'odd'
+    explain: SCAN(<,>) | TFILTER T1 | DISTINCT BY PK | FILTER _.A EQUALS promote(@c12
+        AS LONG) AND _.B EQUALS promote(@c16 AS STRING) | MAP (_.ID AS ID, _.A AS
+        A, _.B AS B, _.C AS C) | UPDATE T1
+    task_count: 333
+    task_total_time_ms: 4
+    transform_count: 78
+    transform_time_ms: 1
+    transform_yield_count: 21
+    insert_time_ms: 0
+    insert_new_count: 34
+    insert_reused_count: 2
+-   query: EXPLAIN select * from T1;
+    explain: SCAN(<,>) | TFILTER T1 | MAP (_.ID AS ID, _.A AS A, _.B AS B, _.C AS
+        C)
+    task_count: 159
+    task_total_time_ms: 2
+    transform_count: 41
+    transform_time_ms: 1
+    transform_yield_count: 13
+    insert_time_ms: 0
+    insert_new_count: 15
+    insert_reused_count: 2
+-   query: EXPLAIN select "__ROW_VERSION", T1.* from T1;
+    explain: SCAN(<,>) | TFILTER T1 | MAP (version([_]) AS __ROW_VERSION, _.ID AS
+        ID, _.A AS A, _.B AS B, _.C AS C)
+    task_count: 159
+    task_total_time_ms: 2
+    transform_count: 41
+    transform_time_ms: 1
+    transform_yield_count: 13
+    insert_time_ms: 0
+    insert_new_count: 15
+    insert_reused_count: 2
+-   query: EXPLAIN select * from T2 where a = 30 and id < 100 and b = 'even'
+    explain: ISCAN(T2$a_with_b [EQUALS promote(@c8 AS LONG)]) | FILTER _.ID LESS_THAN
+        promote(@c12 AS LONG) AND _.B EQUALS promote(@c16 AS STRING) | MAP (_.ID AS
+        ID, _.A AS A, _.B AS B, _.C AS C)
+    task_count: 971
+    task_total_time_ms: 15
+    transform_count: 218
+    transform_time_ms: 6
+    transform_yield_count: 67
+    insert_time_ms: 0
+    insert_new_count: 111
+    insert_reused_count: 6
+-   query: EXPLAIN update T2 set c = c + 1 where a = 30 and id < 100 and b = 'even'
+    explain: ISCAN(T2$a_with_b [EQUALS promote(@c12 AS LONG)]) | DISTINCT BY PK |
+        FILTER _.ID LESS_THAN promote(@c16 AS LONG) AND _.B EQUALS promote(@c20 AS
+        STRING) | MAP (_.ID AS ID, _.A AS A, _.B AS B, _.C AS C) | UPDATE T2
+    task_count: 1238
+    task_total_time_ms: 17
+    transform_count: 256
+    transform_time_ms: 6
+    transform_yield_count: 76
+    insert_time_ms: 1
+    insert_new_count: 142
+    insert_reused_count: 6
+-   query: EXPLAIN select * from T2;
+    explain: ISCAN(T2$a_with_b <,>) | MAP (_.ID AS ID, _.A AS A, _.B AS B, _.C AS
+        C)
+    task_count: 360
+    task_total_time_ms: 6
+    transform_count: 84
+    transform_time_ms: 3
+    transform_yield_count: 43
+    insert_time_ms: 0
+    insert_new_count: 45
+    insert_reused_count: 8
+-   query: EXPLAIN select "__ROW_VERSION", T2.* from T2 order by "__ROW_VERSION";
+    explain: ISCAN(T2$version <,>) | MAP (version([_]) AS __ROW_VERSION, _.ID AS ID,
+        _.A AS A, _.B AS B, _.C AS C)
+    task_count: 206
+    task_total_time_ms: 4
+    transform_count: 57
+    transform_time_ms: 2
+    transform_yield_count: 32
+    insert_time_ms: 0
+    insert_new_count: 17
+    insert_reused_count: 2
+-   query: EXPLAIN select "__ROW_VERSION", T2.* from T2 where a = 30 order by "__ROW_VERSION";
+    explain: ISCAN(T2$a_version [EQUALS promote(@c12 AS LONG)]) | MAP (version([_])
+        AS __ROW_VERSION, _.ID AS ID, _.A AS A, _.B AS B, _.C AS C)
+    task_count: 351
+    task_total_time_ms: 7
+    transform_count: 101
+    transform_time_ms: 3
+    transform_yield_count: 39
+    insert_time_ms: 0
+    insert_new_count: 33
+    insert_reused_count: 2

--- a/yaml-tests/src/test/resources/update-with-versions.yamsql
+++ b/yaml-tests/src/test/resources/update-with-versions.yamsql
@@ -1,0 +1,177 @@
+#
+# update-with-versions.yamsql
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2021-2026 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+schema_template:
+    create table T1(id bigint, a bigint, b string, c bigint, primary key(id))
+
+    create table T2(id bigint, a bigint, b string, c bigint, primary key(id))
+    create index "T2$a_with_b" as select a from T2 order by a
+    create index "T2$version" as select "__ROW_VERSION" from t2
+    create index "T2$a_version" as select a, "__ROW_VERSION" from t2 order by a, "__ROW_VERSION"
+
+    with options (store_row_versions=true)
+---
+test_block:
+  preset: single_repetition_ordered
+  options:
+    connection_lifecycle: block
+  name: update-queries-with-versions
+  tests:
+    -
+      # Insert an initial set of records into T1
+      - query: insert into T1 values
+          (1, 10, 'odd', 0),
+          (2, 10, 'even', 0),
+          (3, 20, 'odd', 0),
+          (4, 20, 'even', 0)
+      - count: 4
+    -
+      - query: select * from T1;
+      - explain: "SCAN(<,>) | TFILTER T1 | MAP (_.ID AS ID, _.A AS A, _.B AS B, _.C AS C)"
+      - unorderedResult: [
+           { ID: 1, A: 10, B: "odd" , C: 0 },
+           { ID: 2, A: 10, B: "even", C: 0 },
+           { ID: 3, A: 20, B: "odd" , C: 0 },
+           { ID: 4, A: 20, B: "even", C: 0 },
+        ]
+    -
+      - query: select "__ROW_VERSION", T1.* from T1;
+      - explain: "SCAN(<,>) | TFILTER T1 | MAP (_.__ROW_VERSION AS __ROW_VERSION, _.ID AS ID, _.A AS A, _.B AS B, _.C AS C)"
+      - unorderedResult: [
+           { '__ROW_VERSION': !not_null _, ID: 1, A: 10, B: "odd",  C: 0 },
+           { '__ROW_VERSION': !not_null _, ID: 2, A: 10, B: "even", C: 0 },
+           { '__ROW_VERSION': !not_null _, ID: 3, A: 20, B: "odd",  C: 0 },
+           { '__ROW_VERSION': !not_null _, ID: 4, A: 20, B: "even", C: 0 },
+        ]
+    -
+      # Insert an initial set of records into T2
+      - query: insert into T2 values
+          (1, 30, 'odd', 0),
+          (2, 30, 'even', 0),
+          (3, 40, 'odd', 0),
+          (4, 40, 'even', 0)
+      - count: 4
+    -
+      - query: select * from T2;
+      - explain: "ISCAN(T2$a_with_b <,>) | MAP (_.ID AS ID, _.A AS A, _.B AS B, _.C AS C)"
+      - unorderedResult: [
+           { ID: 1, A: 30, B: "odd",  C: 0 },
+           { ID: 2, A: 30, B: "even", C: 0 },
+           { ID: 3, A: 40, B: "odd",  C: 0 },
+           { ID: 4, A: 40, B: "even", C: 0 },
+        ]
+    -
+      - query: select * from T2 order by a;
+      - explain: "ISCAN(T2$a_with_b <,>) | MAP (_.ID AS ID, _.A AS A, _.B AS B, _.C AS C)"
+      - result: [
+           { ID: 1, A: 30, B: "odd",  C: 0 },
+           { ID: 2, A: 30, B: "even", C: 0 },
+           { ID: 3, A: 40, B: "odd",  C: 0 },
+           { ID: 4, A: 40, B: "even", C: 0 },
+        ]
+    -
+      - query: select "__ROW_VERSION", T2.* from T2 order by "__ROW_VERSION";
+      - explain: "ISCAN(T2$version <,>) | MAP (_.__ROW_VERSION AS __ROW_VERSION, _.ID AS ID, _.A AS A, _.B AS B, _.C AS C)"
+      - result: [
+           { '__ROW_VERSION': !not_null _, ID: 1, A: 30, B: "odd",  C: 0},
+           { '__ROW_VERSION': !not_null _, ID: 2, A: 30, B: "even", C: 0},
+           { '__ROW_VERSION': !not_null _, ID: 3, A: 40, B: "odd",  C: 0},
+           { '__ROW_VERSION': !not_null _, ID: 4, A: 40, B: "even", C: 0},
+        ]
+    -
+      - query: select "__ROW_VERSION", T2.* from T2 where a = 40 order by "__ROW_VERSION";
+      - explain: "ISCAN(T2$a_version [EQUALS promote(@c12 AS LONG)]) | MAP (_.__ROW_VERSION AS __ROW_VERSION, _.ID AS ID, _.A AS A, _.B AS B, _.C AS C)"
+      - result: [
+           { '__ROW_VERSION': !not_null _, ID: 3, A: 40, B: "odd",  C: 0},
+           { '__ROW_VERSION': !not_null _, ID: 4, A: 40, B: "even", C: 0},
+        ]
+    -
+      # Issue a query on T1 that selects the elements from T1 that will be updated in the next query. This allows us to get the result set and compare the plans
+      - query: select * from T1 where a = 10 and b = 'odd'
+      - explain: "SCAN(<,>) | TFILTER T1 | FILTER _.A EQUALS promote(@c8 AS LONG) AND _.B EQUALS promote(@c12 AS STRING) | MAP (_.ID AS ID, _.A AS A, _.B AS B, _.C AS C)"
+      - result: [
+           { ID: 1, A: 10, B: "odd",  C: 0 },
+        ]
+    -
+      # Update one record in T1. As there are no indexes on the type, it must do a full scan
+      - query: update T1 set c = c + 1 where a = 10 and b = 'odd'
+      - explain: "SCAN(<,>) | TFILTER T1 | DISTINCT BY PK | FILTER _.A EQUALS promote(@c12 AS LONG) AND _.B EQUALS promote(@c16 AS STRING) | MAP (_.ID AS ID, _.A AS A, _.B AS B, _.C AS C) | UPDATE T1"
+      - count: 1
+    -
+      # Validate the update
+      - query: select * from T1;
+      - explain: "SCAN(<,>) | TFILTER T1 | MAP (_.ID AS ID, _.A AS A, _.B AS B, _.C AS C)"
+      - unorderedResult: [
+           { ID: 1, A: 10, B: "odd" , C: 1 },
+           { ID: 2, A: 10, B: "even", C: 0 },
+           { ID: 3, A: 20, B: "odd" , C: 0 },
+           { ID: 4, A: 20, B: "even", C: 0 },
+        ]
+    -
+      - query: select "__ROW_VERSION", T1.* from T1;
+      - explain: "SCAN(<,>) | TFILTER T1 | MAP (_.__ROW_VERSION AS __ROW_VERSION, _.ID AS ID, _.A AS A, _.B AS B, _.C AS C)"
+      - unorderedResult: [
+           { '__ROW_VERSION': !not_null _, ID: 1, A: 10, B: "odd",  C: 1 },
+           { '__ROW_VERSION': !not_null _, ID: 2, A: 10, B: "even", C: 0 },
+           { '__ROW_VERSION': !not_null _, ID: 3, A: 20, B: "odd",  C: 0 },
+           { '__ROW_VERSION': !not_null _, ID: 4, A: 20, B: "even", C: 0 },
+        ]
+
+    -
+      # Issue a query on T2 that selects the elements from T2 that will be updated in the next query
+      - query: select * from T2 where a = 30 and id < 100 and b = 'even'
+      - explain: "ISCAN(T2$a_with_b [EQUALS promote(@c8 AS LONG)]) | FILTER _.ID LESS_THAN promote(@c12 AS LONG) AND _.B EQUALS promote(@c16 AS STRING) | MAP (_.ID AS ID, _.A AS A, _.B AS B, _.C AS C)"
+      - result: [
+           { ID: 2, A: 30, B: "even", C: 0},
+        ]
+    -
+      # Update one record in T2
+      - query: update T2 set c = c + 1 where a = 30 and id < 100 and b = 'even'
+      - explain: "ISCAN(T2$a_with_b [EQUALS promote(@c12 AS LONG)]) | DISTINCT BY PK | FILTER _.ID LESS_THAN promote(@c16 AS LONG) AND _.B EQUALS promote(@c20 AS STRING) | MAP (_.ID AS ID, _.A AS A, _.B AS B, _.C AS C) | UPDATE T2"
+      - count: 1
+    -
+      # Validate the results
+      - query: select * from T2;
+      - explain: "ISCAN(T2$a_with_b <,>) | MAP (_.ID AS ID, _.A AS A, _.B AS B, _.C AS C)"
+      - unorderedResult: [
+           { ID: 1, A: 30, B: "odd",  C: 0 },
+           { ID: 2, A: 30, B: "even", C: 1 },
+           { ID: 3, A: 40, B: "odd",  C: 0 },
+           { ID: 4, A: 40, B: "even", C: 0 },
+        ]
+    -
+      # Make sure the updated record now has the largest version
+      - query: select "__ROW_VERSION", T2.* from T2 order by "__ROW_VERSION";
+      - explain: "ISCAN(T2$version <,>) | MAP (_.__ROW_VERSION AS __ROW_VERSION, _.ID AS ID, _.A AS A, _.B AS B, _.C AS C)"
+      - unorderedResult: [
+           { '__ROW_VERSION': !not_null _, ID: 1, A: 30, B: "odd",  C: 0 },
+           { '__ROW_VERSION': !not_null _, ID: 3, A: 40, B: "odd",  C: 0 },
+           { '__ROW_VERSION': !not_null _, ID: 4, A: 40, B: "even", C: 0 },
+           { '__ROW_VERSION': !not_null _, ID: 2, A: 30, B: "even", C: 1 },
+        ]
+    -
+      # Make sure the updated record still has the largest version within the group of values sharing the same "A" value
+      - query: select "__ROW_VERSION", T2.* from T2 where a = 30 order by "__ROW_VERSION";
+      - explain: "ISCAN(T2$a_version [EQUALS promote(@c12 AS LONG)]) | MAP (_.__ROW_VERSION AS __ROW_VERSION, _.ID AS ID, _.A AS A, _.B AS B, _.C AS C)"
+      - unorderedResult: [
+           { '__ROW_VERSION': !not_null _, ID: 1, A: 30, B: "odd",  C: 0 },
+           { '__ROW_VERSION': !not_null _, ID: 2, A: 30, B: "even", C: 1 },
+        ]
+...

--- a/yaml-tests/src/test/resources/valid-identifiers.metrics.binpb
+++ b/yaml-tests/src/test/resources/valid-identifiers.metrics.binpb
@@ -540,7 +540,7 @@ S
 }ı
 k
 update-delete-statementsOEXPLAIN UPDATE "foo.tableA" SET "foo.tableA.A2" = 100 WHERE "foo.tableA.A1" = 1Ö
-Á˝ã⁄í ≈“Ï(90ÂÓw8W@æCOVERING(foo.tableA.idx [EQUALS promote(@c10 AS LONG)] -> [foo__2tableA__2A1: KEY:[0], foo__2tableA__2A2: KEY:[1], foo__2tableA__2A3: KEY:[2]]) | DISTINCT BY PK | FETCH | UPDATE foo__2tableA•digraph G {
+Ú˛·”í åùª(90î¸8W@æCOVERING(foo.tableA.idx [EQUALS promote(@c10 AS LONG)] -> [foo__2tableA__2A1: KEY:[0], foo__2tableA__2A2: KEY:[1], foo__2tableA__2A3: KEY:[2]]) | DISTINCT BY PK | FETCH | UPDATE foo__2tableA•digraph G {
   fontname=courier;
   rankdir=BT;
   splines=polyline;
@@ -563,27 +563,27 @@ k
 }√
 ã
 update-delete-statementsoEXPLAIN UPDATE "foo.tableA" SET "foo.tableA.A2" = 100 WHERE "foo.tableA.A1" > 1 RETURNING "new"."foo.tableA.A1"≤
-†Ø◊ß† ”–Ô(90äÍ<8[@ÛCOVERING(foo.tableA.idx [[GREATER_THAN promote(@c10 AS LONG)]] -> [foo__2tableA__2A1: KEY:[0], foo__2tableA__2A2: KEY:[1], foo__2tableA__2A3: KEY:[2]]) | DISTINCT BY PK | FETCH | UPDATE foo__2tableA | MAP (_.new.foo.tableA.A1 AS foo.tableA.A1)ùdigraph G {
+´Ü¢Ï† ÅÕƒ(90ﬁô8[@ÛCOVERING(foo.tableA.idx [[GREATER_THAN promote(@c10 AS LONG)]] -> [foo__2tableA__2A1: KEY:[0], foo__2tableA__2A2: KEY:[1], foo__2tableA__2A3: KEY:[2]]) | DISTINCT BY PK | FETCH | UPDATE foo__2tableA | MAP (_.new.foo.tableA.A1 AS foo.tableA.A1)ùdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=polyline;
   1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q6.new.foo.tableA.A1 AS foo.tableA.A1)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS foo.tableA.A1)" ];
   2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Modification</td></tr><tr><td align="left">UPDATE</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightcoral" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS foo.tableA.A1, LONG AS foo.tableA.A2, LONG AS foo.tableA.A3 AS old, LONG AS foo.tableA.A1, LONG AS foo.tableA.A2, LONG AS foo.tableA.A3 AS new)" ];
-  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Fetch Records</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="12" tooltip="RELATION(LONG AS foo.tableA.A1, LONG AS foo.tableA.A2, LONG AS foo.tableA.A3)" ];
-  4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Primary Storage</td></tr><tr><td align="left">foo__2tableA</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS foo.tableA.A1, LONG AS foo.tableA.A2, LONG AS foo.tableA.A3 AS old, LONG AS foo.tableA.A1, LONG AS foo.tableA.A2, LONG AS foo.tableA.A3 AS new)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Primary Storage</td></tr><tr><td align="left">foo__2tableA</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS foo.tableA.A1, LONG AS foo.tableA.A2, LONG AS foo.tableA.A3 AS old, LONG AS foo.tableA.A1, LONG AS foo.tableA.A2, LONG AS foo.tableA.A3 AS new)" ];
+  4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Fetch Records</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="12" tooltip="RELATION(LONG AS foo.tableA.A1, LONG AS foo.tableA.A2, LONG AS foo.tableA.A3)" ];
   5 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Unordered Primary Key Distinct</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="12" tooltip="RELATION(LONG AS foo.tableA.A1, LONG AS foo.tableA.A2, LONG AS foo.tableA.A3)" ];
   6 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Covering Index Scan</td></tr><tr><td align="left">comparisons: [[GREATER_THAN promote(@c10 AS LONG)]]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS foo.tableA.A1, LONG AS foo.tableA.A2, LONG AS foo.tableA.A3)" ];
   7 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">foo.tableA.idx</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS foo.tableA.A1, LONG AS foo.tableA.A2, LONG AS foo.tableA.A3)" ];
-  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  4 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="none" arrowtail="normal" dir="both" ];
-  5 -> 3 [ label=<&nbsp;q115> label="q115" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="none" arrowtail="normal" dir="both" ];
+  4 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  5 -> 4 [ label=<&nbsp;q115> label="q115" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   6 -> 5 [ label=<&nbsp;q113> label="q113" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   7 -> 6 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   {
     rank=same;
     rankDir=LR;
-    3 -> 4 [ color="red" style="invis" ];
+    4 -> 3 [ color="red" style="invis" ];
   }
 }≈
 î

--- a/yaml-tests/src/test/resources/valid-identifiers.metrics.yaml
+++ b/yaml-tests/src/test/resources/valid-identifiers.metrics.yaml
@@ -498,12 +498,12 @@ update-delete-statements:
     explain: 'COVERING(foo.tableA.idx [EQUALS promote(@c10 AS LONG)] -> [foo__2tableA__2A1:
         KEY:[0], foo__2tableA__2A2: KEY:[1], foo__2tableA__2A3: KEY:[2]]) | DISTINCT
         BY PK | FETCH | UPDATE foo__2tableA'
-    task_count: 743
-    task_total_time_ms: 18
+    task_count: 754
+    task_total_time_ms: 7
     transform_count: 146
-    transform_time_ms: 8
+    transform_time_ms: 3
     transform_yield_count: 57
-    insert_time_ms: 1
+    insert_time_ms: 0
     insert_new_count: 87
     insert_reused_count: 6
 -   query: EXPLAIN UPDATE "foo.tableA" SET "foo.tableA.A2" = 100 WHERE "foo.tableA.A1"
@@ -512,10 +512,10 @@ update-delete-statements:
     explain: 'COVERING(foo.tableA.idx [[GREATER_THAN promote(@c10 AS LONG)]] -> [foo__2tableA__2A1:
         KEY:[0], foo__2tableA__2A2: KEY:[1], foo__2tableA__2A3: KEY:[2]]) | DISTINCT
         BY PK | FETCH | UPDATE foo__2tableA | MAP (_.new.foo.tableA.A1 AS foo.tableA.A1)'
-    task_count: 800
-    task_total_time_ms: 13
+    task_count: 811
+    task_total_time_ms: 8
     transform_count: 160
-    transform_time_ms: 6
+    transform_time_ms: 3
     transform_yield_count: 57
     insert_time_ms: 0
     insert_new_count: 91

--- a/yaml-tests/src/test/resources/versions-tests.metrics.binpb
+++ b/yaml-tests/src/test/resources/versions-tests.metrics.binpb
@@ -1,25 +1,25 @@
-Ÿ&
+Ú&
 X
-versions-dmlHEXPLAIN UPDATE t3 SET col2 = col2 + 1 WHERE col1 = 'a' RETURNING "new".*¸%
-®ïıüSá èÆ£7($0ﬂ¶˜8=@êCOVERING(T3_VERSION_WITH_COL1 <,> -> [COL1: VALUE:[0], ID: KEY:[2]]) | FILTER _.COL1 EQUALS promote(@c12 AS STRING) | FETCH | MAP (_.ID AS ID, _.COL1 AS COL1, _.COL2 AS COL2) | DISTINCT BY PK | UPDATE T3 | MAP ((_.new).ID AS ID, (_.new).COL1 AS COL1, (_.new).COL2 AS COL2)…#digraph G {
+versions-dmlHEXPLAIN UPDATE t3 SET col2 = col2 + 1 WHERE col1 = 'a' RETURNING "new".*ï&
+ßØÀ»ô »Ïñ()0Ñœ8I@êCOVERING(T3_VERSION_WITH_COL1 <,> -> [COL1: VALUE:[0], ID: KEY:[2]]) | DISTINCT BY PK | FILTER _.COL1 EQUALS promote(@c12 AS STRING) | FETCH | MAP (_.ID AS ID, _.COL1 AS COL1, _.COL2 AS COL2) | UPDATE T3 | MAP ((_.new).ID AS ID, (_.new).COL1 AS COL1, (_.new).COL2 AS COL2)„#digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
   1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP ((q6.new).ID AS ID, (q6.new).COL1 AS COL1, (q6.new).COL2 AS COL2)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS COL1, LONG AS COL2)" ];
   2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Modification</td></tr><tr><td align="left">UPDATE</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightcoral" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS COL1, LONG AS COL2 AS old, LONG AS ID, STRING AS COL1, LONG AS COL2 AS new)" ];
-  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Unordered Primary Key Distinct</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="12" tooltip="RELATION(LONG AS ID, STRING AS COL1, LONG AS COL2)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q87.ID AS ID, q87.COL1 AS COL1, q87.COL2 AS COL2)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS COL1, LONG AS COL2)" ];
   4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Primary Storage</td></tr><tr><td align="left">T3</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS COL1, LONG AS COL2 AS old, LONG AS ID, STRING AS COL1, LONG AS COL2 AS new)" ];
-  5 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q50.ID AS ID, q50.COL1 AS COL1, q50.COL2 AS COL2)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS COL1, LONG AS COL2)" ];
-  6 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Fetch Records</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="12" tooltip="RELATION(LONG AS ID, STRING AS COL1, LONG AS COL2, VERSION AS __ROW_VERSION)" ];
-  7 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE q52.COL1 EQUALS promote(@c12 AS STRING)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS COL1, LONG AS COL2, VERSION AS __ROW_VERSION)" ];
+  5 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Fetch Records</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="12" tooltip="RELATION(LONG AS ID, STRING AS COL1, LONG AS COL2, VERSION AS __ROW_VERSION)" ];
+  6 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE q99.COL1 EQUALS promote(@c12 AS STRING)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS COL1, LONG AS COL2, VERSION AS __ROW_VERSION)" ];
+  7 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Unordered Primary Key Distinct</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="12" tooltip="RELATION(LONG AS ID, STRING AS COL1, LONG AS COL2, VERSION AS __ROW_VERSION)" ];
   8 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Covering Index Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS COL1, LONG AS COL2, VERSION AS __ROW_VERSION)" ];
   9 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">T3_VERSION_WITH_COL1</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS COL1, LONG AS COL2, VERSION AS __ROW_VERSION)" ];
   3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   4 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="none" arrowtail="normal" dir="both" ];
-  5 -> 3 [ label=<&nbsp;q78> label="q78" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  6 -> 5 [ label=<&nbsp;q50> label="q50" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  7 -> 6 [ label=<&nbsp;q54> label="q54" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  8 -> 7 [ label=<&nbsp;q52> label="q52" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  5 -> 3 [ label=<&nbsp;q87> label="q87" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  6 -> 5 [ label=<&nbsp;q95> label="q95" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  7 -> 6 [ label=<&nbsp;q99> label="q99" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  8 -> 7 [ label=<&nbsp;q97> label="q97" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   9 -> 8 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   {

--- a/yaml-tests/src/test/resources/versions-tests.metrics.yaml
+++ b/yaml-tests/src/test/resources/versions-tests.metrics.yaml
@@ -2,17 +2,17 @@ versions-dml:
 -   query: EXPLAIN UPDATE t3 SET col2 = col2 + 1 WHERE col1 = 'a' RETURNING "new".*
     ref: versions-tests.yamsql:146
     explain: 'COVERING(T3_VERSION_WITH_COL1 <,> -> [COL1: VALUE:[0], ID: KEY:[2]])
-        | FILTER _.COL1 EQUALS promote(@c12 AS STRING) | FETCH | MAP (_.ID AS ID,
-        _.COL1 AS COL1, _.COL2 AS COL2) | DISTINCT BY PK | UPDATE T3 | MAP ((_.new).ID
+        | DISTINCT BY PK | FILTER _.COL1 EQUALS promote(@c12 AS STRING) | FETCH |
+        MAP (_.ID AS ID, _.COL1 AS COL1, _.COL2 AS COL2) | UPDATE T3 | MAP ((_.new).ID
         AS ID, (_.new).COL1 AS COL1, (_.new).COL2 AS COL2)'
-    task_count: 552
-    task_total_time_ms: 174
-    transform_count: 135
-    transform_time_ms: 115
-    transform_yield_count: 36
-    insert_time_ms: 12
-    insert_new_count: 61
-    insert_reused_count: 3
+    task_count: 679
+    task_total_time_ms: 7
+    transform_count: 153
+    transform_time_ms: 2
+    transform_yield_count: 41
+    insert_time_ms: 0
+    insert_new_count: 73
+    insert_reused_count: 4
 versions-queries:
 -   query: EXPLAIN select "__ROW_VERSION" as version, t1.col2 from t1 where col1 =
         10;
@@ -680,7 +680,7 @@ versions-queries:
     insert_reused_count: 12
 -   query: EXPLAIN select (A.*), (B.*) from t2_v(2) as A, t3_v(2) as B where A.col2
         = B.col1
-    ref: versions-tests.yamsql:740
+    ref: versions-tests.yamsql:741
     explain: ISCAN(T3_VERSION_WITH_COL1 <,>) | FILTER _.COL2 EQUALS promote(@c16 AS
         LONG) | FLATMAP q0 -> { ISCAN(T2_COL2 [EQUALS q0.COL1]) | FILTER _.COL1 EQUALS
         promote(@c16 AS LONG) AS q1 RETURN ((q1.__ROW_VERSION AS __ROW_VERSION, q1.ID
@@ -696,7 +696,7 @@ versions-queries:
     insert_reused_count: 10
 -   query: EXPLAIN select (A.*) as A, (B.*) as B, (C.*) as C from t2_v(2) as A, t3_v(2)
         as B, t4_v(2) as C where A.col2 = B.col1 AND B.col1 = C.col1
-    ref: versions-tests.yamsql:753
+    ref: versions-tests.yamsql:754
     explain: ISCAN(T3_VERSION_WITH_COL1 <,>) | FILTER _.COL2 EQUALS promote(@c28 AS
         LONG) | FLATMAP q0 -> { ISCAN(T3_VERSION_WITH_COL1 <,>) | FILTER _.COL2 EQUALS
         promote(@c28 AS LONG) AND q0.COL1 EQUALS _.COL1 | FLATMAP q1 -> { ISCAN(T2_COL2

--- a/yaml-tests/src/test/resources/versions-tests.yamsql
+++ b/yaml-tests/src/test/resources/versions-tests.yamsql
@@ -143,7 +143,7 @@ test_block:
            SET col2 = col2 + 1
            WHERE col1 = 'a'
            RETURNING "new".*
-      - explain: "COVERING(T3_VERSION_WITH_COL1 <,> -> [COL1: VALUE:[0], ID: KEY:[2]]) | FILTER _.COL1 EQUALS promote(@c12 AS STRING) | FETCH | MAP (_.ID AS ID, _.COL1 AS COL1, _.COL2 AS COL2) | DISTINCT BY PK | UPDATE T3 | MAP ((_.new).ID AS ID, (_.new).COL1 AS COL1, (_.new).COL2 AS COL2)"
+      - explain: "COVERING(T3_VERSION_WITH_COL1 <,> -> [COL1: VALUE:[0], ID: KEY:[2]]) | DISTINCT BY PK | FILTER _.COL1 EQUALS promote(@c12 AS STRING) | FETCH | MAP (_.ID AS ID, _.COL1 AS COL1, _.COL2 AS COL2) | UPDATE T3 | MAP ((_.new).ID AS ID, (_.new).COL1 AS COL1, (_.new).COL2 AS COL2)"
       - unorderedResult: [
           { ID:  1, COL1: "a", COL2: 2},
           { ID:  5, COL1: "a", COL2: 2},


### PR DESCRIPTION
This adds a new planner rule to push a distinct-by-primary-key operator below a map operator. This can be relevant for plans like an update plan when there are version columns (now broken out into its own yamsql file) as the new logic added in 4.9.0.1 (see: #3809) can result in additional maps being inserted into plans in such a way that the distinct was forced to happen after. This also had some knock on effects like resulting in preferring an index scan over a covering scan if there were some predicates that could be pushed below a fetch (but also some that couldn't).

This resolves #3858.