### PR TITLE
Make `RecordMetadataDeserializer` more static to avoid `this-escape` errors

### DIFF
--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/RecordLayerSchemaTemplate.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/RecordLayerSchemaTemplate.java
@@ -57,6 +57,7 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -481,6 +482,11 @@ public final class RecordLayerSchemaTemplate implements SchemaTemplate {
             verifyNameIsNotUsed(invokedRoutine.getName());
             invokedRoutines.put(invokedRoutine.getName(), invokedRoutine);
             return this;
+        }
+
+        @Nonnull
+        public List<RecordLayerInvokedRoutine> getInvokedRoutines() {
+            return ImmutableList.copyOf(invokedRoutines.values());
         }
 
         @Nonnull

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/serde/RecordMetadataDeserializer.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/serde/RecordMetadataDeserializer.java
@@ -58,10 +58,10 @@ import java.util.stream.Collectors;
 public class RecordMetadataDeserializer {
 
     @Nonnull
-    private final RecordMetaData recordMetaData;
+    protected final RecordMetaData recordMetaData;
 
     @Nonnull
-    private final RecordLayerSchemaTemplate.Builder builder;
+    protected final RecordLayerSchemaTemplate.Builder builder;
 
     public RecordMetadataDeserializer(@Nonnull final RecordMetaData recordMetaData) {
         this.recordMetaData = recordMetaData;


### PR DESCRIPTION
This will avoid `this-escape` problems with a newer compiler.