### PR TITLE
Upgrade source/target compatibility to JDK 17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -191,8 +191,8 @@ subprojects {
     apply from: rootProject.file('gradle/testing.gradle')
 
     java {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     def publishBuild = Boolean.parseBoolean(findProperty('publishBuild') ?: 'false')

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@
 #
 
 rootProject.name=fdb-record-layer
-version=4.10.6.0
+version=4.11.0.0
 releaseBuild=false
 
 # this should be false for release branches (i.e. if there is no -SNAPSHOT on the above version)


### PR DESCRIPTION
This upgrades the source/target compatibility to JDK 17, requiring consumers to be running on a JRE of 17 (or newer)