### PR TITLE
refetch node references for the current layer

### DIFF
--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/Primitives.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/Primitives.java
@@ -323,7 +323,7 @@ public class Primitives {
                                         @Nonnull final Map<Tuple, AbstractNode<N>> nodeCache) {
         return fetchSomeNodesAndApply(storageAdapter, readTransaction, storageTransform, layer, neighborReferences,
                 neighborReference -> {
-                    if (neighborReference.isNodeReferenceWithVector()) {
+                    if (storageAdapter.isInliningStorageAdapter() && neighborReference.isNodeReferenceWithVector()) {
                         return neighborReference.asNodeReferenceWithVector();
                     }
                     final AbstractNode<N> neighborNode = nodeCache.get(neighborReference.getPrimaryKey());

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/rabitq/RaBitQuantizerTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/rabitq/RaBitQuantizerTest.java
@@ -318,12 +318,18 @@ public class RaBitQuantizerTest {
             logger.trace("(cosine/dot product metric) reconstructed v = {}", reconstructedV);
             logger.trace("true distance(qDec, vDec) = {}", metric.distance(reconstructedV, reconstructedQ));
             final double reconstructedDistance = metric.distance(reconstructedV, q);
-            logger.trace("true 1 - cos(q, vDec) = {}", reconstructedDistance);
+            logger.trace("true distance(q, vDec) = {}", reconstructedDistance);
             double error = Math.abs(estimatedDistance.getDistance() - trueDistance);
             if (error < Math.abs(reconstructedDistance - trueDistance)) {
                 numEstimationBetter ++;
             }
-            sumRelativeError += error / trueDistance;
+
+            //
+            // Add up the relative error. Some metrics tend to have a probabilistic maximum around 0
+            // (like dot-product metric) and/or can be negative (like dot-product metric). In order to guarantee
+            // some stability here, cap the true distance to be at least 1e-3.
+            //
+            sumRelativeError += error / Math.max(Math.abs(trueDistance), 1e-3);
         }
         logger.info("(cosine/dot product metric) estimator within bounds = {}%",
                 String.format(Locale.ROOT, "%.2f", (double)numEstimationWithinBounds * 100.0d / numRounds));


### PR DESCRIPTION
- fixes a numerical stability problem in `RaBitQuantizerTest` that only occurs for `DOT_PRODUCT_METRIC`
- fixes a bug in the code that would only manifest in very rare cases:
   - use RaBitQ
   - recently flipped to encoding in RaBitQ
   - same record is present on layer `n` and `n - 1` (in the test it was layer `1` and layer `0`)
   - it can happen that the vector in layer `1` is encoded in RaBitQ while the one on layer `0` is not (yet) or the other way around
   - if we use that vector from layer `n` as entry vector for layer `n - 1` we need to refetch the record on layer `n - 1` before continuing the search on layer `n - 1`