### PR TITLE
Fix up `versions-test.yamsql` query that was failing in mixed mode

### DIFF
--- a/yaml-tests/src/test/resources/versions-tests.yamsql
+++ b/yaml-tests/src/test/resources/versions-tests.yamsql
@@ -207,7 +207,24 @@ test_block:
         ]
     -
       # Should not be able to select the row version from a sub-select
-      - query: select "__ROW_VERSION" from (select * from t1) a;
+      - query: select "__ROW_VERSION", a.id from (select * from t1) a;
+      - initialVersionLessThan: 4.9.1.0
+      - unorderedResult: [
+          { '__ROW_VERSION': !not_null _, ID:  1 },
+          { '__ROW_VERSION': !not_null _, ID:  2 },
+          { '__ROW_VERSION': !not_null _, ID:  3 },
+          { '__ROW_VERSION': !not_null _, ID:  4 },
+          { '__ROW_VERSION': !not_null _, ID:  5 },
+          { '__ROW_VERSION': !not_null _, ID:  6 },
+          { '__ROW_VERSION': !not_null _, ID:  7 },
+          { '__ROW_VERSION': !not_null _, ID:  8 },
+          { '__ROW_VERSION': !not_null _, ID:  9 },
+          { '__ROW_VERSION': !not_null _, ID: 10 },
+          { '__ROW_VERSION': !not_null _, ID: 11 },
+          { '__ROW_VERSION': !not_null _, ID: 12 },
+          { '__ROW_VERSION': !not_null _, ID: 13 },
+        ]
+      - initialVersionAtLeast: 4.9.1.0
       - error: 'XXXXX'
     -
       # Do not include __ROW_VERSION (as a pseudo-column) in nested (*) without identifier


### PR DESCRIPTION
This test case in `versions-test.yamsql` resulted in 4.9.4.0 being marked as incompatible with 4.8. The issue is that one of the test cases covered a place where there were some legitimate changes in behavior from 4.8 to 4.9, namely around what happens with a query like:

```
SELECT "__ROW_VERSION" FROM (SELECT * FROM t)
```

In 4.8, we would have translated the `__ROW_VERSION` into a `VersionValue` and then tried to get the version from `t`. In 4.9, we now consider this to be an error. This is because the `__ROW_VERSION` is not actually returned from star expansions, and indeed, both 4.8 and 4.9 would have been consistent with a query like:

```
SELECT * FROM t
```

In that neither would have projected the `__ROW_VERSION`. As of 4.9, we now limit the set of fields that are available from a sub-select to the set of fields that it projects, which is more in line with the standard. Note that this has been the behavior for all of 4.9, but we only noticed this now because the test case was introduced with 4.9.4.0.

This fixes #3878.