### PR TITLE
Make new store lock exceptions final.

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/StoreIsFullyLockedException.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/StoreIsFullyLockedException.java
@@ -33,7 +33,7 @@ import javax.annotation.Nullable;
  * guarantee that no operations will be performed on the store while it is locked.
  */
 @API(API.Status.EXPERIMENTAL)
-public class StoreIsFullyLockedException extends RecordCoreStorageException {
+public final class StoreIsFullyLockedException extends RecordCoreStorageException {
     private static final long serialVersionUID = -2341887654789012345L;
 
     public StoreIsFullyLockedException(@Nonnull final RecordMetaDataProto.DataStoreInfo.StoreLockState storeLockState,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/UnknownStoreLockStateException.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/UnknownStoreLockStateException.java
@@ -35,7 +35,7 @@ import javax.annotation.Nullable;
  * that operations are not performed on a store whose lock semantics are not understood.
  */
 @API(API.Status.EXPERIMENTAL)
-public class UnknownStoreLockStateException extends RecordCoreStorageException {
+public final class UnknownStoreLockStateException extends RecordCoreStorageException {
     private static final long serialVersionUID = 5487301928475634129L;
 
     public UnknownStoreLockStateException(@Nonnull String message,


### PR DESCRIPTION
They call the overridable addLogInfo method.
These were added by #3859, after the other Java 21 changes.