### PR TITLE
Prevent rebuildIndexes from concurrent index state changes

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -4415,6 +4415,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
         List<Index> indexesToBeBuilt = new ArrayList<>();
         for (Index index: indexes.keySet()) {
             addIndexStateReadConflict(index.getName());
+            // TODO je: This is a bug as the newStates may return READABLE from another function
             if (newStates.getOrDefault(index, READY_READABLE) == READY_READABLE) {
                 indexesToBeBuilt.add(index);
             }


### PR DESCRIPTION
   These index state changes are protected by semaphores, and doing them in multiple threads
   was occasionally causing a failure.

This PR should change `rebuildIndexes` to first rebuild (i.e. build inline) as a multi-target all the indexes that are targeted to become readable and then:
         - raise index state write semaphore
        - locklessly change the states of all indexes and clear data (if needed). if rebuild had failed (very rare) convert all the desired READABLE to DISABLED.
        - release the index state write semaphore

This PR is intended to be followed by another one that simplifies the index rebuild/state-change mechanism and probably move it to an external class. 