### PR TITLE
Fix `LIKE` predicate literal stripping in AST normalizer

### DIFF
--- a/fdb-relational-core/src/main/antlr/RelationalParser.g4
+++ b/fdb-relational-core/src/main/antlr/RelationalParser.g4
@@ -1227,7 +1227,7 @@ expression
 predicate
     : NOT? BETWEEN left=expressionAtom AND right=expressionAtom           #betweenComparisonPredicate // done
     | NOT? IN inList                                                      #inPredicate // done
-    | NOT? LIKE pattern=STRING_LITERAL (ESCAPE escape=STRING_LITERAL)?    #likePredicate // done
+    | NOT? LIKE pattern=constant (ESCAPE escape=STRING_LITERAL)?          #likePredicate // done
     | IS NOT? testValue=(TRUE | FALSE | NULL_LITERAL)                     #isExpression      // done
     ;
 

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/ExpressionVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/ExpressionVisitor.java
@@ -599,10 +599,8 @@ public final class ExpressionVisitor extends DelegatingVisitor<BaseVisitor> {
         } else {
             escapeValue = new LiteralValue<>(null);
         }
-        final var pattern = Assert.notNullUnchecked(getDelegate().normalizeString(ctx.pattern.getText()));
-        final var patternValueBinding = getDelegate().getPlanGenerationContext().processQueryLiteral(
-                Type.primitiveType(Type.TypeCode.STRING), pattern, ctx.pattern.getTokenIndex());
-        final var patternFunction = getDelegate().resolveFunction("__pattern_for_like", Expression.ofUnnamed(patternValueBinding),
+        final var patternValueBinding = Assert.castUnchecked(ctx.pattern.accept(this), Expression.class);
+        final var patternFunction = getDelegate().resolveFunction("__pattern_for_like", patternValueBinding,
                 Expression.ofUnnamed(escapeValue));
         final var likeFunction = getDelegate().resolveFunction(ctx.LIKE().getText(), operand, patternFunction);
         if (ctx.NOT() != null) {

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/AstNormalizerTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/AstNormalizerTests.java
@@ -1426,6 +1426,18 @@ public class AstNormalizerTests {
     }
 
     @Test
+    void likePatternConstantIsStripped() throws RelationalException {
+        // Verify that the LIKE pattern constant is stripped and replaced with a placeholder,
+        // so queries with different LIKE patterns share the same canonical representation.
+        validate(List.of(
+                        "select * from t1 where col1 like 'hello%'",
+                        "select * from t1 where col1 like 'world%'"),
+                "select * from \"T1\" where \"COL1\" like ? ",
+                List.of(Map.of(constantId(7), "hello%"),
+                        Map.of(constantId(7), "world%")));
+    }
+
+    @Test
     void windowFunctionOptionsAreNotStripped() throws Exception {
         // Test that EF_SEARCH option in window function is preserved during normalization
         validate("select * from t1 qualify row_number() over (partition by zone order by distance OPTIONS EF_SEARCH = 100) < 10",

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/cache/RelationalPlanCacheTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/cache/RelationalPlanCacheTests.java
@@ -822,7 +822,7 @@ public class RelationalPlanCacheTests {
                 "SELECT * FROM SCI_FI_BOOKS_OF_80S()", "SCHEMA_TEMPLATE_1", 10, 100, Set.of(i1970, i1980, i1990), i1980);
 
         shouldBe(cache, Map.of(new Tuple("SELECT * FROM \"SCI_FI_BOOKS_OF_80S\" ( ) ", "SCHEMA_TEMPLATE_1", 10, 100, configOf(Set.of(i1970, i1980, i1990)), "CREATE TEMPORARY FUNCTION \"SCI_FI_BOOKS\" ( ) " +
-                        "ON COMMIT DROP FUNCTION AS SELECT * FROM \"BOOKS\" WHERE \"TITLE\" LIKE 'SCIFI' ||CREATE TEMPORARY FUNCTION \"SCI_FI_BOOKS_OF_80S\" ( ) " +
+                        "ON COMMIT DROP FUNCTION AS SELECT * FROM \"BOOKS\" WHERE \"TITLE\" LIKE ? ||CREATE TEMPORARY FUNCTION \"SCI_FI_BOOKS_OF_80S\" ( ) " +
                         "ON COMMIT DROP FUNCTION AS SELECT * FROM \"SCI_FI_BOOKS\" ( ) WHERE \"YEAR\" > ? AND \"YEAR\" < ? "),
                 Map.of(ppe(cons(
                         cons(c1980Cp0(20, "SCI_FI_BOOKS_OF_80S"), c1980Cp0(24, "SCI_FI_BOOKS_OF_80S")),
@@ -849,8 +849,8 @@ public class RelationalPlanCacheTests {
                 "SELECT * FROM SCI_FI_BOOKS_OF_80S()", "SCHEMA_TEMPLATE_1", 10, 100, Set.of(i1970, i1980, i1990), i1980);
 
         shouldBe(cache, Map.of(new Tuple("SELECT * FROM \"SCI_FI_BOOKS_OF_80S\" ( ) ", "SCHEMA_TEMPLATE_1", 10, 100, configOf(Set.of(i1970, i1980, i1990)), "CREATE TEMPORARY FUNCTION \"OTHER_BOOKS\" ( ) " +
-                        "ON COMMIT DROP FUNCTION AS SELECT * FROM \"BOOKS\" WHERE \"TITLE\" LIKE 'OTHER' ||CREATE TEMPORARY FUNCTION \"SCI_FI_BOOKS\" ( ) " +
-                        "ON COMMIT DROP FUNCTION AS SELECT * FROM \"BOOKS\" WHERE \"TITLE\" LIKE 'SCIFI' ||CREATE TEMPORARY FUNCTION \"SCI_FI_BOOKS_OF_80S\" ( ) " +
+                        "ON COMMIT DROP FUNCTION AS SELECT * FROM \"BOOKS\" WHERE \"TITLE\" LIKE ? ||CREATE TEMPORARY FUNCTION \"SCI_FI_BOOKS\" ( ) " +
+                        "ON COMMIT DROP FUNCTION AS SELECT * FROM \"BOOKS\" WHERE \"TITLE\" LIKE ? ||CREATE TEMPORARY FUNCTION \"SCI_FI_BOOKS_OF_80S\" ( ) " +
                         "ON COMMIT DROP FUNCTION AS SELECT * FROM \"SCI_FI_BOOKS\" ( ) WHERE \"YEAR\" > ? AND \"YEAR\" < ? "),
                 Map.of(ppe(cons(
                         cons(c1980Cp0(20, "SCI_FI_BOOKS_OF_80S"), c1980Cp0(24, "SCI_FI_BOOKS_OF_80S")),
@@ -875,7 +875,7 @@ public class RelationalPlanCacheTests {
 
         shouldBe(cache, Map.of(new Tuple("SELECT * FROM \"SCI_FI_BOOKS_OF_80S\" ( ) , \"SCI_FI_BOOKS_OF_80S\" ( ) ", "SCHEMA_TEMPLATE_1", 10, 100, configOf(Set.of(i1970, i1980, i1990)),
                         "CREATE TEMPORARY FUNCTION \"SCI_FI_BOOKS\" ( ) " +
-                        "ON COMMIT DROP FUNCTION AS SELECT * FROM \"BOOKS\" WHERE \"TITLE\" LIKE 'SCIFI' ||CREATE TEMPORARY FUNCTION \"SCI_FI_BOOKS_OF_80S\" ( ) " +
+                        "ON COMMIT DROP FUNCTION AS SELECT * FROM \"BOOKS\" WHERE \"TITLE\" LIKE ? ||CREATE TEMPORARY FUNCTION \"SCI_FI_BOOKS_OF_80S\" ( ) " +
                         "ON COMMIT DROP FUNCTION AS SELECT * FROM \"SCI_FI_BOOKS\" ( ) WHERE \"YEAR\" > ? AND \"YEAR\" < ? "),
                 Map.of(ppe(cons(
                         cons(cons(c1980Cp0(20, "SCI_FI_BOOKS_OF_80S"), c1980Cp0(24, "SCI_FI_BOOKS_OF_80S")), cons(c1980Cp0(20, "SCI_FI_BOOKS_OF_80S"), c1980Cp0(24, "SCI_FI_BOOKS_OF_80S"))),
@@ -901,8 +901,8 @@ public class RelationalPlanCacheTests {
 
         shouldBe(cache, Map.of(new Tuple("SELECT * FROM \"SCI_FI_BOOKS_OF_80S\" ( ) AS \"A\" , \"OTHER_BOOKS\" ( ) AS \"B\" WHERE \"A\" . \"YEAR\" > ? AND \"A\" . \"TITLE\" = ? ",
                         "SCHEMA_TEMPLATE_1", 10, 100, configOf(Set.of(i1970, i1980, i1990)), "CREATE TEMPORARY FUNCTION \"OTHER_BOOKS\" ( ) " +
-                        "ON COMMIT DROP FUNCTION AS SELECT * FROM \"BOOKS\" WHERE \"TITLE\" LIKE 'OTHER' ||CREATE TEMPORARY FUNCTION \"SCI_FI_BOOKS\" ( ) " +
-                        "ON COMMIT DROP FUNCTION AS SELECT * FROM \"BOOKS\" WHERE \"TITLE\" LIKE 'SCIFI' ||CREATE TEMPORARY FUNCTION \"SCI_FI_BOOKS_OF_80S\" ( ) " +
+                        "ON COMMIT DROP FUNCTION AS SELECT * FROM \"BOOKS\" WHERE \"TITLE\" LIKE ? ||CREATE TEMPORARY FUNCTION \"SCI_FI_BOOKS\" ( ) " +
+                        "ON COMMIT DROP FUNCTION AS SELECT * FROM \"BOOKS\" WHERE \"TITLE\" LIKE ? ||CREATE TEMPORARY FUNCTION \"SCI_FI_BOOKS_OF_80S\" ( ) " +
                         "ON COMMIT DROP FUNCTION AS SELECT * FROM \"SCI_FI_BOOKS\" ( ) WHERE \"YEAR\" > ? AND \"YEAR\" < ? "),
                 Map.of(ppe(cons(
                         cons(c1980Cp0(20, "SCI_FI_BOOKS_OF_80S"), c1980Cp0(24, "SCI_FI_BOOKS_OF_80S"), c1980Cp0(19)),

--- a/yaml-tests/src/test/resources/like.yamsql
+++ b/yaml-tests/src/test/resources/like.yamsql
@@ -72,8 +72,7 @@ setup:
         ;
 ---
 test_block:
-  # TODO (Investigate `Missing binding for __const_CONSTANT` error with queries when using plan from cache)
-  preset: single_repetition_parallelized
+  supported_version: !current_version
   tests:
     -
       - query: select * from B WHERE B2 LIKE 'X'
@@ -101,8 +100,7 @@ test_block:
       - result: [{2, 'Z'}, {4, 'Z'}]
 ---
 test_block:
-  # TODO (Investigate `Missing binding for __const_CONSTANT` error with queries when using plan from cache)
-  preset: single_repetition_parallelized
+  supported_version: !current_version
   tests:
     -
       - query: select * from A WHERE A1 LIKE 'A'
@@ -376,11 +374,8 @@ test_block:
       - result: [
         ]
 ---
-# TODO (Investigate `Missing binding for __const_CONSTANT` error with queries when using plan from cache)
 test_block:
-  options:
-    repetition: 1
-    check_cache: false
+  supported_version: !current_version
   tests:
     -
       - query: select * from A WHERE A1 LIKE '|_|_%' ESCAPE '|'

--- a/yaml-tests/src/test/resources/like.yamsql
+++ b/yaml-tests/src/test/resources/like.yamsql
@@ -16,7 +16,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+---
+options:
+  supported_version: !current_version
 ---
 schema_template:
     create table A(a1 string, primary key(a1))
@@ -72,7 +74,6 @@ setup:
         ;
 ---
 test_block:
-  supported_version: !current_version
   tests:
     -
       - query: select * from B WHERE B2 LIKE 'X'
@@ -100,7 +101,6 @@ test_block:
       - result: [{2, 'Z'}, {4, 'Z'}]
 ---
 test_block:
-  supported_version: !current_version
   tests:
     -
       - query: select * from A WHERE A1 LIKE 'A'
@@ -375,7 +375,6 @@ test_block:
         ]
 ---
 test_block:
-  supported_version: !current_version
   tests:
     -
       - query: select * from A WHERE A1 LIKE '|_|_%' ESCAPE '|'


### PR DESCRIPTION
The `LIKE` predicate's pattern was previously parsed as a raw `STRING_LITERAL` in the grammar, which meant the AST normalizer could not strip it like other constants. This caused the pattern value to be baked into the canonical query string rather than replaced with a `?` placeholder, leading to `Missing binding
 for __const_CONSTANT` errors when a cached plan was reused with a different literal. This change updates the grammar rule to parse the `LIKE` pattern as a constant and adjusts the `ExpressionVisitor` to visit it through the standard constant-handling path, aligning `LIKE` with how every other literal in the query is normalized. The YAML tests that were previously restricted to `single_repetition_parallelized` or had caching disabled now run normally with plan cache enabled.
                                                                                                                                                                                                                                                                                                                    
A unit test (`likePatternConstantIsStripped`) is added to `AstNormalizerTests` confirming that queries differing only in their `LIKE` pattern value produce the same canonical representation and that the stripped literal is correctly stored in the execution parameters.

This fixes #3389.