### PR TITLE
Support CARDINALITY() in indexes

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/CardinalityFunctionKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/CardinalityFunctionKeyExpression.java
@@ -1,0 +1,184 @@
+/*
+ * CardinalityFunctionKeyExpression.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2023-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.metadata.expressions;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.FunctionNames;
+import com.apple.foundationdb.record.ObjectPlanHash;
+import com.apple.foundationdb.record.metadata.Key;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecord;
+import com.apple.foundationdb.record.query.plan.cascades.NullableArrayTypeUtils;
+import com.apple.foundationdb.record.query.plan.cascades.values.Value;
+import com.google.auto.service.AutoService;
+import com.google.common.base.Verify;
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.Message;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A key expression representing the {@code CARDINALITY(<expr>)} function.
+ *
+ * <p>When the {@code CARDINALITY()} SQL function is applied to a nullable array column, the repeated field will be
+ * wrapped on the Protobuf level and the key expression will look like this:
+ * {@code function("cardinality", field("ARRAY_FIELD").nest(field("values", KeyExpression.FanType.Concatenate)))}
+ * … where {@code "values"} is the repeated field of the appropriate array element type, and the {@code Concatenate}
+ * fan-out type collects all array elements into a single {@code Key.Evaluated} holding the array.
+ */
+@API(API.Status.EXPERIMENTAL)
+public class CardinalityFunctionKeyExpression extends FunctionKeyExpression {
+    private static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("Cardinality-Function");
+
+    protected CardinalityFunctionKeyExpression(@Nonnull String name, @Nonnull KeyExpression arguments) {
+        super(name, arguments);
+    }
+
+    @Override
+    public int getMinArguments() {
+        return 1;
+    }
+
+    @Override
+    public int getMaxArguments() {
+        return 1;
+    }
+
+    @Override
+    public boolean createsDuplicates() {
+        return false;
+    }
+
+    @Override
+    public int getColumnSize() {
+        return 1;
+    }
+
+    @Nonnull
+    @Override
+    public Value toValue(@Nonnull final List<? extends Value> argumentValues) {
+        return resolveAndEncapsulateFunction(getName(), argumentValues);
+    }
+
+    /**
+     * Evaluates the cardinality against a record or protobuf message. Where possible, this counts the repeated Protobuf
+     * field directly via {@link Message#getRepeatedFieldCount} to avoid the materialization of the argument array into
+     * a {@link Key.Evaluated}.
+     *
+     * <p>Two common argument shapes are recognized and fast-pathed:
+     * <ul>
+     * <li>{@code field("arr", Concatenate)} — Corresponds to a {@code NOT NULL} array column in SQL.
+     * <li>{@code field("arr").nest(field("values", Concatenate))} — Corresponds to the nullable-array wrapper pattern
+     * for a nullable array column in SQL.
+     * </ul>
+     * Anything else (for example, deeper nestings like {@code field("struct").nest(field("arr", Concatenate))}) and
+     * the null cases fall back to {@code super.evaluateMessage}, which then routes into {@link #evaluateFunction}
+     * with a materialized argument list (or a {@code null} argument, for the null cases).
+     */
+    @Nonnull
+    @Override
+    public <M extends Message> List<Key.Evaluated> evaluateMessage(@Nullable FDBRecord<M> record,
+                                                                   @Nullable Message message) {
+        if (message != null) {
+            if (arguments instanceof NestingKeyExpression nesting
+                    && NullableArrayTypeUtils.matchArrayWrapper(nesting).isPresent()) {
+                final FieldKeyExpression wrapper = nesting.getParent();
+                final Descriptors.FieldDescriptor wrapperDescriptor =
+                        message.getDescriptorForType().findFieldByName(wrapper.getFieldName());
+                if (wrapperDescriptor != null && message.hasField(wrapperDescriptor)) {
+                    return evaluateOnWrappedArray((Message)message.getField(wrapperDescriptor));
+                }
+            } else if (arguments instanceof FieldKeyExpression field) {
+                final Descriptors.FieldDescriptor descriptor =
+                        message.getDescriptorForType().findFieldByName(field.getFieldName());
+                if (descriptor != null && descriptor.isRepeated()) {
+                    final int cardinality = message.getRepeatedFieldCount(descriptor);
+                    return Collections.singletonList(Key.Evaluated.scalar(cardinality));
+                }
+            }
+        }
+        return super.evaluateMessage(record, message);
+    }
+
+    /**
+     * Fast path to count the elements of a nullable-array wrapper message that is known to be present.
+     */
+    @Nonnull
+    private static List<Key.Evaluated> evaluateOnWrappedArray(@Nonnull Message wrapperMessage) {
+        final Descriptors.FieldDescriptor valuesDescriptor =
+                wrapperMessage.getDescriptorForType().findFieldByName(NullableArrayTypeUtils.getRepeatedFieldName());
+        Verify.verifyNotNull(valuesDescriptor);
+        Verify.verify(valuesDescriptor.isRepeated());
+        final int cardinality = wrapperMessage.getRepeatedFieldCount(valuesDescriptor);
+        return Collections.singletonList(Key.Evaluated.scalar(cardinality));
+    }
+
+    /**
+     * Evaluates the cardinality for argument shapes that {@link #evaluateMessage} did not recognize.
+     */
+    @Nonnull
+    @Override
+    public <M extends Message> List<Key.Evaluated> evaluateFunction(@Nullable FDBRecord<M> rec,
+                                                                    @Nullable Message message,
+                                                                    @Nonnull Key.Evaluated argvals) {
+        Verify.verify(argvals.size() == 1);
+        final Object arg = argvals.getObject(0);
+        if (arg == null) {
+            return Collections.singletonList(Key.Evaluated.NULL);
+        }
+        final List<?> argList = (List<?>) arg;
+        return Collections.singletonList(Key.Evaluated.scalar(argList.size()));
+    }
+
+    /// @see FunctionKeyExpression#create
+    @Override
+    public List<Descriptors.FieldDescriptor> validate(@Nonnull Descriptors.Descriptor descriptor) {
+        // Note: `arguments.getColumnSize()` must be 1, but `create()` already validates that.
+        if (arguments.createsDuplicates()) {
+            throw new InvalidExpressionException("The CARDINALITY() argument must produce a single value.");
+        }
+        return super.validate(descriptor);
+    }
+
+    @Override
+    public int planHash(@Nonnull final PlanHashMode mode) {
+        return super.basePlanHash(mode, BASE_HASH);
+    }
+
+    /**
+     * Factory for {@link CardinalityFunctionKeyExpression}.
+     */
+    @AutoService(FunctionKeyExpression.Factory.class)
+    @API(API.Status.EXPERIMENTAL)
+    public static class CardinalityFunctionKeyExpressionFactory implements FunctionKeyExpression.Factory {
+        @Nonnull
+        @Override
+        public List<FunctionKeyExpression.Builder> getBuilders() {
+            return ImmutableList.of(
+                    new FunctionKeyExpression.BiFunctionBuilder(FunctionNames.CARDINALITY,
+                            CardinalityFunctionKeyExpression::new)
+            );
+        }
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/KeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/KeyExpression.java
@@ -40,12 +40,13 @@ import java.util.List;
 
 /**
  * Interface for expressions that evaluate to keys.
- * While Java will let you extend this class, you probably shouldn't because the planner does lots of instanceof
+ *
+ * <p>While Java will let you extend this class, you probably shouldn't because the planner does lots of instanceof
  * calls to figure out what query to use. If you're ok with always just doing a scan of all records, and evaluating
  * the expression on that, I guess that's ok.
  *
- * When implementing a new key expression, care should be taken to implement at least one (and possibly both) of
- * the interfaces Key.AtomExpression and Key.ExpressionWithChildren.
+ * <p>When implementing a new key expression, care should be taken to implement at least one (and possibly both) of
+ * the interfaces {@link AtomKeyExpression} and {@link KeyExpressionWithChildren}.
  */
 @API(API.Status.UNSTABLE)
 public interface KeyExpression extends PlanHashable {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/KeyExpressionExpansionVisitor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/KeyExpressionExpansionVisitor.java
@@ -55,7 +55,13 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
- * Expansion visitor that implements the shared logic between primary scan data access and value index access.
+ * Expansion visitor that walks a {@link KeyExpression} tree and translates each node into a {@link GraphExpansion}.
+ *
+ * <p>This base class implements the shared expansion logic; subclasses tailor it to a specific access path. Current
+ * subclasses include {@link PrimaryAccessExpansionVisitor} (for primary scan data access) and
+ * {@link ValueIndexExpansionVisitor} (for value index access).
+ *
+ * <p>Per-visit context is carried on a stack of {@link VisitorState} objects.
  */
 public class KeyExpressionExpansionVisitor implements KeyExpressionVisitor<VisitorState, GraphExpansion> {
     /**
@@ -154,7 +160,10 @@ public class KeyExpressionExpansionVisitor implements KeyExpressionVisitor<Visit
                         .builderWithInheritedPlaceholders()
                         .pullUpQuantifier(childQuantifier)
                         .build();
+            case Concatenate:
             case None:
+                // Note: `Concatenate` and `None` can use the graph expansion logic. Both just access the field directly
+                // via `FieldValue.ofFieldNames()`.
                 value = state.registerValue(FieldValue.ofFieldNames(baseQuantifier.getFlowedObjectValue(), fieldNames));
                 if (state.isSelectStar()) {
                     if (state.isKey() && !state.isInternalExpansion()) {
@@ -168,10 +177,9 @@ public class KeyExpressionExpansionVisitor implements KeyExpressionVisitor<Visit
                     }
                     return GraphExpansion.ofResultColumn(column);
                 }
-            case Concatenate: // TODO collect/concatenate function
             default:
+                throw new UnsupportedOperationException();
         }
-        throw new UnsupportedOperationException();
     }
 
     @Nonnull
@@ -230,6 +238,21 @@ public class KeyExpressionExpansionVisitor implements KeyExpressionVisitor<Visit
         throw new RecordCoreException("expression should have been handled at top level");
     }
 
+    /**
+     * Expands a {@link NestingKeyExpression}. The behavior depends on the fan-out type of the parent field:
+     * <ul>
+     * <li>{@code None} — The parent contributes a path segment; the child is expanded with the extended field-name
+     *     prefix. A special case is when the whole nesting matches the nullable-array wrapper pattern
+     *     {@code field(x).nest(field("values", FAN_OUT|CONCATENATE))}. In this case the {@code "values"} level is
+     *     stripped and expansion is delegated back to {@code visitExpression(FieldKeyExpression)} with the
+     *     corresponding fan-type on the parent.</li>
+     * <li>{@code FanOut} — The parent is exploded into a {@link Quantifier.ForEach}, the child is expanded under
+     *     that quantifier, and the resulting columns, predicates, and placeholders are pulled up through a newly
+     *     introduced {@link SelectExpression}.</li>
+     * <li>{@code Concatenate} — Rejected. A parent with this fan-type produces a single list-typed value, which has
+     *     no sub-fields to nest into, so {@code field(…, Concatenate).nest(...)} is not a meaningful construct.</li>
+     * </ul>
+     */
     @Nonnull
     @Override
     public GraphExpansion visitExpression(@Nonnull final NestingKeyExpression nestingKeyExpression) {
@@ -241,22 +264,44 @@ public class KeyExpressionExpansionVisitor implements KeyExpressionVisitor<Visit
         final KeyExpression child = nestingKeyExpression.getChild();
         switch (parent.getFanType()) {
             case None:
-                List<String> newPrefix = ImmutableList.<String>builder()
-                        .addAll(fieldNamePrefix)
-                        .add(ProtoUtils.toUserIdentifier((parent.getFieldName())))
-                        .build();
-                if (NullableArrayTypeUtils.isArrayWrapper(nestingKeyExpression)) {
-                    final RecordKeyExpressionProto.KeyExpression childProto = nestingKeyExpression.getChild().toKeyExpression();
-                    if (childProto.hasNesting()) {
-                        RecordKeyExpressionProto.Nesting.Builder newNestingBuilder = RecordKeyExpressionProto.Nesting.newBuilder()
-                                .setParent(parent.toProto().toBuilder().setFanType(RecordKeyExpressionProto.Field.FanType.FAN_OUT))
-                                .setChild(childProto.getNesting().getChild());
-                        return visitExpression(new NestingKeyExpression(newNestingBuilder.build()));
-                    } else {
-                        return visitExpression(new FieldKeyExpression(parent.toProto().toBuilder().setFanType(RecordKeyExpressionProto.Field.FanType.FAN_OUT).build()));
+                final var arrayWrapperFanType = NullableArrayTypeUtils.matchArrayWrapper(nestingKeyExpression);
+                if (arrayWrapperFanType.isPresent()) {
+                    switch (arrayWrapperFanType.get()) {
+                        case FAN_OUT:
+                            final RecordKeyExpressionProto.KeyExpression childProto = nestingKeyExpression.getChild().toKeyExpression();
+                            if (childProto.hasNesting()) {
+                                RecordKeyExpressionProto.Nesting.Builder newNestingBuilder = RecordKeyExpressionProto.Nesting.newBuilder()
+                                        .setParent(parent.toProto().toBuilder().setFanType(RecordKeyExpressionProto.Field.FanType.FAN_OUT))
+                                        .setChild(childProto.getNesting().getChild());
+                                return visitExpression(new NestingKeyExpression(newNestingBuilder.build()));
+                            } else {
+                                return visitExpression(new FieldKeyExpression(parent.toProto()
+                                        .toBuilder()
+                                        .setFanType(RecordKeyExpressionProto.Field.FanType.FAN_OUT)
+                                        .build()));
+                            }
+                        case CONCATENATE:
+                            // "values" is always a leaf for a `Concatenate` wrapper: Concatenation produces a list,
+                            // which has no sub-fields. Rewrite this as a direct field access with fan-type
+                            // `Concatenate` on the parent, and delegate to the visitor for `FieldKeyExpression`.
+                            Verify.verify(!nestingKeyExpression.getChild().toKeyExpression().hasNesting(),
+                                    "\"values\" field in a `Concatenate` array wrapper must be a leaf");
+                            return visitExpression(
+                                    new FieldKeyExpression(parent.toProto()
+                                            .toBuilder()
+                                            .setFanType(RecordKeyExpressionProto.Field.FanType.CONCATENATE)
+                                            .build()));
+                        case SCALAR:
+                        default:
+                            throw new RecordCoreException("unexpected fan type for array wrapper values field");
                     }
+                } else {
+                    List<String> newPrefix = ImmutableList.<String>builder()
+                            .addAll(fieldNamePrefix)
+                            .add(ProtoUtils.toUserIdentifier((parent.getFieldName())))
+                            .build();
+                    return pop(child.expand(push(state.withFieldNamePrefix(newPrefix))));
                 }
-                return pop(child.expand(push(state.withFieldNamePrefix(newPrefix))));
             case FanOut:
                 // explode the parent field(s) also depending on the prefix
                 final Quantifier.ForEach childBaseQuantifier = parent.explodeField(baseQuantifier, fieldNamePrefix);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/NullableArrayTypeUtils.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/NullableArrayTypeUtils.java
@@ -29,6 +29,7 @@ import com.google.protobuf.Message;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Optional;
 
 /**
  * A Utils class that holds logic related to nullable arrays.
@@ -72,23 +73,24 @@ public class NullableArrayTypeUtils {
     }
 
     /**
-     * Check whether a nesting keyExpression is a wrapped array field.
+     * Check whether the given nesting key expression is a wrapped array field.
      *
      * @param nestingKeyExpression the nesting keyExpression.
      *
-     * @return <code>true</code> if it describes a wrapped array, otherwise <code>false</code>.
+     * @return The fan type of the wrapped {@code "values"} field, or empty if this is not an array wrapper.
      */
-    public static boolean isArrayWrapper(@Nonnull NestingKeyExpression nestingKeyExpression) {
+    @Nonnull
+    public static Optional<RecordKeyExpressionProto.Field.FanType> matchArrayWrapper(@Nonnull NestingKeyExpression nestingKeyExpression) {
         RecordKeyExpressionProto.KeyExpression child = nestingKeyExpression.getChild().toKeyExpression();
         if (child.hasNesting()) {
             // if child is Nesting, check child.parent
             RecordKeyExpressionProto.Field firstChild = child.getNesting().getParent();
-            return isWrappedField(firstChild);
+            return matchWrappedField(firstChild);
         } else if (child.hasField()) {
             // if child is Field, check itself
-            return isWrappedField(child.getField());
+            return matchWrappedField(child.getField());
         }
-        return false;
+        return Optional.empty();
     }
 
     /**
@@ -112,13 +114,17 @@ public class NullableArrayTypeUtils {
     }
 
     /**
-     * Return whether a Field is a wrapped array.
+     * Check whether the given field is a wrapped array.
      *
-     * @param field The input field
+     * @param field The input field.
      *
-     * @return <code>true</code> if it is a wrapped array, otherwise <code>false</code>.
+     * @return The fan type if this is a wrapped array field, or empty otherwise.
      */
-    private static boolean isWrappedField(@Nonnull RecordKeyExpressionProto.Field field) {
-        return REPEATED_FIELD_NAME.equals(field.getFieldName()) && RecordKeyExpressionProto.Field.FanType.FAN_OUT.equals(field.getFanType());
+    @Nonnull
+    private static Optional<RecordKeyExpressionProto.Field.FanType> matchWrappedField(@Nonnull RecordKeyExpressionProto.Field field) {
+        if (REPEATED_FIELD_NAME.equals(field.getFieldName())) {
+            return Optional.of(field.getFanType());
+        }
+        return Optional.empty();
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ScalarTranslationVisitor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ScalarTranslationVisitor.java
@@ -119,9 +119,11 @@ public class ScalarTranslationVisitor implements KeyExpressionVisitor<ScalarTran
     @Nonnull
     @Override
     public Value visitExpression(@Nonnull FieldKeyExpression fieldKeyExpression) {
+        // The fan-out type is usually expected to be `None` aka. SCALAR here. It may also be `Concatenate`, for example
+        // when a function key expression invokes CARDINALITY() on an ARRAY field.
         final KeyExpression.FanType fanType = fieldKeyExpression.getFanType();
-        if (fanType != KeyExpression.FanType.None) {
-            throw new RecordCoreException("cannot expand fan outs in scalar expansion");
+        if (!(fanType == KeyExpression.FanType.None || fanType == KeyExpression.FanType.Concatenate)) {
+            throw new RecordCoreException("cannot expand fan-outs in scalar expansion");
         }
 
         final ScalarVisitorState state = getCurrentState();
@@ -169,12 +171,18 @@ public class ScalarTranslationVisitor implements KeyExpressionVisitor<ScalarTran
 
         final ScalarVisitorState state = getCurrentState();
         final List<String> fieldNamePrefix = state.getFieldNamePrefix();
-        final KeyExpression child = nestingKeyExpression.getChild();
         final String parentFieldName = ProtoUtils.toUserIdentifier(parent.getFieldName());
         final List<String> newPrefix = ImmutableList.<String>builder()
                 .addAll(fieldNamePrefix)
                 .add(parentFieldName)
                 .build();
+
+        // Strip the "values" wrapper for nullable arrays.
+        if (NullableArrayTypeUtils.matchArrayWrapper(nestingKeyExpression).isPresent()) {
+            return FieldValue.ofFieldNames(QuantifiedObjectValue.of(state.getBaseAlias(), state.inputType), newPrefix);
+        }
+
+        final KeyExpression child = nestingKeyExpression.getChild();
         // TODO resolve type
         return pop(child.expand(push(state.withFieldNamePrefix(newPrefix))));
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/CardinalityValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/CardinalityValue.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2023-2030 Apple Inc. and the FoundationDB project authors
+ * Copyright 2023-2026 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/KeyExpressionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/KeyExpressionTest.java
@@ -23,12 +23,14 @@ package com.apple.foundationdb.record.metadata;
 import com.apple.foundationdb.record.ObjectPlanHash;
 import com.apple.foundationdb.record.PlanHashable;
 import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.TypeTestProto;
 import com.apple.foundationdb.record.UnstoredRecord;
 import com.apple.foundationdb.record.metadata.ExpressionTestsProto.Customer;
 import com.apple.foundationdb.record.metadata.ExpressionTestsProto.NestedField;
 import com.apple.foundationdb.record.metadata.ExpressionTestsProto.SubString;
 import com.apple.foundationdb.record.metadata.ExpressionTestsProto.SubStrings;
 import com.apple.foundationdb.record.metadata.ExpressionTestsProto.TestScalarFieldAccess;
+import com.apple.foundationdb.record.metadata.expressions.CardinalityFunctionKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.EmptyKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.FieldKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.FunctionKeyExpression;
@@ -46,6 +48,7 @@ import com.apple.foundationdb.record.query.plan.cascades.values.Value;
 import com.google.auto.service.AutoService;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import com.google.protobuf.ByteString;
 import com.google.protobuf.Message;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -84,6 +87,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -325,10 +329,10 @@ public class KeyExpressionTest {
         List<Key.Evaluated> results = evaluate(expression, subString);
         assertEquals(4, results.size(), "Wrong number of results");
         assertEquals(ImmutableList.of(
-                    Key.Evaluated.scalar("co"),
-                    Key.Evaluated.scalar("ke"),
-                    Key.Evaluated.scalar("j"),
-                    Key.Evaluated.scalar("tos")),
+                        Key.Evaluated.scalar("co"),
+                        Key.Evaluated.scalar("ke"),
+                        Key.Evaluated.scalar("j"),
+                        Key.Evaluated.scalar("tos")),
                 results);
     }
 
@@ -873,8 +877,8 @@ public class KeyExpressionTest {
         assertEquals(Collections.emptyList(),
                 evaluate(expression, emptyNested));
         assertEquals(Arrays.asList(
-                Key.Evaluated.concatenate("Lonely", NULL),
-                Key.Evaluated.concatenate("Lonely", NULL)),
+                        Key.Evaluated.concatenate("Lonely", NULL),
+                        Key.Evaluated.concatenate("Lonely", NULL)),
                 evaluate(expression, lonelyDoll));
         assertEquals(Collections.emptyList(),
                 evaluate(expression, null));
@@ -979,7 +983,7 @@ public class KeyExpressionTest {
         final KeyExpression concat = concat(field("f1"),
                 concat(field("f2"), field("f3")),
                 field("f4"));
-        ThenKeyExpression then = (ThenKeyExpression) concat;
+        ThenKeyExpression then = (ThenKeyExpression)concat;
         assertFalse(then.createsDuplicates());
         assertEquals(4, then.getChildren().size());
         for (KeyExpression child : then.getChildren()) {
@@ -994,8 +998,8 @@ public class KeyExpressionTest {
         final KeyExpression list = list(field("field"), field("repeat_me", Concatenate));
         list.validate(TestScalarFieldAccess.getDescriptor());
         assertEquals(Collections.singletonList(concatenate(
-                scalar("Plants").values(),
-                scalar(concatenate("Boxes", "Bowls").values()).values())),
+                        scalar("Plants").values(),
+                        scalar(concatenate("Boxes", "Bowls").values()).values())),
                 evaluate(list, plantsBoxesAndBowls));
     }
 
@@ -1029,7 +1033,7 @@ public class KeyExpressionTest {
         final NestingKeyExpression nest = field("f1").nest(field("f2", FanOut).nest("f3"));
         final NestingKeyExpression reserialized = new NestingKeyExpression(nest.toProto());
         assertEquals("f1", reserialized.getParent().getFieldName());
-        final NestingKeyExpression child = (NestingKeyExpression) reserialized.getChild();
+        final NestingKeyExpression child = (NestingKeyExpression)reserialized.getChild();
         assertEquals("f2", child.getParent().getFieldName());
         assertEquals(FanOut, child.getParent().getFanType());
     }
@@ -1039,9 +1043,9 @@ public class KeyExpressionTest {
         final SplitKeyExpression split = field("repeat_me", FanOut).split(3);
         split.validate(TestScalarFieldAccess.getDescriptor());
         assertEquals(Arrays.asList(
-                concatenate("one", "two", "three"),
-                concatenate("four", "five", "six"),
-                concatenate("seven", "eight", "nine")),
+                        concatenate("one", "two", "three"),
+                        concatenate("four", "five", "six"),
+                        concatenate("seven", "eight", "nine")),
                 evaluate(split, numbers));
         assertEquals(Collections.emptyList(), evaluate(split, null));
     }
@@ -1061,9 +1065,9 @@ public class KeyExpressionTest {
                 field("repeat_me", FanOut).split(3));
         splitConcat.validate(TestScalarFieldAccess.getDescriptor());
         assertEquals(Arrays.asList(
-                concatenate("numbers", "one", "two", "three"),
-                concatenate("numbers", "four", "five", "six"),
-                concatenate("numbers", "seven", "eight", "nine")),
+                        concatenate("numbers", "one", "two", "three"),
+                        concatenate("numbers", "four", "five", "six"),
+                        concatenate("numbers", "seven", "eight", "nine")),
                 evaluate(splitConcat, numbers));
     }
 
@@ -1248,7 +1252,7 @@ public class KeyExpressionTest {
     @MethodSource
     void testRecordTypePrefix(@Nonnull KeyExpression key, boolean hasRecordTypePrefix) {
         assertEquals(hasRecordTypePrefix, Key.Expressions.hasRecordTypePrefix(key),
-                () ->  key + " should" + (hasRecordTypePrefix ? "" : " not") + " have a record type prefix");
+                () -> key + " should" + (hasRecordTypePrefix ? "" : " not") + " have a record type prefix");
     }
 
     @SuppressWarnings("unused")
@@ -1580,5 +1584,71 @@ public class KeyExpressionTest {
         public Value toValue(@Nonnull final List<? extends Value> argumentValues) {
             throw new UnsupportedOperationException("not implemented");
         }
+    }
+
+    /**
+     * Basic tests for {@link CardinalityFunctionKeyExpression}.
+     */
+    @Test
+    void testCardinalityFunctionKeyExpression() {
+        // CARDINALITY() is not meant to be applied to a repeated field with `FanOut`, as that produces duplicates.
+        assertThrows(KeyExpression.InvalidExpressionException.class, () -> function("cardinality", field("repeat_me", FanType.FanOut)).validate(TestScalarFieldAccess.getDescriptor()));
+
+        // A basic application of CARDINALITY() to a plain repeated field (i.e., a non-nullable array).
+        final KeyExpression expr1 = function("cardinality", field("repeat_me", FanType.Concatenate));
+        expr1.validate(TestScalarFieldAccess.getDescriptor());
+        assertFalse(expr1.createsDuplicates());
+        assertEquals(1, expr1.getColumnSize());
+        // On a non-empty repeated field, CARDINALITY() is the element count.
+        assertEquals(Collections.singletonList(scalar(2)), evaluate(expr1, plantsBoxesAndBowls));
+        // On an empty repeated field, CARDINALITY() is 0.
+        assertEquals(Collections.singletonList(scalar(0)), evaluate(expr1, emptyScalar));
+        // A NULL record means there is no record to count; CARDINALITY() yields NULL.
+        assertEquals(Collections.singletonList(Key.Evaluated.NULL), evaluate(expr1, null));
+
+        // Applying CARDINALITY() to a nullable array (i.e., an optional field/sub-message containing a repeated field
+        // named `values`). For added "realism" we reuse the protos from {@link TypeTestProto} here, set up as follows:
+        // `arr_boolean_field` is an array of size 2; `arr_bytes_field` is an empty array; `arr_double_field` is NULL.
+        final TypeTestProto.PrimitiveFields message = TypeTestProto.PrimitiveFields.newBuilder()
+                .setReqBooleanField(false).setReqBytesField(ByteString.EMPTY).setReqDoubleField(0).setReqFloatField(0).setReqIntField(0).setReqLongField(0).setReqStringField("")
+                .setArrBooleanField(TypeTestProto.PrimitiveFields.BooleanArray.newBuilder().addValues(false).addValues(true).build())
+                .setArrBytesField(TypeTestProto.PrimitiveFields.BytesArray.newBuilder().build()).build();
+        // CARDINALITY() on an array of size 2.
+        final KeyExpression expr2 = function("cardinality", field("arr_boolean_field").nest(field("values", FanType.Concatenate)));
+        expr2.validate(TypeTestProto.PrimitiveFields.getDescriptor());
+        assertFalse(expr2.createsDuplicates());
+        assertEquals(Collections.singletonList(Key.Evaluated.concatenate(2)), evaluate(expr2, message));
+        // CARDINALITY() on an array of size 0.
+        final KeyExpression expr3 = function("cardinality", field("arr_bytes_field").nest(field("values", FanType.Concatenate)));
+        assertEquals(Collections.singletonList(Key.Evaluated.concatenate(0)), evaluate(expr3, message));
+        // CARDINALITY() on a NULL array: the wrapper field is absent, so the result is NULL (not 0).
+        final KeyExpression expr4 = function("cardinality", field("arr_double_field").nest(field("values", FanType.Concatenate)));
+        assertEquals(Collections.singletonList(Key.Evaluated.NULL), evaluate(expr4, message));
+        // A null record implies the wrapper field is absent, so CARDINALITY() also yields NULL.
+        assertEquals(Collections.singletonList(Key.Evaluated.NULL), evaluate(expr4, null));
+
+        // Test a deeper nesting case that’s not the nullable-array wrapper pattern (since the inner repeated field is
+        // not named `values`). These shapes bypass the fast paths in `evaluateMessage()`.
+        final KeyExpression exprNested = function("cardinality",
+                field("nesty").nest(field("repeated_field", FanType.Concatenate)));
+        exprNested.validate(NestedField.getDescriptor());
+        // `matryoshkaDolls.nesty.repeated_field = ["lily", "rose"]`, so CARDINALITY() is 2.
+        assertEquals(Collections.singletonList(Key.Evaluated.concatenate(2)), evaluate(exprNested, matryoshkaDolls));
+        // `lonelyDoll.nesty` is set (to an empty sub-message), so `repeated_field` is the empty list.
+        assertEquals(Collections.singletonList(Key.Evaluated.concatenate(0)), evaluate(exprNested, lonelyDoll));
+        // `emptyNested.nesty` is absent, so `evaluateFunction()` sees a NULL.
+        assertEquals(Collections.singletonList(Key.Evaluated.NULL), evaluate(exprNested, emptyNested));
+        // A null record propagates the same way.
+        assertEquals(Collections.singletonList(Key.Evaluated.NULL), evaluate(exprNested, null));
+
+        // Some coverage for `CardinalityFunctionKeyExpression#planHash()`.
+        // Check that `planHash()` is deterministic.
+        final var expr5 = (CardinalityFunctionKeyExpression)function("cardinality", field("field"));
+        assertEquals(expr5.planHash(PlanHashable.CURRENT_LEGACY), expr5.planHash(PlanHashable.CURRENT_LEGACY));
+        assertEquals(expr5.planHash(PlanHashable.CURRENT_FOR_CONTINUATION), expr5.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
+        // Check that `planHash()` depends on the argument expression.
+        final var expr6 = (CardinalityFunctionKeyExpression)function("cardinality", field("other_field"));
+        assertNotEquals(expr5.planHash(PlanHashable.CURRENT_LEGACY), expr6.planHash(PlanHashable.CURRENT_LEGACY));
+        assertNotEquals(expr5.planHash(PlanHashable.CURRENT_FOR_CONTINUATION), expr6.planHash(PlanHashable.CURRENT_FOR_CONTINUATION));
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/values/CardinalityValueTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/values/CardinalityValueTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2023-2030 Apple Inc. and the FoundationDB project authors
+ * Copyright 2023-2026 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/ddl/MaterializedViewIndexGenerator.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/ddl/MaterializedViewIndexGenerator.java
@@ -22,6 +22,7 @@ package com.apple.foundationdb.relational.recordlayer.query.ddl;
 
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.EvaluationContext;
+import com.apple.foundationdb.record.FunctionNames;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.metadata.IndexOptions;
 import com.apple.foundationdb.record.metadata.IndexPredicate;
@@ -54,6 +55,7 @@ import com.apple.foundationdb.record.query.plan.cascades.typing.PseudoField;
 import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
 import com.apple.foundationdb.record.query.plan.cascades.values.AggregateValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.ArithmeticValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.CardinalityValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.CountValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.FieldValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.IndexableAggregateValue;
@@ -175,7 +177,7 @@ public final class MaterializedViewIndexGenerator {
         Assert.thatUnchecked(unsupportedAggregates.isEmpty(), ErrorCode.UNSUPPORTED_OPERATION,
                 () -> String.format(Locale.ROOT, "Unsupported aggregate index definition containing non-indexable aggregation (%s), consider using a value index on the aggregated column instead.", unsupportedAggregates.stream().map(Objects::toString).collect(joining(","))));
 
-        Assert.thatUnchecked(simplifiedValues.stream().allMatch(sv -> sv instanceof FieldValue || sv instanceof IndexableAggregateValue || sv instanceof ArithmeticValue));
+        Assert.thatUnchecked(simplifiedValues.stream().allMatch(sv -> sv instanceof FieldValue || sv instanceof IndexableAggregateValue || sv instanceof ArithmeticValue || sv instanceof CardinalityValue));
         final var aggregateValues = simplifiedValues.stream().filter(sv -> sv instanceof IndexableAggregateValue).collect(toList());
         final var fieldValues = simplifiedValues.stream().filter(sv -> !(sv instanceof IndexableAggregateValue)).collect(toList());
         final var versionValues = simplifiedValues.stream().filter(sv -> sv instanceof FieldValue && sv.getResultType().equals(PseudoField.ROW_VERSION.getType())).collect(toList());
@@ -184,7 +186,7 @@ public final class MaterializedViewIndexGenerator {
         final var orderByValues = getOrderByValues(relationalExpression, orderingFunctions);
         if (aggregateValues.isEmpty()) {
             indexBuilder.setIndexType(versionValues.isEmpty() ? IndexTypes.VALUE : IndexTypes.VERSION);
-            Assert.thatUnchecked(orderByValues.stream().allMatch(sv -> sv instanceof FieldValue || sv instanceof ArithmeticValue), ErrorCode.UNSUPPORTED_OPERATION, "Unsupported index definition, order by must be a subset of projection list");
+            Assert.thatUnchecked(orderByValues.stream().allMatch(sv -> sv instanceof FieldValue || sv instanceof ArithmeticValue || sv instanceof CardinalityValue), ErrorCode.UNSUPPORTED_OPERATION, "Unsupported index definition, order by must be a subset of projection list");
             if (fieldValues.size() > 1) {
                 Assert.thatUnchecked(!orderByValues.isEmpty(), ErrorCode.UNSUPPORTED_OPERATION, "Unsupported index definition, value indexes must have an order by clause at the top level");
             }
@@ -531,27 +533,46 @@ public final class MaterializedViewIndexGenerator {
         }
     }
 
+    /**
+     * Build the key expression representing the arguments of a {@link FunctionKeyExpression}.
+     */
+    @Nonnull
+    private static KeyExpression buildArgumentKeyExpression(List<KeyExpression> argumentList) {
+        if (argumentList.isEmpty()) {
+            return empty();
+        } else if (argumentList.size() == 1) {
+            return argumentList.get(0);
+        } else {
+            return concat(argumentList);
+        }
+    }
+
     @Nonnull
     private KeyExpression toKeyExpression(@Nonnull Value value) {
         if (value instanceof FieldValue) {
             final FieldValue fieldValue = (FieldValue) value;
-            return toKeyExpression(fieldValue.getFieldPath().getFieldAccessors().iterator());
+            return toKeyExpression(fieldValue.getFieldPath().getFieldAccessors().iterator(), KeyExpression.FanType.FanOut);
+        } else if (value instanceof CardinalityValue) {
+            // CARDINALITY() consumes an array value. Currently, it can only be applied to a `field` directly. We make
+            // sure here that the field gets accessed with fan-out type `Concatenate` instead of `FanOut` so that it
+            // produces the materialized array.
+            final var it = value.getChildren().iterator();
+            Assert.thatUnchecked(it.hasNext(), "Invalid children list for `CardinalityValue`");
+            final Value childValue = it.next();
+            Assert.thatUnchecked(!it.hasNext(), "Invalid children list for `CardinalityValue`");
+            Assert.thatUnchecked(childValue instanceof FieldValue, "CARDINALITY() must be applied to a `field()` in an index key expression.");
+            final var fieldValue = (FieldValue)childValue;
+            final KeyExpression childKeyExpression = toKeyExpression(fieldValue.getFieldPath().getFieldAccessors().iterator(), KeyExpression.FanType.Concatenate);
+            return function(FunctionNames.CARDINALITY, childKeyExpression);
         } else if (value instanceof ArithmeticValue) {
             var children = value.getChildren();
             var builder = ImmutableList.<KeyExpression>builder();
             for (Value child : children) {
                 builder.add(toKeyExpression(child));
             }
-            final List<KeyExpression> argumentList = builder.build();
-            KeyExpression argumentExpr;
-            if (argumentList.isEmpty()) {
-                argumentExpr = empty();
-            } else if (argumentList.size() == 1) {
-                argumentExpr = argumentList.get(0);
-            } else {
-                argumentExpr = concat(argumentList);
-            }
-            return function(((ArithmeticValue) value).getLogicalOperator().name().toLowerCase(Locale.ROOT), argumentExpr);
+            KeyExpression argumentExpr = buildArgumentKeyExpression(builder.build());
+            final String name = ((ArithmeticValue)value).getLogicalOperator().name().toLowerCase(Locale.ROOT);
+            return function(name, argumentExpr);
         } else if (value instanceof LiteralValue<?>) {
             return Key.Expressions.value(((LiteralValue<?>) value).getLiteralValue());
         } else {
@@ -570,7 +591,7 @@ public final class MaterializedViewIndexGenerator {
         final var exprConstituents = childrenMap.entrySet().stream().map(nodeEntry -> {
             final FieldValue.ResolvedAccessor accessor = nodeEntry.getKey();
             final FieldValueTrieNode node = nodeEntry.getValue();
-            final KeyExpression expr = toFieldKeyExpression(accessor);
+            final KeyExpression expr = toFieldKeyExpression(accessor, KeyExpression.FanType.FanOut);
             if (node.getChildrenMap() != null) {
                 final FieldKeyExpression fieldExpr = Assert.castUnchecked(expr, FieldKeyExpression.class);
                 return fieldExpr.nest(toKeyExpression(node, orderingFunctions));
@@ -611,7 +632,7 @@ public final class MaterializedViewIndexGenerator {
         // Fields of result values of each record-typed operation must be simple or arithmetic values.
         final var allSimpleValues = expressions.stream()
                 .filter(r -> r.getResultType().getInnerType() instanceof Type.Record)
-                .allMatch(r -> Values.deconstructRecord(r.getResultValue()).stream().allMatch(v -> v instanceof FieldValue || v instanceof QuantifiedObjectValue || v instanceof AggregateValue || v instanceof ArithmeticValue || v instanceof LiteralValue));
+                .allMatch(r -> Values.deconstructRecord(r.getResultValue()).stream().allMatch(v -> v instanceof FieldValue || v instanceof QuantifiedObjectValue || v instanceof AggregateValue || v instanceof ArithmeticValue || v instanceof LiteralValue || v instanceof CardinalityValue));
         Assert.thatUnchecked(allSimpleValues, ErrorCode.UNSUPPORTED_OPERATION, "Unsupported index definition, not all fields can be mapped to key expression in");
     }
 
@@ -754,12 +775,12 @@ public final class MaterializedViewIndexGenerator {
     }
 
     @Nonnull
-    private KeyExpression toKeyExpression(@Nonnull Iterator<FieldValue.ResolvedAccessor> resolvedAccessors) {
+    private KeyExpression toKeyExpression(@Nonnull Iterator<FieldValue.ResolvedAccessor> resolvedAccessors, KeyExpression.FanType fanTypeForArray) {
         Assert.thatUnchecked(resolvedAccessors.hasNext(), "cannot resolve empty list");
         final FieldValue.ResolvedAccessor accessor = resolvedAccessors.next();
-        final KeyExpression expression = toFieldKeyExpression(accessor);
+        final KeyExpression expression = toFieldKeyExpression(accessor, fanTypeForArray);
         if (resolvedAccessors.hasNext()) {
-            KeyExpression childExpression = toKeyExpression(resolvedAccessors);
+            KeyExpression childExpression = toKeyExpression(resolvedAccessors, fanTypeForArray);
             final FieldKeyExpression fieldExpression = Assert.castUnchecked(expression, FieldKeyExpression.class);
             return fieldExpression.nest(childExpression);
         } else {
@@ -779,22 +800,29 @@ public final class MaterializedViewIndexGenerator {
         return recordTypes.stream().findFirst().orElseThrow();
     }
 
+    /**
+     * Return a {@link FieldKeyExpression} or {@link VersionKeyExpression} for the given field type, as appropriate.
+     *
+     * @param fanTypeForArray The fan-out type to use for the {@code field} key expression in case the field is an
+     * ARRAY. This should be either {@code FanOut} or {@code Concatenate}.
+     */
     @Nonnull
-    private static KeyExpression toFieldKeyExpression(@Nonnull FieldValue.ResolvedAccessor accessor) {
+    private static KeyExpression toFieldKeyExpression(@Nonnull FieldValue.ResolvedAccessor accessor, KeyExpression.FanType fanTypeForArray) {
         final Type.Record.Field fieldType = accessor.getField();
         Assert.notNullUnchecked(fieldType.getFieldStorageName());
-        Assert.thatUnchecked(!fieldType.getFieldType().isArray() || (accessor instanceof AnnotatedAccessor),
+        Assert.thatUnchecked(fanTypeForArray == KeyExpression.FanType.FanOut || fanTypeForArray == KeyExpression.FanType.Concatenate);
+        Assert.thatUnchecked(!fieldType.getFieldType().isArray()
+                        || (accessor instanceof AnnotatedAccessor)
+                        || (fanTypeForArray == KeyExpression.FanType.Concatenate),
                 ErrorCode.UNSUPPORTED_OPERATION,
                 "Unsupported index definition, cannot create index on array field '" +
                 fieldType.getFieldName() + "' without unnesting");
-        final var fanType = fieldType.getFieldType().getTypeCode() == Type.TypeCode.ARRAY ?
-                KeyExpression.FanType.FanOut :
-                KeyExpression.FanType.None;
-        if (PseudoField.ROW_VERSION.getType().equals(fieldType.getFieldType()) && PseudoField.ROW_VERSION.getFieldName().equals(fieldType.getFieldName())) {
+        final Type type = fieldType.getFieldType();
+        if (PseudoField.ROW_VERSION.getType().equals(type) && PseudoField.ROW_VERSION.getFieldName().equals(fieldType.getFieldName())) {
             return VersionKeyExpression.VERSION;
         }
-        // At this point, we need to use the storage field name as that will be the name referenced
-        // in Protobuf storage
+        final var fanType = type.isArray() ? fanTypeForArray : KeyExpression.FanType.None;
+        // Here we need to use the storage field name, as that will be the name referenced in Protobuf storage.
         return field(fieldType.getFieldStorageName(), fanType);
     }
 

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/util/NullableArrayUtils.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/util/NullableArrayUtils.java
@@ -55,19 +55,26 @@ public final class NullableArrayUtils {
         }
     }
 
+    /**
+     * Returns whether the given descriptor represents a wrapped ARRAY, that is, whether it contains a single repeated
+     * field named {@code values}.
+     */
     public static boolean isWrappedArrayDescriptor(@Nonnull final Descriptors.Descriptor descriptor) {
-        return descriptor.getFields().size() == 1 && REPEATED_FIELD_NAME.equals(descriptor.getFields().get(0).getName()) && descriptor.findFieldByName(REPEATED_FIELD_NAME).isRepeated();
+        return descriptor.getFields().size() == 1
+                && REPEATED_FIELD_NAME.equals(descriptor.getFields().get(0).getName())
+                && descriptor.findFieldByName(REPEATED_FIELD_NAME).isRepeated();
     }
 
     /**
-     * Adds the wrapped array structure in key expressions if the schema doesn't contain non-nullable array.
-     * For example, reviews.rating will change to reviews.values.rating
+     * Adds the wrapped array structure for any nullable arrays referenced in the given key expression (if the schema
+     * contains any such arrays).
+     *
+     * <p>For example, {@code reviews.rating} will change to {@code reviews.values.rating}.
+     *
      * @param keyExpression The key expression to modify.
      * @param record The record of the table.
      * @param containsNullableArray true if nullable arrays are to be found, otherwise false.
      * @return modified key expression where any nullable array is wrapped.
-     *
-     * TODO Add the wrapped array structure for nullable arrays.
      */
     public static RecordKeyExpressionProto.KeyExpression wrapArray(RecordKeyExpressionProto.KeyExpression keyExpression,
                                                                    final Type.Record record,
@@ -87,8 +94,8 @@ public final class NullableArrayUtils {
     (TODO): Add the wrapped array structure for nullable arrays.
      */
     public static RecordKeyExpressionProto.KeyExpression wrapArray(RecordKeyExpressionProto.KeyExpression keyExpression,
-                                                              Descriptors.Descriptor parentDescriptor,
-                                                              boolean containsNullableArray) {
+                                                                   Descriptors.Descriptor parentDescriptor,
+                                                                   boolean containsNullableArray) {
         if (!containsNullableArray) {
             return keyExpression;
         }
@@ -97,7 +104,7 @@ public final class NullableArrayUtils {
     }
 
     private static RecordKeyExpressionProto.KeyExpression wrapArrayInternal(RecordKeyExpressionProto.KeyExpression keyExpression,
-                                                                      Descriptors.Descriptor parentDescriptor) {
+                                                                            Descriptors.Descriptor parentDescriptor) {
         // handle concat (straightforward recursion)
         if (keyExpression.hasThen()) {
             final var newThenBuilder = RecordKeyExpressionProto.Then.newBuilder();
@@ -184,7 +191,19 @@ public final class NullableArrayUtils {
         return keyExpression;
     }
 
-    // wrap repeated fields in a Field type keyExpression
+    /**
+     * Wraps repeated fields in the given {@code field} key expression.
+     *
+     * @param original The original `field` key expression for the array field.
+     *
+     * <p>For example, {@code Field {field_name: "ARRAY_FIELD" fan_type: CONCATENATE …}} gets converted to:
+     * {@snippet :
+     *   nesting {
+     *     parent { field_name: "ARRAY_FIELD" fan_type: SCALAR …}
+     *     child { field { field_name: "values" fan_type: CONCATENATE …}}
+     *   }
+     *}
+     */
     private static RecordKeyExpressionProto.Nesting splitFieldIntoNestedWithValues(@Nonnull final RecordKeyExpressionProto.Field original) {
         final var nestedArrayBuilder = RecordKeyExpressionProto.Field.newBuilder()
                 .setFieldName(original.getFieldName())

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/api/ddl/IndexTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/api/ddl/IndexTest.java
@@ -530,6 +530,25 @@ public class IndexTest {
     }
 
     @Test
+    void createIndexWithCardinalityFunctionOnNonNullableArrayIsSupported() throws Exception {
+        final String stmt = "CREATE SCHEMA TEMPLATE test_template " +
+                "CREATE TABLE T1(p1 BIGINT, int_arr INTEGER ARRAY NOT NULL, PRIMARY KEY(p1)) " +
+                "CREATE INDEX mv1 AS SELECT CARDINALITY(int_arr) FROM T1";
+        var exp = function("cardinality", field("INT_ARR", KeyExpression.FanType.Concatenate));
+        indexIs(stmt, exp, IndexTypes.VALUE);
+    }
+
+    @Test
+    void createIndexWithCardinalityFunctionOnNullableArrayIsSupported() throws Exception {
+        final String stmt = "CREATE SCHEMA TEMPLATE test_template " +
+                "CREATE TABLE T1(p1 BIGINT, int_arr INTEGER ARRAY NULL, PRIMARY KEY(p1)) " +
+                "CREATE INDEX mv1 AS SELECT CARDINALITY(int_arr) FROM T1";
+        // Notice the nested "values" field that gets introduced when the array is nullable.
+        var exp = function("cardinality", field("INT_ARR").nest(field("values", KeyExpression.FanType.Concatenate)));
+        indexIs(stmt, exp, IndexTypes.VALUE);
+    }
+
+    @Test
     void createIndexWithFieldSumInProjectionIsSupported() throws Exception {
         final String stmt = "CREATE SCHEMA TEMPLATE test_template " +
                 "CREATE TABLE T1(p1 bigint, a bigint, b bigint, primary key(p1)) " +

--- a/yaml-tests/src/test/resources/arrays-cardinality.metrics.binpb
+++ b/yaml-tests/src/test/resources/arrays-cardinality.metrics.binpb
@@ -24,4 +24,218 @@ digraph G {
   3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Primary Storage</td></tr><tr><td align="left">record types: [dummy, tab1_nn, tab1]</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id, ARRAY(INT) AS int_arr)" ];
   3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}ˆ
+>
+arrays-cardinality-index-testsEXPLAIN SELECT * FROM "tab1"≥
+åÇõ•* ÈıË(0Æâ8
+@SCAN([IS tab1])Ñdigraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=line;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Scan</td></tr><tr><td align="left">comparisons: [IS tab1]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id, ARRAY(INT) AS int_arr)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Primary Storage</td></tr><tr><td align="left">record types: [dummy, tab1, tab1_indexed_nn, tab2, tab1_nn, tab1_indexed]</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id, ARRAY(INT) AS int_arr)" ];
+  2 -> 1 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}‹
+I
+arrays-cardinality-index-tests'EXPLAIN SELECT * FROM "tab1_indexed_nn"é
+›≈ÍË
+> ¸ˇ¥(0ˇ¿'8@ ISCAN(tab1_indexed_nn_index <,>)Œdigraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=line;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id, ARRAY(INT) AS int_arr)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">tab1_indexed_nn_index</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id, ARRAY(INT) AS int_arr)" ];
+  2 -> 1 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}”
+F
+arrays-cardinality-index-tests$EXPLAIN SELECT * FROM "tab1_indexed"à
+›≤ƒÓ> ï´Ã(0Å (8@ISCAN(tab1_indexed_index <,>)Àdigraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=line;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id, ARRAY(INT) AS int_arr)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">tab1_indexed_index</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id, ARRAY(INT) AS int_arr)" ];
+  2 -> 1 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}‹
+L
+arrays-cardinality-index-tests*EXPLAIN SELECT "id" FROM "tab1_indexed_nn"ã
+Ò¸ˆ≥; ø·(0ßÇ78@GCOVERING(tab1_indexed_nn_index <,> -> [id: KEY:[2]]) | MAP (_.id AS id)§
+digraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=line;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q37.id AS id)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Covering Index Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id, ARRAY(INT) AS int_arr)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">tab1_indexed_nn_index</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id, ARRAY(INT) AS int_arr)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q37> label="q37" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}”
+I
+arrays-cardinality-index-tests'EXPLAIN SELECT "id" FROM "tab1_indexed"Ö
+Ò∞≈÷; ¨‘È(0Ÿ ,8@DCOVERING(tab1_indexed_index <,> -> [id: KEY:[2]]) | MAP (_.id AS id)°
+digraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=line;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q37.id AS id)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Covering Index Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id, ARRAY(INT) AS int_arr)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">tab1_indexed_index</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id, ARRAY(INT) AS int_arr)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q37> label="q37" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}¨
+n
+arrays-cardinality-index-testsLEXPLAIN SELECT "id", CARDINALITY("int_arr") AS "card" FROM "tab1_indexed_nn"π
+’∫∑Ï7 ü◊˝(0¨ÃZ8@SISCAN(tab1_indexed_nn_index <,>) | MAP (_.id AS id, cardinality(_.int_arr) AS card)∆
+digraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=line;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q2.id AS id, cardinality(q2.int_arr) AS card)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id, INT AS card)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id, ARRAY(INT) AS int_arr)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">tab1_indexed_nn_index</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id, ARRAY(INT) AS int_arr)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}£
+k
+arrays-cardinality-index-testsIEXPLAIN SELECT "id", CARDINALITY("int_arr") AS "card" FROM "tab1_indexed"≥
+’‚Î¯7 ®∞≠(0å©-8@PISCAN(tab1_indexed_index <,>) | MAP (_.id AS id, cardinality(_.int_arr) AS card)√
+digraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=line;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q2.id AS id, cardinality(q2.int_arr) AS card)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id, INT AS card)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id, ARRAY(INT) AS int_arr)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">tab1_indexed_index</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id, ARRAY(INT) AS int_arr)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}º
+_
+arrays-cardinality-index-tests=EXPLAIN SELECT "id" FROM "tab1_indexed_nn" ORDER BY "id" DESCÿ
+ûÑ¬û, ˆÊÒ(0Ã∆8@-SCAN([IS tab1_indexed_nn]) | MAP (_.id AS id)ãdigraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=line;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q2.id AS id)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Scan</td></tr><tr><td align="left">comparisons: [IS tab1_indexed_nn]</td></tr><tr><td align="left">direction: reversed</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id, ARRAY(INT) AS int_arr)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Primary Storage</td></tr><tr><td align="left">record types: [dummy, tab1, tab1_indexed_nn, tab2, tab1_nn, tab1_indexed]</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id, ARRAY(INT) AS int_arr)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}≥
+\
+arrays-cardinality-index-tests:EXPLAIN SELECT "id" FROM "tab1_indexed" ORDER BY "id" DESC“
+û‹©ã, Úà–(0ˇ–8@*SCAN([IS tab1_indexed]) | MAP (_.id AS id)àdigraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=line;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q2.id AS id)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Scan</td></tr><tr><td align="left">comparisons: [IS tab1_indexed]</td></tr><tr><td align="left">direction: reversed</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id, ARRAY(INT) AS int_arr)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Primary Storage</td></tr><tr><td align="left">record types: [dummy, tab1, tab1_indexed_nn, tab2, tab1_nn, tab1_indexed]</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id, ARRAY(INT) AS int_arr)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}¿
+q
+arrays-cardinality-index-testsOEXPLAIN SELECT "id" FROM "tab1_indexed_nn" ORDER BY CARDINALITY("int_arr") DESC 
+ÙíˇÆA Ï€é(0¿Ë 8@lISCAN(tab1_indexed_nn_index <,> REVERSE) | MAP (_.id AS id, cardinality(_.int_arr) AS _1) | MAP (_.id AS id)ædigraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=line;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q6.id AS id)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q2.id AS id, cardinality(q2.int_arr) AS _1)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id, INT AS _1)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr><tr><td align="left">direction: reversed</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id, ARRAY(INT) AS int_arr)" ];
+  4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">tab1_indexed_nn_index</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id, ARRAY(INT) AS int_arr)" ];
+  3 -> 2 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  4 -> 3 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}∑
+n
+arrays-cardinality-index-testsLEXPLAIN SELECT "id" FROM "tab1_indexed" ORDER BY CARDINALITY("int_arr") DESCƒ
+ÙöÜÔA î±õ(0Ò◊8@iISCAN(tab1_indexed_index <,> REVERSE) | MAP (_.id AS id, cardinality(_.int_arr) AS _1) | MAP (_.id AS id)ªdigraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=line;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q6.id AS id)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q2.id AS id, cardinality(q2.int_arr) AS _1)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id, INT AS _1)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr><tr><td align="left">direction: reversed</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id, ARRAY(INT) AS int_arr)" ];
+  4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">tab1_indexed_index</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id, ARRAY(INT) AS int_arr)" ];
+  3 -> 2 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  4 -> 3 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}Õ
+é
+arrays-cardinality-index-testslEXPLAIN SELECT CARDINALITY("int_arr") AS "card", "id" FROM "tab1_indexed_nn" ORDER BY CARDINALITY("int_arr")π
+∂Õç‹1 „ÔŒ(0©¶8@SISCAN(tab1_indexed_nn_index <,>) | MAP (cardinality(_.int_arr) AS card, _.id AS id)∆
+digraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=line;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (cardinality(q2.int_arr) AS card, q2.id AS id)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS card, INT AS id)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id, ARRAY(INT) AS int_arr)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">tab1_indexed_nn_index</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id, ARRAY(INT) AS int_arr)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}ƒ
+ã
+arrays-cardinality-index-testsiEXPLAIN SELECT CARDINALITY("int_arr") AS "card", "id" FROM "tab1_indexed" ORDER BY CARDINALITY("int_arr")≥
+∂ú·Î1 ⁄Ö…(0Ö≤8@PISCAN(tab1_indexed_index <,>) | MAP (cardinality(_.int_arr) AS card, _.id AS id)√
+digraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=line;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (cardinality(q2.int_arr) AS card, q2.id AS id)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS card, INT AS id)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id, ARRAY(INT) AS int_arr)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">tab1_indexed_index</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id, ARRAY(INT) AS int_arr)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}©
+m
+arrays-cardinality-index-testsKEXPLAIN SELECT "id" FROM "tab1_indexed_nn" WHERE CARDINALITY("int_arr") = 1∑
+ãÊ“èh Áªµ(!0≈æN8*@aCOVERING(tab1_indexed_nn_index [EQUALS promote(@c11 AS INT)] -> [id: KEY:[2]]) | MAP (_.id AS id)∂
+digraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=line;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q53.id AS id)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Covering Index Scan</td></tr><tr><td align="left">comparisons: [EQUALS promote(@c11 AS INT)]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id, ARRAY(INT) AS int_arr)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">tab1_indexed_nn_index</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id, ARRAY(INT) AS int_arr)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q53> label="q53" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}†
+j
+arrays-cardinality-index-testsHEXPLAIN SELECT "id" FROM "tab1_indexed" WHERE CARDINALITY("int_arr") = 1±
+ã‚µÆh ÒèÂ(!0‡ƒ@8*@^COVERING(tab1_indexed_index [EQUALS promote(@c11 AS INT)] -> [id: KEY:[2]]) | MAP (_.id AS id)≥
+digraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=line;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q53.id AS id)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Covering Index Scan</td></tr><tr><td align="left">comparisons: [EQUALS promote(@c11 AS INT)]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id, ARRAY(INT) AS int_arr)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">tab1_indexed_index</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id, ARRAY(INT) AS int_arr)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q53> label="q53" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}õ
+∞
+arrays-cardinality-index-testsçEXPLAIN SELECT CARDINALITY("int_arr") AS "card", "id" FROM "tab1_indexed_nn" WHERE CARDINALITY("int_arr") = 1 ORDER BY CARDINALITY("int_arr")Â
+îÿòåM Ø˚(0•õ8@mISCAN(tab1_indexed_nn_index [EQUALS promote(@c18 AS INT)]) | MAP (cardinality(_.int_arr) AS card, _.id AS id)ÿ
+digraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=line;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (cardinality(q2.int_arr) AS card, q2.id AS id)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS card, INT AS id)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">comparisons: [EQUALS promote(@c18 AS INT)]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id, ARRAY(INT) AS int_arr)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">tab1_indexed_nn_index</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id, ARRAY(INT) AS int_arr)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}∑
+¿
+arrays-cardinality-index-testsùEXPLAIN SELECT CARDINALITY("struct"."int_arr") AS "card", "id" FROM "tab2" WHERE CARDINALITY("struct"."int_arr") = 1 ORDER BY CARDINALITY("struct"."int_arr")Ò
+îÄÍ©M óÛÑ(0ó˙8@iISCAN(tab2_index [EQUALS promote(@c22 AS INT)]) | MAP (cardinality(_.struct.int_arr) AS card, _.id AS id)Ë
+digraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=line;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (cardinality(q2.struct.int_arr) AS card, q2.id AS id)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS card, INT AS id)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">comparisons: [EQUALS promote(@c22 AS INT)]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id, ARRAY(INT) AS int_arr AS struct)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">tab2_index</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id, ARRAY(INT) AS int_arr AS struct)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
 }

--- a/yaml-tests/src/test/resources/arrays-cardinality.metrics.yaml
+++ b/yaml-tests/src/test/resources/arrays-cardinality.metrics.yaml
@@ -1,6 +1,6 @@
 arrays-cardinality-tests:
 -   query: EXPLAIN SELECT CARDINALITY("int_arr") FROM "tab1_nn"
-    ref: arrays_cardinality.yamsql:57
+    ref: arrays_cardinality.yamsql:72
     explain: SCAN([IS tab1_nn]) | MAP (cardinality(_.int_arr) AS _0)
     task_count: 146
     task_total_time_ms: 71
@@ -11,7 +11,7 @@ arrays-cardinality-tests:
     insert_new_count: 12
     insert_reused_count: 2
 -   query: EXPLAIN SELECT CARDINALITY("int_arr") FROM "tab1"
-    ref: arrays_cardinality.yamsql:61
+    ref: arrays_cardinality.yamsql:76
     explain: SCAN([IS tab1]) | MAP (cardinality(_.int_arr) AS _0)
     task_count: 146
     task_total_time_ms: 9
@@ -21,3 +21,210 @@ arrays-cardinality-tests:
     insert_time_ms: 0
     insert_new_count: 12
     insert_reused_count: 2
+arrays-cardinality-index-tests:
+-   query: EXPLAIN SELECT * FROM "tab1"
+    ref: arrays_cardinality.yamsql:86
+    explain: SCAN([IS tab1])
+    task_count: 140
+    task_total_time_ms: 6
+    transform_count: 42
+    transform_time_ms: 3
+    transform_yield_count: 13
+    insert_time_ms: 0
+    insert_new_count: 10
+    insert_reused_count: 2
+-   query: EXPLAIN SELECT * FROM "tab1_indexed_nn"
+    ref: arrays_cardinality.yamsql:88
+    explain: ISCAN(tab1_indexed_nn_index <,>)
+    task_count: 221
+    task_total_time_ms: 22
+    transform_count: 62
+    transform_time_ms: 15
+    transform_yield_count: 25
+    insert_time_ms: 0
+    insert_new_count: 19
+    insert_reused_count: 6
+-   query: EXPLAIN SELECT * FROM "tab1_indexed"
+    ref: arrays_cardinality.yamsql:90
+    explain: ISCAN(tab1_indexed_index <,>)
+    task_count: 221
+    task_total_time_ms: 12
+    transform_count: 62
+    transform_time_ms: 7
+    transform_yield_count: 25
+    insert_time_ms: 0
+    insert_new_count: 19
+    insert_reused_count: 6
+-   query: EXPLAIN SELECT "id" FROM "tab1_indexed_nn"
+    ref: arrays_cardinality.yamsql:93
+    explain: 'COVERING(tab1_indexed_nn_index <,> -> [id: KEY:[2]]) | MAP (_.id AS
+        id)'
+    task_count: 241
+    task_total_time_ms: 15
+    transform_count: 59
+    transform_time_ms: 7
+    transform_yield_count: 25
+    insert_time_ms: 0
+    insert_new_count: 25
+    insert_reused_count: 4
+-   query: EXPLAIN SELECT "id" FROM "tab1_indexed"
+    ref: arrays_cardinality.yamsql:96
+    explain: 'COVERING(tab1_indexed_index <,> -> [id: KEY:[2]]) | MAP (_.id AS id)'
+    task_count: 241
+    task_total_time_ms: 11
+    transform_count: 59
+    transform_time_ms: 5
+    transform_yield_count: 25
+    insert_time_ms: 0
+    insert_new_count: 25
+    insert_reused_count: 4
+-   query: EXPLAIN SELECT "id", CARDINALITY("int_arr") AS "card" FROM "tab1_indexed_nn"
+    ref: arrays_cardinality.yamsql:100
+    explain: ISCAN(tab1_indexed_nn_index <,>) | MAP (_.id AS id, cardinality(_.int_arr)
+        AS card)
+    task_count: 213
+    task_total_time_ms: 16
+    transform_count: 55
+    transform_time_ms: 8
+    transform_yield_count: 23
+    insert_time_ms: 1
+    insert_new_count: 22
+    insert_reused_count: 4
+-   query: EXPLAIN SELECT "id", CARDINALITY("int_arr") AS "card" FROM "tab1_indexed"
+    ref: arrays_cardinality.yamsql:103
+    explain: ISCAN(tab1_indexed_index <,>) | MAP (_.id AS id, cardinality(_.int_arr)
+        AS card)
+    task_count: 213
+    task_total_time_ms: 12
+    transform_count: 55
+    transform_time_ms: 7
+    transform_yield_count: 23
+    insert_time_ms: 0
+    insert_new_count: 22
+    insert_reused_count: 4
+-   query: EXPLAIN SELECT "id" FROM "tab1_indexed_nn" ORDER BY "id" DESC
+    ref: arrays_cardinality.yamsql:107
+    explain: SCAN([IS tab1_indexed_nn]) | MAP (_.id AS id)
+    task_count: 158
+    task_total_time_ms: 8
+    transform_count: 44
+    transform_time_ms: 6
+    transform_yield_count: 19
+    insert_time_ms: 0
+    insert_new_count: 12
+    insert_reused_count: 2
+-   query: EXPLAIN SELECT "id" FROM "tab1_indexed" ORDER BY "id" DESC
+    ref: arrays_cardinality.yamsql:110
+    explain: SCAN([IS tab1_indexed]) | MAP (_.id AS id)
+    task_count: 158
+    task_total_time_ms: 8
+    transform_count: 44
+    transform_time_ms: 5
+    transform_yield_count: 19
+    insert_time_ms: 0
+    insert_new_count: 12
+    insert_reused_count: 2
+-   query: EXPLAIN SELECT "id" FROM "tab1_indexed_nn" ORDER BY CARDINALITY("int_arr")
+        DESC
+    ref: arrays_cardinality.yamsql:115
+    explain: ISCAN(tab1_indexed_nn_index <,> REVERSE) | MAP (_.id AS id, cardinality(_.int_arr)
+        AS _1) | MAP (_.id AS id)
+    task_count: 244
+    task_total_time_ms: 11
+    transform_count: 65
+    transform_time_ms: 6
+    transform_yield_count: 22
+    insert_time_ms: 0
+    insert_new_count: 21
+    insert_reused_count: 2
+-   query: EXPLAIN SELECT "id" FROM "tab1_indexed" ORDER BY CARDINALITY("int_arr")
+        DESC
+    ref: arrays_cardinality.yamsql:118
+    explain: ISCAN(tab1_indexed_index <,> REVERSE) | MAP (_.id AS id, cardinality(_.int_arr)
+        AS _1) | MAP (_.id AS id)
+    task_count: 244
+    task_total_time_ms: 8
+    transform_count: 65
+    transform_time_ms: 4
+    transform_yield_count: 22
+    insert_time_ms: 0
+    insert_new_count: 21
+    insert_reused_count: 2
+-   query: EXPLAIN SELECT CARDINALITY("int_arr") AS "card", "id" FROM "tab1_indexed_nn"
+        ORDER BY CARDINALITY("int_arr")
+    ref: arrays_cardinality.yamsql:123
+    explain: ISCAN(tab1_indexed_nn_index <,>) | MAP (cardinality(_.int_arr) AS card,
+        _.id AS id)
+    task_count: 182
+    task_total_time_ms: 5
+    transform_count: 49
+    transform_time_ms: 3
+    transform_yield_count: 20
+    insert_time_ms: 0
+    insert_new_count: 17
+    insert_reused_count: 2
+-   query: EXPLAIN SELECT CARDINALITY("int_arr") AS "card", "id" FROM "tab1_indexed"
+        ORDER BY CARDINALITY("int_arr")
+    ref: arrays_cardinality.yamsql:126
+    explain: ISCAN(tab1_indexed_index <,>) | MAP (cardinality(_.int_arr) AS card,
+        _.id AS id)
+    task_count: 182
+    task_total_time_ms: 5
+    transform_count: 49
+    transform_time_ms: 3
+    transform_yield_count: 20
+    insert_time_ms: 0
+    insert_new_count: 17
+    insert_reused_count: 2
+-   query: EXPLAIN SELECT "id" FROM "tab1_indexed_nn" WHERE CARDINALITY("int_arr")
+        = 1
+    ref: arrays_cardinality.yamsql:130
+    explain: 'COVERING(tab1_indexed_nn_index [EQUALS promote(@c11 AS INT)] -> [id:
+        KEY:[2]]) | MAP (_.id AS id)'
+    task_count: 395
+    task_total_time_ms: 14
+    transform_count: 104
+    transform_time_ms: 7
+    transform_yield_count: 33
+    insert_time_ms: 1
+    insert_new_count: 42
+    insert_reused_count: 3
+-   query: EXPLAIN SELECT "id" FROM "tab1_indexed" WHERE CARDINALITY("int_arr") =
+        1
+    ref: arrays_cardinality.yamsql:133
+    explain: 'COVERING(tab1_indexed_index [EQUALS promote(@c11 AS INT)] -> [id: KEY:[2]])
+        | MAP (_.id AS id)'
+    task_count: 395
+    task_total_time_ms: 13
+    transform_count: 104
+    transform_time_ms: 5
+    transform_yield_count: 33
+    insert_time_ms: 1
+    insert_new_count: 42
+    insert_reused_count: 3
+-   query: EXPLAIN SELECT CARDINALITY("int_arr") AS "card", "id" FROM "tab1_indexed_nn"
+        WHERE CARDINALITY("int_arr") = 1 ORDER BY CARDINALITY("int_arr")
+    ref: arrays_cardinality.yamsql:138
+    explain: ISCAN(tab1_indexed_nn_index [EQUALS promote(@c18 AS INT)]) | MAP (cardinality(_.int_arr)
+        AS card, _.id AS id)
+    task_count: 276
+    task_total_time_ms: 8
+    transform_count: 77
+    transform_time_ms: 3
+    transform_yield_count: 26
+    insert_time_ms: 0
+    insert_new_count: 28
+    insert_reused_count: 1
+-   query: EXPLAIN SELECT CARDINALITY("struct"."int_arr") AS "card", "id" FROM "tab2"
+        WHERE CARDINALITY("struct"."int_arr") = 1 ORDER BY CARDINALITY("struct"."int_arr")
+    ref: arrays_cardinality.yamsql:143
+    explain: ISCAN(tab2_index [EQUALS promote(@c22 AS INT)]) | MAP (cardinality(_.struct.int_arr)
+        AS card, _.id AS id)
+    task_count: 276
+    task_total_time_ms: 9
+    transform_count: 77
+    transform_time_ms: 4
+    transform_yield_count: 26
+    insert_time_ms: 0
+    insert_new_count: 28
+    insert_reused_count: 1

--- a/yaml-tests/src/test/resources/arrays-cardinality.yamsql
+++ b/yaml-tests/src/test/resources/arrays-cardinality.yamsql
@@ -3,7 +3,7 @@
 #
 # This source file is part of the FoundationDB open source project
 #
-# Copyright 2023-2030 Apple Inc. and the FoundationDB project authors
+# Copyright 2023-2026 Apple Inc. and the FoundationDB project authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,22 +19,39 @@
 
 ---
 options:
-  supported_version: 4.11.1.0
+  supported_version: !current_version
 ---
+# Create three analogous base tables, with a CARDINALITY() index defined for two of them. With these we exercise both a
+# nullable and a non-nullable ARRAY column. Nullable arrays are special in that a `values` field gets wrapped around the
+# repeated field at the Protobuf level.
 schema_template:
   CREATE TABLE "dummy" ("id" INTEGER, PRIMARY KEY ("id"))
-  CREATE TABLE "tab1_nn" ("id" INTEGER, "int_arr" INTEGER ARRAY NOT NULL, PRIMARY KEY ("id"))
   CREATE TABLE "tab1" ("id" INTEGER, "int_arr" INTEGER ARRAY NULL, PRIMARY KEY ("id"))
+  CREATE TABLE "tab1_nn" ("id" INTEGER, "int_arr" INTEGER ARRAY NOT NULL, PRIMARY KEY ("id"))
+  CREATE TABLE "tab1_indexed" ("id" INTEGER, "int_arr" INTEGER ARRAY NULL, PRIMARY KEY ("id"))
+  CREATE INDEX "tab1_indexed_index" AS SELECT CARDINALITY("int_arr") AS "card" FROM "tab1_indexed" ORDER BY "card"
+  CREATE TABLE "tab1_indexed_nn" ("id" INTEGER, "int_arr" INTEGER ARRAY NOT NULL, PRIMARY KEY ("id"))
+  CREATE INDEX "tab1_indexed_nn_index" AS SELECT CARDINALITY("int_arr") AS "card" FROM "tab1_indexed_nn" ORDER BY "card"
+
+  CREATE TYPE AS STRUCT "Struct1" ("int_arr" INTEGER ARRAY)
+  CREATE TABLE "tab2" ("id" INTEGER, "struct" "Struct1", PRIMARY KEY ("id"))
+  CREATE INDEX "tab2_index" AS SELECT CARDINALITY("struct"."int_arr") AS "card" FROM "tab2" ORDER BY "card"
 ---
 setup:
   steps:
+    # Populate the tables with arrays of size 0, 1, >1, as well as a NULL array if nullable.
     - query: INSERT INTO "dummy" ("id") VALUES (1)
     - query: INSERT INTO "tab1_nn" ("id", "int_arr") VALUES (1, []), (2, [1]), (3, [1, 2])
     - query: INSERT INTO "tab1" ("id", "int_arr") VALUES (0, NULL), (1, []), (2, [1]), (3, [1, 2])
+    - query: INSERT INTO "tab1_indexed_nn" ("id", "int_arr") VALUES (1, []), (2, [1]), (3, [1, 2])
+    - query: INSERT INTO "tab1_indexed" ("id", "int_arr") VALUES (0, NULL), (1, []), (2, [1]), (3, [1, 2])
+    # For `tab2`, also include a row with the entire struct NULL and a row where the struct is set but the inner array
+    # is NULL. Both should evaluate `CARDINALITY("struct"."int_arr")` to NULL.
+    - query: INSERT INTO "tab2" ("id", "struct")  VALUES (1, ([])), (2, ([1])), (3, ([1, 2])), (4, NULL), (5, (NULL))
 ---
 test_block:
-  name: arrays-cardinality-tests
   # Basic tests for CARDINALITY().
+  name: arrays-cardinality-tests
   preset: single_repetition_ordered
   tests:
     - # Incorrect argument type: Passing a non-array (here: INTEGER) raises error 22000.
@@ -45,19 +62,142 @@ test_block:
       - error: "22000"
     - # NULL argument array (constant case): NULL gets mapped to NULL.
       - query: SELECT CARDINALITY(CAST(NULL AS INTEGER ARRAY)) FROM "tab1" WHERE "id" = 1
+      - resultMetadata: [{_0: INTEGER}]
       - result: [{!null _}]
     - # Non-NULL constant cases using array constructor literals.
       - query: SELECT CARDINALITY(CAST([] AS INTEGER ARRAY)),
                       CARDINALITY(CAST([1] AS INTEGER ARRAY)),
                       CARDINALITY(CAST([1, 2] AS INTEGER ARRAY))
                 FROM "dummy"
+      - resultMetadata: [{_0: INTEGER}, {_1: INTEGER}, {_2: INTEGER}]
       - result: [{0, 1, 2}]
     - # Not-nullable array column containing arrays of size 0, 1, >1.
       - query: SELECT CARDINALITY("int_arr") FROM "tab1_nn"
       - explain: "SCAN([IS tab1_nn]) | MAP (cardinality(_.int_arr) AS _0)"
+      - resultMetadata: [{_0: INTEGER}]
       - unorderedResult: [{0}, {1}, {2}]
     - # Nullable array column containing arrays of size 0, 1, >1 as well as a NULL array.
       - query: SELECT CARDINALITY("int_arr") FROM "tab1"
       - explain: "SCAN([IS tab1]) | MAP (cardinality(_.int_arr) AS _0)"
+      - resultMetadata: [{_0: INTEGER}]
       - unorderedResult: [{!null _}, {0}, {1}, {2}]
+    - # Array nested inside a (nullable) struct. This exercises the `CardinalityFunctionKeyExpression` “deeper nesting”
+      # fallback path. The rows include a NULL struct and a struct with a NULL inner array; both yield NULL.
+      - query: SELECT CARDINALITY("struct"."int_arr") FROM "tab2"
+      - resultMetadata: [{_0: INTEGER}]
+      - unorderedResult: [{!null _}, {!null _}, {0}, {1}, {2}]
+    - # WHERE CARDINALITY() IS NULL on a nullable array column matches only the row with NULL array.
+      - query: SELECT "id" FROM "tab1" WHERE CARDINALITY("int_arr") IS NULL
+      - unorderedResult: [{id: 0}]
+    - # WHERE CARDINALITY() IS NOT NULL on a nullable array column matches all non-NULL rows (including the empty array).
+      - query: SELECT "id" FROM "tab1" WHERE CARDINALITY("int_arr") IS NOT NULL
+      - unorderedResult: [{id: 1}, {id: 2}, {id: 3}]
+    - # WHERE CARDINALITY() IS NULL on a NOT-NULL array column returns no rows.
+      - query: SELECT "id" FROM "tab1_nn" WHERE CARDINALITY("int_arr") IS NULL
+      - unorderedResult: []
+    - # WHERE CARDINALITY() IS NOT NULL on a NOT-NULL array column matches all rows.
+      - query: SELECT "id" FROM "tab1_nn" WHERE CARDINALITY("int_arr") IS NOT NULL
+      - unorderedResult: [{id: 1}, {id: 2}, {id: 3}]
+---
+test_block:
+  # Tests focused on CARDINALITY() use in an INDEX.
+  name: arrays-cardinality-index-tests
+  preset: single_repetition_ordered
+  tests:
+    - # Basic `SELECT *` query, non-indexed vs. indexed tables.
+      - query: SELECT * FROM "tab1"
+      - explain: "SCAN([IS tab1])"
+    - - query: SELECT * FROM "tab1_indexed_nn"
+      - explain: "ISCAN(tab1_indexed_nn_index <,>)"
+    - - query: SELECT * FROM "tab1_indexed"
+      - explain: "ISCAN(tab1_indexed_index <,>)"
+    - # Just `SELECT "id"`, no CARDINALITY() involved.
+      - query: SELECT "id" FROM "tab1_indexed_nn"
+      - explain: "COVERING(tab1_indexed_nn_index <,> -> [id: KEY:[2]]) | MAP (_.id AS id)"
+      - unorderedResult: [{id: 1}, {id: 2}, {id: 3}]
+    - - query: SELECT "id" FROM "tab1_indexed"
+      - explain: "COVERING(tab1_indexed_index <,> -> [id: KEY:[2]]) | MAP (_.id AS id)"
+      - unorderedResult: [{id: 0}, {id: 1}, {id: 2}, {id: 3}]
+    - # Just `SELECT "id", CARDINALITY()`.
+      # Note: Not a COVERING index scan. It is currently not possible to extract computed fields
+      # such as CARDINALITY() from an index scan.
+      - query: SELECT "id", CARDINALITY("int_arr") AS "card" FROM "tab1_indexed_nn"
+      - explain: "ISCAN(tab1_indexed_nn_index <,>) | MAP (_.id AS id, cardinality(_.int_arr) AS card)"
+      - resultMetadata: [{id: INTEGER}, {card: INTEGER}]
+      - unorderedResult: [{id: 1, card: 0}, {id: 2, card: 1}, {id: 3, card: 2}]
+    - - query: SELECT "id", CARDINALITY("int_arr") AS "card" FROM "tab1_indexed"
+      - explain: "ISCAN(tab1_indexed_index <,>) | MAP (_.id AS id, cardinality(_.int_arr) AS card)"
+      - unorderedResult: [{id: 0, card: !null _}, {id: 1, card: 0}, {id: 2, card: 1}, {id: 3, card: 2}]
+    - # SELECT + ORDER BY "id", which is not compatible with the index order.
+      - query: SELECT "id" FROM "tab1_indexed_nn" ORDER BY "id" DESC
+      - explain: "SCAN([IS tab1_indexed_nn]) | MAP (_.id AS id)"
+      - result: [{id: 3}, {id: 2}, {id: 1}]
+    - - query: SELECT "id" FROM "tab1_indexed" ORDER BY "id" DESC
+      - explain: "SCAN([IS tab1_indexed]) | MAP (_.id AS id)"
+      - result: [{id: 3}, {id: 2}, {id: 1}, {id: 0}]
+    - # SELECT + ORDER BY CARDINALITY(), which is compatible with the index order.
+      - query: SELECT "id" FROM "tab1_indexed_nn" ORDER BY CARDINALITY("int_arr") DESC
+      - explain: "ISCAN(tab1_indexed_nn_index <,> REVERSE) | MAP (_.id AS id, cardinality(_.int_arr) AS _1) | MAP (_.id AS id)"
+      - result: [{id: 3}, {id: 2}, {id: 1}]
+    - - query: SELECT "id" FROM "tab1_indexed" ORDER BY CARDINALITY("int_arr") DESC
+      - explain: "ISCAN(tab1_indexed_index <,> REVERSE) | MAP (_.id AS id, cardinality(_.int_arr) AS _1) | MAP (_.id AS id)"
+      - result: [{id: 3}, {id: 2}, {id: 1}, {id: 0}]
+    - # SELECT + ORDER BY CARDINALITY(), but also include the CARDINALITY() in the target list.
+      - query: SELECT CARDINALITY("int_arr") AS "card", "id" FROM "tab1_indexed_nn" ORDER BY CARDINALITY("int_arr")
+      - explain: "ISCAN(tab1_indexed_nn_index <,>) | MAP (cardinality(_.int_arr) AS card, _.id AS id)"
+      - resultMetadata: [{card: INTEGER}, {id: INTEGER}]
+      - result: [{card: 0, id: 1}, {card: 1, id: 2}, {card: 2, id: 3}]
+    - - query: SELECT CARDINALITY("int_arr") AS "card", "id" FROM "tab1_indexed" ORDER BY CARDINALITY("int_arr")
+      - resultMetadata: [{card: INTEGER}, {id: INTEGER}]
+      - explain: "ISCAN(tab1_indexed_index <,>) | MAP (cardinality(_.int_arr) AS card, _.id AS id)"
+      - result: [{card: !null _, id: 0}, {card: 0, id: 1}, {card: 1, id: 2}, {card: 2, id: 3}]
+    - # SELECT + WHERE CARDINALITY(). The index is leveraged to evaluate the predicate.
+      - query: SELECT "id" FROM "tab1_indexed_nn" WHERE CARDINALITY("int_arr") = 1
+      - explain: "COVERING(tab1_indexed_nn_index [EQUALS promote(@c10 AS INT)] -> [id: KEY:[2]]) | MAP (_.id AS id)"
+      - result: [{id: 2}]
+    - - query: SELECT "id" FROM "tab1_indexed" WHERE CARDINALITY("int_arr") = 1
+      - explain: "COVERING(tab1_indexed_index [EQUALS promote(@c10 AS INT)] -> [id: KEY:[2]]) | MAP (_.id AS id)"
+      - result: [{id: 2}]
+    - # SELECT + WHERE CARDINALITY() IS [NOT] NULL. The index should be leveraged for the predicate.
+      - query: SELECT "id" FROM "tab1_indexed" WHERE CARDINALITY("int_arr") IS NULL
+      - explain: "COVERING(tab1_indexed_index [[null],[null]] -> [id: KEY:[2]]) | MAP (_.id AS id)"
+      - unorderedResult: [{id: 0}]
+    - - query: SELECT "id" FROM "tab1_indexed" WHERE CARDINALITY("int_arr") IS NOT NULL
+      - explain: "COVERING(tab1_indexed_index ([null],> -> [id: KEY:[2]]) | MAP (_.id AS id)"
+      - unorderedResult: [{id: 1}, {id: 2}, {id: 3}]
+    - - query: SELECT "id" FROM "tab1_indexed_nn" WHERE CARDINALITY("int_arr") IS NULL
+      # Future optimization: The planner emits a `[null]` range scan despite the NOT NULL constraint. If it considered
+      # the constraint it could simplify the predicate to a constant FALSE/TRUE at plan time.
+      - explain: "COVERING(tab1_indexed_nn_index [[null],[null]] -> [id: KEY:[2]]) | MAP (_.id AS id)"
+      - unorderedResult: []
+    - - query: SELECT "id" FROM "tab1_indexed_nn" WHERE CARDINALITY("int_arr") IS NOT NULL
+      - explain: "COVERING(tab1_indexed_nn_index ([null],> -> [id: KEY:[2]]) | MAP (_.id AS id)"
+      - unorderedResult: [{id: 1}, {id: 2}, {id: 3}]
+    - # WHERE CARDINALITY() = NULL. By SQL semantics this should always return 0 rows (the predicate evaluates to
+      # UNKNOWN). The non-indexed cases get this right (the planner constant-folds the predicate to `null`), but the
+      # indexed nullable case currently exhibits a general planner bug where `«indexed_field» = NULL` is incorrectly
+      # mapped to an IS NULL index range scan. The tests below document the current behavior. See also Issue #4170.
+      - query: SELECT "id" FROM "tab1" WHERE CARDINALITY("int_arr") = NULL
+      - explain: "SCAN([IS tab1]) | FILTER null | MAP (_.id AS id)"
+      - unorderedResult: []
+    - - query: SELECT "id" FROM "tab1_nn" WHERE CARDINALITY("int_arr") = NULL
+      - explain: "SCAN([IS tab1_nn]) | FILTER null | MAP (_.id AS id)"
+      - unorderedResult: []
+    - # TODO Issue #4170: This should return [].
+      - query: SELECT "id" FROM "tab1_indexed" WHERE CARDINALITY("int_arr") = NULL
+      - explain: "COVERING(tab1_indexed_index [EQUALS NULL] -> [id: KEY:[2]]) | MAP (_.id AS id)"
+      - unorderedResult: [{id: 0}]
+    - - query: SELECT "id" FROM "tab1_indexed_nn" WHERE CARDINALITY("int_arr") = NULL
+      - explain: "COVERING(tab1_indexed_nn_index [EQUALS NULL] -> [id: KEY:[2]]) | MAP (_.id AS id)"
+      - unorderedResult: []
+    - # SELECT + WHERE + ORDER BY.
+      - query: SELECT CARDINALITY("int_arr") AS "card", "id" FROM "tab1_indexed_nn" WHERE CARDINALITY("int_arr") = 1 ORDER BY CARDINALITY("int_arr")
+      - explain: "ISCAN(tab1_indexed_nn_index [EQUALS promote(@c17 AS INT)]) | MAP (cardinality(_.int_arr) AS card, _.id AS id)"
+      - resultMetadata: [{card: INTEGER}, {id: INTEGER}]
+      - result: [{card: 1, id: 2}]
+    - # SELECT + WHERE + ORDER BY like above, but on an array nested in a struct (as opposed to a top-level array).
+      - query: SELECT CARDINALITY("struct"."int_arr") AS "card", "id" FROM "tab2" WHERE CARDINALITY("struct"."int_arr") = 1 ORDER BY CARDINALITY("struct"."int_arr")
+      - explain: "ISCAN(tab2_index [EQUALS promote(@c21 AS INT)]) | MAP (cardinality(_.struct.int_arr) AS card, _.id AS id)"
+      - resultMetadata: [{card: INTEGER}, {id: INTEGER}]
+      - result: [{card: 1, id: 2}]
 ...

--- a/yaml-tests/src/test/resources/arrays-operators.yamsql
+++ b/yaml-tests/src/test/resources/arrays-operators.yamsql
@@ -3,7 +3,7 @@
 #
 # This source file is part of the FoundationDB open source project
 #
-# Copyright 2023-2030 Apple Inc. and the FoundationDB project authors
+# Copyright 2023-2026 Apple Inc. and the FoundationDB project authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
* Introduce a `CardinalityFunctionKeyExpression` to make it possible to define indexes with a `function("cardinality", …)` key expression.
* In `MaterializedViewIndexGenerator`, add the necessary logic to convert `CardinalityValue` into a key expression.

For a nullable ARRAY field, the key expression produced from a `CARDINALITY(int_arr)` SQL expression will look as follows:

```
function("cardinality",
         field("int_arr").nest(field("values", Concatenate)))
```

The use of the Concatenate fan-out type currently runs into some gaps in the code that we also fix with this PR.

Testing:
* Integration tests in `arrays_cardinality.yamsql`.
* Unit tests in `IndexTest.java` and `KeyExpressionTest.java`.