### PR TITLE
Lucene queue: add end to end serialization/deserialization tests

### DIFF
--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/PendingWriteQueueSerializationTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/PendingWriteQueueSerializationTest.java
@@ -128,7 +128,7 @@ class PendingWriteQueueSerializationTest extends FDBRecordStoreTestBase {
         final int score = 42;
         final boolean isSeen = false;
         final double time = 123.456;
-        final List<String> searchTerms = List.of("score:42", "text:quick", "text:dog", "time:123.456", "*:*");
+        final List<String> searchTerms = List.of("score:42", "text:quick", "text:dog", "time:123.456", "is_seen:false", "group:5", "*:*");
 
         // Write record directly to index (no queue)
         try (FDBRecordContext context = openContext()) {


### PR DESCRIPTION
Add high level end to end serialization/deserialization tests for Lucene write pending queue. 