### PR TITLE
Fix javadoc of QueryInterpreter

### DIFF
--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryInterpreter.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryInterpreter.java
@@ -58,7 +58,7 @@ import static com.apple.foundationdb.relational.yamltests.Matchers.constructVect
  * {@link QueryCommand} command. The query in the framework is expected to be a valid query string based on the
  * Relational parser except that it can have parameter injection snippets.
  * <p>
- * A parameter injection snippet is a statement surrounded by `/{` and `}/` that can substitute anywhere in the query
+ * A parameter injection snippet is a statement surrounded by `!!` and `!!` that can substitute anywhere in the query
  * where a prepared statement parameter can be put. For example, lets take a simple query:
  * <pre>{@code
  *      SELECT * FROM foo WHERE foo.a > 10
@@ -66,7 +66,7 @@ import static com.apple.foundationdb.relational.yamltests.Matchers.constructVect
  * Here, 10 can be substituted for a parameter and hence qualify to be substituted by our parameter injection snippet,
  * as:
  * <pre>{@code
- *      SELECT * FROM foo WHERE foo.a > %% 10 %%
+ *      SELECT * FROM foo WHERE foo.a > !! 10 !!
  *}</pre>
  * QueryInterpreter interprets {@code /{10}/} as a singleton {@link PrimitiveParameter}. A mapping of {@link Parameter}s
  * in the given query helps to adapt the query to be executed as a simple statement or as a prepared statement, as required.
@@ -75,7 +75,7 @@ import static com.apple.foundationdb.relational.yamltests.Matchers.constructVect
  * can be an {@link UnboundParameter} that is not literal and needs to be "bound" using a {@link Random} generator to
  * take a literal value. An example of query with {@link UnboundParameter} is:
  * <pre>{@code
- *      SELECT * FROM foo WHERE foo.a > %% !r [2, 9] %%
+ *      SELECT * FROM foo WHERE foo.a > !! !r [2, 9] !!
  *}</pre>
  * Here, the parameter can randomly take different values between 2 and 9 in each binding.
  */


### PR DESCRIPTION
The code uses `!!` but the javadoc references `\{`/`\}` and `%%`. 