### PR TITLE
Fix issues with ARRAY columns and NULL values

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/NullableArrayTypeUtils.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/NullableArrayTypeUtils.java
@@ -92,23 +92,23 @@ public class NullableArrayTypeUtils {
     }
 
     /**
-     * If the value is a nullable array, unwrap the value wrapper.
+     * If the value is a {@link Message} for a nullable array, unwrap the value wrapper.
      *
-     * @param wrappedValue The input value
-     * @param type The input type
-     *
-     * @return The unwrapped value
+     * @param value The input value.
+     * @param type The input type.
+     * @return The unwrapped value.
      */
     @Nullable
-    public static Object unwrapIfArray(@Nullable Object wrappedValue, @Nonnull Type type) {
-        //
-        // If the last step in the field path is an array that is also nullable, then we need to unwrap the value
-        // wrapper.
-        //
-        if (wrappedValue != null && type.isArray() && type.isNullable()) {
-            return MessageHelpers.getFieldOnMessage((Message)wrappedValue, NullableArrayTypeUtils.getRepeatedFieldName());
+    public static Object unwrapIfArray(@Nullable Object value, @Nonnull Type type) {
+        if (value == null) {
+            return null;
         }
-        return wrappedValue;
+        // Note: The value may already be a `List`, as this is also called during evaluation (e.g. `FieldValue#eval()`).
+        if (value instanceof Message && type.isArray() && type.isNullable()) {
+            return MessageHelpers.getFieldOnMessage((Message)value, NullableArrayTypeUtils.getRepeatedFieldName());
+        } else {
+            return value;
+        }
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/MessageHelpers.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/MessageHelpers.java
@@ -368,6 +368,8 @@ public class MessageHelpers {
                     // want to get the value of that field as a 'runtime' type, hence we get the raw message itself.
                     var fieldResult = messageFieldDescriptor.isRepeated() || !messageFieldDescriptor.getType().equals(Descriptors.FieldDescriptor.Type.MESSAGE) ?
                                       getFieldOnMessage(currentMessage, messageFieldDescriptor) : getFieldMessageOnMessage(currentMessage, messageFieldDescriptor);
+                    // If the last step in the field path is an array that is also nullable, then we need to unwrap the
+                    // value wrapper.
                     fieldResult = NullableArrayTypeUtils.unwrapIfArray(fieldResult, currentFieldType);
                     final var coercedObject =
                             coerceObject(promotionTrieForField, targetFieldType, targetDescriptorForField, currentFieldType, fieldResult);
@@ -408,6 +410,21 @@ public class MessageHelpers {
                 Verify.verify(targetDescriptor instanceof Descriptors.Descriptor);
                 return deepCopyMessageIfNeeded((Descriptors.Descriptor)targetDescriptor, (Message)current);
             }
+
+            // “Re-wrap” `List` values when the target is a nullable ARRAY. Such arrays are stored as a wrapper message
+            // { repeated <type> values = 1; }. Without this wrapping, when the evaluated value is a plain `List` (e.g.,
+            // from an array literal or from `unwrapIfArray()`), subsequently setting it on the protobuf builder would
+            // cause `setField()` to reject the `List<>` with a type mismatch error.
+            if (targetType.isNullable() && targetType.isArray()) {
+                Verify.verify(current instanceof List);
+                Verify.verify(targetDescriptor instanceof Descriptors.Descriptor);
+                final var wrapperDescriptor = (Descriptors.Descriptor)targetDescriptor;
+                final var valuesField = Verify.verifyNotNull(wrapperDescriptor.findFieldByName(NullableArrayTypeUtils.getRepeatedFieldName()));
+                final var wrapperBuilder = DynamicMessage.newBuilder(wrapperDescriptor);
+                wrapperBuilder.setField(valuesField, current);
+                return wrapperBuilder.build();
+            }
+
             return current;
         }
 
@@ -557,8 +574,12 @@ public class MessageHelpers {
     }
 
     private static boolean hasAnySuchField(@Nonnull final Message message, Descriptors.FieldDescriptor fieldDescriptor) {
+        // A repeated field represents an array and must be treated as always present by `coerceMessage()`, even when
+        // `fieldDescriptor.getRepeatedFieldCount()` is 0 (which is a valid state that represents the empty array []).
+        // (Note: A nullable array that is NULL is represented by the absence of the optional wrapper message field;
+        // this is handled by the else branch below.)
         if (fieldDescriptor.isRepeated()) {
-            return message.getRepeatedFieldCount(fieldDescriptor) > 0;
+            return true;
         } else {
             return message.hasField(fieldDescriptor);
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/RecordConstructorValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/RecordConstructorValue.java
@@ -133,7 +133,7 @@ public class RecordConstructorValue extends AbstractValue implements AggregateVa
                 }
                 resultMessageBuilder.setField(fieldDescriptor, childResult);
             } else {
-                Verify.verify(fieldType.isNullable());
+                Verify.verify(fieldType.isNullable(), "Cannot set a non-nullable field to the NULL value");
             }
             i++;
         }

--- a/yaml-tests/src/test/resources/arrays.yamsql
+++ b/yaml-tests/src/test/resources/arrays.yamsql
@@ -19,60 +19,157 @@
 
 ---
 schema_template:
-    create table A(pk integer, x integer array, primary key(pk))
-    create table B(pk integer, x string array, primary key(pk))
-    create table C(pk integer, x double array, primary key(pk))
-    create type as struct S(f integer)
-    create table D(pk integer, x S array, primary key(pk))
-    create type as struct T(x integer, y double)
-    create table E(pk integer, x T array, primary key(pk))
-    create type as struct U(x integer, y double, z integer array)
-    create table F(pk integer, x U array, primary key(pk))
-    create table G(pk integer, x string array, primary key(pk))
+    CREATE TABLE A_NOT_NULL (pk INTEGER, x INTEGER ARRAY NOT NULL, PRIMARY KEY (pk))
+    CREATE TABLE A_NULL (pk INTEGER, x INTEGER ARRAY NULL, PRIMARY KEY (pk))
+    CREATE TABLE A (pk INTEGER, x INTEGER ARRAY, PRIMARY KEY (pk))
+    CREATE TABLE B (pk INTEGER, x STRING ARRAY, PRIMARY KEY (pk))
+    CREATE TABLE C (pk INTEGER, x DOUBLE ARRAY, PRIMARY KEY (pk))
+    CREATE TYPE AS STRUCT S (f INTEGER)
+    CREATE TABLE D (pk INTEGER, x S ARRAY, PRIMARY KEY (pk))
+    CREATE TYPE AS STRUCT T (x INTEGER, y DOUBLE)
+    CREATE TABLE E (pk INTEGER, x T ARRAY, PRIMARY KEY (pk))
+    CREATE TYPE AS STRUCT U (x INTEGER, y DOUBLE, z INTEGER ARRAY)
+    CREATE TABLE F (pk INTEGER, x U ARRAY, PRIMARY KEY (pk))
+    CREATE TABLE G (pk INTEGER, x STRING ARRAY, PRIMARY KEY (pk))
 ---
 test_block:
   name: arrays-tests
   preset: single_repetition_ordered
   tests:
     -
+      # Attempting to insert a NULL value into a not-nullable ARRAY column.
+      - query: INSERT INTO A_NOT_NULL VALUES (0, NULL)
+      - supported_version: !current_version
+      - error: "XX000"
+    -
+      # INSERT + basic SELECT for a not-nullable INTEGER ARRAY.
+      - query: INSERT INTO A_NOT_NULL VALUES (0, []), (1, [1]), (2, [1, 2])
+      - count: 3
+    -
+      - query: SELECT * FROM A_NOT_NULL
+      - result: [{0, []}, {1, [1]}, {2, [1, 2]}]
+    -
+      # INSERT + basic SELECT for a nullable INTEGER ARRAY, including a NULL array value.
+      - query: INSERT INTO A_NULL VALUES (-1, NULL), (0, []), (1, [1]), (2, [1, 2])
+      - supported_version: !current_version
+      - count: 4
+    -
+      - query: SELECT * FROM A_NULL
+      - supported_version: !current_version
+      - result: [{-1, !null _}, {0, []}, {1, [1]}, {2, [1, 2]}]
+    -
+      # INSERT + basic SELECT for a nullable INTEGER ARRAY.
       - query: INSERT INTO A VALUES (1, [1, 2, 3]), (2, [2, 3, 4]), (3, [3, 4, 5])
       - count: 3
     -
-      - query: SELECT * FROM A
-      - result: [{1, [1, 2, 3]}, {2, [2, 3, 4]}, {3, [3, 4, 5]}]
+      # INSERT NULL for a nullable INTEGER ARRAY.
+      - query: INSERT INTO A VALUES (-1, NULL)
+      - supported_version: !current_version
+      - count: 1
     -
+      # INSERT empty array for a nullable INTEGER ARRAY.
+      - query: INSERT INTO A VALUES (0, [])
+      - supported_version: !current_version
+      - count: 1
+    -
+      - query: SELECT * FROM A
+      - supported_version: !current_version
+      - result: [{-1, !null _}, {0, []}, {1, [1, 2, 3]}, {2, [2, 3, 4]}, {3, [3, 4, 5]}]
+    -
+      # INSERT for a nullable STRING ARRAY.
       - query: INSERT INTO B VALUES (1, ['a', 'b', 'c']), (2, ['b', 'c', 'd']), (3, ['c', 'd', 'e'])
       - count: 3
     -
+      # INSERT NULL for a nullable STRING ARRAY.
+      - query: INSERT INTO B VALUES (0, NULL)
+      - supported_version: !current_version
+      - count: 1
+    -
+      # INSERT + basic SELECT for a nullable DOUBLE ARRAY.
       - query: INSERT INTO C VALUES (1, [1.1, 2.1, 3.1]), (2, [2.1, 3.1, 4.1]), (3, [3.1, 4.1, 5.1])
       - count: 3
     -
-      - query: select x from c
-      - result: [{[1.1, 2.1, 3.1]}, {[2.1, 3.1, 4.1]}, {[3.1, 4.1, 5.1]}]
+      # INSERT NULL for a nullable DOUBLE ARRAY.
+      - query: INSERT INTO C VALUES (0, NULL)
+      - supported_version: !current_version
+      - count: 1
     -
+      - query: select x from c
+      - supported_version: !current_version
+      - result: [{!null _}, {[1.1, 2.1, 3.1]}, {[2.1, 3.1, 4.1]}, {[3.1, 4.1, 5.1]}]
+    -
+      # INSERT for an ARRAY of a 1-element STRUCT type.
       - query: INSERT INTO D VALUES (1, [(1), (2), (3)]), (2, [(2), (3), (4)]), (3, [(3), (4), (5)])
       - count: 3
     -
+      # INSERT NULL for an ARRAY of a 1-element STRUCT type.
+      - query: INSERT INTO D VALUES (0, NULL)
+      - supported_version: !current_version
+      - count: 1
+    -
+      # INSERT for an ARRAY of a multi-element STRUCT type.
       - query: INSERT INTO E VALUES (1, [(1, 1.0), (2, 2.0), (3, 3.0)]), (2, [(2, 2.0), (3, 3.0), (4, 4.0)]), (3, [(3, 3.0), (4, 4.0), (5, 5.0)])
       - count: 3
     -
+      # INSERT NULL for an ARRAY of a multi-element STRUCT type.
+      - query: INSERT INTO E VALUES (0, NULL)
+      - supported_version: !current_version
+      - count: 1
+    -
+      # INSERT for an ARRAY of a multi-element STRUCT type featuring an INTEGER ARRAY member.
       - query: INSERT INTO F VALUES
               (1, [(1, 1.0, [1, 1, 1]), (2, 2.0, [1, 1, 1]), (3, 3.0, [1, 1, 1])]),
               (2, [(2, 2.0, [1, 1, 1]), (3, 3.0, [1, 1, 1]), (4, 4.0, [1, 1, 1])]),
               (3, [(3, 3.0, [1, 1, 1]), (4, 4.0, [1, 1, 1]), (5, 5.0, [1, 1, 1])])
       - count: 3
     -
+      # INSERT NULL for an ARRAY of a multi-element STRUCT type featuring an INTEGER ARRAY member.
+      - query: INSERT INTO F VALUES (0, NULL)
+      - supported_version: !current_version
+      - count: 1
+    -
+      # INSERT for a nullable STRING ARRAY using the untyped empty array literal [].
       - query: INSERT INTO G VALUES (1, [])
       - supported_version: 4.5.13.0
       - count: 1
     -
-      # "new" should not be quoted. TODO ([Post] Fix identifiers case-sensitivity matching in plan generator)
+      # INSERT NULL for a nullable STRING ARRAY.
+      - query: INSERT INTO G VALUES (0, NULL)
+      - supported_version: !current_version
+      - count: 1
+    -
+      # UPDATE for a not-nullable INTEGER ARRAY.
+      # Note: `"new"` should not be quoted here and below! TODO [Post] Fix identifiers case-sensitivity matching in plan generator
+      - query: UPDATE A_NOT_NULL SET X = [11, 12, 13] WHERE PK = 1 RETURNING "new".X
+      - supported_version: !current_version
+      - result: [{[11, 12, 13]}]
+    -
+      # UPDATE for a nullable INTEGER ARRAY.
       - query: UPDATE A SET X = [11, 12, 13] WHERE PK = 1 RETURNING "new".X
       - result: [{[11, 12, 13]}]
     -
-      # "new" should not be quoted. TODO ([Post] Fix identifiers case-sensitivity matching in plan generator)
       - query: UPDATE D SET X = [(11), (12), (13)] WHERE PK = 1 RETURNING "new".X
       - result: [{[{F: 11}, {F: 12}, {F: 13}]}]
+    -
+      # UPDATE nullable array to empty array.
+      - query: UPDATE A SET X = CAST([] AS INTEGER ARRAY) WHERE PK = 0 RETURNING "new".X
+      - supported_version: !current_version
+      - result: [{[]}]
+    -
+      # UPDATE nullable array to NULL.
+      - query: UPDATE A SET X = NULL WHERE PK = -1 RETURNING "new".X
+      - supported_version: !current_version
+      - result: [{!null _}]
+    -
+      # UPDATE NOT NULL array to empty array.
+      - query: UPDATE A_NOT_NULL SET X = CAST([] AS INTEGER ARRAY) WHERE PK = 1 RETURNING "new".X
+      - supported_version: !current_version
+      - result: [{[]}]
+    -
+      # UPDATE explicitly-nullable column from NULL to non-null array.
+      - query: UPDATE A_NULL SET X = [99] WHERE PK = -1 RETURNING "new".X
+      - supported_version: !current_version
+      - result: [{[99]}]
     -
       - query: select X[3] from A where PK = 1
       - supported_version: 4.5.13.0


### PR DESCRIPTION
This change fixes various issues related to the nullability of ARRAYs that can surface in INSERT/UPDATE statements against such columns.

* In `MessageHelper#coerceObject()`, add code to correctly wrap the evaluated array into the appropriate wrapper message when the target is a nullable array. Before, it would return the array value as-is as a `List` object, which later causes a protobuf type mismatch in `FieldSet$Builder#verifyType()`. This issue surfaces in SQL when trying to INSERT a NULL array into a nullable ARRAY column.

* In `MessageHelper#hasAnySuchField()`, change the code so that a repeated field is reported as present even when it has 0 repetitions. (See the explaining comment there.) This fixes INSERTing an empty array via `VALUES ([])`, where the [] would incorrectly get mapped to NULL by `MessageHelper#coerceMessage()`.

* In `NullableArrayTypeUtils#unwrapIfArray()`, skip unwrapping the wrapper message in the case where the `wrappedValue` is not actually a `Message` but already a `List`. Without this, a simple SQL UPDATE query against an ARRAY NOT NULL column runs into `ClassCastException`.

* In `RecordConstructorValue#eval()`, improve the message of the verify statement that prevents assigning a NULL array to a non-nullable field as in `INSERT INTO … (…, not_null_array) VALUES (…, NULL)`.

Testing:
* Add small regression tests to `arrays.yamsql` for the three items.

This fixes #4069.