### PR TITLE
Yaml test result statement can be array of arrays

### DIFF
--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/Matchers.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/Matchers.java
@@ -455,11 +455,7 @@ public class Matchers {
                 printCurrentAndRemaining(actual, resultSetPrettyPrinter);
                 return ImmutablePair.of(ResultSetMatchResult.fail(String.format(Locale.ROOT, "result does not contain all expected rows! expected %d rows, got %d", expectedAsList.size(), i - 1)), null);
             }
-            if (!isMap(expectedRow)) { // I think it should be possible to expect a result set like: [[1,2,3], [4,5,6]]. But ok for now.
-                printCurrentAndRemaining(actual, resultSetPrettyPrinter);
-                return ImmutablePair.of(ResultSetMatchResult.fail("unknown format of expected result set"), resultSetPrettyPrinter);
-            }
-            final var matchResult = matchRow(map(expectedRow), actual.getMetaData().getColumnCount(), valueByName(actual), valueByIndex(actual), i++);
+            final var matchResult = matchRow(expectedRow, actual.getMetaData().getColumnCount(), valueByName(actual), valueByIndex(actual), i++);
             if (!matchResult.equals(ResultSetMatchResult.success())) {
                 printCurrentAndRemaining(actual, resultSetPrettyPrinter);
                 return ImmutablePair.of(matchResult, resultSetPrettyPrinter); // fail.
@@ -487,11 +483,7 @@ public class Matchers {
                 return ImmutablePair.of(ResultSetMatchResult.fail(String.format(Locale.ROOT, "too many rows in actual result set! expected %d row(s), got %d row(s) instead.", expectedRowCount, actualRowsCounter - 1)), resultSetPrettyPrinter);
             }
             for (final var expectedRow : expectedAsMultiSet.elementSet()) {
-                if (!isMap(expectedRow)) { // I think it should be possible to expect a result set like: [[1,2,3], [4,5,6]]. But ok for now.
-                    printCurrentAndRemaining(actual, resultSetPrettyPrinter);
-                    return ImmutablePair.of(ResultSetMatchResult.fail("unknown format of expected result set"), resultSetPrettyPrinter);
-                }
-                final var matchResult = matchRow(map(expectedRow), actual.getMetaData().getColumnCount(), valueByName(actual), valueByIndex(actual), actualRowsCounter);
+                final var matchResult = matchRow(expectedRow, actual.getMetaData().getColumnCount(), valueByName(actual), valueByIndex(actual), actualRowsCounter);
                 if (matchResult.equals(ResultSetMatchResult.success())) {
                     found = true;
                     expectedAsMultiSet.remove(expectedRow);
@@ -533,16 +525,41 @@ public class Matchers {
     }
 
     @Nonnull
-    private static ResultSetMatchResult matchRow(@Nonnull final Map<?, ?> expected,
+    private static ResultSetMatchResult matchRow(@Nonnull final Object expected,
                                                  final int actualEntriesCount,
                                                  @Nonnull final Function<String, Object> entryByNameAccessor,
                                                  @Nonnull final Function<Integer, Object> entryByNumberAccessor,
                                                  int rowNumber) throws SQLException {
-        final var expectedColCount = expected.entrySet().size();
-        if (actualEntriesCount != expectedColCount) {
-            return ResultSetMatchResult.fail(String.format(Locale.ROOT, "row cardinality mismatch at %d! expected a row comprising %d column(s), received %d column(s) instead.", rowNumber, expectedColCount, actualEntriesCount));
+        if (expected instanceof Map) {
+            return matchMap((Map<?, ?>)expected, actualEntriesCount, entryByNameAccessor, entryByNumberAccessor, rowNumber, "");
         }
-        return matchMap(expected, actualEntriesCount, entryByNameAccessor, entryByNumberAccessor, rowNumber, "");
+        if (expected instanceof List) {
+            return matchArray((List<?>)expected, actualEntriesCount, entryByNumberAccessor, rowNumber, "");
+        }
+        return ResultSetMatchResult.fail(String.format(Locale.ROOT, "Expecting %s to be of type Map or List, however it is of type %s", expected.toString(), expected.getClass().getSimpleName()));
+    }
+
+    @Nonnull
+    private static ResultSetMatchResult matchArray(@Nonnull final List<?> expected,
+                                                 final int actualEntriesCount,
+                                                 @Nonnull final Function<Integer, Object> entryByNumberAccessor,
+                                                 int rowNumber,
+                                                 @Nonnull String cellRef) throws SQLException {
+        final var expectedColCount = expected.size();
+        if (actualEntriesCount != expectedColCount) {
+            return ResultSetMatchResult.fail(String.format(Locale.ROOT, "! expected a row comprising %d column(s), received %d column(s) instead.", expectedColCount, actualEntriesCount));
+        }
+        int counter = 1;
+        for (final var expectedField : expected) {
+            final var actualField = entryByNumberAccessor.apply(counter);
+            final var currentCellRef = "pos<" + counter + ">";
+            final var matchResult = matchField(expectedField, actualField, rowNumber, cellRef + (cellRef.isEmpty() ? "" : ".") + currentCellRef);
+            if (!matchResult.equals(ResultSetMatchResult.success())) {
+                return matchResult; // propagate failure.
+            }
+            counter++;
+        }
+        return ResultSetMatchResult.success();
     }
 
     @Nonnull

--- a/yaml-tests/src/test/java/YamlIntegrationTests.java
+++ b/yaml-tests/src/test/java/YamlIntegrationTests.java
@@ -273,6 +273,11 @@ public class YamlIntegrationTests {
     }
 
     @TestTemplate
+    public void resultAsArrayOfArrays(YamlTest.Runner runner) throws Exception {
+        runner.runYamsql("result-as-array-of-arrays.yamsql");
+    }
+
+    @TestTemplate
     public void scenarioTests(YamlTest.Runner runner) throws Exception {
         runner.runYamsql("scenario-tests.yamsql");
     }

--- a/yaml-tests/src/test/resources/result-as-array-of-arrays.yamsql
+++ b/yaml-tests/src/test/resources/result-as-array-of-arrays.yamsql
@@ -1,0 +1,39 @@
+#
+# result-as-array-of-arrays.yamsql
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2021-2025 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+schema_template:
+    create table t1(c1 bigint, c2 bigint, c3 bigint, primary key(c1))
+---
+setup:
+  steps:
+    - query: insert into t1 values (10, 20, 30)
+    - query: insert into t1 values (11, 21, 31)
+    - query: insert into t1 values (12, 22, 32)
+---
+test_block:
+  preset: single_repetition_ordered
+  tests:
+    -
+      - query: select * from t1 where c1=10
+      - result: [[10, 20, 30]]
+    -
+      - query: select * from t1
+      - unorderedResult: [[12, 22, 32],
+                          [10, 20, 30],
+                          [11, 21, 31]]


### PR DESCRIPTION
This PR introduce the new representation of the `result` statement in the `yamsql` test files.
Now `result` can be represented as a simple array of arrays.
```
     - result: [[12, 22, 32],
                [10, 20, 30],
                [11, 21, 31]]
```
It simplifies the construction of simple tests and can be useful for some corner cases (e.g. when we can't specify the name of the column)
