### PR TITLE
Make ThrottledRetryingIterator use read-write transaction by default.

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/runners/throttled/ThrottledRetryingIterator.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/runners/throttled/ThrottledRetryingIterator.java
@@ -434,7 +434,7 @@ public class ThrottledRetryingIterator<T> implements AutoCloseable {
             this.maxRecordScannedPerSec = 0;
             this.maxRecordDeletesPerSec = 0;
             this.numOfRetries = NUMBER_OF_RETRIES;
-            this.commitWhenDone = false;
+            this.commitWhenDone = true;
         }
 
         /**
@@ -528,7 +528,7 @@ public class ThrottledRetryingIterator<T> implements AutoCloseable {
          * Set whether to commit the transaction when done.
          * Setting this to TRUE will commit every transaction created before creating a new one. Setting to FALSE will
          * roll back the transactions.
-         * Defaults to FALSE.
+         * Defaults to TRUE.
          * @param commitWhenDone whether to commit or roll back the transactions created
          * @return this builder
          */


### PR DESCRIPTION
The `RetryingThrottledIterator` has an option to use read-only transactions (for example in case we are doing validation only for records without repair). The default of `FALSE` (read-only) is confusing to developers that assume that the runner "just runs" and commits the work. Therefore, this change that used a commit on the internal transactions created by the runner.
As part of ensuring no public behavior change, I went over the usage of the throttled iterator and ensured production code usages explicitly set the `commitWhenDone` parameter, so the default does not apply to them.

Resolves #3889