### PR TITLE
Fix the `cast-tests.yamsql` mixed mode test failures with versions older than 4.9

### DIFF
--- a/yaml-tests/src/test/resources/cast-tests.metrics.binpb
+++ b/yaml-tests/src/test/resources/cast-tests.metrics.binpb
@@ -402,16 +402,26 @@ Z
   6 -> 5 [ label=<&nbsp;q25> label="q25" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   7 -> 6 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}Ð
-ÿ
-cast-operator-testsçEXPLAIN select cast(null as integer) as a, cast(null as bigint) as b, cast(null as string) as c, cast(null as double) as d, cast(null as boolean) as e, cast(null as string) as f, cast(null as uuid) as g from values (1), (2) as X(X)Ë
+}ú
+æ
+cast-operator-testsÎEXPLAIN select cast(null as integer) as a, cast(null as bigint) as b, cast(null as string) as c, cast(null as double) as d, cast(null as boolean) as e, cast(null as string) as f from values (1), (2) as X(X)Ž
 
-tÎŒò ÷Õ%(0®ó8	@ åEXPLODE array((@c67 AS X), (@c71 AS X)) | MAP (CAST(NULL AS INT) AS A, CAST(NULL AS LONG) AS B, CAST(NULL AS STRING) AS C, CAST(NULL AS DOUBLE) AS D, CAST(NULL AS BOOLEAN) AS E, CAST(NULL AS STRING) AS F, CAST(NULL AS UUID) AS G)Çdigraph G {
+t´´¾ ¢µ'(0«¨8	@ ÌEXPLODE array((@c58 AS X), (@c62 AS X)) | MAP (CAST(NULL AS INT) AS A, CAST(NULL AS LONG) AS B, CAST(NULL AS STRING) AS C, CAST(NULL AS DOUBLE) AS D, CAST(NULL AS BOOLEAN) AS E, CAST(NULL AS STRING) AS F)£digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
-  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (CAST(NULL AS INT) AS A, CAST(NULL AS LONG) AS B, CAST(NULL AS STRING) AS C, CAST(NULL AS DOUBLE) AS D, CAST(NULL AS BOOLEAN) AS E, CAST(NULL AS STRING) AS F, CAST(NULL AS UUID) AS G)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS A, LONG AS B, STRING AS C, DOUBLE AS D, BOOLEAN AS E, STRING AS F, UUID AS G)" ];
-  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">EXPLODE array((@c67 AS X), (@c71 AS X))</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS X)" ];
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (CAST(NULL AS INT) AS A, CAST(NULL AS LONG) AS B, CAST(NULL AS STRING) AS C, CAST(NULL AS DOUBLE) AS D, CAST(NULL AS BOOLEAN) AS E, CAST(NULL AS STRING) AS F)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS A, LONG AS B, STRING AS C, DOUBLE AS D, BOOLEAN AS E, STRING AS F)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">EXPLODE array((@c58 AS X), (@c62 AS X))</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS X)" ];
+  2 -> 1 [ label=<&nbsp;q0> label="q0" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+} 
+U
+cast-operator-tests>EXPLAIN select cast(null as uuid) from values (1), (2) as X(X)Æ
+töña ¬«(0ê§8	@ HEXPLODE array((@c11 AS X), (@c15 AS X)) | MAP (CAST(NULL AS UUID) AS _0)ádigraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=line;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (CAST(NULL AS UUID) AS _0)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(UUID AS _0)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">EXPLODE array((@c11 AS X), (@c15 AS X))</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS X)" ];
   2 -> 1 [ label=<&nbsp;q0> label="q0" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
 }¤
 V
@@ -444,15 +454,25 @@ V
   1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (CAST(NULL AS VECTOR(16, 10)) AS A, CAST(NULL AS VECTOR(32, 15)) AS B, CAST(NULL AS VECTOR(64, 30)) AS C)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(VECTOR(16, 10) AS A, VECTOR(32, 15) AS B, VECTOR(64, 30) AS C)" ];
   2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">EXPLODE array((@c46 AS X), (@c50 AS X))</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS X)" ];
   2 -> 1 [ label=<&nbsp;q0> label="q0" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}Œ
-©
-cast-operator-tests‘EXPLAIN select cast(null as integer array) as a, cast(null as bigint array) as b, cast(null as string array) as c, cast(null as double array) as d, cast(null as boolean array) as e, cast(null as string array) as f, cast(null as uuid array) as g from values (1), (2) as X(X)Ý
-t¦œT ÖÊ(0Ê–8	@ –EXPLODE array((@c74 AS X), (@c78 AS X)) | MAP (CAST(NULL AS ARRAY(INT)) AS A, CAST(NULL AS ARRAY(LONG)) AS B, CAST(NULL AS ARRAY(STRING)) AS C, CAST(NULL AS ARRAY(DOUBLE)) AS D, CAST(NULL AS ARRAY(BOOLEAN)) AS E, CAST(NULL AS ARRAY(STRING)) AS F, CAST(NULL AS ARRAY(UUID)) AS G)©	digraph G {
+}›
+Š
+cast-operator-testsòEXPLAIN select cast(null as integer array) as a, cast(null as bigint array) as b, cast(null as string array) as c, cast(null as double array) as d, cast(null as boolean array) as e, cast(null as string array) as f from values (1), (2) as X(X)‹
+tÌŒY ’Ð(0äÄ8	@ öEXPLODE array((@c64 AS X), (@c68 AS X)) | MAP (CAST(NULL AS ARRAY(INT)) AS A, CAST(NULL AS ARRAY(LONG)) AS B, CAST(NULL AS ARRAY(STRING)) AS C, CAST(NULL AS ARRAY(DOUBLE)) AS D, CAST(NULL AS ARRAY(BOOLEAN)) AS E, CAST(NULL AS ARRAY(STRING)) AS F)÷digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
-  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (CAST(NULL AS ARRAY(INT)) AS A, CAST(NULL AS ARRAY(LONG)) AS B, CAST(NULL AS ARRAY(STRING)) AS C, CAST(NULL AS ARRAY(DOUBLE)) AS D, CAST(NULL AS ARRAY(BOOLEAN)) AS E, CAST(NULL AS ARRAY(STRING)) AS F, CAST(NULL AS ARRAY(UUID)) AS G)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(ARRAY(INT) AS A, ARRAY(LONG) AS B, ARRAY(STRING) AS C, ARRAY(DOUBLE) AS D, ARRAY(BOOLEAN) AS E, ARRAY(STRING) AS F, ARRAY(UUID) AS G)" ];
-  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">EXPLODE array((@c74 AS X), (@c78 AS X))</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS X)" ];
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (CAST(NULL AS ARRAY(INT)) AS A, CAST(NULL AS ARRAY(LONG)) AS B, CAST(NULL AS ARRAY(STRING)) AS C, CAST(NULL AS ARRAY(DOUBLE)) AS D, CAST(NULL AS ARRAY(BOOLEAN)) AS E, CAST(NULL AS ARRAY(STRING)) AS F)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(ARRAY(INT) AS A, ARRAY(LONG) AS B, ARRAY(STRING) AS C, ARRAY(DOUBLE) AS D, ARRAY(BOOLEAN) AS E, ARRAY(STRING) AS F)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">EXPLODE array((@c64 AS X), (@c68 AS X))</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS X)" ];
+  2 -> 1 [ label=<&nbsp;q0> label="q0" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}»
+[
+cast-operator-testsDEXPLAIN select cast(null as uuid array) from values (1), (2) as X(X)Û
+t¡‹T ü©(0©ç8	@ OEXPLODE array((@c12 AS X), (@c16 AS X)) | MAP (CAST(NULL AS ARRAY(UUID)) AS _0)ïdigraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=line;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (CAST(NULL AS ARRAY(UUID)) AS _0)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(ARRAY(UUID) AS _0)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">EXPLODE array((@c12 AS X), (@c16 AS X))</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS X)" ];
   2 -> 1 [ label=<&nbsp;q0> label="q0" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
 }¿
 \

--- a/yaml-tests/src/test/resources/cast-tests.metrics.yaml
+++ b/yaml-tests/src/test/resources/cast-tests.metrics.yaml
@@ -298,13 +298,23 @@ cast-operator-tests:
     insert_reused_count: 2
 -   query: EXPLAIN select cast(null as integer) as a, cast(null as bigint) as b, cast(null
         as string) as c, cast(null as double) as d, cast(null as boolean) as e, cast(null
-        as string) as f, cast(null as uuid) as g from values (1), (2) as X(X)
-    explain: EXPLODE array((@c67 AS X), (@c71 AS X)) | MAP (CAST(NULL AS INT) AS A,
+        as string) as f from values (1), (2) as X(X)
+    explain: EXPLODE array((@c58 AS X), (@c62 AS X)) | MAP (CAST(NULL AS INT) AS A,
         CAST(NULL AS LONG) AS B, CAST(NULL AS STRING) AS C, CAST(NULL AS DOUBLE) AS
-        D, CAST(NULL AS BOOLEAN) AS E, CAST(NULL AS STRING) AS F, CAST(NULL AS UUID)
-        AS G)
+        D, CAST(NULL AS BOOLEAN) AS E, CAST(NULL AS STRING) AS F)
     task_count: 116
     task_total_time_ms: 3
+    transform_count: 27
+    transform_time_ms: 0
+    transform_yield_count: 6
+    insert_time_ms: 0
+    insert_new_count: 9
+    insert_reused_count: 0
+-   query: EXPLAIN select cast(null as uuid) from values (1), (2) as X(X)
+    explain: EXPLODE array((@c11 AS X), (@c15 AS X)) | MAP (CAST(NULL AS UUID) AS
+        _0)
+    task_count: 116
+    task_total_time_ms: 1
     transform_count: 27
     transform_time_ms: 0
     transform_yield_count: 6
@@ -349,12 +359,23 @@ cast-operator-tests:
     insert_reused_count: 0
 -   query: EXPLAIN select cast(null as integer array) as a, cast(null as bigint array)
         as b, cast(null as string array) as c, cast(null as double array) as d, cast(null
-        as boolean array) as e, cast(null as string array) as f, cast(null as uuid
-        array) as g from values (1), (2) as X(X)
-    explain: EXPLODE array((@c74 AS X), (@c78 AS X)) | MAP (CAST(NULL AS ARRAY(INT))
+        as boolean array) as e, cast(null as string array) as f from values (1), (2)
+        as X(X)
+    explain: EXPLODE array((@c64 AS X), (@c68 AS X)) | MAP (CAST(NULL AS ARRAY(INT))
         AS A, CAST(NULL AS ARRAY(LONG)) AS B, CAST(NULL AS ARRAY(STRING)) AS C, CAST(NULL
         AS ARRAY(DOUBLE)) AS D, CAST(NULL AS ARRAY(BOOLEAN)) AS E, CAST(NULL AS ARRAY(STRING))
-        AS F, CAST(NULL AS ARRAY(UUID)) AS G)
+        AS F)
+    task_count: 116
+    task_total_time_ms: 1
+    transform_count: 27
+    transform_time_ms: 0
+    transform_yield_count: 6
+    insert_time_ms: 0
+    insert_new_count: 9
+    insert_reused_count: 0
+-   query: EXPLAIN select cast(null as uuid array) from values (1), (2) as X(X)
+    explain: EXPLODE array((@c12 AS X), (@c16 AS X)) | MAP (CAST(NULL AS ARRAY(UUID))
+        AS _0)
     task_count: 116
     task_total_time_ms: 1
     transform_count: 27

--- a/yaml-tests/src/test/resources/cast-tests.yamsql
+++ b/yaml-tests/src/test/resources/cast-tests.yamsql
@@ -180,15 +180,24 @@ test_block:
 
     # Cast null
     -
-      - query: select cast(null as integer) as a, cast(null as bigint) as b, cast(null as string) as c, cast(null as double) as d, cast(null as boolean) as e, cast(null as string) as f, cast(null as uuid) as g from values (1), (2) as X(X)
-      - explain: "EXPLODE array((@c67 AS X), (@c71 AS X)) | MAP (CAST(NULL AS INT) AS A, CAST(NULL AS LONG) AS B, CAST(NULL AS STRING) AS C, CAST(NULL AS DOUBLE) AS D, CAST(NULL AS BOOLEAN) AS E, CAST(NULL AS STRING) AS F, CAST(NULL AS UUID) AS G)"
+      - query: select cast(null as integer) as a, cast(null as bigint) as b, cast(null as string) as c, cast(null as double) as d, cast(null as boolean) as e, cast(null as string) as f from values (1), (2) as X(X)
+      - explain: "EXPLODE array((@c58 AS X), (@c62 AS X)) | MAP (CAST(NULL AS INT) AS A, CAST(NULL AS LONG) AS B, CAST(NULL AS STRING) AS C, CAST(NULL AS DOUBLE) AS D, CAST(NULL AS BOOLEAN) AS E, CAST(NULL AS STRING) AS F)"
       - initialVersionLessThan: !current_version
       - error: 'XXXXX'
       - initialVersionAtLeast: !current_version
       - result: [
-          { A: !null _, B: !null _, C: !null _, D: !null _, E: !null _, F: !null _, G: !null _, },
-          { A: !null _, B: !null _, C: !null _, D: !null _, E: !null _, F: !null _, G: !null _, },
+          { A: !null _, B: !null _, C: !null _, D: !null _, E: !null _, F: !null _ },
+          { A: !null _, B: !null _, C: !null _, D: !null _, E: !null _, F: !null _ },
         ]
+    -
+      - query: select cast(null as uuid) from values (1), (2) as X(X)
+      # UUID types had non-stable plan hashes before 4.9.1.0
+      - supported_version: 4.9.1.0
+      - explain: "EXPLODE array((@c11 AS X), (@c15 AS X)) | MAP (CAST(NULL AS UUID) AS _0)"
+      - initialVersionLessThan: !current_version
+      - error: 'XXXXX'
+      - initialVersionAtLeast: !current_version
+      - result: [{ !null _ }, { !null _ }]
     -
       # Floats are only supported starting with !current_version because the JDBC façade was missing support for them
       - query: select cast(null as float) from values (1), (2) as X(X)
@@ -210,15 +219,24 @@ test_block:
           { A: !null _, B: !null _, C: !null _ },
         ]
     -
-      - query: select cast(null as integer array) as a, cast(null as bigint array) as b, cast(null as string array) as c, cast(null as double array) as d, cast(null as boolean array) as e, cast(null as string array) as f, cast(null as uuid array) as g from values (1), (2) as X(X)
-      - explain: "EXPLODE array((@c74 AS X), (@c78 AS X)) | MAP (CAST(NULL AS ARRAY(INT)) AS A, CAST(NULL AS ARRAY(LONG)) AS B, CAST(NULL AS ARRAY(STRING)) AS C, CAST(NULL AS ARRAY(DOUBLE)) AS D, CAST(NULL AS ARRAY(BOOLEAN)) AS E, CAST(NULL AS ARRAY(STRING)) AS F, CAST(NULL AS ARRAY(UUID)) AS G)"
+      - query: select cast(null as integer array) as a, cast(null as bigint array) as b, cast(null as string array) as c, cast(null as double array) as d, cast(null as boolean array) as e, cast(null as string array) as f from values (1), (2) as X(X)
+      - explain: "EXPLODE array((@c64 AS X), (@c68 AS X)) | MAP (CAST(NULL AS ARRAY(INT)) AS A, CAST(NULL AS ARRAY(LONG)) AS B, CAST(NULL AS ARRAY(STRING)) AS C, CAST(NULL AS ARRAY(DOUBLE)) AS D, CAST(NULL AS ARRAY(BOOLEAN)) AS E, CAST(NULL AS ARRAY(STRING)) AS F)"
       - initialVersionLessThan: !current_version
       - error: 'XXXXX'
       - initialVersionAtLeast: !current_version
       - result: [
-          { A: !null _, B: !null _, C: !null _, D: !null _, E: !null _, F: !null _, G: !null _, },
-          { A: !null _, B: !null _, C: !null _, D: !null _, E: !null _, F: !null _, G: !null _, },
+          { A: !null _, B: !null _, C: !null _, D: !null _, E: !null _, F: !null _, },
+          { A: !null _, B: !null _, C: !null _, D: !null _, E: !null _, F: !null _, },
         ]
+    -
+      - query: select cast(null as uuid array) from values (1), (2) as X(X)
+      # UUID types had non-stable plan hashes before 4.9.1.0
+      - supported_version: 4.9.1.0
+      - explain: "EXPLODE array((@c12 AS X), (@c16 AS X)) | MAP (CAST(NULL AS ARRAY(UUID)) AS _0)"
+      - initialVersionLessThan: !current_version
+      - error: 'XXXXX'
+      - initialVersionAtLeast: !current_version
+      - result: [{ !null _ }, { !null _ }]
     -
       # Unlike float scalars, float arrays are supported on versions older than !current_version when continuing
       - query: select cast(null as float array) from values (1), (2) as X(X)


### PR DESCRIPTION
This fixes some tests in `cast-test.yamsql` that resulted in mixed mode test failures when we tried to release 4.9.5.0: https://github.com/FoundationDB/fdb-record-layer/actions/runs/21480359817

The issue is that two new queries introduced in #3884 had UUID-valued columns. Prior to 4.9.1.0 (see: #3679), the plan hash for UUIDs was unstable, so we get plan hash problems whenever we try and continue such a query on that older version. To address that, I've modified the queries so that:

* The original failing queries no longer have UUID-valued columns. They now pass against 4.8 and 4.9 versions
* New queries have been added that have the UUID-valued columns, but they only run for 4.9.1.0 and newer

I've run mixed mode tests locally for this file, and it now passes for 4.8 and 4.9 versions. 