### PR TITLE
Additional tests of scan plans with versions

### DIFF
--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBVersionsQueryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBVersionsQueryTest.java
@@ -132,7 +132,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * For additional tests, see {@link com.apple.foundationdb.record.provider.foundationdb.indexes.VersionIndexTest}.
  */
 @Tag(Tags.RequiresFDB)
-public class FDBVersionsQueryTest extends FDBRecordStoreQueryTestBase {
+class FDBVersionsQueryTest extends FDBRecordStoreQueryTestBase {
     private static final Index VERSION_INDEX = new Index("versionIndex", version(), IndexTypes.VERSION);
     private static final Index VERSION_BY_NUM_VALUE_2_INDEX = new Index("versionByNumValue2Index", concat(field("num_value_2"), version()), IndexTypes.VERSION);
 


### PR DESCRIPTION
This adds additional test cases for executing scans with versions. The goal of these tests is to provide tests that would fail without #3870. That PR did have some additional tests, but those would only fail once we un-reverted #3800.

To add relevant tests, they need to reference the `__ROW_VERSION` field directly. That's currently not really possible through SQL, as the plan generator translates that field into `VersionValue`s. So, what this does is create tests at a lower level and then validates the plan and behavior. Note that none of these plans can use an index, as the index match candidates also use a `VersionValue`, and they will need to continue to do so until we can update the plan generator to migrate as well. (All of that was done in #3800, but had to be taken out to avoid breaking scan plans in a bacwkards compatible way.) So the new tests just project the row version, using either the `VersionValue` or the `FieldValue`. In the future, we'll want to take out the `VersionValue` and then these tests can be non-parameterized.