### PR TITLE
Support mixed-type partition columns in HNSW indexes and validate sort order specifications.

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/AbstractArrayConstructorValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/AbstractArrayConstructorValue.java
@@ -215,6 +215,12 @@ public abstract class AbstractArrayConstructorValue extends AbstractValue implem
             if (Iterables.isEmpty(newChildren)) {
                 return this;
             }
+            if (getElementType().isAny()) {
+                if (elementsArePairwiseReferenceEqual(newChildren, getChildren())) {
+                    return this;
+                }
+                return LightArrayConstructorValue.of(ImmutableList.copyOf(newChildren), getElementType());
+            }
             Verify.verify(resolveElementType(newChildren).equals(getElementType()));
             final var newChildrenPromoted = injectPromotions(newChildren, getElementType());
             if (elementsArePairwiseReferenceEqual(newChildrenPromoted, getChildren())) {

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/exceptions/ErrorCode.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/exceptions/ErrorCode.java
@@ -76,6 +76,7 @@ public enum ErrorCode {
     // Class 0A - Feature not supported
     UNSUPPORTED_OPERATION("0A000"),
     UNSUPPORTED_QUERY("0AF00"),
+    UNSUPPORTED_SORT("0AF01"),
 
     // Class 22 - Data Exception
     CANNOT_CONVERT_TYPE("22000"),

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/ExpressionVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/ExpressionVisitor.java
@@ -22,6 +22,7 @@ package com.apple.foundationdb.relational.recordlayer.query.visitors;
 
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.provider.foundationdb.VectorIndexScanOptions;
+import com.apple.foundationdb.record.query.plan.cascades.OrderingPart;
 import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
 import com.apple.foundationdb.record.query.plan.cascades.predicates.CompatibleTypeEvolutionPredicate;
 import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
@@ -267,16 +268,18 @@ public final class ExpressionVisitor extends DelegatingVisitor<BaseVisitor> {
 
         final var partitionExpressions = windowSpecExpression.getPartitions();
         final var partitionValues = Streams.stream(partitionExpressions.underlying()).collect(ImmutableList.toImmutableList());
-        final var partitionArray = partitionValues.isEmpty() ? AbstractArrayConstructorValue.LightArrayConstructorValue.emptyArray(Type.any())
-                                                             : AbstractArrayConstructorValue.LightArrayConstructorValue.of(partitionValues);
+        final var partitionArray = AbstractArrayConstructorValue.LightArrayConstructorValue.of(partitionValues, Type.any());
 
         final var orderByExpressions = windowSpecExpression.getOrderByExpressions();
+        final var allowedSortSpecs = StreamSupport.stream(orderByExpressions.spliterator(), false)
+                .allMatch(exp -> exp.toSortOrder() == OrderingPart.RequestedSortOrder.ASCENDING || exp.toSortOrder() == OrderingPart.RequestedSortOrder.ANY);
+        Assert.thatUnchecked(allowedSortSpecs, ErrorCode.UNSUPPORTED_SORT, "provided sort specification not supported with window function");
+        // TODO should pass down sort specification correctly.
         final var orderByValues = StreamSupport.stream(orderByExpressions.spliterator(), false).map(r -> r.getExpression().getUnderlying())
                 .collect(ImmutableList.toImmutableList());
 
         final ImmutableList.Builder<Expression> argumentsBuilder = ImmutableList.builder();
-        final var orderByArray = orderByValues.isEmpty() ? AbstractArrayConstructorValue.LightArrayConstructorValue.emptyArray(Type.any())
-                                                         :  AbstractArrayConstructorValue.LightArrayConstructorValue.of(orderByValues);
+        final var orderByArray = AbstractArrayConstructorValue.LightArrayConstructorValue.of(orderByValues, Type.any());
         argumentsBuilder.add(Expression.ofUnnamed(partitionArray)).add(Expression.ofUnnamed(orderByArray));
 
         final var higherOrderArgumentsBuilder = ImmutableList.<Expressions>builder();

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/cache/ValueSpecificConstraintTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/cache/ValueSpecificConstraintTests.java
@@ -312,31 +312,31 @@ public class ValueSpecificConstraintTests {
             // First query with EF_SEARCH = 100 and k = 10
             preparedQueryShouldMissCache(connection,
                     "SELECT * FROM photos WHERE zone = '1' and name = 'Alice' " +
-                    "qualify row_number() OVER (PARTITION BY zone, name ORDER BY euclidean_distance(embedding, ?) DESC OPTIONS EF_SEARCH = 100) < ?",
+                    "qualify row_number() OVER (PARTITION BY zone, name ORDER BY euclidean_distance(embedding, ?) ASC OPTIONS EF_SEARCH = 100) < ?",
                     ImmutableMap.of(1, queryVector, 2, 10));
 
             // Same query should hit cache
             preparedQueryShouldHitCache(connection,
                     "SELECT * FROM photos WHERE zone = '1' and name = 'Alice' " +
-                    "qualify row_number() OVER (PARTITION BY zone, name ORDER BY euclidean_distance(embedding, ?) DESC OPTIONS EF_SEARCH = 100) < ?",
+                    "qualify row_number() OVER (PARTITION BY zone, name ORDER BY euclidean_distance(embedding, ?) ASC OPTIONS EF_SEARCH = 100) < ?",
                     ImmutableMap.of(1, queryVector, 2, 10));
 
             // Different EF_SEARCH value should miss cache
             preparedQueryShouldMissCache(connection,
                     "SELECT * FROM photos WHERE zone = '1' and name = 'Alice' " +
-                    "qualify row_number() OVER (PARTITION BY zone, name ORDER BY euclidean_distance(embedding, ?) DESC OPTIONS EF_SEARCH = 200) < ?",
+                    "qualify row_number() OVER (PARTITION BY zone, name ORDER BY euclidean_distance(embedding, ?) ASC OPTIONS EF_SEARCH = 200) < ?",
                     ImmutableMap.of(1, queryVector, 2, 10));
 
             // Same EF_SEARCH = 200 should hit cache
             preparedQueryShouldHitCache(connection,
                     "SELECT * FROM photos WHERE zone = '1' and name = 'Alice' " +
-                    "qualify row_number() OVER (PARTITION BY zone, name ORDER BY euclidean_distance(embedding, ?) DESC OPTIONS EF_SEARCH = 200) < ?",
+                    "qualify row_number() OVER (PARTITION BY zone, name ORDER BY euclidean_distance(embedding, ?) ASC OPTIONS EF_SEARCH = 200) < ?",
                     ImmutableMap.of(1, queryVector, 2, 10));
 
             // Different k value (15 instead of 10) should miss cache
             preparedQueryShouldHitCache(connection,
                     "SELECT * FROM photos WHERE zone = '1' and name = 'Alice' " +
-                    "qualify row_number() OVER (PARTITION BY zone, name ORDER BY euclidean_distance(embedding, ?) DESC OPTIONS EF_SEARCH = 200) < ?",
+                    "qualify row_number() OVER (PARTITION BY zone, name ORDER BY euclidean_distance(embedding, ?) ASC OPTIONS EF_SEARCH = 200) < ?",
                     ImmutableMap.of(1, queryVector, 2, 15));
         }
     }

--- a/yaml-tests/src/test/resources/semantic-search.metrics.binpb
+++ b/yaml-tests/src/test/resources/semantic-search.metrics.binpb
@@ -321,4 +321,100 @@
     rankDir=LR;
     6 -> 7 [ color="red" style="invis" ];
   }
+}Ó
+å
+semantic-search-testsÚEXPLAIN select docId, title, euclidean_distance(embedding, ?) from multiTypePartitionDocs where zoneId = 1 and bookshelf = 'fiction' qualify row_number() over (partition by zoneId, bookshelf order by euclidean_distance(embedding, ?) asc) <= 1‹
+‰®ÁÛC ÌÛ∂(0√Ñ8@ÚISCAN(MULTITYPEEUCLIDEANINDEX [EQUALS promote(@c17 AS LONG), EQUALS promote(@c21 AS STRING)]:{DISTANCE_RANK_LESS_THAN_OR_EQUAL @c39: @c17}:[] BY_DISTANCE) | MAP (_.DOCID AS DOCID, _.TITLE AS TITLE, (_.EMBEDDING) euclidean_distance @c39 AS _2)…digraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=line;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q2.DOCID AS DOCID, q2.TITLE AS TITLE, (q2.EMBEDDING) euclidean_distance @c39 AS _2)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(STRING AS DOCID, STRING AS TITLE, DOUBLE AS _2)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">prefix comparisons: [EQUALS promote(@c17 AS LONG), EQUALS promote(@c21 AS STRING)]</td></tr><tr><td align="left">distanceRank: DISTANCE_RANK_LESS_THAN_OR_EQUAL @c39: @c17</td></tr><tr><td align="left">scan options: []</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ZONEID, STRING AS DOCID, STRING AS BOOKSHELF, STRING AS TITLE, VECTOR(16, 3) AS EMBEDDING)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">MULTITYPEEUCLIDEANINDEX</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ZONEID, STRING AS DOCID, STRING AS BOOKSHELF, STRING AS TITLE, VECTOR(16, 3) AS EMBEDDING)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}§
+„
+semantic-search-tests…EXPLAIN select docId from multiTypePartitionDocs where zoneId = 1 and bookshelf = 'science' qualify row_number() over (partition by zoneId, bookshelf order by euclidean_distance(embedding, ?) asc) <= 2ª
+‰∏ê“C ﬂÔ˚(0æâ8@≤ISCAN(MULTITYPEEUCLIDEANINDEX [EQUALS promote(@c8 AS LONG), EQUALS promote(@c12 AS STRING)]:{DISTANCE_RANK_LESS_THAN_OR_EQUAL @c30: @c36}:[] BY_DISTANCE) | MAP (_.DOCID AS DOCID)Ëdigraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=line;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q2.DOCID AS DOCID)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(STRING AS DOCID)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">prefix comparisons: [EQUALS promote(@c8 AS LONG), EQUALS promote(@c12 AS STRING)]</td></tr><tr><td align="left">distanceRank: DISTANCE_RANK_LESS_THAN_OR_EQUAL @c30: @c36</td></tr><tr><td align="left">scan options: []</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ZONEID, STRING AS DOCID, STRING AS BOOKSHELF, STRING AS TITLE, VECTOR(16, 3) AS EMBEDDING)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">MULTITYPEEUCLIDEANINDEX</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ZONEID, STRING AS DOCID, STRING AS BOOKSHELF, STRING AS TITLE, VECTOR(16, 3) AS EMBEDDING)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}è
+‚
+semantic-search-tests»EXPLAIN select docId from multiTypePartitionDocs where zoneId = 2 and bookshelf = 'fiction' qualify row_number() over (partition by zoneId, bookshelf order by euclidean_distance(embedding, ?) asc) < 2ß
+‰ëÒ∂C …≥ﬁ(0°«8@®ISCAN(MULTITYPEEUCLIDEANINDEX [EQUALS promote(@c8 AS LONG), EQUALS promote(@c12 AS STRING)]:{DISTANCE_RANK_LESS_THAN @c30: @c8}:[] BY_DISTANCE) | MAP (_.DOCID AS DOCID)ﬁdigraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=line;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q2.DOCID AS DOCID)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(STRING AS DOCID)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">prefix comparisons: [EQUALS promote(@c8 AS LONG), EQUALS promote(@c12 AS STRING)]</td></tr><tr><td align="left">distanceRank: DISTANCE_RANK_LESS_THAN @c30: @c8</td></tr><tr><td align="left">scan options: []</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ZONEID, STRING AS DOCID, STRING AS BOOKSHELF, STRING AS TITLE, VECTOR(16, 3) AS EMBEDDING)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">MULTITYPEEUCLIDEANINDEX</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ZONEID, STRING AS DOCID, STRING AS BOOKSHELF, STRING AS TITLE, VECTOR(16, 3) AS EMBEDDING)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}ü
+ˇ
+semantic-search-testsÂEXPLAIN select docId, cosine_distance(embedding, ?) from multiTypePartitionDocs where zoneId = 1 and bookshelf = 'fiction' qualify row_number() over (partition by zoneId, bookshelf order by cosine_distance(embedding, ?) asc) <= 3ö
+‰∆·¡C àÿÜ(0§à8@⁄ISCAN(MULTITYPECOSINEINDEX [EQUALS promote(@c15 AS LONG), EQUALS promote(@c19 AS STRING)]:{DISTANCE_RANK_LESS_THAN_OR_EQUAL @c37: @c43}:[] BY_DISTANCE) | MAP (_.DOCID AS DOCID, (_.EMBEDDING) cosine_distance @c37 AS _1)üdigraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=line;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q2.DOCID AS DOCID, (q2.EMBEDDING) cosine_distance @c37 AS _1)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(STRING AS DOCID, DOUBLE AS _1)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">prefix comparisons: [EQUALS promote(@c15 AS LONG), EQUALS promote(@c19 AS STRING)]</td></tr><tr><td align="left">distanceRank: DISTANCE_RANK_LESS_THAN_OR_EQUAL @c37: @c43</td></tr><tr><td align="left">scan options: []</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ZONEID, STRING AS DOCID, STRING AS BOOKSHELF, STRING AS TITLE, VECTOR(16, 3) AS EMBEDDING)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">MULTITYPECOSINEINDEX</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ZONEID, STRING AS DOCID, STRING AS BOOKSHELF, STRING AS TITLE, VECTOR(16, 3) AS EMBEDDING)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}ﬁ
+˚
+semantic-search-tests·EXPLAIN select docId from multiTypePartitionDocs where zoneId = 2 and bookshelf = 'science' qualify row_number() over (partition by zoneId, bookshelf order by euclidean_distance(embedding, ?) asc options ef_search = 100) <= 1›
+‰€âæC ‰«Ö(0ÏÅ8@√ISCAN(MULTITYPEEUCLIDEANINDEX [EQUALS promote(@c8 AS LONG), EQUALS promote(@c12 AS STRING)]:{DISTANCE_RANK_LESS_THAN_OR_EQUAL @c30: @c40}:[hnswEfSearch: 100] BY_DISTANCE) | MAP (_.DOCID AS DOCID)˘digraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=line;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q2.DOCID AS DOCID)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(STRING AS DOCID)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">prefix comparisons: [EQUALS promote(@c8 AS LONG), EQUALS promote(@c12 AS STRING)]</td></tr><tr><td align="left">distanceRank: DISTANCE_RANK_LESS_THAN_OR_EQUAL @c30: @c40</td></tr><tr><td align="left">scan options: [hnswEfSearch: 100]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ZONEID, STRING AS DOCID, STRING AS BOOKSHELF, STRING AS TITLE, VECTOR(16, 3) AS EMBEDDING)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">MULTITYPEEUCLIDEANINDEX</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ZONEID, STRING AS DOCID, STRING AS BOOKSHELF, STRING AS TITLE, VECTOR(16, 3) AS EMBEDDING)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}„
+Í
+semantic-search-tests–EXPLAIN select docId, title from multiTypePartitionDocs where zoneId = ? and bookshelf = 'fiction' qualify row_number() over (partition by zoneId, bookshelf order by euclidean_distance(embedding, ?) asc) <= ?Û
+‰úŒ¶C Ö‡È(0À˝8@≈ISCAN(MULTITYPEEUCLIDEANINDEX [EQUALS promote(@c10 AS LONG), EQUALS promote(@c14 AS STRING)]:{DISTANCE_RANK_LESS_THAN_OR_EQUAL @c32: @c10}:[] BY_DISTANCE) | MAP (_.DOCID AS DOCID, _.TITLE AS TITLE)çdigraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=line;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q2.DOCID AS DOCID, q2.TITLE AS TITLE)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(STRING AS DOCID, STRING AS TITLE)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">prefix comparisons: [EQUALS promote(@c10 AS LONG), EQUALS promote(@c14 AS STRING)]</td></tr><tr><td align="left">distanceRank: DISTANCE_RANK_LESS_THAN_OR_EQUAL @c32: @c10</td></tr><tr><td align="left">scan options: []</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ZONEID, STRING AS DOCID, STRING AS BOOKSHELF, STRING AS TITLE, VECTOR(16, 3) AS EMBEDDING)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">MULTITYPEEUCLIDEANINDEX</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ZONEID, STRING AS DOCID, STRING AS BOOKSHELF, STRING AS TITLE, VECTOR(16, 3) AS EMBEDDING)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}Ô
+ˆ
+semantic-search-tests‹EXPLAIN select docId, title from multiTypePartitionDocs where zoneId = ? and bookshelf = 'fiction' qualify row_number() over (partition by zoneId, bookshelf order by euclidean_distance(embedding, ?) asc nulls first) <= ?Û
+‰»›˚C ¨±∆(0◊ı8@≈ISCAN(MULTITYPEEUCLIDEANINDEX [EQUALS promote(@c10 AS LONG), EQUALS promote(@c14 AS STRING)]:{DISTANCE_RANK_LESS_THAN_OR_EQUAL @c32: @c10}:[] BY_DISTANCE) | MAP (_.DOCID AS DOCID, _.TITLE AS TITLE)çdigraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=line;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q2.DOCID AS DOCID, q2.TITLE AS TITLE)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(STRING AS DOCID, STRING AS TITLE)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">prefix comparisons: [EQUALS promote(@c10 AS LONG), EQUALS promote(@c14 AS STRING)]</td></tr><tr><td align="left">distanceRank: DISTANCE_RANK_LESS_THAN_OR_EQUAL @c32: @c10</td></tr><tr><td align="left">scan options: []</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ZONEID, STRING AS DOCID, STRING AS BOOKSHELF, STRING AS TITLE, VECTOR(16, 3) AS EMBEDDING)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">MULTITYPEEUCLIDEANINDEX</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ZONEID, STRING AS DOCID, STRING AS BOOKSHELF, STRING AS TITLE, VECTOR(16, 3) AS EMBEDDING)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}Î
+Ú
+semantic-search-testsÿEXPLAIN select docId, title from multiTypePartitionDocs where zoneId = ? and bookshelf = 'fiction' qualify row_number() over (partition by zoneId, bookshelf order by euclidean_distance(embedding, ?) nulls first) <= ?Û
+‰∆êΩC ¿≠â(0¢¿8@≈ISCAN(MULTITYPEEUCLIDEANINDEX [EQUALS promote(@c10 AS LONG), EQUALS promote(@c14 AS STRING)]:{DISTANCE_RANK_LESS_THAN_OR_EQUAL @c32: @c10}:[] BY_DISTANCE) | MAP (_.DOCID AS DOCID, _.TITLE AS TITLE)çdigraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=line;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q2.DOCID AS DOCID, q2.TITLE AS TITLE)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(STRING AS DOCID, STRING AS TITLE)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">prefix comparisons: [EQUALS promote(@c10 AS LONG), EQUALS promote(@c14 AS STRING)]</td></tr><tr><td align="left">distanceRank: DISTANCE_RANK_LESS_THAN_OR_EQUAL @c32: @c10</td></tr><tr><td align="left">scan options: []</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ZONEID, STRING AS DOCID, STRING AS BOOKSHELF, STRING AS TITLE, VECTOR(16, 3) AS EMBEDDING)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">MULTITYPEEUCLIDEANINDEX</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ZONEID, STRING AS DOCID, STRING AS BOOKSHELF, STRING AS TITLE, VECTOR(16, 3) AS EMBEDDING)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
 }

--- a/yaml-tests/src/test/resources/semantic-search.metrics.yaml
+++ b/yaml-tests/src/test/resources/semantic-search.metrics.yaml
@@ -246,3 +246,116 @@ semantic-search-tests:
     insert_time_ms: 6
     insert_new_count: 152
     insert_reused_count: 23
+-   query: EXPLAIN select docId, title, euclidean_distance(embedding, ?) from multiTypePartitionDocs
+        where zoneId = 1 and bookshelf = 'fiction' qualify row_number() over (partition
+        by zoneId, bookshelf order by euclidean_distance(embedding, ?) asc) <= 1
+    explain: 'ISCAN(MULTITYPEEUCLIDEANINDEX [EQUALS promote(@c17 AS LONG), EQUALS
+        promote(@c21 AS STRING)]:{DISTANCE_RANK_LESS_THAN_OR_EQUAL @c39: @c17}:[]
+        BY_DISTANCE) | MAP (_.DOCID AS DOCID, _.TITLE AS TITLE, (_.EMBEDDING) euclidean_distance
+        @c39 AS _2)'
+    task_count: 228
+    task_total_time_ms: 8
+    transform_count: 67
+    transform_time_ms: 5
+    transform_yield_count: 28
+    insert_time_ms: 0
+    insert_new_count: 20
+    insert_reused_count: 1
+-   query: EXPLAIN select docId from multiTypePartitionDocs where zoneId = 1 and bookshelf
+        = 'science' qualify row_number() over (partition by zoneId, bookshelf order
+        by euclidean_distance(embedding, ?) asc) <= 2
+    explain: 'ISCAN(MULTITYPEEUCLIDEANINDEX [EQUALS promote(@c8 AS LONG), EQUALS promote(@c12
+        AS STRING)]:{DISTANCE_RANK_LESS_THAN_OR_EQUAL @c30: @c36}:[] BY_DISTANCE)
+        | MAP (_.DOCID AS DOCID)'
+    task_count: 228
+    task_total_time_ms: 9
+    transform_count: 67
+    transform_time_ms: 6
+    transform_yield_count: 28
+    insert_time_ms: 0
+    insert_new_count: 20
+    insert_reused_count: 1
+-   query: EXPLAIN select docId from multiTypePartitionDocs where zoneId = 2 and bookshelf
+        = 'fiction' qualify row_number() over (partition by zoneId, bookshelf order
+        by euclidean_distance(embedding, ?) asc) < 2
+    explain: 'ISCAN(MULTITYPEEUCLIDEANINDEX [EQUALS promote(@c8 AS LONG), EQUALS promote(@c12
+        AS STRING)]:{DISTANCE_RANK_LESS_THAN @c30: @c8}:[] BY_DISTANCE) | MAP (_.DOCID
+        AS DOCID)'
+    task_count: 228
+    task_total_time_ms: 9
+    transform_count: 67
+    transform_time_ms: 5
+    transform_yield_count: 28
+    insert_time_ms: 0
+    insert_new_count: 20
+    insert_reused_count: 1
+-   query: EXPLAIN select docId, cosine_distance(embedding, ?) from multiTypePartitionDocs
+        where zoneId = 1 and bookshelf = 'fiction' qualify row_number() over (partition
+        by zoneId, bookshelf order by cosine_distance(embedding, ?) asc) <= 3
+    explain: 'ISCAN(MULTITYPECOSINEINDEX [EQUALS promote(@c15 AS LONG), EQUALS promote(@c19
+        AS STRING)]:{DISTANCE_RANK_LESS_THAN_OR_EQUAL @c37: @c43}:[] BY_DISTANCE)
+        | MAP (_.DOCID AS DOCID, (_.EMBEDDING) cosine_distance @c37 AS _1)'
+    task_count: 228
+    task_total_time_ms: 7
+    transform_count: 67
+    transform_time_ms: 4
+    transform_yield_count: 28
+    insert_time_ms: 0
+    insert_new_count: 20
+    insert_reused_count: 1
+-   query: EXPLAIN select docId from multiTypePartitionDocs where zoneId = 2 and bookshelf
+        = 'science' qualify row_number() over (partition by zoneId, bookshelf order
+        by euclidean_distance(embedding, ?) asc options ef_search = 100) <= 1
+    explain: 'ISCAN(MULTITYPEEUCLIDEANINDEX [EQUALS promote(@c8 AS LONG), EQUALS promote(@c12
+        AS STRING)]:{DISTANCE_RANK_LESS_THAN_OR_EQUAL @c30: @c40}:[hnswEfSearch: 100]
+        BY_DISTANCE) | MAP (_.DOCID AS DOCID)'
+    task_count: 228
+    task_total_time_ms: 7
+    transform_count: 67
+    transform_time_ms: 4
+    transform_yield_count: 28
+    insert_time_ms: 0
+    insert_new_count: 20
+    insert_reused_count: 1
+-   query: EXPLAIN select docId, title from multiTypePartitionDocs where zoneId =
+        ? and bookshelf = 'fiction' qualify row_number() over (partition by zoneId,
+        bookshelf order by euclidean_distance(embedding, ?) asc) <= ?
+    explain: 'ISCAN(MULTITYPEEUCLIDEANINDEX [EQUALS promote(@c10 AS LONG), EQUALS
+        promote(@c14 AS STRING)]:{DISTANCE_RANK_LESS_THAN_OR_EQUAL @c32: @c10}:[]
+        BY_DISTANCE) | MAP (_.DOCID AS DOCID, _.TITLE AS TITLE)'
+    task_count: 228
+    task_total_time_ms: 9
+    transform_count: 67
+    transform_time_ms: 5
+    transform_yield_count: 28
+    insert_time_ms: 0
+    insert_new_count: 20
+    insert_reused_count: 1
+-   query: EXPLAIN select docId, title from multiTypePartitionDocs where zoneId =
+        ? and bookshelf = 'fiction' qualify row_number() over (partition by zoneId,
+        bookshelf order by euclidean_distance(embedding, ?) asc nulls first) <= ?
+    explain: 'ISCAN(MULTITYPEEUCLIDEANINDEX [EQUALS promote(@c10 AS LONG), EQUALS
+        promote(@c14 AS STRING)]:{DISTANCE_RANK_LESS_THAN_OR_EQUAL @c32: @c10}:[]
+        BY_DISTANCE) | MAP (_.DOCID AS DOCID, _.TITLE AS TITLE)'
+    task_count: 228
+    task_total_time_ms: 8
+    transform_count: 67
+    transform_time_ms: 5
+    transform_yield_count: 28
+    insert_time_ms: 0
+    insert_new_count: 20
+    insert_reused_count: 1
+-   query: EXPLAIN select docId, title from multiTypePartitionDocs where zoneId =
+        ? and bookshelf = 'fiction' qualify row_number() over (partition by zoneId,
+        bookshelf order by euclidean_distance(embedding, ?) nulls first) <= ?
+    explain: 'ISCAN(MULTITYPEEUCLIDEANINDEX [EQUALS promote(@c10 AS LONG), EQUALS
+        promote(@c14 AS STRING)]:{DISTANCE_RANK_LESS_THAN_OR_EQUAL @c32: @c10}:[]
+        BY_DISTANCE) | MAP (_.DOCID AS DOCID, _.TITLE AS TITLE)'
+    task_count: 228
+    task_total_time_ms: 7
+    transform_count: 67
+    transform_time_ms: 4
+    transform_yield_count: 28
+    insert_time_ms: 0
+    insert_new_count: 20
+    insert_reused_count: 1

--- a/yaml-tests/src/test/resources/semantic-search.yamsql
+++ b/yaml-tests/src/test/resources/semantic-search.yamsql
@@ -18,7 +18,7 @@
 # limitations under the License.
 ---
 options:
-  supported_version: 4.9.3.0
+  supported_version: !current_version
 ---
 schema_template:
     create table documents(zone string, docId string, bookshelf string, title string, embedding vector(3, half), primary key (zone, docId))
@@ -26,6 +26,10 @@ schema_template:
     create vector index documentsEuclideanIndex using hnsw on documentsView(embedding) partition by(zone, bookshelf) options (metric = euclidean_metric, rabitq_num_ex_bits = 3, use_rabitq = true)
     create vector index documentsCosineIndex using hnsw on documentsView(embedding) partition by(zone, bookshelf) options (metric = cosine_metric)
     create table reviews(reviewId string, zone string, docId string, rating bigint, reviewText string, primary key (reviewId))
+    create table multiTypePartitionDocs(zoneId bigint, docId string, bookshelf string, title string, embedding vector(3, half), primary key (zoneId, docId))
+    create view multiTypePartitionView as select embedding, zoneId, bookshelf, docId, title from multiTypePartitionDocs
+    create vector index multiTypeEuclideanIndex using hnsw on multiTypePartitionView(embedding) partition by(zoneId, bookshelf) options (metric = euclidean_metric)
+    create vector index multiTypeCosineIndex using hnsw on multiTypePartitionView(embedding) partition by(zoneId, bookshelf) options (metric = cosine_metric)
 ---
 test_block:
   preset: single_repetition_ordered
@@ -211,7 +215,7 @@ test_block:
           join documents d2 on d2.zone = d1.zone and d2.bookshelf = 'science'
           where r.zone = 'zone1'
           qualify row_number() over (partition by d2.zone, d2.bookshelf order by euclidean_distance(d2.embedding, d1.embedding) asc options ef_search = 100) < 2
-      - explain: "SCAN(<,>) | TFILTER REVIEWS | FLATMAP q0 -> { SCAN(<,>) | TFILTER DOCUMENTS | FILTER q0.ZONE EQUALS _.ZONE AND q0.ZONE EQUALS promote(@c57 AS STRING) AND q0.DOCID EQUALS _.DOCID | FLATMAP q1 -> { ISCAN(DOCUMENTSEUCLIDEANINDEX [EQUALS q1.ZONE, EQUALS promote(@c51 AS STRING)]:{DISTANCE_RANK_LESS_THAN q1.EMBEDDING: @c92}:[hnswEfSearch: 100] BY_DISTANCE) AS q2 RETURN q2 } AS q2 RETURN (q0.REVIEWID AS REVIEWID, q2.DOCID AS DOCID, q2.TITLE AS TITLE) }"
+      - explain: "SCAN(<,>) | TFILTER DOCUMENTS | FLATMAP q0 -> { ISCAN(DOCUMENTSEUCLIDEANINDEX [EQUALS q0.ZONE, EQUALS promote(@c51 AS STRING)]:{DISTANCE_RANK_LESS_THAN q0.EMBEDDING: @c92}:[hnswEfSearch: 100] BY_DISTANCE) | FLATMAP q1 -> { SCAN(<,>) | TFILTER REVIEWS | FILTER _.ZONE EQUALS q0.ZONE AND _.ZONE EQUALS promote(@c57 AS STRING) AND _.DOCID EQUALS q0.DOCID AS q2 RETURN (q2 AS _0, q1 AS _1) } AS q3 RETURN (q3._0.REVIEWID AS REVIEWID, q3._1.DOCID AS DOCID, q3._1.TITLE AS TITLE) }"
       - unorderedResult: [
           {'r1', 'd10', 'Relativity'},
           {'r2', 'd10', 'Relativity'},
@@ -226,3 +230,98 @@ test_block:
           where r.zone = 'zone1'
           qualify row_number() over (partition by d2.zone, d2.bookshelf order by manhattan_distance(d2.embedding, d1.embedding) asc options ef_search = 100) < 2
       - error: "0AF00"
+# Test HNSW index with mixed-type partition columns (bigint and string)
+    -
+      - query:
+          insert into multiTypePartitionDocs values
+          (1, 'd1', 'fiction', 'The Great Gatsby', !! !v16 [1.0, 0.0, 0.0] !!),
+          (1, 'd2', 'fiction', '1984', !! !v16 [0.9, 0.1, 0.0] !!),
+          (1, 'd3', 'fiction', 'To Kill a Mockingbird', !! !v16 [0.8, 0.2, 0.0] !!),
+          (1, 'd4', 'science', 'A Brief History of Time', !! !v16 [0.0, 1.0, 0.0] !!),
+          (1, 'd5', 'science', 'Cosmos', !! !v16 [0.1, 0.9, 0.0] !!),
+          (2, 'd6', 'fiction', 'Moby Dick', !! !v16 [0.0, 0.0, 1.0] !!),
+          (2, 'd7', 'fiction', 'War and Peace', !! !v16 [0.0, 0.1, 0.9] !!),
+          (2, 'd8', 'science', 'The Gene', !! !v16 [0.5, 0.5, 0.0] !!),
+          (2, 'd9', 'science', 'Sapiens', !! !v16 [0.4, 0.4, 0.2] !!)
+      - count: 9
+    -
+      - query:
+          select docId, title, euclidean_distance(embedding, !! !v16 [1.0, 0.0, 0.0] !!) from multiTypePartitionDocs
+          where zoneId = 1 and bookshelf = 'fiction'
+          qualify row_number() over (partition by zoneId, bookshelf order by euclidean_distance(embedding, !! !v16 [1.0, 0.0, 0.0] !!) asc) <= 1
+      - explain: "ISCAN(MULTITYPEEUCLIDEANINDEX [EQUALS promote(@c17 AS LONG), EQUALS promote(@c21 AS STRING)]:{DISTANCE_RANK_LESS_THAN_OR_EQUAL @c39: @c17}:[] BY_DISTANCE) | MAP (_.DOCID AS DOCID, _.TITLE AS TITLE, (_.EMBEDDING) euclidean_distance @c39 AS _2)"
+      - result: [{'d1', 'The Great Gatsby', 0.0}]
+    -
+      - query:
+          select docId from multiTypePartitionDocs
+          where zoneId = 1 and bookshelf = 'science'
+          qualify row_number() over (partition by zoneId, bookshelf order by euclidean_distance(embedding, !! !v16 [0.0, 1.0, 0.0] !!) asc) <= 2
+      - explain: "ISCAN(MULTITYPEEUCLIDEANINDEX [EQUALS promote(@c8 AS LONG), EQUALS promote(@c12 AS STRING)]:{DISTANCE_RANK_LESS_THAN_OR_EQUAL @c30: @c36}:[] BY_DISTANCE) | MAP (_.DOCID AS DOCID)"
+      - result: [{'d4'}, {'d5'}]
+    -
+      - query:
+          select docId from multiTypePartitionDocs
+          where zoneId = 2 and bookshelf = 'fiction'
+          qualify row_number() over (partition by zoneId, bookshelf order by euclidean_distance(embedding, !! !v16 [0.0, 0.0, 1.0] !!) asc) < 2
+      - explain: "ISCAN(MULTITYPEEUCLIDEANINDEX [EQUALS promote(@c8 AS LONG), EQUALS promote(@c12 AS STRING)]:{DISTANCE_RANK_LESS_THAN @c30: @c8}:[] BY_DISTANCE) | MAP (_.DOCID AS DOCID)"
+      - result: [{'d6'}]
+    -
+      - query:
+          select docId, cosine_distance(embedding, !! !v16 [1.0, 0.0, 0.0] !!) from multiTypePartitionDocs
+          where zoneId = 1 and bookshelf = 'fiction'
+          qualify row_number() over (partition by zoneId, bookshelf order by cosine_distance(embedding, !! !v16 [1.0, 0.0, 0.0] !!) asc) <= 3
+      - explain: "ISCAN(MULTITYPECOSINEINDEX [EQUALS promote(@c15 AS LONG), EQUALS promote(@c19 AS STRING)]:{DISTANCE_RANK_LESS_THAN_OR_EQUAL @c37: @c43}:[] BY_DISTANCE) | MAP (_.DOCID AS DOCID, (_.EMBEDDING) cosine_distance @c37 AS _1)"
+      - result: [{'d1', 0.0}, {'d2', 0.006114621302865664}, {'d3', 0.029857499854668124}]
+    -
+      - query:
+          select docId from multiTypePartitionDocs
+          where zoneId = 2 and bookshelf = 'science'
+          qualify row_number() over (partition by zoneId, bookshelf order by euclidean_distance(embedding, !! !v16 [0.5, 0.5, 0.0] !!) asc options ef_search = 100) <= 1
+      - explain: "ISCAN(MULTITYPEEUCLIDEANINDEX [EQUALS promote(@c8 AS LONG), EQUALS promote(@c12 AS STRING)]:{DISTANCE_RANK_LESS_THAN_OR_EQUAL @c30: @c40}:[hnswEfSearch: 100] BY_DISTANCE) | MAP (_.DOCID AS DOCID)"
+      - result: [{'d8'}]
+    -
+      - query:
+          select docId, title from multiTypePartitionDocs
+          where zoneId = !! 2 !! and bookshelf = 'fiction'
+          qualify row_number() over (partition by zoneId, bookshelf order by euclidean_distance(embedding, !! !v16 [0.0, 0.1, 0.9] !!) asc) <= !! 2 !!
+      - explain: "ISCAN(MULTITYPEEUCLIDEANINDEX [EQUALS promote(@c10 AS LONG), EQUALS promote(@c14 AS STRING)]:{DISTANCE_RANK_LESS_THAN_OR_EQUAL @c32: @c10}:[] BY_DISTANCE) | MAP (_.DOCID AS DOCID, _.TITLE AS TITLE)"
+      - result: [{'d7', 'War and Peace'}, {'d6', 'Moby Dick'}]
+# verify supported and unsupported sort specifications within window function.
+    -
+      - query:
+          select docId, title from multiTypePartitionDocs
+          where zoneId = !! 2 !! and bookshelf = 'fiction'
+          qualify row_number() over (partition by zoneId, bookshelf order by euclidean_distance(embedding, !! !v16 [0.0, 0.1, 0.9] !!) asc nulls first) <= !! 2 !!
+      - explain: "ISCAN(MULTITYPEEUCLIDEANINDEX [EQUALS promote(@c10 AS LONG), EQUALS promote(@c14 AS STRING)]:{DISTANCE_RANK_LESS_THAN_OR_EQUAL @c32: @c10}:[] BY_DISTANCE) | MAP (_.DOCID AS DOCID, _.TITLE AS TITLE)"
+      - result: [{'d7', 'War and Peace'}, {'d6', 'Moby Dick'}]
+    -
+      - query:
+          select docId, title from multiTypePartitionDocs
+          where zoneId = !! 2 !! and bookshelf = 'fiction'
+          qualify row_number() over (partition by zoneId, bookshelf order by euclidean_distance(embedding, !! !v16 [0.0, 0.1, 0.9] !!) nulls first) <= !! 2 !!
+      - explain: "ISCAN(MULTITYPEEUCLIDEANINDEX [EQUALS promote(@c10 AS LONG), EQUALS promote(@c14 AS STRING)]:{DISTANCE_RANK_LESS_THAN_OR_EQUAL @c32: @c10}:[] BY_DISTANCE) | MAP (_.DOCID AS DOCID, _.TITLE AS TITLE)"
+      - result: [{'d7', 'War and Peace'}, {'d6', 'Moby Dick'}]
+    -
+      - query:
+          select docId, title from multiTypePartitionDocs
+          where zoneId = !! 2 !! and bookshelf = 'fiction'
+          qualify row_number() over (partition by zoneId, bookshelf order by euclidean_distance(embedding, !! !v16 [0.0, 0.1, 0.9] !!) desc) <= !! 2 !!
+      - error: "0AF01"
+    -
+      - query:
+          select docId, title from multiTypePartitionDocs
+          where zoneId = !! 2 !! and bookshelf = 'fiction'
+          qualify row_number() over (partition by zoneId, bookshelf order by euclidean_distance(embedding, !! !v16 [0.0, 0.1, 0.9] !!) desc nulls first) <= !! 2 !!
+      - error: "0AF01"
+    -
+      - query:
+          select docId, title from multiTypePartitionDocs
+          where zoneId = !! 2 !! and bookshelf = 'fiction'
+          qualify row_number() over (partition by zoneId, bookshelf order by euclidean_distance(embedding, !! !v16 [0.0, 0.1, 0.9] !!) desc nulls last) <= !! 2 !!
+      - error: "0AF01"
+    -
+      - query:
+          select docId, title from multiTypePartitionDocs
+          where zoneId = !! 2 !! and bookshelf = 'fiction'
+          qualify row_number() over (partition by zoneId, bookshelf order by euclidean_distance(embedding, !! !v16 [0.0, 0.1, 0.9] !!) nulls last) <= !! 2 !!
+      - error: "0AF01"


### PR DESCRIPTION

This PR introduces two improvements to HNSW vector index handling:

1. **Mixed-type partition column support**: HNSW indexes can now be partitioned by columns of different types (e.g., `BIGINT` and `STRING` together). Previously, all partition columns had to be of the same type. This enables more flexible partitioning strategies for vector similarity search.

2. **Sort order validation in window functions**: Added proper validation for sort order specifications in window functions used with vector distance queries. The system now correctly:
     - Accepts supported specifications: `ASC`, `ASC NULLS FIRST`, and `NULLS FIRST` (default ascending)
     - Rejects unsupported specifications with error `0AF01`: `DESC`, `DESC NULLS FIRST`, `DESC NULLS LAST`, and `NULLS LAST`

This ensures users receive clear error messages when attempting to use descending sort orders, which are not supported for HNSW index scans, rather than silencing ignoring them.

This fixes #3872 and #3871