### PR TITLE
Updating !current_version in yamsql files to 4.10.1.0

### DIFF
--- a/yaml-tests/src/test/resources/bitmap-aggregate-index.yamsql
+++ b/yaml-tests/src/test/resources/bitmap-aggregate-index.yamsql
@@ -57,17 +57,17 @@ test_block:
                           {BITMAP: xStartsWith_1250'0400008', 'CATEGORY': 'world', 'OFFSET':0}]
     -
       - query: SELECT bitmap_construct_agg(bitmap_bit_position(id)) as bitmap, bitmap_bucket_offset(id) as offset FROM T1 GROUP BY bitmap_bucket_offset(id), bitmap_bucket_offset(id), bitmap_bucket_offset(id)
-      - initialVersionLessThan: !current_version
+      - initialVersionLessThan: 4.10.1.0
       - unorderedResult: [{BITMAP: xStartsWith_1250'060000c', 'OFFSET':0}, {BITMAP: xStartsWith_1250'02', 'OFFSET':10000}]
-      - initialVersionAtLeast: !current_version
+      - initialVersionAtLeast: 4.10.1.0
       - error: "42702"
     -
       - query: SELECT bitmap_construct_agg(bitmap_bit_position(id)) as bitmap, category, bitmap_bucket_offset(id) as offset FROM T1 GROUP BY bitmap_bucket_offset(id), category, bitmap_bucket_offset(id)
-      - initialVersionLessThan: !current_version
+      - initialVersionLessThan: 4.10.1.0
       - unorderedResult: [{BITMAP: xStartsWith_1250'0200004', 'CATEGORY': 'hello', 'OFFSET':0},
                           {BITMAP: xStartsWith_1250'02', 'CATEGORY': 'hello', 'OFFSET':10000},
                           {BITMAP: xStartsWith_1250'0400008', 'CATEGORY': 'world', 'OFFSET':0}]
-      - initialVersionAtLeast: !current_version
+      - initialVersionAtLeast: 4.10.1.0
       - error: "42702"
     -
       - query: SELECT bitmap_construct_agg(bitmap_bit_position(id)) as bitmap, bitmap_bucket_offset(id) as offset FROM T2 GROUP BY bitmap_bucket_offset(id)

--- a/yaml-tests/src/test/resources/cte.yamsql
+++ b/yaml-tests/src/test/resources/cte.yamsql
@@ -87,9 +87,9 @@ test_block:
                           {W: 7, Z: 20, A: 2, B: 10}]
     -
       - query: with c1(w, z) as (select id, col1 from t1), c2(a, b) as (with c3(A, B) as (select id, col1 from c1 where id in (1, 2)) select * from c3) select * from c1,c2
-      - initialVersionAtLeast: !current_version
+      - initialVersionAtLeast: 4.10.1.0
       - error: "42703"
-      - initialVersionLessThan: !current_version
+      - initialVersionLessThan: 4.10.1.0
       - error: "42F01"
     -
       - query: with c1(w, z, x1, x2, x3, x4) as (select id, col1 from t1) select * from c1
@@ -134,7 +134,7 @@ test_block:
       - query: with dept_data(dept, id, val) as (select col1 as dept, id, col2 as val from t1),
                     large_vals(dept, id) as (select dept, id from dept_data where val >= 6)
                     select dept, id from large_vals
-      - supported_version: !current_version
+      - supported_version: 4.10.1.0
       - explain: "COVERING(I1 [[GREATER_THAN_OR_EQUALS promote(@c44 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], ID: KEY:[3]]) | MAP (_.COL1 AS DEPT, _.ID AS ID)"
       - result: [{DEPT: 20, ID: 6},
                  {DEPT: 20, ID: 7}]
@@ -143,7 +143,7 @@ test_block:
                     filtered(d, i, v) as (select d, i, v from base_data where v > 1),
                     final_data(dept, ident) as (select d, i from filtered where d = 20)
                     select dept, ident from final_data
-      - supported_version: !current_version
+      - supported_version: 4.10.1.0
       - explain: "COVERING(I1 [[GREATER_THAN promote(@c43 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], ID: KEY:[3]]) | FILTER _.COL1 EQUALS promote(@c63 AS LONG) | MAP (_.COL1 AS DEPT, _.ID AS IDENT)"
       - result: [{DEPT: 20, IDENT: 6},
                  {DEPT: 20, IDENT: 7}]
@@ -152,7 +152,7 @@ test_block:
                     c2(a, b) as (select id, col2 from t1 where col1 = 20),
                     combined(x1, y1, a1, b1) as (select c1.x, c1.y, c2.a, c2.b from c1, c2 where c1.x < c2.a)
                     select x1, y1, a1, b1 from combined
-      - supported_version: !current_version
+      - supported_version: 4.10.1.0
       - explain: "ISCAN(I1 [[LESS_THAN promote(@c19 AS LONG)]]) | FLATMAP q0 -> { COVERING(I1 <,> -> [COL1: KEY:[1], COL2: KEY:[0], ID: KEY:[3]]) | FILTER _.COL1 EQUALS promote(@c39 AS LONG) AND q0.ID LESS_THAN _.ID | FETCH AS q1 RETURN (q0.ID AS X1, q0.COL1 AS Y1, q1.ID AS A1, q1.COL2 AS B1) }"
       - unorderedResult: [
                  {X1: 1, Y1: 10, A1: 6, B1: 6},

--- a/yaml-tests/src/test/resources/orderby.yamsql
+++ b/yaml-tests/src/test/resources/orderby.yamsql
@@ -268,7 +268,7 @@ test_block:
     -
       # Ordering by a ambiguous projected column
       - query: select q as "nested", q.a as "ordered" from t2 order by "ordered"
-      - supported_version: !current_version
+      - supported_version: 4.10.1.0
       - explain: "ISCAN(I4 <,>) | MAP (_.Q AS nested, _.Q.A AS ordered)"
       - result: [ {{1, 2}, 1}, {{2, 1}, 2}, {{3, 2}, 3}, {{4, 1}, 4}, {{5, 2}, 5}, {{6, 1}, 6}, {{7, 2}, 7}, {{8, 1}, 8} ]
     -
@@ -278,13 +278,13 @@ test_block:
     -
       # Ordering by a ambiguous projected column in subquery
       - query: select (T.*) from (select q as "nested", q.a as "ordered" from t2) as T order by "ordered"
-      - supported_version: !current_version
+      - supported_version: 4.10.1.0
       - explain: "ISCAN(I4 <,>) | MAP ((_.Q AS nested, _.Q.A AS ordered) AS _0)"
       - result: [ {{{1, 2}, 1}}, {{{2, 1}, 2}}, {{{3, 2}, 3}}, {{{4, 1}, 4}}, {{{5, 2}, 5}}, {{{6, 1}, 6}}, {{{7, 2}, 7}}, {{{8, 1}, 8}} ]
     -
       # Ordering by a column in table function that has been projected in multiple ways
       - query: select (*) from t2_func() order by "ordered"
-      - supported_version: !current_version
+      - supported_version: 4.10.1.0
       - explain: "ISCAN(I4 <,>) | MAP ((_.Q AS nesting, _.Q.A AS ordered) AS _0)"
       - result: [ {{{1, 2}, 1}}, {{{2, 1}, 2}}, {{{3, 2}, 3}}, {{{4, 1}, 4}}, {{{5, 2}, 5}}, {{{6, 1}, 6}}, {{{7, 2}, 7}}, {{{8, 1}, 8}} ]
     -
@@ -295,11 +295,11 @@ test_block:
     -
       # qualification on order by clause is currently not supported entirely
       - query: select (q as "nested", q.a as "ordered") as "st" from t2 order by "st"."ordered"
-      - supported_version: !current_version
+      - supported_version: 4.10.1.0
       - error: "42703"
     -
       # Ordering by a column in table function that has been projected in multiple ways
       - query: select (*) from t2_func_3() order by "ordered2", "ordered1"
-      - supported_version: !current_version
+      - supported_version: 4.10.1.0
       - result: [ {{{2, 1}, 2, 1}}, {{{4, 1}, 4, 1}}, {{{6, 1}, 6, 1}}, {{{8, 1}, 8, 1}}, {{{1, 2}, 1, 2}}, {{{3, 2}, 3, 2}}, {{{5, 2}, 5, 2}}, {{{7, 2}, 7, 2}} ]
 ...

--- a/yaml-tests/src/test/resources/pseudo-field-clash.yamsql
+++ b/yaml-tests/src/test/resources/pseudo-field-clash.yamsql
@@ -257,9 +257,9 @@ test_block:
                  FROM t1, t2, t3
                 WHERE t2.id = t1.id AND t3.id = t1.id
       - explain: "ISCAN(T2_VERSION <,>) | FLATMAP q0 -> { ISCAN(T3_VERSION <,>) | FLATMAP q1 -> { SCAN(<,>) | TFILTER T1 | FILTER q0.ID EQUALS _.ID AND q1.ID EQUALS _.ID AS q2 RETURN (q2 AS _0, q1 AS _1) } AS q3 RETURN ((q3._0.ID AS ID, q3._0.COL1 AS COL1, q3._0.__ROW_VERSION AS __ROW_VERSION) AS _0, (q0.ID AS ID, q0.COL1 AS COL1, q0.__ROW_VERSION AS __ROW_VERSION) AS _1, (q3._1.ID AS ID, q3._1.COL1 AS COL1, q3._1.COL2 AS COL2, q3._1.__ROW_VERSION AS __ROW_VERSION) AS _2) }"
-      - initialVersionLessThan: !current_version
+      - initialVersionLessThan: 4.10.1.0
       - error: 'XXXXX'
-      - initialVersionAtLeast: !current_version
+      - initialVersionAtLeast: 4.10.1.0
       - unorderedResult: [
           { { ID: 1, COL1: "a", '__ROW_VERSION': x'0000' }, { ID: 1, COL1: 10, '__ROW_VERSION': "aa" }, { ID: 1, COL1: 10, COL2: "aa", '__ROW_VERSION': !not_null _ } },
           { { ID: 2, COL1: "b", '__ROW_VERSION': x'0001' }, { ID: 2, COL1: 20, '__ROW_VERSION': "ab" }, { ID: 2, COL1: 20, COL2: "ab", '__ROW_VERSION': !not_null _ } },

--- a/yaml-tests/src/test/resources/recursive-cte.yamsql
+++ b/yaml-tests/src/test/resources/recursive-cte.yamsql
@@ -457,7 +457,7 @@ test_block:
             select b.id, b.parent, a.y as level from (select parent, id from t1 use index (childIdx) where parent is not null and id is not null) as b, (select id, parent, level + 1 as y from c1) as a  where b.id = a.parent)
             traversal order pre_order
             select id, parent, level from c1
-      - supported_version: !current_version
+      - supported_version: 4.10.1.0
       - explain: "RUNION-DFS PREORDER q0 { COVERING(CHILDIDX [EQUALS promote(@c24 AS LONG), [NOT_NULL]] -> [ID: KEY:[0], PARENT: KEY:[1]]) | MAP (_.ID AS ID, _.PARENT AS PARENT, @c11 AS LEVEL) } { RECURSIVE COVERING(CHILDIDX [EQUALS q0.PARENT, [NOT_NULL]] -> [ID: KEY:[0], PARENT: KEY:[1]]) | MAP (_.ID AS ID, _.PARENT AS PARENT, q0.LEVEL + @c81 AS LEVEL) } | MAP (_.ID AS ID, _.PARENT AS PARENT, _.LEVEL AS LEVEL)"
       - result: [{250, 50, 0},
                  {50, 10, 1},

--- a/yaml-tests/src/test/resources/versions-tests.yamsql
+++ b/yaml-tests/src/test/resources/versions-tests.yamsql
@@ -246,14 +246,14 @@ test_block:
         ]
       - initialVersionAtLeast: 4.9.1.0
       # Handled in following test case. There are three branches here: one where the initial version is less than 4.9.1.0,
-      # one where the initial version is between 4.9.1.0 and !current_version, and one where the initial version is greater
-      # than !current_version. This test case handles the first one, and the following one handles the latter two
+      # one where the initial version is between 4.9.1.0 and 4.10.1.0, and one where the initial version is greater
+      # than 4.10.1.0. This test case handles the first one, and the following one handles the latter two
     -
       - query: select "__ROW_VERSION" from (select * from t1) a;
       - supported_version: 4.9.1.0
-      - initialVersionLessThan: !current_version
+      - initialVersionLessThan: 4.10.1.0
       - error: 'XXXXX'
-      - initialVersionAtLeast: !current_version
+      - initialVersionAtLeast: 4.10.1.0
       - error: '42703'
     -
       # Do not include __ROW_VERSION (as a pseudo-column) in nested (*) without identifier
@@ -549,11 +549,11 @@ test_block:
                  from t1 as a, (select * from t2) b
                  where a.col2 = b.col1
       - explain: "ISCAN(I1 <,>) | FLATMAP q0 -> { ISCAN(T2_COL2 <,>) | FILTER q0.COL2 EQUALS _.COL1 AS q1 RETURN (q0.__ROW_VERSION AS __ROW_VERSION, (q0.ID AS ID, q0.COL1 AS COL1, q0.COL2 AS COL2) AS _1, (q1.ID AS ID, q1.COL1 AS COL1, q1.COL2 AS COL2) AS _2) }"
-      - initialVersionLessThan: !current_version
-      # Prior to !current_version, we did not keep track of which quantifiers actually had the version, so this would default to
+      - initialVersionLessThan: 4.10.1.0
+      # Prior to 4.10.1.0, we did not keep track of which quantifiers actually had the version, so this would default to
       # assuming that the row version column was ambiguous
       - error: '42702'
-      - initialVersionAtLeast: !current_version
+      - initialVersionAtLeast: 4.10.1.0
       - unorderedResult: [
           { '__ROW_VERSION': !not_null _, { ID: 1, COL1: 10, COL2: 1 }, { ID:  1, COL1: 1, COL2: 'a' } },
           { '__ROW_VERSION': !not_null _, { ID: 1, COL1: 10, COL2: 1 }, { ID:  5, COL1: 1, COL2: 'a' } },
@@ -716,12 +716,12 @@ test_block:
            where t2.col2 = 'b' and t3.col1 = 'b'
            and t2."__ROW_VERSION" > t3."__ROW_VERSION"
       - explain: "ISCAN(T2_COL2 [EQUALS promote(@c22 AS STRING)]) | FLATMAP q0 -> { ISCAN(T3_VERSION_WITH_COL1 <,>) | FILTER _.COL1 EQUALS promote(@c22 AS STRING) AND q0.__ROW_VERSION GREATER_THAN _.__ROW_VERSION AS q1 RETURN ((q0.ID AS ID, q0.COL1 AS COL1, q0.COL2 AS COL2) AS _0, (q1.ID AS ID, q1.COL1 AS COL1, q1.COL2 AS COL2) AS _1) }"
-      - initialVersionLessThan: !current_version
-      # Prior to !current_version, the two row version predicates would be transformed incorrectly so that they were
+      - initialVersionLessThan: 4.10.1.0
+      # Prior to 4.10.1.0, the two row version predicates would be transformed incorrectly so that they were
       # evaluated twice on the same record (i.e., `version([_]) > version([_])`) which is a contradiction, so we
       # would not get any results.
       - result: []
-      - initialVersionAtLeast: !current_version
+      - initialVersionAtLeast: 4.10.1.0
       - unorderedResult: [
          { { ID:  4, COL1: 2, COL2: 'b' }, { ID:  3, COL1: 'b', COL2: 1 } },
          { { ID:  4, COL1: 2, COL2: 'b' }, { ID:  7, COL1: 'b', COL2: 3 } },
@@ -752,9 +752,9 @@ test_block:
            from t2_v(2) as A, t3_v(2) as B, t4_v(2) as C
            where A.col2 = B.col1 AND B.col1 = C.col1
       - explain: "ISCAN(T3_VERSION_WITH_COL1 <,>) | FILTER _.COL2 EQUALS promote(@c28 AS LONG) | FLATMAP q0 -> { ISCAN(T3_VERSION_WITH_COL1 <,>) | FILTER _.COL2 EQUALS promote(@c28 AS LONG) AND q0.COL1 EQUALS _.COL1 | FLATMAP q1 -> { ISCAN(T2_COL2 [EQUALS q0.COL1]) | FILTER _.COL1 EQUALS promote(@c28 AS LONG) AS q2 RETURN (q2 AS _0, q1 AS _1) } AS q3 RETURN ((q3._0.__ROW_VERSION AS __ROW_VERSION, q3._0.ID AS ID, q3._0.COL1 AS COL1, q3._0.COL2 AS COL2) AS A, (q0.__ROW_VERSION AS __ROW_VERSION, q0.ID AS ID, q0.COL1 AS COL1, q0.COL2 AS COL2) AS B, (q3._1.__ROW_VERSION AS __ROW_VERSION, q3._1.ID AS ID, q3._1.COL1 AS COL1, q3._1.COL2 AS COL2) AS C) }"
-      - initialVersionLessThan: !current_version
+      - initialVersionLessThan: 4.10.1.0
       - error: 'XXXXX'
-      - initialVersionAtLeast: !current_version
+      - initialVersionAtLeast: 4.10.1.0
       - unorderedResult: [
           { A: { '__ROW_VERSION': !not_null _, ID: 4, COL1: 2, COL2: 'b' }, B: { '__ROW_VERSION': !not_null _, ID: 4, COL1: 'b', COL2: 2 }, C: { '__ROW_VERSION': !not_null _, ID: 4, COL1: 'b', COL2: 2 } },
           { A: { '__ROW_VERSION': !not_null _, ID: 2, COL1: 2, COL2: 'a' }, B: { '__ROW_VERSION': !not_null _, ID: 1, COL1: 'a', COL2: 2 }, C: { '__ROW_VERSION': !not_null _, ID: 1, COL1: 'a', COL2: 2 } },


### PR DESCRIPTION
This failed to update during the 4.10.1.0 release due to a merge conflict: https://github.com/FoundationDB/fdb-record-layer/actions/runs/22069766021/job/63780347089

This manually updates the yamsql files so that they now use 4.10.1.0 instead of `!current_version`. To do this, I just ran the two commands around updating the yaml files in the automatic job locally