### PR TITLE
Bump version to 4.10.18.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@
 #
 
 rootProject.name=fdb-record-layer
-version=4.10.17.0
+version=4.10.18.0
 releaseBuild=false
 
 # this should be false for release branches (i.e. if there is no -SNAPSHOT on the above version)


### PR DESCRIPTION
Release failed to complete, but published the release, so this bumps the version manually to avoid the conflict.