### PR TITLE
Assert that yaml test connections to `ExternalServer`s are connections to the right version

### DIFF
--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/ExternalServerYamlConnectionFactory.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/ExternalServerYamlConnectionFactory.java
@@ -21,18 +21,23 @@
 package com.apple.foundationdb.relational.yamltests.connectionfactory;
 
 import com.apple.foundationdb.record.logging.KeyValueLogMessage;
+import com.apple.foundationdb.relational.util.BuildVersion;
 import com.apple.foundationdb.relational.yamltests.SimpleYamlConnection;
 import com.apple.foundationdb.relational.yamltests.YamlConnection;
 import com.apple.foundationdb.relational.yamltests.YamlConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.server.ExternalServer;
 import com.apple.foundationdb.relational.yamltests.server.SemanticVersion;
+import com.google.common.base.Verify;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import javax.annotation.Nonnull;
 import java.net.URI;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.util.Objects;
 import java.util.Set;
 
 public class ExternalServerYamlConnectionFactory implements YamlConnectionFactory {
@@ -52,7 +57,16 @@ public class ExternalServerYamlConnectionFactory implements YamlConnectionFactor
                     "rewritten", uriStr,
                     "version", externalServer.getVersion()));
         }
-        return new SimpleYamlConnection(DriverManager.getConnection(uriStr), externalServer.getVersion(), externalServer.getClusterFile());
+
+        // Validate that the server has the expected version. Connect and make a request to the meta-data API,
+        // and validate that the database product version matches the external server's version
+        final Connection connection = DriverManager.getConnection(uriStr);
+        final DatabaseMetaData metaData = connection.getMetaData();
+        final String serverVersion = metaData.getDatabaseProductVersion();
+        final String expectedVersion = externalServer.getVersion().equals(SemanticVersion.current()) ? BuildVersion.getInstance().getVersion() : externalServer.getVersion().toString();
+        Verify.verify(Objects.equals(expectedVersion, serverVersion), "server version %s should match expected version %s", serverVersion, expectedVersion);
+
+        return new SimpleYamlConnection(connection, externalServer.getVersion(), externalServer.getClusterFile());
     }
 
     @Override


### PR DESCRIPTION
This attempts to validate that we are connecting to the right server by having the connection factory make an additional call at connection creation time. It uses the the database meta-data API to ask the server what version it is, and then it compares the server's answer to the expected answer, which is based on the `ExternalServer` object's `SemanticVersion`.

This is an attempt to look more into the failures that recently plagued the build, as those tests hit problems that are consistent with talking to the wrong version. This is an attempt to try and falsify that theory by adding more validation that we're talking to the right place.