### PR TITLE
Validate external servers started during yaml tests are up by waiting for a successful connection

### DIFF
--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/ExternalServerYamlConnectionFactory.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/ExternalServerYamlConnectionFactory.java
@@ -21,23 +21,19 @@
 package com.apple.foundationdb.relational.yamltests.connectionfactory;
 
 import com.apple.foundationdb.record.logging.KeyValueLogMessage;
-import com.apple.foundationdb.relational.util.BuildVersion;
 import com.apple.foundationdb.relational.yamltests.SimpleYamlConnection;
 import com.apple.foundationdb.relational.yamltests.YamlConnection;
 import com.apple.foundationdb.relational.yamltests.YamlConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.server.ExternalServer;
 import com.apple.foundationdb.relational.yamltests.server.SemanticVersion;
-import com.google.common.base.Verify;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import javax.annotation.Nonnull;
 import java.net.URI;
 import java.sql.Connection;
-import java.sql.DatabaseMetaData;
 import java.sql.DriverManager;
 import java.sql.SQLException;
-import java.util.Objects;
 import java.util.Set;
 
 public class ExternalServerYamlConnectionFactory implements YamlConnectionFactory {
@@ -58,14 +54,8 @@ public class ExternalServerYamlConnectionFactory implements YamlConnectionFactor
                     "version", externalServer.getVersion()));
         }
 
-        // Validate that the server has the expected version. Connect and make a request to the meta-data API,
-        // and validate that the database product version matches the external server's version
         final Connection connection = DriverManager.getConnection(uriStr);
-        final DatabaseMetaData metaData = connection.getMetaData();
-        final String serverVersion = metaData.getDatabaseProductVersion();
-        final String expectedVersion = externalServer.getVersion().equals(SemanticVersion.current()) ? BuildVersion.getInstance().getVersion() : externalServer.getVersion().toString();
-        Verify.verify(Objects.equals(expectedVersion, serverVersion), "server version %s should match expected version %s", serverVersion, expectedVersion);
-
+        externalServer.validateConnectionVersion(connection);
         return new SimpleYamlConnection(connection, externalServer.getVersion(), externalServer.getClusterFile());
     }
 


### PR DESCRIPTION
This updates the logic in `ExternalServer.startServer` so that rather than waiting for a 3 seconds, we instead attempt to make connections to it via the JDBC driver. We then make a call to get the server meta-data and validate the version. Generally, this is much faster than three seconds, which speeds up tests, particularly tests where we only want to run one test file. But it also should be more resilient, in that in the off chance that a process takes longer than 3 seconds before it starts, we won't move on thinking that it did.