### PR TITLE
Join two unjoined futures in FDBRecordStoreRepairHeaderTest

### DIFF
--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreRepairHeaderTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreRepairHeaderTest.java
@@ -671,7 +671,7 @@ public class FDBRecordStoreRepairHeaderTest extends FDBRecordStoreConcurrentTest
                 assertThat(recordStore.getAllIndexStates().values())
                         .contains(IndexState.READABLE);
                 for (final Index index : toRebuild) {
-                    recordStore.markIndexDisabled(index);
+                    recordStore.markIndexDisabled(index).join();
                 }
             } else {
                 assertAllIndexStates(recordStore, IndexState.DISABLED);
@@ -806,7 +806,7 @@ public class FDBRecordStoreRepairHeaderTest extends FDBRecordStoreConcurrentTest
     private static void disableAllIndexesAndClearLock(final FDBRecordStore recordStore) {
         recordStore.getAllIndexStates().forEach((index, indexState) ->
                 recordStore.markIndexDisabled(index).join());
-        recordStore.clearStoreLockStateAsync();
+        recordStore.clearStoreLockStateAsync().join();
     }
 
     private void validateRecords(final List<FDBStoredRecord<Message>> records, final FDBRecordStoreBase<Message> recordStore) {


### PR DESCRIPTION
I noticed some rare flakiness in repairWithIndexes, and have not been able to reproduce, but noticed these two spots where futures were not joined which could have been the cause.