### PR TITLE
Publish the server logs for mixed mode tests

### DIFF
--- a/yaml-tests/yaml-tests.gradle
+++ b/yaml-tests/yaml-tests.gradle
@@ -198,12 +198,6 @@ singleVersionTest {
     systemProperty("yaml_testing_external_server", project.layout.buildDirectory.dir('externalServer').get().asFile)
 }
 
-def copyTempLogs = tasks.register("copyTempLogs", Copy) {
-    from(".out/tmp-test")
-    include "*.log"
-    into(".out/reports/logs")
-}
-
 test {
     dependsOn "serverJars"
     systemProperty("yaml_testing_external_server", project.layout.buildDirectory.dir('externalServer').get().asFile)
@@ -222,7 +216,19 @@ test {
         // we may want to decrease this multiplying factor.
         systemProperties['tests.yaml.iterations'] = Integer.parseInt(project.getProperty('tests.iterations')) * 20
     }
+}
 
+def copyTempLogs = tasks.register("copyTempLogs", Copy) {
+    from(".out/")
+    include "tmp-*/*.log"
+    into(".out/reports/logs")
+    eachFile {
+        it.path = it.path.replaceFirst("tmp-", "")
+    }
+    setIncludeEmptyDirs(false)
+}
+
+tasks.withType(Test).configureEach {
     if (project.hasProperty("tests.ci") || project.hasProperty("tests.saveServerLogs")) {
         systemProperties['tests.saveServerLogs'] = "true"
         finalizedBy(copyTempLogs)


### PR DESCRIPTION
We've already added server logs in test reports (see: #3897 and #3904). Because that was only done to the `test` task, we didn't get the logs if the failure was in `mixedModeTest`. This updates the logic in `yaml-tets.gradle` so that all available test tasks now do the copying. This should help debug mixed mode errors like we saw with https://github.com/FoundationDB/fdb-record-layer/actions/runs/21620783294/attempts/1#summary-62309171472