### PR TITLE
Support Arrays of byte[] and float in JDBC

### DIFF
--- a/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/TypeConversion.java
+++ b/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/TypeConversion.java
@@ -432,7 +432,14 @@ public class TypeConversion {
                 builder.setString((String)obj);
                 break;
             case Types.BINARY:
-                builder.setBinary((ByteString)obj);
+                if (obj instanceof ByteString) {
+                    builder.setBinary((ByteString)obj);
+                } else if (obj instanceof byte[]) {
+                    builder.setBinary(ByteString.copyFrom((byte[]) obj));
+                } else {
+                    throw new SQLException(obj.getClass().getCanonicalName() + " is not a valid BINARY object",
+                            ErrorCode.INVALID_BINARY_REPRESENTATION.getErrorCode());
+                }
                 break;
             case Types.FLOAT:
                 builder.setFloat((Float) obj);

--- a/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/TypeConversion.java
+++ b/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/TypeConversion.java
@@ -351,6 +351,9 @@ public class TypeConversion {
             case Types.BINARY:
                 checkColumnType(columnType, column.hasBinary());
                 return column.getBinary().toByteArray();
+            case Types.FLOAT:
+                checkColumnType(columnType, column.hasFloat());
+                return column.getFloat();
             case Types.DOUBLE:
                 checkColumnType(columnType, column.hasDouble());
                 return column.getDouble();
@@ -417,28 +420,31 @@ public class TypeConversion {
         Column.Builder builder = Column.newBuilder();
         switch (columnType) {
             case Types.BIGINT:
-                builder = builder.setLong((Long)obj);
+                builder.setLong((Long)obj);
                 break;
             case Types.INTEGER:
-                builder = builder.setInteger((Integer)obj);
+                builder.setInteger((Integer)obj);
                 break;
             case Types.BOOLEAN:
-                builder = builder.setBoolean((Boolean)obj);
+                builder.setBoolean((Boolean)obj);
                 break;
             case Types.VARCHAR:
-                builder = builder.setString((String)obj);
+                builder.setString((String)obj);
                 break;
             case Types.BINARY:
-                builder = builder.setBinary((ByteString)obj);
+                builder.setBinary((ByteString)obj);
+                break;
+            case Types.FLOAT:
+                builder.setFloat((Float) obj);
                 break;
             case Types.DOUBLE:
-                builder = builder.setDouble((Double)obj);
+                builder.setDouble((Double)obj);
                 break;
             case Types.ARRAY:
-                builder = builder.setArray(toArray((java.sql.Array)obj));
+                builder.setArray(toArray((java.sql.Array)obj));
                 break;
             case Types.NULL:
-                builder = builder.setNullType((Integer)obj);
+                builder.setNullType((Integer)obj);
                 break;
             default:
                 throw new SQLException("java.sql.Type=" + columnType + " not supported",

--- a/fdb-relational-jdbc/fdb-relational-jdbc.gradle
+++ b/fdb-relational-jdbc/fdb-relational-jdbc.gradle
@@ -44,6 +44,7 @@ dependencies {
     testCompileOnly(libs.bundles.test.compileOnly)
     // Server in the TEST context ONLY!!
     testImplementation project(":fdb-relational-server")
+    testImplementation project(":fdb-test-utils")
     testImplementation(testFixtures(project(":fdb-relational-server")))
     // FDB Relational core test fixture in the TEST context only -- not in main!!!!
     testImplementation(testFixtures(project(":fdb-relational-core")))

--- a/fdb-relational-jdbc/src/main/java/com/apple/foundationdb/relational/jdbc/JDBCRelationalConnection.java
+++ b/fdb-relational-jdbc/src/main/java/com/apple/foundationdb/relational/jdbc/JDBCRelationalConnection.java
@@ -415,7 +415,7 @@ class JDBCRelationalConnection implements RelationalConnection {
 
     @Override
     public Struct createStruct(String typeName, Object[] attributes) throws SQLException {
-        // TODO: Implement
+        // TODO: Implement: https://github.com/FoundationDB/fdb-record-layer/issues/4064
         return null;
     }
 

--- a/fdb-relational-jdbc/src/test/java/com/apple/foundationdb/relational/jdbc/JDBCParameterizedQueryComparisonTest.java
+++ b/fdb-relational-jdbc/src/test/java/com/apple/foundationdb/relational/jdbc/JDBCParameterizedQueryComparisonTest.java
@@ -29,6 +29,7 @@ import com.apple.foundationdb.relational.recordlayer.RelationalKeyspaceProvider;
 import com.apple.foundationdb.relational.server.InProcessRelationalServer;
 import com.apple.foundationdb.test.FDBTestEnvironment;
 import com.apple.test.ParameterizedTestUtils;
+import com.apple.test.RandomizedTestUtils;
 import com.google.protobuf.ByteString;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -52,8 +53,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Random;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 /**
@@ -89,11 +92,11 @@ public class JDBCParameterizedQueryComparisonTest {
      * optionally {@link #assertEquals} to customize behavior per type.
      */
     enum TypeTestCase {
-        BIGINT("bigint", "", "BIGINT", new Object[] {10L, 20L, 30L}) {
+        BIGINT("bigint", "", "BIGINT") {
             @Nonnull
             @Override
-            Object createValue(@Nonnull Connection conn) {
-                return 42L;
+            Object createValue(@Nonnull Connection conn, @Nonnull Random random) {
+                return random.nextLong();
             }
 
             @Override
@@ -107,11 +110,11 @@ public class JDBCParameterizedQueryComparisonTest {
                 return resultSet.getLong(columnIndex);
             }
         },
-        INTEGER("integer", "", "INTEGER", new Object[] {10, 20, 30}) {
+        INTEGER("integer", "", "INTEGER") {
             @Nonnull
             @Override
-            Object createValue(@Nonnull Connection conn) {
-                return 42;
+            Object createValue(@Nonnull Connection conn, @Nonnull Random random) {
+                return random.nextInt();
             }
 
             @Override
@@ -125,11 +128,11 @@ public class JDBCParameterizedQueryComparisonTest {
                 return resultSet.getInt(columnIndex);
             }
         },
-        DOUBLE("double", "", "DOUBLE", new Object[] {1.1, 2.2, 3.3}) {
+        DOUBLE("double", "", "DOUBLE") {
             @Nonnull
             @Override
-            Object createValue(@Nonnull Connection conn) {
-                return 3.141592653589793;
+            Object createValue(@Nonnull Connection conn, @Nonnull Random random) {
+                return random.nextDouble();
             }
 
             @Override
@@ -149,11 +152,11 @@ public class JDBCParameterizedQueryComparisonTest {
                         ((Number)actual).doubleValue(), 1e-10, message);
             }
         },
-        FLOAT("float", "", "FLOAT", new Object[] {1.1f, 2.2f, 3.3f}) {
+        FLOAT("float", "", "FLOAT") {
             @Nonnull
             @Override
-            Object createValue(@Nonnull Connection conn) {
-                return 2.718f;
+            Object createValue(@Nonnull Connection conn, @Nonnull Random random) {
+                return random.nextFloat();
             }
 
             @Override
@@ -173,11 +176,11 @@ public class JDBCParameterizedQueryComparisonTest {
                         ((Number)actual).floatValue(), 0.001f, message);
             }
         },
-        STRING("string", "", "STRING", new Object[] {"a", "b", "c"}) {
+        STRING("string", "", "STRING") {
             @Nonnull
             @Override
-            Object createValue(@Nonnull Connection conn) {
-                return "hello world";
+            Object createValue(@Nonnull Connection conn, @Nonnull Random random) {
+                return randomAlphanumericString(random, random.nextInt(20) + 1);
             }
 
             @Override
@@ -191,11 +194,11 @@ public class JDBCParameterizedQueryComparisonTest {
                 return resultSet.getString(columnIndex);
             }
         },
-        BOOLEAN("boolean", "", "BOOLEAN", new Object[] {true, false, true}) {
+        BOOLEAN("boolean", "", "BOOLEAN") {
             @Nonnull
             @Override
-            Object createValue(@Nonnull Connection conn) {
-                return true;
+            Object createValue(@Nonnull Connection conn, @Nonnull Random random) {
+                return random.nextBoolean();
             }
 
             @Override
@@ -209,11 +212,13 @@ public class JDBCParameterizedQueryComparisonTest {
                 return resultSet.getBoolean(columnIndex);
             }
         },
-        BYTES("bytes", "", "BINARY", new Object[] {new byte[] {1, 2, 3, 4, 5}, new byte[] {-1, 0, 1}}) {
+        BYTES("bytes", "", "BINARY") {
             @Nonnull
             @Override
-            Object createValue(@Nonnull Connection conn) {
-                return new byte[] {1, 2, 3, 4, 5};
+            Object createValue(@Nonnull Connection conn, @Nonnull Random random) {
+                byte[] bytes = new byte[random.nextInt(20) + 1];
+                random.nextBytes(bytes);
+                return bytes;
             }
 
             @Override
@@ -232,11 +237,16 @@ public class JDBCParameterizedQueryComparisonTest {
                 Assertions.assertArrayEquals((byte[])expected, (byte[])actual, message);
             }
         },
-        INTEGER_ARRAY("integer array", "", null, null) {
-            @Nullable
+        INTEGER_ARRAY("integer array", "", null) {
+            @Nonnull
             @Override
-            Object createValue(@Nonnull Connection conn) throws SQLException {
-                return conn.createArrayOf("INTEGER", new Object[] {10, 20, 30});
+            Object createValue(@Nonnull Connection conn, @Nonnull Random random) throws SQLException {
+                int count = random.nextInt(5) + 1;
+                Object[] elements = new Object[count];
+                for (int i = 0; i < count; i++) {
+                    elements[i] = random.nextInt();
+                }
+                return conn.createArrayOf("INTEGER", elements);
             }
 
             @Override
@@ -261,11 +271,12 @@ public class JDBCParameterizedQueryComparisonTest {
                 }
             }
         },
-        STRUCT("MyStruct", "CREATE TYPE AS STRUCT MyStruct (f0 bigint, f1 string)", null, null) {
-            @Nullable
+        STRUCT("MyStruct", "CREATE TYPE AS STRUCT MyStruct (f0 bigint, f1 string)", null) {
+            @Nonnull
             @Override
-            Object createValue(@Nonnull Connection conn) throws SQLException {
-                return conn.createStruct("MyStruct", new Object[] {100L, "test_value"});
+            Object createValue(@Nonnull Connection conn, @Nonnull Random random) throws SQLException {
+                return conn.createStruct("MyStruct", new Object[] {random.nextLong(),
+                        randomAlphanumericString(random, random.nextInt(20) + 1)});
             }
 
             @Override
@@ -308,23 +319,19 @@ public class JDBCParameterizedQueryComparisonTest {
          */
         @Nullable
         private final String arrayTypeName;
-        /**
-         * Sample values for creating an array of this type, or {@code null} if arrays are not supported.
-         */
-        @Nullable
-        private final Object[] sampleArrayElements;
 
         TypeTestCase(@Nonnull String columnDdl, @Nonnull String extraTypeDdl,
-                     @Nullable String arrayTypeName,
-                     @Nullable Object[] sampleArrayElements) {
+                     @Nullable String arrayTypeName) {
             this.columnDdl = columnDdl;
             this.extraTypeDdl = extraTypeDdl;
             this.arrayTypeName = arrayTypeName;
-            this.sampleArrayElements = sampleArrayElements;
         }
 
-        @Nullable
-        abstract Object createValue(@Nonnull Connection conn) throws SQLException;
+        /**
+         * Create a random value of this type, suitable for insertion into the test table.
+         */
+        @Nonnull
+        abstract Object createValue(@Nonnull Connection conn, @Nonnull Random random) throws SQLException;
 
         abstract void setTyped(@Nonnull PreparedStatement statement, int parameterIndex, @Nonnull Object val) throws SQLException;
 
@@ -333,6 +340,15 @@ public class JDBCParameterizedQueryComparisonTest {
 
         void assertEquals(@Nonnull String message, @Nonnull Object expected, @Nonnull Object actual) {
             Assertions.assertEquals(expected, actual, message);
+        }
+
+        @Nonnull
+        private static String randomAlphanumericString(@Nonnull Random random, int length) {
+            char[] chars = new char[length];
+            for (int i = 0; i < length; i++) {
+                chars[i] = (char)('a' + random.nextInt(26));
+            }
+            return new String(chars);
         }
 
         /**
@@ -407,6 +423,7 @@ public class JDBCParameterizedQueryComparisonTest {
     @Nonnull
     static Stream<Arguments> testCases() {
         return ParameterizedTestUtils.cartesianProduct(
+                RandomizedTestUtils.randomSeeds(),
                 Arrays.stream(TypeTestCase.values()),
                 ParameterizedTestUtils.booleans("typedSetter", "setObject"),
                 ParameterizedTestUtils.booleans("insertJdbc", "insertEmbedded"),
@@ -415,7 +432,7 @@ public class JDBCParameterizedQueryComparisonTest {
 
     @ParameterizedTest
     @MethodSource("testCases")
-    void testParameterizedInsertAndSelect(@Nonnull TypeTestCase testCase, boolean useTypedSetter,
+    void testParameterizedInsertAndSelect(long seed, @Nonnull TypeTestCase testCase, boolean useTypedSetter,
                                           boolean insertWithJdbc, boolean readWithJdbc) throws Exception {
         if (insertWithJdbc || readWithJdbc) {
             // JDBC does not support createStruct (always returns null), so inserting with jdbc is not supported.
@@ -423,13 +440,14 @@ public class JDBCParameterizedQueryComparisonTest {
             Assumptions.assumeFalse(testCase == TypeTestCase.STRUCT);
         }
 
+        final Random random = new Random(seed);
         createSchema(testCase.columnDdl, testCase.extraTypeDdl);
 
         // Create the value on the insert connection, insert it, then verify the read-back
         // matches the original inserted value (not a freshly created one).
         final Object insertedValue;
         try (Connection insertConn = getConnection(insertWithJdbc)) {
-            insertedValue = testCase.createValue(insertConn);
+            insertedValue = testCase.createValue(insertConn, random);
             Assertions.assertNotNull(insertedValue);
             insert(insertConn, insertedValue, useTypedSetter
                     ? (statement, value) -> testCase.setTyped(statement, 2, value)
@@ -445,20 +463,30 @@ public class JDBCParameterizedQueryComparisonTest {
 
     @ParameterizedTest
     @MethodSource("testCases")
-    void testArrayOfTypeInsertAndSelect(@Nonnull TypeTestCase testCase, boolean useTypedSetter,
+    void testArrayOfTypeInsertAndSelect(long seed, @Nonnull TypeTestCase testCase, boolean useTypedSetter,
                                         boolean insertWithJdbc, boolean readWithJdbc) throws Exception {
         Assumptions.assumeFalse(testCase == TypeTestCase.STRUCT,
                 "createArrayOf does not support STRUCT in either implementation");
         Assumptions.assumeFalse(testCase == TypeTestCase.INTEGER_ARRAY,
                 "array array is not supported by DDL");
 
+        final Random random = new Random(seed);
         createSchema(testCase.columnDdl + " array", testCase.extraTypeDdl);
 
         // Create the array on the insert connection, insert it, then verify the read-back
         // matches the original inserted array elements.
         final Array insertedArray;
         try (Connection insertConn = getConnection(insertWithJdbc)) {
-            insertedArray = insertConn.createArrayOf(testCase.arrayTypeName, testCase.sampleArrayElements);
+            Object[] arrayValue = IntStream.range(0, random.nextInt(20) + 1)
+                    .mapToObj(i -> {
+                        try {
+                            return testCase.createValue(insertConn, random);
+                        } catch (SQLException e) {
+                            throw new RuntimeException(e);
+                        }
+                    })
+                    .toArray(Object[]::new);
+            insertedArray = insertConn.createArrayOf(testCase.arrayTypeName, arrayValue);
             insert(insertConn, insertedArray, useTypedSetter
                     ? (statement, value) -> statement.setArray(2, (Array) value)
                     : (statement, value) -> statement.setObject(2, value));

--- a/fdb-relational-jdbc/src/test/java/com/apple/foundationdb/relational/jdbc/JDBCParameterizedQueryComparisonTest.java
+++ b/fdb-relational-jdbc/src/test/java/com/apple/foundationdb/relational/jdbc/JDBCParameterizedQueryComparisonTest.java
@@ -129,7 +129,7 @@ public class JDBCParameterizedQueryComparisonTest {
             @Nonnull
             @Override
             Object createValue(@Nonnull Connection conn) {
-                return 3.14159;
+                return 3.141592653589793;
             }
 
             @Override
@@ -141,6 +141,12 @@ public class JDBCParameterizedQueryComparisonTest {
             @Override
             Object getTyped(@Nonnull ResultSet resultSet, int columnIndex) throws SQLException {
                 return resultSet.getDouble(columnIndex);
+            }
+
+            @Override
+            void assertEquals(@Nonnull String message, @Nonnull Object expected, @Nonnull Object actual) {
+                Assertions.assertEquals(((Number)expected).doubleValue(),
+                        ((Number)actual).doubleValue(), 1e-10, message);
             }
         },
         FLOAT("float", "", "FLOAT", new Object[] {1.1f, 2.2f, 3.3f}) {

--- a/fdb-relational-jdbc/src/test/java/com/apple/foundationdb/relational/jdbc/JDBCParameterizedQueryComparisonTest.java
+++ b/fdb-relational-jdbc/src/test/java/com/apple/foundationdb/relational/jdbc/JDBCParameterizedQueryComparisonTest.java
@@ -88,7 +88,7 @@ public class JDBCParameterizedQueryComparisonTest {
      * optionally {@link #assertEqual} to customize behavior per type.
      */
     enum TypeTestCase {
-        BIGINT("bigint", null, true, "BIGINT", new Object[]{10L, 20L, 30L}) {
+        BIGINT("bigint", null, true, "BIGINT", true, new Object[]{10L, 20L, 30L}) {
             @Override
             Object createValue(Connection conn) {
                 return 42L;
@@ -104,7 +104,7 @@ public class JDBCParameterizedQueryComparisonTest {
                 return resultSet.getLong(columnIndex);
             }
         },
-        INTEGER("integer", null, true, "INTEGER", new Object[]{10, 20, 30}) {
+        INTEGER("integer", null, true, "INTEGER", true, new Object[]{10, 20, 30}) {
             @Override
             Object createValue(Connection conn) {
                 return 42;
@@ -120,7 +120,7 @@ public class JDBCParameterizedQueryComparisonTest {
                 return resultSet.getInt(columnIndex);
             }
         },
-        DOUBLE("double", null, true, "DOUBLE", new Object[]{1.1, 2.2, 3.3}) {
+        DOUBLE("double", null, true, "DOUBLE", true, new Object[]{1.1, 2.2, 3.3}) {
             @Override
             Object createValue(Connection conn) {
                 return 3.14159;
@@ -136,7 +136,7 @@ public class JDBCParameterizedQueryComparisonTest {
                 return resultSet.getDouble(columnIndex);
             }
         },
-        FLOAT("float", null, true, "FLOAT", new Object[]{1.1f, 2.2f, 3.3f}) {
+        FLOAT("float", null, true, "FLOAT", false, new Object[]{1.1f, 2.2f, 3.3f}) {
             @Override
             Object createValue(Connection conn) {
                 return 2.718f;
@@ -158,7 +158,7 @@ public class JDBCParameterizedQueryComparisonTest {
                         ((Number) actual).floatValue(), 0.001f, message);
             }
         },
-        STRING("string", null, true, "STRING", new Object[]{"a", "b", "c"}) {
+        STRING("string", null, true, "STRING", true, new Object[]{"a", "b", "c"}) {
             @Override
             Object createValue(Connection conn) {
                 return "hello world";
@@ -174,7 +174,7 @@ public class JDBCParameterizedQueryComparisonTest {
                 return resultSet.getString(columnIndex);
             }
         },
-        BOOLEAN("boolean", null, true, "BOOLEAN", new Object[]{true, false, true}) {
+        BOOLEAN("boolean", null, true, "BOOLEAN", true, new Object[]{true, false, true}) {
             @Override
             Object createValue(Connection conn) {
                 return true;
@@ -190,7 +190,7 @@ public class JDBCParameterizedQueryComparisonTest {
                 return resultSet.getBoolean(columnIndex);
             }
         },
-        BYTES("bytes", null, true, null, null) {
+        BYTES("bytes", null, true, null, false, null) {
             @Override
             Object createValue(Connection conn) {
                 return new byte[]{1, 2, 3, 4, 5};
@@ -211,7 +211,7 @@ public class JDBCParameterizedQueryComparisonTest {
                 Assertions.assertArrayEquals((byte[]) expected, (byte[]) actual, message);
             }
         },
-        INTEGER_ARRAY("integer array", null, true, null, null) {
+        INTEGER_ARRAY("integer array", null, true, null, false, null) {
             @Override
             Object createValue(Connection conn) throws SQLException {
                 return conn.createArrayOf("INTEGER", new Object[]{10, 20, 30});
@@ -238,11 +238,7 @@ public class JDBCParameterizedQueryComparisonTest {
                 }
             }
         },
-        /**
-         * JDBC does not support createStruct (always returns {@code null}), so inserting with jdbc is not supported.
-         * See: <a href="https://github.com/FoundationDB/fdb-record-layer/issues/4064">#4064</a>.
-         */
-        STRUCT("MyStruct", "CREATE TYPE AS STRUCT MyStruct (f0 bigint, f1 string)", false, null, null) {
+        STRUCT("MyStruct", "CREATE TYPE AS STRUCT MyStruct (f0 bigint, f1 string)", false, null, false, null) {
             @Override
             Object createValue(Connection conn) throws SQLException {
                 return conn.createStruct("MyStruct", new Object[]{100L, "test_value"});
@@ -284,16 +280,23 @@ public class JDBCParameterizedQueryComparisonTest {
         /** The SQL type name for use with {@code createArrayOf}, or {@code null} if this type cannot be an array element. */
         @Nullable
         private final String arrayTypeName;
+        /**
+         * Whether JDBC {@code createArrayOf} supports this type. {@code false} when {@code TypeConversion.toColumn}
+         * does not handle the JDBC type code (e.g. FLOAT, BINARY).
+         */
+        private final boolean jdbcArraySupported;
         /** Sample values for creating an array of this type, or {@code null} if arrays are not supported. */
         @Nullable
         private final Object[] sampleArrayElements;
 
         TypeTestCase(String columnDdl, @Nullable String extraTypeDdl, boolean jdbcSetterSupported,
-                     @Nullable String arrayTypeName, @Nullable Object[] sampleArrayElements) {
+                     @Nullable String arrayTypeName, boolean jdbcArraySupported,
+                     @Nullable Object[] sampleArrayElements) {
             this.columnDdl = columnDdl;
             this.extraTypeDdl = extraTypeDdl;
             this.jdbcSetterSupported = jdbcSetterSupported;
             this.arrayTypeName = arrayTypeName;
+            this.jdbcArraySupported = jdbcArraySupported;
             this.sampleArrayElements = sampleArrayElements;
         }
 
@@ -386,22 +389,21 @@ public class JDBCParameterizedQueryComparisonTest {
     @MethodSource("testCases")
     void testParameterizedInsertAndSelect(TypeTestCase testCase, boolean useTypedSetter,
                                           boolean insertWithJdbc, boolean readWithJdbc) throws Exception {
-        // JDBC insert requires createValue to succeed on JDBC connections and the JDBC setter to be supported
-        Assumptions.assumeTrue(!insertWithJdbc || testCase.jdbcSetterSupported,
-                "JDBC insert not supported for " + testCase);
+        if (insertWithJdbc || readWithJdbc) {
+            // JDBC does not support createStruct (always returns null), so inserting with jdbc is not supported.
+            // See: https://github.com/FoundationDB/fdb-record-layer/issues/4064
+            Assumptions.assumeFalse(testCase == TypeTestCase.STRUCT);
+        }
 
         createSchema(testCase);
 
         try (Connection insertConn = getConnection(insertWithJdbc)) {
             Object value = testCase.createValue(insertConn);
-            Assumptions.assumeTrue(value != null, "createValue returned null for " + testCase);
             insert(testCase, insertConn, value, useTypedSetter);
         }
 
         try (Connection readConn = getConnection(readWithJdbc)) {
             Object expectedValue = testCase.createValue(readConn);
-            Assumptions.assumeTrue(expectedValue != null,
-                    "createValue returned null for read-side comparison on " + testCase);
             readAndAssert(testCase, readConn, expectedValue,
                     testCase + " " + (useTypedSetter ? "typedSetter" : "setObject")
                             + " " + (insertWithJdbc ? "insertJdbc" : "insertEmbedded")
@@ -413,21 +415,20 @@ public class JDBCParameterizedQueryComparisonTest {
     @MethodSource("testCases")
     void testArrayOfTypeInsertAndSelect(TypeTestCase testCase, boolean useTypedSetter,
                                         boolean insertWithJdbc, boolean readWithJdbc) throws Exception {
-        Assumptions.assumeTrue(testCase.arrayTypeName != null,
-                testCase + " does not support array element type");
-        // JDBC insert requires the JDBC setter to be supported for the array type
-        Assumptions.assumeTrue(!insertWithJdbc || testCase.jdbcSetterSupported,
-                "JDBC insert not supported for " + testCase);
+        Assumptions.assumeFalse(testCase == TypeTestCase.STRUCT,
+                "createArrayOf does not support STRUCT in either implementation");
+        Assumptions.assumeFalse(testCase == TypeTestCase.INTEGER_ARRAY,
+                "array array is not supported by DDL");
 
         createArraySchema(testCase);
 
         try (Connection insertConn = getConnection(insertWithJdbc)) {
-            Array arrayValue = createArrayOfOrSkip(insertConn, testCase);
+            Array arrayValue = insertConn.createArrayOf(testCase.arrayTypeName, testCase.sampleArrayElements);
             insertArray(insertConn, arrayValue, useTypedSetter);
         }
 
         try (Connection readConn = getConnection(readWithJdbc)) {
-            Array expectedArray = createArrayOfOrSkip(readConn, testCase);
+            Array expectedArray = readConn.createArrayOf(testCase.arrayTypeName, testCase.sampleArrayElements);
             readAndAssertArray(readConn, expectedArray,
                     testCase + "_array " + (useTypedSetter ? "typedSetter" : "setObject")
                             + " " + (insertWithJdbc ? "insertJdbc" : "insertEmbedded")
@@ -435,25 +436,11 @@ public class JDBCParameterizedQueryComparisonTest {
         }
     }
 
-    /**
-     * Create an array via {@code createArrayOf}, skipping the test if the connection does not support
-     * creating arrays of this type (e.g. JDBC does not support FLOAT or BINARY in {@code TypeConversion.toColumn}).
-     */
-    private static Array createArrayOfOrSkip(Connection conn, TypeTestCase testCase) throws SQLException {
-        try {
-            Array array = conn.createArrayOf(testCase.arrayTypeName, testCase.sampleArrayElements);
-            Assumptions.assumeTrue(array != null, "createArrayOf returned null for " + testCase);
-            return array;
-        } catch (SQLException e) {
-            Assumptions.abort("createArrayOf not supported for " + testCase + ": " + e.getMessage());
-            throw e; // unreachable
-        }
-    }
-
     private void createArraySchema(TypeTestCase testCase) throws SQLException {
         try (RelationalConnection conn = getJdbcCatalogConnection()) {
             try (RelationalStatement stmt = conn.createStatement()) {
                 String createTemplate = "CREATE SCHEMA TEMPLATE \"" + templateName + "\" " +
+                        (testCase.extraTypeDdl != null ? testCase.extraTypeDdl + " " : "") +
                         "CREATE TABLE test_table (pk bigint, val " + testCase.columnDdl + " array, PRIMARY KEY(pk))";
                 stmt.executeUpdate(createTemplate);
                 stmt.executeUpdate("CREATE SCHEMA \"" + dbPath + "/" + SCHEMA_NAME +

--- a/fdb-relational-jdbc/src/test/java/com/apple/foundationdb/relational/jdbc/JDBCParameterizedQueryComparisonTest.java
+++ b/fdb-relational-jdbc/src/test/java/com/apple/foundationdb/relational/jdbc/JDBCParameterizedQueryComparisonTest.java
@@ -237,40 +237,6 @@ public class JDBCParameterizedQueryComparisonTest {
                 Assertions.assertArrayEquals((byte[])expected, (byte[])actual, message);
             }
         },
-        INTEGER_ARRAY("integer array", "", null) {
-            @Nonnull
-            @Override
-            Object createValue(@Nonnull Connection conn, @Nonnull Random random) throws SQLException {
-                int count = random.nextInt(5) + 1;
-                Object[] elements = new Object[count];
-                for (int i = 0; i < count; i++) {
-                    elements[i] = random.nextInt();
-                }
-                return conn.createArrayOf("INTEGER", elements);
-            }
-
-            @Override
-            void setTyped(@Nonnull PreparedStatement statement, int parameterIndex, @Nonnull Object val) throws SQLException {
-                statement.setArray(parameterIndex, (Array)val);
-            }
-
-            @Nonnull
-            @Override
-            Object getTyped(@Nonnull ResultSet resultSet, int columnIndex) throws SQLException {
-                return resultSet.getArray(columnIndex);
-            }
-
-            @Override
-            void assertEquals(@Nonnull String message, @Nonnull Object expected, @Nonnull Object actual) {
-                try {
-                    List<Object> expectedElements = extractArrayElements(expected);
-                    List<Object> actualElements = extractArrayElements(actual);
-                    Assertions.assertEquals(expectedElements, actualElements, message);
-                } catch (SQLException e) {
-                    throw new AssertionError(message + ": failed to extract array", e);
-                }
-            }
-        },
         STRUCT("MyStruct", "CREATE TYPE AS STRUCT MyStruct (f0 bigint, f1 string)", null) {
             @Nonnull
             @Override
@@ -467,8 +433,7 @@ public class JDBCParameterizedQueryComparisonTest {
                                         boolean insertWithJdbc, boolean readWithJdbc) throws Exception {
         Assumptions.assumeFalse(testCase == TypeTestCase.STRUCT,
                 "createArrayOf does not support STRUCT in either implementation");
-        Assumptions.assumeFalse(testCase == TypeTestCase.INTEGER_ARRAY,
-                "array array is not supported by DDL");
+        // "array array" is not supported in the DDL, if it is we should add test coverage of that
 
         final Random random = new Random(seed);
         createSchema(testCase.columnDdl + " array", testCase.extraTypeDdl);

--- a/fdb-relational-jdbc/src/test/java/com/apple/foundationdb/relational/jdbc/JDBCParameterizedQueryComparisonTest.java
+++ b/fdb-relational-jdbc/src/test/java/com/apple/foundationdb/relational/jdbc/JDBCParameterizedQueryComparisonTest.java
@@ -29,6 +29,7 @@ import com.apple.foundationdb.relational.recordlayer.RelationalKeyspaceProvider;
 import com.apple.foundationdb.relational.server.InProcessRelationalServer;
 import com.apple.foundationdb.test.FDBTestEnvironment;
 import com.apple.test.ParameterizedTestUtils;
+import com.google.protobuf.ByteString;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -39,6 +40,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.sql.Array;
 import java.sql.Connection;
@@ -51,6 +53,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -190,7 +193,7 @@ public class JDBCParameterizedQueryComparisonTest {
                 return resultSet.getBoolean(columnIndex);
             }
         },
-        BYTES("bytes", null, true, null, false, null) {
+        BYTES("bytes", null, true, "BINARY", false, new Object[] {new byte[]{1, 2, 3, 4, 5}, new byte[]{-1, 0, 1}}) {
             @Override
             Object createValue(Connection conn) {
                 return new byte[]{1, 2, 3, 4, 5};
@@ -322,7 +325,8 @@ public class JDBCParameterizedQueryComparisonTest {
             if (arrayObj instanceof RelationalArray) {
                 RelationalResultSet rs = ((RelationalArray) arrayObj).getResultSet();
                 while (rs.next()) {
-                    elements.add(rs.getObject(2)); // column 2 is the value in ARRAY result sets
+                    final Object obj = rs.getObject(2);
+                    elements.add(obj); // column 2 is the value in ARRAY result sets
                 }
             } else if (arrayObj instanceof Array) {
                 Object[] arr = (Object[]) ((Array) arrayObj).getArray();
@@ -471,9 +475,20 @@ public class JDBCParameterizedQueryComparisonTest {
                 Array actualArray = rs.getArray(1);
                 List<Object> expectedElements = TypeTestCase.extractArrayElements(expectedArray);
                 List<Object> actualElements = TypeTestCase.extractArrayElements(actualArray);
-                Assertions.assertEquals(expectedElements, actualElements, description);
+                if (expectedElements.stream().allMatch(obj -> obj instanceof byte[])) {
+                    // If we have List<byte[]> assertEquals will fail unless they are the same, so convert to ByteString
+                    // first so we have an actual equals method
+                    Assertions.assertEquals(asListOfByteStrings(expectedElements), asListOfByteStrings(actualElements));
+                } else {
+                    Assertions.assertEquals(expectedElements, actualElements, description);
+                }
             }
         }
+    }
+
+    @Nonnull
+    private static List<ByteString> asListOfByteStrings(final List<Object> expectedElements) {
+        return expectedElements.stream().map(obj -> ByteString.copyFrom((byte[])obj)).collect(Collectors.toList());
     }
 
     private static RelationalConnection getJdbcCatalogConnection() throws SQLException {

--- a/fdb-relational-jdbc/src/test/java/com/apple/foundationdb/relational/jdbc/JDBCParameterizedQueryComparisonTest.java
+++ b/fdb-relational-jdbc/src/test/java/com/apple/foundationdb/relational/jdbc/JDBCParameterizedQueryComparisonTest.java
@@ -1,0 +1,456 @@
+/*
+ * JDBCParameterizedQueryComparisonTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.relational.jdbc;
+
+import com.apple.foundationdb.relational.api.RelationalArray;
+import com.apple.foundationdb.relational.api.RelationalConnection;
+import com.apple.foundationdb.relational.api.RelationalResultSet;
+import com.apple.foundationdb.relational.api.RelationalStatement;
+import com.apple.foundationdb.relational.api.RelationalStruct;
+import com.apple.foundationdb.relational.recordlayer.RelationalKeyspaceProvider;
+import com.apple.foundationdb.relational.server.InProcessRelationalServer;
+import com.apple.foundationdb.test.FDBTestEnvironment;
+import com.apple.test.ParameterizedTestUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import javax.annotation.Nullable;
+import java.sql.Array;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+/**
+ * Verify that the JDBC (remote/gRPC) driver and the embedded driver produce identical behavior
+ * for parameterized inserts and selects across all SQL types. This catches serialization/deserialization
+ * bugs in the gRPC/protobuf layer.
+ *
+ * <p>The {@link InProcessRelationalServer} creates an {@code FRL} instance which registers both the
+ * embedded driver (for {@code jdbc:embed:} URLs) and the gRPC service (for {@code jdbc:relational:}
+ * URLs). This allows the test to use both connection types against the same backing database.</p>
+ *
+ * <p>The test is parameterized on the cartesian product of:
+ * <ul>
+ *   <li>{@link TypeTestCase} - the SQL type under test</li>
+ *   <li>{@code useTypedSetter} - whether to use type-specific setters (e.g. {@code setLong}) or {@code setObject}</li>
+ *   <li>{@code insertWithJdbc} - whether the insert goes through JDBC (gRPC) or the embedded driver</li>
+ *   <li>{@code readWithJdbc} - whether the read-back goes through JDBC (gRPC) or the embedded driver</li>
+ * </ul>
+ */
+public class JDBCParameterizedQueryComparisonTest {
+
+    private static final String SYS_DB_PATH = "/" + RelationalKeyspaceProvider.SYS;
+    private static final String SCHEMA_NAME = "test_schema";
+    private static final long PRIMARY_KEY = 1;
+
+    private static InProcessRelationalServer server;
+    private static String serverName;
+
+    private String dbPath;
+    private String templateName;
+
+    /**
+     * Enum defining each SQL type test case. The parameterized test iterates over all values.
+     * Subclasses override {@link #createValue}, {@link #setTyped}, {@link #readValue}, and
+     * optionally {@link #assertEqual} to customize behavior per type.
+     */
+    enum TypeTestCase {
+        BIGINT("bigint", null, true) {
+            @Override
+            Object createValue(Connection conn) {
+                return 42L;
+            }
+
+            @Override
+            void setTyped(PreparedStatement statement, int parameterIndex, Object val) throws SQLException {
+                statement.setLong(parameterIndex, (Long) val);
+            }
+
+            @Override
+            Object readValue(ResultSet resultSet, int columnIndex) throws SQLException {
+                return resultSet.getLong(columnIndex);
+            }
+        },
+        INTEGER("integer", null, true) {
+            @Override
+            Object createValue(Connection conn) {
+                return 42;
+            }
+
+            @Override
+            void setTyped(PreparedStatement statement, int parameterIndex, Object val) throws SQLException {
+                statement.setInt(parameterIndex, (Integer) val);
+            }
+
+            @Override
+            Object readValue(ResultSet resultSet, int columnIndex) throws SQLException {
+                return resultSet.getInt(columnIndex);
+            }
+        },
+        DOUBLE("double", null, true) {
+            @Override
+            Object createValue(Connection conn) {
+                return 3.14159;
+            }
+
+            @Override
+            void setTyped(PreparedStatement statement, int parameterIndex, Object val) throws SQLException {
+                statement.setDouble(parameterIndex, (Double) val);
+            }
+
+            @Override
+            Object readValue(ResultSet resultSet, int columnIndex) throws SQLException {
+                return resultSet.getDouble(columnIndex);
+            }
+        },
+        FLOAT("float", null, true) {
+            @Override
+            Object createValue(Connection conn) {
+                return 2.718f;
+            }
+
+            @Override
+            void setTyped(PreparedStatement statement, int parameterIndex, Object val) throws SQLException {
+                statement.setFloat(parameterIndex, (Float) val);
+            }
+
+            @Override
+            Object readValue(ResultSet resultSet, int columnIndex) throws SQLException {
+                return resultSet.getFloat(columnIndex);
+            }
+
+            @Override
+            void assertEqual(String message, Object expected, Object actual) {
+                Assertions.assertEquals(((Number) expected).floatValue(),
+                        ((Number) actual).floatValue(), 0.001f, message);
+            }
+        },
+        STRING("string", null, true) {
+            @Override
+            Object createValue(Connection conn) {
+                return "hello world";
+            }
+
+            @Override
+            void setTyped(PreparedStatement statement, int parameterIndex, Object val) throws SQLException {
+                statement.setString(parameterIndex, (String) val);
+            }
+
+            @Override
+            Object readValue(ResultSet resultSet, int columnIndex) throws SQLException {
+                return resultSet.getString(columnIndex);
+            }
+        },
+        BOOLEAN("boolean", null, true) {
+            @Override
+            Object createValue(Connection conn) {
+                return true;
+            }
+
+            @Override
+            void setTyped(PreparedStatement statement, int parameterIndex, Object val) throws SQLException {
+                statement.setBoolean(parameterIndex, (Boolean) val);
+            }
+
+            @Override
+            Object readValue(ResultSet resultSet, int columnIndex) throws SQLException {
+                return resultSet.getBoolean(columnIndex);
+            }
+        },
+        BYTES("bytes", null, true) {
+            @Override
+            Object createValue(Connection conn) {
+                return new byte[]{1, 2, 3, 4, 5};
+            }
+
+            @Override
+            void setTyped(PreparedStatement statement, int parameterIndex, Object val) throws SQLException {
+                statement.setBytes(parameterIndex, (byte[]) val);
+            }
+
+            @Override
+            Object readValue(ResultSet resultSet, int columnIndex) throws SQLException {
+                return resultSet.getBytes(columnIndex);
+            }
+
+            @Override
+            void assertEqual(String message, Object expected, Object actual) {
+                Assertions.assertArrayEquals((byte[]) expected, (byte[]) actual, message);
+            }
+        },
+        INTEGER_ARRAY("integer array", null, true) {
+            @Override
+            Object createValue(Connection conn) throws SQLException {
+                return conn.createArrayOf("INTEGER", new Object[]{10, 20, 30});
+            }
+
+            @Override
+            void setTyped(PreparedStatement statement, int parameterIndex, Object val) throws SQLException {
+                statement.setArray(parameterIndex, (Array) val);
+            }
+
+            @Override
+            Object readValue(ResultSet resultSet, int columnIndex) throws SQLException {
+                return resultSet.getArray(columnIndex);
+            }
+
+            @Override
+            void assertEqual(String message, Object expected, Object actual) {
+                try {
+                    List<Object> expectedElements = extractArrayElements(expected);
+                    List<Object> actualElements = extractArrayElements(actual);
+                    Assertions.assertEquals(expectedElements, actualElements, message);
+                } catch (SQLException e) {
+                    throw new AssertionError(message + ": failed to extract array", e);
+                }
+            }
+        },
+        /**
+         * JDBC does not support createStruct (always returns {@code null}), so inserting with jdbc is not supported.
+         * See: <a href="https://github.com/FoundationDB/fdb-record-layer/issues/4064">#4064</a>.
+         */
+        STRUCT("MyStruct", "CREATE TYPE AS STRUCT MyStruct (f0 bigint, f1 string)", false) {
+            @Override
+            Object createValue(Connection conn) throws SQLException {
+                return conn.createStruct("MyStruct", new Object[]{100L, "test_value"});
+            }
+
+            @Override
+            void setTyped(PreparedStatement statement, int parameterIndex, Object val) throws SQLException {
+                statement.setObject(parameterIndex, val);
+            }
+
+            @Override
+            Object readValue(ResultSet resultSet, int columnIndex) throws SQLException {
+                RelationalResultSet rrs = resultSet.unwrap(RelationalResultSet.class);
+                return rrs.getStruct(columnIndex);
+            }
+
+            @Override
+            void assertEqual(String message, Object expected, Object actual) {
+                try {
+                    RelationalStruct expStruct = (RelationalStruct) expected;
+                    RelationalStruct actStruct = (RelationalStruct) actual;
+                    int expCount = expStruct.getMetaData().getColumnCount();
+                    int actCount = actStruct.getMetaData().getColumnCount();
+                    Assertions.assertEquals(expCount, actCount, message + " (field count)");
+                    for (int i = 1; i <= expCount; i++) {
+                        Assertions.assertEquals(expStruct.getObject(i), actStruct.getObject(i),
+                                message + " (field " + i + ")");
+                    }
+                } catch (SQLException e) {
+                    throw new AssertionError(message + ": failed to compare structs", e);
+                }
+            }
+        };
+
+        private final String columnDdl;
+        @Nullable
+        private final String extraTypeDdl;
+        private final boolean jdbcSetterSupported;
+
+        TypeTestCase(String columnDdl, @Nullable String extraTypeDdl, boolean jdbcSetterSupported) {
+            this.columnDdl = columnDdl;
+            this.extraTypeDdl = extraTypeDdl;
+            this.jdbcSetterSupported = jdbcSetterSupported;
+        }
+
+        abstract Object createValue(Connection conn) throws SQLException;
+
+        abstract void setTyped(PreparedStatement statement, int parameterIndex, Object val) throws SQLException;
+
+        abstract Object readValue(ResultSet resultSet, int columnIndex) throws SQLException;
+
+        void assertEqual(String message, Object expected, Object actual) {
+            Assertions.assertEquals(expected, actual, message);
+        }
+
+        /**
+         * Extract elements from an array object for comparison. Uses {@code getResultSet()} on
+         * {@link RelationalArray} (returned by result set reads). Falls back to {@code getArray()}
+         * for plain {@link Array} instances (e.g. from {@code createArrayOf}) since
+         * {@link JDBCArrayImpl#getResultSet()} throws {@code SQLFeatureNotSupportedException}.
+         */
+        private static List<Object> extractArrayElements(Object arrayObj) throws SQLException {
+            List<Object> elements = new ArrayList<>();
+            if (arrayObj instanceof RelationalArray) {
+                RelationalResultSet rs = ((RelationalArray) arrayObj).getResultSet();
+                while (rs.next()) {
+                    elements.add(rs.getObject(2)); // column 2 is the value in ARRAY result sets
+                }
+            } else if (arrayObj instanceof Array) {
+                Object[] arr = (Object[]) ((Array) arrayObj).getArray();
+                Collections.addAll(elements, arr);
+            } else {
+                throw new SQLException("Unexpected array type: " + arrayObj.getClass());
+            }
+            return elements;
+        }
+    }
+
+    @BeforeAll
+    public static void beforeAll() throws Exception {
+        // Start in-process gRPC server. This also registers an embedded driver via FRL.
+        server = new InProcessRelationalServer(FDBTestEnvironment.randomClusterFile()).start();
+        serverName = server.getServerName();
+
+        // Load JDBC driver (via ServiceLoader)
+        JDBCRelationalDriverTest.getDriver();
+    }
+
+    @AfterAll
+    public static void afterAll() throws Exception {
+        if (server != null) {
+            server.close();
+        }
+    }
+
+    @BeforeEach
+    public void setUp() throws SQLException {
+        String uuid = UUID.randomUUID().toString().replace("-", "").substring(0, 12);
+        dbPath = "/FRL/parameters_" + uuid;
+        templateName = "template_" + uuid;
+
+        try (RelationalConnection conn = getJdbcCatalogConnection()) {
+            try (RelationalStatement stmt = conn.createStatement()) {
+                stmt.executeUpdate("DROP DATABASE IF EXISTS \"" + dbPath + "\"");
+                stmt.executeUpdate("CREATE DATABASE \"" + dbPath + "\"");
+            }
+        }
+    }
+
+    @AfterEach
+    public void tearDown() {
+        try (RelationalConnection conn = getJdbcCatalogConnection()) {
+            try (RelationalStatement stmt = conn.createStatement()) {
+                stmt.executeUpdate("DROP DATABASE \"" + dbPath + "\"");
+                stmt.executeUpdate("DROP SCHEMA TEMPLATE IF EXISTS \"" + templateName + "\"");
+            }
+        } catch (Exception e) {
+            // best-effort cleanup
+        }
+    }
+
+    static Stream<Arguments> testCases() {
+        return ParameterizedTestUtils.cartesianProduct(
+                Arrays.stream(TypeTestCase.values()),
+                ParameterizedTestUtils.booleans("typedSetter", "setObject"),
+                ParameterizedTestUtils.booleans("insertJdbc", "insertEmbedded"),
+                ParameterizedTestUtils.booleans("readJdbc", "readEmbedded"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("testCases")
+    void testParameterizedInsertAndSelect(TypeTestCase testCase, boolean useTypedSetter,
+                                          boolean insertWithJdbc, boolean readWithJdbc) throws Exception {
+        // JDBC insert requires createValue to succeed on JDBC connections and the JDBC setter to be supported
+        Assumptions.assumeTrue(!insertWithJdbc || testCase.jdbcSetterSupported,
+                "JDBC insert not supported for " + testCase);
+
+        createSchema(testCase);
+
+        try (Connection insertConn = getConnection(insertWithJdbc)) {
+            Object value = testCase.createValue(insertConn);
+            Assumptions.assumeTrue(value != null, "createValue returned null for " + testCase);
+            insert(testCase, insertConn, value, useTypedSetter);
+        }
+
+        try (Connection readConn = getConnection(readWithJdbc)) {
+            Object expectedValue = testCase.createValue(readConn);
+            Assumptions.assumeTrue(expectedValue != null,
+                    "createValue returned null for read-side comparison on " + testCase);
+            readAndAssert(testCase, readConn, expectedValue,
+                    testCase + " " + (useTypedSetter ? "typedSetter" : "setObject")
+                            + " " + (insertWithJdbc ? "insertJdbc" : "insertEmbedded")
+                            + " -> " + (readWithJdbc ? "readJdbc" : "readEmbedded"));
+        }
+    }
+
+    private static RelationalConnection getJdbcCatalogConnection() throws SQLException {
+        String uri = "jdbc:relational://" + SYS_DB_PATH + "?schema=" + RelationalKeyspaceProvider.CATALOG
+                + "&server=" + serverName;
+        return DriverManager.getConnection(uri).unwrap(RelationalConnection.class);
+    }
+
+    private Connection getConnection(boolean useJdbc) throws SQLException {
+        if (useJdbc) {
+            String uri = "jdbc:relational://" + dbPath + "?schema=" + SCHEMA_NAME
+                    + "&server=" + serverName;
+            return DriverManager.getConnection(uri);
+        } else {
+            return DriverManager.getConnection("jdbc:embed:" + dbPath + "?schema=" + SCHEMA_NAME);
+        }
+    }
+
+    private void createSchema(TypeTestCase testCase) throws SQLException {
+        try (RelationalConnection conn = getJdbcCatalogConnection()) {
+            try (RelationalStatement stmt = conn.createStatement()) {
+                String createTemplate = "CREATE SCHEMA TEMPLATE \"" + templateName + "\" " +
+                        (testCase.extraTypeDdl != null ? testCase.extraTypeDdl + " " : "") +
+                        "CREATE TABLE test_table (pk bigint, val " + testCase.columnDdl + ", PRIMARY KEY(pk))";
+                stmt.executeUpdate(createTemplate);
+                stmt.executeUpdate("CREATE SCHEMA \"" + dbPath + "/" + SCHEMA_NAME +
+                        "\" WITH TEMPLATE \"" + templateName + "\"");
+            }
+        }
+    }
+
+    private void insert(TypeTestCase testCase, Connection conn, Object value, boolean useTypedSetter) throws SQLException {
+        try (PreparedStatement ps = conn.prepareStatement(
+                "INSERT INTO test_table (pk, val) VALUES (?, ?)")) {
+            ps.setLong(1, PRIMARY_KEY);
+            if (useTypedSetter) {
+                testCase.setTyped(ps, 2, value);
+            } else {
+                ps.setObject(2, value);
+            }
+            ps.executeUpdate();
+        }
+    }
+
+    private void readAndAssert(TypeTestCase testCase, Connection conn, Object expectedValue, String description) throws SQLException {
+        try (PreparedStatement ps = conn.prepareStatement(
+                "SELECT val FROM test_table WHERE pk = ?")) {
+            ps.setLong(1, PRIMARY_KEY);
+            try (ResultSet rs = ps.executeQuery()) {
+                Assertions.assertTrue(rs.next(), "Expected row for: " + description);
+                Object readValue = testCase.readValue(rs, 1);
+                testCase.assertEqual(description, expectedValue, readValue);
+            }
+        }
+    }
+
+}

--- a/fdb-relational-jdbc/src/test/java/com/apple/foundationdb/relational/jdbc/JDBCParameterizedQueryComparisonTest.java
+++ b/fdb-relational-jdbc/src/test/java/com/apple/foundationdb/relational/jdbc/JDBCParameterizedQueryComparisonTest.java
@@ -423,21 +423,22 @@ public class JDBCParameterizedQueryComparisonTest {
             Assumptions.assumeFalse(testCase == TypeTestCase.STRUCT);
         }
 
-        createSchema(testCase);
+        createSchema(testCase.columnDdl, testCase.extraTypeDdl);
 
         try (Connection insertConn = getConnection(insertWithJdbc)) {
-            Object value = testCase.createValue(insertConn);
-            Assertions.assertNotNull(value);
-            insert(testCase, insertConn, value, useTypedSetter);
+            Object insertValue = testCase.createValue(insertConn);
+            Assertions.assertNotNull(insertValue);
+            insert(insertConn, insertValue, useTypedSetter
+                    ? (statement, value) -> testCase.setTyped(statement, 2, value)
+                    : (statement, value) -> statement.setObject(2, value));
         }
 
         try (Connection readConn = getConnection(readWithJdbc)) {
             Object expectedValue = testCase.createValue(readConn);
             Assertions.assertNotNull(expectedValue);
-            readAndAssert(testCase, readConn, expectedValue,
-                    testCase + " " + (useTypedSetter ? "typedSetter" : "setObject")
-                            + " " + (insertWithJdbc ? "insertJdbc" : "insertEmbedded")
-                            + " -> " + (readWithJdbc ? "readJdbc" : "readEmbedded"));
+            readAndAssert(readConn, expectedValue,
+                    resultSet -> testCase.getTyped(resultSet, 1),
+                    testCase::assertEquals);
         }
     }
 
@@ -450,71 +451,41 @@ public class JDBCParameterizedQueryComparisonTest {
         Assumptions.assumeFalse(testCase == TypeTestCase.INTEGER_ARRAY,
                 "array array is not supported by DDL");
 
-        createArraySchema(testCase);
+        createSchema(testCase.columnDdl + " array", testCase.extraTypeDdl);
 
         try (Connection insertConn = getConnection(insertWithJdbc)) {
             Array arrayValue = insertConn.createArrayOf(testCase.arrayTypeName, testCase.sampleArrayElements);
-            insertArray(insertConn, arrayValue, useTypedSetter);
+            insert(insertConn, arrayValue, useTypedSetter
+                    ? (statement, value) -> statement.setArray(2, (Array) value)
+                    : (statement, value) -> statement.setObject(2, value));
         }
 
         try (Connection readConn = getConnection(readWithJdbc)) {
             Array expectedArray = readConn.createArrayOf(testCase.arrayTypeName, testCase.sampleArrayElements);
-            readAndAssertArray(readConn, expectedArray,
-                    testCase + "_array " + (useTypedSetter ? "typedSetter" : "setObject")
-                            + " " + (insertWithJdbc ? "insertJdbc" : "insertEmbedded")
-                            + " -> " + (readWithJdbc ? "readJdbc" : "readEmbedded"));
+            readAndAssert(readConn, expectedArray,
+                    resultSet -> resultSet.getArray(1),
+                    this::assertArrayEquals);
         }
     }
 
-    private void createArraySchema(@Nonnull TypeTestCase testCase) throws SQLException {
-        try (RelationalConnection conn = getJdbcCatalogConnection()) {
-            try (RelationalStatement stmt = conn.createStatement()) {
-                String createTemplate = "CREATE SCHEMA TEMPLATE \"" + templateName + "\" " +
-                        testCase.extraTypeDdl + " " +
-                        "CREATE TABLE test_table (pk bigint, val " + testCase.columnDdl + " array, PRIMARY KEY(pk))";
-                stmt.executeUpdate(createTemplate);
-                stmt.executeUpdate("CREATE SCHEMA \"" + dbPath + "/" + SCHEMA_NAME +
-                        "\" WITH TEMPLATE \"" + templateName + "\"");
-            }
-        }
-    }
-
-    private void insertArray(@Nonnull Connection conn, @Nonnull Array value, boolean useTypedSetter) throws SQLException {
-        try (PreparedStatement ps = conn.prepareStatement(
-                "INSERT INTO test_table (pk, val) VALUES (?, ?)")) {
-            ps.setLong(1, PRIMARY_KEY);
-            if (useTypedSetter) {
-                ps.setArray(2, value);
+    private void assertArrayEquals(@Nonnull String message, @Nonnull Object expected, @Nonnull Object actual) {
+        try {
+            List<Object> expectedElements = TypeTestCase.extractArrayElements(expected);
+            List<Object> actualElements = TypeTestCase.extractArrayElements(actual);
+            if (expectedElements.stream().allMatch(obj -> obj instanceof byte[])) {
+                // byte[] uses identity equality, so convert to ByteString for comparison
+                Assertions.assertEquals(asListOfByteStrings(expectedElements), asListOfByteStrings(actualElements), message);
             } else {
-                ps.setObject(2, value);
+                Assertions.assertEquals(expectedElements, actualElements, message);
             }
-            ps.executeUpdate();
-        }
-    }
-
-    private void readAndAssertArray(@Nonnull Connection conn, @Nonnull Array expectedArray, @Nonnull String description) throws SQLException {
-        try (PreparedStatement ps = conn.prepareStatement(
-                "SELECT val FROM test_table WHERE pk = ?")) {
-            ps.setLong(1, PRIMARY_KEY);
-            try (ResultSet rs = ps.executeQuery()) {
-                Assertions.assertTrue(rs.next(), "Expected row for: " + description);
-                Array actualArray = rs.getArray(1);
-                List<Object> expectedElements = TypeTestCase.extractArrayElements(expectedArray);
-                List<Object> actualElements = TypeTestCase.extractArrayElements(actualArray);
-                if (expectedElements.stream().allMatch(obj -> obj instanceof byte[])) {
-                    // If we have List<byte[]> assertEquals will fail unless they are the same, so convert to ByteString
-                    // first so we have an actual equals method
-                    Assertions.assertEquals(asListOfByteStrings(expectedElements), asListOfByteStrings(actualElements));
-                } else {
-                    Assertions.assertEquals(expectedElements, actualElements, description);
-                }
-            }
+        } catch (SQLException e) {
+            throw new AssertionError(message + ": failed to extract array", e);
         }
     }
 
     @Nonnull
-    private static List<ByteString> asListOfByteStrings(@Nonnull final List<Object> expectedElements) {
-        return expectedElements.stream().map(obj -> ByteString.copyFrom((byte[])obj)).collect(Collectors.toList());
+    private static List<ByteString> asListOfByteStrings(@Nonnull List<Object> elements) {
+        return elements.stream().map(obj -> ByteString.copyFrom((byte[])obj)).collect(Collectors.toList());
     }
 
     @Nonnull
@@ -535,12 +506,12 @@ public class JDBCParameterizedQueryComparisonTest {
         }
     }
 
-    private void createSchema(@Nonnull TypeTestCase testCase) throws SQLException {
+    private void createSchema(@Nonnull String columnDdl, @Nonnull String extraTypeDdl) throws SQLException {
         try (RelationalConnection conn = getJdbcCatalogConnection()) {
             try (RelationalStatement stmt = conn.createStatement()) {
                 String createTemplate = "CREATE SCHEMA TEMPLATE \"" + templateName + "\" " +
-                        testCase.extraTypeDdl + " " +
-                        "CREATE TABLE test_table (pk bigint, val " + testCase.columnDdl + ", PRIMARY KEY(pk))";
+                        extraTypeDdl + " " +
+                        "CREATE TABLE test_table (pk bigint, val " + columnDdl + ", PRIMARY KEY(pk))";
                 stmt.executeUpdate(createTemplate);
                 stmt.executeUpdate("CREATE SCHEMA \"" + dbPath + "/" + SCHEMA_NAME +
                         "\" WITH TEMPLATE \"" + templateName + "\"");
@@ -548,27 +519,41 @@ public class JDBCParameterizedQueryComparisonTest {
         }
     }
 
-    private void insert(@Nonnull TypeTestCase testCase, @Nonnull Connection conn, @Nonnull Object value, boolean useTypedSetter) throws SQLException {
-        try (PreparedStatement ps = conn.prepareStatement(
+    @FunctionalInterface
+    interface ValueSetter {
+        void set(@Nonnull PreparedStatement statement, @Nonnull Object value) throws SQLException;
+    }
+
+    @FunctionalInterface
+    interface ValueReader {
+        @Nonnull
+        Object read(@Nonnull ResultSet resultSet) throws SQLException;
+    }
+
+    @FunctionalInterface
+    interface EqualityAssertion {
+        void assertEquals(@Nonnull String message, @Nonnull Object expected, @Nonnull Object actual);
+    }
+
+    private void insert(@Nonnull Connection conn, @Nonnull Object value,
+                        @Nonnull ValueSetter setter) throws SQLException {
+        try (PreparedStatement statement = conn.prepareStatement(
                 "INSERT INTO test_table (pk, val) VALUES (?, ?)")) {
-            ps.setLong(1, PRIMARY_KEY);
-            if (useTypedSetter) {
-                testCase.setTyped(ps, 2, value);
-            } else {
-                ps.setObject(2, value);
-            }
-            ps.executeUpdate();
+            statement.setLong(1, PRIMARY_KEY);
+            setter.set(statement, value);
+            statement.executeUpdate();
         }
     }
 
-    private void readAndAssert(@Nonnull TypeTestCase testCase, @Nonnull Connection conn, @Nonnull Object expectedValue, @Nonnull String description) throws SQLException {
-        try (PreparedStatement ps = conn.prepareStatement(
+    private void readAndAssert(@Nonnull Connection conn, @Nonnull Object expectedValue,
+                               @Nonnull ValueReader reader, @Nonnull EqualityAssertion assertion) throws SQLException {
+        try (PreparedStatement statement = conn.prepareStatement(
                 "SELECT val FROM test_table WHERE pk = ?")) {
-            ps.setLong(1, PRIMARY_KEY);
-            try (ResultSet rs = ps.executeQuery()) {
-                Assertions.assertTrue(rs.next(), "Expected row for: " + description);
-                Object readValue = testCase.getTyped(rs, 1);
-                testCase.assertEquals(description, expectedValue, readValue);
+            statement.setLong(1, PRIMARY_KEY);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                Assertions.assertTrue(resultSet.next(), "Expected row");
+                Object readValue = reader.read(resultSet);
+                assertion.assertEquals("read value should match expected", expectedValue, readValue);
             }
         }
     }

--- a/fdb-relational-jdbc/src/test/java/com/apple/foundationdb/relational/jdbc/JDBCParameterizedQueryComparisonTest.java
+++ b/fdb-relational-jdbc/src/test/java/com/apple/foundationdb/relational/jdbc/JDBCParameterizedQueryComparisonTest.java
@@ -425,18 +425,19 @@ public class JDBCParameterizedQueryComparisonTest {
 
         createSchema(testCase.columnDdl, testCase.extraTypeDdl);
 
+        // Create the value on the insert connection, insert it, then verify the read-back
+        // matches the original inserted value (not a freshly created one).
+        final Object insertedValue;
         try (Connection insertConn = getConnection(insertWithJdbc)) {
-            Object insertValue = testCase.createValue(insertConn);
-            Assertions.assertNotNull(insertValue);
-            insert(insertConn, insertValue, useTypedSetter
+            insertedValue = testCase.createValue(insertConn);
+            Assertions.assertNotNull(insertedValue);
+            insert(insertConn, insertedValue, useTypedSetter
                     ? (statement, value) -> testCase.setTyped(statement, 2, value)
                     : (statement, value) -> statement.setObject(2, value));
         }
 
         try (Connection readConn = getConnection(readWithJdbc)) {
-            Object expectedValue = testCase.createValue(readConn);
-            Assertions.assertNotNull(expectedValue);
-            readAndAssert(readConn, expectedValue,
+            readAndAssert(readConn, insertedValue,
                     resultSet -> testCase.getTyped(resultSet, 1),
                     testCase::assertEquals);
         }
@@ -453,16 +454,18 @@ public class JDBCParameterizedQueryComparisonTest {
 
         createSchema(testCase.columnDdl + " array", testCase.extraTypeDdl);
 
+        // Create the array on the insert connection, insert it, then verify the read-back
+        // matches the original inserted array elements.
+        final Array insertedArray;
         try (Connection insertConn = getConnection(insertWithJdbc)) {
-            Array arrayValue = insertConn.createArrayOf(testCase.arrayTypeName, testCase.sampleArrayElements);
-            insert(insertConn, arrayValue, useTypedSetter
+            insertedArray = insertConn.createArrayOf(testCase.arrayTypeName, testCase.sampleArrayElements);
+            insert(insertConn, insertedArray, useTypedSetter
                     ? (statement, value) -> statement.setArray(2, (Array) value)
                     : (statement, value) -> statement.setObject(2, value));
         }
 
         try (Connection readConn = getConnection(readWithJdbc)) {
-            Array expectedArray = readConn.createArrayOf(testCase.arrayTypeName, testCase.sampleArrayElements);
-            readAndAssert(readConn, expectedArray,
+            readAndAssert(readConn, insertedArray,
                     resultSet -> resultSet.getArray(1),
                     this::assertArrayEquals);
         }

--- a/fdb-relational-jdbc/src/test/java/com/apple/foundationdb/relational/jdbc/JDBCParameterizedQueryComparisonTest.java
+++ b/fdb-relational-jdbc/src/test/java/com/apple/foundationdb/relational/jdbc/JDBCParameterizedQueryComparisonTest.java
@@ -392,13 +392,15 @@ public class JDBCParameterizedQueryComparisonTest {
                 RandomizedTestUtils.randomSeeds(),
                 Arrays.stream(TypeTestCase.values()),
                 ParameterizedTestUtils.booleans("typedSetter", "setObject"),
+                ParameterizedTestUtils.booleans("typedGetter", "getObject"),
                 ParameterizedTestUtils.booleans("insertJdbc", "insertEmbedded"),
                 ParameterizedTestUtils.booleans("readJdbc", "readEmbedded"));
     }
 
     @ParameterizedTest
     @MethodSource("testCases")
-    void testParameterizedInsertAndSelect(long seed, @Nonnull TypeTestCase testCase, boolean useTypedSetter,
+    void testParameterizedInsertAndSelect(long seed, @Nonnull TypeTestCase testCase,
+                                          boolean useTypedSetter, boolean useTypedGetter,
                                           boolean insertWithJdbc, boolean readWithJdbc) throws Exception {
         if (insertWithJdbc || readWithJdbc) {
             // JDBC does not support createStruct (always returns null), so inserting with jdbc is not supported.
@@ -415,15 +417,17 @@ public class JDBCParameterizedQueryComparisonTest {
         try (Connection insertConn = getConnection(insertWithJdbc)) {
             insertedValue = testCase.createValue(insertConn, random);
             Assertions.assertNotNull(insertedValue);
-            insert(insertConn, insertedValue, useTypedSetter
-                    ? (statement, value) -> testCase.setTyped(statement, 2, value)
-                    : (statement, value) -> statement.setObject(2, value));
+            final ValueSetter valueSetter = useTypedSetter
+                                       ? (statement, value) -> testCase.setTyped(statement, 2, value)
+                                       : (statement, value) -> statement.setObject(2, value);
+            insert(insertConn, insertedValue, valueSetter);
         }
 
         try (Connection readConn = getConnection(readWithJdbc)) {
-            readAndAssert(readConn, insertedValue,
-                    resultSet -> testCase.getTyped(resultSet, 1),
-                    testCase::assertEquals);
+            ValueReader valueReader = useTypedGetter
+                                      ? (resultSet -> testCase.getTyped(resultSet, 1))
+                                      : (resultSet -> resultSet.getObject(1));
+            readAndAssert(readConn, insertedValue, valueReader, testCase::assertEquals);
         }
     }
 

--- a/fdb-relational-jdbc/src/test/java/com/apple/foundationdb/relational/jdbc/JDBCParameterizedQueryComparisonTest.java
+++ b/fdb-relational-jdbc/src/test/java/com/apple/foundationdb/relational/jdbc/JDBCParameterizedQueryComparisonTest.java
@@ -91,7 +91,7 @@ public class JDBCParameterizedQueryComparisonTest {
      * optionally {@link #assertEqual} to customize behavior per type.
      */
     enum TypeTestCase {
-        BIGINT("bigint", null, true, "BIGINT", true, new Object[]{10L, 20L, 30L}) {
+        BIGINT("bigint", null, "BIGINT", new Object[] {10L, 20L, 30L}) {
             @Override
             Object createValue(Connection conn) {
                 return 42L;
@@ -99,7 +99,7 @@ public class JDBCParameterizedQueryComparisonTest {
 
             @Override
             void setTyped(PreparedStatement statement, int parameterIndex, Object val) throws SQLException {
-                statement.setLong(parameterIndex, (Long) val);
+                statement.setLong(parameterIndex, (Long)val);
             }
 
             @Override
@@ -107,7 +107,7 @@ public class JDBCParameterizedQueryComparisonTest {
                 return resultSet.getLong(columnIndex);
             }
         },
-        INTEGER("integer", null, true, "INTEGER", true, new Object[]{10, 20, 30}) {
+        INTEGER("integer", null, "INTEGER", new Object[] {10, 20, 30}) {
             @Override
             Object createValue(Connection conn) {
                 return 42;
@@ -115,7 +115,7 @@ public class JDBCParameterizedQueryComparisonTest {
 
             @Override
             void setTyped(PreparedStatement statement, int parameterIndex, Object val) throws SQLException {
-                statement.setInt(parameterIndex, (Integer) val);
+                statement.setInt(parameterIndex, (Integer)val);
             }
 
             @Override
@@ -123,7 +123,7 @@ public class JDBCParameterizedQueryComparisonTest {
                 return resultSet.getInt(columnIndex);
             }
         },
-        DOUBLE("double", null, true, "DOUBLE", true, new Object[]{1.1, 2.2, 3.3}) {
+        DOUBLE("double", null, "DOUBLE", new Object[] {1.1, 2.2, 3.3}) {
             @Override
             Object createValue(Connection conn) {
                 return 3.14159;
@@ -131,7 +131,7 @@ public class JDBCParameterizedQueryComparisonTest {
 
             @Override
             void setTyped(PreparedStatement statement, int parameterIndex, Object val) throws SQLException {
-                statement.setDouble(parameterIndex, (Double) val);
+                statement.setDouble(parameterIndex, (Double)val);
             }
 
             @Override
@@ -139,7 +139,7 @@ public class JDBCParameterizedQueryComparisonTest {
                 return resultSet.getDouble(columnIndex);
             }
         },
-        FLOAT("float", null, true, "FLOAT", false, new Object[]{1.1f, 2.2f, 3.3f}) {
+        FLOAT("float", null, "FLOAT", new Object[] {1.1f, 2.2f, 3.3f}) {
             @Override
             Object createValue(Connection conn) {
                 return 2.718f;
@@ -147,7 +147,7 @@ public class JDBCParameterizedQueryComparisonTest {
 
             @Override
             void setTyped(PreparedStatement statement, int parameterIndex, Object val) throws SQLException {
-                statement.setFloat(parameterIndex, (Float) val);
+                statement.setFloat(parameterIndex, (Float)val);
             }
 
             @Override
@@ -157,11 +157,11 @@ public class JDBCParameterizedQueryComparisonTest {
 
             @Override
             void assertEqual(String message, Object expected, Object actual) {
-                Assertions.assertEquals(((Number) expected).floatValue(),
-                        ((Number) actual).floatValue(), 0.001f, message);
+                Assertions.assertEquals(((Number)expected).floatValue(),
+                        ((Number)actual).floatValue(), 0.001f, message);
             }
         },
-        STRING("string", null, true, "STRING", true, new Object[]{"a", "b", "c"}) {
+        STRING("string", null, "STRING", new Object[] {"a", "b", "c"}) {
             @Override
             Object createValue(Connection conn) {
                 return "hello world";
@@ -169,7 +169,7 @@ public class JDBCParameterizedQueryComparisonTest {
 
             @Override
             void setTyped(PreparedStatement statement, int parameterIndex, Object val) throws SQLException {
-                statement.setString(parameterIndex, (String) val);
+                statement.setString(parameterIndex, (String)val);
             }
 
             @Override
@@ -177,7 +177,7 @@ public class JDBCParameterizedQueryComparisonTest {
                 return resultSet.getString(columnIndex);
             }
         },
-        BOOLEAN("boolean", null, true, "BOOLEAN", true, new Object[]{true, false, true}) {
+        BOOLEAN("boolean", null, "BOOLEAN", new Object[] {true, false, true}) {
             @Override
             Object createValue(Connection conn) {
                 return true;
@@ -185,7 +185,7 @@ public class JDBCParameterizedQueryComparisonTest {
 
             @Override
             void setTyped(PreparedStatement statement, int parameterIndex, Object val) throws SQLException {
-                statement.setBoolean(parameterIndex, (Boolean) val);
+                statement.setBoolean(parameterIndex, (Boolean)val);
             }
 
             @Override
@@ -193,15 +193,15 @@ public class JDBCParameterizedQueryComparisonTest {
                 return resultSet.getBoolean(columnIndex);
             }
         },
-        BYTES("bytes", null, true, "BINARY", false, new Object[] {new byte[]{1, 2, 3, 4, 5}, new byte[]{-1, 0, 1}}) {
+        BYTES("bytes", null, "BINARY", new Object[] {new byte[] {1, 2, 3, 4, 5}, new byte[] {-1, 0, 1}}) {
             @Override
             Object createValue(Connection conn) {
-                return new byte[]{1, 2, 3, 4, 5};
+                return new byte[] {1, 2, 3, 4, 5};
             }
 
             @Override
             void setTyped(PreparedStatement statement, int parameterIndex, Object val) throws SQLException {
-                statement.setBytes(parameterIndex, (byte[]) val);
+                statement.setBytes(parameterIndex, (byte[])val);
             }
 
             @Override
@@ -211,18 +211,18 @@ public class JDBCParameterizedQueryComparisonTest {
 
             @Override
             void assertEqual(String message, Object expected, Object actual) {
-                Assertions.assertArrayEquals((byte[]) expected, (byte[]) actual, message);
+                Assertions.assertArrayEquals((byte[])expected, (byte[])actual, message);
             }
         },
-        INTEGER_ARRAY("integer array", null, true, null, false, null) {
+        INTEGER_ARRAY("integer array", null, null, null) {
             @Override
             Object createValue(Connection conn) throws SQLException {
-                return conn.createArrayOf("INTEGER", new Object[]{10, 20, 30});
+                return conn.createArrayOf("INTEGER", new Object[] {10, 20, 30});
             }
 
             @Override
             void setTyped(PreparedStatement statement, int parameterIndex, Object val) throws SQLException {
-                statement.setArray(parameterIndex, (Array) val);
+                statement.setArray(parameterIndex, (Array)val);
             }
 
             @Override
@@ -241,10 +241,10 @@ public class JDBCParameterizedQueryComparisonTest {
                 }
             }
         },
-        STRUCT("MyStruct", "CREATE TYPE AS STRUCT MyStruct (f0 bigint, f1 string)", false, null, false, null) {
+        STRUCT("MyStruct", "CREATE TYPE AS STRUCT MyStruct (f0 bigint, f1 string)", null, null) {
             @Override
             Object createValue(Connection conn) throws SQLException {
-                return conn.createStruct("MyStruct", new Object[]{100L, "test_value"});
+                return conn.createStruct("MyStruct", new Object[] {100L, "test_value"});
             }
 
             @Override
@@ -261,8 +261,8 @@ public class JDBCParameterizedQueryComparisonTest {
             @Override
             void assertEqual(String message, Object expected, Object actual) {
                 try {
-                    RelationalStruct expStruct = (RelationalStruct) expected;
-                    RelationalStruct actStruct = (RelationalStruct) actual;
+                    RelationalStruct expStruct = (RelationalStruct)expected;
+                    RelationalStruct actStruct = (RelationalStruct)actual;
                     int expCount = expStruct.getMetaData().getColumnCount();
                     int actCount = actStruct.getMetaData().getColumnCount();
                     Assertions.assertEquals(expCount, actCount, message + " (field count)");
@@ -279,27 +279,24 @@ public class JDBCParameterizedQueryComparisonTest {
         private final String columnDdl;
         @Nullable
         private final String extraTypeDdl;
-        private final boolean jdbcSetterSupported;
-        /** The SQL type name for use with {@code createArrayOf}, or {@code null} if this type cannot be an array element. */
+        /**
+         * The SQL type name for use with {@code createArrayOf}, or {@code null} if this type cannot be an array
+         * element.
+         */
         @Nullable
         private final String arrayTypeName;
         /**
-         * Whether JDBC {@code createArrayOf} supports this type. {@code false} when {@code TypeConversion.toColumn}
-         * does not handle the JDBC type code (e.g. FLOAT, BINARY).
+         * Sample values for creating an array of this type, or {@code null} if arrays are not supported.
          */
-        private final boolean jdbcArraySupported;
-        /** Sample values for creating an array of this type, or {@code null} if arrays are not supported. */
         @Nullable
         private final Object[] sampleArrayElements;
 
-        TypeTestCase(String columnDdl, @Nullable String extraTypeDdl, boolean jdbcSetterSupported,
-                     @Nullable String arrayTypeName, boolean jdbcArraySupported,
+        TypeTestCase(String columnDdl, @Nullable String extraTypeDdl,
+                     @Nullable String arrayTypeName,
                      @Nullable Object[] sampleArrayElements) {
             this.columnDdl = columnDdl;
             this.extraTypeDdl = extraTypeDdl;
-            this.jdbcSetterSupported = jdbcSetterSupported;
             this.arrayTypeName = arrayTypeName;
-            this.jdbcArraySupported = jdbcArraySupported;
             this.sampleArrayElements = sampleArrayElements;
         }
 
@@ -323,13 +320,13 @@ public class JDBCParameterizedQueryComparisonTest {
         static List<Object> extractArrayElements(Object arrayObj) throws SQLException {
             List<Object> elements = new ArrayList<>();
             if (arrayObj instanceof RelationalArray) {
-                RelationalResultSet rs = ((RelationalArray) arrayObj).getResultSet();
+                RelationalResultSet rs = ((RelationalArray)arrayObj).getResultSet();
                 while (rs.next()) {
                     final Object obj = rs.getObject(2);
                     elements.add(obj); // column 2 is the value in ARRAY result sets
                 }
             } else if (arrayObj instanceof Array) {
-                Object[] arr = (Object[]) ((Array) arrayObj).getArray();
+                Object[] arr = (Object[])((Array)arrayObj).getArray();
                 Collections.addAll(elements, arr);
             } else {
                 throw new SQLException("Unexpected array type: " + arrayObj.getClass());

--- a/fdb-relational-jdbc/src/test/java/com/apple/foundationdb/relational/jdbc/JDBCParameterizedQueryComparisonTest.java
+++ b/fdb-relational-jdbc/src/test/java/com/apple/foundationdb/relational/jdbc/JDBCParameterizedQueryComparisonTest.java
@@ -88,7 +88,7 @@ public class JDBCParameterizedQueryComparisonTest {
      * optionally {@link #assertEqual} to customize behavior per type.
      */
     enum TypeTestCase {
-        BIGINT("bigint", null, true) {
+        BIGINT("bigint", null, true, "BIGINT", new Object[]{10L, 20L, 30L}) {
             @Override
             Object createValue(Connection conn) {
                 return 42L;
@@ -104,7 +104,7 @@ public class JDBCParameterizedQueryComparisonTest {
                 return resultSet.getLong(columnIndex);
             }
         },
-        INTEGER("integer", null, true) {
+        INTEGER("integer", null, true, "INTEGER", new Object[]{10, 20, 30}) {
             @Override
             Object createValue(Connection conn) {
                 return 42;
@@ -120,7 +120,7 @@ public class JDBCParameterizedQueryComparisonTest {
                 return resultSet.getInt(columnIndex);
             }
         },
-        DOUBLE("double", null, true) {
+        DOUBLE("double", null, true, "DOUBLE", new Object[]{1.1, 2.2, 3.3}) {
             @Override
             Object createValue(Connection conn) {
                 return 3.14159;
@@ -136,7 +136,7 @@ public class JDBCParameterizedQueryComparisonTest {
                 return resultSet.getDouble(columnIndex);
             }
         },
-        FLOAT("float", null, true) {
+        FLOAT("float", null, true, "FLOAT", new Object[]{1.1f, 2.2f, 3.3f}) {
             @Override
             Object createValue(Connection conn) {
                 return 2.718f;
@@ -158,7 +158,7 @@ public class JDBCParameterizedQueryComparisonTest {
                         ((Number) actual).floatValue(), 0.001f, message);
             }
         },
-        STRING("string", null, true) {
+        STRING("string", null, true, "STRING", new Object[]{"a", "b", "c"}) {
             @Override
             Object createValue(Connection conn) {
                 return "hello world";
@@ -174,7 +174,7 @@ public class JDBCParameterizedQueryComparisonTest {
                 return resultSet.getString(columnIndex);
             }
         },
-        BOOLEAN("boolean", null, true) {
+        BOOLEAN("boolean", null, true, "BOOLEAN", new Object[]{true, false, true}) {
             @Override
             Object createValue(Connection conn) {
                 return true;
@@ -190,7 +190,7 @@ public class JDBCParameterizedQueryComparisonTest {
                 return resultSet.getBoolean(columnIndex);
             }
         },
-        BYTES("bytes", null, true) {
+        BYTES("bytes", null, true, null, null) {
             @Override
             Object createValue(Connection conn) {
                 return new byte[]{1, 2, 3, 4, 5};
@@ -211,7 +211,7 @@ public class JDBCParameterizedQueryComparisonTest {
                 Assertions.assertArrayEquals((byte[]) expected, (byte[]) actual, message);
             }
         },
-        INTEGER_ARRAY("integer array", null, true) {
+        INTEGER_ARRAY("integer array", null, true, null, null) {
             @Override
             Object createValue(Connection conn) throws SQLException {
                 return conn.createArrayOf("INTEGER", new Object[]{10, 20, 30});
@@ -242,7 +242,7 @@ public class JDBCParameterizedQueryComparisonTest {
          * JDBC does not support createStruct (always returns {@code null}), so inserting with jdbc is not supported.
          * See: <a href="https://github.com/FoundationDB/fdb-record-layer/issues/4064">#4064</a>.
          */
-        STRUCT("MyStruct", "CREATE TYPE AS STRUCT MyStruct (f0 bigint, f1 string)", false) {
+        STRUCT("MyStruct", "CREATE TYPE AS STRUCT MyStruct (f0 bigint, f1 string)", false, null, null) {
             @Override
             Object createValue(Connection conn) throws SQLException {
                 return conn.createStruct("MyStruct", new Object[]{100L, "test_value"});
@@ -281,11 +281,20 @@ public class JDBCParameterizedQueryComparisonTest {
         @Nullable
         private final String extraTypeDdl;
         private final boolean jdbcSetterSupported;
+        /** The SQL type name for use with {@code createArrayOf}, or {@code null} if this type cannot be an array element. */
+        @Nullable
+        private final String arrayTypeName;
+        /** Sample values for creating an array of this type, or {@code null} if arrays are not supported. */
+        @Nullable
+        private final Object[] sampleArrayElements;
 
-        TypeTestCase(String columnDdl, @Nullable String extraTypeDdl, boolean jdbcSetterSupported) {
+        TypeTestCase(String columnDdl, @Nullable String extraTypeDdl, boolean jdbcSetterSupported,
+                     @Nullable String arrayTypeName, @Nullable Object[] sampleArrayElements) {
             this.columnDdl = columnDdl;
             this.extraTypeDdl = extraTypeDdl;
             this.jdbcSetterSupported = jdbcSetterSupported;
+            this.arrayTypeName = arrayTypeName;
+            this.sampleArrayElements = sampleArrayElements;
         }
 
         abstract Object createValue(Connection conn) throws SQLException;
@@ -303,8 +312,9 @@ public class JDBCParameterizedQueryComparisonTest {
          * {@link RelationalArray} (returned by result set reads). Falls back to {@code getArray()}
          * for plain {@link Array} instances (e.g. from {@code createArrayOf}) since
          * {@link JDBCArrayImpl#getResultSet()} throws {@code SQLFeatureNotSupportedException}.
+         * See <a href="https://github.com/FoundationDB/fdb-record-layer/issues/3665">#3665</a>
          */
-        private static List<Object> extractArrayElements(Object arrayObj) throws SQLException {
+        static List<Object> extractArrayElements(Object arrayObj) throws SQLException {
             List<Object> elements = new ArrayList<>();
             if (arrayObj instanceof RelationalArray) {
                 RelationalResultSet rs = ((RelationalArray) arrayObj).getResultSet();
@@ -396,6 +406,86 @@ public class JDBCParameterizedQueryComparisonTest {
                     testCase + " " + (useTypedSetter ? "typedSetter" : "setObject")
                             + " " + (insertWithJdbc ? "insertJdbc" : "insertEmbedded")
                             + " -> " + (readWithJdbc ? "readJdbc" : "readEmbedded"));
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("testCases")
+    void testArrayOfTypeInsertAndSelect(TypeTestCase testCase, boolean useTypedSetter,
+                                        boolean insertWithJdbc, boolean readWithJdbc) throws Exception {
+        Assumptions.assumeTrue(testCase.arrayTypeName != null,
+                testCase + " does not support array element type");
+        // JDBC insert requires the JDBC setter to be supported for the array type
+        Assumptions.assumeTrue(!insertWithJdbc || testCase.jdbcSetterSupported,
+                "JDBC insert not supported for " + testCase);
+
+        createArraySchema(testCase);
+
+        try (Connection insertConn = getConnection(insertWithJdbc)) {
+            Array arrayValue = createArrayOfOrSkip(insertConn, testCase);
+            insertArray(insertConn, arrayValue, useTypedSetter);
+        }
+
+        try (Connection readConn = getConnection(readWithJdbc)) {
+            Array expectedArray = createArrayOfOrSkip(readConn, testCase);
+            readAndAssertArray(readConn, expectedArray,
+                    testCase + "_array " + (useTypedSetter ? "typedSetter" : "setObject")
+                            + " " + (insertWithJdbc ? "insertJdbc" : "insertEmbedded")
+                            + " -> " + (readWithJdbc ? "readJdbc" : "readEmbedded"));
+        }
+    }
+
+    /**
+     * Create an array via {@code createArrayOf}, skipping the test if the connection does not support
+     * creating arrays of this type (e.g. JDBC does not support FLOAT or BINARY in {@code TypeConversion.toColumn}).
+     */
+    private static Array createArrayOfOrSkip(Connection conn, TypeTestCase testCase) throws SQLException {
+        try {
+            Array array = conn.createArrayOf(testCase.arrayTypeName, testCase.sampleArrayElements);
+            Assumptions.assumeTrue(array != null, "createArrayOf returned null for " + testCase);
+            return array;
+        } catch (SQLException e) {
+            Assumptions.abort("createArrayOf not supported for " + testCase + ": " + e.getMessage());
+            throw e; // unreachable
+        }
+    }
+
+    private void createArraySchema(TypeTestCase testCase) throws SQLException {
+        try (RelationalConnection conn = getJdbcCatalogConnection()) {
+            try (RelationalStatement stmt = conn.createStatement()) {
+                String createTemplate = "CREATE SCHEMA TEMPLATE \"" + templateName + "\" " +
+                        "CREATE TABLE test_table (pk bigint, val " + testCase.columnDdl + " array, PRIMARY KEY(pk))";
+                stmt.executeUpdate(createTemplate);
+                stmt.executeUpdate("CREATE SCHEMA \"" + dbPath + "/" + SCHEMA_NAME +
+                        "\" WITH TEMPLATE \"" + templateName + "\"");
+            }
+        }
+    }
+
+    private void insertArray(Connection conn, Array value, boolean useTypedSetter) throws SQLException {
+        try (PreparedStatement ps = conn.prepareStatement(
+                "INSERT INTO test_table (pk, val) VALUES (?, ?)")) {
+            ps.setLong(1, PRIMARY_KEY);
+            if (useTypedSetter) {
+                ps.setArray(2, value);
+            } else {
+                ps.setObject(2, value);
+            }
+            ps.executeUpdate();
+        }
+    }
+
+    private void readAndAssertArray(Connection conn, Array expectedArray, String description) throws SQLException {
+        try (PreparedStatement ps = conn.prepareStatement(
+                "SELECT val FROM test_table WHERE pk = ?")) {
+            ps.setLong(1, PRIMARY_KEY);
+            try (ResultSet rs = ps.executeQuery()) {
+                Assertions.assertTrue(rs.next(), "Expected row for: " + description);
+                Array actualArray = rs.getArray(1);
+                List<Object> expectedElements = TypeTestCase.extractArrayElements(expectedArray);
+                List<Object> actualElements = TypeTestCase.extractArrayElements(actualArray);
+                Assertions.assertEquals(expectedElements, actualElements, description);
+            }
         }
     }
 

--- a/fdb-relational-jdbc/src/test/java/com/apple/foundationdb/relational/jdbc/JDBCParameterizedQueryComparisonTest.java
+++ b/fdb-relational-jdbc/src/test/java/com/apple/foundationdb/relational/jdbc/JDBCParameterizedQueryComparisonTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2025 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,14 +64,6 @@ import java.util.stream.Stream;
  * <p>The {@link InProcessRelationalServer} creates an {@code FRL} instance which registers both the
  * embedded driver (for {@code jdbc:embed:} URLs) and the gRPC service (for {@code jdbc:relational:}
  * URLs). This allows the test to use both connection types against the same backing database.</p>
- *
- * <p>The test is parameterized on the cartesian product of:
- * <ul>
- *   <li>{@link TypeTestCase} - the SQL type under test</li>
- *   <li>{@code useTypedSetter} - whether to use type-specific setters (e.g. {@code setLong}) or {@code setObject}</li>
- *   <li>{@code insertWithJdbc} - whether the insert goes through JDBC (gRPC) or the embedded driver</li>
- *   <li>{@code readWithJdbc} - whether the read-back goes through JDBC (gRPC) or the embedded driver</li>
- * </ul>
  */
 public class JDBCParameterizedQueryComparisonTest {
 
@@ -93,8 +85,8 @@ public class JDBCParameterizedQueryComparisonTest {
 
     /**
      * Enum defining each SQL type test case. The parameterized test iterates over all values.
-     * Subclasses override {@link #createValue}, {@link #setTyped}, {@link #readValue}, and
-     * optionally {@link #assertEqual} to customize behavior per type.
+     * Subclasses override {@link #createValue}, {@link #setTyped}, {@link #getTyped}, and
+     * optionally {@link #assertEquals} to customize behavior per type.
      */
     enum TypeTestCase {
         BIGINT("bigint", "", "BIGINT", new Object[] {10L, 20L, 30L}) {
@@ -111,7 +103,7 @@ public class JDBCParameterizedQueryComparisonTest {
 
             @Nonnull
             @Override
-            Object readValue(@Nonnull ResultSet resultSet, int columnIndex) throws SQLException {
+            Object getTyped(@Nonnull ResultSet resultSet, int columnIndex) throws SQLException {
                 return resultSet.getLong(columnIndex);
             }
         },
@@ -129,7 +121,7 @@ public class JDBCParameterizedQueryComparisonTest {
 
             @Nonnull
             @Override
-            Object readValue(@Nonnull ResultSet resultSet, int columnIndex) throws SQLException {
+            Object getTyped(@Nonnull ResultSet resultSet, int columnIndex) throws SQLException {
                 return resultSet.getInt(columnIndex);
             }
         },
@@ -147,7 +139,7 @@ public class JDBCParameterizedQueryComparisonTest {
 
             @Nonnull
             @Override
-            Object readValue(@Nonnull ResultSet resultSet, int columnIndex) throws SQLException {
+            Object getTyped(@Nonnull ResultSet resultSet, int columnIndex) throws SQLException {
                 return resultSet.getDouble(columnIndex);
             }
         },
@@ -165,12 +157,12 @@ public class JDBCParameterizedQueryComparisonTest {
 
             @Nonnull
             @Override
-            Object readValue(@Nonnull ResultSet resultSet, int columnIndex) throws SQLException {
+            Object getTyped(@Nonnull ResultSet resultSet, int columnIndex) throws SQLException {
                 return resultSet.getFloat(columnIndex);
             }
 
             @Override
-            void assertEqual(@Nonnull String message, @Nonnull Object expected, @Nonnull Object actual) {
+            void assertEquals(@Nonnull String message, @Nonnull Object expected, @Nonnull Object actual) {
                 Assertions.assertEquals(((Number)expected).floatValue(),
                         ((Number)actual).floatValue(), 0.001f, message);
             }
@@ -189,7 +181,7 @@ public class JDBCParameterizedQueryComparisonTest {
 
             @Nonnull
             @Override
-            Object readValue(@Nonnull ResultSet resultSet, int columnIndex) throws SQLException {
+            Object getTyped(@Nonnull ResultSet resultSet, int columnIndex) throws SQLException {
                 return resultSet.getString(columnIndex);
             }
         },
@@ -207,7 +199,7 @@ public class JDBCParameterizedQueryComparisonTest {
 
             @Nonnull
             @Override
-            Object readValue(@Nonnull ResultSet resultSet, int columnIndex) throws SQLException {
+            Object getTyped(@Nonnull ResultSet resultSet, int columnIndex) throws SQLException {
                 return resultSet.getBoolean(columnIndex);
             }
         },
@@ -225,12 +217,12 @@ public class JDBCParameterizedQueryComparisonTest {
 
             @Nonnull
             @Override
-            Object readValue(@Nonnull ResultSet resultSet, int columnIndex) throws SQLException {
+            Object getTyped(@Nonnull ResultSet resultSet, int columnIndex) throws SQLException {
                 return resultSet.getBytes(columnIndex);
             }
 
             @Override
-            void assertEqual(@Nonnull String message, @Nonnull Object expected, @Nonnull Object actual) {
+            void assertEquals(@Nonnull String message, @Nonnull Object expected, @Nonnull Object actual) {
                 Assertions.assertArrayEquals((byte[])expected, (byte[])actual, message);
             }
         },
@@ -248,12 +240,12 @@ public class JDBCParameterizedQueryComparisonTest {
 
             @Nonnull
             @Override
-            Object readValue(@Nonnull ResultSet resultSet, int columnIndex) throws SQLException {
+            Object getTyped(@Nonnull ResultSet resultSet, int columnIndex) throws SQLException {
                 return resultSet.getArray(columnIndex);
             }
 
             @Override
-            void assertEqual(@Nonnull String message, @Nonnull Object expected, @Nonnull Object actual) {
+            void assertEquals(@Nonnull String message, @Nonnull Object expected, @Nonnull Object actual) {
                 try {
                     List<Object> expectedElements = extractArrayElements(expected);
                     List<Object> actualElements = extractArrayElements(actual);
@@ -277,13 +269,13 @@ public class JDBCParameterizedQueryComparisonTest {
 
             @Nonnull
             @Override
-            Object readValue(@Nonnull ResultSet resultSet, int columnIndex) throws SQLException {
+            Object getTyped(@Nonnull ResultSet resultSet, int columnIndex) throws SQLException {
                 RelationalResultSet rrs = resultSet.unwrap(RelationalResultSet.class);
                 return rrs.getStruct(columnIndex);
             }
 
             @Override
-            void assertEqual(@Nonnull String message, @Nonnull Object expected, @Nonnull Object actual) {
+            void assertEquals(@Nonnull String message, @Nonnull Object expected, @Nonnull Object actual) {
                 try {
                     RelationalStruct expStruct = (RelationalStruct)expected;
                     RelationalStruct actStruct = (RelationalStruct)actual;
@@ -331,9 +323,9 @@ public class JDBCParameterizedQueryComparisonTest {
         abstract void setTyped(@Nonnull PreparedStatement statement, int parameterIndex, @Nonnull Object val) throws SQLException;
 
         @Nonnull
-        abstract Object readValue(@Nonnull ResultSet resultSet, int columnIndex) throws SQLException;
+        abstract Object getTyped(@Nonnull ResultSet resultSet, int columnIndex) throws SQLException;
 
-        void assertEqual(@Nonnull String message, @Nonnull Object expected, @Nonnull Object actual) {
+        void assertEquals(@Nonnull String message, @Nonnull Object expected, @Nonnull Object actual) {
             Assertions.assertEquals(expected, actual, message);
         }
 
@@ -569,8 +561,8 @@ public class JDBCParameterizedQueryComparisonTest {
             ps.setLong(1, PRIMARY_KEY);
             try (ResultSet rs = ps.executeQuery()) {
                 Assertions.assertTrue(rs.next(), "Expected row for: " + description);
-                Object readValue = testCase.readValue(rs, 1);
-                testCase.assertEqual(description, expectedValue, readValue);
+                Object readValue = testCase.getTyped(rs, 1);
+                testCase.assertEquals(description, expectedValue, readValue);
             }
         }
     }

--- a/fdb-relational-jdbc/src/test/java/com/apple/foundationdb/relational/jdbc/JDBCParameterizedQueryComparisonTest.java
+++ b/fdb-relational-jdbc/src/test/java/com/apple/foundationdb/relational/jdbc/JDBCParameterizedQueryComparisonTest.java
@@ -75,14 +75,20 @@ import java.util.stream.Stream;
  */
 public class JDBCParameterizedQueryComparisonTest {
 
+    @Nonnull
     private static final String SYS_DB_PATH = "/" + RelationalKeyspaceProvider.SYS;
+    @Nonnull
     private static final String SCHEMA_NAME = "test_schema";
     private static final long PRIMARY_KEY = 1;
 
+    @Nullable
     private static InProcessRelationalServer server;
+    @Nullable
     private static String serverName;
 
+    @Nullable
     private String dbPath;
+    @Nullable
     private String templateName;
 
     /**
@@ -91,147 +97,163 @@ public class JDBCParameterizedQueryComparisonTest {
      * optionally {@link #assertEqual} to customize behavior per type.
      */
     enum TypeTestCase {
-        BIGINT("bigint", null, "BIGINT", new Object[] {10L, 20L, 30L}) {
+        BIGINT("bigint", "", "BIGINT", new Object[] {10L, 20L, 30L}) {
+            @Nonnull
             @Override
-            Object createValue(Connection conn) {
+            Object createValue(@Nonnull Connection conn) {
                 return 42L;
             }
 
             @Override
-            void setTyped(PreparedStatement statement, int parameterIndex, Object val) throws SQLException {
+            void setTyped(@Nonnull PreparedStatement statement, int parameterIndex, @Nonnull Object val) throws SQLException {
                 statement.setLong(parameterIndex, (Long)val);
             }
 
+            @Nonnull
             @Override
-            Object readValue(ResultSet resultSet, int columnIndex) throws SQLException {
+            Object readValue(@Nonnull ResultSet resultSet, int columnIndex) throws SQLException {
                 return resultSet.getLong(columnIndex);
             }
         },
-        INTEGER("integer", null, "INTEGER", new Object[] {10, 20, 30}) {
+        INTEGER("integer", "", "INTEGER", new Object[] {10, 20, 30}) {
+            @Nonnull
             @Override
-            Object createValue(Connection conn) {
+            Object createValue(@Nonnull Connection conn) {
                 return 42;
             }
 
             @Override
-            void setTyped(PreparedStatement statement, int parameterIndex, Object val) throws SQLException {
+            void setTyped(@Nonnull PreparedStatement statement, int parameterIndex, @Nonnull Object val) throws SQLException {
                 statement.setInt(parameterIndex, (Integer)val);
             }
 
+            @Nonnull
             @Override
-            Object readValue(ResultSet resultSet, int columnIndex) throws SQLException {
+            Object readValue(@Nonnull ResultSet resultSet, int columnIndex) throws SQLException {
                 return resultSet.getInt(columnIndex);
             }
         },
-        DOUBLE("double", null, "DOUBLE", new Object[] {1.1, 2.2, 3.3}) {
+        DOUBLE("double", "", "DOUBLE", new Object[] {1.1, 2.2, 3.3}) {
+            @Nonnull
             @Override
-            Object createValue(Connection conn) {
+            Object createValue(@Nonnull Connection conn) {
                 return 3.14159;
             }
 
             @Override
-            void setTyped(PreparedStatement statement, int parameterIndex, Object val) throws SQLException {
+            void setTyped(@Nonnull PreparedStatement statement, int parameterIndex, @Nonnull Object val) throws SQLException {
                 statement.setDouble(parameterIndex, (Double)val);
             }
 
+            @Nonnull
             @Override
-            Object readValue(ResultSet resultSet, int columnIndex) throws SQLException {
+            Object readValue(@Nonnull ResultSet resultSet, int columnIndex) throws SQLException {
                 return resultSet.getDouble(columnIndex);
             }
         },
-        FLOAT("float", null, "FLOAT", new Object[] {1.1f, 2.2f, 3.3f}) {
+        FLOAT("float", "", "FLOAT", new Object[] {1.1f, 2.2f, 3.3f}) {
+            @Nonnull
             @Override
-            Object createValue(Connection conn) {
+            Object createValue(@Nonnull Connection conn) {
                 return 2.718f;
             }
 
             @Override
-            void setTyped(PreparedStatement statement, int parameterIndex, Object val) throws SQLException {
+            void setTyped(@Nonnull PreparedStatement statement, int parameterIndex, @Nonnull Object val) throws SQLException {
                 statement.setFloat(parameterIndex, (Float)val);
             }
 
+            @Nonnull
             @Override
-            Object readValue(ResultSet resultSet, int columnIndex) throws SQLException {
+            Object readValue(@Nonnull ResultSet resultSet, int columnIndex) throws SQLException {
                 return resultSet.getFloat(columnIndex);
             }
 
             @Override
-            void assertEqual(String message, Object expected, Object actual) {
+            void assertEqual(@Nonnull String message, @Nonnull Object expected, @Nonnull Object actual) {
                 Assertions.assertEquals(((Number)expected).floatValue(),
                         ((Number)actual).floatValue(), 0.001f, message);
             }
         },
-        STRING("string", null, "STRING", new Object[] {"a", "b", "c"}) {
+        STRING("string", "", "STRING", new Object[] {"a", "b", "c"}) {
+            @Nonnull
             @Override
-            Object createValue(Connection conn) {
+            Object createValue(@Nonnull Connection conn) {
                 return "hello world";
             }
 
             @Override
-            void setTyped(PreparedStatement statement, int parameterIndex, Object val) throws SQLException {
+            void setTyped(@Nonnull PreparedStatement statement, int parameterIndex, @Nonnull Object val) throws SQLException {
                 statement.setString(parameterIndex, (String)val);
             }
 
+            @Nonnull
             @Override
-            Object readValue(ResultSet resultSet, int columnIndex) throws SQLException {
+            Object readValue(@Nonnull ResultSet resultSet, int columnIndex) throws SQLException {
                 return resultSet.getString(columnIndex);
             }
         },
-        BOOLEAN("boolean", null, "BOOLEAN", new Object[] {true, false, true}) {
+        BOOLEAN("boolean", "", "BOOLEAN", new Object[] {true, false, true}) {
+            @Nonnull
             @Override
-            Object createValue(Connection conn) {
+            Object createValue(@Nonnull Connection conn) {
                 return true;
             }
 
             @Override
-            void setTyped(PreparedStatement statement, int parameterIndex, Object val) throws SQLException {
+            void setTyped(@Nonnull PreparedStatement statement, int parameterIndex, @Nonnull Object val) throws SQLException {
                 statement.setBoolean(parameterIndex, (Boolean)val);
             }
 
+            @Nonnull
             @Override
-            Object readValue(ResultSet resultSet, int columnIndex) throws SQLException {
+            Object readValue(@Nonnull ResultSet resultSet, int columnIndex) throws SQLException {
                 return resultSet.getBoolean(columnIndex);
             }
         },
-        BYTES("bytes", null, "BINARY", new Object[] {new byte[] {1, 2, 3, 4, 5}, new byte[] {-1, 0, 1}}) {
+        BYTES("bytes", "", "BINARY", new Object[] {new byte[] {1, 2, 3, 4, 5}, new byte[] {-1, 0, 1}}) {
+            @Nonnull
             @Override
-            Object createValue(Connection conn) {
+            Object createValue(@Nonnull Connection conn) {
                 return new byte[] {1, 2, 3, 4, 5};
             }
 
             @Override
-            void setTyped(PreparedStatement statement, int parameterIndex, Object val) throws SQLException {
+            void setTyped(@Nonnull PreparedStatement statement, int parameterIndex, @Nonnull Object val) throws SQLException {
                 statement.setBytes(parameterIndex, (byte[])val);
             }
 
+            @Nonnull
             @Override
-            Object readValue(ResultSet resultSet, int columnIndex) throws SQLException {
+            Object readValue(@Nonnull ResultSet resultSet, int columnIndex) throws SQLException {
                 return resultSet.getBytes(columnIndex);
             }
 
             @Override
-            void assertEqual(String message, Object expected, Object actual) {
+            void assertEqual(@Nonnull String message, @Nonnull Object expected, @Nonnull Object actual) {
                 Assertions.assertArrayEquals((byte[])expected, (byte[])actual, message);
             }
         },
-        INTEGER_ARRAY("integer array", null, null, null) {
+        INTEGER_ARRAY("integer array", "", null, null) {
+            @Nullable
             @Override
-            Object createValue(Connection conn) throws SQLException {
+            Object createValue(@Nonnull Connection conn) throws SQLException {
                 return conn.createArrayOf("INTEGER", new Object[] {10, 20, 30});
             }
 
             @Override
-            void setTyped(PreparedStatement statement, int parameterIndex, Object val) throws SQLException {
+            void setTyped(@Nonnull PreparedStatement statement, int parameterIndex, @Nonnull Object val) throws SQLException {
                 statement.setArray(parameterIndex, (Array)val);
             }
 
+            @Nonnull
             @Override
-            Object readValue(ResultSet resultSet, int columnIndex) throws SQLException {
+            Object readValue(@Nonnull ResultSet resultSet, int columnIndex) throws SQLException {
                 return resultSet.getArray(columnIndex);
             }
 
             @Override
-            void assertEqual(String message, Object expected, Object actual) {
+            void assertEqual(@Nonnull String message, @Nonnull Object expected, @Nonnull Object actual) {
                 try {
                     List<Object> expectedElements = extractArrayElements(expected);
                     List<Object> actualElements = extractArrayElements(actual);
@@ -242,24 +264,26 @@ public class JDBCParameterizedQueryComparisonTest {
             }
         },
         STRUCT("MyStruct", "CREATE TYPE AS STRUCT MyStruct (f0 bigint, f1 string)", null, null) {
+            @Nullable
             @Override
-            Object createValue(Connection conn) throws SQLException {
+            Object createValue(@Nonnull Connection conn) throws SQLException {
                 return conn.createStruct("MyStruct", new Object[] {100L, "test_value"});
             }
 
             @Override
-            void setTyped(PreparedStatement statement, int parameterIndex, Object val) throws SQLException {
+            void setTyped(@Nonnull PreparedStatement statement, int parameterIndex, @Nonnull Object val) throws SQLException {
                 statement.setObject(parameterIndex, val);
             }
 
+            @Nonnull
             @Override
-            Object readValue(ResultSet resultSet, int columnIndex) throws SQLException {
+            Object readValue(@Nonnull ResultSet resultSet, int columnIndex) throws SQLException {
                 RelationalResultSet rrs = resultSet.unwrap(RelationalResultSet.class);
                 return rrs.getStruct(columnIndex);
             }
 
             @Override
-            void assertEqual(String message, Object expected, Object actual) {
+            void assertEqual(@Nonnull String message, @Nonnull Object expected, @Nonnull Object actual) {
                 try {
                     RelationalStruct expStruct = (RelationalStruct)expected;
                     RelationalStruct actStruct = (RelationalStruct)actual;
@@ -276,8 +300,9 @@ public class JDBCParameterizedQueryComparisonTest {
             }
         };
 
+        @Nonnull
         private final String columnDdl;
-        @Nullable
+        @Nonnull
         private final String extraTypeDdl;
         /**
          * The SQL type name for use with {@code createArrayOf}, or {@code null} if this type cannot be an array
@@ -291,7 +316,7 @@ public class JDBCParameterizedQueryComparisonTest {
         @Nullable
         private final Object[] sampleArrayElements;
 
-        TypeTestCase(String columnDdl, @Nullable String extraTypeDdl,
+        TypeTestCase(@Nonnull String columnDdl, @Nonnull String extraTypeDdl,
                      @Nullable String arrayTypeName,
                      @Nullable Object[] sampleArrayElements) {
             this.columnDdl = columnDdl;
@@ -300,13 +325,15 @@ public class JDBCParameterizedQueryComparisonTest {
             this.sampleArrayElements = sampleArrayElements;
         }
 
-        abstract Object createValue(Connection conn) throws SQLException;
+        @Nullable
+        abstract Object createValue(@Nonnull Connection conn) throws SQLException;
 
-        abstract void setTyped(PreparedStatement statement, int parameterIndex, Object val) throws SQLException;
+        abstract void setTyped(@Nonnull PreparedStatement statement, int parameterIndex, @Nonnull Object val) throws SQLException;
 
-        abstract Object readValue(ResultSet resultSet, int columnIndex) throws SQLException;
+        @Nonnull
+        abstract Object readValue(@Nonnull ResultSet resultSet, int columnIndex) throws SQLException;
 
-        void assertEqual(String message, Object expected, Object actual) {
+        void assertEqual(@Nonnull String message, @Nonnull Object expected, @Nonnull Object actual) {
             Assertions.assertEquals(expected, actual, message);
         }
 
@@ -317,7 +344,8 @@ public class JDBCParameterizedQueryComparisonTest {
          * {@link JDBCArrayImpl#getResultSet()} throws {@code SQLFeatureNotSupportedException}.
          * See <a href="https://github.com/FoundationDB/fdb-record-layer/issues/3665">#3665</a>
          */
-        static List<Object> extractArrayElements(Object arrayObj) throws SQLException {
+        @Nonnull
+        static List<Object> extractArrayElements(@Nonnull Object arrayObj) throws SQLException {
             List<Object> elements = new ArrayList<>();
             if (arrayObj instanceof RelationalArray) {
                 RelationalResultSet rs = ((RelationalArray)arrayObj).getResultSet();
@@ -378,6 +406,7 @@ public class JDBCParameterizedQueryComparisonTest {
         }
     }
 
+    @Nonnull
     static Stream<Arguments> testCases() {
         return ParameterizedTestUtils.cartesianProduct(
                 Arrays.stream(TypeTestCase.values()),
@@ -388,7 +417,7 @@ public class JDBCParameterizedQueryComparisonTest {
 
     @ParameterizedTest
     @MethodSource("testCases")
-    void testParameterizedInsertAndSelect(TypeTestCase testCase, boolean useTypedSetter,
+    void testParameterizedInsertAndSelect(@Nonnull TypeTestCase testCase, boolean useTypedSetter,
                                           boolean insertWithJdbc, boolean readWithJdbc) throws Exception {
         if (insertWithJdbc || readWithJdbc) {
             // JDBC does not support createStruct (always returns null), so inserting with jdbc is not supported.
@@ -400,11 +429,13 @@ public class JDBCParameterizedQueryComparisonTest {
 
         try (Connection insertConn = getConnection(insertWithJdbc)) {
             Object value = testCase.createValue(insertConn);
+            Assertions.assertNotNull(value);
             insert(testCase, insertConn, value, useTypedSetter);
         }
 
         try (Connection readConn = getConnection(readWithJdbc)) {
             Object expectedValue = testCase.createValue(readConn);
+            Assertions.assertNotNull(expectedValue);
             readAndAssert(testCase, readConn, expectedValue,
                     testCase + " " + (useTypedSetter ? "typedSetter" : "setObject")
                             + " " + (insertWithJdbc ? "insertJdbc" : "insertEmbedded")
@@ -414,7 +445,7 @@ public class JDBCParameterizedQueryComparisonTest {
 
     @ParameterizedTest
     @MethodSource("testCases")
-    void testArrayOfTypeInsertAndSelect(TypeTestCase testCase, boolean useTypedSetter,
+    void testArrayOfTypeInsertAndSelect(@Nonnull TypeTestCase testCase, boolean useTypedSetter,
                                         boolean insertWithJdbc, boolean readWithJdbc) throws Exception {
         Assumptions.assumeFalse(testCase == TypeTestCase.STRUCT,
                 "createArrayOf does not support STRUCT in either implementation");
@@ -437,11 +468,11 @@ public class JDBCParameterizedQueryComparisonTest {
         }
     }
 
-    private void createArraySchema(TypeTestCase testCase) throws SQLException {
+    private void createArraySchema(@Nonnull TypeTestCase testCase) throws SQLException {
         try (RelationalConnection conn = getJdbcCatalogConnection()) {
             try (RelationalStatement stmt = conn.createStatement()) {
                 String createTemplate = "CREATE SCHEMA TEMPLATE \"" + templateName + "\" " +
-                        (testCase.extraTypeDdl != null ? testCase.extraTypeDdl + " " : "") +
+                        testCase.extraTypeDdl + " " +
                         "CREATE TABLE test_table (pk bigint, val " + testCase.columnDdl + " array, PRIMARY KEY(pk))";
                 stmt.executeUpdate(createTemplate);
                 stmt.executeUpdate("CREATE SCHEMA \"" + dbPath + "/" + SCHEMA_NAME +
@@ -450,7 +481,7 @@ public class JDBCParameterizedQueryComparisonTest {
         }
     }
 
-    private void insertArray(Connection conn, Array value, boolean useTypedSetter) throws SQLException {
+    private void insertArray(@Nonnull Connection conn, @Nonnull Array value, boolean useTypedSetter) throws SQLException {
         try (PreparedStatement ps = conn.prepareStatement(
                 "INSERT INTO test_table (pk, val) VALUES (?, ?)")) {
             ps.setLong(1, PRIMARY_KEY);
@@ -463,7 +494,7 @@ public class JDBCParameterizedQueryComparisonTest {
         }
     }
 
-    private void readAndAssertArray(Connection conn, Array expectedArray, String description) throws SQLException {
+    private void readAndAssertArray(@Nonnull Connection conn, @Nonnull Array expectedArray, @Nonnull String description) throws SQLException {
         try (PreparedStatement ps = conn.prepareStatement(
                 "SELECT val FROM test_table WHERE pk = ?")) {
             ps.setLong(1, PRIMARY_KEY);
@@ -484,16 +515,18 @@ public class JDBCParameterizedQueryComparisonTest {
     }
 
     @Nonnull
-    private static List<ByteString> asListOfByteStrings(final List<Object> expectedElements) {
+    private static List<ByteString> asListOfByteStrings(@Nonnull final List<Object> expectedElements) {
         return expectedElements.stream().map(obj -> ByteString.copyFrom((byte[])obj)).collect(Collectors.toList());
     }
 
+    @Nonnull
     private static RelationalConnection getJdbcCatalogConnection() throws SQLException {
         String uri = "jdbc:relational://" + SYS_DB_PATH + "?schema=" + RelationalKeyspaceProvider.CATALOG
                 + "&server=" + serverName;
         return DriverManager.getConnection(uri).unwrap(RelationalConnection.class);
     }
 
+    @Nonnull
     private Connection getConnection(boolean useJdbc) throws SQLException {
         if (useJdbc) {
             String uri = "jdbc:relational://" + dbPath + "?schema=" + SCHEMA_NAME
@@ -504,11 +537,11 @@ public class JDBCParameterizedQueryComparisonTest {
         }
     }
 
-    private void createSchema(TypeTestCase testCase) throws SQLException {
+    private void createSchema(@Nonnull TypeTestCase testCase) throws SQLException {
         try (RelationalConnection conn = getJdbcCatalogConnection()) {
             try (RelationalStatement stmt = conn.createStatement()) {
                 String createTemplate = "CREATE SCHEMA TEMPLATE \"" + templateName + "\" " +
-                        (testCase.extraTypeDdl != null ? testCase.extraTypeDdl + " " : "") +
+                        testCase.extraTypeDdl + " " +
                         "CREATE TABLE test_table (pk bigint, val " + testCase.columnDdl + ", PRIMARY KEY(pk))";
                 stmt.executeUpdate(createTemplate);
                 stmt.executeUpdate("CREATE SCHEMA \"" + dbPath + "/" + SCHEMA_NAME +
@@ -517,7 +550,7 @@ public class JDBCParameterizedQueryComparisonTest {
         }
     }
 
-    private void insert(TypeTestCase testCase, Connection conn, Object value, boolean useTypedSetter) throws SQLException {
+    private void insert(@Nonnull TypeTestCase testCase, @Nonnull Connection conn, @Nonnull Object value, boolean useTypedSetter) throws SQLException {
         try (PreparedStatement ps = conn.prepareStatement(
                 "INSERT INTO test_table (pk, val) VALUES (?, ?)")) {
             ps.setLong(1, PRIMARY_KEY);
@@ -530,7 +563,7 @@ public class JDBCParameterizedQueryComparisonTest {
         }
     }
 
-    private void readAndAssert(TypeTestCase testCase, Connection conn, Object expectedValue, String description) throws SQLException {
+    private void readAndAssert(@Nonnull TypeTestCase testCase, @Nonnull Connection conn, @Nonnull Object expectedValue, @Nonnull String description) throws SQLException {
         try (PreparedStatement ps = conn.prepareStatement(
                 "SELECT val FROM test_table WHERE pk = ?")) {
             ps.setLong(1, PRIMARY_KEY);

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/Matchers.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/Matchers.java
@@ -677,6 +677,12 @@ public class Matchers {
             }
         }
 
+        if (expected instanceof byte[] && actual instanceof byte[]) {
+            if (Arrays.equals((byte[]) expected, (byte[]) actual)) {
+                return ResultSetMatchResult.success();
+            }
+        }
+
         // exact comparison.
         if (Objects.equals(expected, actual)) {
             return ResultSetMatchResult.success();

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/Matchers.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/Matchers.java
@@ -26,18 +26,17 @@ import com.apple.foundationdb.linear.HalfRealVector;
 import com.apple.foundationdb.linear.RealVector;
 import com.apple.foundationdb.record.util.pair.ImmutablePair;
 import com.apple.foundationdb.record.util.pair.Pair;
-import com.apple.foundationdb.relational.util.Assert;
-import com.apple.foundationdb.relational.yamltests.tags.PosTag;
-import com.apple.foundationdb.relational.yamltests.tags.IgnoreTag;
-import com.apple.foundationdb.relational.yamltests.tags.Matchable;
-import com.apple.foundationdb.relational.yamltests.tags.IsNullTag;
-import com.apple.foundationdb.tuple.ByteArrayUtil2;
 import com.apple.foundationdb.relational.api.RelationalArray;
 import com.apple.foundationdb.relational.api.RelationalResultSet;
 import com.apple.foundationdb.relational.api.RelationalStruct;
 import com.apple.foundationdb.relational.recordlayer.query.ParseHelpers;
+import com.apple.foundationdb.relational.util.Assert;
 import com.apple.foundationdb.relational.util.SpotBugsSuppressWarnings;
-
+import com.apple.foundationdb.relational.yamltests.tags.IgnoreTag;
+import com.apple.foundationdb.relational.yamltests.tags.IsNullTag;
+import com.apple.foundationdb.relational.yamltests.tags.Matchable;
+import com.apple.foundationdb.relational.yamltests.tags.PosTag;
+import com.apple.foundationdb.tuple.ByteArrayUtil2;
 import com.google.common.collect.HashMultiset;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multiset;
@@ -659,6 +658,11 @@ public class Matchers {
             return matchIntField((Integer) expected, actual, rowNumber, cellRef);
         }
 
+        // float comparison (with possible promotion to double)
+        if (expected instanceof Float) {
+            return matchFloatField((Float) expected, actual, rowNumber, cellRef);
+        }
+
         if (expected instanceof String && actual instanceof byte[]) {
             if (Objects.equals(expected, new String((byte[]) actual, StandardCharsets.UTF_8))) {
                 return ResultSetMatchResult.success();
@@ -710,6 +714,27 @@ public class Matchers {
             }
         }
         return ResultSetMatchResult.fail(String.format(Locale.ROOT, "cell mismatch at row: %d cellRef: %s%n expected 🟢 does not match 🟡.%n🟢 %s (Integer) %n🟡 %s (%s)", rowNumber, cellRef, expected, actual, actual.getClass().getSimpleName()));
+    }
+
+    /**
+     * Performs float matching against float, or against double (with promotion).
+     * @param expected expected value.
+     * @param actual actual value.
+     * @return success if {@code expected} matches {@code actual}, otherwise fail.
+     */
+    @Nonnull
+    private static ResultSetMatchResult matchFloatField(@Nonnull final Float expected, @Nonnull final Object actual, int rowNumber, @Nonnull String cellRef) {
+        if (actual instanceof Float) {
+            if (Objects.equals(expected, actual)) {
+                return ResultSetMatchResult.success();
+            }
+        }
+        if (actual instanceof Double) {
+            if (Objects.equals(expected.doubleValue(), actual)) {
+                return ResultSetMatchResult.success();
+            }
+        }
+        return ResultSetMatchResult.fail(String.format(Locale.ROOT, "cell mismatch at row: %d cellRef: %s%n expected 🟢 does not match 🟡.%n🟢 %s (Float) %n🟡 %s (%s)", rowNumber, cellRef, expected, actual, actual.getClass().getSimpleName()));
     }
 
     @Nonnull

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryInterpreter.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryInterpreter.java
@@ -29,6 +29,7 @@ import com.apple.foundationdb.relational.yamltests.command.parameterinjection.Pa
 import com.apple.foundationdb.relational.yamltests.command.parameterinjection.PrimitiveParameter;
 import com.apple.foundationdb.relational.yamltests.command.parameterinjection.TupleParameter;
 import com.apple.foundationdb.relational.yamltests.command.parameterinjection.UnboundParameter;
+import com.apple.foundationdb.relational.yamltests.tags.BytesTag;
 import com.apple.foundationdb.relational.yamltests.tags.LongTag;
 import org.apache.commons.lang3.tuple.Pair;
 import org.yaml.snakeyaml.LoaderOptions;
@@ -121,6 +122,9 @@ public final class QueryInterpreter {
 
             final var longTag = new LongTag();
             this.yamlConstructors.put(longTag.getTag(), longTag.getConstruct());
+
+            final var bytesTag = new BytesTag();
+            this.yamlConstructors.put(bytesTag.getTag(), bytesTag.getConstruct());
         }
 
         @Override

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryInterpreter.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryInterpreter.java
@@ -30,6 +30,7 @@ import com.apple.foundationdb.relational.yamltests.command.parameterinjection.Pr
 import com.apple.foundationdb.relational.yamltests.command.parameterinjection.TupleParameter;
 import com.apple.foundationdb.relational.yamltests.command.parameterinjection.UnboundParameter;
 import com.apple.foundationdb.relational.yamltests.tags.BytesTag;
+import com.apple.foundationdb.relational.yamltests.tags.FloatTag;
 import com.apple.foundationdb.relational.yamltests.tags.LongTag;
 import org.apache.commons.lang3.tuple.Pair;
 import org.yaml.snakeyaml.LoaderOptions;
@@ -125,6 +126,9 @@ public final class QueryInterpreter {
 
             final var bytesTag = new BytesTag();
             this.yamlConstructors.put(bytesTag.getTag(), bytesTag.getConstruct());
+
+            final var floatTag = new FloatTag();
+            this.yamlConstructors.put(floatTag.getTag(), floatTag.getConstruct());
         }
 
         @Override

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/parameterinjection/ListParameter.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/parameterinjection/ListParameter.java
@@ -92,10 +92,16 @@ public class ListParameter implements Parameter {
             return SqlTypeNamesSupport.getSqlTypeName(Types.INTEGER);
         } else if (firstNonNull instanceof Long) {
             return SqlTypeNamesSupport.getSqlTypeName(Types.BIGINT);
+        } else if (firstNonNull instanceof Boolean) {
+            return SqlTypeNamesSupport.getSqlTypeName(Types.BOOLEAN);
         } else if (firstNonNull instanceof Double) {
             return SqlTypeNamesSupport.getSqlTypeName(Types.DOUBLE);
+        } else if (firstNonNull instanceof Float) {
+            return SqlTypeNamesSupport.getSqlTypeName(Types.FLOAT);
         } else if (firstNonNull instanceof String) {
             return SqlTypeNamesSupport.getSqlTypeName(Types.VARCHAR);
+        } else if (firstNonNull instanceof byte[]) {
+            return SqlTypeNamesSupport.getSqlTypeName(Types.BINARY);
         } else if (firstNonNull instanceof Array) {
             return SqlTypeNamesSupport.getSqlTypeName(Types.ARRAY);
         } else if (firstNonNull instanceof Struct) {

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/parameterinjection/PrimitiveParameter.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/parameterinjection/PrimitiveParameter.java
@@ -20,6 +20,8 @@
 
 package com.apple.foundationdb.relational.yamltests.command.parameterinjection;
 
+import com.apple.foundationdb.relational.recordlayer.util.Hex;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.sql.Connection;
@@ -44,6 +46,8 @@ public class PrimitiveParameter implements Parameter {
             return "null";
         } else if (object instanceof String || object instanceof UUID) {
             return "'" + object + "'";
+        } else if (object instanceof byte[]) {
+            return "x'" + Hex.encodeHexString((byte[]) object) + "'";
         } else {
             return object.toString();
         }
@@ -68,6 +72,12 @@ public class PrimitiveParameter implements Parameter {
 
     @Override
     public String toString() {
-        return object == null ? "null" : object.toString();
+        if (object == null) {
+            return "null";
+        } else if (object instanceof byte[]) {
+            return "x'" + Hex.encodeHexString((byte[]) object) + "'";
+        } else {
+            return object.toString();
+        }
     }
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/tags/BytesTag.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/tags/BytesTag.java
@@ -1,0 +1,82 @@
+/*
+ * BytesTag.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.relational.yamltests.tags;
+
+import com.apple.foundationdb.relational.api.exceptions.RelationalException;
+import com.apple.foundationdb.relational.recordlayer.util.Hex;
+import com.apple.foundationdb.relational.util.Assert;
+import com.google.auto.service.AutoService;
+import org.yaml.snakeyaml.constructor.AbstractConstruct;
+import org.yaml.snakeyaml.constructor.Construct;
+import org.yaml.snakeyaml.nodes.Node;
+import org.yaml.snakeyaml.nodes.ScalarNode;
+import org.yaml.snakeyaml.nodes.Tag;
+
+import javax.annotation.Nonnull;
+
+/**
+ * A custom YAML tag for byte array values in the {@code x'...'} hex format.
+ * <p>
+ *     Usage in parameter injection: {@code !! !b x'deadbeef' !!}
+ * </p>
+ * <p>
+ *     Usage in result matching: {@code result: [{!b x'deadbeef'}]}
+ * </p>
+ */
+@AutoService(CustomTag.class)
+public class BytesTag implements CustomTag {
+
+    @Nonnull
+    private static final Tag tag = new Tag("!b");
+
+    @Nonnull
+    private static final Construct CONSTRUCT_INSTANCE = new AbstractConstruct() {
+        @Override
+        public byte[] construct(final Node node) {
+            if (!(node instanceof ScalarNode)) {
+                Assert.failUnchecked("The value of the bytes (!b) tag must be a scalar, however '" + node + "' is found!");
+            }
+            final String value = ((ScalarNode) node).getValue();
+            Assert.thatUnchecked(value.startsWith("x'") && value.endsWith("'"),
+                    "The value of the bytes (!b) tag must be in x'...' hex format, however '" + value + "' is found!");
+            try {
+                return Hex.decodeHex(value.substring(2, value.length() - 1));
+            } catch (RelationalException e) {
+                throw e.toUncheckedWrappedException();
+            }
+        }
+    };
+
+    public BytesTag() {
+    }
+
+    @Nonnull
+    @Override
+    public Tag getTag() {
+        return tag;
+    }
+
+    @Nonnull
+    @Override
+    public Construct getConstruct() {
+        return CONSTRUCT_INSTANCE;
+    }
+}

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/tags/FloatTag.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/tags/FloatTag.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/tags/FloatTag.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/tags/FloatTag.java
@@ -1,0 +1,75 @@
+/*
+ * FloatTag.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.relational.yamltests.tags;
+
+import com.apple.foundationdb.relational.util.Assert;
+import com.google.auto.service.AutoService;
+import org.yaml.snakeyaml.constructor.AbstractConstruct;
+import org.yaml.snakeyaml.constructor.Construct;
+import org.yaml.snakeyaml.nodes.Node;
+import org.yaml.snakeyaml.nodes.ScalarNode;
+import org.yaml.snakeyaml.nodes.Tag;
+
+import javax.annotation.Nonnull;
+
+/**
+ * A custom YAML tag for {@code float} values. Without this tag, YAML parses decimal numbers
+ * as {@link Double}, which causes comparison failures against {@code float} column values
+ * (since {@code Float.equals(Double)} is always {@code false}).
+ * <p>
+ *     Usage in parameter injection: {@code !! !f 1.5 !!}
+ * </p>
+ * <p>
+ *     Usage in result matching: {@code result: [{!f 1.5}]}
+ * </p>
+ */
+@AutoService(CustomTag.class)
+public class FloatTag implements CustomTag {
+
+    @Nonnull
+    private static final Tag tag = new Tag("!f");
+
+    @Nonnull
+    private static final Construct CONSTRUCT_INSTANCE = new AbstractConstruct() {
+        @Override
+        public Float construct(final Node node) {
+            if (!(node instanceof ScalarNode)) {
+                Assert.failUnchecked("The value of the float (!f) tag must be a scalar, however '" + node + "' is found!");
+            }
+            return Float.valueOf(((ScalarNode) node).getValue());
+        }
+    };
+
+    public FloatTag() {
+    }
+
+    @Nonnull
+    @Override
+    public Tag getTag() {
+        return tag;
+    }
+
+    @Nonnull
+    @Override
+    public Construct getConstruct() {
+        return CONSTRUCT_INSTANCE;
+    }
+}

--- a/yaml-tests/src/test/resources/prepared.yamsql
+++ b/yaml-tests/src/test/resources/prepared.yamsql
@@ -3,7 +3,7 @@
 #
 # This source file is part of the FoundationDB open source project
 #
-# Copyright 2021-2024 Apple Inc. and the FoundationDB project authors
+# Copyright 2021-2026 Apple Inc. and the FoundationDB project authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,7 +24,11 @@ options:
     supported_version: 4.0.559.6 # This will only work on 4.0.559.6 and then on 4.1.6.0+
 ---
 schema_template:
+    create type as struct test_struct(f0 bigint, f1 string)
     create table ta(a bigint, b double, c boolean, d integer, e integer array, f string, primary key(a))
+    create table tb(a bigint, b float, primary key(a))
+    create table tc(a bigint, b bytes, primary key(a))
+    create table td(a bigint, b test_struct, primary key(a))
 ---
 setup:
   steps:
@@ -39,6 +43,9 @@ setup:
                (15, 16.01, false, 1566, [17, 18, 19], 'black widow'),
                (17, 18.01, true, 1744, [19, 20, 21], 'jessica jones'),
                (19, 20.01, false, 1853, [21, 22, 23], 'luke cage')
+#    - query: INSERT INTO TB VALUES (1, 1.5), (2, 2.25), (3, 3.75)
+    - query: INSERT INTO TC VALUES (1, x'deadbeef'), (2, x'cafe'), (3, x'0ff1ce')
+    - query: INSERT INTO TD VALUES (1, (100, 'hello')), (2, (200, 'world'))
 ---
 test_block:
   name: prepared-tests
@@ -146,4 +153,79 @@ test_block:
     -
       - query: update ta set e = !! [10, 100, 1000] !! where a = 1 returning "new".e
       - result: [{[10, 100, 1000]}]
+#---
+# ---------- float ----------
+#test_block:
+#  name: float-prepared-tests
+#  tests:
+#    -
+#      # parameterized comparison against float column (using double parameter)
+#      - query: select a from tb where b < !! 3.0 !!
+#      - result: [{!l 1}, {!l 2}]
+#    -
+#      # parameterized equality on float column
+#      - query: select a from tb where b = !! 1.5 !!
+#      - result: [{!l 1}]
+#    -
+#      # read back float value via cast to double to avoid Float/Double mismatch
+#      - query: select cast(b as double) from tb where a = !! !l 1 !!
+#      - result: [{1.5}]
+#    -
+#      - query: select cast(b as double) from tb where a = !! !l 3 !!
+#      - result: [{3.75}]
+#---
+#test_block:
+#  name: float-insert-test
+#  preset: single_repetition_ordered
+#  tests:
+#    -
+#      # parameterized insert into float column
+#      - query: insert into tb(a, b) values (!! !l 100 !!, !! 0.5 !!)
+#      - count: 1
+#    -
+#      # verify the inserted float value round-trips
+#      - query: select cast(b as double) from tb where a = !! !l 100 !!
+#      - result: [{0.5}]
+# ---------- bytes ----------
+---
+test_block:
+  name: bytes-insert-test
+  preset: single_repetition_ordered
+  tests:
+    -
+      # parameterized insert into bytes column
+      - query: insert into tc(a, b) values (!! !l 100 !!, !! !b x'baadf00d' !!)
+      - count: 1
+---
+test_block:
+  name: bytes-prepared-tests
+  tests:
+    -
+      # select bytes value using prepared bigint parameter
+      - query: select b from tc where b = !! !b x'deadbeef' !!
+      - result: [{x'deadbeef'}]
+    -
+      # verify the inserted bytes value
+      - query: select b from tc where a = !! !l 100 !!
+      - result: [{x'baadf00d'}]
+# ---------- struct ----------
+---
+test_block:
+  name: struct-insert-test
+  preset: single_repetition_ordered
+  options:
+    # struct tuple parameter creates a JDBC Struct with generic type name,
+    # so use simple statement for the insert
+    statement_type: simple
+  tests:
+    -
+      - query: insert into td values !! {!l 100, {!l 42, 'test_value'}} !!
+      - count: 1
+---
+test_block:
+  name: struct-prepared-tests
+  tests:
+    -
+      - query: select b from td where a = 100
+      - result: [{{f0: 42, f1: 'test_value'}}]
 ...

--- a/yaml-tests/src/test/resources/prepared.yamsql
+++ b/yaml-tests/src/test/resources/prepared.yamsql
@@ -24,11 +24,15 @@ options:
     supported_version: 4.0.559.6 # This will only work on 4.0.559.6 and then on 4.1.6.0+
 ---
 schema_template:
-    create type as struct test_struct(f0 bigint, f1 string)
     create table ta(a bigint, b double, c boolean, d integer, e integer array, f string, primary key(a))
-    create table tb(a bigint, b float, primary key(a))
-    create table tc(a bigint, b bytes, primary key(a))
-    create table td(a bigint, b test_struct, primary key(a))
+    create table type_with_scalars(pk bigint, bigint_value bigint, integer_value integer, double_value double,
+                                   float_value float, string_value string, boolean_value boolean,
+                                   bytes_value bytes, primary key(pk))
+    create table type_with_arrays(pk bigint, bigint_array bigint array, integer_array integer array,
+                                  double_array double array, float_array float array, string_array string array,
+                                  boolean_array boolean array, bytes_array bytes array, primary key(pk))
+# Note: STRUCT is not included because it is not supported in JDBC
+# See: https://github.com/FoundationDB/fdb-record-layer/issues/4064
 ---
 setup:
   steps:
@@ -43,9 +47,6 @@ setup:
                (15, 16.01, false, 1566, [17, 18, 19], 'black widow'),
                (17, 18.01, true, 1744, [19, 20, 21], 'jessica jones'),
                (19, 20.01, false, 1853, [21, 22, 23], 'luke cage')
-    - query: INSERT INTO TB VALUES (1, cast(1.5 as float)), (2, cast(2.25 as float)), (3, cast(3.75 as float))
-    - query: INSERT INTO TC VALUES (1, x'deadbeef'), (2, x'cafe'), (3, x'0ff1ce')
-    - query: INSERT INTO TD VALUES (1, (100, 'hello')), (2, (200, 'world'))
 ---
 test_block:
   name: prepared-tests
@@ -155,57 +156,66 @@ test_block:
       - result: [{[10, 100, 1000]}]
 ---
 test_block:
-  name: float-insert-test
+  name: type-with-scalars-roundtrip
   preset: single_repetition_ordered
   options:
-    statement_type: prepared # ensure we are testing with inserting via parameters
+    statement_type: prepared
   tests:
     -
-      - query: insert into tb(a, b) values (!! !l 100 !!, !! !f 0.5 !!)
+      - query: insert into type_with_scalars(pk, bigint_value, integer_value, double_value, float_value, string_value, boolean_value, bytes_value)
+          values (!! !l 1 !!, !! !l 178 !!, !! 42 !!, !! 3.14 !!, !! !f 1.5 !!, !! 'hello' !!, !!true!!, !! !b x'deadbeef' !!)
+      - count: 1
+    -
+      # bigint beyond integer range; double beyond float precision; boolean false
+      - query: insert into type_with_scalars(pk, bigint_value, integer_value, double_value, float_value, string_value, boolean_value, bytes_value)
+          values (!! !l 2 !!, !! !l 3000000000 !!, !! -999 !!, !! 3.141592653589793 !!, !! !f 2.25 !!, !! 'prepared' !!, !!false!!, !! !b x'cafe' !!)
+      - count: 1
+    -
+      # negative bigint beyond integer range; very large double outside float range
+      - query: insert into type_with_scalars(pk, bigint_value, integer_value, double_value, float_value, string_value, boolean_value, bytes_value)
+          values (!! !l 3 !!, !! !l -5000000000 !!, !! 2147483647 !!, !! 1.0E300 !!, !! !f 0.125 !!, !! '' !!, !!true!!, !! !b x'0ff1ce' !!)
       - count: 1
 ---
 test_block:
-  name: float-prepared-tests
+  name: type-with-scalars-roundtrip-read
   tests:
     -
-      - query: select a from tb where b < !! !f 3.0 !!
-      - result: [{a: 1}, {a: 2}, {a: 100}]
+      - query: select * from type_with_scalars where pk = !! !l 1 !!
+      - result: [{!l 1, !l 178, 42, 3.14, !f 1.5, 'hello', true, x'deadbeef'}]
     -
-      - query: select a from tb where b = !! !f 1.5 !!
-      - result: [{!l 1}]
+      - query: select * from type_with_scalars where pk = !! !l 2 !!
+      - result: [{!l 2, !l 3000000000, -999, 3.141592653589793, !f 2.25, 'prepared', false, x'cafe'}]
     -
-      - query: select b from tb where a = !! !l 1 !!
-      - result: [{!f 1.5}]
-    -
-      - query: select b from tb where a = !! !l 3 !!
-      - result: [{!f 3.75}]
-    -
-      # verify the inserted float value round-trips
-      - query: select b from tb where a = !! !l 100 !!
-      - result: [{!f 0.5}]
+      - query: select * from type_with_scalars where pk = !! !l 3 !!
+      - result: [{!l 3, !l -5000000000, 2147483647, 1.0E300, !f 0.125, '', true, x'0ff1ce'}]
+
 ---
 test_block:
-  name: bytes-insert-test
+  name: type-with-arrays-roundtrip
   preset: single_repetition_ordered
   options:
-    statement_type: prepared # ensure we are testing with inserting via parameters
+    statement_type: prepared
+    supported_version: !current_version
   tests:
     -
-      # parameterized insert into bytes column
-      - query: insert into tc(a, b) values (!! !l 100 !!, !! !b x'baadf00d' !!)
+      - query: insert into type_with_arrays(pk, bigint_array, integer_array, double_array, float_array, string_array, boolean_array, bytes_array)
+          values (!! !l 1 !!, !! [!l 10, !l 20] !!, !! [1, 2, 3] !!, !! [1.1, 2.2] !!, !! [!f 1.5, !f 2.5] !!, !! ['a', 'b'] !!, !! [true, false] !!, !! [!b x'cafe', !b x'f00d'] !!)
+      - count: 1
+    -
+      # arrays with boundary values: bigints beyond int range, doubles beyond float range
+      - query: insert into type_with_arrays(pk, bigint_array, integer_array, double_array, float_array, string_array, boolean_array, bytes_array)
+          values (!! !l 2 !!, !! [!l 3000000000, !l -5000000000] !!, !! [-1, 0, 1] !!, !! [1.0E300, 3.141592653589793] !!, !! [!f 0.125, !f 3.75] !!, !! ['', 'prepared'] !!, !! [false, false, true] !!, !! [!b x'deadbeef', !b x'0ff1ce', !b x'baadf00d'] !!)
       - count: 1
 ---
 test_block:
-  name: bytes-prepared-tests
+  name: type-with-arrays-roundtrip-read
+  options:
+    supported_version: !current_version
   tests:
     -
-      # select bytes value using prepared bigint parameter
-      - query: select b from tc where b = !! !b x'deadbeef' !!
-      - result: [{x'deadbeef'}]
+      - query: select * from type_with_arrays where pk = !! !l 1 !!
+      - result: [{!l 1, [!l 10, !l 20], [1, 2, 3], [1.1, 2.2], [!f 1.5, !f 2.5], ['a', 'b'], [true, false], [x'cafe', x'f00d']}]
     -
-      # verify the inserted bytes value
-      - query: select b from tc where a = !! !l 100 !!
-      - result: [{x'baadf00d'}]
-# JDBC does not support createStruct (always returns null), so inserting with jdbc parameters is not supported.
-# See: https://github.com/FoundationDB/fdb-record-layer/issues/4064
+      - query: select * from type_with_arrays where pk = !! !l 2 !!
+      - result: [{!l 2, [!l 3000000000, !l -5000000000], [-1, 0, 1], [1.0E300, 3.141592653589793], [!f 0.125, !f 3.75], ['', 'prepared'], [false, false, true], [x'deadbeef', x'0ff1ce', x'baadf00d']}]
 ...

--- a/yaml-tests/src/test/resources/prepared.yamsql
+++ b/yaml-tests/src/test/resources/prepared.yamsql
@@ -43,7 +43,7 @@ setup:
                (15, 16.01, false, 1566, [17, 18, 19], 'black widow'),
                (17, 18.01, true, 1744, [19, 20, 21], 'jessica jones'),
                (19, 20.01, false, 1853, [21, 22, 23], 'luke cage')
-#    - query: INSERT INTO TB VALUES (1, 1.5), (2, 2.25), (3, 3.75)
+    - query: INSERT INTO TB VALUES (1, cast(1.5 as float)), (2, cast(2.25 as float)), (3, cast(3.75 as float))
     - query: INSERT INTO TC VALUES (1, x'deadbeef'), (2, x'cafe'), (3, x'0ff1ce')
     - query: INSERT INTO TD VALUES (1, (100, 'hello')), (2, (200, 'world'))
 ---
@@ -140,7 +140,7 @@ test_block:
 test_block:
   preset: single_repetition_ordered
   options:
-    # insert statements do not take parameter
+    # insert statements do not take parameter by itself
     statement_type: simple
   tests:
     -
@@ -153,44 +153,42 @@ test_block:
     -
       - query: update ta set e = !! [10, 100, 1000] !! where a = 1 returning "new".e
       - result: [{[10, 100, 1000]}]
-#---
-# ---------- float ----------
-#test_block:
-#  name: float-prepared-tests
-#  tests:
-#    -
-#      # parameterized comparison against float column (using double parameter)
-#      - query: select a from tb where b < !! 3.0 !!
-#      - result: [{!l 1}, {!l 2}]
-#    -
-#      # parameterized equality on float column
-#      - query: select a from tb where b = !! 1.5 !!
-#      - result: [{!l 1}]
-#    -
-#      # read back float value via cast to double to avoid Float/Double mismatch
-#      - query: select cast(b as double) from tb where a = !! !l 1 !!
-#      - result: [{1.5}]
-#    -
-#      - query: select cast(b as double) from tb where a = !! !l 3 !!
-#      - result: [{3.75}]
-#---
-#test_block:
-#  name: float-insert-test
-#  preset: single_repetition_ordered
-#  tests:
-#    -
-#      # parameterized insert into float column
-#      - query: insert into tb(a, b) values (!! !l 100 !!, !! 0.5 !!)
-#      - count: 1
-#    -
-#      # verify the inserted float value round-trips
-#      - query: select cast(b as double) from tb where a = !! !l 100 !!
-#      - result: [{0.5}]
-# ---------- bytes ----------
+---
+test_block:
+  name: float-insert-test
+  preset: single_repetition_ordered
+  options:
+    statement_type: prepared # ensure we are testing with inserting via parameters
+  tests:
+    -
+      - query: insert into tb(a, b) values (!! !l 100 !!, !! !f 0.5 !!)
+      - count: 1
+---
+test_block:
+  name: float-prepared-tests
+  tests:
+    -
+      - query: select a from tb where b < !! !f 3.0 !!
+      - result: [{a: 1}, {a: 2}, {a: 100}]
+    -
+      - query: select a from tb where b = !! !f 1.5 !!
+      - result: [{!l 1}]
+    -
+      - query: select b from tb where a = !! !l 1 !!
+      - result: [{!f 1.5}]
+    -
+      - query: select b from tb where a = !! !l 3 !!
+      - result: [{!f 3.75}]
+    -
+      # verify the inserted float value round-trips
+      - query: select b from tb where a = !! !l 100 !!
+      - result: [{!f 0.5}]
 ---
 test_block:
   name: bytes-insert-test
   preset: single_repetition_ordered
+  options:
+    statement_type: prepared # ensure we are testing with inserting via parameters
   tests:
     -
       # parameterized insert into bytes column

--- a/yaml-tests/src/test/resources/prepared.yamsql
+++ b/yaml-tests/src/test/resources/prepared.yamsql
@@ -206,24 +206,6 @@ test_block:
       # verify the inserted bytes value
       - query: select b from tc where a = !! !l 100 !!
       - result: [{x'baadf00d'}]
-# ---------- struct ----------
----
-test_block:
-  name: struct-insert-test
-  preset: single_repetition_ordered
-  options:
-    # struct tuple parameter creates a JDBC Struct with generic type name,
-    # so use simple statement for the insert
-    statement_type: simple
-  tests:
-    -
-      - query: insert into td values !! {!l 100, {!l 42, 'test_value'}} !!
-      - count: 1
----
-test_block:
-  name: struct-prepared-tests
-  tests:
-    -
-      - query: select b from td where a = 100
-      - result: [{{f0: 42, f1: 'test_value'}}]
+# JDBC does not support createStruct (always returns null), so inserting with jdbc parameters is not supported.
+# See: https://github.com/FoundationDB/fdb-record-layer/issues/4064
 ...


### PR DESCRIPTION
This adds test coverage for reading and writing between JDBC / embedded to ensure that the data is interoperable, and that the same code can run against either. 

I fixed the easy ones, but left the following issues still unresolved: #3665 #4064

This also adds support to yamsql for the following:
- Floats via a new `!f` tag. Yaml, by default will parse anything that looks like a double as a double, so this is needed to support float parameters and float results
- Bytes via a new `!b` tag that takes a hex string (i.e. `x'1975ab`)