### PR TITLE
Make FDBDatabaseTest.testPostCloseHookFailsToCreate not flaky

### DIFF
--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseTest.java
@@ -441,11 +441,17 @@ class FDBDatabaseTest {
 
         FDBRecordContext context = database.openContext();
 
-        context.addPostCloseHook("foo", () -> CompletableFuture.runAsync(() -> called.add("foo")));
+        context.addPostCloseHook("foo", () -> {
+            called.add("foo");
+            return CompletableFuture.completedFuture(null);
+        });
         context.addPostCloseHook("close-fails", () -> {
             throw new RuntimeException("Blah");
         } );
-        context.addPostCloseHook("bar", () -> CompletableFuture.runAsync(() -> called.add("bar")));
+        context.addPostCloseHook("bar", () -> {
+            called.add("bar");
+            return CompletableFuture.completedFuture(null);
+        });
 
         // Context now fails to close
         assertThrows(RuntimeException.class, context::close);


### PR DESCRIPTION
I saw two failures of this test:
https://github.com/FoundationDB/fdb-record-layer/actions/runs/21620783294
```
org.opentest4j.AssertionFailedError: expected: java.util.ImmutableCollections$Set12@a37a150<[foo]> but was: java.util.HashSet@77ab77ef<[foo]>
	at app//org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
	at app//org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
	at app//org.junit.jupiter.api.AssertEquals.failNotEqual(AssertEquals.java:197)
	at app//org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:182)
	at app//org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:177)
	at app//org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1145)
	at app//com.apple.foundationdb.record.provider.foundationdb.FDBDatabaseTest.testPostCloseHookFailsToCreate(FDBDatabaseTest.java:454)
```

and
https://github.com/FoundationDB/fdb-record-layer/actions/runs/21634337782?pr=3832
```
FDBDatabaseTest > testPostCloseHookFailsToCreate()
org.opentest4j.AssertionFailedError: expected: <[foo]> but was: <[]>
	at app//org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
	at app//org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
	at app//org.junit.jupiter.api.AssertEquals.failNotEqual(AssertEquals.java:197)
	at app//org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:182)
	at app//org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:177)
	at app//org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1145)
	at app//com.apple.foundationdb.record.provider.foundationdb.FDBDatabaseTest.testPostCloseHookFailsToCreate(FDBDatabaseTest.java:454)
```

The issue was that the future for `foo` would be scheduled, but may not execute until the middle of the `assertEquals`, this means that sometimes it would compare the sets before `foo` gets added, but log the failure after `foo` was added (the first failure above), and sometimes it would complete the entire assertion beforehand. 


We don't actually depend on the future being run in a future, so I changed it to not.
This was failing reliably, locally if I did `@RepeatedTest(100)`, and with the change, it does not.