### PR TITLE
Introduce metric to count CACHE_SKIP

### DIFF
--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/metrics/RelationalMetric.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/metrics/RelationalMetric.java
@@ -125,6 +125,7 @@ public class RelationalMetric {
 
     public enum RelationalCount implements StoreTimer.Count {
 
+        PLAN_CACHE_SKIP("cache skip", false),
         PLAN_CACHE_PRIMARY_MISS("primary cache miss", false),
         PLAN_CACHE_SECONDARY_MISS("secondary cache miss", false),
         PLAN_CACHE_TERTIARY_MISS("tertiary cache miss", false),

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/PlanGenerator.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/PlanGenerator.java
@@ -157,6 +157,7 @@ public final class PlanGenerator {
             // shortcut plan cache if the query is determined not-cacheable or the cache is not set (disabled).
             if (shouldNotCache(astHashResult.getQueryCachingFlags()) || cache.isEmpty()) {
                 return planContext.getMetricsCollector().clock(RelationalMetric.RelationalEvent.CACHE_BYPASS, () -> {
+                    planContext.getMetricsCollector().increment(RelationalMetric.RelationalCount.PLAN_CACHE_SKIP);
                     Plan<?> plan = generatePhysicalPlan(astHashResult, validPlanHashModes, currentPlanHashMode);
                     RelationalLoggingUtil.publishPlanCacheLogs(message, RelationalLoggingUtil.PlanCacheEvent.SKIP, stepTimeMicros(), 0);
                     return plan;


### PR DESCRIPTION
This PR is in continuation to https://github.com/FoundationDB/fdb-record-layer/pull/3957 and introduces one more metric `PLAN_CACHE_SKIP`. This metric counts the number of queries that skips the plan cache - similar to the other count metrics that counts various cache misses and hit. 