### PR TITLE
Multi-Cluster support for yamsql & support not-registering the driver with FRL

### DIFF
--- a/fdb-relational-server/src/main/java/com/apple/foundationdb/relational/server/FRL.java
+++ b/fdb-relational-server/src/main/java/com/apple/foundationdb/relational/server/FRL.java
@@ -214,8 +214,7 @@ public class FRL implements AutoCloseable {
     }
 
     private RelationalConnection connect(String database, String schema, Options options) throws SQLException {
-        final var driver = (RelationalDriver) DriverManager.getDriver(createEmbeddedJDBCURI(database, schema));
-        return driver.connect(URI.create(createEmbeddedJDBCURI(database, schema)), options);
+        return registeredDriver.connect(URI.create(createEmbeddedJDBCURI(database, schema)), options);
     }
 
     private Response executeInternal(@Nonnull RelationalConnection connection,
@@ -341,8 +340,7 @@ public class FRL implements AutoCloseable {
     }
 
     public TransactionalToken createTransactionalToken(String database, String schema, Options options) throws SQLException {
-        final var driver = (RelationalDriver) DriverManager.getDriver(createEmbeddedJDBCURI(database, schema));
-        RelationalConnection transactionalConnection = driver.connect(URI.create(createEmbeddedJDBCURI(database, schema)), options);
+        RelationalConnection transactionalConnection = registeredDriver.connect(URI.create(createEmbeddedJDBCURI(database, schema)), options);
         transactionalConnection.setAutoCommit(false);
         return new TransactionalToken(transactionalConnection);
     }

--- a/fdb-relational-server/src/main/java/com/apple/foundationdb/relational/server/FRL.java
+++ b/fdb-relational-server/src/main/java/com/apple/foundationdb/relational/server/FRL.java
@@ -91,6 +91,10 @@ public class FRL implements AutoCloseable {
     }
 
     public FRL(@Nonnull Options options, @Nullable String clusterFile) throws RelationalException {
+        this(options, clusterFile, true);
+    }
+
+    public FRL(@Nonnull Options options, @Nullable String clusterFile, boolean registerDriver) throws RelationalException {
         final FDBDatabase fdbDb = FDBDatabaseFactory.instance().getDatabase(clusterFile);
         final Long asyncToSyncTimeout = options.getOption(Options.Name.ASYNC_OPERATIONS_TIMEOUT_MILLIS);
         if (asyncToSyncTimeout > 0) {
@@ -130,11 +134,17 @@ public class FRL implements AutoCloseable {
                             .setTertiarySize(options.getOption(Options.Name.PLAN_CACHE_TERTIARY_MAX_ENTRIES))
                             .build()));
 
-            DriverManager.registerDriver(this.registeredDriver);
-            this.registeredJDBCEmbedDriver = true;
+            if (registerDriver) {
+                DriverManager.registerDriver(this.registeredDriver);
+                this.registeredJDBCEmbedDriver = true;
+            }
         } catch (SQLException ve) {
             throw new RelationalException(ve);
         }
+    }
+
+    public RelationalDriver getDriver() {
+        return registeredDriver;
     }
 
     @SuppressWarnings("AbbreviationAsWordInName") // allow JDBCURI, though perhaps we should update this to make it clearer

--- a/fdb-relational-server/src/main/java/com/apple/foundationdb/relational/server/FRL.java
+++ b/fdb-relational-server/src/main/java/com/apple/foundationdb/relational/server/FRL.java
@@ -79,7 +79,7 @@ import java.util.concurrent.TimeUnit;
 @API(API.Status.EXPERIMENTAL)
 public class FRL implements AutoCloseable {
     private final FdbConnection fdbDatabase;
-    private final RelationalDriver registeredDriver;
+    private final RelationalDriver driver;
     private boolean registeredJDBCEmbedDriver;
 
     public FRL() throws RelationalException {
@@ -118,7 +118,7 @@ public class FRL implements AutoCloseable {
                 .setStoreCatalog(storeCatalog).build();
 
         try {
-            this.registeredDriver = new EmbeddedRelationalDriver(RecordLayerEngine.makeEngine(
+            this.driver = new EmbeddedRelationalDriver(RecordLayerEngine.makeEngine(
                     rlConfig,
                     Collections.singletonList(fdbDb),
                     keySpace,
@@ -135,7 +135,7 @@ public class FRL implements AutoCloseable {
                             .build()));
 
             if (registerDriver) {
-                DriverManager.registerDriver(this.registeredDriver);
+                DriverManager.registerDriver(this.driver);
                 this.registeredJDBCEmbedDriver = true;
             }
         } catch (SQLException ve) {
@@ -144,7 +144,7 @@ public class FRL implements AutoCloseable {
     }
 
     public RelationalDriver getDriver() {
-        return registeredDriver;
+        return driver;
     }
 
     @SuppressWarnings("AbbreviationAsWordInName") // allow JDBCURI, though perhaps we should update this to make it clearer
@@ -214,7 +214,7 @@ public class FRL implements AutoCloseable {
     }
 
     private RelationalConnection connect(String database, String schema, Options options) throws SQLException {
-        return registeredDriver.connect(URI.create(createEmbeddedJDBCURI(database, schema)), options);
+        return driver.connect(URI.create(createEmbeddedJDBCURI(database, schema)), options);
     }
 
     private Response executeInternal(@Nonnull RelationalConnection connection,
@@ -340,7 +340,7 @@ public class FRL implements AutoCloseable {
     }
 
     public TransactionalToken createTransactionalToken(String database, String schema, Options options) throws SQLException {
-        RelationalConnection transactionalConnection = registeredDriver.connect(URI.create(createEmbeddedJDBCURI(database, schema)), options);
+        RelationalConnection transactionalConnection = driver.connect(URI.create(createEmbeddedJDBCURI(database, schema)), options);
         transactionalConnection.setAutoCommit(false);
         return new TransactionalToken(transactionalConnection);
     }
@@ -403,7 +403,7 @@ public class FRL implements AutoCloseable {
         }
         // We registered the Relational embed driver... cleanup.
         if (this.registeredJDBCEmbedDriver) {
-            DriverManager.deregisterDriver(registeredDriver);
+            DriverManager.deregisterDriver(driver);
         }
     }
 }

--- a/fdb-test-utils/src/main/java/com/apple/foundationdb/test/FDBTestEnvironment.java
+++ b/fdb-test-utils/src/main/java/com/apple/foundationdb/test/FDBTestEnvironment.java
@@ -26,6 +26,7 @@ import org.yaml.snakeyaml.Yaml;
 import javax.annotation.Nullable;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -71,6 +72,12 @@ public final class FDBTestEnvironment {
 
     public static List<String> allClusterFiles() {
         return clusterFiles;
+    }
+
+    public static List<String> allClusterFilesInRandomOrder() {
+        final List<String> randomized = new ArrayList<>(clusterFiles);
+        Collections.shuffle(randomized);
+        return List.copyOf(randomized);
     }
 
     public static String randomClusterFile() {

--- a/fdb-test-utils/src/main/java/com/apple/foundationdb/test/FDBTestEnvironment.java
+++ b/fdb-test-utils/src/main/java/com/apple/foundationdb/test/FDBTestEnvironment.java
@@ -77,7 +77,7 @@ public final class FDBTestEnvironment {
     public static List<String> allClusterFilesInRandomOrder() {
         final List<String> randomized = new ArrayList<>(clusterFiles);
         Collections.shuffle(randomized);
-        return List.copyOf(randomized);
+        return randomized;
     }
 
     public static String randomClusterFile() {

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/ConnectionTarget.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/ConnectionTarget.java
@@ -26,8 +26,8 @@ import java.net.URI;
 /**
  * A resolved connection target consisting of a URI and a cluster index.
  *
- * <p>The cluster index identifies which FDB cluster to connect to. Index 0 is the default (and only) cluster
- * in single-cluster configurations. Additional clusters can be specified in YAMSQL files using the map form
+ * <p>The cluster index identifies which FDB cluster to connect to. Index 0 is the default.
+ * Additional clusters can be accessed in YAMSQL files using the map form
  * of the {@code connect} directive:
  * <pre>{@code
  * connect: { cluster: 1, uri: 0 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/ConnectionTarget.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/ConnectionTarget.java
@@ -1,0 +1,66 @@
+/*
+ * ConnectionTarget.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.relational.yamltests;
+
+import javax.annotation.Nonnull;
+import java.net.URI;
+
+/**
+ * A resolved connection target consisting of a URI and a cluster index.
+ *
+ * <p>The cluster index identifies which FDB cluster to connect to. Index 0 is the default (and only) cluster
+ * in single-cluster configurations. Additional clusters can be specified in YAMSQL files using the map form
+ * of the {@code connect} directive:
+ * <pre>{@code
+ * connect: { cluster: 1, uri: 0 }
+ * }</pre>
+ */
+public class ConnectionTarget {
+    @Nonnull
+    private final URI uri;
+    private final int clusterIndex;
+
+    public ConnectionTarget(@Nonnull URI uri, int clusterIndex) {
+        this.uri = uri;
+        this.clusterIndex = clusterIndex;
+    }
+
+    public ConnectionTarget(@Nonnull URI uri) {
+        this(uri, 0);
+    }
+
+    @Nonnull
+    public URI getUri() {
+        return uri;
+    }
+
+    public int getClusterIndex() {
+        return clusterIndex;
+    }
+
+    @Override
+    public String toString() {
+        if (clusterIndex == 0) {
+            return uri.toString();
+        }
+        return uri + " [cluster=" + clusterIndex + "]";
+    }
+}

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/ConnectionTarget.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/ConnectionTarget.java
@@ -32,6 +32,14 @@ import java.net.URI;
  * <pre>{@code
  * connect: { cluster: 1, uri: 0 }
  * }</pre>
+ * The uri component can be a few different things:
+ * <ul>
+ *     <li>An index, in which case {@code 0} is the catalog, and other positive numbers refer to the schemas created
+ *     automatically with the {@code schema_template:} block</li>
+ *     <li>A fully qualified uri such as {@code "jdbc:embed:/FRL/MCI_DB?schema=S1"} or
+ *     {@code "jdbc:embed:/__SYS?schema=CATALOG"}. The scheme should always be {@code jdbc:embed:}, and the framework
+ *     will update it to control whether it goes to the embedded connection, or one of the servers.</li>
+ * </ul>
  */
 public class ConnectionTarget {
     @Nonnull

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/ConnectionTarget.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/ConnectionTarget.java
@@ -43,10 +43,6 @@ public class ConnectionTarget {
         this.clusterIndex = clusterIndex;
     }
 
-    public ConnectionTarget(@Nonnull URI uri) {
-        this(uri, 0);
-    }
-
     @Nonnull
     public URI getUri() {
         return uri;

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlConnectionFactory.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlConnectionFactory.java
@@ -33,17 +33,6 @@ import java.util.Set;
  */
 public interface YamlConnectionFactory {
     /**
-     * Convert a connection uri into an actual connection.
-     *
-     * @param connectPath the path to connect to
-     *
-     * @return A new {@link RelationalConnection} for the given path appropriate for this test class
-     *
-     * @throws SQLException if we cannot connect
-     */
-    YamlConnection getNewConnection(@Nonnull URI connectPath) throws SQLException;
-
-    /**
      * Convert a connection uri into an actual connection on a specific cluster.
      *
      * @param connectPath the path to connect to
@@ -53,12 +42,7 @@ public interface YamlConnectionFactory {
      *
      * @throws SQLException if we cannot connect or the cluster index is not supported
      */
-    default YamlConnection getNewConnection(@Nonnull URI connectPath, int clusterIndex) throws SQLException {
-        if (clusterIndex != 0) {
-            throw new SQLException("This connection factory does not support multiple clusters (requested cluster " + clusterIndex + ")");
-        }
-        return getNewConnection(connectPath);
-    }
+    YamlConnection getNewConnection(@Nonnull URI connectPath, int clusterIndex) throws SQLException;
 
     /**
      * The versions that the connection has, other than the current code.

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlConnectionFactory.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlConnectionFactory.java
@@ -44,6 +44,23 @@ public interface YamlConnectionFactory {
     YamlConnection getNewConnection(@Nonnull URI connectPath) throws SQLException;
 
     /**
+     * Convert a connection uri into an actual connection on a specific cluster.
+     *
+     * @param connectPath the path to connect to
+     * @param clusterIndex the cluster to connect to (0 is the default cluster)
+     *
+     * @return A new {@link RelationalConnection} for the given path on the specified cluster
+     *
+     * @throws SQLException if we cannot connect or the cluster index is not supported
+     */
+    default YamlConnection getNewConnection(@Nonnull URI connectPath, int clusterIndex) throws SQLException {
+        if (clusterIndex != 0) {
+            throw new SQLException("This connection factory does not support multiple clusters (requested cluster " + clusterIndex + ")");
+        }
+        return getNewConnection(connectPath);
+    }
+
+    /**
      * The versions that the connection has, other than the current code.
      * <p>
      * If we are just testing against the current code, this will be empty, but otherwise it will include the

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlConnectionFactory.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlConnectionFactory.java
@@ -83,4 +83,13 @@ public interface YamlConnectionFactory {
     default boolean isMultiServer() {
         return false;
     }
+
+    /**
+     * Returns the number of clusters available for testing.
+     *
+     * @return the number of available clusters (1 means only the default cluster)
+     */
+    default int getAvailableClusterCount() {
+        return 1;
+    }
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlConnectionFactoryWithOptions.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlConnectionFactoryWithOptions.java
@@ -61,6 +61,11 @@ public class YamlConnectionFactoryWithOptions implements YamlConnectionFactory {
     }
 
     @Override
+    public int getAvailableClusterCount() {
+        return underlying.getAvailableClusterCount();
+    }
+
+    @Override
     public boolean isMultiServer() {
         return underlying.isMultiServer();
     }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlConnectionFactoryWithOptions.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlConnectionFactoryWithOptions.java
@@ -42,13 +42,6 @@ public class YamlConnectionFactoryWithOptions implements YamlConnectionFactory {
     }
 
     @Override
-    public YamlConnection getNewConnection(@Nonnull final URI connectPath) throws SQLException {
-        final var connection = underlying.getNewConnection(connectPath);
-        connection.setConnectionOptions(options);
-        return connection;
-    }
-
-    @Override
     public YamlConnection getNewConnection(@Nonnull final URI connectPath, int clusterIndex) throws SQLException {
         final var connection = underlying.getNewConnection(connectPath, clusterIndex);
         connection.setConnectionOptions(options);

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlConnectionFactoryWithOptions.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlConnectionFactoryWithOptions.java
@@ -49,6 +49,13 @@ public class YamlConnectionFactoryWithOptions implements YamlConnectionFactory {
     }
 
     @Override
+    public YamlConnection getNewConnection(@Nonnull final URI connectPath, int clusterIndex) throws SQLException {
+        final var connection = underlying.getNewConnection(connectPath, clusterIndex);
+        connection.setConnectionOptions(options);
+        return connection;
+    }
+
+    @Override
     public Set<SemanticVersion> getVersionsUnderTest() {
         return underlying.getVersionsUnderTest();
     }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlExecutionContext.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlExecutionContext.java
@@ -286,33 +286,25 @@ public final class YamlExecutionContext {
     }
 
     /**
-     * Infers the URI of the database to which a block should connect to.
-     * <br>
-     * A block can declare a connection in multiple ways:
-     * 1. no explicit declaration: Try to connect to the only registered connection URI in the local {@link YamlReference.YamlResource}.
-     *    If not, try to connect to the only connection across all parent resources.
-     *    A URI can be registered by defining a "schema_template" block before that, which sets up the database and schema for a provided schema template.
-     * 2. Parameter 0: connects to the system tables (catalog).
-     * 3. Parameter One-based Number: connects to the registered connection URI, number denotes the sequence of definitions in the local YamlResource.
-     *    To access parent connection URIs, this number should be prepended by `(global)` tag.
-     * 4. Parameter String: connects to the defined String
-     *
-     * @param connectObject can be {@code null}, an {@link Integer} value or a {@link String}.
-     *
-     * @return a valid connection URI
-     */
-    public URI inferConnectionURI(@Nonnull final YamlReference.YamlResource resource, @Nullable Object connectObject) {
-        return inferConnectionTarget(resource, connectObject).getUri();
-    }
-
-    /**
      * Infers the connection target (URI and cluster index) for a block.
      * <br>
-     * Supports all the forms of {@link #inferConnectionURI}, plus a map form for specifying the cluster:
+     * <ul>
+     *   <li>no explicit declaration: Try to connect to the only registered connection URI in the local {@link YamlReference.YamlResource}.
+     *    If not, try to connect to the only connection across all parent resources.
+     *    A URI can be registered by defining a "schema_template" block before that, which sets up the database and schema for a provided schema template.
+     *    </li>
+     *    <li>Parameter 0: connects to the system tables (catalog). </li>
+     *    <li>Parameter One-based Number: connects to the registered connection URI, number denotes the sequence of definitions in the local YamlResource.
+     *    To access parent connection URIs, this number should be prepended by `(global)` tag.
+     *    </li>
+     *    <li>Parameter String: connects to the defined String</li>
+     *    <li>A map form for specifying the cluster:
      * <pre>{@code
      * connect: { cluster: 1, uri: 0 }
      * connect: { cluster: 1 }
      * }</pre>
+     * </li>
+     * </ul>
      *
      * @param connectObject can be {@code null}, an {@link Integer}, a {@link String}, or a {@link Map} with
      *                      optional {@code cluster} and {@code uri} keys.
@@ -337,7 +329,7 @@ public final class YamlExecutionContext {
         } else if (connectObject instanceof Integer) {
             return getConnectionFromConnectionURIList(resource, false, (Integer) connectObject, false);
         } else {
-            final var stringURI = Matchers.string(connectObject);
+            final var stringURI = Matchers.string(connectObject, "connection object");
             if (stringURI.startsWith("(global)")) {
                 return getConnectionFromConnectionURIList(resource, false, Integer.parseInt(stringURI.substring(8).trim()), true);
             }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlExecutionContext.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlExecutionContext.java
@@ -302,7 +302,36 @@ public final class YamlExecutionContext {
      * @return a valid connection URI
      */
     public URI inferConnectionURI(@Nonnull final YamlReference.YamlResource resource, @Nullable Object connectObject) {
+        return inferConnectionTarget(resource, connectObject).getUri();
+    }
+
+    /**
+     * Infers the connection target (URI and cluster index) for a block.
+     * <br>
+     * Supports all the forms of {@link #inferConnectionURI}, plus a map form for specifying the cluster:
+     * <pre>{@code
+     * connect: { cluster: 1, uri: 0 }
+     * connect: { cluster: 1 }
+     * }</pre>
+     *
+     * @param connectObject can be {@code null}, an {@link Integer}, a {@link String}, or a {@link Map} with
+     *                      optional {@code cluster} and {@code uri} keys.
+     *
+     * @return a valid connection target
+     */
+    public ConnectionTarget inferConnectionTarget(@Nonnull final YamlReference.YamlResource resource, @Nullable Object connectObject) {
         Assert.thatUnchecked(registeredResources.contains(resource), "A YamlResource should be registered before registering available connection URIs");
+        if (connectObject instanceof Map) {
+            final Map<?, ?> connectMap = CustomYamlConstructor.LinedObject.unlineKeys(Matchers.map(connectObject, "connect"));
+            final int clusterIndex = connectMap.containsKey("cluster")
+                    ? ((Number) connectMap.get("cluster")).intValue() : 0;
+            final Object uriSpec = connectMap.getOrDefault("uri", null);
+            return new ConnectionTarget(resolveConnectionURI(resource, uriSpec), clusterIndex);
+        }
+        return new ConnectionTarget(resolveConnectionURI(resource, connectObject), 0);
+    }
+
+    private URI resolveConnectionURI(@Nonnull final YamlReference.YamlResource resource, @Nullable Object connectObject) {
         if (connectObject == null) {
             return getConnectionFromConnectionURIList(resource, true, -1, true);
         } else if (connectObject instanceof Integer) {

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlTestExtension.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlTestExtension.java
@@ -130,8 +130,8 @@ public class YamlTestExtension implements TestTemplateInvocationContextProvider,
                     }
                 });
                 externalServerGroups.add(group);
-                for (Clusters.Entry<ExternalServer> entry : group) {
-                    allExternalServers.add(entry.server());
+                for (ExternalServer server : group) {
+                    allExternalServers.add(server);
                 }
             }
             ExternalServer.startMultiple(allExternalServers);
@@ -196,8 +196,8 @@ public class YamlTestExtension implements TestTemplateInvocationContextProvider,
                         }).filter(Objects::nonNull).findFirst();
         if (externalServerGroups != null) {
             for (Clusters<ExternalServer> group : externalServerGroups) {
-                for (Clusters.Entry<ExternalServer> entry : group) {
-                    stopServerSafely(entry);
+                for (ExternalServer server : group) {
+                    stopServerSafely(server);
                 }
             }
             externalServerGroups = null;
@@ -207,12 +207,12 @@ public class YamlTestExtension implements TestTemplateInvocationContextProvider,
         }
     }
 
-    private static void stopServerSafely(final Clusters.Entry<ExternalServer> entry) {
+    private static void stopServerSafely(final ExternalServer server) {
         try {
-            entry.server().stop();
+            server.stop();
         } catch (Exception ex) {
             if (logger.isWarnEnabled()) {
-                logger.warn("Failed to stop server " + entry.server().getVersion() + " on " + entry.server().getPort());
+                logger.warn("Failed to stop server " + server.getVersion() + " on " + server.getPort());
             }
         }
     }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlTestExtension.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlTestExtension.java
@@ -198,19 +198,23 @@ public class YamlTestExtension implements TestTemplateInvocationContextProvider,
         if (externalServerGroups != null) {
             for (Clusters<ExternalServer> group : externalServerGroups) {
                 for (Clusters.Entry<ExternalServer> entry : group) {
-                    try {
-                        entry.server().stop();
-                    } catch (Exception ex) {
-                        if (logger.isWarnEnabled()) {
-                            logger.warn("Failed to stop server " + entry.server().getVersion() + " on " + entry.server().getPort());
-                        }
-                    }
+                    stopServerSafely(entry);
                 }
             }
             externalServerGroups = null;
         }
         if (exception.isPresent()) {
             throw exception.get();
+        }
+    }
+
+    private static void stopServerSafely(final Clusters.Entry<ExternalServer> entry) {
+        try {
+            entry.server().stop();
+        } catch (Exception ex) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("Failed to stop server " + entry.server().getVersion() + " on " + entry.server().getPort());
+            }
         }
     }
 

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlTestExtension.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlTestExtension.java
@@ -51,8 +51,11 @@ import org.opentest4j.TestAbortedException;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -66,6 +69,9 @@ public class YamlTestExtension implements TestTemplateInvocationContextProvider,
     private List<YamlTestConfig> testConfigs;
     private List<YamlTestConfig> maintainConfigs;
     private List<ExternalServer> servers;
+    /** Additional external servers for non-primary cluster files, keyed by the primary server they belong to. */
+    @Nonnull
+    private final Map<ExternalServer, List<ExternalServer>> additionalClusterExternalServers = new HashMap<>();
     @Nullable
     private final String clusterFile;
     private final boolean includeMethodInDescriptions;
@@ -108,10 +114,24 @@ public class YamlTestExtension implements TestTemplateInvocationContextProvider,
             // not a likely scenario.
             Assertions.assertFalse(jars.isEmpty(), "There are no external servers available to run");
             servers = new ArrayList<>();
+            List<ExternalServer> allExternalServers = new ArrayList<>();
+            final List<String> otherClusterFiles = FDBTestEnvironment.allClusterFiles().stream()
+                    .filter(cf -> !Objects.equals(cf, clusterFile))
+                    .collect(Collectors.toList());
             for (File jar : jars) {
-                servers.add(new ExternalServer(jar, clusterFile));
+                ExternalServer primaryServer = new ExternalServer(jar, clusterFile);
+                servers.add(primaryServer);
+                allExternalServers.add(primaryServer);
+                // Create additional external servers for non-primary cluster files
+                List<ExternalServer> additionalServers = new ArrayList<>();
+                for (String otherClusterFile : otherClusterFiles) {
+                    ExternalServer additionalServer = new ExternalServer(jar, otherClusterFile);
+                    additionalServers.add(additionalServer);
+                    allExternalServers.add(additionalServer);
+                }
+                additionalClusterExternalServers.put(primaryServer, additionalServers);
             }
-            ExternalServer.startMultiple(servers);
+            ExternalServer.startMultiple(allExternalServers);
             final boolean mixedModeOnly = Boolean.parseBoolean(System.getProperty("tests.mixedModeOnly", "false"));
             final boolean singleExternalVersionOnly = Boolean.parseBoolean(System.getProperty("tests.singleVersion", "false"));
             Stream<YamlTestConfig> localTestingConfigs = localConfigs(mixedModeOnly, singleExternalVersionOnly);
@@ -145,12 +165,15 @@ public class YamlTestExtension implements TestTemplateInvocationContextProvider,
                             Stream.of(new ExternalMultiServerConfig(0, server, server),
                                     new ForceContinuations(new ExternalMultiServerConfig(0, server, server))));
         } else {
-            return servers.stream().flatMap(server ->
+            return servers.stream().flatMap(server -> {
+                    List<ExternalServer> additionalServers =
+                            additionalClusterExternalServers.getOrDefault(server, List.of());
                     // (4 configs for each server available)
-                    Stream.of(new JDBCMultiServerConfig(0, server, clusterFile),
-                            new ForceContinuations(new JDBCMultiServerConfig(0, server, clusterFile)),
-                            new JDBCMultiServerConfig(1, server, clusterFile),
-                            new ForceContinuations(new JDBCMultiServerConfig(1, server, clusterFile))));
+                    return Stream.of(new JDBCMultiServerConfig(0, server, clusterFile, additionalServers),
+                            new ForceContinuations(new JDBCMultiServerConfig(0, server, clusterFile, additionalServers)),
+                            new JDBCMultiServerConfig(1, server, clusterFile, additionalServers),
+                            new ForceContinuations(new JDBCMultiServerConfig(1, server, clusterFile, additionalServers)));
+            });
         }
     }
 
@@ -181,6 +204,18 @@ public class YamlTestExtension implements TestTemplateInvocationContextProvider,
                     }
                 }
             }
+            for (List<ExternalServer> additionalServers : additionalClusterExternalServers.values()) {
+                for (ExternalServer server : additionalServers) {
+                    try {
+                        server.stop();
+                    } catch (Exception ex) {
+                        if (logger.isWarnEnabled()) {
+                            logger.warn("Failed to stop additional cluster server " + server.getVersion() + " on " + server.getPort());
+                        }
+                    }
+                }
+            }
+            additionalClusterExternalServers.clear();
         }
         if (exception.isPresent()) {
             throw exception.get();

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlTestExtension.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlTestExtension.java
@@ -75,7 +75,7 @@ public class YamlTestExtension implements TestTemplateInvocationContextProvider,
 
     @SuppressWarnings("unused") // Used implicitly with @ExtendWith(YamlTestExtension.class)
     public YamlTestExtension() {
-        this(FDBTestEnvironment.allClusterFiles(), false);
+        this(FDBTestEnvironment.allClusterFilesInRandomOrder(), false);
     }
 
     /**

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlTestExtension.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlTestExtension.java
@@ -51,11 +51,8 @@ import org.opentest4j.TestAbortedException;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -68,44 +65,53 @@ public class YamlTestExtension implements TestTemplateInvocationContextProvider,
     private static final Logger logger = LogManager.getLogger(YamlTestExtension.class);
     private List<YamlTestConfig> testConfigs;
     private List<YamlTestConfig> maintainConfigs;
-    private List<ExternalServer> servers;
-    /** Additional external servers for non-primary cluster files, keyed by the primary server they belong to. */
-    @Nonnull
-    private final Map<ExternalServer, List<ExternalServer>> additionalClusterExternalServers = new HashMap<>();
+    /** External servers grouped by jar version. Each inner list has one server per cluster file (same order as {@link #clusterFiles}). */
     @Nullable
-    private final String clusterFile;
+    private List<List<ExternalServer>> externalServerGroups;
+    @Nonnull
+    private final List<String> clusterFiles;
     private final boolean includeMethodInDescriptions;
 
     @SuppressWarnings("unused") // Used implicitly with @ExtendWith(YamlTestExtension.class)
     public YamlTestExtension() {
-        this(FDBTestEnvironment.randomClusterFile(), false);
+        this(FDBTestEnvironment.allClusterFiles(), false);
     }
 
     /**
      * Create a new extension with some configuration.
-     * @param clusterFile a custom cluster file to use, or {@code null} to inherit it from the environment, namely
-     * {@code FDB_CLUSTER_FILE}.
+     * @param clusterFile a custom cluster file to use as the primary, or {@code null} to inherit it from the
+     * environment, namely {@code FDB_CLUSTER_FILE}.
      * @param includeMethodInDescriptions Set this to {@code true} if publishing test results to something that cannot
      * handle complex test hierarchies. In the record layer we maintain the full hierarchy in the output, so this is not
      * necessary, but if integrating some other tools this might be necessary.
      */
     public YamlTestExtension(@Nullable final String clusterFile, final boolean includeMethodInDescriptions) {
-        this.clusterFile = clusterFile;
+        this(List.of(clusterFile), includeMethodInDescriptions);
+    }
+
+    /**
+     * Create a new extension with an explicit list of cluster files.
+     * @param clusterFiles the cluster files to use, where index 0 is the primary cluster
+     * @param includeMethodInDescriptions Set this to {@code true} if publishing test results to something that cannot
+     * handle complex test hierarchies.
+     */
+    public YamlTestExtension(@Nonnull final List<String> clusterFiles, final boolean includeMethodInDescriptions) {
+        this.clusterFiles = clusterFiles;
         this.includeMethodInDescriptions = includeMethodInDescriptions;
     }
 
     @Override
     public void beforeAll(final ExtensionContext context) throws Exception {
         maintainConfigs = List.of(
-                new CorrectExplains(new EmbeddedConfig(clusterFile)),
-                new CorrectMetrics(new EmbeddedConfig(clusterFile)),
-                new CorrectExplainsAndMetrics(new EmbeddedConfig(clusterFile)),
-                new ShowPlanOnDiff(new EmbeddedConfig(clusterFile))
+                new CorrectExplains(new EmbeddedConfig(clusterFiles)),
+                new CorrectMetrics(new EmbeddedConfig(clusterFiles)),
+                new CorrectExplainsAndMetrics(new EmbeddedConfig(clusterFiles)),
+                new ShowPlanOnDiff(new EmbeddedConfig(clusterFiles))
         );
         if (Boolean.parseBoolean(System.getProperty("tests.runQuick", "false"))) {
-            testConfigs = List.of(new EmbeddedConfig(clusterFile));
+            testConfigs = List.of(new EmbeddedConfig(clusterFiles));
         } else if (Boolean.parseBoolean(System.getProperty("tests.runRPC", "false"))) {
-            testConfigs = List.of(new JDBCInProcessConfig(clusterFile));
+            testConfigs = List.of(new JDBCInProcessConfig(clusterFiles));
         } else {
             List<File> jars = ExternalServer.getAvailableServers();
             // Fail the test if there are no available servers. This would force the execution in "runQuick" mode in case
@@ -113,23 +119,15 @@ public class YamlTestExtension implements TestTemplateInvocationContextProvider,
             // Potentially, we can relax this a little if all tests are disabled for multi-server execution, but this is
             // not a likely scenario.
             Assertions.assertFalse(jars.isEmpty(), "There are no external servers available to run");
-            servers = new ArrayList<>();
+            externalServerGroups = new ArrayList<>();
             List<ExternalServer> allExternalServers = new ArrayList<>();
-            final List<String> otherClusterFiles = FDBTestEnvironment.allClusterFiles().stream()
-                    .filter(cf -> !Objects.equals(cf, clusterFile))
-                    .collect(Collectors.toList());
             for (File jar : jars) {
-                ExternalServer primaryServer = new ExternalServer(jar, clusterFile);
-                servers.add(primaryServer);
-                allExternalServers.add(primaryServer);
-                // Create additional external servers for non-primary cluster files
-                List<ExternalServer> additionalServers = new ArrayList<>();
-                for (String otherClusterFile : otherClusterFiles) {
-                    ExternalServer additionalServer = new ExternalServer(jar, otherClusterFile);
-                    additionalServers.add(additionalServer);
-                    allExternalServers.add(additionalServer);
+                List<ExternalServer> group = new ArrayList<>();
+                for (String cf : clusterFiles) {
+                    group.add(new ExternalServer(jar, cf));
                 }
-                additionalClusterExternalServers.put(primaryServer, additionalServers);
+                externalServerGroups.add(group);
+                allExternalServers.addAll(group);
             }
             ExternalServer.startMultiple(allExternalServers);
             final boolean mixedModeOnly = Boolean.parseBoolean(System.getProperty("tests.mixedModeOnly", "false"));
@@ -152,28 +150,26 @@ public class YamlTestExtension implements TestTemplateInvocationContextProvider,
         if (mixedModeOnly || singleExternalVersionOnly) {
             return Stream.of();
         } else {
-            return Stream.of(new EmbeddedConfig(clusterFile), new JDBCInProcessConfig(clusterFile));
+            return Stream.of(new EmbeddedConfig(clusterFiles), new JDBCInProcessConfig(clusterFiles));
         }
     }
 
     private Stream<YamlTestConfig> externalServerConfigs(final boolean singleExternalVersionOnly) {
         if (singleExternalVersionOnly) {
-            return servers.stream()
+            return externalServerGroups.stream()
+                    .map(group -> group.get(0))
                     // Create an ExternalServer config with two servers of the same version for each server
                     // (with and without forced continuations)
                     .flatMap(server ->
                             Stream.of(new ExternalMultiServerConfig(0, server, server),
                                     new ForceContinuations(new ExternalMultiServerConfig(0, server, server))));
         } else {
-            return servers.stream().flatMap(server -> {
-                    List<ExternalServer> additionalServers =
-                            additionalClusterExternalServers.getOrDefault(server, List.of());
-                    // (4 configs for each server available)
-                    return Stream.of(new JDBCMultiServerConfig(0, server, clusterFile, additionalServers),
-                            new ForceContinuations(new JDBCMultiServerConfig(0, server, clusterFile, additionalServers)),
-                            new JDBCMultiServerConfig(1, server, clusterFile, additionalServers),
-                            new ForceContinuations(new JDBCMultiServerConfig(1, server, clusterFile, additionalServers)));
-            });
+            return externalServerGroups.stream().flatMap(group ->
+                    // (4 configs for each server version available)
+                    Stream.of(new JDBCMultiServerConfig(0, group, clusterFiles),
+                            new ForceContinuations(new JDBCMultiServerConfig(0, group, clusterFiles)),
+                            new JDBCMultiServerConfig(1, group, clusterFiles),
+                            new ForceContinuations(new JDBCMultiServerConfig(1, group, clusterFiles))));
         }
     }
 
@@ -194,28 +190,19 @@ public class YamlTestExtension implements TestTemplateInvocationContextProvider,
                                 return e;
                             }
                         }).filter(Objects::nonNull).findFirst();
-        if (servers != null) {
-            for (ExternalServer server : servers) {
-                try {
-                    server.stop();
-                } catch (Exception ex) {
-                    if (logger.isWarnEnabled()) {
-                        logger.warn("Failed to stop server " + server.getVersion() + " on " + server.getPort());
-                    }
-                }
-            }
-            for (List<ExternalServer> additionalServers : additionalClusterExternalServers.values()) {
-                for (ExternalServer server : additionalServers) {
+        if (externalServerGroups != null) {
+            for (List<ExternalServer> group : externalServerGroups) {
+                for (ExternalServer server : group) {
                     try {
                         server.stop();
                     } catch (Exception ex) {
                         if (logger.isWarnEnabled()) {
-                            logger.warn("Failed to stop additional cluster server " + server.getVersion() + " on " + server.getPort());
+                            logger.warn("Failed to stop server " + server.getVersion() + " on " + server.getPort());
                         }
                     }
                 }
             }
-            additionalClusterExternalServers.clear();
+            externalServerGroups = null;
         }
         if (exception.isPresent()) {
             throw exception.get();

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlTestExtension.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlTestExtension.java
@@ -172,10 +172,10 @@ public class YamlTestExtension implements TestTemplateInvocationContextProvider,
         } else {
             return externalServerGroups.stream().flatMap(group ->
                     // (4 configs for each server version available)
-                    Stream.of(new JDBCMultiServerConfig(0, group, clusterFiles),
-                            new ForceContinuations(new JDBCMultiServerConfig(0, group, clusterFiles)),
-                            new JDBCMultiServerConfig(1, group, clusterFiles),
-                            new ForceContinuations(new JDBCMultiServerConfig(1, group, clusterFiles))));
+                    Stream.of(new JDBCMultiServerConfig(0, group),
+                            new ForceContinuations(new JDBCMultiServerConfig(0, group)),
+                            new JDBCMultiServerConfig(1, group),
+                            new ForceContinuations(new JDBCMultiServerConfig(1, group))));
         }
     }
 

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlTestExtension.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlTestExtension.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.relational.yamltests;
 
+import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.relational.yamltests.configs.CorrectExplains;
 import com.apple.foundationdb.relational.yamltests.configs.CorrectExplainsAndMetrics;
 import com.apple.foundationdb.relational.yamltests.configs.CorrectMetrics;
@@ -85,6 +86,7 @@ public class YamlTestExtension implements TestTemplateInvocationContextProvider,
      * handle complex test hierarchies. In the record layer we maintain the full hierarchy in the output, so this is not
      * necessary, but if integrating some other tools this might be necessary.
      */
+    @API(API.Status.DEPRECATED)
     public YamlTestExtension(@Nonnull final String clusterFile, final boolean includeMethodInDescriptions) {
         this(List.of(clusterFile), includeMethodInDescriptions);
     }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlTestExtension.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlTestExtension.java
@@ -30,6 +30,7 @@ import com.apple.foundationdb.relational.yamltests.configs.JDBCInProcessConfig;
 import com.apple.foundationdb.relational.yamltests.configs.JDBCMultiServerConfig;
 import com.apple.foundationdb.relational.yamltests.configs.ShowPlanOnDiff;
 import com.apple.foundationdb.relational.yamltests.configs.YamlTestConfig;
+import com.apple.foundationdb.relational.yamltests.connectionfactory.Clusters;
 import com.apple.foundationdb.relational.yamltests.server.ExternalServer;
 import com.apple.foundationdb.test.FDBTestEnvironment;
 import com.google.common.collect.Iterables;
@@ -65,9 +66,9 @@ public class YamlTestExtension implements TestTemplateInvocationContextProvider,
     private static final Logger logger = LogManager.getLogger(YamlTestExtension.class);
     private List<YamlTestConfig> testConfigs;
     private List<YamlTestConfig> maintainConfigs;
-    /** External servers grouped by jar version. Each inner list has one server per cluster file (same order as {@link #clusterFiles}). */
+    /** External servers grouped by jar version. Each {@link Clusters} has one server per cluster file (same order as {@link #clusterFiles}). */
     @Nullable
-    private List<List<ExternalServer>> externalServerGroups;
+    private List<Clusters<ExternalServer>> externalServerGroups;
     @Nonnull
     private final List<String> clusterFiles;
     private final boolean includeMethodInDescriptions;
@@ -122,12 +123,17 @@ public class YamlTestExtension implements TestTemplateInvocationContextProvider,
             externalServerGroups = new ArrayList<>();
             List<ExternalServer> allExternalServers = new ArrayList<>();
             for (File jar : jars) {
-                List<ExternalServer> group = new ArrayList<>();
-                for (String cf : clusterFiles) {
-                    group.add(new ExternalServer(jar, cf));
-                }
+                Clusters<ExternalServer> group = Clusters.fromClusterFiles(clusterFiles, cf -> {
+                    try {
+                        return new ExternalServer(jar, cf);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                });
                 externalServerGroups.add(group);
-                allExternalServers.addAll(group);
+                for (Clusters.Entry<ExternalServer> entry : group) {
+                    allExternalServers.add(entry.server());
+                }
             }
             ExternalServer.startMultiple(allExternalServers);
             final boolean mixedModeOnly = Boolean.parseBoolean(System.getProperty("tests.mixedModeOnly", "false"));
@@ -157,7 +163,7 @@ public class YamlTestExtension implements TestTemplateInvocationContextProvider,
     private Stream<YamlTestConfig> externalServerConfigs(final boolean singleExternalVersionOnly) {
         if (singleExternalVersionOnly) {
             return externalServerGroups.stream()
-                    .map(group -> group.get(0))
+                    .map(group -> group.iterator().next().server())
                     // Create an ExternalServer config with two servers of the same version for each server
                     // (with and without forced continuations)
                     .flatMap(server ->
@@ -191,13 +197,13 @@ public class YamlTestExtension implements TestTemplateInvocationContextProvider,
                             }
                         }).filter(Objects::nonNull).findFirst();
         if (externalServerGroups != null) {
-            for (List<ExternalServer> group : externalServerGroups) {
-                for (ExternalServer server : group) {
+            for (Clusters<ExternalServer> group : externalServerGroups) {
+                for (Clusters.Entry<ExternalServer> entry : group) {
                     try {
-                        server.stop();
+                        entry.server().stop();
                     } catch (Exception ex) {
                         if (logger.isWarnEnabled()) {
-                            logger.warn("Failed to stop server " + server.getVersion() + " on " + server.getPort());
+                            logger.warn("Failed to stop server " + entry.server().getVersion() + " on " + entry.server().getPort());
                         }
                     }
                 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlTestExtension.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlTestExtension.java
@@ -163,7 +163,7 @@ public class YamlTestExtension implements TestTemplateInvocationContextProvider,
     private Stream<YamlTestConfig> externalServerConfigs(final boolean singleExternalVersionOnly) {
         if (singleExternalVersionOnly) {
             return externalServerGroups.stream()
-                    .map(group -> group.iterator().next().server())
+                    .map(group -> group.primary().server())
                     // Create an ExternalServer config with two servers of the same version for each server
                     // (with and without forced continuations)
                     .flatMap(server ->

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlTestExtension.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlTestExtension.java
@@ -163,12 +163,11 @@ public class YamlTestExtension implements TestTemplateInvocationContextProvider,
     private Stream<YamlTestConfig> externalServerConfigs(final boolean singleExternalVersionOnly) {
         if (singleExternalVersionOnly) {
             return externalServerGroups.stream()
-                    .map(group -> group.primary().server())
-                    // Create an ExternalServer config with two servers of the same version for each server
+                    // Create an ExternalServer config with two connections to the same servers for each version
                     // (with and without forced continuations)
-                    .flatMap(server ->
-                            Stream.of(new ExternalMultiServerConfig(0, server, server),
-                                    new ForceContinuations(new ExternalMultiServerConfig(0, server, server))));
+                    .flatMap(group ->
+                            Stream.of(new ExternalMultiServerConfig(0, group, group),
+                                    new ForceContinuations(new ExternalMultiServerConfig(0, group, group))));
         } else {
             return externalServerGroups.stream().flatMap(group ->
                     // (4 configs for each server version available)

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlTestExtension.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlTestExtension.java
@@ -80,13 +80,12 @@ public class YamlTestExtension implements TestTemplateInvocationContextProvider,
 
     /**
      * Create a new extension with some configuration.
-     * @param clusterFile a custom cluster file to use as the primary, or {@code null} to inherit it from the
-     * environment, namely {@code FDB_CLUSTER_FILE}.
+     * @param clusterFile a custom cluster file to use as the primary.
      * @param includeMethodInDescriptions Set this to {@code true} if publishing test results to something that cannot
      * handle complex test hierarchies. In the record layer we maintain the full hierarchy in the output, so this is not
      * necessary, but if integrating some other tools this might be necessary.
      */
-    public YamlTestExtension(@Nullable final String clusterFile, final boolean includeMethodInDescriptions) {
+    public YamlTestExtension(@Nonnull final String clusterFile, final boolean includeMethodInDescriptions) {
         this(List.of(clusterFile), includeMethodInDescriptions);
     }
 

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/ConnectedBlock.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/ConnectedBlock.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.relational.yamltests.block;
 
+import com.apple.foundationdb.relational.yamltests.ConnectionTarget;
 import com.apple.foundationdb.relational.yamltests.YamlReference;
 import com.apple.foundationdb.relational.yamltests.YamlConnection;
 import com.apple.foundationdb.relational.yamltests.YamlConnectionFactory;
@@ -28,7 +29,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import javax.annotation.Nonnull;
-import java.net.URI;
 import java.sql.SQLException;
 import java.util.Collection;
 import java.util.List;
@@ -54,14 +54,14 @@ public abstract class ConnectedBlock extends ReferencedBlock implements Block {
     @Nonnull
     YamlExecutionContext executionContext;
     @Nonnull
-    private final URI connectionURI;
+    private final ConnectionTarget connectionTarget;
     @Nonnull
     final List<Consumer<YamlConnection>> executables;
 
-    ConnectedBlock(@Nonnull YamlReference reference, @Nonnull List<Consumer<YamlConnection>> executables, @Nonnull URI connectionURI, @Nonnull YamlExecutionContext executionContext) {
+    ConnectedBlock(@Nonnull YamlReference reference, @Nonnull List<Consumer<YamlConnection>> executables, @Nonnull ConnectionTarget connectionTarget, @Nonnull YamlExecutionContext executionContext) {
         super(reference);
         this.executables = executables;
-        this.connectionURI = connectionURI;
+        this.connectionTarget = connectionTarget;
         this.executionContext = executionContext;
     }
 
@@ -75,14 +75,14 @@ public abstract class ConnectedBlock extends ReferencedBlock implements Block {
      * @param consumer operations to be performed on the database using the established connection.
      */
     void connectToDatabaseAndExecute(Consumer<YamlConnection> consumer) {
-        logger.debug("🚠 Connecting to database: `{}`", connectionURI);
-        try (var connection = executionContext.getConnectionFactory().getNewConnection(connectionURI)) {
-            logger.debug("✅ Connected to database: `{}`", connectionURI);
+        logger.debug("🚠 Connecting to database: `{}`", connectionTarget);
+        try (var connection = executionContext.getConnectionFactory().getNewConnection(connectionTarget.getUri(), connectionTarget.getClusterIndex())) {
+            logger.debug("✅ Connected to database: `{}`", connectionTarget);
             consumer.accept(connection);
         } catch (SQLException sqle) {
             throw YamlExecutionContext.wrapContext(sqle,
-                    () -> String.format(Locale.ROOT, "‼️ Error connecting to the database `%s` in block at %s", connectionURI, getReference()),
-                    "connection [" + connectionURI + "]", getReference());
+                    () -> String.format(Locale.ROOT, "‼️ Error connecting to the database `%s` in block at %s", connectionTarget, getReference()),
+                    "connection [" + connectionTarget + "]", getReference());
         }
     }
 

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/PreambleBlock.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/PreambleBlock.java
@@ -42,6 +42,7 @@ public class PreambleBlock extends SupportBlock {
 
     public static final String OPTIONS = "options";
     public static final String PREAMBLE_BLOCK_SUPPORTED_VERSION = "supported_version";
+    public static final String PREAMBLE_BLOCK_REQUIRED_CLUSTERS = "required_clusters";
     public static final String PREAMBLE_BLOCK_CONNECTION_OPTIONS = "connection_options";
     private static final Logger logger = LogManager.getLogger(PreambleBlock.class);
 
@@ -62,6 +63,15 @@ public class PreambleBlock extends SupportBlock {
             }
             Assumptions.assumeTrue(check.isSupported(), check.getMessage());
         }
+
+        // read the required_clusters option, and skip the test if not enough clusters are available.
+        if (optionsMap.containsKey(PREAMBLE_BLOCK_REQUIRED_CLUSTERS)) {
+            final int requiredClusters = ((Number) optionsMap.get(PREAMBLE_BLOCK_REQUIRED_CLUSTERS)).intValue();
+            final int availableClusters = executionContext.getConnectionFactory().getAvailableClusterCount();
+            Assumptions.assumeTrue(availableClusters >= requiredClusters,
+                    "Test requires " + requiredClusters + " clusters but only " + availableClusters + " available");
+        }
+
         var connectionOptions = Options.none();
         if (optionsMap.containsKey(PREAMBLE_BLOCK_CONNECTION_OPTIONS)) {
             connectionOptions = TestBlock.TestBlockOptions.parseConnectionOptions(Matchers.map(optionsMap.get(PREAMBLE_BLOCK_CONNECTION_OPTIONS)));

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/SetupBlock.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/SetupBlock.java
@@ -30,8 +30,9 @@ import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
 import com.apple.foundationdb.relational.yamltests.command.Command;
 import com.apple.foundationdb.relational.yamltests.command.QueryCommand;
 
+import com.apple.foundationdb.relational.yamltests.ConnectionTarget;
+
 import javax.annotation.Nonnull;
-import java.net.URI;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
@@ -56,9 +57,9 @@ public class SetupBlock extends ConnectedBlock {
 
     public static final String SETUP_BLOCK = "setup";
 
-    protected SetupBlock(@Nonnull YamlReference reference, @Nonnull List<Consumer<YamlConnection>> executables, @Nonnull URI connectionURI,
+    protected SetupBlock(@Nonnull YamlReference reference, @Nonnull List<Consumer<YamlConnection>> executables, @Nonnull ConnectionTarget connectionTarget,
                          @Nonnull YamlExecutionContext executionContext) {
-        super(reference, executables, connectionURI, executionContext);
+        super(reference, executables, connectionTarget, executionContext);
     }
 
     @Override
@@ -99,16 +100,16 @@ public class SetupBlock extends ConnectedBlock {
                     final var resolvedCommand = Objects.requireNonNull(Command.parse(reference.getResource(), List.of(step), "unnamed-setup-block", executionContext));
                     executables.add(createSetupExecutable(resolvedCommand, connectionOptions));
                 }
-                return List.of(new ManualSetupBlock(reference, executables, executionContext.inferConnectionURI(reference.getResource(), setupMap.getOrDefault(BLOCK_CONNECT, null)),
+                return List.of(new ManualSetupBlock(reference, executables, executionContext.inferConnectionTarget(reference.getResource(), setupMap.getOrDefault(BLOCK_CONNECT, null)),
                         executionContext));
             } catch (Throwable e) {
                 throw YamlExecutionContext.wrapContext(e, () -> "‼️ Error parsing the setup block at " + reference, SETUP_BLOCK, reference);
             }
         }
 
-        private ManualSetupBlock(@Nonnull YamlReference reference, @Nonnull List<Consumer<YamlConnection>> executables, @Nonnull URI connectionURI,
+        private ManualSetupBlock(@Nonnull YamlReference reference, @Nonnull List<Consumer<YamlConnection>> executables, @Nonnull ConnectionTarget connectionTarget,
                                  @Nonnull YamlExecutionContext executionContext) {
-            super(reference, executables, connectionURI, executionContext);
+            super(reference, executables, connectionTarget, executionContext);
         }
 
         @Nonnull
@@ -159,7 +160,7 @@ public class SetupBlock extends ConnectedBlock {
         private SchemaTemplateBlock(@Nonnull final YamlReference reference, @Nonnull final String schemaTemplateName,
                                     @Nonnull final String databaseName, @Nonnull List<Consumer<YamlConnection>> executables,
                                     @Nonnull YamlExecutionContext executionContext) {
-            super(reference, executables, executionContext.inferConnectionURI(reference.getResource(), 0), executionContext);
+            super(reference, executables, executionContext.inferConnectionTarget(reference.getResource(), 0), executionContext);
             this.finalizingBlocks = List.of(DestructTemplateBlock.withDatabaseAndSchema(reference, executionContext, schemaTemplateName, databaseName));
         }
 
@@ -192,7 +193,7 @@ public class SetupBlock extends ConnectedBlock {
         }
 
         private DestructTemplateBlock(@Nonnull final YamlReference reference, @Nonnull List<Consumer<YamlConnection>> executables, @Nonnull YamlExecutionContext executionContext) {
-            super(reference, executables, executionContext.inferConnectionURI(reference.getResource(), 0), executionContext);
+            super(reference, executables, executionContext.inferConnectionTarget(reference.getResource(), 0), executionContext);
         }
     }
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/TestBlock.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/TestBlock.java
@@ -22,6 +22,7 @@ package com.apple.foundationdb.relational.yamltests.block;
 
 import com.apple.foundationdb.relational.api.Options;
 import com.apple.foundationdb.relational.util.Assert;
+import com.apple.foundationdb.relational.yamltests.ConnectionTarget;
 import com.apple.foundationdb.relational.yamltests.CustomYamlConstructor;
 import com.apple.foundationdb.relational.yamltests.Matchers;
 import com.apple.foundationdb.relational.yamltests.YamlReference;
@@ -42,7 +43,6 @@ import org.opentest4j.TestAbortedException;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.net.URI;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -400,7 +400,7 @@ public final class TestBlock extends ConnectedBlock {
 
             Assert.thatUnchecked(!executables.isEmpty(), "‼️ Test block at " + reference + " have no tests to execute");
             return ImmutableList.of(new TestBlock(reference, blockName, queryCommands, executables, executableTestsWithCacheCheck,
-                    executionContext.inferConnectionURI(reference.getResource(), testsMap.getOrDefault(BLOCK_CONNECT, null)), options, executionContext));
+                    executionContext.inferConnectionTarget(reference.getResource(), testsMap.getOrDefault(BLOCK_CONNECT, null)), options, executionContext));
         } catch (Throwable e) {
             throw executionContext.wrapContext(e, () -> "‼️ Error parsing the test block at " + reference, TEST_BLOCK, reference);
         }
@@ -408,9 +408,9 @@ public final class TestBlock extends ConnectedBlock {
 
     private TestBlock(@Nonnull final YamlReference reference, @Nonnull final String blockName, @Nonnull final List<QueryCommand> queryCommands,
                       @Nonnull final List<Consumer<YamlConnection>> executables,
-                      @Nonnull final List<Consumer<YamlConnection>> executableTestsWithCacheCheck, @Nonnull final URI connectionURI,
+                      @Nonnull final List<Consumer<YamlConnection>> executableTestsWithCacheCheck, @Nonnull final ConnectionTarget connectionTarget,
                       @Nonnull final TestBlockOptions options, @Nonnull final YamlExecutionContext executionContext) {
-        super(reference, executables, connectionURI, executionContext);
+        super(reference, executables, connectionTarget, executionContext);
         this.blockName = blockName;
         this.queryCommands = queryCommands;
         this.options = options;

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/EmbeddedConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/EmbeddedConfig.java
@@ -53,6 +53,7 @@ public class EmbeddedConfig implements YamlTestConfig {
     }
 
     @Override
+    @SuppressWarnings("PMD.CloseResource") // FRLs are tracked in the list and closed in afterAll()
     public void beforeAll() throws Exception {
         var options = Options.builder()
                 .withOption(Options.Name.PLAN_CACHE_PRIMARY_TIME_TO_LIVE_MILLIS, 3_600_000L)
@@ -73,6 +74,7 @@ public class EmbeddedConfig implements YamlTestConfig {
     }
 
     @Override
+    @SuppressWarnings("PMD.CloseResource") // FRLs are being closed in this loop
     public void afterAll() throws Exception {
         for (final FRL frl : frls) {
             frl.close();

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/EmbeddedConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/EmbeddedConfig.java
@@ -32,6 +32,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Run directly against an instance of {@link FRL}.
@@ -64,10 +65,10 @@ public class EmbeddedConfig implements YamlTestConfig {
                 .build();
         // The primary FRL registers its driver in DriverManager; additional ones do not
         final String registeredCluster = clusterFiles.get(0);
-        clusters = Clusters.mapped(clusterFiles,
+        clusters = Clusters.fromClusterFiles(clusterFiles,
                 clusterFile -> {
                     try {
-                        return new FRL(options, clusterFile, clusterFile == registeredCluster);
+                        return new FRL(options, clusterFile, Objects.equals(clusterFile, registeredCluster));
                     } catch (RelationalException e) {
                         throw e.toUncheckedWrappedException();
                     }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/EmbeddedConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/EmbeddedConfig.java
@@ -25,9 +25,13 @@ import com.apple.foundationdb.relational.server.FRL;
 import com.apple.foundationdb.relational.yamltests.YamlConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
 import com.apple.foundationdb.relational.yamltests.connectionfactory.EmbeddedYamlConnectionFactory;
+import com.apple.foundationdb.test.FDBTestEnvironment;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * Run directly against an instance of {@link FRL}.
@@ -36,6 +40,8 @@ public class EmbeddedConfig implements YamlTestConfig {
     private FRL frl;
     @Nullable
     private final String clusterFile;
+    @Nonnull
+    private final List<FRL> additionalClusterFrls = new ArrayList<>();
 
     public EmbeddedConfig(@Nullable final String clusterFile) {
         this.clusterFile = clusterFile;
@@ -50,10 +56,21 @@ public class EmbeddedConfig implements YamlTestConfig {
                 .withOption(Options.Name.PLAN_CACHE_PRIMARY_MAX_ENTRIES, 10)
                 .build();
         frl = new FRL(options, clusterFile);
+
+        // Create drivers for additional clusters (without registering them in DriverManager)
+        for (final String otherClusterFile : FDBTestEnvironment.allClusterFiles()) {
+            if (!Objects.equals(otherClusterFile, clusterFile)) {
+                additionalClusterFrls.add(new FRL(options, otherClusterFile, false));
+            }
+        }
     }
 
     @Override
     public void afterAll() throws Exception {
+        for (final FRL additionalFrl : additionalClusterFrls) {
+            additionalFrl.close();
+        }
+        additionalClusterFrls.clear();
         if (frl != null) {
             frl.close();
             frl = null;
@@ -62,7 +79,19 @@ public class EmbeddedConfig implements YamlTestConfig {
 
     @Override
     public YamlConnectionFactory createConnectionFactory() {
-        return new EmbeddedYamlConnectionFactory(clusterFile);
+        final List<EmbeddedYamlConnectionFactory.ClusterDriver> additionalDrivers = new ArrayList<>();
+        final List<String> allClusterFiles = FDBTestEnvironment.allClusterFiles();
+        for (int i = 0; i < additionalClusterFrls.size(); i++) {
+            // Find the cluster file for this additional FRL
+            final String otherClusterFile = allClusterFiles.stream()
+                    .filter(cf -> !Objects.equals(cf, clusterFile))
+                    .skip(i)
+                    .findFirst()
+                    .orElseThrow();
+            additionalDrivers.add(new EmbeddedYamlConnectionFactory.ClusterDriver(
+                    additionalClusterFrls.get(i).getDriver(), otherClusterFile));
+        }
+        return new EmbeddedYamlConnectionFactory(clusterFile, additionalDrivers);
     }
 
     @Override

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/EmbeddedConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/EmbeddedConfig.java
@@ -42,7 +42,7 @@ public class EmbeddedConfig implements YamlTestConfig {
     @Nonnull
     private final List<String> clusterFiles;
     @Nonnull
-    private Clusters<FRL> clusters = Clusters.empty();
+    private Clusters<Clusters.Entry<FRL>> clusters = Clusters.empty();
 
     public EmbeddedConfig(@Nonnull final String clusterFile) {
         this(List.of(clusterFile));
@@ -63,7 +63,7 @@ public class EmbeddedConfig implements YamlTestConfig {
                 .build();
         // The primary FRL registers its driver in DriverManager; additional ones do not
         final String registeredCluster = clusterFiles.get(0);
-        clusters = Clusters.fromClusterFiles(clusterFiles,
+        clusters = Clusters.fromClusterFilesAsEntries(clusterFiles,
                 clusterFile -> {
                     try {
                         return new FRL(options, clusterFile, Objects.equals(clusterFile, registeredCluster));
@@ -84,7 +84,7 @@ public class EmbeddedConfig implements YamlTestConfig {
 
     @Override
     public YamlConnectionFactory createConnectionFactory() {
-        return new EmbeddedYamlConnectionFactory(clusters.map(FRL::getDriver));
+        return new EmbeddedYamlConnectionFactory(clusters.map(e -> Clusters.mapEntry(e, FRL::getDriver)));
     }
 
     @Nonnull

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/EmbeddedConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/EmbeddedConfig.java
@@ -25,26 +25,31 @@ import com.apple.foundationdb.relational.server.FRL;
 import com.apple.foundationdb.relational.yamltests.YamlConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
 import com.apple.foundationdb.relational.yamltests.connectionfactory.EmbeddedYamlConnectionFactory;
-import com.apple.foundationdb.test.FDBTestEnvironment;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * Run directly against an instance of {@link FRL}.
+ * <p>
+ * Starts one FRL per cluster file so that multi-cluster tests
+ * (using {@code connect: { cluster: N }}) can route to the correct cluster.
  */
 public class EmbeddedConfig implements YamlTestConfig {
-    private FRL frl;
-    @Nullable
-    private final String clusterFile;
     @Nonnull
-    private final List<FRL> additionalClusterFrls = new ArrayList<>();
+    private final List<String> clusterFiles;
+    @Nonnull
+    private final List<FRL> frls = new ArrayList<>();
 
     public EmbeddedConfig(@Nullable final String clusterFile) {
-        this.clusterFile = clusterFile;
+        this(Collections.singletonList(clusterFile));
+    }
+
+    public EmbeddedConfig(@Nonnull final List<String> clusterFiles) {
+        this.clusterFiles = clusterFiles;
     }
 
     @Override
@@ -55,43 +60,34 @@ public class EmbeddedConfig implements YamlTestConfig {
                 .withOption(Options.Name.PLAN_CACHE_TERTIARY_TIME_TO_LIVE_MILLIS, 3_600_000L)
                 .withOption(Options.Name.PLAN_CACHE_PRIMARY_MAX_ENTRIES, 10)
                 .build();
-        frl = new FRL(options, clusterFile);
-
-        // Create drivers for additional clusters (without registering them in DriverManager)
-        for (final String otherClusterFile : FDBTestEnvironment.allClusterFiles()) {
-            if (!Objects.equals(otherClusterFile, clusterFile)) {
-                additionalClusterFrls.add(new FRL(options, otherClusterFile, false));
+        // The primary FRL registers its driver in DriverManager; additional ones do not
+        boolean first = true;
+        for (final String clusterFile : clusterFiles) {
+            if (first) {
+                frls.add(new FRL(options, clusterFile));
+                first = false;
+            } else {
+                frls.add(new FRL(options, clusterFile, false));
             }
         }
     }
 
     @Override
     public void afterAll() throws Exception {
-        for (final FRL additionalFrl : additionalClusterFrls) {
-            additionalFrl.close();
-        }
-        additionalClusterFrls.clear();
-        if (frl != null) {
+        for (final FRL frl : frls) {
             frl.close();
-            frl = null;
         }
+        frls.clear();
     }
 
     @Override
     public YamlConnectionFactory createConnectionFactory() {
-        final List<EmbeddedYamlConnectionFactory.ClusterDriver> additionalDrivers = new ArrayList<>();
-        final List<String> allClusterFiles = FDBTestEnvironment.allClusterFiles();
-        for (int i = 0; i < additionalClusterFrls.size(); i++) {
-            // Find the cluster file for this additional FRL
-            final String otherClusterFile = allClusterFiles.stream()
-                    .filter(cf -> !Objects.equals(cf, clusterFile))
-                    .skip(i)
-                    .findFirst()
-                    .orElseThrow();
-            additionalDrivers.add(new EmbeddedYamlConnectionFactory.ClusterDriver(
-                    additionalClusterFrls.get(i).getDriver(), otherClusterFile));
+        final List<EmbeddedYamlConnectionFactory.ClusterDriver> clusterDrivers = new ArrayList<>();
+        for (int i = 0; i < frls.size(); i++) {
+            clusterDrivers.add(new EmbeddedYamlConnectionFactory.ClusterDriver(
+                    frls.get(i).getDriver(), clusterFiles.get(i)));
         }
-        return new EmbeddedYamlConnectionFactory(clusterFile, additionalDrivers);
+        return new EmbeddedYamlConnectionFactory(clusterDrivers);
     }
 
     @Override

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/EmbeddedConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/EmbeddedConfig.java
@@ -29,8 +29,6 @@ import com.apple.foundationdb.relational.yamltests.connectionfactory.Clusters;
 import com.apple.foundationdb.relational.yamltests.connectionfactory.EmbeddedYamlConnectionFactory;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -46,8 +44,8 @@ public class EmbeddedConfig implements YamlTestConfig {
     @Nonnull
     private Clusters<FRL> clusters = Clusters.empty();
 
-    public EmbeddedConfig(@Nullable final String clusterFile) {
-        this(Collections.singletonList(clusterFile));
+    public EmbeddedConfig(@Nonnull final String clusterFile) {
+        this(List.of(clusterFile));
     }
 
     public EmbeddedConfig(@Nonnull final List<String> clusterFiles) {

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/EmbeddedConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/EmbeddedConfig.java
@@ -21,14 +21,15 @@
 package com.apple.foundationdb.relational.yamltests.configs;
 
 import com.apple.foundationdb.relational.api.Options;
+import com.apple.foundationdb.relational.api.exceptions.RelationalException;
 import com.apple.foundationdb.relational.server.FRL;
 import com.apple.foundationdb.relational.yamltests.YamlConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
+import com.apple.foundationdb.relational.yamltests.connectionfactory.Clusters;
 import com.apple.foundationdb.relational.yamltests.connectionfactory.EmbeddedYamlConnectionFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -42,7 +43,7 @@ public class EmbeddedConfig implements YamlTestConfig {
     @Nonnull
     private final List<String> clusterFiles;
     @Nonnull
-    private final List<FRL> frls = new ArrayList<>();
+    private Clusters<FRL> clusters = Clusters.empty();
 
     public EmbeddedConfig(@Nullable final String clusterFile) {
         this(Collections.singletonList(clusterFile));
@@ -62,38 +63,34 @@ public class EmbeddedConfig implements YamlTestConfig {
                 .withOption(Options.Name.PLAN_CACHE_PRIMARY_MAX_ENTRIES, 10)
                 .build();
         // The primary FRL registers its driver in DriverManager; additional ones do not
-        boolean first = true;
-        for (final String clusterFile : clusterFiles) {
-            if (first) {
-                frls.add(new FRL(options, clusterFile));
-                first = false;
-            } else {
-                frls.add(new FRL(options, clusterFile, false));
-            }
-        }
+        final String registeredCluster = clusterFiles.get(0);
+        clusters = Clusters.mapped(clusterFiles,
+                clusterFile -> {
+                    try {
+                        return new FRL(options, clusterFile, clusterFile == registeredCluster);
+                    } catch (RelationalException e) {
+                        throw e.toUncheckedWrappedException();
+                    }
+                });
     }
 
     @Override
     @SuppressWarnings("PMD.CloseResource") // FRLs are being closed in this loop
     public void afterAll() throws Exception {
-        for (final FRL frl : frls) {
-            frl.close();
+        for (final Clusters.Entry<FRL> cluster : clusters) {
+            cluster.server().close();
         }
-        frls.clear();
+        clusters = Clusters.empty();
     }
 
     @Override
     public YamlConnectionFactory createConnectionFactory() {
-        final List<EmbeddedYamlConnectionFactory.ClusterDriver> clusterDrivers = new ArrayList<>();
-        for (int i = 0; i < frls.size(); i++) {
-            clusterDrivers.add(new EmbeddedYamlConnectionFactory.ClusterDriver(
-                    frls.get(i).getDriver(), clusterFiles.get(i)));
-        }
-        return new EmbeddedYamlConnectionFactory(clusterDrivers);
+        return new EmbeddedYamlConnectionFactory(clusters.map(FRL::getDriver));
     }
 
+    @Nonnull
     @Override
-    public @Nonnull YamlExecutionContext.ContextOptions getRunnerOptions() {
+    public YamlExecutionContext.ContextOptions getRunnerOptions() {
         return YamlExecutionContext.ContextOptions.EMPTY_OPTIONS;
     }
 

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/EmbeddedConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/EmbeddedConfig.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.relational.yamltests.configs;
 
+import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.relational.api.Options;
 import com.apple.foundationdb.relational.api.exceptions.RelationalException;
 import com.apple.foundationdb.relational.server.FRL;
@@ -44,6 +45,7 @@ public class EmbeddedConfig implements YamlTestConfig {
     @Nonnull
     private Clusters<Clusters.Entry<FRL>> clusters = Clusters.empty();
 
+    @API(API.Status.DEPRECATED)
     public EmbeddedConfig(@Nonnull final String clusterFile) {
         this(List.of(clusterFile));
     }
@@ -62,6 +64,8 @@ public class EmbeddedConfig implements YamlTestConfig {
                 .withOption(Options.Name.PLAN_CACHE_PRIMARY_MAX_ENTRIES, 10)
                 .build();
         // The primary FRL registers its driver in DriverManager; additional ones do not
+        // We register the primary one to make sure that everything works the same if it is registered vs not, to
+        // the extent that is validated in the yaml test framework.
         final String registeredCluster = clusterFiles.get(0);
         clusters = Clusters.fromClusterFilesAsEntries(clusterFiles,
                 clusterFile -> {

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/ExternalMultiServerConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/ExternalMultiServerConfig.java
@@ -22,6 +22,7 @@ package com.apple.foundationdb.relational.yamltests.configs;
 
 import com.apple.foundationdb.relational.yamltests.YamlConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
+import com.apple.foundationdb.relational.yamltests.connectionfactory.Clusters;
 import com.apple.foundationdb.relational.yamltests.connectionfactory.ExternalServerYamlConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.connectionfactory.MultiServerConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.server.ExternalServer;
@@ -59,8 +60,8 @@ public class ExternalMultiServerConfig implements YamlTestConfig {
         return new MultiServerConnectionFactory(
                 MultiServerConnectionFactory.ConnectionSelectionPolicy.ALTERNATE,
                 initialConnection,
-                new ExternalServerYamlConnectionFactory(JDBCMultiServerConfig.toExternalClusters(List.of(server0))),
-                List.of(new ExternalServerYamlConnectionFactory(JDBCMultiServerConfig.toExternalClusters(List.of(server1)))));
+                new ExternalServerYamlConnectionFactory(Clusters.fromServers(List.of(server0), ExternalServer::getClusterFile)),
+                List.of(new ExternalServerYamlConnectionFactory(Clusters.fromServers(List.of(server1), ExternalServer::getClusterFile))));
     }
 
     @Override

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/ExternalMultiServerConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/ExternalMultiServerConfig.java
@@ -26,6 +26,7 @@ import com.apple.foundationdb.relational.yamltests.connectionfactory.Clusters;
 import com.apple.foundationdb.relational.yamltests.connectionfactory.ExternalServerYamlConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.connectionfactory.MultiServerConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.server.ExternalServer;
+import com.apple.foundationdb.relational.yamltests.server.SemanticVersion;
 
 import javax.annotation.Nonnull;
 import java.util.List;
@@ -70,10 +71,12 @@ public class ExternalMultiServerConfig implements YamlTestConfig {
 
     @Override
     public String toString() {
+        final SemanticVersion version0 = servers0.getInfo(ExternalServer::getVersion);
+        final SemanticVersion version1 = servers1.getInfo(ExternalServer::getVersion);
         if (initialConnection == 0) {
-            return "MultiServer (" + servers0.primary().getVersion() + " then " + servers1.primary().getVersion() + ")";
+            return "MultiServer (" + version0 + " then " + version1 + ")";
         } else {
-            return "MultiServer (" + servers1.primary().getVersion() + " then " + servers0.primary().getVersion() + ")";
+            return "MultiServer (" + version1 + " then " + version0 + ")";
         }
     }
 

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/ExternalMultiServerConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/ExternalMultiServerConfig.java
@@ -59,8 +59,8 @@ public class ExternalMultiServerConfig implements YamlTestConfig {
         return new MultiServerConnectionFactory(
                 MultiServerConnectionFactory.ConnectionSelectionPolicy.ALTERNATE,
                 initialConnection,
-                new ExternalServerYamlConnectionFactory(List.of(server0)),
-                List.of(new ExternalServerYamlConnectionFactory(List.of(server1))));
+                new ExternalServerYamlConnectionFactory(JDBCMultiServerConfig.toExternalClusters(List.of(server0))),
+                List.of(new ExternalServerYamlConnectionFactory(JDBCMultiServerConfig.toExternalClusters(List.of(server1)))));
     }
 
     @Override

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/ExternalMultiServerConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/ExternalMultiServerConfig.java
@@ -71,9 +71,9 @@ public class ExternalMultiServerConfig implements YamlTestConfig {
     @Override
     public String toString() {
         if (initialConnection == 0) {
-            return "MultiServer (" + servers0.primary().server().getVersion() + " then " + servers1.primary().server().getVersion() + ")";
+            return "MultiServer (" + servers0.primary().getVersion() + " then " + servers1.primary().getVersion() + ")";
         } else {
-            return "MultiServer (" + servers1.primary().server().getVersion() + " then " + servers0.primary().server().getVersion() + ")";
+            return "MultiServer (" + servers1.primary().getVersion() + " then " + servers0.primary().getVersion() + ")";
         }
     }
 

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/ExternalMultiServerConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/ExternalMultiServerConfig.java
@@ -59,8 +59,8 @@ public class ExternalMultiServerConfig implements YamlTestConfig {
         return new MultiServerConnectionFactory(
                 MultiServerConnectionFactory.ConnectionSelectionPolicy.ALTERNATE,
                 initialConnection,
-                new ExternalServerYamlConnectionFactory(server0),
-                List.of(new ExternalServerYamlConnectionFactory(server1)));
+                new ExternalServerYamlConnectionFactory(List.of(server0)),
+                List.of(new ExternalServerYamlConnectionFactory(List.of(server1))));
     }
 
     @Override

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/ExternalMultiServerConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/ExternalMultiServerConfig.java
@@ -37,14 +37,18 @@ import java.util.List;
 public class ExternalMultiServerConfig implements YamlTestConfig {
 
     private final int initialConnection;
-    private final ExternalServer server0;
-    private final ExternalServer server1;
+    @Nonnull
+    private final Clusters<ExternalServer> servers0;
+    @Nonnull
+    private final Clusters<ExternalServer> servers1;
 
-    public ExternalMultiServerConfig(final int initialConnection, ExternalServer server0, ExternalServer server1) {
+    public ExternalMultiServerConfig(final int initialConnection,
+                                     @Nonnull Clusters<ExternalServer> servers0,
+                                     @Nonnull Clusters<ExternalServer> servers1) {
         super();
         this.initialConnection = initialConnection;
-        this.server0 = server0;
-        this.server1 = server1;
+        this.servers0 = servers0;
+        this.servers1 = servers1;
     }
 
     @Override
@@ -60,16 +64,16 @@ public class ExternalMultiServerConfig implements YamlTestConfig {
         return new MultiServerConnectionFactory(
                 MultiServerConnectionFactory.ConnectionSelectionPolicy.ALTERNATE,
                 initialConnection,
-                new ExternalServerYamlConnectionFactory(Clusters.fromServers(List.of(server0), ExternalServer::getClusterFile)),
-                List.of(new ExternalServerYamlConnectionFactory(Clusters.fromServers(List.of(server1), ExternalServer::getClusterFile))));
+                new ExternalServerYamlConnectionFactory(servers0),
+                List.of(new ExternalServerYamlConnectionFactory(servers1)));
     }
 
     @Override
     public String toString() {
         if (initialConnection == 0) {
-            return "MultiServer (" + server0.getVersion() + " then " + server1.getVersion() + ")";
+            return "MultiServer (" + servers0.primary().server().getVersion() + " then " + servers1.primary().server().getVersion() + ")";
         } else {
-            return "MultiServer (" + server1.getVersion() + " then " + server0.getVersion() + ")";
+            return "MultiServer (" + servers1.primary().server().getVersion() + " then " + servers0.primary().server().getVersion() + ")";
         }
     }
 

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCInProcessConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCInProcessConfig.java
@@ -67,6 +67,15 @@ public class JDBCInProcessConfig implements YamlTestConfig {
         return new JDBCInProcessYamlConnectionFactory(server, clusterFile);
     }
 
+    protected InProcessRelationalServer getServer() {
+        return server;
+    }
+
+    @Nullable
+    protected String getClusterFile() {
+        return clusterFile;
+    }
+
     @Nonnull
     @Override
     public YamlExecutionContext.ContextOptions getRunnerOptions() {

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCInProcessConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCInProcessConfig.java
@@ -49,7 +49,7 @@ public class JDBCInProcessConfig implements YamlTestConfig {
     @Override
     @SuppressWarnings("PMD.CloseResource") // Servers are tracked in the list and closed in afterAll()
     public void beforeAll() throws Exception {
-        clusters = Clusters.mapped(clusterFiles,
+        clusters = Clusters.fromClusterFiles(clusterFiles,
                 clusterFile -> {
                     try {
                         return new InProcessRelationalServer(clusterFile).start();

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCInProcessConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCInProcessConfig.java
@@ -24,18 +24,27 @@ import com.apple.foundationdb.relational.server.InProcessRelationalServer;
 import com.apple.foundationdb.relational.yamltests.YamlConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
 import com.apple.foundationdb.relational.yamltests.connectionfactory.JDBCInProcessYamlConnectionFactory;
+import com.apple.foundationdb.test.FDBTestEnvironment;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * Run against an embedded JDBC server.
+ * <p>
+ * When multiple cluster files are available, starts one in-process server per additional cluster so that
+ * multi-cluster tests (using {@code connect: { cluster: N }}) can route to the correct cluster.
  */
 public class JDBCInProcessConfig implements YamlTestConfig {
     @Nullable
     private InProcessRelationalServer server;
     @Nullable
     private final String clusterFile;
+    @Nonnull
+    private final List<InProcessRelationalServer> additionalClusterServers = new ArrayList<>();
 
     public JDBCInProcessConfig() {
         this(null);
@@ -52,10 +61,21 @@ public class JDBCInProcessConfig implements YamlTestConfig {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+        // Start one in-process server per additional cluster file
+        for (final String otherClusterFile : FDBTestEnvironment.allClusterFiles()) {
+            if (!Objects.equals(otherClusterFile, clusterFile)) {
+                final InProcessRelationalServer additionalServer = new InProcessRelationalServer(otherClusterFile).start();
+                additionalClusterServers.add(additionalServer);
+            }
+        }
     }
 
     @Override
     public void afterAll() throws Exception {
+        for (final InProcessRelationalServer additionalServer : additionalClusterServers) {
+            additionalServer.close();
+        }
+        additionalClusterServers.clear();
         if (server != null) {
             server.close();
             server = null;
@@ -64,7 +84,26 @@ public class JDBCInProcessConfig implements YamlTestConfig {
 
     @Override
     public YamlConnectionFactory createConnectionFactory() {
-        return new JDBCInProcessYamlConnectionFactory(server, clusterFile);
+        return new JDBCInProcessYamlConnectionFactory(server, clusterFile, buildClusterServers());
+    }
+
+    /**
+     * Build the list of {@link JDBCInProcessYamlConnectionFactory.ClusterServer} entries for the additional clusters.
+     */
+    @Nonnull
+    protected List<JDBCInProcessYamlConnectionFactory.ClusterServer> buildClusterServers() {
+        final List<JDBCInProcessYamlConnectionFactory.ClusterServer> clusterServers = new ArrayList<>();
+        final List<String> allClusterFiles = FDBTestEnvironment.allClusterFiles();
+        for (int i = 0; i < additionalClusterServers.size(); i++) {
+            final String otherClusterFile = allClusterFiles.stream()
+                    .filter(cf -> !Objects.equals(cf, clusterFile))
+                    .skip(i)
+                    .findFirst()
+                    .orElseThrow();
+            clusterServers.add(new JDBCInProcessYamlConnectionFactory.ClusterServer(
+                    additionalClusterServers.get(i), otherClusterFile));
+        }
+        return clusterServers;
     }
 
     protected InProcessRelationalServer getServer() {

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCInProcessConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCInProcessConfig.java
@@ -40,7 +40,7 @@ public class JDBCInProcessConfig implements YamlTestConfig {
     @Nonnull
     private final List<String> clusterFiles;
     @Nonnull
-    private Clusters<InProcessRelationalServer> clusters = Clusters.empty();
+    private Clusters<Clusters.Entry<InProcessRelationalServer>> clusters = Clusters.empty();
 
     public JDBCInProcessConfig(@Nonnull final List<String> clusterFiles) {
         this.clusterFiles = clusterFiles;
@@ -49,7 +49,7 @@ public class JDBCInProcessConfig implements YamlTestConfig {
     @Override
     @SuppressWarnings("PMD.CloseResource") // Servers are tracked in the list and closed in afterAll()
     public void beforeAll() throws Exception {
-        clusters = Clusters.fromClusterFiles(clusterFiles,
+        clusters = Clusters.fromClusterFilesAsEntries(clusterFiles,
                 clusterFile -> {
                     try {
                         return new InProcessRelationalServer(clusterFile).start();
@@ -73,7 +73,7 @@ public class JDBCInProcessConfig implements YamlTestConfig {
     }
 
     @Nonnull
-    protected Clusters<InProcessRelationalServer> getClusters() {
+    protected Clusters<Clusters.Entry<InProcessRelationalServer>> getClusters() {
         return clusters;
     }
 

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCInProcessConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCInProcessConfig.java
@@ -23,10 +23,11 @@ package com.apple.foundationdb.relational.yamltests.configs;
 import com.apple.foundationdb.relational.server.InProcessRelationalServer;
 import com.apple.foundationdb.relational.yamltests.YamlConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
+import com.apple.foundationdb.relational.yamltests.connectionfactory.Clusters;
 import com.apple.foundationdb.relational.yamltests.connectionfactory.JDBCInProcessYamlConnectionFactory;
 
 import javax.annotation.Nonnull;
-import java.util.ArrayList;
+import java.io.IOException;
 import java.util.List;
 
 /**
@@ -39,7 +40,7 @@ public class JDBCInProcessConfig implements YamlTestConfig {
     @Nonnull
     private final List<String> clusterFiles;
     @Nonnull
-    private final List<JDBCInProcessYamlConnectionFactory.ClusterServer> clusterServers = new ArrayList<>();
+    private Clusters<InProcessRelationalServer> clusters = Clusters.empty();
 
     public JDBCInProcessConfig(@Nonnull final List<String> clusterFiles) {
         this.clusterFiles = clusterFiles;
@@ -48,28 +49,32 @@ public class JDBCInProcessConfig implements YamlTestConfig {
     @Override
     @SuppressWarnings("PMD.CloseResource") // Servers are tracked in the list and closed in afterAll()
     public void beforeAll() throws Exception {
-        for (final String clusterFile : clusterFiles) {
-            final InProcessRelationalServer server = new InProcessRelationalServer(clusterFile).start();
-            clusterServers.add(new JDBCInProcessYamlConnectionFactory.ClusterServer(server, clusterFile));
-        }
+        clusters = Clusters.mapped(clusterFiles,
+                clusterFile -> {
+                    try {
+                        return new InProcessRelationalServer(clusterFile).start();
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
     }
 
     @Override
     public void afterAll() throws Exception {
-        for (final JDBCInProcessYamlConnectionFactory.ClusterServer cs : clusterServers) {
-            cs.server().close();
+        for (final Clusters.Entry<InProcessRelationalServer> cluster : clusters) {
+            cluster.server().close();
         }
-        clusterServers.clear();
+        clusters = Clusters.empty();
     }
 
     @Override
     public YamlConnectionFactory createConnectionFactory() {
-        return new JDBCInProcessYamlConnectionFactory(clusterServers);
+        return new JDBCInProcessYamlConnectionFactory(clusters);
     }
 
     @Nonnull
-    protected List<JDBCInProcessYamlConnectionFactory.ClusterServer> getClusterServers() {
-        return clusterServers;
+    protected Clusters<InProcessRelationalServer> getClusters() {
+        return clusters;
     }
 
     @Nonnull

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCInProcessConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCInProcessConfig.java
@@ -46,6 +46,7 @@ public class JDBCInProcessConfig implements YamlTestConfig {
     }
 
     @Override
+    @SuppressWarnings("PMD.CloseResource") // Servers are tracked in the list and closed in afterAll()
     public void beforeAll() throws Exception {
         for (final String clusterFile : clusterFiles) {
             final InProcessRelationalServer server = new InProcessRelationalServer(clusterFile).start();

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCInProcessConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCInProcessConfig.java
@@ -24,95 +24,51 @@ import com.apple.foundationdb.relational.server.InProcessRelationalServer;
 import com.apple.foundationdb.relational.yamltests.YamlConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
 import com.apple.foundationdb.relational.yamltests.connectionfactory.JDBCInProcessYamlConnectionFactory;
-import com.apple.foundationdb.test.FDBTestEnvironment;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * Run against an embedded JDBC server.
  * <p>
- * When multiple cluster files are available, starts one in-process server per additional cluster so that
- * multi-cluster tests (using {@code connect: { cluster: N }}) can route to the correct cluster.
+ * Starts one in-process server per cluster file so that multi-cluster tests
+ * (using {@code connect: { cluster: N }}) can route to the correct cluster.
  */
 public class JDBCInProcessConfig implements YamlTestConfig {
-    @Nullable
-    private InProcessRelationalServer server;
-    @Nullable
-    private final String clusterFile;
     @Nonnull
-    private final List<InProcessRelationalServer> additionalClusterServers = new ArrayList<>();
+    private final List<String> clusterFiles;
+    @Nonnull
+    private final List<JDBCInProcessYamlConnectionFactory.ClusterServer> clusterServers = new ArrayList<>();
 
-    public JDBCInProcessConfig() {
-        this(null);
-    }
-
-    public JDBCInProcessConfig(@Nullable final String clusterFile) {
-        this.clusterFile = clusterFile;
+    public JDBCInProcessConfig(@Nonnull final List<String> clusterFiles) {
+        this.clusterFiles = clusterFiles;
     }
 
     @Override
     public void beforeAll() throws Exception {
-        try {
-            server = new InProcessRelationalServer(clusterFile).start();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-        // Start one in-process server per additional cluster file
-        for (final String otherClusterFile : FDBTestEnvironment.allClusterFiles()) {
-            if (!Objects.equals(otherClusterFile, clusterFile)) {
-                final InProcessRelationalServer additionalServer = new InProcessRelationalServer(otherClusterFile).start();
-                additionalClusterServers.add(additionalServer);
-            }
+        for (final String clusterFile : clusterFiles) {
+            final InProcessRelationalServer server = new InProcessRelationalServer(clusterFile).start();
+            clusterServers.add(new JDBCInProcessYamlConnectionFactory.ClusterServer(server, clusterFile));
         }
     }
 
     @Override
     public void afterAll() throws Exception {
-        for (final InProcessRelationalServer additionalServer : additionalClusterServers) {
-            additionalServer.close();
+        for (final JDBCInProcessYamlConnectionFactory.ClusterServer cs : clusterServers) {
+            cs.server().close();
         }
-        additionalClusterServers.clear();
-        if (server != null) {
-            server.close();
-            server = null;
-        }
+        clusterServers.clear();
     }
 
     @Override
     public YamlConnectionFactory createConnectionFactory() {
-        return new JDBCInProcessYamlConnectionFactory(server, clusterFile, buildClusterServers());
+        return new JDBCInProcessYamlConnectionFactory(clusterServers);
     }
 
-    /**
-     * Build the list of {@link JDBCInProcessYamlConnectionFactory.ClusterServer} entries for the additional clusters.
-     */
     @Nonnull
-    protected List<JDBCInProcessYamlConnectionFactory.ClusterServer> buildClusterServers() {
-        final List<JDBCInProcessYamlConnectionFactory.ClusterServer> clusterServers = new ArrayList<>();
-        final List<String> allClusterFiles = FDBTestEnvironment.allClusterFiles();
-        for (int i = 0; i < additionalClusterServers.size(); i++) {
-            final String otherClusterFile = allClusterFiles.stream()
-                    .filter(cf -> !Objects.equals(cf, clusterFile))
-                    .skip(i)
-                    .findFirst()
-                    .orElseThrow();
-            clusterServers.add(new JDBCInProcessYamlConnectionFactory.ClusterServer(
-                    additionalClusterServers.get(i), otherClusterFile));
-        }
+    protected List<JDBCInProcessYamlConnectionFactory.ClusterServer> getClusterServers() {
         return clusterServers;
-    }
-
-    protected InProcessRelationalServer getServer() {
-        return server;
-    }
-
-    @Nullable
-    protected String getClusterFile() {
-        return clusterFile;
     }
 
     @Nonnull

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCMultiServerConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCMultiServerConfig.java
@@ -59,7 +59,7 @@ public class JDBCMultiServerConfig extends JDBCInProcessConfig {
 
     @Override
     public String toString() {
-        final ExternalServer primaryExternal = externalServers.primary().server();
+        final ExternalServer primaryExternal = externalServers.primary();
         if (initialConnection == 0) {
             return "MultiServer (" + super.toString() + " then " + primaryExternal.getVersion() + ")";
         } else {

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCMultiServerConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCMultiServerConfig.java
@@ -23,7 +23,6 @@ package com.apple.foundationdb.relational.yamltests.configs;
 import com.apple.foundationdb.relational.yamltests.YamlConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.connectionfactory.Clusters;
 import com.apple.foundationdb.relational.yamltests.connectionfactory.ExternalServerYamlConnectionFactory;
-import com.apple.foundationdb.relational.yamltests.connectionfactory.JDBCInProcessYamlConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.connectionfactory.MultiServerConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.server.ExternalServer;
 
@@ -54,7 +53,7 @@ public class JDBCMultiServerConfig extends JDBCInProcessConfig {
         return new MultiServerConnectionFactory(
                 MultiServerConnectionFactory.ConnectionSelectionPolicy.ALTERNATE,
                 initialConnection,
-                new JDBCInProcessYamlConnectionFactory(getClusters()),
+                super.createConnectionFactory(),
                 List.of(new ExternalServerYamlConnectionFactory(externalServers)));
     }
 

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCMultiServerConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCMultiServerConfig.java
@@ -20,25 +20,22 @@
 
 package com.apple.foundationdb.relational.yamltests.configs;
 
-import com.apple.foundationdb.relational.server.InProcessRelationalServer;
 import com.apple.foundationdb.relational.yamltests.YamlConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.connectionfactory.ExternalServerYamlConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.connectionfactory.JDBCInProcessYamlConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.connectionfactory.MultiServerConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.server.ExternalServer;
-import com.apple.foundationdb.test.FDBTestEnvironment;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * Run against an embedded JDBC driver, and an external server, alternating commands that go against each.
  * <p>
- * When multiple cluster files are available, starts one in-process server per additional cluster so that
- * multi-cluster tests (using {@code connect: { cluster: N }}) can route to the correct cluster.
+ * Multi-cluster support (additional in-process servers for non-primary cluster files) is inherited from
+ * {@link JDBCInProcessConfig}. When additional cluster external servers are provided, they are passed to
+ * the {@link ExternalServerYamlConnectionFactory} so that cluster-specific connections also alternate.
  */
 public class JDBCMultiServerConfig extends JDBCInProcessConfig {
 
@@ -46,8 +43,6 @@ public class JDBCMultiServerConfig extends JDBCInProcessConfig {
     private final int initialConnection;
     @Nonnull
     private final List<ExternalServer> additionalClusterExternalServers;
-    @Nonnull
-    private final List<InProcessRelationalServer> additionalClusterServers = new ArrayList<>();
 
     public JDBCMultiServerConfig(final int initialConnection, ExternalServer externalServer) {
         this(initialConnection, externalServer, null, List.of());
@@ -68,42 +63,9 @@ public class JDBCMultiServerConfig extends JDBCInProcessConfig {
     }
 
     @Override
-    public void beforeAll() throws Exception {
-        super.beforeAll();
-        // Start one in-process server per additional cluster file
-        for (final String otherClusterFile : FDBTestEnvironment.allClusterFiles()) {
-            if (!Objects.equals(otherClusterFile, getClusterFile())) {
-                final InProcessRelationalServer server = new InProcessRelationalServer(otherClusterFile).start();
-                additionalClusterServers.add(server);
-            }
-        }
-    }
-
-    @Override
-    public void afterAll() throws Exception {
-        for (final InProcessRelationalServer server : additionalClusterServers) {
-            server.close();
-        }
-        additionalClusterServers.clear();
-        super.afterAll();
-    }
-
-    @Override
     public YamlConnectionFactory createConnectionFactory() {
-        // Build the JDBCInProcessYamlConnectionFactory with multi-cluster support
-        final List<JDBCInProcessYamlConnectionFactory.ClusterServer> clusterServers = new ArrayList<>();
-        final List<String> allClusterFiles = FDBTestEnvironment.allClusterFiles();
-        for (int i = 0; i < additionalClusterServers.size(); i++) {
-            final String otherClusterFile = allClusterFiles.stream()
-                    .filter(cf -> !Objects.equals(cf, getClusterFile()))
-                    .skip(i)
-                    .findFirst()
-                    .orElseThrow();
-            clusterServers.add(new JDBCInProcessYamlConnectionFactory.ClusterServer(
-                    additionalClusterServers.get(i), otherClusterFile));
-        }
         final JDBCInProcessYamlConnectionFactory jdbcFactory =
-                new JDBCInProcessYamlConnectionFactory(getServer(), getClusterFile(), clusterServers);
+                new JDBCInProcessYamlConnectionFactory(getServer(), getClusterFile(), buildClusterServers());
 
         return new MultiServerConnectionFactory(
                 MultiServerConnectionFactory.ConnectionSelectionPolicy.ALTERNATE,

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCMultiServerConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCMultiServerConfig.java
@@ -43,9 +43,8 @@ public class JDBCMultiServerConfig extends JDBCInProcessConfig {
     private final Clusters<ExternalServer> externalServers;
     private final int initialConnection;
 
-    public JDBCMultiServerConfig(final int initialConnection, @Nonnull Clusters<ExternalServer> externalServers,
-                                 @Nonnull final List<String> clusterFiles) {
-        super(clusterFiles);
+    public JDBCMultiServerConfig(final int initialConnection, @Nonnull Clusters<ExternalServer> externalServers) {
+        super(externalServers.clusterFiles());
         this.initialConnection = initialConnection;
         this.externalServers = externalServers;
     }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCMultiServerConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCMultiServerConfig.java
@@ -27,59 +27,48 @@ import com.apple.foundationdb.relational.yamltests.connectionfactory.MultiServer
 import com.apple.foundationdb.relational.yamltests.server.ExternalServer;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.List;
 
 /**
  * Run against an embedded JDBC driver, and an external server, alternating commands that go against each.
  * <p>
- * Multi-cluster support (additional in-process servers for non-primary cluster files) is inherited from
- * {@link JDBCInProcessConfig}. When additional cluster external servers are provided, they are passed to
- * the {@link ExternalServerYamlConnectionFactory} so that cluster-specific connections also alternate.
+ * Multi-cluster support (in-process servers for all cluster files) is inherited from
+ * {@link JDBCInProcessConfig}. The external servers list should have one entry per cluster file
+ * (matching the in-process servers), so that cluster-specific connections also alternate.
  */
 public class JDBCMultiServerConfig extends JDBCInProcessConfig {
 
-    private final ExternalServer externalServer;
-    private final int initialConnection;
     @Nonnull
-    private final List<ExternalServer> additionalClusterExternalServers;
+    private final List<ExternalServer> externalServers;
+    private final int initialConnection;
 
-    public JDBCMultiServerConfig(final int initialConnection, ExternalServer externalServer) {
-        this(initialConnection, externalServer, null, List.of());
+    public JDBCMultiServerConfig(final int initialConnection, @Nonnull List<ExternalServer> externalServers) {
+        this(initialConnection, externalServers, List.of());
     }
 
-    public JDBCMultiServerConfig(final int initialConnection, ExternalServer externalServer,
-                                 @Nullable final String clusterFile) {
-        this(initialConnection, externalServer, clusterFile, List.of());
-    }
-
-    public JDBCMultiServerConfig(final int initialConnection, ExternalServer externalServer,
-                                 @Nullable final String clusterFile,
-                                 @Nonnull List<ExternalServer> additionalClusterExternalServers) {
-        super(clusterFile);
+    public JDBCMultiServerConfig(final int initialConnection, @Nonnull List<ExternalServer> externalServers,
+                                 @Nonnull final List<String> clusterFiles) {
+        super(clusterFiles);
         this.initialConnection = initialConnection;
-        this.externalServer = externalServer;
-        this.additionalClusterExternalServers = additionalClusterExternalServers;
+        this.externalServers = externalServers;
     }
 
     @Override
     public YamlConnectionFactory createConnectionFactory() {
-        final JDBCInProcessYamlConnectionFactory jdbcFactory =
-                new JDBCInProcessYamlConnectionFactory(getServer(), getClusterFile(), buildClusterServers());
-
         return new MultiServerConnectionFactory(
                 MultiServerConnectionFactory.ConnectionSelectionPolicy.ALTERNATE,
                 initialConnection,
-                jdbcFactory,
-                List.of(new ExternalServerYamlConnectionFactory(externalServer, additionalClusterExternalServers)));
+                new JDBCInProcessYamlConnectionFactory(getClusterServers()),
+                List.of(new ExternalServerYamlConnectionFactory(externalServers)));
     }
 
     @Override
     public String toString() {
+        final ExternalServer primaryExternal = externalServers.get(0);
         if (initialConnection == 0) {
-            return "MultiServer (" + super.toString() + " then " + externalServer.getVersion() + ")";
+            return "MultiServer (" + super.toString() + " then " + primaryExternal.getVersion() + ")";
         } else {
-            return "MultiServer (" + externalServer.getVersion() + " then " + super.toString() + ")";
+            return "MultiServer (" + primaryExternal.getVersion() + " then " + super.toString() + ")";
         }
     }
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCMultiServerConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCMultiServerConfig.java
@@ -61,7 +61,7 @@ public class JDBCMultiServerConfig extends JDBCInProcessConfig {
 
     @Override
     public String toString() {
-        final ExternalServer primaryExternal = externalServers.iterator().next().server();
+        final ExternalServer primaryExternal = externalServers.primary().server();
         if (initialConnection == 0) {
             return "MultiServer (" + super.toString() + " then " + primaryExternal.getVersion() + ")";
         } else {

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCMultiServerConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCMultiServerConfig.java
@@ -25,6 +25,7 @@ import com.apple.foundationdb.relational.yamltests.connectionfactory.Clusters;
 import com.apple.foundationdb.relational.yamltests.connectionfactory.ExternalServerYamlConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.connectionfactory.MultiServerConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.server.ExternalServer;
+import com.apple.foundationdb.relational.yamltests.server.SemanticVersion;
 
 import javax.annotation.Nonnull;
 import java.util.List;
@@ -59,11 +60,11 @@ public class JDBCMultiServerConfig extends JDBCInProcessConfig {
 
     @Override
     public String toString() {
-        final ExternalServer primaryExternal = externalServers.primary();
+        final SemanticVersion externalVersion = externalServers.getInfo(ExternalServer::getVersion);
         if (initialConnection == 0) {
-            return "MultiServer (" + super.toString() + " then " + primaryExternal.getVersion() + ")";
+            return "MultiServer (" + super.toString() + " then " + externalVersion + ")";
         } else {
-            return "MultiServer (" + primaryExternal.getVersion() + " then " + super.toString() + ")";
+            return "MultiServer (" + externalVersion + " then " + super.toString() + ")";
         }
     }
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCMultiServerConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCMultiServerConfig.java
@@ -45,17 +45,26 @@ public class JDBCMultiServerConfig extends JDBCInProcessConfig {
     private final ExternalServer externalServer;
     private final int initialConnection;
     @Nonnull
+    private final List<ExternalServer> additionalClusterExternalServers;
+    @Nonnull
     private final List<InProcessRelationalServer> additionalClusterServers = new ArrayList<>();
 
     public JDBCMultiServerConfig(final int initialConnection, ExternalServer externalServer) {
-        this(initialConnection, externalServer, null);
+        this(initialConnection, externalServer, null, List.of());
     }
 
     public JDBCMultiServerConfig(final int initialConnection, ExternalServer externalServer,
                                  @Nullable final String clusterFile) {
+        this(initialConnection, externalServer, clusterFile, List.of());
+    }
+
+    public JDBCMultiServerConfig(final int initialConnection, ExternalServer externalServer,
+                                 @Nullable final String clusterFile,
+                                 @Nonnull List<ExternalServer> additionalClusterExternalServers) {
         super(clusterFile);
         this.initialConnection = initialConnection;
         this.externalServer = externalServer;
+        this.additionalClusterExternalServers = additionalClusterExternalServers;
     }
 
     @Override
@@ -100,7 +109,7 @@ public class JDBCMultiServerConfig extends JDBCInProcessConfig {
                 MultiServerConnectionFactory.ConnectionSelectionPolicy.ALTERNATE,
                 initialConnection,
                 jdbcFactory,
-                List.of(new ExternalServerYamlConnectionFactory(externalServer)));
+                List.of(new ExternalServerYamlConnectionFactory(externalServer, additionalClusterExternalServers)));
     }
 
     @Override

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCMultiServerConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCMultiServerConfig.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.relational.yamltests.configs;
 
 import com.apple.foundationdb.relational.yamltests.YamlConnectionFactory;
+import com.apple.foundationdb.relational.yamltests.connectionfactory.Clusters;
 import com.apple.foundationdb.relational.yamltests.connectionfactory.ExternalServerYamlConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.connectionfactory.JDBCInProcessYamlConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.connectionfactory.MultiServerConnectionFactory;
@@ -28,6 +29,7 @@ import com.apple.foundationdb.relational.yamltests.server.ExternalServer;
 
 import javax.annotation.Nonnull;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Run against an embedded JDBC driver, and an external server, alternating commands that go against each.
@@ -58,8 +60,8 @@ public class JDBCMultiServerConfig extends JDBCInProcessConfig {
         return new MultiServerConnectionFactory(
                 MultiServerConnectionFactory.ConnectionSelectionPolicy.ALTERNATE,
                 initialConnection,
-                new JDBCInProcessYamlConnectionFactory(getClusterServers()),
-                List.of(new ExternalServerYamlConnectionFactory(externalServers)));
+                new JDBCInProcessYamlConnectionFactory(getClusters()),
+                List.of(new ExternalServerYamlConnectionFactory(toExternalClusters(externalServers))));
     }
 
     @Override
@@ -70,5 +72,12 @@ public class JDBCMultiServerConfig extends JDBCInProcessConfig {
         } else {
             return "MultiServer (" + primaryExternal.getVersion() + " then " + super.toString() + ")";
         }
+    }
+
+    @Nonnull
+    static Clusters<ExternalServer> toExternalClusters(@Nonnull List<ExternalServer> servers) {
+        return new Clusters<>(servers.stream()
+                .map(s -> new Clusters.Entry<>(s, s.getClusterFile()))
+                .collect(Collectors.toList()));
     }
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCMultiServerConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCMultiServerConfig.java
@@ -20,21 +20,32 @@
 
 package com.apple.foundationdb.relational.yamltests.configs;
 
+import com.apple.foundationdb.relational.server.InProcessRelationalServer;
 import com.apple.foundationdb.relational.yamltests.YamlConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.connectionfactory.ExternalServerYamlConnectionFactory;
+import com.apple.foundationdb.relational.yamltests.connectionfactory.JDBCInProcessYamlConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.connectionfactory.MultiServerConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.server.ExternalServer;
+import com.apple.foundationdb.test.FDBTestEnvironment;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Run against an embedded JDBC driver, and an external server, alternating commands that go against each.
+ * <p>
+ * When multiple cluster files are available, starts one in-process server per additional cluster so that
+ * multi-cluster tests (using {@code connect: { cluster: N }}) can route to the correct cluster.
  */
 public class JDBCMultiServerConfig extends JDBCInProcessConfig {
 
     private final ExternalServer externalServer;
     private final int initialConnection;
+    @Nonnull
+    private final List<InProcessRelationalServer> additionalClusterServers = new ArrayList<>();
 
     public JDBCMultiServerConfig(final int initialConnection, ExternalServer externalServer) {
         this(initialConnection, externalServer, null);
@@ -50,14 +61,45 @@ public class JDBCMultiServerConfig extends JDBCInProcessConfig {
     @Override
     public void beforeAll() throws Exception {
         super.beforeAll();
+        // Start one in-process server per additional cluster file
+        for (final String otherClusterFile : FDBTestEnvironment.allClusterFiles()) {
+            if (!Objects.equals(otherClusterFile, getClusterFile())) {
+                final InProcessRelationalServer server = new InProcessRelationalServer(otherClusterFile).start();
+                additionalClusterServers.add(server);
+            }
+        }
+    }
+
+    @Override
+    public void afterAll() throws Exception {
+        for (final InProcessRelationalServer server : additionalClusterServers) {
+            server.close();
+        }
+        additionalClusterServers.clear();
+        super.afterAll();
     }
 
     @Override
     public YamlConnectionFactory createConnectionFactory() {
+        // Build the JDBCInProcessYamlConnectionFactory with multi-cluster support
+        final List<JDBCInProcessYamlConnectionFactory.ClusterServer> clusterServers = new ArrayList<>();
+        final List<String> allClusterFiles = FDBTestEnvironment.allClusterFiles();
+        for (int i = 0; i < additionalClusterServers.size(); i++) {
+            final String otherClusterFile = allClusterFiles.stream()
+                    .filter(cf -> !Objects.equals(cf, getClusterFile()))
+                    .skip(i)
+                    .findFirst()
+                    .orElseThrow();
+            clusterServers.add(new JDBCInProcessYamlConnectionFactory.ClusterServer(
+                    additionalClusterServers.get(i), otherClusterFile));
+        }
+        final JDBCInProcessYamlConnectionFactory jdbcFactory =
+                new JDBCInProcessYamlConnectionFactory(getServer(), getClusterFile(), clusterServers);
+
         return new MultiServerConnectionFactory(
                 MultiServerConnectionFactory.ConnectionSelectionPolicy.ALTERNATE,
                 initialConnection,
-                super.createConnectionFactory(),
+                jdbcFactory,
                 List.of(new ExternalServerYamlConnectionFactory(externalServer)));
     }
 

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCMultiServerConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCMultiServerConfig.java
@@ -29,26 +29,21 @@ import com.apple.foundationdb.relational.yamltests.server.ExternalServer;
 
 import javax.annotation.Nonnull;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Run against an embedded JDBC driver, and an external server, alternating commands that go against each.
  * <p>
  * Multi-cluster support (in-process servers for all cluster files) is inherited from
- * {@link JDBCInProcessConfig}. The external servers list should have one entry per cluster file
+ * {@link JDBCInProcessConfig}. The external server clusters should have one entry per cluster file
  * (matching the in-process servers), so that cluster-specific connections also alternate.
  */
 public class JDBCMultiServerConfig extends JDBCInProcessConfig {
 
     @Nonnull
-    private final List<ExternalServer> externalServers;
+    private final Clusters<ExternalServer> externalServers;
     private final int initialConnection;
 
-    public JDBCMultiServerConfig(final int initialConnection, @Nonnull List<ExternalServer> externalServers) {
-        this(initialConnection, externalServers, List.of());
-    }
-
-    public JDBCMultiServerConfig(final int initialConnection, @Nonnull List<ExternalServer> externalServers,
+    public JDBCMultiServerConfig(final int initialConnection, @Nonnull Clusters<ExternalServer> externalServers,
                                  @Nonnull final List<String> clusterFiles) {
         super(clusterFiles);
         this.initialConnection = initialConnection;
@@ -61,23 +56,16 @@ public class JDBCMultiServerConfig extends JDBCInProcessConfig {
                 MultiServerConnectionFactory.ConnectionSelectionPolicy.ALTERNATE,
                 initialConnection,
                 new JDBCInProcessYamlConnectionFactory(getClusters()),
-                List.of(new ExternalServerYamlConnectionFactory(toExternalClusters(externalServers))));
+                List.of(new ExternalServerYamlConnectionFactory(externalServers)));
     }
 
     @Override
     public String toString() {
-        final ExternalServer primaryExternal = externalServers.get(0);
+        final ExternalServer primaryExternal = externalServers.iterator().next().server();
         if (initialConnection == 0) {
             return "MultiServer (" + super.toString() + " then " + primaryExternal.getVersion() + ")";
         } else {
             return "MultiServer (" + primaryExternal.getVersion() + " then " + super.toString() + ")";
         }
-    }
-
-    @Nonnull
-    static Clusters<ExternalServer> toExternalClusters(@Nonnull List<ExternalServer> servers) {
-        return new Clusters<>(servers.stream()
-                .map(s -> new Clusters.Entry<>(s, s.getClusterFile()))
-                .collect(Collectors.toList()));
     }
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/Clusters.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/Clusters.java
@@ -37,6 +37,11 @@ public class Clusters<T> implements Iterable<Clusters.Entry<T>> {
     @Nonnull
     private final List<Entry<T>> entries;
 
+    /** Private constructor to support the static {@link Clusters#empty()} **/
+    private Clusters() {
+        this.entries = List.of();
+    }
+
     public Clusters(@Nonnull List<Entry<T>> entries) {
         if (entries.isEmpty()) {
             throw new IllegalArgumentException("At least one cluster entry is required");
@@ -45,7 +50,7 @@ public class Clusters<T> implements Iterable<Clusters.Entry<T>> {
     }
 
     public static <T> Clusters<T> empty() {
-        return new Clusters<>(List.of());
+        return new Clusters<>();
     }
 
     public static <T> Clusters<T> fromClusterFiles(List<String> clusterFiles, Function<String, T> toServer) {

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/Clusters.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/Clusters.java
@@ -48,9 +48,18 @@ public class Clusters<T> implements Iterable<Clusters.Entry<T>> {
         return new Clusters<>(List.of());
     }
 
-    public static <T> Clusters<T> mapped(List<String> clusterFiles, Function<String, T> toServer) {
+    public static <T> Clusters<T> fromClusterFiles(List<String> clusterFiles, Function<String, T> toServer) {
         return new Clusters<>(clusterFiles.stream()
                 .map(clusterFile -> new Entry<>(toServer.apply(clusterFile), clusterFile))
+                .collect(Collectors.toList()));
+    }
+
+    /**
+     * Create a {@code Clusters} from a list of items that already carry their cluster file.
+     */
+    public static <T> Clusters<T> fromServers(@Nonnull List<T> items, @Nonnull Function<T, String> clusterFileExtractor) {
+        return new Clusters<>(items.stream()
+                .map(item -> new Entry<>(item, clusterFileExtractor.apply(item)))
                 .collect(Collectors.toList()));
     }
 

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/Clusters.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/Clusters.java
@@ -70,6 +70,14 @@ public class Clusters<T> implements Iterable<Clusters.Entry<T>> {
     }
 
     /**
+     * Returns the first (primary) entry.
+     */
+    @Nonnull
+    public Entry<T> primary() {
+        return entries.get(0);
+    }
+
+    /**
      * Returns the number of clusters.
      */
     public int size() {

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/Clusters.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/Clusters.java
@@ -34,43 +34,52 @@ import java.util.stream.Collectors;
  *
  * @param <T> the type of server or driver held by each entry
  */
-public class Clusters<T> implements Iterable<Clusters.Entry<T>> {
+public class Clusters<T extends Clusters.BoundToCluster> implements Iterable<T> {
     @Nonnull
-    private final List<Entry<T>> entries;
+    private final List<T> entries;
 
     /** Private constructor to support the static {@link Clusters#empty()}. */
     private Clusters() {
         this.entries = List.of();
     }
 
-    public Clusters(@Nonnull List<Entry<T>> entries) {
+    private Clusters(@Nonnull List<T> entries) {
         if (entries.isEmpty()) {
             throw new IllegalArgumentException("At least one cluster entry is required");
         }
         this.entries = List.copyOf(entries);
     }
 
-    public static <T> Clusters<T> empty() {
+    public static <T extends BoundToCluster> Clusters<T> empty() {
         return new Clusters<>();
     }
 
-    public static <T> Clusters<T> fromClusterFiles(List<String> clusterFiles, Function<String, T> toServer) {
+    public static <T extends BoundToCluster> Clusters<T> fromClusterFiles(List<String> clusterFiles, Function<String, T> toServer) {
         return new Clusters<>(clusterFiles.stream()
-                .map(clusterFile -> new Entry<>(toServer.apply(clusterFile), clusterFile))
+                .map(toServer)
                 .collect(Collectors.toList()));
     }
 
-    public <R> Clusters<R> map(Function<T, R> mapper) {
+    public static <V> Clusters<Clusters.Entry<V>> fromClusterFilesAsEntries(List<String> clusterFiles, Function<String, V> toServer) {
+        return fromClusterFiles(clusterFiles,
+                clusterFile -> new Clusters.Entry<>(toServer.apply(clusterFile), clusterFile));
+    }
+
+    public <R extends BoundToCluster> Clusters<R> map(Function<T, R> mapper) {
         return new Clusters<>(entries.stream()
-                .map(entry -> new Entry<>(mapper.apply(entry.server), entry.clusterFile))
+                .map(mapper)
                 .collect(Collectors.toList()));
+    }
+
+    public static <K, V> Entry<V> mapEntry(Clusters.Entry<K> existing, Function<K, V> mapper) {
+        return new Clusters.Entry<V>(mapper.apply(existing.server), existing.clusterFile);
     }
 
     /**
      * Returns the first (primary) entry.
      */
     @Nonnull
-    public Entry<T> primary() {
+    public T primary() {
         return entries.get(0);
     }
 
@@ -79,7 +88,7 @@ public class Clusters<T> implements Iterable<Clusters.Entry<T>> {
      */
     @Nonnull
     public List<String> clusterFiles() {
-        return entries.stream().map(Entry::clusterFile).collect(Collectors.toList());
+        return entries.stream().map(BoundToCluster::clusterFile).collect(Collectors.toList());
     }
 
     /**
@@ -97,7 +106,7 @@ public class Clusters<T> implements Iterable<Clusters.Entry<T>> {
      * @throws SQLException if the index is out of range
      */
     @Nonnull
-    public Entry<T> get(int clusterIndex) throws SQLException {
+    public T get(int clusterIndex) throws SQLException {
         if (clusterIndex < 0 || clusterIndex >= entries.size()) {
             throw new SQLException("Cluster index " + clusterIndex + " not available (only " +
                     entries.size() + " clusters configured)");
@@ -107,7 +116,7 @@ public class Clusters<T> implements Iterable<Clusters.Entry<T>> {
 
     @Override
     @Nonnull
-    public Iterator<Entry<T>> iterator() {
+    public Iterator<T> iterator() {
         return entries.iterator();
     }
 
@@ -116,7 +125,7 @@ public class Clusters<T> implements Iterable<Clusters.Entry<T>> {
      *
      * @param <T> the type of server or driver
      */
-    public static class Entry<T> {
+    public static class Entry<T> implements BoundToCluster {
         @Nonnull
         private final T server;
         @Nonnull
@@ -133,8 +142,17 @@ public class Clusters<T> implements Iterable<Clusters.Entry<T>> {
         }
 
         @Nonnull
+        @Override
         public String clusterFile() {
             return clusterFile;
         }
+    }
+
+    /**
+     * An interface for a server (or driver) and its associated cluster file.
+     */
+    public interface BoundToCluster {
+        @Nonnull
+        String clusterFile();
     }
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/Clusters.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/Clusters.java
@@ -37,7 +37,7 @@ public class Clusters<T> implements Iterable<Clusters.Entry<T>> {
     @Nonnull
     private final List<Entry<T>> entries;
 
-    /** Private constructor to support the static {@link Clusters#empty()} **/
+    /** Private constructor to support the static {@link Clusters#empty()}. */
     private Clusters() {
         this.entries = List.of();
     }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/Clusters.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/Clusters.java
@@ -59,15 +59,6 @@ public class Clusters<T> implements Iterable<Clusters.Entry<T>> {
                 .collect(Collectors.toList()));
     }
 
-    /**
-     * Create a {@code Clusters} from a list of items that already carry their cluster file.
-     */
-    public static <T> Clusters<T> fromServers(@Nonnull List<T> items, @Nonnull Function<T, String> clusterFileExtractor) {
-        return new Clusters<>(items.stream()
-                .map(item -> new Entry<>(item, clusterFileExtractor.apply(item)))
-                .collect(Collectors.toList()));
-    }
-
     public <R> Clusters<R> map(Function<T, R> mapper) {
         return new Clusters<>(entries.stream()
                 .map(entry -> new Entry<>(mapper.apply(entry.server), entry.clusterFile))

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/Clusters.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/Clusters.java
@@ -76,11 +76,15 @@ public class Clusters<T extends Clusters.BoundToCluster> implements Iterable<T> 
     }
 
     /**
-     * Returns the first (primary) entry.
+     * Return a piece of information about the underlying connections.
+     * @param getter a function to extract information that should be the same for all clusters (since they are identical)
+     * @param <R> the type of the extracted information.
+     * @return the information
      */
-    @Nonnull
-    public T primary() {
-        return entries.get(0);
+    public <R> R getInfo(Function<T, R> getter) {
+        return entries.stream().map(getter)
+                .findFirst()
+                .orElseThrow(() -> new IndexOutOfBoundsException("No Clusters found"));
     }
 
     /**

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/Clusters.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/Clusters.java
@@ -29,7 +29,8 @@ import java.util.stream.Collectors;
 
 /**
  * An ordered, immutable collection of cluster entries, each pairing a server (or driver) of type {@code T}
- * with the cluster file it is connected to. Must contain at least one entry.
+ * with the cluster file it is connected to. Each server (or driver) must be identical, except that it is pointing to a
+ * different cluster file. Must contain at least one entry.
  *
  * @param <T> the type of server or driver held by each entry
  */

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/Clusters.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/Clusters.java
@@ -78,6 +78,14 @@ public class Clusters<T> implements Iterable<Clusters.Entry<T>> {
     }
 
     /**
+     * Returns the cluster files in order.
+     */
+    @Nonnull
+    public List<String> clusterFiles() {
+        return entries.stream().map(Entry::clusterFile).collect(Collectors.toList());
+    }
+
+    /**
      * Returns the number of clusters.
      */
     public int size() {

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/Clusters.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/Clusters.java
@@ -1,0 +1,118 @@
+/*
+ * Clusters.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.relational.yamltests.connectionfactory;
+
+import javax.annotation.Nonnull;
+import java.sql.SQLException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * An ordered, immutable collection of cluster entries, each pairing a server (or driver) of type {@code T}
+ * with the cluster file it is connected to. Must contain at least one entry.
+ *
+ * @param <T> the type of server or driver held by each entry
+ */
+public class Clusters<T> implements Iterable<Clusters.Entry<T>> {
+    @Nonnull
+    private final List<Entry<T>> entries;
+
+    public Clusters(@Nonnull List<Entry<T>> entries) {
+        if (entries.isEmpty()) {
+            throw new IllegalArgumentException("At least one cluster entry is required");
+        }
+        this.entries = List.copyOf(entries);
+    }
+
+    public static <T> Clusters<T> empty() {
+        return new Clusters<>(List.of());
+    }
+
+    public static <T> Clusters<T> mapped(List<String> clusterFiles, Function<String, T> toServer) {
+        return new Clusters<>(clusterFiles.stream()
+                .map(clusterFile -> new Entry<>(toServer.apply(clusterFile), clusterFile))
+                .collect(Collectors.toList()));
+    }
+
+    public <R> Clusters<R> map(Function<T, R> mapper) {
+        return new Clusters<>(entries.stream()
+                .map(entry -> new Entry<>(mapper.apply(entry.server), entry.clusterFile))
+                .collect(Collectors.toList()));
+    }
+
+    /**
+     * Returns the number of clusters.
+     */
+    public int size() {
+        return entries.size();
+    }
+
+    /**
+     * Returns the entry at the given cluster index, after bounds-checking.
+     *
+     * @param clusterIndex the zero-based cluster index
+     * @return the entry at that index
+     * @throws SQLException if the index is out of range
+     */
+    @Nonnull
+    public Entry<T> get(int clusterIndex) throws SQLException {
+        if (clusterIndex < 0 || clusterIndex >= entries.size()) {
+            throw new SQLException("Cluster index " + clusterIndex + " not available (only " +
+                    entries.size() + " clusters configured)");
+        }
+        return entries.get(clusterIndex);
+    }
+
+    @Override
+    @Nonnull
+    public Iterator<Entry<T>> iterator() {
+        return entries.iterator();
+    }
+
+    /**
+     * A server (or driver) paired with its cluster file.
+     *
+     * @param <T> the type of server or driver
+     */
+    public static class Entry<T> {
+        @Nonnull
+        private final T server;
+        @Nonnull
+        private final String clusterFile;
+
+        public Entry(@Nonnull T server, @Nonnull String clusterFile) {
+            this.server = server;
+            this.clusterFile = clusterFile;
+        }
+
+        @Nonnull
+        public T server() {
+            return server;
+        }
+
+        @Nonnull
+        public String clusterFile() {
+            return clusterFile;
+        }
+    }
+}

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/EmbeddedYamlConnectionFactory.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/EmbeddedYamlConnectionFactory.java
@@ -46,20 +46,15 @@ public class EmbeddedYamlConnectionFactory implements YamlConnectionFactory {
     }
 
     @Override
-    public YamlConnection getNewConnection(@Nonnull URI connectPath) throws SQLException {
-        // The primary cluster's driver is registered in DriverManager, so use that path
-        return new SimpleYamlConnection(DriverManager.getConnection(connectPath.toString()),
-                SemanticVersion.current(), "Embedded", clusterDrivers.get(0).clusterFile());
-    }
-
-    @Override
     public YamlConnection getNewConnection(@Nonnull URI connectPath, int clusterIndex) throws SQLException {
-        if (clusterIndex == 0) {
-            return getNewConnection(connectPath);
-        }
         if (clusterIndex < 0 || clusterIndex >= clusterDrivers.size()) {
             throw new SQLException("Cluster index " + clusterIndex + " not available (only " +
                     clusterDrivers.size() + " clusters configured)");
+        }
+        if (clusterIndex == 0) {
+            // The primary cluster's driver is registered in DriverManager, so use that path
+            return new SimpleYamlConnection(DriverManager.getConnection(connectPath.toString()),
+                    SemanticVersion.current(), "Embedded", clusterDrivers.get(0).clusterFile());
         }
         // Non-primary clusters are not registered in DriverManager, so connect via the driver directly
         final ClusterDriver clusterDriver = clusterDrivers.get(clusterIndex);

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/EmbeddedYamlConnectionFactory.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/EmbeddedYamlConnectionFactory.java
@@ -20,6 +20,8 @@
 
 package com.apple.foundationdb.relational.yamltests.connectionfactory;
 
+import com.apple.foundationdb.relational.api.Options;
+import com.apple.foundationdb.relational.api.RelationalDriver;
 import com.apple.foundationdb.relational.yamltests.SimpleYamlConnection;
 import com.apple.foundationdb.relational.yamltests.YamlConnection;
 import com.apple.foundationdb.relational.yamltests.YamlConnectionFactory;
@@ -29,13 +31,21 @@ import javax.annotation.Nonnull;
 import java.net.URI;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.util.List;
 import java.util.Set;
 
 public class EmbeddedYamlConnectionFactory implements YamlConnectionFactory {
     private final String clusterFile;
+    @Nonnull
+    private final List<ClusterDriver> additionalClusterDrivers;
 
     public EmbeddedYamlConnectionFactory(String clusterFile) {
+        this(clusterFile, List.of());
+    }
+
+    public EmbeddedYamlConnectionFactory(String clusterFile, @Nonnull List<ClusterDriver> additionalClusterDrivers) {
         this.clusterFile = clusterFile;
+        this.additionalClusterDrivers = additionalClusterDrivers;
     }
 
     @Override
@@ -45,8 +55,40 @@ public class EmbeddedYamlConnectionFactory implements YamlConnectionFactory {
     }
 
     @Override
+    public YamlConnection getNewConnection(@Nonnull URI connectPath, int clusterIndex) throws SQLException {
+        if (clusterIndex == 0) {
+            return getNewConnection(connectPath);
+        }
+        final int idx = clusterIndex - 1;
+        if (idx >= additionalClusterDrivers.size()) {
+            throw new SQLException("Cluster index " + clusterIndex + " not available (only " +
+                    (additionalClusterDrivers.size() + 1) + " clusters configured)");
+        }
+        final ClusterDriver clusterDriver = additionalClusterDrivers.get(idx);
+        return new SimpleYamlConnection(
+                clusterDriver.driver.connect(connectPath, Options.NONE),
+                SemanticVersion.current(),
+                "Embedded[cluster=" + clusterIndex + "]",
+                clusterDriver.clusterFile);
+    }
+
+    @Override
     public Set<SemanticVersion> getVersionsUnderTest() {
         return Set.of(SemanticVersion.current());
     }
 
+    /**
+     * A driver associated with its cluster file, for additional (non-primary) clusters.
+     */
+    public static class ClusterDriver {
+        @Nonnull
+        final RelationalDriver driver;
+        @Nonnull
+        final String clusterFile;
+
+        public ClusterDriver(@Nonnull RelationalDriver driver, @Nonnull String clusterFile) {
+            this.driver = driver;
+            this.clusterFile = clusterFile;
+        }
+    }
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/EmbeddedYamlConnectionFactory.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/EmbeddedYamlConnectionFactory.java
@@ -35,9 +35,9 @@ import java.util.Set;
 
 public class EmbeddedYamlConnectionFactory implements YamlConnectionFactory {
     @Nonnull
-    private final Clusters<RelationalDriver> clusters;
+    private final Clusters<Clusters.Entry<RelationalDriver>> clusters;
 
-    public EmbeddedYamlConnectionFactory(@Nonnull Clusters<RelationalDriver> clusters) {
+    public EmbeddedYamlConnectionFactory(@Nonnull Clusters<Clusters.Entry<RelationalDriver>> clusters) {
         this.clusters = clusters;
     }
 

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/EmbeddedYamlConnectionFactory.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/EmbeddedYamlConnectionFactory.java
@@ -35,23 +35,21 @@ import java.util.List;
 import java.util.Set;
 
 public class EmbeddedYamlConnectionFactory implements YamlConnectionFactory {
-    private final String clusterFile;
     @Nonnull
-    private final List<ClusterDriver> additionalClusterDrivers;
+    private final List<ClusterDriver> clusterDrivers;
 
-    public EmbeddedYamlConnectionFactory(String clusterFile) {
-        this(clusterFile, List.of());
-    }
-
-    public EmbeddedYamlConnectionFactory(String clusterFile, @Nonnull List<ClusterDriver> additionalClusterDrivers) {
-        this.clusterFile = clusterFile;
-        this.additionalClusterDrivers = additionalClusterDrivers;
+    public EmbeddedYamlConnectionFactory(@Nonnull List<ClusterDriver> clusterDrivers) {
+        if (clusterDrivers.isEmpty()) {
+            throw new IllegalArgumentException("At least one cluster driver is required");
+        }
+        this.clusterDrivers = clusterDrivers;
     }
 
     @Override
     public YamlConnection getNewConnection(@Nonnull URI connectPath) throws SQLException {
+        // The primary cluster's driver is registered in DriverManager, so use that path
         return new SimpleYamlConnection(DriverManager.getConnection(connectPath.toString()),
-                SemanticVersion.current(), "Embedded", clusterFile);
+                SemanticVersion.current(), "Embedded", clusterDrivers.get(0).clusterFile());
     }
 
     @Override
@@ -59,22 +57,22 @@ public class EmbeddedYamlConnectionFactory implements YamlConnectionFactory {
         if (clusterIndex == 0) {
             return getNewConnection(connectPath);
         }
-        final int idx = clusterIndex - 1;
-        if (idx >= additionalClusterDrivers.size()) {
+        if (clusterIndex < 0 || clusterIndex >= clusterDrivers.size()) {
             throw new SQLException("Cluster index " + clusterIndex + " not available (only " +
-                    (additionalClusterDrivers.size() + 1) + " clusters configured)");
+                    clusterDrivers.size() + " clusters configured)");
         }
-        final ClusterDriver clusterDriver = additionalClusterDrivers.get(idx);
+        // Non-primary clusters are not registered in DriverManager, so connect via the driver directly
+        final ClusterDriver clusterDriver = clusterDrivers.get(clusterIndex);
         return new SimpleYamlConnection(
-                clusterDriver.driver.connect(connectPath, Options.NONE),
+                clusterDriver.driver().connect(connectPath, Options.NONE),
                 SemanticVersion.current(),
                 "Embedded[cluster=" + clusterIndex + "]",
-                clusterDriver.clusterFile);
+                clusterDriver.clusterFile());
     }
 
     @Override
     public int getAvailableClusterCount() {
-        return 1 + additionalClusterDrivers.size();
+        return clusterDrivers.size();
     }
 
     @Override
@@ -83,17 +81,27 @@ public class EmbeddedYamlConnectionFactory implements YamlConnectionFactory {
     }
 
     /**
-     * A driver associated with its cluster file, for additional (non-primary) clusters.
+     * A driver associated with its cluster file.
      */
     public static class ClusterDriver {
         @Nonnull
-        final RelationalDriver driver;
+        private final RelationalDriver driver;
         @Nonnull
-        final String clusterFile;
+        private final String clusterFile;
 
         public ClusterDriver(@Nonnull RelationalDriver driver, @Nonnull String clusterFile) {
             this.driver = driver;
             this.clusterFile = clusterFile;
+        }
+
+        @Nonnull
+        public RelationalDriver driver() {
+            return driver;
+        }
+
+        @Nonnull
+        public String clusterFile() {
+            return clusterFile;
         }
     }
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/EmbeddedYamlConnectionFactory.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/EmbeddedYamlConnectionFactory.java
@@ -73,6 +73,11 @@ public class EmbeddedYamlConnectionFactory implements YamlConnectionFactory {
     }
 
     @Override
+    public int getAvailableClusterCount() {
+        return 1 + additionalClusterDrivers.size();
+    }
+
+    @Override
     public Set<SemanticVersion> getVersionsUnderTest() {
         return Set.of(SemanticVersion.current());
     }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/EmbeddedYamlConnectionFactory.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/EmbeddedYamlConnectionFactory.java
@@ -31,72 +31,39 @@ import javax.annotation.Nonnull;
 import java.net.URI;
 import java.sql.DriverManager;
 import java.sql.SQLException;
-import java.util.List;
 import java.util.Set;
 
 public class EmbeddedYamlConnectionFactory implements YamlConnectionFactory {
     @Nonnull
-    private final List<ClusterDriver> clusterDrivers;
+    private final Clusters<RelationalDriver> clusters;
 
-    public EmbeddedYamlConnectionFactory(@Nonnull List<ClusterDriver> clusterDrivers) {
-        if (clusterDrivers.isEmpty()) {
-            throw new IllegalArgumentException("At least one cluster driver is required");
-        }
-        this.clusterDrivers = clusterDrivers;
+    public EmbeddedYamlConnectionFactory(@Nonnull Clusters<RelationalDriver> clusters) {
+        this.clusters = clusters;
     }
 
     @Override
     public YamlConnection getNewConnection(@Nonnull URI connectPath, int clusterIndex) throws SQLException {
-        if (clusterIndex < 0 || clusterIndex >= clusterDrivers.size()) {
-            throw new SQLException("Cluster index " + clusterIndex + " not available (only " +
-                    clusterDrivers.size() + " clusters configured)");
-        }
+        final Clusters.Entry<RelationalDriver> entry = clusters.get(clusterIndex);
         if (clusterIndex == 0) {
             // The primary cluster's driver is registered in DriverManager, so use that path
             return new SimpleYamlConnection(DriverManager.getConnection(connectPath.toString()),
-                    SemanticVersion.current(), "Embedded", clusterDrivers.get(0).clusterFile());
+                    SemanticVersion.current(), "Embedded", entry.clusterFile());
         }
         // Non-primary clusters are not registered in DriverManager, so connect via the driver directly
-        final ClusterDriver clusterDriver = clusterDrivers.get(clusterIndex);
         return new SimpleYamlConnection(
-                clusterDriver.driver().connect(connectPath, Options.NONE),
+                entry.server().connect(connectPath, Options.NONE),
                 SemanticVersion.current(),
                 "Embedded[cluster=" + clusterIndex + "]",
-                clusterDriver.clusterFile());
+                entry.clusterFile());
     }
 
     @Override
     public int getAvailableClusterCount() {
-        return clusterDrivers.size();
+        return clusters.size();
     }
 
     @Override
     public Set<SemanticVersion> getVersionsUnderTest() {
         return Set.of(SemanticVersion.current());
-    }
-
-    /**
-     * A driver associated with its cluster file.
-     */
-    public static class ClusterDriver {
-        @Nonnull
-        private final RelationalDriver driver;
-        @Nonnull
-        private final String clusterFile;
-
-        public ClusterDriver(@Nonnull RelationalDriver driver, @Nonnull String clusterFile) {
-            this.driver = driver;
-            this.clusterFile = clusterFile;
-        }
-
-        @Nonnull
-        public RelationalDriver driver() {
-            return driver;
-        }
-
-        @Nonnull
-        public String clusterFile() {
-            return clusterFile;
-        }
     }
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/ExternalServerYamlConnectionFactory.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/ExternalServerYamlConnectionFactory.java
@@ -39,41 +39,33 @@ import java.util.Set;
 
 public class ExternalServerYamlConnectionFactory implements YamlConnectionFactory {
     private static final Logger LOG = LogManager.getLogger(ExternalServerYamlConnectionFactory.class);
-    private final ExternalServer externalServer;
     @Nonnull
-    private final List<ExternalServer> additionalClusterServers;
+    private final List<ExternalServer> servers;
 
-    public ExternalServerYamlConnectionFactory(final ExternalServer externalServer) {
-        this(externalServer, List.of());
-    }
-
-    public ExternalServerYamlConnectionFactory(final ExternalServer externalServer,
-                                               @Nonnull List<ExternalServer> additionalClusterServers) {
-        this.externalServer = externalServer;
-        this.additionalClusterServers = additionalClusterServers;
+    public ExternalServerYamlConnectionFactory(@Nonnull List<ExternalServer> servers) {
+        if (servers.isEmpty()) {
+            throw new IllegalArgumentException("At least one external server is required");
+        }
+        this.servers = servers;
     }
 
     @Override
     public YamlConnection getNewConnection(@Nonnull URI connectPath) throws SQLException {
-        return createConnection(connectPath, externalServer);
+        return createConnection(connectPath, servers.get(0));
     }
 
     @Override
     public YamlConnection getNewConnection(@Nonnull URI connectPath, int clusterIndex) throws SQLException {
-        if (clusterIndex == 0) {
-            return getNewConnection(connectPath);
-        }
-        final int idx = clusterIndex - 1;
-        if (idx >= additionalClusterServers.size()) {
+        if (clusterIndex < 0 || clusterIndex >= servers.size()) {
             throw new SQLException("Cluster index " + clusterIndex + " not available (only " +
-                    (additionalClusterServers.size() + 1) + " clusters configured)");
+                    servers.size() + " clusters configured)");
         }
-        return createConnection(connectPath, additionalClusterServers.get(idx));
+        return createConnection(connectPath, servers.get(clusterIndex));
     }
 
     @Override
     public int getAvailableClusterCount() {
-        return 1 + additionalClusterServers.size();
+        return servers.size();
     }
 
     private YamlConnection createConnection(@Nonnull URI connectPath, @Nonnull ExternalServer server) throws SQLException {
@@ -92,7 +84,7 @@ public class ExternalServerYamlConnectionFactory implements YamlConnectionFactor
 
     @Override
     public Set<SemanticVersion> getVersionsUnderTest() {
-        return Set.of(externalServer.getVersion());
+        return Set.of(servers.get(0).getVersion());
     }
 
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/ExternalServerYamlConnectionFactory.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/ExternalServerYamlConnectionFactory.java
@@ -34,29 +34,60 @@ import java.net.URI;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.util.List;
 import java.util.Set;
 
 public class ExternalServerYamlConnectionFactory implements YamlConnectionFactory {
     private static final Logger LOG = LogManager.getLogger(ExternalServerYamlConnectionFactory.class);
     private final ExternalServer externalServer;
+    @Nonnull
+    private final List<ExternalServer> additionalClusterServers;
 
     public ExternalServerYamlConnectionFactory(final ExternalServer externalServer) {
+        this(externalServer, List.of());
+    }
+
+    public ExternalServerYamlConnectionFactory(final ExternalServer externalServer,
+                                               @Nonnull List<ExternalServer> additionalClusterServers) {
         this.externalServer = externalServer;
+        this.additionalClusterServers = additionalClusterServers;
     }
 
     @Override
     public YamlConnection getNewConnection(@Nonnull URI connectPath) throws SQLException {
-        String uriStr = connectPath.toString().replaceFirst("embed:", "relational://localhost:" + externalServer.getPort());
+        return createConnection(connectPath, externalServer);
+    }
+
+    @Override
+    public YamlConnection getNewConnection(@Nonnull URI connectPath, int clusterIndex) throws SQLException {
+        if (clusterIndex == 0) {
+            return getNewConnection(connectPath);
+        }
+        final int idx = clusterIndex - 1;
+        if (idx >= additionalClusterServers.size()) {
+            throw new SQLException("Cluster index " + clusterIndex + " not available (only " +
+                    (additionalClusterServers.size() + 1) + " clusters configured)");
+        }
+        return createConnection(connectPath, additionalClusterServers.get(idx));
+    }
+
+    @Override
+    public int getAvailableClusterCount() {
+        return 1 + additionalClusterServers.size();
+    }
+
+    private YamlConnection createConnection(@Nonnull URI connectPath, @Nonnull ExternalServer server) throws SQLException {
+        String uriStr = connectPath.toString().replaceFirst("embed:", "relational://localhost:" + server.getPort());
         if (LOG.isInfoEnabled()) {
             LOG.info(KeyValueLogMessage.of("Rewrote connection string for external server",
                     "original", connectPath,
                     "rewritten", uriStr,
-                    "version", externalServer.getVersion()));
+                    "version", server.getVersion()));
         }
 
         final Connection connection = DriverManager.getConnection(uriStr);
-        externalServer.validateConnectionVersion(connection);
-        return new SimpleYamlConnection(connection, externalServer.getVersion(), externalServer.getClusterFile());
+        server.validateConnectionVersion(connection);
+        return new SimpleYamlConnection(connection, server.getVersion(), server.getClusterFile());
     }
 
     @Override

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/ExternalServerYamlConnectionFactory.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/ExternalServerYamlConnectionFactory.java
@@ -73,7 +73,7 @@ public class ExternalServerYamlConnectionFactory implements YamlConnectionFactor
 
     @Override
     public Set<SemanticVersion> getVersionsUnderTest() {
-        return Set.of(clusters.iterator().next().server().getVersion());
+        return Set.of(clusters.primary().server().getVersion());
     }
 
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/ExternalServerYamlConnectionFactory.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/ExternalServerYamlConnectionFactory.java
@@ -34,36 +34,30 @@ import java.net.URI;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
-import java.util.List;
 import java.util.Set;
 
 public class ExternalServerYamlConnectionFactory implements YamlConnectionFactory {
     private static final Logger LOG = LogManager.getLogger(ExternalServerYamlConnectionFactory.class);
     @Nonnull
-    private final List<ExternalServer> servers;
+    private final Clusters<ExternalServer> clusters;
 
-    public ExternalServerYamlConnectionFactory(@Nonnull List<ExternalServer> servers) {
-        if (servers.isEmpty()) {
-            throw new IllegalArgumentException("At least one external server is required");
-        }
-        this.servers = servers;
+    public ExternalServerYamlConnectionFactory(@Nonnull Clusters<ExternalServer> clusters) {
+        this.clusters = clusters;
     }
 
     @Override
     public YamlConnection getNewConnection(@Nonnull URI connectPath, int clusterIndex) throws SQLException {
-        if (clusterIndex < 0 || clusterIndex >= servers.size()) {
-            throw new SQLException("Cluster index " + clusterIndex + " not available (only " +
-                    servers.size() + " clusters configured)");
-        }
-        return createConnection(connectPath, servers.get(clusterIndex));
+        final Clusters.Entry<ExternalServer> entry = clusters.get(clusterIndex);
+        return createConnection(connectPath, entry.server(), entry.clusterFile());
     }
 
     @Override
     public int getAvailableClusterCount() {
-        return servers.size();
+        return clusters.size();
     }
 
-    private YamlConnection createConnection(@Nonnull URI connectPath, @Nonnull ExternalServer server) throws SQLException {
+    private YamlConnection createConnection(@Nonnull URI connectPath, @Nonnull ExternalServer server,
+                                            @Nonnull String clusterFile) throws SQLException {
         String uriStr = connectPath.toString().replaceFirst("embed:", "relational://localhost:" + server.getPort());
         if (LOG.isInfoEnabled()) {
             LOG.info(KeyValueLogMessage.of("Rewrote connection string for external server",
@@ -74,12 +68,12 @@ public class ExternalServerYamlConnectionFactory implements YamlConnectionFactor
 
         final Connection connection = DriverManager.getConnection(uriStr);
         server.validateConnectionVersion(connection);
-        return new SimpleYamlConnection(connection, server.getVersion(), server.getClusterFile());
+        return new SimpleYamlConnection(connection, server.getVersion(), clusterFile);
     }
 
     @Override
     public Set<SemanticVersion> getVersionsUnderTest() {
-        return Set.of(servers.get(0).getVersion());
+        return Set.of(clusters.iterator().next().server().getVersion());
     }
 
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/ExternalServerYamlConnectionFactory.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/ExternalServerYamlConnectionFactory.java
@@ -50,11 +50,6 @@ public class ExternalServerYamlConnectionFactory implements YamlConnectionFactor
     }
 
     @Override
-    public YamlConnection getNewConnection(@Nonnull URI connectPath) throws SQLException {
-        return createConnection(connectPath, servers.get(0));
-    }
-
-    @Override
     public YamlConnection getNewConnection(@Nonnull URI connectPath, int clusterIndex) throws SQLException {
         if (clusterIndex < 0 || clusterIndex >= servers.size()) {
             throw new SQLException("Cluster index " + clusterIndex + " not available (only " +

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/ExternalServerYamlConnectionFactory.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/ExternalServerYamlConnectionFactory.java
@@ -47,8 +47,7 @@ public class ExternalServerYamlConnectionFactory implements YamlConnectionFactor
 
     @Override
     public YamlConnection getNewConnection(@Nonnull URI connectPath, int clusterIndex) throws SQLException {
-        final Clusters.Entry<ExternalServer> entry = clusters.get(clusterIndex);
-        return createConnection(connectPath, entry.server(), entry.clusterFile());
+        return createConnection(connectPath, clusters.get(clusterIndex));
     }
 
     @Override
@@ -56,8 +55,7 @@ public class ExternalServerYamlConnectionFactory implements YamlConnectionFactor
         return clusters.size();
     }
 
-    private YamlConnection createConnection(@Nonnull URI connectPath, @Nonnull ExternalServer server,
-                                            @Nonnull String clusterFile) throws SQLException {
+    private YamlConnection createConnection(@Nonnull URI connectPath, @Nonnull ExternalServer server) throws SQLException {
         String uriStr = connectPath.toString().replaceFirst("embed:", "relational://localhost:" + server.getPort());
         if (LOG.isInfoEnabled()) {
             LOG.info(KeyValueLogMessage.of("Rewrote connection string for external server",
@@ -68,12 +66,12 @@ public class ExternalServerYamlConnectionFactory implements YamlConnectionFactor
 
         final Connection connection = DriverManager.getConnection(uriStr);
         server.validateConnectionVersion(connection);
-        return new SimpleYamlConnection(connection, server.getVersion(), clusterFile);
+        return new SimpleYamlConnection(connection, server.getVersion(), server.clusterFile());
     }
 
     @Override
     public Set<SemanticVersion> getVersionsUnderTest() {
-        return Set.of(clusters.primary().server().getVersion());
+        return Set.of(clusters.primary().getVersion());
     }
 
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/ExternalServerYamlConnectionFactory.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/ExternalServerYamlConnectionFactory.java
@@ -71,7 +71,7 @@ public class ExternalServerYamlConnectionFactory implements YamlConnectionFactor
 
     @Override
     public Set<SemanticVersion> getVersionsUnderTest() {
-        return Set.of(clusters.primary().getVersion());
+        return Set.of(clusters.getInfo(ExternalServer::getVersion));
     }
 
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/JDBCInProcessYamlConnectionFactory.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/JDBCInProcessYamlConnectionFactory.java
@@ -34,34 +34,81 @@ import javax.annotation.Nonnull;
 import java.net.URI;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.util.List;
 import java.util.Set;
 
 public class JDBCInProcessYamlConnectionFactory implements YamlConnectionFactory {
     private static final Logger LOG = LogManager.getLogger(JDBCInProcessYamlConnectionFactory.class);
     private final InProcessRelationalServer server;
     private final String clusterFile;
+    @Nonnull
+    private final List<ClusterServer> additionalClusterServers;
 
     public JDBCInProcessYamlConnectionFactory(final InProcessRelationalServer server, final String clusterFile) {
+        this(server, clusterFile, List.of());
+    }
+
+    public JDBCInProcessYamlConnectionFactory(final InProcessRelationalServer server, final String clusterFile,
+                                              @Nonnull List<ClusterServer> additionalClusterServers) {
         this.server = server;
         this.clusterFile = clusterFile;
+        this.additionalClusterServers = additionalClusterServers;
     }
 
     @Override
     public YamlConnection getNewConnection(@Nonnull URI connectPath) throws SQLException {
-        // Add name of the in-process running server to the connectPath.
-        URI connectPathPlusServerName = JDBCURI.addQueryParameter(connectPath, JDBCURI.INPROCESS_URI_QUERY_SERVERNAME_KEY, server.getServerName());
+        return createConnection(connectPath, server, clusterFile);
+    }
+
+    @Override
+    public YamlConnection getNewConnection(@Nonnull URI connectPath, int clusterIndex) throws SQLException {
+        if (clusterIndex == 0) {
+            return getNewConnection(connectPath);
+        }
+        final int idx = clusterIndex - 1;
+        if (idx >= additionalClusterServers.size()) {
+            throw new SQLException("Cluster index " + clusterIndex + " not available (only " +
+                    (additionalClusterServers.size() + 1) + " clusters configured)");
+        }
+        final ClusterServer clusterServer = additionalClusterServers.get(idx);
+        return createConnection(connectPath, clusterServer.server, clusterServer.clusterFile);
+    }
+
+    @Override
+    public int getAvailableClusterCount() {
+        return 1 + additionalClusterServers.size();
+    }
+
+    private YamlConnection createConnection(@Nonnull URI connectPath, @Nonnull InProcessRelationalServer targetServer,
+                                            @Nonnull String targetClusterFile) throws SQLException {
+        URI connectPathPlusServerName = JDBCURI.addQueryParameter(connectPath, JDBCURI.INPROCESS_URI_QUERY_SERVERNAME_KEY, targetServer.getServerName());
         String uriStr = connectPathPlusServerName.toString().replaceFirst("embed:", "relational://");
         if (LOG.isInfoEnabled()) {
             LOG.info(KeyValueLogMessage.of("Rewrote connection string for in-process server",
                     "original", connectPath,
                     "rewritten", uriStr,
-                    "server", server.getServerName()));
+                    "server", targetServer.getServerName()));
         }
-        return new SimpleYamlConnection(DriverManager.getConnection(uriStr), SemanticVersion.current(), "JDBC In-Process", clusterFile);
+        return new SimpleYamlConnection(DriverManager.getConnection(uriStr), SemanticVersion.current(), "JDBC In-Process", targetClusterFile);
     }
 
     @Override
     public Set<SemanticVersion> getVersionsUnderTest() {
         return Set.of(SemanticVersion.current());
+    }
+
+    /**
+     * A server associated with its cluster file, for additional (non-primary) clusters.
+     */
+    public static class ClusterServer {
+        @Nonnull
+        final InProcessRelationalServer server;
+        @Nonnull
+        final String clusterFile;
+
+        public ClusterServer(@Nonnull InProcessRelationalServer server, @Nonnull String clusterFile) {
+            this.server = server;
+            this.clusterFile = clusterFile;
+        }
     }
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/JDBCInProcessYamlConnectionFactory.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/JDBCInProcessYamlConnectionFactory.java
@@ -39,44 +39,35 @@ import java.util.Set;
 
 public class JDBCInProcessYamlConnectionFactory implements YamlConnectionFactory {
     private static final Logger LOG = LogManager.getLogger(JDBCInProcessYamlConnectionFactory.class);
-    private final InProcessRelationalServer server;
-    private final String clusterFile;
     @Nonnull
-    private final List<ClusterServer> additionalClusterServers;
+    private final List<ClusterServer> clusterServers;
 
-    public JDBCInProcessYamlConnectionFactory(final InProcessRelationalServer server, final String clusterFile) {
-        this(server, clusterFile, List.of());
-    }
-
-    public JDBCInProcessYamlConnectionFactory(final InProcessRelationalServer server, final String clusterFile,
-                                              @Nonnull List<ClusterServer> additionalClusterServers) {
-        this.server = server;
-        this.clusterFile = clusterFile;
-        this.additionalClusterServers = additionalClusterServers;
+    public JDBCInProcessYamlConnectionFactory(@Nonnull List<ClusterServer> clusterServers) {
+        if (clusterServers.isEmpty()) {
+            throw new IllegalArgumentException("At least one cluster server is required");
+        }
+        this.clusterServers = clusterServers;
     }
 
     @Override
     public YamlConnection getNewConnection(@Nonnull URI connectPath) throws SQLException {
-        return createConnection(connectPath, server, clusterFile);
+        final ClusterServer primary = clusterServers.get(0);
+        return createConnection(connectPath, primary.server, primary.clusterFile);
     }
 
     @Override
     public YamlConnection getNewConnection(@Nonnull URI connectPath, int clusterIndex) throws SQLException {
-        if (clusterIndex == 0) {
-            return getNewConnection(connectPath);
-        }
-        final int idx = clusterIndex - 1;
-        if (idx >= additionalClusterServers.size()) {
+        if (clusterIndex < 0 || clusterIndex >= clusterServers.size()) {
             throw new SQLException("Cluster index " + clusterIndex + " not available (only " +
-                    (additionalClusterServers.size() + 1) + " clusters configured)");
+                    clusterServers.size() + " clusters configured)");
         }
-        final ClusterServer clusterServer = additionalClusterServers.get(idx);
+        final ClusterServer clusterServer = clusterServers.get(clusterIndex);
         return createConnection(connectPath, clusterServer.server, clusterServer.clusterFile);
     }
 
     @Override
     public int getAvailableClusterCount() {
-        return 1 + additionalClusterServers.size();
+        return clusterServers.size();
     }
 
     private YamlConnection createConnection(@Nonnull URI connectPath, @Nonnull InProcessRelationalServer targetServer,
@@ -98,17 +89,27 @@ public class JDBCInProcessYamlConnectionFactory implements YamlConnectionFactory
     }
 
     /**
-     * A server associated with its cluster file, for additional (non-primary) clusters.
+     * A server associated with its cluster file.
      */
     public static class ClusterServer {
         @Nonnull
-        final InProcessRelationalServer server;
+        private final InProcessRelationalServer server;
         @Nonnull
-        final String clusterFile;
+        private final String clusterFile;
 
         public ClusterServer(@Nonnull InProcessRelationalServer server, @Nonnull String clusterFile) {
             this.server = server;
             this.clusterFile = clusterFile;
+        }
+
+        @Nonnull
+        public InProcessRelationalServer server() {
+            return server;
+        }
+
+        @Nonnull
+        public String clusterFile() {
+            return clusterFile;
         }
     }
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/JDBCInProcessYamlConnectionFactory.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/JDBCInProcessYamlConnectionFactory.java
@@ -39,9 +39,9 @@ import java.util.Set;
 public class JDBCInProcessYamlConnectionFactory implements YamlConnectionFactory {
     private static final Logger LOG = LogManager.getLogger(JDBCInProcessYamlConnectionFactory.class);
     @Nonnull
-    private final Clusters<InProcessRelationalServer> clusters;
+    private final Clusters<Clusters.Entry<InProcessRelationalServer>> clusters;
 
-    public JDBCInProcessYamlConnectionFactory(@Nonnull Clusters<InProcessRelationalServer> clusters) {
+    public JDBCInProcessYamlConnectionFactory(@Nonnull Clusters<Clusters.Entry<InProcessRelationalServer>> clusters) {
         this.clusters = clusters;
     }
 

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/JDBCInProcessYamlConnectionFactory.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/JDBCInProcessYamlConnectionFactory.java
@@ -50,12 +50,6 @@ public class JDBCInProcessYamlConnectionFactory implements YamlConnectionFactory
     }
 
     @Override
-    public YamlConnection getNewConnection(@Nonnull URI connectPath) throws SQLException {
-        final ClusterServer primary = clusterServers.get(0);
-        return createConnection(connectPath, primary.server, primary.clusterFile);
-    }
-
-    @Override
     public YamlConnection getNewConnection(@Nonnull URI connectPath, int clusterIndex) throws SQLException {
         if (clusterIndex < 0 || clusterIndex >= clusterServers.size()) {
             throw new SQLException("Cluster index " + clusterIndex + " not available (only " +

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/JDBCInProcessYamlConnectionFactory.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/JDBCInProcessYamlConnectionFactory.java
@@ -34,34 +34,26 @@ import javax.annotation.Nonnull;
 import java.net.URI;
 import java.sql.DriverManager;
 import java.sql.SQLException;
-import java.util.List;
 import java.util.Set;
 
 public class JDBCInProcessYamlConnectionFactory implements YamlConnectionFactory {
     private static final Logger LOG = LogManager.getLogger(JDBCInProcessYamlConnectionFactory.class);
     @Nonnull
-    private final List<ClusterServer> clusterServers;
+    private final Clusters<InProcessRelationalServer> clusters;
 
-    public JDBCInProcessYamlConnectionFactory(@Nonnull List<ClusterServer> clusterServers) {
-        if (clusterServers.isEmpty()) {
-            throw new IllegalArgumentException("At least one cluster server is required");
-        }
-        this.clusterServers = clusterServers;
+    public JDBCInProcessYamlConnectionFactory(@Nonnull Clusters<InProcessRelationalServer> clusters) {
+        this.clusters = clusters;
     }
 
     @Override
     public YamlConnection getNewConnection(@Nonnull URI connectPath, int clusterIndex) throws SQLException {
-        if (clusterIndex < 0 || clusterIndex >= clusterServers.size()) {
-            throw new SQLException("Cluster index " + clusterIndex + " not available (only " +
-                    clusterServers.size() + " clusters configured)");
-        }
-        final ClusterServer clusterServer = clusterServers.get(clusterIndex);
-        return createConnection(connectPath, clusterServer.server, clusterServer.clusterFile);
+        final Clusters.Entry<InProcessRelationalServer> entry = clusters.get(clusterIndex);
+        return createConnection(connectPath, entry.server(), entry.clusterFile());
     }
 
     @Override
     public int getAvailableClusterCount() {
-        return clusterServers.size();
+        return clusters.size();
     }
 
     private YamlConnection createConnection(@Nonnull URI connectPath, @Nonnull InProcessRelationalServer targetServer,
@@ -80,30 +72,5 @@ public class JDBCInProcessYamlConnectionFactory implements YamlConnectionFactory
     @Override
     public Set<SemanticVersion> getVersionsUnderTest() {
         return Set.of(SemanticVersion.current());
-    }
-
-    /**
-     * A server associated with its cluster file.
-     */
-    public static class ClusterServer {
-        @Nonnull
-        private final InProcessRelationalServer server;
-        @Nonnull
-        private final String clusterFile;
-
-        public ClusterServer(@Nonnull InProcessRelationalServer server, @Nonnull String clusterFile) {
-            this.server = server;
-            this.clusterFile = clusterFile;
-        }
-
-        @Nonnull
-        public InProcessRelationalServer server() {
-            return server;
-        }
-
-        @Nonnull
-        public String clusterFile() {
-            return clusterFile;
-        }
     }
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/MultiServerConnectionFactory.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/MultiServerConnectionFactory.java
@@ -102,6 +102,16 @@ public class MultiServerConnectionFactory implements YamlConnectionFactory {
     }
 
     @Override
+    public YamlConnection getNewConnection(@Nonnull URI connectPath, int clusterIndex) throws SQLException {
+        if (connectionSelectionPolicy == ConnectionSelectionPolicy.DEFAULT) {
+            return defaultFactory.getNewConnection(connectPath, clusterIndex);
+        } else {
+            return new MultiServerConnection(connectionSelectionPolicy, getNextConnectionNumber(),
+                    defaultFactory.getNewConnection(connectPath, clusterIndex), alternateConnections(connectPath, clusterIndex));
+        }
+    }
+
+    @Override
     public Set<SemanticVersion> getVersionsUnderTest() {
         return versionsUnderTest;
     }
@@ -111,11 +121,31 @@ public class MultiServerConnectionFactory implements YamlConnectionFactory {
         return true;
     }
 
+    @Override
+    public int getAvailableClusterCount() {
+        int min = defaultFactory.getAvailableClusterCount();
+        for (final YamlConnectionFactory factory : alternateFactories) {
+            min = Math.min(min, factory.getAvailableClusterCount());
+        }
+        return min;
+    }
+
     @Nonnull
     private List<YamlConnection> alternateConnections(URI connectPath) {
         return alternateFactories.stream().map(factory -> {
             try {
                 return factory.getNewConnection(connectPath);
+            } catch (SQLException e) {
+                throw new IllegalStateException("Failed to create a connection", e);
+            }
+        }).collect(Collectors.toList());
+    }
+
+    @Nonnull
+    private List<YamlConnection> alternateConnections(URI connectPath, int clusterIndex) {
+        return alternateFactories.stream().map(factory -> {
+            try {
+                return factory.getNewConnection(connectPath, clusterIndex);
             } catch (SQLException e) {
                 throw new IllegalStateException("Failed to create a connection", e);
             }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/MultiServerConnectionFactory.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/MultiServerConnectionFactory.java
@@ -92,16 +92,6 @@ public class MultiServerConnectionFactory implements YamlConnectionFactory {
     }
 
     @Override
-    public YamlConnection getNewConnection(@Nonnull URI connectPath) throws SQLException {
-        if (connectionSelectionPolicy == ConnectionSelectionPolicy.DEFAULT) {
-            return defaultFactory.getNewConnection(connectPath);
-        } else {
-            return new MultiServerConnection(connectionSelectionPolicy, getNextConnectionNumber(),
-                    defaultFactory.getNewConnection(connectPath), alternateConnections(connectPath));
-        }
-    }
-
-    @Override
     public YamlConnection getNewConnection(@Nonnull URI connectPath, int clusterIndex) throws SQLException {
         if (connectionSelectionPolicy == ConnectionSelectionPolicy.DEFAULT) {
             return defaultFactory.getNewConnection(connectPath, clusterIndex);
@@ -125,17 +115,6 @@ public class MultiServerConnectionFactory implements YamlConnectionFactory {
     @Override
     public int getAvailableClusterCount() {
         return defaultFactory.getAvailableClusterCount();
-    }
-
-    @Nonnull
-    private List<YamlConnection> alternateConnections(URI connectPath) {
-        return alternateFactories.stream().map(factory -> {
-            try {
-                return factory.getNewConnection(connectPath);
-            } catch (SQLException e) {
-                throw new IllegalStateException("Failed to create a connection", e);
-            }
-        }).collect(Collectors.toList());
     }
 
     @Nonnull

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/MultiServerConnectionFactory.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/MultiServerConnectionFactory.java
@@ -103,10 +103,13 @@ public class MultiServerConnectionFactory implements YamlConnectionFactory {
 
     @Override
     public YamlConnection getNewConnection(@Nonnull URI connectPath, int clusterIndex) throws SQLException {
-        // For multi-cluster connections, delegate directly to the default factory which has multi-cluster support.
-        // Alternation is not applied here because alternate factories (e.g. external servers) may not support
-        // all clusters.
-        return defaultFactory.getNewConnection(connectPath, clusterIndex);
+        if (connectionSelectionPolicy == ConnectionSelectionPolicy.DEFAULT) {
+            return defaultFactory.getNewConnection(connectPath, clusterIndex);
+        } else {
+            return new MultiServerConnection(connectionSelectionPolicy, getNextConnectionNumber(),
+                    defaultFactory.getNewConnection(connectPath, clusterIndex),
+                    alternateConnections(connectPath, clusterIndex));
+        }
     }
 
     @Override
@@ -129,6 +132,17 @@ public class MultiServerConnectionFactory implements YamlConnectionFactory {
         return alternateFactories.stream().map(factory -> {
             try {
                 return factory.getNewConnection(connectPath);
+            } catch (SQLException e) {
+                throw new IllegalStateException("Failed to create a connection", e);
+            }
+        }).collect(Collectors.toList());
+    }
+
+    @Nonnull
+    private List<YamlConnection> alternateConnections(URI connectPath, int clusterIndex) {
+        return alternateFactories.stream().map(factory -> {
+            try {
+                return factory.getNewConnection(connectPath, clusterIndex);
             } catch (SQLException e) {
                 throw new IllegalStateException("Failed to create a connection", e);
             }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/MultiServerConnectionFactory.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/MultiServerConnectionFactory.java
@@ -103,12 +103,10 @@ public class MultiServerConnectionFactory implements YamlConnectionFactory {
 
     @Override
     public YamlConnection getNewConnection(@Nonnull URI connectPath, int clusterIndex) throws SQLException {
-        if (connectionSelectionPolicy == ConnectionSelectionPolicy.DEFAULT) {
-            return defaultFactory.getNewConnection(connectPath, clusterIndex);
-        } else {
-            return new MultiServerConnection(connectionSelectionPolicy, getNextConnectionNumber(),
-                    defaultFactory.getNewConnection(connectPath, clusterIndex), alternateConnections(connectPath, clusterIndex));
-        }
+        // For multi-cluster connections, delegate directly to the default factory which has multi-cluster support.
+        // Alternation is not applied here because alternate factories (e.g. external servers) may not support
+        // all clusters.
+        return defaultFactory.getNewConnection(connectPath, clusterIndex);
     }
 
     @Override
@@ -123,11 +121,7 @@ public class MultiServerConnectionFactory implements YamlConnectionFactory {
 
     @Override
     public int getAvailableClusterCount() {
-        int min = defaultFactory.getAvailableClusterCount();
-        for (final YamlConnectionFactory factory : alternateFactories) {
-            min = Math.min(min, factory.getAvailableClusterCount());
-        }
-        return min;
+        return defaultFactory.getAvailableClusterCount();
     }
 
     @Nonnull
@@ -135,17 +129,6 @@ public class MultiServerConnectionFactory implements YamlConnectionFactory {
         return alternateFactories.stream().map(factory -> {
             try {
                 return factory.getNewConnection(connectPath);
-            } catch (SQLException e) {
-                throw new IllegalStateException("Failed to create a connection", e);
-            }
-        }).collect(Collectors.toList());
-    }
-
-    @Nonnull
-    private List<YamlConnection> alternateConnections(URI connectPath, int clusterIndex) {
-        return alternateFactories.stream().map(factory -> {
-            try {
-                return factory.getNewConnection(connectPath, clusterIndex);
             } catch (SQLException e) {
                 throw new IllegalStateException("Failed to create a connection", e);
             }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/ExternalServer.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/ExternalServer.java
@@ -129,6 +129,7 @@ public class ExternalServer implements Clusters.BoundToCluster {
         return version;
     }
 
+    @Nonnull
     @Override
     public String clusterFile() {
         return clusterFile;

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/ExternalServer.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/ExternalServer.java
@@ -25,6 +25,7 @@ import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.relational.api.exceptions.RelationalException;
 import com.apple.foundationdb.relational.util.Assert;
 import com.apple.foundationdb.relational.util.BuildVersion;
+import com.apple.foundationdb.relational.yamltests.connectionfactory.Clusters;
 import com.google.common.base.Verify;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -54,7 +55,7 @@ import java.util.jar.Manifest;
 /**
  * Class to manage running an external server.
  */
-public class ExternalServer {
+public class ExternalServer implements Clusters.BoundToCluster {
 
     private static final Logger logger = LogManager.getLogger(ExternalServer.class);
     public static final String EXTERNAL_SERVER_PROPERTY_NAME = "yaml_testing_external_server";
@@ -128,7 +129,8 @@ public class ExternalServer {
         return version;
     }
 
-    public String getClusterFile() {
+    @Override
+    public String clusterFile() {
         return clusterFile;
     }
 

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/ExternalServer.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/ExternalServer.java
@@ -65,7 +65,7 @@ public class ExternalServer {
     private int httpPort;
     private final SemanticVersion version;
     private Process serverProcess;
-    @Nullable
+    @Nonnull
     private final String clusterFile;
 
     /**
@@ -74,7 +74,7 @@ public class ExternalServer {
      * @param serverJar the path to the jar to run
      */
     public ExternalServer(@Nonnull final File serverJar,
-                          @Nullable final String clusterFile) throws IOException {
+                          @Nonnull final String clusterFile) throws IOException {
         this.clusterFile = clusterFile;
 
         this.serverJar = serverJar;

--- a/yaml-tests/src/test/java/CustomTagTest.java
+++ b/yaml-tests/src/test/java/CustomTagTest.java
@@ -29,14 +29,14 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nonnull;
+import java.util.List;
 import java.util.stream.Stream;
 
 /**
  * Tests for custom YAML tags such as {@link com.apple.foundationdb.relational.yamltests.tags.IgnoreTag}.
  */
 class CustomTagTest {
-    private static final String CLUSTER_FILE = FDBTestEnvironment.randomClusterFile();
-    private static final EmbeddedConfig config = new EmbeddedConfig(CLUSTER_FILE);
+    private static final EmbeddedConfig config = new EmbeddedConfig(List.of(FDBTestEnvironment.randomClusterFile()));
 
     @BeforeAll
     static void beforeAll() throws Exception {

--- a/yaml-tests/src/test/java/IncludeBlockTest.java
+++ b/yaml-tests/src/test/java/IncludeBlockTest.java
@@ -74,7 +74,7 @@ public class IncludeBlockTest {
     YamlConnectionFactory createConnectionFactory() {
         return new YamlConnectionFactory() {
             @Override
-            public YamlConnection getNewConnection(@Nonnull URI connectPath) throws SQLException {
+            public YamlConnection getNewConnection(@Nonnull URI connectPath, int clusterIndex) throws SQLException {
                 return new SimpleYamlConnection(DriverManager.getConnection(connectPath.toString()), VERSION, CLUSTER_FILE);
             }
 

--- a/yaml-tests/src/test/java/IncludeBlockTest.java
+++ b/yaml-tests/src/test/java/IncludeBlockTest.java
@@ -18,25 +18,17 @@
  * limitations under the License.
  */
 
-import com.apple.foundationdb.relational.yamltests.SimpleYamlConnection;
-import com.apple.foundationdb.relational.yamltests.YamlConnection;
-import com.apple.foundationdb.relational.yamltests.YamlConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
 import com.apple.foundationdb.relational.yamltests.YamlRunner;
 import com.apple.foundationdb.relational.yamltests.configs.EmbeddedConfig;
 import com.apple.foundationdb.relational.yamltests.configs.YamlTestConfig;
-import com.apple.foundationdb.relational.yamltests.server.SemanticVersion;
 import com.apple.foundationdb.test.FDBTestEnvironment;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import javax.annotation.Nonnull;
-import java.net.URI;
-import java.sql.DriverManager;
-import java.sql.SQLException;
-import java.util.Set;
+import java.util.List;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -46,10 +38,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  */
 public class IncludeBlockTest {
 
-    private static final SemanticVersion VERSION = SemanticVersion.parse("4.4.8.0");
-    private static final YamlTestConfig config = new EmbeddedConfig(FDBTestEnvironment.randomClusterFile());
+    private static final YamlTestConfig config = new EmbeddedConfig(List.of(FDBTestEnvironment.randomClusterFile()));
     private static final boolean CORRECT_METRICS = false;
-    private static final String CLUSTER_FILE = FDBTestEnvironment.randomClusterFile();
 
     @BeforeAll
     static void beforeAll() throws Exception {
@@ -68,21 +58,7 @@ public class IncludeBlockTest {
         } else {
             options = YamlExecutionContext.ContextOptions.EMPTY_OPTIONS;
         }
-        new YamlRunner(fileName, createConnectionFactory(), options).run();
-    }
-
-    YamlConnectionFactory createConnectionFactory() {
-        return new YamlConnectionFactory() {
-            @Override
-            public YamlConnection getNewConnection(@Nonnull URI connectPath, int clusterIndex) throws SQLException {
-                return new SimpleYamlConnection(DriverManager.getConnection(connectPath.toString()), VERSION, CLUSTER_FILE);
-            }
-
-            @Override
-            public Set<SemanticVersion> getVersionsUnderTest() {
-                return Set.of(VERSION);
-            }
-        };
+        new YamlRunner(fileName, config.createConnectionFactory(), options).run();
     }
 
     // yamsql files that works if they are rightly included in their parent yamsql file (that is, the parent file has

--- a/yaml-tests/src/test/java/InitialVersionTest.java
+++ b/yaml-tests/src/test/java/InitialVersionTest.java
@@ -35,6 +35,7 @@ import javax.annotation.Nonnull;
 import java.net.URI;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -46,7 +47,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class InitialVersionTest {
     private static final SemanticVersion VERSION = SemanticVersion.parse("3.0.18.0");
     private static final String CLUSTER_FILE = FDBTestEnvironment.randomClusterFile();
-    private static final EmbeddedConfig config = new EmbeddedConfig(CLUSTER_FILE);
+    private static final EmbeddedConfig config = new EmbeddedConfig(List.of(CLUSTER_FILE));
 
     @BeforeAll
     static void beforeAll() throws Exception {

--- a/yaml-tests/src/test/java/InitialVersionTest.java
+++ b/yaml-tests/src/test/java/InitialVersionTest.java
@@ -73,7 +73,7 @@ public class InitialVersionTest {
     YamlConnectionFactory createConnectionFactory() {
         return new YamlConnectionFactory() {
             @Override
-            public YamlConnection getNewConnection(@Nonnull URI connectPath) throws SQLException {
+            public YamlConnection getNewConnection(@Nonnull URI connectPath, int clusterIndex) throws SQLException {
                 return new SimpleYamlConnection(DriverManager.getConnection(connectPath.toString()), VERSION, CLUSTER_FILE);
             }
 

--- a/yaml-tests/src/test/java/MultiServerConnectionFactoryTest.java
+++ b/yaml-tests/src/test/java/MultiServerConnectionFactoryTest.java
@@ -40,6 +40,7 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+// TODO add tests of multiple clusters
 public class MultiServerConnectionFactoryTest {
     private static final SemanticVersion PRIMARY_VERSION = SemanticVersion.parse("2.2.2.0");
     private static final SemanticVersion ALTERNATE_VERSION = SemanticVersion.parse("1.1.1.0");
@@ -59,17 +60,17 @@ public class MultiServerConnectionFactoryTest {
         // just the default for the set of versions
         assertEquals(Set.of(PRIMARY_VERSION, ALTERNATE_VERSION), classUnderTest.getVersionsUnderTest());
 
-        var connection = classUnderTest.getNewConnection(URI.create("Blah"));
+        var connection = classUnderTest.getNewConnection(URI.create("Blah"), 0);
         assertConnection(connection, PRIMARY_VERSION, List.of(PRIMARY_VERSION));
         assertStatement(connection.prepareStatement("SQL"), PRIMARY_VERSION);
         assertStatement(connection.prepareStatement("SQL"), PRIMARY_VERSION);
 
-        connection = classUnderTest.getNewConnection(URI.create("Blah"));
+        connection = classUnderTest.getNewConnection(URI.create("Blah"), 0);
         assertConnection(connection, PRIMARY_VERSION, List.of(PRIMARY_VERSION));
         assertStatement(connection.prepareStatement("SQL"), PRIMARY_VERSION);
         assertStatement(connection.prepareStatement("SQL"), PRIMARY_VERSION);
 
-        connection = classUnderTest.getNewConnection(URI.create("Blah"));
+        connection = classUnderTest.getNewConnection(URI.create("Blah"), 0);
         assertConnection(connection, PRIMARY_VERSION, List.of(PRIMARY_VERSION));
         assertStatement(connection.prepareStatement("SQL"), PRIMARY_VERSION);
         assertStatement(connection.prepareStatement("SQL"), PRIMARY_VERSION);
@@ -92,7 +93,7 @@ public class MultiServerConnectionFactoryTest {
         // - Factory current connection: initial connection
         // - connection current connection: initial connection
         // - statement: initial connection (2 statements)
-        var connection = classUnderTest.getNewConnection(URI.create("Blah"));
+        var connection = classUnderTest.getNewConnection(URI.create("Blah"), 0);
         assertConnection(connection, initialConnectionVersion, List.of(initialConnectionVersion, otherConnectionVersion));
         assertStatement(connection.prepareStatement("SQL"), initialConnectionVersion);
         // next statement
@@ -102,7 +103,7 @@ public class MultiServerConnectionFactoryTest {
         // - Factory current connection: alternate connection
         // - connection current connection: alternate connection
         // - statement: alternate connection (2 statements)
-        connection = classUnderTest.getNewConnection(URI.create("Blah"));
+        connection = classUnderTest.getNewConnection(URI.create("Blah"), 0);
         assertConnection(connection, otherConnectionVersion, List.of(otherConnectionVersion, initialConnectionVersion));
         assertStatement(connection.prepareStatement("SQL"), otherConnectionVersion);
         // next statement
@@ -112,7 +113,7 @@ public class MultiServerConnectionFactoryTest {
         // - Factory current connection: initial connection
         // - connection current connection: initial connection
         // - statement: initial connection (1 statement)
-        connection = classUnderTest.getNewConnection(URI.create("Blah"));
+        connection = classUnderTest.getNewConnection(URI.create("Blah"), 0);
         assertConnection(connection, initialConnectionVersion, List.of(initialConnectionVersion, otherConnectionVersion));
         // just one statement for this connection
         assertStatement(connection.prepareStatement("SQL"), initialConnectionVersion);
@@ -121,7 +122,7 @@ public class MultiServerConnectionFactoryTest {
         // - Factory current connection: alternate connection
         // - connection current connection: alternate connection
         // - statement: alternate connection (3 statements)
-        connection = classUnderTest.getNewConnection(URI.create("Blah"));
+        connection = classUnderTest.getNewConnection(URI.create("Blah"), 0);
         assertConnection(connection, otherConnectionVersion, List.of(otherConnectionVersion, initialConnectionVersion));
         assertStatement(connection.prepareStatement("SQL"), otherConnectionVersion);
         // next statements
@@ -155,7 +156,7 @@ public class MultiServerConnectionFactoryTest {
     YamlConnectionFactory dummyConnectionFactory(@Nonnull SemanticVersion version) {
         return new YamlConnectionFactory() {
             @Override
-            public YamlConnection getNewConnection(@Nonnull URI connectPath) throws SQLException {
+            public YamlConnection getNewConnection(@Nonnull URI connectPath, int clusterIndex) throws SQLException {
                 // Add query string to connection so we can tell where it came from
                 URI newPath = URI.create(connectPath + "?version=" + version);
                 return new SimpleYamlConnection(dummyConnection(newPath), version, CLUSTER_FILE);

--- a/yaml-tests/src/test/java/MultiServerConnectionFactoryTest.java
+++ b/yaml-tests/src/test/java/MultiServerConnectionFactoryTest.java
@@ -25,7 +25,6 @@ import com.apple.foundationdb.relational.yamltests.YamlConnection;
 import com.apple.foundationdb.relational.yamltests.YamlConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.connectionfactory.MultiServerConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.server.SemanticVersion;
-import com.apple.foundationdb.test.FDBTestEnvironment;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -40,11 +39,11 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-// TODO add tests of multiple clusters
 public class MultiServerConnectionFactoryTest {
     private static final SemanticVersion PRIMARY_VERSION = SemanticVersion.parse("2.2.2.0");
     private static final SemanticVersion ALTERNATE_VERSION = SemanticVersion.parse("1.1.1.0");
-    private static final String CLUSTER_FILE = FDBTestEnvironment.randomClusterFile();
+    private static final String CLUSTER_FILE = "cluster0";
+    private static final String CLUSTER_FILE_1 = "cluster1";
 
     @ParameterizedTest
     @CsvSource({"0", "1"})
@@ -62,18 +61,18 @@ public class MultiServerConnectionFactoryTest {
 
         var connection = classUnderTest.getNewConnection(URI.create("Blah"), 0);
         assertConnection(connection, PRIMARY_VERSION, List.of(PRIMARY_VERSION));
-        assertStatement(connection.prepareStatement("SQL"), PRIMARY_VERSION);
-        assertStatement(connection.prepareStatement("SQL"), PRIMARY_VERSION);
+        assertStatement(connection.prepareStatement("SQL"), PRIMARY_VERSION, CLUSTER_FILE);
+        assertStatement(connection.prepareStatement("SQL"), PRIMARY_VERSION, CLUSTER_FILE);
 
         connection = classUnderTest.getNewConnection(URI.create("Blah"), 0);
         assertConnection(connection, PRIMARY_VERSION, List.of(PRIMARY_VERSION));
-        assertStatement(connection.prepareStatement("SQL"), PRIMARY_VERSION);
-        assertStatement(connection.prepareStatement("SQL"), PRIMARY_VERSION);
+        assertStatement(connection.prepareStatement("SQL"), PRIMARY_VERSION, CLUSTER_FILE);
+        assertStatement(connection.prepareStatement("SQL"), PRIMARY_VERSION, CLUSTER_FILE);
 
         connection = classUnderTest.getNewConnection(URI.create("Blah"), 0);
         assertConnection(connection, PRIMARY_VERSION, List.of(PRIMARY_VERSION));
-        assertStatement(connection.prepareStatement("SQL"), PRIMARY_VERSION);
-        assertStatement(connection.prepareStatement("SQL"), PRIMARY_VERSION);
+        assertStatement(connection.prepareStatement("SQL"), PRIMARY_VERSION, CLUSTER_FILE);
+        assertStatement(connection.prepareStatement("SQL"), PRIMARY_VERSION, CLUSTER_FILE);
     }
 
     @ParameterizedTest
@@ -95,9 +94,9 @@ public class MultiServerConnectionFactoryTest {
         // - statement: initial connection (2 statements)
         var connection = classUnderTest.getNewConnection(URI.create("Blah"), 0);
         assertConnection(connection, initialConnectionVersion, List.of(initialConnectionVersion, otherConnectionVersion));
-        assertStatement(connection.prepareStatement("SQL"), initialConnectionVersion);
+        assertStatement(connection.prepareStatement("SQL"), initialConnectionVersion, CLUSTER_FILE);
         // next statement
-        assertStatement(connection.prepareStatement("SQL"), otherConnectionVersion);
+        assertStatement(connection.prepareStatement("SQL"), otherConnectionVersion, CLUSTER_FILE);
 
         // Second run:
         // - Factory current connection: alternate connection
@@ -105,9 +104,9 @@ public class MultiServerConnectionFactoryTest {
         // - statement: alternate connection (2 statements)
         connection = classUnderTest.getNewConnection(URI.create("Blah"), 0);
         assertConnection(connection, otherConnectionVersion, List.of(otherConnectionVersion, initialConnectionVersion));
-        assertStatement(connection.prepareStatement("SQL"), otherConnectionVersion);
+        assertStatement(connection.prepareStatement("SQL"), otherConnectionVersion, CLUSTER_FILE);
         // next statement
-        assertStatement(connection.prepareStatement("SQL"), initialConnectionVersion);
+        assertStatement(connection.prepareStatement("SQL"), initialConnectionVersion, CLUSTER_FILE);
 
         // Third run:
         // - Factory current connection: initial connection
@@ -116,7 +115,7 @@ public class MultiServerConnectionFactoryTest {
         connection = classUnderTest.getNewConnection(URI.create("Blah"), 0);
         assertConnection(connection, initialConnectionVersion, List.of(initialConnectionVersion, otherConnectionVersion));
         // just one statement for this connection
-        assertStatement(connection.prepareStatement("SQL"), initialConnectionVersion);
+        assertStatement(connection.prepareStatement("SQL"), initialConnectionVersion, CLUSTER_FILE);
 
         // Fourth run:
         // - Factory current connection: alternate connection
@@ -124,10 +123,10 @@ public class MultiServerConnectionFactoryTest {
         // - statement: alternate connection (3 statements)
         connection = classUnderTest.getNewConnection(URI.create("Blah"), 0);
         assertConnection(connection, otherConnectionVersion, List.of(otherConnectionVersion, initialConnectionVersion));
-        assertStatement(connection.prepareStatement("SQL"), otherConnectionVersion);
+        assertStatement(connection.prepareStatement("SQL"), otherConnectionVersion, CLUSTER_FILE);
         // next statements
-        assertStatement(connection.prepareStatement("SQL"), initialConnectionVersion);
-        assertStatement(connection.prepareStatement("SQL"), otherConnectionVersion);
+        assertStatement(connection.prepareStatement("SQL"), initialConnectionVersion, CLUSTER_FILE);
+        assertStatement(connection.prepareStatement("SQL"), otherConnectionVersion, CLUSTER_FILE);
     }
 
     @Test
@@ -144,8 +143,58 @@ public class MultiServerConnectionFactoryTest {
                 List.of(dummyConnectionFactory(ALTERNATE_VERSION))));
     }
 
-    private void assertStatement(final RelationalPreparedStatement statement, final SemanticVersion version) throws SQLException {
-        assertEquals("version=" + version, ((RelationalConnection)statement.getConnection()).getPath().getQuery());
+    @ParameterizedTest
+    @CsvSource({"0", "1"})
+    void testDefaultPolicyWithCluster(int initialConnection) throws SQLException {
+        MultiServerConnectionFactory classUnderTest = new MultiServerConnectionFactory(
+                MultiServerConnectionFactory.ConnectionSelectionPolicy.DEFAULT,
+                initialConnection,
+                dummyMultiClusterConnectionFactory(PRIMARY_VERSION, List.of(CLUSTER_FILE, CLUSTER_FILE_1)),
+                List.of(dummyMultiClusterConnectionFactory(ALTERNATE_VERSION, List.of(CLUSTER_FILE, CLUSTER_FILE_1))));
+
+        // Cluster 0 should use the default factory and return CLUSTER_FILE
+        var connection = classUnderTest.getNewConnection(URI.create("Blah"), 0);
+        assertConnection(connection, PRIMARY_VERSION, List.of(PRIMARY_VERSION));
+        assertEquals(CLUSTER_FILE, connection.getClusterFile());
+        assertStatement(connection.prepareStatement("SQL"), PRIMARY_VERSION, CLUSTER_FILE);
+
+        // Cluster 1 should use the default factory and return CLUSTER_FILE_1
+        connection = classUnderTest.getNewConnection(URI.create("Blah"), 1);
+        assertConnection(connection, PRIMARY_VERSION, List.of(PRIMARY_VERSION));
+        assertEquals(CLUSTER_FILE_1, connection.getClusterFile());
+        assertStatement(connection.prepareStatement("SQL"), PRIMARY_VERSION, CLUSTER_FILE_1);
+    }
+
+    @ParameterizedTest
+    @CsvSource({"0", "1"})
+    void testAlternatePolicyWithCluster(int initialConnection) throws SQLException {
+        final SemanticVersion[] versions = new SemanticVersion[] { PRIMARY_VERSION, ALTERNATE_VERSION };
+        final SemanticVersion initialConnectionVersion = versions[initialConnection];
+        final SemanticVersion otherConnectionVersion = versions[(initialConnection + 1) % 2];
+
+        MultiServerConnectionFactory classUnderTest = new MultiServerConnectionFactory(
+                MultiServerConnectionFactory.ConnectionSelectionPolicy.ALTERNATE,
+                initialConnection,
+                dummyMultiClusterConnectionFactory(PRIMARY_VERSION, List.of(CLUSTER_FILE, CLUSTER_FILE_1)),
+                List.of(dummyMultiClusterConnectionFactory(ALTERNATE_VERSION, List.of(CLUSTER_FILE, CLUSTER_FILE_1))));
+
+        // Cluster 0: alternation works and cluster file is CLUSTER_FILE
+        var connection = classUnderTest.getNewConnection(URI.create("Blah"), 0);
+        assertConnection(connection, initialConnectionVersion, List.of(initialConnectionVersion, otherConnectionVersion));
+        assertEquals(CLUSTER_FILE, connection.getClusterFile());
+        assertStatement(connection.prepareStatement("SQL"), initialConnectionVersion, CLUSTER_FILE);
+        assertStatement(connection.prepareStatement("SQL"), otherConnectionVersion, CLUSTER_FILE);
+
+        // Cluster 1: alternation works and cluster file is CLUSTER_FILE_1
+        connection = classUnderTest.getNewConnection(URI.create("Blah"), 1);
+        assertConnection(connection, otherConnectionVersion, List.of(otherConnectionVersion, initialConnectionVersion));
+        assertEquals(CLUSTER_FILE_1, connection.getClusterFile());
+        assertStatement(connection.prepareStatement("SQL"), otherConnectionVersion, CLUSTER_FILE_1);
+        assertStatement(connection.prepareStatement("SQL"), initialConnectionVersion, CLUSTER_FILE_1);
+    }
+
+    private void assertStatement(final RelationalPreparedStatement statement, final SemanticVersion version, final String clusterFile) throws SQLException {
+        assertEquals("version=" + version + "&cluster=" + clusterFile, ((RelationalConnection)statement.getConnection()).getPath().getQuery());
     }
 
     private static void assertConnection(final YamlConnection connection, final SemanticVersion initialVersion, final List<SemanticVersion> expectedVersions) {
@@ -154,17 +203,29 @@ public class MultiServerConnectionFactoryTest {
     }
 
     YamlConnectionFactory dummyConnectionFactory(@Nonnull SemanticVersion version) {
+        return dummyMultiClusterConnectionFactory(version, List.of(CLUSTER_FILE));
+    }
+
+    YamlConnectionFactory dummyMultiClusterConnectionFactory(@Nonnull SemanticVersion version, @Nonnull List<String> clusterFiles) {
         return new YamlConnectionFactory() {
             @Override
             public YamlConnection getNewConnection(@Nonnull URI connectPath, int clusterIndex) throws SQLException {
-                // Add query string to connection so we can tell where it came from
-                URI newPath = URI.create(connectPath + "?version=" + version);
-                return new SimpleYamlConnection(dummyConnection(newPath), version, CLUSTER_FILE);
+                if (clusterIndex < 0 || clusterIndex >= clusterFiles.size()) {
+                    throw new SQLException("Cluster index " + clusterIndex + " not available (only " +
+                            clusterFiles.size() + " clusters configured)");
+                }
+                URI newPath = URI.create(connectPath + "?version=" + version + "&cluster=" + clusterFiles.get(clusterIndex));
+                return new SimpleYamlConnection(dummyConnection(newPath), version, clusterFiles.get(clusterIndex));
             }
 
             @Override
             public Set<SemanticVersion> getVersionsUnderTest() {
                 return Set.of(version);
+            }
+
+            @Override
+            public int getAvailableClusterCount() {
+                return clusterFiles.size();
             }
         };
     }

--- a/yaml-tests/src/test/java/SupportedVersionTest.java
+++ b/yaml-tests/src/test/java/SupportedVersionTest.java
@@ -66,7 +66,7 @@ public class SupportedVersionTest {
     YamlConnectionFactory createConnectionFactory() {
         return new YamlConnectionFactory() {
             @Override
-            public YamlConnection getNewConnection(@Nonnull URI connectPath) throws SQLException {
+            public YamlConnection getNewConnection(@Nonnull URI connectPath, int clusterIndex) throws SQLException {
                 return new SimpleYamlConnection(DriverManager.getConnection(connectPath.toString()), VERSION, CLUSTER_FILE);
             }
 

--- a/yaml-tests/src/test/java/SupportedVersionTest.java
+++ b/yaml-tests/src/test/java/SupportedVersionTest.java
@@ -35,6 +35,7 @@ import javax.annotation.Nonnull;
 import java.net.URI;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -47,7 +48,7 @@ public class SupportedVersionTest {
 
     private static final SemanticVersion VERSION = SemanticVersion.parse("3.0.18.0");
     private static final String CLUSTER_FILE = FDBTestEnvironment.randomClusterFile();
-    private static final EmbeddedConfig config = new EmbeddedConfig(CLUSTER_FILE);
+    private static final EmbeddedConfig config = new EmbeddedConfig(List.of(CLUSTER_FILE));
 
     @BeforeAll
     static void beforeAll() throws Exception {

--- a/yaml-tests/src/test/java/TransactionSetupTest.java
+++ b/yaml-tests/src/test/java/TransactionSetupTest.java
@@ -74,7 +74,7 @@ public class TransactionSetupTest {
     YamlConnectionFactory createConnectionFactory() {
         return new YamlConnectionFactory() {
             @Override
-            public YamlConnection getNewConnection(@Nonnull URI connectPath) throws SQLException {
+            public YamlConnection getNewConnection(@Nonnull URI connectPath, int clusterIndex) throws SQLException {
                 return new SimpleYamlConnection(DriverManager.getConnection(connectPath.toString()), VERSION, CLUSTER_FILE);
             }
 

--- a/yaml-tests/src/test/java/TransactionSetupTest.java
+++ b/yaml-tests/src/test/java/TransactionSetupTest.java
@@ -18,25 +18,17 @@
  * limitations under the License.
  */
 
-import com.apple.foundationdb.relational.yamltests.SimpleYamlConnection;
-import com.apple.foundationdb.relational.yamltests.YamlConnection;
-import com.apple.foundationdb.relational.yamltests.YamlConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
 import com.apple.foundationdb.relational.yamltests.YamlRunner;
 import com.apple.foundationdb.relational.yamltests.configs.EmbeddedConfig;
 import com.apple.foundationdb.relational.yamltests.configs.YamlTestConfig;
-import com.apple.foundationdb.relational.yamltests.server.SemanticVersion;
 import com.apple.foundationdb.test.FDBTestEnvironment;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import javax.annotation.Nonnull;
-import java.net.URI;
-import java.sql.DriverManager;
-import java.sql.SQLException;
-import java.util.Set;
+import java.util.List;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -46,10 +38,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  */
 public class TransactionSetupTest {
 
-    private static final SemanticVersion VERSION = SemanticVersion.parse("4.4.8.0");
-    private static final YamlTestConfig config = new EmbeddedConfig(FDBTestEnvironment.randomClusterFile());
+    private static final YamlTestConfig config = new EmbeddedConfig(List.of(FDBTestEnvironment.randomClusterFile()));
     private static final boolean CORRECT_METRICS = false;
-    private static final String CLUSTER_FILE = FDBTestEnvironment.randomClusterFile();
 
     @BeforeAll
     static void beforeAll() throws Exception {
@@ -68,21 +58,7 @@ public class TransactionSetupTest {
         } else {
             options = YamlExecutionContext.ContextOptions.EMPTY_OPTIONS;
         }
-        new YamlRunner(fileName, createConnectionFactory(), options).run();
-    }
-
-    YamlConnectionFactory createConnectionFactory() {
-        return new YamlConnectionFactory() {
-            @Override
-            public YamlConnection getNewConnection(@Nonnull URI connectPath, int clusterIndex) throws SQLException {
-                return new SimpleYamlConnection(DriverManager.getConnection(connectPath.toString()), VERSION, CLUSTER_FILE);
-            }
-
-            @Override
-            public Set<SemanticVersion> getVersionsUnderTest() {
-                return Set.of(VERSION);
-            }
-        };
+        new YamlRunner(fileName, config.createConnectionFactory(), options).run();
     }
 
     static Stream<String> shouldFail() {

--- a/yaml-tests/src/test/java/YamlIntegrationTests.java
+++ b/yaml-tests/src/test/java/YamlIntegrationTests.java
@@ -223,6 +223,11 @@ public class YamlIntegrationTests {
     }
 
     @TestTemplate
+    public void multiClusterIsolation(YamlTest.Runner runner) throws Exception {
+        runner.runYamsql("multi-cluster-isolation.yamsql");
+    }
+
+    @TestTemplate
     public void indexDdl(YamlTest.Runner runner) throws Exception {
         runner.runYamsql("index-ddl.yamsql");
     }

--- a/yaml-tests/src/test/java/com/apple/foundationdb/relational/yamltests/server/ExternalServerTest.java
+++ b/yaml-tests/src/test/java/com/apple/foundationdb/relational/yamltests/server/ExternalServerTest.java
@@ -48,7 +48,8 @@ class ExternalServerTest {
     private static File getCurrentServerPath() throws IOException {
         final List<File> availableServers = ExternalServer.getAvailableServers();
         for (File path : availableServers) {
-            if (new ExternalServer(path, null).getVersion().equals(SemanticVersion.current())) {
+            if (new ExternalServer(path, FDBTestEnvironment.randomClusterFile())
+                    .getVersion().equals(SemanticVersion.current())) {
                 return path;
             }
         }

--- a/yaml-tests/src/test/resources/multi-cluster-isolation.yamsql
+++ b/yaml-tests/src/test/resources/multi-cluster-isolation.yamsql
@@ -55,7 +55,6 @@ setup:
 # Verify cluster 1 does not have the database
 test_block:
   connect: { cluster: 1, uri: "jdbc:embed:/__SYS?schema=CATALOG" }
-  preset: single_repetition_ordered
   tests:
     -
       - query: select count(*) from "DATABASES" where database_id = '/FRL/MCI_DB'
@@ -80,7 +79,6 @@ setup:
 # Verify cluster 1 has only its own data
 test_block:
   connect: { cluster: 1, uri: "jdbc:embed:/FRL/MCI_DB?schema=S1" }
-  preset: single_repetition_ordered
   tests:
     -
       - query: select * from T1

--- a/yaml-tests/src/test/resources/multi-cluster-isolation.yamsql
+++ b/yaml-tests/src/test/resources/multi-cluster-isolation.yamsql
@@ -1,0 +1,110 @@
+#
+# multi-cluster-isolation.yamsql
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2021-2026 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Verifies that data written to one cluster is not visible on another cluster.
+# Requires at least 2 clusters; skipped otherwise.
+---
+options:
+  required_clusters: 2
+---
+# Cleanup cluster 0
+setup:
+  connect: { cluster: 0, uri: "jdbc:embed:/__SYS?schema=CATALOG" }
+  steps:
+    - query: drop database if exists /FRL/MCI_DB
+    - query: drop schema template if exists MCI_TEMPLATE
+---
+# Cleanup cluster 1
+setup:
+  connect: { cluster: 1, uri: "jdbc:embed:/__SYS?schema=CATALOG" }
+  steps:
+    - query: drop database if exists /FRL/MCI_DB
+    - query: drop schema template if exists MCI_TEMPLATE
+---
+# Create template, database, and schema on cluster 0
+setup:
+  connect: { cluster: 0, uri: "jdbc:embed:/__SYS?schema=CATALOG" }
+  steps:
+    - query: create schema template MCI_TEMPLATE create table T1(ID bigint, NAME string, primary key(ID))
+    - query: create database /FRL/MCI_DB
+    - query: create schema /FRL/MCI_DB/S1 with template MCI_TEMPLATE
+---
+# Insert data on cluster 0
+setup:
+  connect: { cluster: 0, uri: "jdbc:embed:/FRL/MCI_DB?schema=S1" }
+  steps:
+    - query: insert into T1 values (1, 'cluster0_row1')
+    - query: insert into T1 values (2, 'cluster0_row2')
+---
+# Verify cluster 1 does not have the database
+test_block:
+  connect: { cluster: 1, uri: "jdbc:embed:/__SYS?schema=CATALOG" }
+  preset: single_repetition_ordered
+  tests:
+    -
+      - query: select count(*) from "DATABASES" where database_id = '/FRL/MCI_DB'
+      - result: [{0}]
+---
+# Create same template, database, and schema on cluster 1
+setup:
+  connect: { cluster: 1, uri: "jdbc:embed:/__SYS?schema=CATALOG" }
+  steps:
+    - query: create schema template MCI_TEMPLATE create table T1(ID bigint, NAME string, primary key(ID))
+    - query: create database /FRL/MCI_DB
+    - query: create schema /FRL/MCI_DB/S1 with template MCI_TEMPLATE
+---
+# Insert different data on cluster 1
+setup:
+  connect: { cluster: 1, uri: "jdbc:embed:/FRL/MCI_DB?schema=S1" }
+  steps:
+    - query: insert into T1 values (10, 'cluster1_row1')
+    - query: insert into T1 values (20, 'cluster1_row2')
+    - query: insert into T1 values (30, 'cluster1_row3')
+---
+# Verify cluster 1 has only its own data
+test_block:
+  connect: { cluster: 1, uri: "jdbc:embed:/FRL/MCI_DB?schema=S1" }
+  preset: single_repetition_ordered
+  tests:
+    -
+      - query: select * from T1
+      - result: [{ID: 10, NAME: 'cluster1_row1'}, {ID: 20, NAME: 'cluster1_row2'}, {ID: 30, NAME: 'cluster1_row3'}]
+---
+# Verify cluster 0 still has only its own data
+test_block:
+  connect: { cluster: 0, uri: "jdbc:embed:/FRL/MCI_DB?schema=S1" }
+  preset: single_repetition_ordered
+  tests:
+    -
+      - query: select * from T1
+      - result: [{ID: 1, NAME: 'cluster0_row1'}, {ID: 2, NAME: 'cluster0_row2'}]
+---
+# Cleanup cluster 0
+setup:
+  connect: { cluster: 0, uri: "jdbc:embed:/__SYS?schema=CATALOG" }
+  steps:
+    - query: drop database /FRL/MCI_DB
+    - query: drop schema template MCI_TEMPLATE
+---
+# Cleanup cluster 1
+setup:
+  connect: { cluster: 1, uri: "jdbc:embed:/__SYS?schema=CATALOG" }
+  steps:
+    - query: drop database /FRL/MCI_DB
+    - query: drop schema template MCI_TEMPLATE


### PR DESCRIPTION
The primary purpose here is to support multi-cluster testing to yaml tests.
In order to support this, a new option was added to FRL to not-register the driver so that you can create multiple different FRL instances, pointing to different clusters.

This is part of the work for: #3823