### PR TITLE
Ensure logs get published in the test reports even if the tests themselves fail

### DIFF
--- a/yaml-tests/yaml-tests.gradle
+++ b/yaml-tests/yaml-tests.gradle
@@ -198,6 +198,12 @@ singleVersionTest {
     systemProperty("yaml_testing_external_server", project.layout.buildDirectory.dir('externalServer').get().asFile)
 }
 
+def copyTempLogs = tasks.register("copyTempLogs", Copy) {
+    from(".out/tmp-test")
+    include "*.log"
+    into(".out/reports/logs")
+}
+
 test {
     dependsOn "serverJars"
     systemProperty("yaml_testing_external_server", project.layout.buildDirectory.dir('externalServer').get().asFile)
@@ -219,14 +225,7 @@ test {
 
     if (project.hasProperty("tests.ci") || project.hasProperty("tests.saveServerLogs")) {
         systemProperties['tests.saveServerLogs'] = "true"
-    }
-
-    doLast {
-        copy {
-            from(".out/tmp-test")
-            include "*.log"
-            into(".out/reports/logs")
-        }
+        finalizedBy(copyTempLogs)
     }
 }
 


### PR DESCRIPTION
This moves the log copying information out of a `doLast` block and into its own task which is then referenced by `finalizedBy`. The tasks in `finalizedBy` get run even if the task otherwise fails.

I was able to validate locally that I got logs copied over into the reports if and only if the tests succeeded when using the old code, and then that using the new logic ensured that the logs always got copied over. I did this by injecting a failure into one of the tests and running it. This should hopefully mean that we'd get external server logs in the test report the next time there is a CI failure.

This fixes #3903.