### PR TITLE
Fix issue where coverage data might be missing if subproject tested in multiple jobs

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -119,32 +119,16 @@ jobs:
         uses: actions/checkout@v4.2.2
       - name: Setup Base Environment
         uses: ./actions/setup-base-env
-      # It looks like, if you try to download them all as a pattern, the nested directories get stripped
-      # so the coverage data (for e.g. lucene) does not end up in the appropirate subproject directory
-      - name: 'Download lucene'
+      - name: Download coverage data
         uses: actions/download-artifact@v4
         with:
-          name: fdb-record-layer-lucene-coverage-data
-      - name: 'Download extensions'
-        uses: actions/download-artifact@v4
-        with:
-          name: fdb-extensions-coverage-data
-      - name: 'Download core'
-        uses: actions/download-artifact@v4
-        with:
-          name: fdb-record-layer-core-coverage-data
-      - name: 'Download yaml'
-        uses: actions/download-artifact@v4
-        with:
-          name: yaml-tests-coverage-data
-      - name: 'Download other'
-        uses: actions/download-artifact@v4
-        with:
-          name: other-coverage-data
+          pattern: "*-coverage-data"
+          path: coverage-data
+          merge-multiple: false
       - name: Run JaCoCo Report
         uses: ./actions/run-gradle
         with:
-          gradle_command: codeCoverageReport
+          gradle_command: codeCoverageReport -PjacocoCoverageData=coverage-data
       - name: Publish Coverage Report
         uses: actions/upload-artifact@v4.6.0
         with:

--- a/gradle/root.gradle
+++ b/gradle/root.gradle
@@ -79,21 +79,27 @@ tasks.register('codeCoverageReport', JacocoReport) {
             sp.name != 'fdb-record-layer-jmh'
     }
 
-    // Add dependencies on test tasks that generate jacoco execution data
-    // use mustRunAfter so that we can download the jacoco/jar artifacts from parallel jobs
-    // in our pull_request workflow, and then run codeCoverageReport to merge, but this
-    // enforces the order, so that if you run the tests and codeCoverageReport in the same
-    // run (such as our nightly builds), gradle won't complain about implicit dependencies.
-    def t = coverageSubprojects.collectMany { sp ->
-        sp.tasks.withType(Test)
-    }
-    t.addAll(coverageSubprojects.collectMany { sp ->
-        sp.tasks.withType(Jar)
-    })
+    def data
+    if (project.hasProperty("jacocoCoverageData")) {
+        // We have data from an external source (probably from a separate test run). Collect all of the files
+        data = fileTree(dir: getProperty("jacocoCoverageData"), include: "**/*.exec").files.toList()
+    } else {
+        // Add dependencies on test tasks that generate jacoco execution data
+        // use mustRunAfter so that we can download the jacoco/jar artifacts from parallel jobs
+        // in our pull_request workflow, and then run codeCoverageReport to merge, but this
+        // enforces the order, so that if you run the tests and codeCoverageReport in the same
+        // run (such as our nightly builds), gradle won't complain about implicit dependencies.
+        def t = coverageSubprojects.collectMany { sp ->
+            sp.tasks.withType(Test)
+        }
+        t.addAll(coverageSubprojects.collectMany { sp ->
+            sp.tasks.withType(Jar)
+        })
 
-    mustRunAfter t
-    def data = coverageSubprojects.collectMany { sp ->
-        sp.tasks.withType(Test).collect { testTask -> testTask.jacoco.destinationFile }
+        mustRunAfter t
+        data = coverageSubprojects.collectMany {sp ->
+            sp.tasks.withType(Test).collect {testTask -> testTask.jacoco.destinationFile}
+        }
     }
     executionData data
 


### PR DESCRIPTION
This adjusts the way that we download and the process the JaCoCo coverage data. We now:

1. Download all of the data into a new directory, called `coverage-data`
1. The `codeCoverageReport` can be instructed to look at such a directory

This addresses a problem that we saw where if a single sub-project was tested in multiple CI jobs (e.g., `fdb-relational-core` is tested as part of `other-tests` but it also gets excercised as part of the `yaml-tests` framework), then unpacking the artifacts could be problematic as the same files could be extracted from multiple. This attempts to avoid that collision and give the report a more complete set of files.