### PR TITLE
Minimal change to allow release with failing mixed-mode tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,7 @@ jobs:
         uses: ./actions/setup-fdb
       - name: Run Gradle Test
         uses: ./actions/gradle-test
+        continue-on-error: true
         with:
           gradle_command: mixedModeTest
           gradle_args: -PreleaseBuild=false -PpublishBuild=false


### PR DESCRIPTION
This updates the release.yml file so that if there's a mixed-mode failure, we don't mark that part of the build as failed. This is the minimal change, as all it does is add a single `continue-on-error` to the workflow step. The rest of the steps in the `mixed-mode` job will then continue as before.

This is in response to the failing mixed-mode tests that affected https://github.com/FoundationDB/fdb-record-layer/actions/runs/22441725638