### PR TITLE
Updating !current_version in yamsql files to 4.9.4.0

### DIFF
--- a/yaml-tests/src/test/resources/semantic-search.yamsql
+++ b/yaml-tests/src/test/resources/semantic-search.yamsql
@@ -18,7 +18,7 @@
 # limitations under the License.
 ---
 options:
-  supported_version: !current_version
+  supported_version: 4.9.4.0
 ---
 schema_template:
     create table documents(zone string, docId string, bookshelf string, title string, embedding vector(3, half), primary key (zone, docId))


### PR DESCRIPTION
This something that is supposed to happen automatically during the release process, but it failed during the 4.9.4.0 release due to a github merge conflict: https://github.com/FoundationDB/fdb-record-layer/actions/runs/21407612344/job/61645555919

I just ran the two steps in the build locally, and it generated this change set.