### PR TITLE
Add support for using the COPY command in yamsql

### DIFF
--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/CopyPlan.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/CopyPlan.java
@@ -41,6 +41,7 @@ import com.apple.foundationdb.record.query.plan.cascades.CascadesPlanner;
 import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
 import com.apple.foundationdb.record.util.pair.NonnullPair;
 import com.apple.foundationdb.relational.api.Options;
+import com.apple.foundationdb.relational.api.RelationalArray;
 import com.apple.foundationdb.relational.api.RelationalResultSet;
 import com.apple.foundationdb.relational.api.RelationalStructMetaData;
 import com.apple.foundationdb.relational.api.Transaction;
@@ -59,6 +60,7 @@ import com.apple.foundationdb.relational.recordlayer.ArrayRow;
 import com.apple.foundationdb.relational.recordlayer.ContinuationBuilder;
 import com.apple.foundationdb.relational.recordlayer.ContinuationImpl;
 import com.apple.foundationdb.relational.recordlayer.EmbeddedRelationalConnection;
+import com.google.protobuf.ByteString;
 import com.apple.foundationdb.relational.recordlayer.KeySpaceUtils;
 import com.apple.foundationdb.relational.recordlayer.RecordContextTransaction;
 import com.apple.foundationdb.relational.recordlayer.RecordLayerIterator;
@@ -70,6 +72,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.net.URI;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -493,27 +496,45 @@ public final class CopyPlan extends QueryPlan {
                     ErrorCode.INVALID_PARAMETER);
         }
 
-        // Validate it's an array
-        if (!(parameterValue instanceof List)) {
-            throw new RelationalException(
-                    "Parameter must be an ARRAY, got: " + parameterValue.getClass().getName(),
-                    ErrorCode.INVALID_PARAMETER);
+        if (parameterValue instanceof List) {
+            @SuppressWarnings("unchecked")
+            List<Object> dataArray = (List<Object>) parameterValue;
+            return dataArray;
         }
 
-        @SuppressWarnings("unchecked")
-        List<Object> dataArray = (List<Object>) parameterValue;
-        return dataArray;
+        if (parameterValue instanceof java.sql.Array) {
+            try {
+                final java.sql.Array sqlArray = (java.sql.Array) parameterValue;
+                final List<Object> elements = new ArrayList<>();
+                try (RelationalResultSet rs = ((RelationalArray) sqlArray).getResultSet(1, Integer.MAX_VALUE)) {
+                    while (rs.next()) {
+                        elements.add(rs.getBytes("VALUE"));
+                    }
+                }
+                return elements;
+            } catch (SQLException e) {
+                throw new RelationalException(
+                        "Failed to extract elements from ARRAY parameter: " + e.getMessage(),
+                        ErrorCode.INVALID_PARAMETER, e);
+            }
+        }
+
+        throw new RelationalException(
+                "Parameter must be an ARRAY, got: " + parameterValue.getClass().getName(),
+                ErrorCode.INVALID_PARAMETER);
     }
 
     @Nonnull
     private static byte[] convertToBytes(@Nullable final Object element) throws RelationalException {
-        if (!(element instanceof byte[])) {
-            throw new RelationalException(
-                    "Array elements must be BYTES, got: " + (element == null ? null : element.getClass().getName()),
-                    ErrorCode.INVALID_PARAMETER);
+        if (element instanceof byte[]) {
+            return (byte[]) element;
         }
-
-        return (byte[])element;
+        if (element instanceof ByteString) {
+            return ((ByteString) element).toByteArray();
+        }
+        throw new RelationalException(
+                "Array elements must be BYTES, got: " + (element == null ? null : element.getClass().getName()),
+                ErrorCode.INVALID_PARAMETER);
     }
 
     @Nonnull

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/CopyPlan.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/CopyPlan.java
@@ -71,6 +71,7 @@ import com.apple.foundationdb.relational.util.catalog.KeySpaceProvider;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.net.URI;
+import java.sql.Array;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -502,9 +503,9 @@ public final class CopyPlan extends QueryPlan {
             return dataArray;
         }
 
-        if (parameterValue instanceof java.sql.Array) {
+        if (parameterValue instanceof Array) {
             try {
-                final java.sql.Array sqlArray = (java.sql.Array) parameterValue;
+                final Array sqlArray = (Array) parameterValue;
                 final List<Object> elements = new ArrayList<>();
                 try (RelationalResultSet rs = ((RelationalArray) sqlArray).getResultSet(1, Integer.MAX_VALUE)) {
                     while (rs.next()) {

--- a/scripts/YAML-SQL.xml
+++ b/scripts/YAML-SQL.xml
@@ -32,6 +32,7 @@
       <option name="HAS_STRING_ESCAPES" value="true" />
       <option name="LINE_COMMENT_AT_START" value="false" />
     </options>
+    <!-- SQL keywords -->
     <keywords keywords="absolute;action;add;all;allocate;alter;and;any;are;array;as;asc;assertion;at;authorization;
     avg;begin;between;bit_length;both;by;cascade;cascaded;case;cast;catalog;character_length;check;close;coalesce;
     collate;collation;column;commit;connection;constraint;constraints;continue;convert;corresponding;count;create;
@@ -46,13 +47,19 @@
     size;some;space;sql;sqlcode;sqlerror;sqlstate;struct;substring;sum;system_user;table;template;temporary;then;
     timezone_;timezone_minute;to;trailing;transaction;translate;translation;trim;type;union;unique;unknown;update;
     upper;usage;user;using;value;values;varying;view;when;whenever;where;with;work;write;year;zone" ignore_case="true" />
+    <!-- sql type names and some tags -->
     <keywords2 keywords="bigint;bit;boolean;bytes;char;char_;character;date;dec;decimal;double;float;int;integer;nchar;
     numeric;real;smallint;string;time;timestamp;varchar;!!;!r;!in;!a;!current_version" />
+    <!-- values -->
     <keywords3 keywords="false;null;true;ordered;randomized;parallelized;test;block;single_repetition_ordered;
     single_repetition_randomized;single_repetition_parallelized;multi_repetition_ordered;multi_repetition_randomized;
-    multi_repetition_parallelized" />
+    multi_repetition_parallelized;
+    cluster:;uri:;path:;" />
+    <!-- block names & options -->
     <keywords4 keywords="connect:;query:;load schema template:;set schema state:;result:;unorderedResult:;explain:;
     explainContains:;count:;error:;planHash:;setup:;schema_template:;supported_version:;test_block:;options:;tests:;
+    copy_block:;source:;dest:;export_limit:;import_chunk_size:;
+    include:;required_clusters:;
     maxRows:;initialVersionAtLeast:;initialVersionLessThan:;;mode:;repetition:;seed:;setup:;transaction_setups:;
     setupReference:;check_cache:;connection_lifecycle:;steps:;preset:;statement_type:;!r;!in;!a;" />
   </highlighting>

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/CustomYamlConstructor.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/CustomYamlConstructor.java
@@ -23,6 +23,7 @@ package com.apple.foundationdb.relational.yamltests;
 import com.apple.foundationdb.record.util.ServiceLoaderProvider;
 import com.apple.foundationdb.relational.api.exceptions.ErrorCode;
 import com.apple.foundationdb.relational.util.Assert;
+import com.apple.foundationdb.relational.yamltests.block.CopyBlock;
 import com.apple.foundationdb.relational.yamltests.block.IncludeBlock;
 import com.apple.foundationdb.relational.yamltests.block.PreambleBlock;
 import com.apple.foundationdb.relational.yamltests.block.SetupBlock;
@@ -61,6 +62,7 @@ public class CustomYamlConstructor extends SafeConstructor {
         requireLineNumber.add(TransactionSetupsBlock.TRANSACTION_SETUP);
         requireLineNumber.add(TestBlock.TEST_BLOCK);
         requireLineNumber.add(IncludeBlock.INCLUDE);
+        requireLineNumber.add(CopyBlock.COPY_BLOCK);
         // commands
         requireLineNumber.add(Command.COMMAND_LOAD_SCHEMA_TEMPLATE);
         requireLineNumber.add(Command.COMMAND_SET_SCHEMA_STATE);

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/Block.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/Block.java
@@ -93,6 +93,8 @@ public interface Block {
                     return PreambleBlock.parse(entry.getValue(), executionContext);
                 case IncludeBlock.INCLUDE:
                     return IncludeBlock.parse(reference, entry.getValue(), executionContext);
+                case CopyBlock.COPY_BLOCK:
+                    return CopyBlock.parse(reference, entry.getValue(), executionContext);
                 default:
                     throw new RuntimeException("Cannot recognize the type of block");
             }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/CopyBlock.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/CopyBlock.java
@@ -34,7 +34,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.net.URI;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -78,17 +77,15 @@ public class CopyBlock extends ReferencedBlock implements Block {
     private final int destCluster;
     @Nonnull
     private final String destPath;
-    @Nullable
-    private final Integer exportLimit;
-    @Nullable
-    private final Integer importChunkSize;
+    private final int exportLimit;
+    private final int importChunkSize;
     @Nonnull
     private final YamlExecutionContext executionContext;
 
     private CopyBlock(@Nonnull YamlReference reference,
                       int sourceCluster, @Nonnull String sourcePath,
                       int destCluster, @Nonnull String destPath,
-                      @Nullable Integer exportLimit, @Nullable Integer importChunkSize,
+                      int exportLimit, int importChunkSize,
                       @Nonnull YamlExecutionContext executionContext) {
         super(reference);
         this.sourceCluster = sourceCluster;
@@ -112,22 +109,16 @@ public class CopyBlock extends ReferencedBlock implements Block {
                                     @Nonnull YamlExecutionContext executionContext) {
         try {
             final Map<?, ?> blockMap = CustomYamlConstructor.LinedObject.unlineKeys(Matchers.map(document, COPY_BLOCK));
-            final Map<?, ?> sourceMap = CustomYamlConstructor.LinedObject.unlineKeys(
-                    Matchers.map(blockMap.get("source"), "copy_block source"));
-            final int sourceCluster = sourceMap.containsKey("cluster")
-                    ? ((Number) sourceMap.get("cluster")).intValue() : 0;
-            final String sourcePath = Matchers.string(sourceMap.get("path"), "copy_block source path");
+            final Map<?, ?> sourceMap = getMap(blockMap, "source");
+            final int sourceCluster = getIntOrDefault(sourceMap, "cluster", 0);
+            final String sourcePath = getString(sourceMap, "path", "source path");
 
-            final Map<?, ?> destMap = CustomYamlConstructor.LinedObject.unlineKeys(
-                    Matchers.map(blockMap.get("dest"), "copy_block dest"));
-            final int destCluster = destMap.containsKey("cluster")
-                    ? ((Number) destMap.get("cluster")).intValue() : 0;
-            final String destPath = Matchers.string(destMap.get("path"), "copy_block dest path");
+            final Map<?, ?> destMap = getMap(blockMap, "dest");
+            final int destCluster = getIntOrDefault(destMap, "cluster", 0);
+            final String destPath = getString(destMap, "path", "dest path");
 
-            final Integer exportLimit = blockMap.containsKey("export_limit")
-                    ? ((Number) blockMap.get("export_limit")).intValue() : null;
-            final Integer importChunkSize = blockMap.containsKey("import_chunk_size")
-                    ? ((Number) blockMap.get("import_chunk_size")).intValue() : null;
+            final int exportLimit = getIntOrDefault(blockMap, "export_limit", 0);
+            final int importChunkSize = getIntOrDefault(blockMap, "import_chunk_size", 0);
 
             return List.of(new CopyBlock(reference, sourceCluster, sourcePath, destCluster, destPath,
                     exportLimit, importChunkSize, executionContext));
@@ -135,6 +126,20 @@ public class CopyBlock extends ReferencedBlock implements Block {
             throw YamlExecutionContext.wrapContext(e,
                     () -> "Error parsing copy_block at " + reference, COPY_BLOCK, reference);
         }
+    }
+
+    @Nonnull
+    private static String getString(final Map<?, ?> sourceMap, String key, String description) {
+        final String fullDescription = "copy_block " + description;
+        return Matchers.notNull(Matchers.string(sourceMap.get(key), fullDescription), fullDescription);
+    }
+
+    private static int getIntOrDefault(final Map<?, ?> sourceMap, String key, int defaultValue) {
+        return sourceMap.containsKey(key) ? ((Number)sourceMap.get(key)).intValue() : defaultValue;
+    }
+
+    private static Map<?, ?> getMap(final Map<?, ?> blockMap, String name) {
+        return CustomYamlConstructor.LinedObject.unlineKeys(Matchers.map(blockMap.get(name), "copy_block " + name));
     }
 
     @Override
@@ -158,14 +163,14 @@ public class CopyBlock extends ReferencedBlock implements Block {
         try (YamlConnection conn = executionContext.getConnectionFactory().getNewConnection(CATALOG_URI, sourceCluster)) {
             final List<byte[]> allData = new ArrayList<>();
             try (RelationalStatement stmt = conn.createStatement()) {
-                if (exportLimit != null) {
+                if (exportLimit > 0) {
                     stmt.setMaxRows(exportLimit);
                 }
                 try (RelationalResultSet rs = stmt.executeQuery("COPY " + sourcePath)) {
                     while (rs.next()) {
                         allData.add(rs.getBytes(1));
                     }
-                    if (exportLimit != null) {
+                    if (exportLimit > 0) {
                         Assert.thatUnchecked(allData.size() <= exportLimit,
                                 "Expected at most " + exportLimit + " rows from initial export batch, got " + allData.size());
                         Continuation continuation = rs.getContinuation();
@@ -216,7 +221,7 @@ public class CopyBlock extends ReferencedBlock implements Block {
 
     @Nonnull
     private List<List<byte[]>> partition(@Nonnull List<byte[]> data) {
-        if (importChunkSize == null || importChunkSize >= data.size()) {
+        if (importChunkSize <= 0 || importChunkSize >= data.size()) {
             return List.of(data);
         }
         final List<List<byte[]>> chunks = new ArrayList<>();

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/CopyBlock.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/CopyBlock.java
@@ -82,11 +82,11 @@ public class CopyBlock extends ReferencedBlock implements Block {
     @Nonnull
     private final YamlExecutionContext executionContext;
 
-    private CopyBlock(@Nonnull YamlReference reference,
-                      int sourceCluster, @Nonnull String sourcePath,
-                      int destCluster, @Nonnull String destPath,
-                      int exportLimit, int importChunkSize,
-                      @Nonnull YamlExecutionContext executionContext) {
+    private CopyBlock(@Nonnull final YamlReference reference,
+                      final int sourceCluster, @Nonnull final String sourcePath,
+                      final int destCluster, @Nonnull final String destPath,
+                      final int exportLimit, final int importChunkSize,
+                      @Nonnull final YamlExecutionContext executionContext) {
         super(reference);
         this.sourceCluster = sourceCluster;
         this.sourcePath = sourcePath;
@@ -105,8 +105,9 @@ public class CopyBlock extends ReferencedBlock implements Block {
      * @param executionContext the execution context
      * @return a singleton list containing the parsed {@link CopyBlock}
      */
-    public static List<Block> parse(@Nonnull YamlReference reference, @Nonnull Object document,
-                                    @Nonnull YamlExecutionContext executionContext) {
+    @Nonnull
+    public static List<Block> parse(@Nonnull final YamlReference reference, @Nonnull final Object document,
+                                    @Nonnull final YamlExecutionContext executionContext) {
         try {
             final Map<?, ?> blockMap = CustomYamlConstructor.LinedObject.unlineKeys(Matchers.map(document, COPY_BLOCK));
             final Map<?, ?> sourceMap = getMap(blockMap, "source");
@@ -129,17 +130,20 @@ public class CopyBlock extends ReferencedBlock implements Block {
     }
 
     @Nonnull
-    private static String getString(final Map<?, ?> sourceMap, String key, String description) {
-        final String fullDescription = "copy_block " + description;
+    private static String getString(@Nonnull final Map<?, ?> sourceMap, @Nonnull final String key,
+                                    @Nonnull final String description) {
+        final String fullDescription = COPY_BLOCK + " " + description;
         return Matchers.notNull(Matchers.string(sourceMap.get(key), fullDescription), fullDescription);
     }
 
-    private static int getIntOrDefault(final Map<?, ?> sourceMap, String key, int defaultValue) {
+    private static int getIntOrDefault(@Nonnull final Map<?, ?> sourceMap, @Nonnull final String key,
+                                       final int defaultValue) {
         return sourceMap.containsKey(key) ? ((Number)sourceMap.get(key)).intValue() : defaultValue;
     }
 
-    private static Map<?, ?> getMap(final Map<?, ?> blockMap, String name) {
-        return CustomYamlConstructor.LinedObject.unlineKeys(Matchers.map(blockMap.get(name), "copy_block " + name));
+    @Nonnull
+    private static Map<?, ?> getMap(@Nonnull final Map<?, ?> blockMap, @Nonnull final String name) {
+        return CustomYamlConstructor.LinedObject.unlineKeys(Matchers.map(blockMap.get(name), COPY_BLOCK + " " + name));
     }
 
     @Override
@@ -159,6 +163,7 @@ public class CopyBlock extends ReferencedBlock implements Block {
         }
     }
 
+    @Nonnull
     private List<byte[]> executeExport() throws SQLException {
         try (YamlConnection conn = executionContext.getConnectionFactory().getNewConnection(CATALOG_URI, sourceCluster)) {
             final List<byte[]> allData = new ArrayList<>();
@@ -167,60 +172,74 @@ public class CopyBlock extends ReferencedBlock implements Block {
                     stmt.setMaxRows(exportLimit);
                 }
                 try (RelationalResultSet rs = stmt.executeQuery("COPY " + sourcePath)) {
-                    while (rs.next()) {
-                        allData.add(rs.getBytes(1));
+                    Continuation continuation = collectExportBatch(rs, allData);
+                    while (exportLimit > 0 && !continuation.atEnd()) {
+                        continuation = executeContinuation(conn, continuation, allData);
                     }
-                    if (exportLimit > 0) {
-                        Assert.thatUnchecked(allData.size() <= exportLimit,
-                                "Expected at most " + exportLimit + " rows from initial export batch, got " + allData.size());
-                        Continuation continuation = rs.getContinuation();
-                        while (!continuation.atEnd()) {
-                            final int sizeBefore = allData.size();
-                            try (RelationalPreparedStatement ps = conn.prepareStatement("EXECUTE CONTINUATION ?")) {
-                                ps.setBytes(1, continuation.serialize());
-                                ps.setMaxRows(exportLimit);
-                                try (RelationalResultSet crs = ps.executeQuery()) {
-                                    while (crs.next()) {
-                                        allData.add(crs.getBytes(1));
-                                    }
-                                    continuation = crs.getContinuation();
-                                }
-                            }
-                            final int batchSize = allData.size() - sizeBefore;
-                            Assert.thatUnchecked(batchSize <= exportLimit,
-                                    "Expected at most " + exportLimit + " rows from continuation batch, got " + batchSize);
-                        }
-                    }
+
+                    Assert.thatUnchecked(continuation.atEnd(), "Should have exhausted continuations");
                 }
             }
             return allData;
         }
     }
 
-    private void executeImport(@Nonnull List<byte[]> data) throws SQLException {
+    @Nonnull
+    private Continuation executeContinuation(@Nonnull final YamlConnection conn, @Nonnull final Continuation continuation,
+                                             @Nonnull final List<byte[]> allData) throws SQLException {
+        try (RelationalPreparedStatement ps = conn.prepareStatement("EXECUTE CONTINUATION ?")) {
+            ps.setBytes(1, continuation.serialize());
+            ps.setMaxRows(exportLimit);
+            try (RelationalResultSet crs = ps.executeQuery()) {
+                return collectExportBatch(crs, allData);
+            }
+        }
+    }
+
+    @Nonnull
+    private Continuation collectExportBatch(@Nonnull RelationalResultSet rs,
+                                            @Nonnull List<byte[]> allData) throws SQLException {
+        final int sizeBefore = allData.size();
+        while (rs.next()) {
+            allData.add(rs.getBytes(1));
+        }
+        if (exportLimit > 0) {
+            final int batchSize = allData.size() - sizeBefore;
+            Assert.thatUnchecked(batchSize <= exportLimit,
+                    "Expected at most " + exportLimit + " rows from export batch, got " + batchSize);
+        }
+        return rs.getContinuation();
+    }
+
+    private void executeImport(@Nonnull final List<byte[]> data) throws SQLException {
         try (YamlConnection conn = executionContext.getConnectionFactory().getNewConnection(CATALOG_URI, destCluster)) {
             final List<List<byte[]>> chunks = partition(data);
             int totalCount = 0;
             for (List<byte[]> chunk : chunks) {
-                try (RelationalPreparedStatement ps = conn.prepareStatement("COPY " + destPath + " FROM ?")) {
-                    java.sql.Array array = ps.getConnection().createArrayOf("BINARY", chunk.toArray(new byte[0][]));
-                    ps.setArray(1, array);
-                    try (RelationalResultSet rs = ps.executeQuery()) {
-                        if (rs.next()) {
-                            final int count = rs.getInt(1);
-                            Assert.thatUnchecked(count == chunk.size(),
-                                    "Expected import count " + chunk.size() + ", got " + count);
-                            totalCount += count;
-                        }
-                    }
-                }
+                totalCount = importChunk(chunk, conn, totalCount);
             }
             logger.debug("📋 Imported {} record(s) to cluster {}", totalCount, destCluster);
         }
     }
 
+    private int importChunk(@Nonnull final List<byte[]> chunk, @Nonnull final YamlConnection conn, int totalCount) throws SQLException {
+        try (RelationalPreparedStatement ps = conn.prepareStatement("COPY " + destPath + " FROM ?")) {
+            java.sql.Array array = ps.getConnection().createArrayOf("BINARY", chunk.toArray(new byte[0][]));
+            ps.setArray(1, array);
+            try (RelationalResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    final int count = rs.getInt(1);
+                    Assert.thatUnchecked(count == chunk.size(),
+                            "Expected import count " + chunk.size() + ", got " + count);
+                    totalCount += count;
+                }
+            }
+        }
+        return totalCount;
+    }
+
     @Nonnull
-    private List<List<byte[]>> partition(@Nonnull List<byte[]> data) {
+    private List<List<byte[]>> partition(@Nonnull final List<byte[]> data) {
         if (importChunkSize <= 0 || importChunkSize >= data.size()) {
             return List.of(data);
         }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/CopyBlock.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/CopyBlock.java
@@ -171,7 +171,10 @@ public class CopyBlock extends ReferencedBlock implements Block {
                 if (exportLimit > 0) {
                     stmt.setMaxRows(exportLimit);
                 }
-                try (RelationalResultSet rs = stmt.executeQuery("COPY " + sourcePath)) {
+                // Currently this only supports `INCREMENT INCARNATION`, because `PRESERVE INCARNATION` is intended for
+                // validating that the copy was done correctly, and thus would need to be a separate thing (either a
+                // separate block, or a separate step in this block that validates they are the same after copying)
+                try (RelationalResultSet rs = stmt.executeQuery("COPY " + sourcePath  + " INCREMENT INCARNATION")) {
                     Continuation continuation = collectExportBatch(rs, allData);
                     while (exportLimit > 0 && !continuation.atEnd()) {
                         continuation = executeContinuation(conn, continuation, allData);

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/CopyBlock.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/CopyBlock.java
@@ -24,6 +24,7 @@ import com.apple.foundationdb.relational.api.Continuation;
 import com.apple.foundationdb.relational.api.RelationalPreparedStatement;
 import com.apple.foundationdb.relational.api.RelationalResultSet;
 import com.apple.foundationdb.relational.api.RelationalStatement;
+import com.apple.foundationdb.relational.util.Assert;
 import com.apple.foundationdb.relational.yamltests.CustomYamlConstructor;
 import com.apple.foundationdb.relational.yamltests.Matchers;
 import com.apple.foundationdb.relational.yamltests.YamlConnection;
@@ -111,7 +112,6 @@ public class CopyBlock extends ReferencedBlock implements Block {
                                     @Nonnull YamlExecutionContext executionContext) {
         try {
             final Map<?, ?> blockMap = CustomYamlConstructor.LinedObject.unlineKeys(Matchers.map(document, COPY_BLOCK));
-            // TODO can this use executionContext.inferConnectionTarget
             final Map<?, ?> sourceMap = CustomYamlConstructor.LinedObject.unlineKeys(
                     Matchers.map(blockMap.get("source"), "copy_block source"));
             final int sourceCluster = sourceMap.containsKey("cluster")
@@ -166,11 +166,14 @@ public class CopyBlock extends ReferencedBlock implements Block {
                         allData.add(rs.getBytes(1));
                     }
                     if (exportLimit != null) {
+                        Assert.thatUnchecked(allData.size() <= exportLimit,
+                                "Expected at most " + exportLimit + " rows from initial export batch, got " + allData.size());
                         Continuation continuation = rs.getContinuation();
                         while (!continuation.atEnd()) {
+                            final int sizeBefore = allData.size();
                             try (RelationalPreparedStatement ps = conn.prepareStatement("EXECUTE CONTINUATION ?")) {
                                 ps.setBytes(1, continuation.serialize());
-                                ps.setMaxRows(exportLimit); // TODO assert maxRows is respected
+                                ps.setMaxRows(exportLimit);
                                 try (RelationalResultSet crs = ps.executeQuery()) {
                                     while (crs.next()) {
                                         allData.add(crs.getBytes(1));
@@ -178,6 +181,9 @@ public class CopyBlock extends ReferencedBlock implements Block {
                                     continuation = crs.getContinuation();
                                 }
                             }
+                            final int batchSize = allData.size() - sizeBefore;
+                            Assert.thatUnchecked(batchSize <= exportLimit,
+                                    "Expected at most " + exportLimit + " rows from continuation batch, got " + batchSize);
                         }
                     }
                 }
@@ -196,8 +202,10 @@ public class CopyBlock extends ReferencedBlock implements Block {
                     ps.setArray(1, array);
                     try (RelationalResultSet rs = ps.executeQuery()) {
                         if (rs.next()) {
-                            // TODO assert count is same as chunk size
-                            totalCount += rs.getInt(1);
+                            final int count = rs.getInt(1);
+                            Assert.thatUnchecked(count == chunk.size(),
+                                    "Expected import count " + chunk.size() + ", got " + count);
+                            totalCount += count;
                         }
                     }
                 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/CopyBlock.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/CopyBlock.java
@@ -1,0 +1,219 @@
+/*
+ * CopyBlock.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.relational.yamltests.block;
+
+import com.apple.foundationdb.relational.api.Continuation;
+import com.apple.foundationdb.relational.api.RelationalPreparedStatement;
+import com.apple.foundationdb.relational.api.RelationalResultSet;
+import com.apple.foundationdb.relational.api.RelationalStatement;
+import com.apple.foundationdb.relational.yamltests.CustomYamlConstructor;
+import com.apple.foundationdb.relational.yamltests.Matchers;
+import com.apple.foundationdb.relational.yamltests.YamlConnection;
+import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
+import com.apple.foundationdb.relational.yamltests.YamlReference;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.net.URI;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A block that performs a cross-cluster COPY operation, exporting data from a source cluster and importing it into a
+ * destination cluster. This block manages its own connections (one per cluster) rather than using the single-connection
+ * model of {@link ConnectedBlock}.
+ *
+ * <h2>YAML syntax</h2>
+ * <pre>{@code
+ * copy_block:
+ *   source: { cluster: 0, path: "/FRL/MY_DB" }
+ *   dest: { cluster: 1, path: "/FRL/MY_DB" }
+ *   export_limit: 2        # optional: setMaxRows on export (enables chunked export with continuations)
+ *   import_chunk_size: 1    # optional: split exported data into chunks of this size for import
+ * }</pre>
+ *
+ * <h2>Execution</h2>
+ * <ol>
+ *     <li><b>Export phase:</b> Connects to the source cluster at the catalog URI and executes {@code COPY <path>}.
+ *         If {@code export_limit} is set, uses {@link RelationalStatement#setMaxRows(int)} and follows continuations
+ *         to collect all data.</li>
+ *     <li><b>Import phase:</b> Connects to the dest cluster at the catalog URI and executes
+ *         {@code COPY <path> FROM ?} with the exported data. If {@code import_chunk_size} is set, partitions the
+ *         data into chunks and executes a separate import for each.</li>
+ * </ol>
+ */
+public class CopyBlock extends ReferencedBlock implements Block {
+
+    private static final Logger logger = LogManager.getLogger(CopyBlock.class);
+
+    public static final String COPY_BLOCK = "copy_block";
+    private static final URI CATALOG_URI = URI.create("jdbc:embed:/__SYS?schema=CATALOG");
+
+    private final int sourceCluster;
+    @Nonnull
+    private final String sourcePath;
+    private final int destCluster;
+    @Nonnull
+    private final String destPath;
+    @Nullable
+    private final Integer exportLimit;
+    @Nullable
+    private final Integer importChunkSize;
+    @Nonnull
+    private final YamlExecutionContext executionContext;
+
+    private CopyBlock(@Nonnull YamlReference reference,
+                      int sourceCluster, @Nonnull String sourcePath,
+                      int destCluster, @Nonnull String destPath,
+                      @Nullable Integer exportLimit, @Nullable Integer importChunkSize,
+                      @Nonnull YamlExecutionContext executionContext) {
+        super(reference);
+        this.sourceCluster = sourceCluster;
+        this.sourcePath = sourcePath;
+        this.destCluster = destCluster;
+        this.destPath = destPath;
+        this.exportLimit = exportLimit;
+        this.importChunkSize = importChunkSize;
+        this.executionContext = executionContext;
+    }
+
+    /**
+     * Parses a {@code copy_block} from YAML.
+     *
+     * @param reference the YAML reference for error reporting
+     * @param document the parsed YAML value for this block
+     * @param executionContext the execution context
+     * @return a singleton list containing the parsed {@link CopyBlock}
+     */
+    public static List<Block> parse(@Nonnull YamlReference reference, @Nonnull Object document,
+                                    @Nonnull YamlExecutionContext executionContext) {
+        try {
+            final Map<?, ?> blockMap = CustomYamlConstructor.LinedObject.unlineKeys(Matchers.map(document, COPY_BLOCK));
+            // TODO can this use executionContext.inferConnectionTarget
+            final Map<?, ?> sourceMap = CustomYamlConstructor.LinedObject.unlineKeys(
+                    Matchers.map(blockMap.get("source"), "copy_block source"));
+            final int sourceCluster = sourceMap.containsKey("cluster")
+                    ? ((Number) sourceMap.get("cluster")).intValue() : 0;
+            final String sourcePath = Matchers.string(sourceMap.get("path"), "copy_block source path");
+
+            final Map<?, ?> destMap = CustomYamlConstructor.LinedObject.unlineKeys(
+                    Matchers.map(blockMap.get("dest"), "copy_block dest"));
+            final int destCluster = destMap.containsKey("cluster")
+                    ? ((Number) destMap.get("cluster")).intValue() : 0;
+            final String destPath = Matchers.string(destMap.get("path"), "copy_block dest path");
+
+            final Integer exportLimit = blockMap.containsKey("export_limit")
+                    ? ((Number) blockMap.get("export_limit")).intValue() : null;
+            final Integer importChunkSize = blockMap.containsKey("import_chunk_size")
+                    ? ((Number) blockMap.get("import_chunk_size")).intValue() : null;
+
+            return List.of(new CopyBlock(reference, sourceCluster, sourcePath, destCluster, destPath,
+                    exportLimit, importChunkSize, executionContext));
+        } catch (Exception e) {
+            throw YamlExecutionContext.wrapContext(e,
+                    () -> "Error parsing copy_block at " + reference, COPY_BLOCK, reference);
+        }
+    }
+
+    @Override
+    public void execute() {
+        try {
+            logger.debug("📋 Starting copy from cluster {} ({}) to cluster {} ({})",
+                    sourceCluster, sourcePath, destCluster, destPath);
+            final List<byte[]> exportedData = executeExport();
+            if (logger.isDebugEnabled()) {
+                logger.debug("📋 Exported {} record(s) from cluster {}", exportedData.size(), sourceCluster);
+            }
+            executeImport(exportedData);
+            logger.debug("📋 Copy complete");
+        } catch (Exception e) {
+            throw YamlExecutionContext.wrapContext(e,
+                    () -> "Error executing copy_block at " + getReference(), COPY_BLOCK, getReference());
+        }
+    }
+
+    private List<byte[]> executeExport() throws SQLException {
+        try (YamlConnection conn = executionContext.getConnectionFactory().getNewConnection(CATALOG_URI, sourceCluster)) {
+            final List<byte[]> allData = new ArrayList<>();
+            try (RelationalStatement stmt = conn.createStatement()) {
+                if (exportLimit != null) {
+                    stmt.setMaxRows(exportLimit);
+                }
+                try (RelationalResultSet rs = stmt.executeQuery("COPY " + sourcePath)) {
+                    while (rs.next()) {
+                        allData.add(rs.getBytes(1));
+                    }
+                    if (exportLimit != null) {
+                        Continuation continuation = rs.getContinuation();
+                        while (!continuation.atEnd()) {
+                            try (RelationalPreparedStatement ps = conn.prepareStatement("EXECUTE CONTINUATION ?")) {
+                                ps.setBytes(1, continuation.serialize());
+                                ps.setMaxRows(exportLimit); // TODO assert maxRows is respected
+                                try (RelationalResultSet crs = ps.executeQuery()) {
+                                    while (crs.next()) {
+                                        allData.add(crs.getBytes(1));
+                                    }
+                                    continuation = crs.getContinuation();
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            return allData;
+        }
+    }
+
+    private void executeImport(@Nonnull List<byte[]> data) throws SQLException {
+        try (YamlConnection conn = executionContext.getConnectionFactory().getNewConnection(CATALOG_URI, destCluster)) {
+            final List<List<byte[]>> chunks = partition(data);
+            int totalCount = 0;
+            for (List<byte[]> chunk : chunks) {
+                try (RelationalPreparedStatement ps = conn.prepareStatement("COPY " + destPath + " FROM ?")) {
+                    ps.setObject(1, chunk);
+                    try (RelationalResultSet rs = ps.executeQuery()) {
+                        if (rs.next()) {
+                            // TODO assert count is same as chunk size
+                            totalCount += rs.getInt("COUNT");
+                        }
+                    }
+                }
+            }
+            logger.debug("📋 Imported {} record(s) to cluster {}", totalCount, destCluster);
+        }
+    }
+
+    @Nonnull
+    private List<List<byte[]>> partition(@Nonnull List<byte[]> data) {
+        if (importChunkSize == null || importChunkSize >= data.size()) {
+            return List.of(data);
+        }
+        final List<List<byte[]>> chunks = new ArrayList<>();
+        for (int i = 0; i < data.size(); i += importChunkSize) {
+            chunks.add(data.subList(i, Math.min(i + importChunkSize, data.size())));
+        }
+        return chunks;
+    }
+}

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/CopyBlock.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/CopyBlock.java
@@ -192,7 +192,8 @@ public class CopyBlock extends ReferencedBlock implements Block {
             int totalCount = 0;
             for (List<byte[]> chunk : chunks) {
                 try (RelationalPreparedStatement ps = conn.prepareStatement("COPY " + destPath + " FROM ?")) {
-                    ps.setObject(1, chunk);
+                    java.sql.Array array = ps.getConnection().createArrayOf("BINARY", chunk.toArray(new byte[0][]));
+                    ps.setArray(1, array);
                     try (RelationalResultSet rs = ps.executeQuery()) {
                         if (rs.next()) {
                             // TODO assert count is same as chunk size

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/CopyBlock.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/CopyBlock.java
@@ -196,7 +196,7 @@ public class CopyBlock extends ReferencedBlock implements Block {
                     try (RelationalResultSet rs = ps.executeQuery()) {
                         if (rs.next()) {
                             // TODO assert count is same as chunk size
-                            totalCount += rs.getInt("COUNT");
+                            totalCount += rs.getInt(1);
                         }
                     }
                 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/CopyBlock.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/CopyBlock.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2021-2026 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,7 +56,8 @@ import java.util.Map;
  *
  * <h2>Execution</h2>
  * <ol>
- *     <li><b>Export phase:</b> Connects to the source cluster at the catalog URI and executes {@code COPY <path>}.
+ *     <li><b>Export phase:</b> Connects to the source cluster at the catalog URI and executes
+ *         {@code COPY <path> INCREMENT INCARNATION}.
  *         If {@code export_limit} is set, uses {@link RelationalStatement#setMaxRows(int)} and follows continuations
  *         to collect all data.</li>
  *     <li><b>Import phase:</b> Connects to the dest cluster at the catalog URI and executes
@@ -71,29 +72,20 @@ public class CopyBlock extends ReferencedBlock implements Block {
     public static final String COPY_BLOCK = "copy_block";
     private static final URI CATALOG_URI = URI.create("jdbc:embed:/__SYS?schema=CATALOG");
 
-    private final int sourceCluster;
-    @Nonnull
-    private final String sourcePath;
-    private final int destCluster;
-    @Nonnull
-    private final String destPath;
-    private final int exportLimit;
-    private final int importChunkSize;
     @Nonnull
     private final YamlExecutionContext executionContext;
+    private final CopyInfoForCluster sourceInfo;
+    private final CopyInfoForCluster destInfo;
+
+    record CopyInfoForCluster(int cluster, String path, int chunkSize) { }
 
     private CopyBlock(@Nonnull final YamlReference reference,
-                      final int sourceCluster, @Nonnull final String sourcePath,
-                      final int destCluster, @Nonnull final String destPath,
-                      final int exportLimit, final int importChunkSize,
+                      @Nonnull final CopyInfoForCluster sourceInfo,
+                      @Nonnull final CopyInfoForCluster destInfo,
                       @Nonnull final YamlExecutionContext executionContext) {
         super(reference);
-        this.sourceCluster = sourceCluster;
-        this.sourcePath = sourcePath;
-        this.destCluster = destCluster;
-        this.destPath = destPath;
-        this.exportLimit = exportLimit;
-        this.importChunkSize = importChunkSize;
+        this.sourceInfo = sourceInfo;
+        this.destInfo = destInfo;
         this.executionContext = executionContext;
     }
 
@@ -110,23 +102,23 @@ public class CopyBlock extends ReferencedBlock implements Block {
                                     @Nonnull final YamlExecutionContext executionContext) {
         try {
             final Map<?, ?> blockMap = CustomYamlConstructor.LinedObject.unlineKeys(Matchers.map(document, COPY_BLOCK));
-            final Map<?, ?> sourceMap = getMap(blockMap, "source");
-            final int sourceCluster = getIntOrDefault(sourceMap, "cluster", 0);
-            final String sourcePath = getString(sourceMap, "path", "source path");
 
-            final Map<?, ?> destMap = getMap(blockMap, "dest");
-            final int destCluster = getIntOrDefault(destMap, "cluster", 0);
-            final String destPath = getString(destMap, "path", "dest path");
-
-            final int exportLimit = getIntOrDefault(blockMap, "export_limit", 0);
-            final int importChunkSize = getIntOrDefault(blockMap, "import_chunk_size", 0);
-
-            return List.of(new CopyBlock(reference, sourceCluster, sourcePath, destCluster, destPath,
-                    exportLimit, importChunkSize, executionContext));
+            return List.of(new CopyBlock(reference,
+                    getInfo(blockMap, "source", "export_limit"),
+                    getInfo(blockMap, "dest", "import_chunk_size"),
+                    executionContext));
         } catch (Exception e) {
             throw YamlExecutionContext.wrapContext(e,
                     () -> "Error parsing copy_block at " + reference, COPY_BLOCK, reference);
         }
+    }
+
+    private static CopyInfoForCluster getInfo(Map<?, ?> map, String name, String chunkSizeName) {
+        final Map<?, ?> clusterMap = getMap(map, name);
+        return new CopyInfoForCluster(
+                getIntOrDefault(clusterMap, "cluster", 0),
+                getString(clusterMap, "path", name + " path"),
+                getIntOrDefault(map, chunkSizeName, 0));
     }
 
     @Nonnull
@@ -149,11 +141,11 @@ public class CopyBlock extends ReferencedBlock implements Block {
     @Override
     public void execute() {
         try {
-            logger.debug("📋 Starting copy from cluster {} ({}) to cluster {} ({})",
-                    sourceCluster, sourcePath, destCluster, destPath);
+            logger.debug("📋 Starting copy from {} to {}",
+                    sourceInfo, destInfo);
             final List<byte[]> exportedData = executeExport();
             if (logger.isDebugEnabled()) {
-                logger.debug("📋 Exported {} record(s) from cluster {}", exportedData.size(), sourceCluster);
+                logger.debug("📋 Exported {} record(s) from cluster {}", exportedData.size(), sourceInfo.cluster);
             }
             executeImport(exportedData);
             logger.debug("📋 Copy complete");
@@ -165,18 +157,18 @@ public class CopyBlock extends ReferencedBlock implements Block {
 
     @Nonnull
     private List<byte[]> executeExport() throws SQLException {
-        try (YamlConnection conn = executionContext.getConnectionFactory().getNewConnection(CATALOG_URI, sourceCluster)) {
+        try (YamlConnection conn = executionContext.getConnectionFactory().getNewConnection(CATALOG_URI, sourceInfo.cluster)) {
             final List<byte[]> allData = new ArrayList<>();
             try (RelationalStatement stmt = conn.createStatement()) {
-                if (exportLimit > 0) {
-                    stmt.setMaxRows(exportLimit);
+                if (sourceInfo.chunkSize > 0) {
+                    stmt.setMaxRows(sourceInfo.chunkSize);
                 }
                 // Currently this only supports `INCREMENT INCARNATION`, because `PRESERVE INCARNATION` is intended for
                 // validating that the copy was done correctly, and thus would need to be a separate thing (either a
                 // separate block, or a separate step in this block that validates they are the same after copying)
-                try (RelationalResultSet rs = stmt.executeQuery("COPY " + sourcePath  + " INCREMENT INCARNATION")) {
+                try (RelationalResultSet rs = stmt.executeQuery("COPY " + sourceInfo.path  + " INCREMENT INCARNATION")) {
                     Continuation continuation = collectExportBatch(rs, allData);
-                    while (exportLimit > 0 && !continuation.atEnd()) {
+                    while (sourceInfo.chunkSize > 0 && !continuation.atEnd()) {
                         continuation = executeContinuation(conn, continuation, allData);
                     }
 
@@ -192,7 +184,8 @@ public class CopyBlock extends ReferencedBlock implements Block {
                                              @Nonnull final List<byte[]> allData) throws SQLException {
         try (RelationalPreparedStatement ps = conn.prepareStatement("EXECUTE CONTINUATION ?")) {
             ps.setBytes(1, continuation.serialize());
-            ps.setMaxRows(exportLimit);
+            // we'll only ever have a continuation if this was limited previously, no need to check chunkSize>0
+            ps.setMaxRows(sourceInfo.chunkSize);
             try (RelationalResultSet crs = ps.executeQuery()) {
                 return collectExportBatch(crs, allData);
             }
@@ -206,27 +199,27 @@ public class CopyBlock extends ReferencedBlock implements Block {
         while (rs.next()) {
             allData.add(rs.getBytes(1));
         }
-        if (exportLimit > 0) {
+        if (sourceInfo.chunkSize > 0) {
             final int batchSize = allData.size() - sizeBefore;
-            Assert.thatUnchecked(batchSize <= exportLimit,
-                    "Expected at most " + exportLimit + " rows from export batch, got " + batchSize);
+            Assert.thatUnchecked(batchSize <= sourceInfo.chunkSize,
+                    "Expected at most " + sourceInfo.chunkSize + " rows from export batch, got " + batchSize);
         }
         return rs.getContinuation();
     }
 
     private void executeImport(@Nonnull final List<byte[]> data) throws SQLException {
-        try (YamlConnection conn = executionContext.getConnectionFactory().getNewConnection(CATALOG_URI, destCluster)) {
+        try (YamlConnection conn = executionContext.getConnectionFactory().getNewConnection(CATALOG_URI, destInfo.cluster)) {
             final List<List<byte[]>> chunks = partition(data);
             int totalCount = 0;
             for (List<byte[]> chunk : chunks) {
                 totalCount = importChunk(chunk, conn, totalCount);
             }
-            logger.debug("📋 Imported {} record(s) to cluster {}", totalCount, destCluster);
+            logger.debug("📋 Imported {} record(s) to cluster {}", totalCount, destInfo.cluster);
         }
     }
 
     private int importChunk(@Nonnull final List<byte[]> chunk, @Nonnull final YamlConnection conn, int totalCount) throws SQLException {
-        try (RelationalPreparedStatement ps = conn.prepareStatement("COPY " + destPath + " FROM ?")) {
+        try (RelationalPreparedStatement ps = conn.prepareStatement("COPY " + destInfo.path + " FROM ?")) {
             java.sql.Array array = ps.getConnection().createArrayOf("BINARY", chunk.toArray(new byte[0][]));
             ps.setArray(1, array);
             try (RelationalResultSet rs = ps.executeQuery()) {
@@ -243,12 +236,12 @@ public class CopyBlock extends ReferencedBlock implements Block {
 
     @Nonnull
     private List<List<byte[]>> partition(@Nonnull final List<byte[]> data) {
-        if (importChunkSize <= 0 || importChunkSize >= data.size()) {
+        if (destInfo.chunkSize <= 0 || destInfo.chunkSize >= data.size()) {
             return List.of(data);
         }
         final List<List<byte[]>> chunks = new ArrayList<>();
-        for (int i = 0; i < data.size(); i += importChunkSize) {
-            chunks.add(data.subList(i, Math.min(i + importChunkSize, data.size())));
+        for (int i = 0; i < data.size(); i += destInfo.chunkSize) {
+            chunks.add(data.subList(i, Math.min(i + destInfo.chunkSize, data.size())));
         }
         return chunks;
     }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/CopyBlock.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/CopyBlock.java
@@ -35,6 +35,7 @@ import org.apache.logging.log4j.Logger;
 
 import javax.annotation.Nonnull;
 import java.net.URI;
+import java.sql.Array;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
@@ -226,15 +227,15 @@ public class CopyBlock extends ReferencedBlock implements Block {
 
     private int importChunk(@Nonnull final List<byte[]> chunk, @Nonnull final YamlConnection conn, int totalCount) throws SQLException {
         try (RelationalPreparedStatement ps = conn.prepareStatement("COPY " + destInfo.path + " FROM ?")) {
-            java.sql.Array array = ps.getConnection().createArrayOf("BINARY", chunk.toArray(new byte[0][]));
+            Array array = ps.getConnection().createArrayOf("BINARY", chunk.toArray(new byte[0][]));
             ps.setArray(1, array);
             try (RelationalResultSet rs = ps.executeQuery()) {
-                if (rs.next()) {
-                    final int count = rs.getInt(1);
-                    Assert.thatUnchecked(count == chunk.size(),
-                            "Expected import count " + chunk.size() + ", got " + count);
-                    totalCount += count;
-                }
+                Assert.thatUnchecked(rs.next(), "Import should return 1 row");
+                final int count = rs.getInt(1);
+                Assert.thatUnchecked(count == chunk.size(),
+                        "Expected import count " + chunk.size() + ", got " + count);
+                totalCount += count;
+                Assert.thatUnchecked(!rs.next(), "Import should return exactly 1 row");
             }
         }
         return totalCount;

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/CopyBlock.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/CopyBlock.java
@@ -201,8 +201,14 @@ public class CopyBlock extends ReferencedBlock implements Block {
         }
         if (sourceInfo.chunkSize > 0) {
             final int batchSize = allData.size() - sizeBefore;
-            Assert.thatUnchecked(batchSize <= sourceInfo.chunkSize,
-                    "Expected at most " + sourceInfo.chunkSize + " rows from export batch, got " + batchSize);
+            if (rs.getContinuation().atEnd()) {
+                Assert.thatUnchecked(batchSize <= sourceInfo.chunkSize,
+                        "Expected at most " + sourceInfo.chunkSize + " rows from export batch, got " + batchSize);
+            } else {
+                Assert.thatUnchecked(batchSize == sourceInfo.chunkSize,
+                        "Expected " + sourceInfo.chunkSize + " rows from export batch, got " + batchSize);
+            }
+
         }
         return rs.getContinuation();
     }

--- a/yaml-tests/src/test/java/YamlIntegrationTests.java
+++ b/yaml-tests/src/test/java/YamlIntegrationTests.java
@@ -243,6 +243,11 @@ public class YamlIntegrationTests {
     }
 
     @TestTemplate
+    public void copyBasic(YamlTest.Runner runner) throws Exception {
+        runner.runYamsql("copy-basic.yamsql");
+    }
+
+    @TestTemplate
     public void indexDdl(YamlTest.Runner runner) throws Exception {
         runner.runYamsql("index-ddl.yamsql");
     }

--- a/yaml-tests/src/test/resources/copy-basic-includes/copy-clear-dest.yamsql
+++ b/yaml-tests/src/test/resources/copy-basic-includes/copy-clear-dest.yamsql
@@ -1,0 +1,27 @@
+#
+# copy-clear-dest.yamsql
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Clears the destination database on cluster 1 so a fresh copy can be performed.
+# Drops and recreates the database and schema, reusing the existing template.
+---
+setup:
+  connect: { cluster: 1, uri: "jdbc:embed:/__SYS?schema=CATALOG" }
+  steps:
+    - query: drop database if exists /FRL/COPY_DEST_DB
+    - query: drop schema template if exists COPY_TEMPLATE

--- a/yaml-tests/src/test/resources/copy-basic-includes/copy-clear-dest.yamsql
+++ b/yaml-tests/src/test/resources/copy-basic-includes/copy-clear-dest.yamsql
@@ -25,3 +25,4 @@ setup:
   steps:
     - query: drop database if exists /FRL/COPY_DEST_DB
     - query: drop schema template if exists COPY_TEMPLATE
+    - query: drop schema template if exists COPY_TEMPLATE2

--- a/yaml-tests/src/test/resources/copy-basic-includes/copy-verify-dest.yamsql
+++ b/yaml-tests/src/test/resources/copy-basic-includes/copy-verify-dest.yamsql
@@ -1,0 +1,30 @@
+#
+# copy-verify-dest.yamsql
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Verifies that the copied data arrived correctly on cluster 1.
+---
+test_block:
+  connect: { cluster: 1, uri: "jdbc:embed:/FRL/COPY_DEST_DB?schema=S1" }
+  preset: single_repetition_ordered
+  tests:
+    -
+      - query: select * from T1
+      - result: [{ID: 1, NAME: 'alpha'},
+                 {ID: 2, NAME: 'bravo'},
+                 {ID: 3, NAME: 'charlie'}]

--- a/yaml-tests/src/test/resources/copy-basic-includes/copy-verify-dest.yamsql
+++ b/yaml-tests/src/test/resources/copy-basic-includes/copy-verify-dest.yamsql
@@ -17,7 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Verifies that the copied data arrived correctly on cluster 1.
+# Verifies that all copied data arrived correctly on cluster 1.
 ---
 test_block:
   connect: { cluster: 1, uri: "jdbc:embed:/FRL/COPY_DEST_DB?schema=S1" }
@@ -28,3 +28,21 @@ test_block:
       - result: [{ID: 1, NAME: 'alpha'},
                  {ID: 2, NAME: 'bravo'},
                  {ID: 3, NAME: 'charlie'}]
+---
+test_block:
+  connect: { cluster: 1, uri: "jdbc:embed:/FRL/COPY_DEST_DB?schema=S2" }
+  preset: single_repetition_ordered
+  tests:
+    -
+      - query: select * from T1
+      - result: [{ID: 10, NAME: 'delta'},
+                 {ID: 20, NAME: 'echo'}]
+---
+test_block:
+  connect: { cluster: 1, uri: "jdbc:embed:/FRL/COPY_DEST_DB?schema=S3" }
+  preset: single_repetition_ordered
+  tests:
+    -
+      - query: select * from T2
+      - result: [{ID: 100, VAL: 1000},
+                 {ID: 200, VAL: 2000}]

--- a/yaml-tests/src/test/resources/copy-basic.yamsql
+++ b/yaml-tests/src/test/resources/copy-basic.yamsql
@@ -57,15 +57,6 @@ setup:
     - query: insert into T1 values (2, 'bravo')
     - query: insert into T1 values (3, 'charlie')
 ---
-# Create database on cluster 1 (dest) with the same template
-# TODO don't create the database before moving
-setup:
-  connect: { cluster: 1, uri: "jdbc:embed:/__SYS?schema=CATALOG" }
-  steps:
-    - query: create schema template COPY_TEMPLATE create table T1(ID bigint, NAME string, primary key(ID))
-    - query: create database /FRL/COPY_DEST_DB
-    - query: create schema /FRL/COPY_DEST_DB/S1 with template COPY_TEMPLATE
----
 # Copy data from cluster 0 to cluster 1
 copy_block:
   source: { cluster: 0, path: "/FRL/COPY_SRC_DB" }
@@ -78,7 +69,16 @@ test_block:
   tests:
     -
       - query: select * from T1
-      - result: [{ID: 1, NAME: 'alpha'}, {ID: 2, NAME: 'bravo'}, {ID: 3, NAME: 'charlie'}]
+      - result: [{ID: 1, NAME: 'alpha'},
+                 {ID: 2, NAME: 'bravo'},
+                 {ID: 3, NAME: 'charlie'}]
+---
+# Cleanup cluster 1
+setup:
+  connect: { cluster: 1, uri: "jdbc:embed:/__SYS?schema=CATALOG" }
+  steps:
+    - query: drop database if exists /FRL/COPY_DEST_DB
+    - query: drop schema template if exists COPY_TEMPLATE
 ---
 # Test chunked export with continuations and chunked import
 copy_block:
@@ -86,7 +86,17 @@ copy_block:
   dest: { cluster: 1, path: "/FRL/COPY_DEST_DB" }
   export_limit: 2
   import_chunk_size: 1
-# TODO assert about second copy
+---
+# Verify the data arrived on cluster 1
+test_block:
+  connect: { cluster: 1, uri: "jdbc:embed:/FRL/COPY_DEST_DB?schema=S1" }
+  preset: single_repetition_ordered
+  tests:
+    -
+      - query: select * from T1
+      - result: [{ID: 1, NAME: 'alpha'},
+                 {ID: 2, NAME: 'bravo'},
+                 {ID: 3, NAME: 'charlie'}]
 ---
 # Cleanup cluster 0
 setup:

--- a/yaml-tests/src/test/resources/copy-basic.yamsql
+++ b/yaml-tests/src/test/resources/copy-basic.yamsql
@@ -1,0 +1,102 @@
+#
+# copy-basic.yamsql
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Tests basic cross-cluster COPY: export from cluster 0, import to cluster 1, then verify.
+# Requires at least 2 clusters; skipped otherwise.
+# TODO test moving within a cluster
+# TODO test moving just a schema
+---
+options:
+  required_clusters: 2
+---
+# Cleanup cluster 0
+# TODO this cleanup is going to have to happen a lot, can it be more pithy
+setup:
+  connect: { cluster: 0, uri: "jdbc:embed:/__SYS?schema=CATALOG" }
+  steps:
+    - query: drop database if exists /FRL/COPY_SRC_DB
+    - query: drop schema template if exists COPY_TEMPLATE
+---
+# Cleanup cluster 1
+setup:
+  connect: { cluster: 1, uri: "jdbc:embed:/__SYS?schema=CATALOG" }
+  steps:
+    - query: drop database if exists /FRL/COPY_DEST_DB
+    - query: drop schema template if exists COPY_TEMPLATE
+---
+# Create template, database, and schema on cluster 0 (source)
+setup:
+  connect: { cluster: 0, uri: "jdbc:embed:/__SYS?schema=CATALOG" }
+  steps:
+    - query: create schema template COPY_TEMPLATE create table T1(ID bigint, NAME string, primary key(ID))
+    - query: create database /FRL/COPY_SRC_DB
+    - query: create schema /FRL/COPY_SRC_DB/S1 with template COPY_TEMPLATE
+---
+# Insert data on cluster 0
+setup:
+  connect: { cluster: 0, uri: "jdbc:embed:/FRL/COPY_SRC_DB?schema=S1" }
+  steps:
+    - query: insert into T1 values (1, 'alpha')
+    - query: insert into T1 values (2, 'bravo')
+    - query: insert into T1 values (3, 'charlie')
+---
+# Create database on cluster 1 (dest) with the same template
+# TODO don't create the database before moving
+setup:
+  connect: { cluster: 1, uri: "jdbc:embed:/__SYS?schema=CATALOG" }
+  steps:
+    - query: create schema template COPY_TEMPLATE create table T1(ID bigint, NAME string, primary key(ID))
+    - query: create database /FRL/COPY_DEST_DB
+    - query: create schema /FRL/COPY_DEST_DB/S1 with template COPY_TEMPLATE
+---
+# Copy data from cluster 0 to cluster 1
+copy_block:
+  source: { cluster: 0, path: "/FRL/COPY_SRC_DB" }
+  dest: { cluster: 1, path: "/FRL/COPY_DEST_DB" }
+---
+# Verify the data arrived on cluster 1
+test_block:
+  connect: { cluster: 1, uri: "jdbc:embed:/FRL/COPY_DEST_DB?schema=S1" }
+  preset: single_repetition_ordered
+  tests:
+    -
+      - query: select * from T1
+      - result: [{ID: 1, NAME: 'alpha'}, {ID: 2, NAME: 'bravo'}, {ID: 3, NAME: 'charlie'}]
+---
+# Test chunked export with continuations and chunked import
+copy_block:
+  source: { cluster: 0, path: "/FRL/COPY_SRC_DB" }
+  dest: { cluster: 1, path: "/FRL/COPY_DEST_DB" }
+  export_limit: 2
+  import_chunk_size: 1
+# TODO assert about second copy
+---
+# Cleanup cluster 0
+setup:
+  connect: { cluster: 0, uri: "jdbc:embed:/__SYS?schema=CATALOG" }
+  steps:
+    - query: drop database /FRL/COPY_SRC_DB
+    - query: drop schema template COPY_TEMPLATE
+---
+# Cleanup cluster 1
+setup:
+  connect: { cluster: 1, uri: "jdbc:embed:/__SYS?schema=CATALOG" }
+  steps:
+    - query: drop database /FRL/COPY_DEST_DB
+    - query: drop schema template COPY_TEMPLATE

--- a/yaml-tests/src/test/resources/copy-basic.yamsql
+++ b/yaml-tests/src/test/resources/copy-basic.yamsql
@@ -19,32 +19,35 @@
 
 # Tests basic cross-cluster COPY: export from cluster 0, import to cluster 1, then verify.
 # Requires at least 2 clusters; skipped otherwise.
-# TODO test moving just a schema
 ---
 options:
   required_clusters: 2
   supported_version: !current_version
 ---
 # Cleanup cluster 0
-# TODO this cleanup is going to have to happen a lot, can it be more pithy
 setup:
   connect: { cluster: 0, uri: "jdbc:embed:/__SYS?schema=CATALOG" }
   steps:
     - query: drop database if exists /FRL/COPY_SRC_DB
     - query: drop schema template if exists COPY_TEMPLATE
+    - query: drop schema template if exists COPY_TEMPLATE2
 ---
 include:
     copy-basic-includes/copy-clear-dest.yamsql
 ---
-# Create template, database, and schema on cluster 0 (source)
+# Create two templates, a database with 3 schemas on cluster 0 (source).
+# S1 and S2 share COPY_TEMPLATE, S3 uses COPY_TEMPLATE2.
 setup:
   connect: { cluster: 0, uri: "jdbc:embed:/__SYS?schema=CATALOG" }
   steps:
     - query: create schema template COPY_TEMPLATE create table T1(ID bigint, NAME string, primary key(ID))
+    - query: create schema template COPY_TEMPLATE2 create table T2(ID bigint, VAL bigint, primary key(ID))
     - query: create database /FRL/COPY_SRC_DB
     - query: create schema /FRL/COPY_SRC_DB/S1 with template COPY_TEMPLATE
+    - query: create schema /FRL/COPY_SRC_DB/S2 with template COPY_TEMPLATE
+    - query: create schema /FRL/COPY_SRC_DB/S3 with template COPY_TEMPLATE2
 ---
-# Insert data on cluster 0
+# Insert data into S1
 setup:
   connect: { cluster: 0, uri: "jdbc:embed:/FRL/COPY_SRC_DB?schema=S1" }
   steps:
@@ -52,7 +55,21 @@ setup:
     - query: insert into T1 values (2, 'bravo')
     - query: insert into T1 values (3, 'charlie')
 ---
-# Unlimited copy
+# Insert data into S2
+setup:
+  connect: { cluster: 0, uri: "jdbc:embed:/FRL/COPY_SRC_DB?schema=S2" }
+  steps:
+    - query: insert into T1 values (10, 'delta')
+    - query: insert into T1 values (20, 'echo')
+---
+# Insert data into S3
+setup:
+  connect: { cluster: 0, uri: "jdbc:embed:/FRL/COPY_SRC_DB?schema=S3" }
+  steps:
+    - query: insert into T2 values (100, 1000)
+    - query: insert into T2 values (200, 2000)
+---
+# Unlimited copy of entire database
 copy_block:
   source: { cluster: 0, path: "/FRL/COPY_SRC_DB" }
   dest: { cluster: 1, path: "/FRL/COPY_DEST_DB" }
@@ -73,12 +90,56 @@ copy_block:
 include:
     copy-basic-includes/copy-verify-dest.yamsql
 ---
+include:
+    copy-basic-includes/copy-clear-dest.yamsql
+---
+# Test copying a single schema between clusters
+copy_block:
+  source: { cluster: 0, path: "/FRL/COPY_SRC_DB/S2" }
+  dest: { cluster: 1, path: "/FRL/COPY_DEST_DB/S2" }
+---
+# Verify S2 data arrived
+test_block:
+  connect: { cluster: 1, uri: "jdbc:embed:/FRL/COPY_DEST_DB?schema=S2" }
+  preset: single_repetition_ordered
+  tests:
+    -
+      - query: select * from T1
+      - result: [{ID: 10, NAME: 'delta'},
+                 {ID: 20, NAME: 'echo'}]
+---
+# Verify S1 and S3 do not exist on the destination
+test_block:
+  connect: { cluster: 1, uri: "jdbc:embed:/__SYS?schema=CATALOG" }
+  preset: single_repetition_ordered
+  tests:
+    -
+      - query: select count(*) from "SCHEMAS" where database_id = '/FRL/COPY_DEST_DB' and schema_name = 'S1'
+      - result: [{0}]
+    -
+      - query: select count(*) from "SCHEMAS" where database_id = '/FRL/COPY_DEST_DB' and schema_name = 'S3'
+      - result: [{0}]
+---
+# Create S1 on the destination (template was copied with S2) and verify it has no data
+setup:
+  connect: { cluster: 1, uri: "jdbc:embed:/__SYS?schema=CATALOG" }
+  steps:
+    - query: create schema /FRL/COPY_DEST_DB/S1 with template COPY_TEMPLATE
+---
+test_block:
+  connect: { cluster: 1, uri: "jdbc:embed:/FRL/COPY_DEST_DB?schema=S1" }
+  preset: single_repetition_ordered
+  tests:
+    -
+      - query: select * from T1
+      - result: []
+---
 # Test copying within a cluster
 copy_block:
-      source: { cluster: 0, path: "/FRL/COPY_SRC_DB" }
-      dest: { cluster: 0, path: "/FRL/COPY_DEST_DB" }
-      export_limit: 2
-      import_chunk_size: 3
+  source: { cluster: 0, path: "/FRL/COPY_SRC_DB" }
+  dest: { cluster: 0, path: "/FRL/COPY_DEST_DB" }
+  export_limit: 2
+  import_chunk_size: 3
 ---
 test_block:
   connect: { cluster: 0, uri: "jdbc:embed:/FRL/COPY_DEST_DB?schema=S1" }
@@ -95,7 +156,9 @@ setup:
   connect: { cluster: 0, uri: "jdbc:embed:/__SYS?schema=CATALOG" }
   steps:
     - query: drop database /FRL/COPY_SRC_DB
+    - query: drop database if exists /FRL/COPY_DEST_DB
     - query: drop schema template COPY_TEMPLATE
+    - query: drop schema template COPY_TEMPLATE2
 ---
 include:
     copy-basic-includes/copy-clear-dest.yamsql

--- a/yaml-tests/src/test/resources/copy-basic.yamsql
+++ b/yaml-tests/src/test/resources/copy-basic.yamsql
@@ -19,7 +19,6 @@
 
 # Tests basic cross-cluster COPY: export from cluster 0, import to cluster 1, then verify.
 # Requires at least 2 clusters; skipped otherwise.
-# TODO test moving within a cluster
 # TODO test moving just a schema
 ---
 options:
@@ -34,12 +33,8 @@ setup:
     - query: drop database if exists /FRL/COPY_SRC_DB
     - query: drop schema template if exists COPY_TEMPLATE
 ---
-# Cleanup cluster 1
-setup:
-  connect: { cluster: 1, uri: "jdbc:embed:/__SYS?schema=CATALOG" }
-  steps:
-    - query: drop database if exists /FRL/COPY_DEST_DB
-    - query: drop schema template if exists COPY_TEMPLATE
+include:
+    copy-basic-includes/copy-clear-dest.yamsql
 ---
 # Create template, database, and schema on cluster 0 (source)
 setup:
@@ -57,28 +52,16 @@ setup:
     - query: insert into T1 values (2, 'bravo')
     - query: insert into T1 values (3, 'charlie')
 ---
-# Copy data from cluster 0 to cluster 1
+# Unlimited copy
 copy_block:
   source: { cluster: 0, path: "/FRL/COPY_SRC_DB" }
   dest: { cluster: 1, path: "/FRL/COPY_DEST_DB" }
 ---
-# Verify the data arrived on cluster 1
-test_block:
-  connect: { cluster: 1, uri: "jdbc:embed:/FRL/COPY_DEST_DB?schema=S1" }
-  preset: single_repetition_ordered
-  tests:
-    -
-      - query: select * from T1
-      - result: [{ID: 1, NAME: 'alpha'},
-                 {ID: 2, NAME: 'bravo'},
-                 {ID: 3, NAME: 'charlie'}]
+include:
+    copy-basic-includes/copy-verify-dest.yamsql
 ---
-# Cleanup cluster 1
-setup:
-  connect: { cluster: 1, uri: "jdbc:embed:/__SYS?schema=CATALOG" }
-  steps:
-    - query: drop database if exists /FRL/COPY_DEST_DB
-    - query: drop schema template if exists COPY_TEMPLATE
+include:
+    copy-basic-includes/copy-clear-dest.yamsql
 ---
 # Test chunked export with continuations and chunked import
 copy_block:
@@ -87,9 +70,18 @@ copy_block:
   export_limit: 2
   import_chunk_size: 1
 ---
-# Verify the data arrived on cluster 1
+include:
+    copy-basic-includes/copy-verify-dest.yamsql
+---
+# Test copying within a cluster
+copy_block:
+      source: { cluster: 0, path: "/FRL/COPY_SRC_DB" }
+      dest: { cluster: 0, path: "/FRL/COPY_DEST_DB" }
+      export_limit: 2
+      import_chunk_size: 3
+---
 test_block:
-  connect: { cluster: 1, uri: "jdbc:embed:/FRL/COPY_DEST_DB?schema=S1" }
+  connect: { cluster: 0, uri: "jdbc:embed:/FRL/COPY_DEST_DB?schema=S1" }
   preset: single_repetition_ordered
   tests:
     -
@@ -105,9 +97,5 @@ setup:
     - query: drop database /FRL/COPY_SRC_DB
     - query: drop schema template COPY_TEMPLATE
 ---
-# Cleanup cluster 1
-setup:
-  connect: { cluster: 1, uri: "jdbc:embed:/__SYS?schema=CATALOG" }
-  steps:
-    - query: drop database /FRL/COPY_DEST_DB
-    - query: drop schema template COPY_TEMPLATE
+include:
+    copy-basic-includes/copy-clear-dest.yamsql

--- a/yaml-tests/src/test/resources/copy-basic.yamsql
+++ b/yaml-tests/src/test/resources/copy-basic.yamsql
@@ -24,6 +24,7 @@
 ---
 options:
   required_clusters: 2
+  supported_version: !current_version
 ---
 # Cleanup cluster 0
 # TODO this cleanup is going to have to happen a lot, can it be more pithy


### PR DESCRIPTION
This introduces a new Copy block to test the `COPY` command.

## CopyBlock

A block that performs a cross-cluster COPY operation, exporting data from a source cluster and importing it into a destination cluster. This block manages its own connections (one per cluster) rather than using the single-connection model of `ConnectedBlock`.

### YAML syntax

```yaml
copy_block:
  source: { cluster: 0, path: "/FRL/MY_DB" }
  dest: { cluster: 1, path: "/FRL/MY_DB" }
  export_limit: 2        # optional: setMaxRows on export (enables chunked export with continuations)
  import_chunk_size: 1    # optional: split exported data into chunks of this size for import
```

### Execution

1. **Export phase:** Connects to the source cluster at the catalog URI and executes `COPY <path> INCREMENT INCARNATION`. If `export_limit` is set, uses `RelationalStatement.setMaxRows(int)` and follows continuations to collect all data.
2. **Import phase:** Connects to the dest cluster at the catalog URI and executes `COPY <path> FROM ?` with the exported data. If `import_chunk_size` is set, partitions the data into chunks and executes a separate import for each.
