### PR TITLE
Fix NullPointerException in FlatMapPipelinedCursor.close & unclosed resources

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/FlatMapPipelinedCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/FlatMapPipelinedCursor.java
@@ -332,12 +332,17 @@ public class FlatMapPipelinedCursor<T, V> implements RecordCursor<V> {
         }
 
         public void close() {
-            final CompletableFuture<RecordCursorResult<V>> future = innerFuture;
+            CompletableFuture<RecordCursorResult<V>> future = innerFuture;
             if (future != null) {
                 future.cancel(false);
             }
             if (innerCursor != null) {
                 innerCursor.close();
+            }
+            // re-cancel future in case getNextInnerPipelineFuture is running at the same time
+            future = innerFuture;
+            if (future != null) {
+                future.cancel(false);
             }
         }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/FlatMapPipelinedCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/FlatMapPipelinedCursor.java
@@ -280,6 +280,10 @@ public class FlatMapPipelinedCursor<T, V> implements RecordCursor<V> {
     }
 
     private class PipelineQueueEntry {
+        /**
+         * null if-and-only-if this is a sentinel indicating the end of the pipeline.
+         */
+        @Nullable
         final RecordCursor<V> innerCursor;
         final RecordCursorContinuation priorOuterContinuation;
         final RecordCursorResult<T> outerResult;
@@ -287,7 +291,7 @@ public class FlatMapPipelinedCursor<T, V> implements RecordCursor<V> {
 
         private volatile CompletableFuture<RecordCursorResult<V>> innerFuture;
 
-        public PipelineQueueEntry(RecordCursor<V> innerCursor,
+        public PipelineQueueEntry(@Nullable RecordCursor<V> innerCursor,
                                   RecordCursorContinuation priorOuterContinuation,
                                   RecordCursorResult<T> outerResult,
                                   byte[] outerCheckValue) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/FlatMapPipelinedCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/FlatMapPipelinedCursor.java
@@ -285,7 +285,7 @@ public class FlatMapPipelinedCursor<T, V> implements RecordCursor<V> {
         final RecordCursorResult<T> outerResult;
         final byte[] outerCheckValue;
 
-        private CompletableFuture<RecordCursorResult<V>> innerFuture;
+        private volatile CompletableFuture<RecordCursorResult<V>> innerFuture;
 
         public PipelineQueueEntry(RecordCursor<V> innerCursor,
                                   RecordCursorContinuation priorOuterContinuation,
@@ -310,13 +310,14 @@ public class FlatMapPipelinedCursor<T, V> implements RecordCursor<V> {
         }
 
         public boolean doesNotHaveReturnableResult() {
+            final CompletableFuture<RecordCursorResult<V>> future = innerFuture;
             if (innerCursor == null ||       // Hit sentinel, so we have a returnable result
-                    innerFuture == null ||   // Inner future hasn't been started yet.
-                    !innerFuture.isDone()) { // No result yet. Don't know whether result will be returnable.
+                    future == null ||   // Inner future hasn't been started yet.
+                    !future.isDone()) { // No result yet. Don't know whether result will be returnable.
                 return false;
             }
 
-            final RecordCursorResult<V> innerResult = innerFuture.join();
+            final RecordCursorResult<V> innerResult = future.join();
             if (innerResult.hasNext()) {
                 return false; // a result with a value is returnable by the cursor
             } else { // inner cursor exhausted
@@ -327,7 +328,11 @@ public class FlatMapPipelinedCursor<T, V> implements RecordCursor<V> {
         }
 
         public void close() {
-            if (innerFuture != null && innerFuture.cancel(false)) {
+            final CompletableFuture<RecordCursorResult<V>> future = innerFuture;
+            if (future != null) {
+                future.cancel(false);
+            }
+            if (innerCursor != null) {
                 innerCursor.close();
             }
         }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/RecordCursorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/RecordCursorTest.java
@@ -1397,6 +1397,44 @@ public class RecordCursorTest {
     }
 
     @Test
+    void closePipelineClosesAllInnerCursors() {
+        for (int i = 0; i < 200_000; i++) {
+            final int iteration = i;
+            CompletableFuture<Void> signal = new CompletableFuture<>();
+            List<RecordCursor<String>> createdCursors = Collections.synchronizedList(new ArrayList<>());
+            RecordCursor<String> cursor = RecordCursor.flatMapPipelined(
+                    outerContinuation -> RecordCursor.fromList(EXECUTOR,
+                            IntStream.range(0, iteration % 50 + 1).boxed().collect(Collectors.toList()),
+                            outerContinuation),
+                    (outerValue, innerContinuation) -> {
+                        RecordCursor<String> innerCursor = new LazyCursor<>(signal.thenApply(ignore ->
+                                RecordCursor.fromList(EXECUTOR,
+                                        IntStream.range(0, 3).mapToObj(j -> outerValue + ":" + j).collect(Collectors.toList()),
+                                        innerContinuation)));
+                        createdCursors.add(innerCursor);
+                        return innerCursor;
+                    },
+                    null,
+                    null,
+                    iteration % 9 + 2
+            );
+            CompletableFuture<? extends RecordCursorResult<?>> resultFuture = cursor.onNext();
+
+            signal.complete(null);
+            cursor.close();
+            try {
+                resultFuture.get(2, TimeUnit.SECONDS);
+            } catch (Exception ignored) {
+                // We don't care about the result; we care about cursor closure below
+            }
+            for (RecordCursor<String> innerCursor : createdCursors) {
+                assertTrue(innerCursor.isClosed(),
+                        "Inner cursor not closed on iteration " + iteration + " (created " + createdCursors.size() + " cursors)");
+            }
+        }
+    }
+
+    @Test
     void futureCursorTest() {
         CompletableFuture<Integer> future = new CompletableFuture<>();
         final RecordCursorContinuation continuation;

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/RecordCursorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/RecordCursorTest.java
@@ -33,6 +33,7 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.util.pair.Pair;
 import com.apple.foundationdb.test.TestExecutors;
 import com.apple.test.BooleanSource;
+import com.apple.test.RandomSeedSource;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
@@ -58,6 +59,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Random;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.CancellationException;
@@ -1432,6 +1434,59 @@ public class RecordCursorTest {
                         "Inner cursor not closed on iteration " + iteration + " (created " + createdCursors.size() + " cursors)");
             }
         }
+    }
+
+    @ParameterizedTest
+    @RandomSeedSource
+    void closePipelineCancelsInnerFutureRace(long seed) {
+        final Random random = new Random(seed);
+        Map<Class<? extends Throwable>, Integer> exceptionCount = new HashMap<>();
+        for (int i = 0; i < 20_000; i++) {
+            try {
+                // Inner cursors depend on signals that are NEVER completed.
+                // The only way for the pipeline future to resolve is via cancellation of innerFuture.
+                RecordCursor<String> cursor = RecordCursor.flatMapPipelined(
+                        outerContinuation -> RecordCursor.fromList(EXECUTOR,
+                                IntStream.range(0, random.nextInt(100) + 1).boxed().collect(Collectors.toList()),
+                                outerContinuation),
+                        (outerValue, innerContinuation) -> {
+                            CompletableFuture<Void> neverCompleted = new CompletableFuture<>();
+                            return new LazyCursor<>(neverCompleted.thenApply(ignore ->
+                                    RecordCursor.fromList(EXECUTOR,
+                                            Collections.singletonList(String.valueOf(outerValue)),
+                                            innerContinuation)));
+                        },
+                        null,
+                        null,
+                        random.nextInt(20) + 1
+                );
+                CompletableFuture<? extends RecordCursorResult<?>> resultFuture = cursor.onNext();
+
+                // Close immediately — race with getNextInnerPipelineFuture
+                cursor.close();
+
+                // If innerFuture was properly cancelled, this resolves quickly.
+                // If the race caused close() to miss the cancel, this hangs.
+                resultFuture.get(500, TimeUnit.MILLISECONDS);
+            } catch (Exception e) {
+                Throwable errToCount;
+                if (e instanceof ExecutionException && e.getCause() != null) {
+                    errToCount = e.getCause();
+                    errToCount.addSuppressed(e);
+                } else {
+                    errToCount = e;
+                }
+                if (errToCount instanceof CancellationException) {
+                    continue;
+                }
+                LOGGER.error(KeyValueLogMessage.of("error during test"), errToCount);
+                exceptionCount.compute(errToCount.getClass(), (k, v) -> v == null ? 1 : v + 1);
+            }
+        }
+        KeyValueLogMessage msg = KeyValueLogMessage.build("exception counts");
+        msg.addKeysAndValues(exceptionCount);
+        LOGGER.info(msg.toString());
+        assertThat(exceptionCount, Matchers.anEmptyMap());
     }
 
     @Test


### PR DESCRIPTION
We have seen some flakiness in https://github.com/FoundationDB/fdb-record-layer/blob/7a8ff2771acee4aae7de9b7d0acc1704ce446e1c/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/RecordCursorTest.java#L1348 where it gets a `NullPointerException`, e.g.:
https://github.com/FoundationDB/fdb-record-layer/actions/runs/24241062421

This is because `nextResult` may be running in a separate thread at the same time as close, and thus `close()` will get a `NullPointerException` because it checks that `innerFuture` is not null and then tries to cancel.
Additionally in doing this fix I noticed that we may not close all the created cursors. Looking through the history, I cannot figure out why it was done that way, but it has been that way since we reworked the cursor behavior: https://github.com/FoundationDB/fdb-record-layer/pull/213

The new test on my laptop failed first attempt, but even by increasing the count, I could not reproduce the NPE on my laptop. 