### PR TITLE
Remove local variable when push release changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -337,7 +337,7 @@ jobs:
         shell: bash
         run: |
             # Remove the leading "refs/heads/" from the branch name stored in the GITHUB_REF environment variable
-            local branch_name="${GITHUB_REF##*/}"
+            branch_name="${GITHUB_REF##*/}"
             echo "Fetching and merging latest updates from branch ${branch_name} into HEAD..."
             git fetch origin "${branch_name}"
             git merge --no-edit "origin/${branch_name}"


### PR DESCRIPTION
According to the build:
```
/home/runner/work/_temp/299f43f5-50c0-4023-8dfc-9dfa855b3595.sh: line 2: local: can only be used in a function
```

This removes the use of `local`, which I believe was unnecessary.