### PR TITLE
Remove 4.9.5.0 release notes as it was never published

### DIFF
--- a/docs/sphinx/source/ReleaseNotes.md
+++ b/docs/sphinx/source/ReleaseNotes.md
@@ -7,42 +7,6 @@ As the [versioning guide](Versioning.md) details, it cannot always be determined
 
 ## 4.9
 
-### 4.9.5.0
-
-<h4> New Features </h4>
-
-* Avoid generating logical plan for temporary functions - [PR #3877](https://github.com/FoundationDB/fdb-record-layer/pull/3877)
-* Add support for casting and promoting `null` literals to `BYTES`, `VERSION`, and `VECTOR` types - [PR #3884](https://github.com/FoundationDB/fdb-record-layer/pull/3884)
-* Support dot_product and euclidean_square metrics and distance functions. - [PR #3883](https://github.com/FoundationDB/fdb-record-layer/pull/3883)
-* Lucene: Apply pending queue entries during merge - [PR #3852](https://github.com/FoundationDB/fdb-record-layer/pull/3852)
-
-<details>
-<summary>
-
-<h4> Build/Test/Documentation/Style Improvements (click to expand) </h4>
-
-</summary>
-
-* Fix the `cast-tests.yamsql` mixed mode test failures with versions older than 4.9 - [PR #3888](https://github.com/FoundationDB/fdb-record-layer/pull/3888)
-* Additional tests of scan plans with versions - [PR #3875](https://github.com/FoundationDB/fdb-record-layer/pull/3875)
-* Fix up `versions-test.yamsql` query that was failing in mixed mode - [PR #3879](https://github.com/FoundationDB/fdb-record-layer/pull/3879)
-* Updating !current_version in yamsql files to 4.9.4.0 - [PR #3880](https://github.com/FoundationDB/fdb-record-layer/pull/3880)
-
-</details>
-
-
-**[Full Changelog (4.9.4.0...4.9.5.0)](https://github.com/FoundationDB/fdb-record-layer/compare/4.9.4.0...4.9.5.0)**
-
-#### Mixed Mode Test Results
-
-Mixed mode testing run against the following previous versions:
-
-❌`4.8.12.0`, ✅`4.8.13.0`, ✅`4.8.14.0`, ✅`4.8.15.0`, ✅`4.8.16.0`, ✅`4.8.17.0`, ✅`4.9.1.0`, ✅`4.9.2.0`, ✅`4.9.3.0`, ✅`4.9.4.0`
-
-[See full test run](https://github.com/FoundationDB/fdb-record-layer/actions/runs/21489268020)
-
-
-
 ### 4.9.4.0
 
 <h4> Bug Fixes </h4>


### PR DESCRIPTION
The 4.9.5.0 release build failed before it could actually publish anything: https://github.com/FoundationDB/fdb-record-layer/actions/runs/21489268020/job/61916266283 As a result, these release notes are misleading. This deletes them, so that we get a more accurate picture of what's going on in the next run.