### PR TITLE
Increase number of `ExternalServer` retries on connection

### DIFF
--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/ExternalServer.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/ExternalServer.java
@@ -165,13 +165,15 @@ public class ExternalServer {
         }
 
         if (!startServer(processBuilder)) {
-            logger.warn(KeyValueLogMessage.of("Failed to start external server",
-                    "jar", serverJar,
-                    LogMessageKeys.VERSION, version,
-                    "grpc_port", grpcPort,
-                    "http_port", httpPort,
-                    "out_file", outFile,
-                    "err_file", errFile));
+            if (logger.isWarnEnabled()) {
+                logger.warn(KeyValueLogMessage.of("Failed to start external server",
+                        "jar", serverJar,
+                        LogMessageKeys.VERSION, version,
+                        "grpc_port", grpcPort,
+                        "http_port", httpPort,
+                        "out_file", outFile,
+                        "err_file", errFile));
+            }
             Assertions.fail("Failed to start the external server");
         }
 


### PR DESCRIPTION
This increases the number of times we attempt to ping an `ExternalServer` while it's starting up. This should help with #3951 if the problem is that the server is just taking too long to start up by a few seconds. Note that the delay between retries scales with the attempt, so by doubling the number of attempts, this actually quadruples the total time it will wait before giving up.

This adds some additional logs in that case to help diagnose the issue if it persists. This includes the log file, as well as records of the success/failure of pings:

```
2026-02-13 18:33:52,269 [DEBUG] c.a.f.r.y.s.ExternalServer - Attempted to connect to external server attempt="1" grpc_port="1111" success="false" version="!current_version" {}
2026-02-13 18:33:52,328 [DEBUG] c.a.f.r.y.s.ExternalServer - Attempted to connect to external server attempt="2" grpc_port="1111" success="false" version="!current_version" {}
2026-02-13 18:33:52,437 [DEBUG] c.a.f.r.y.s.ExternalServer - Attempted to connect to external server attempt="3" grpc_port="1111" success="false" version="!current_version" {}
2026-02-13 18:33:52,596 [DEBUG] c.a.f.r.y.s.ExternalServer - Attempted to connect to external server attempt="4" grpc_port="1111" success="false" version="!current_version" {}
2026-02-13 18:33:52,912 [DEBUG] c.a.f.r.y.s.ExternalServer - Attempted to connect to external server attempt="5" grpc_port="1111" success="true" version="!current_version" {}
2026-02-13 18:33:52,912 [INFO] c.a.f.r.y.s.ExternalServer - Started external server err_file="null" grpc_port="1111" http_port="1113" jar="/fdb-record-layer/yaml-tests/.out/externalServer/fdb-relational-server-4.10.0.0-SNAPSHOT-all.jar" out_file="null" version="!current_version"
```

(The files won't be `null` in CI.) This includes a new log if the server fails to start, at `WARN`.