### PR TITLE
Reverted: ~Update to minor version 4.10 as continuations are no longer compatible with 4.8~

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@
 #
 
 rootProject.name=fdb-record-layer
-version=4.9.3.0
+version=4.10.0.0
 releaseBuild=false
 
 # this should be false for release branches (i.e. if there is no -SNAPSHOT on the above version)


### PR DESCRIPTION
The PR #3800 leverages logic that was added into 4.9 with #3809. As a result, its continuations are no longer compatible with 4.8. To signal that, this updates the minor version from 4.9 to 4.10