### PR TITLE
VectorIndexIndexingTest: preset seeds for Random objects

### DIFF
--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VectorIndexIndexingTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VectorIndexIndexingTest.java
@@ -53,7 +53,8 @@ class VectorIndexIndexingTest extends VectorIndexTestBase {
 
     @Test
     void buildVectorIndexOnlineUngrouped() throws Exception {
-        final Random random = new Random();
+        final int seed = 1;
+        final Random random = new Random(seed);
         final int numRecords = 500 + random.nextInt(20);
         final int maxSize = 50 + random.nextInt(5) ;
 
@@ -72,7 +73,8 @@ class VectorIndexIndexingTest extends VectorIndexTestBase {
 
     @Test
     void buildVectorIndexOnlineGrouped() throws Exception {
-        final Random random = new Random();
+        final int seed = 8;
+        final Random random = new Random(seed);
         final int numRecords = 500 + random.nextInt(20);
         final int maxSize = 50 + random.nextInt(5) ;
 
@@ -91,7 +93,8 @@ class VectorIndexIndexingTest extends VectorIndexTestBase {
 
     @Test
     void buildVectorIndexOnlineMoreUngrouped() throws Exception {
-        final Random random = new Random();
+        final int seed = 7001;
+        final Random random = new Random(seed);
         final int initialRecords = 400 + random.nextInt(50);
         final int additionalRecords = 100 + random.nextInt(10);
         final int maxSize = 50 + random.nextInt(10);
@@ -121,7 +124,8 @@ class VectorIndexIndexingTest extends VectorIndexTestBase {
 
     @Test
     void buildVectorIndexOnlineMoreGrouped() throws Exception {
-        final Random random = new Random();
+        final int seed = 7;
+        final Random random = new Random(seed);
         final int initialRecords = 400 + random.nextInt(50);
         final int additionalRecords = 100 + random.nextInt(10);
         final int maxSize = 50 + random.nextInt(10);


### PR DESCRIPTION
HNSW algorithm is inherently approximate, but consistent when presented with similar data. Hence the tests should follow persistent patterns to avoid flakiness.

(Other tests can use random values and assert that that the results are "close enough". But this test was never designed for that) 