### PR TITLE
Fix flaky test `FDBRecordStoreIndexTest.failUpdateConcurrentWithStateChange`

### DIFF
--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreIndexTest.java
@@ -1982,7 +1982,7 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
 
         try (FDBRecordContext context1 = openContext(); FDBRecordContext context2 = openContext()) {
             openSimpleRecordStore(context1);
-            recordStore.markIndexWriteOnly(indexName);
+            recordStore.markIndexWriteOnly(indexName).get();
 
             openSimpleRecordStore(context2);
             recordStore.saveRecord(record);


### PR DESCRIPTION
There was a flaky test reported in #3292. This resulted in a test failure for PR #4101 (see: https://github.com/FoundationDB/fdb-record-layer/actions/runs/24783051401/attempts/1#summary-72519276479). The underlying problem appears to be that we were starting a future (associated with transaction) and then relying on it having completed by the time we committed. This usually was the case, but it would very occaisionally fail.

I was able to validate that if I injected a delay before the future, then I was able to reproduce the error I saw during the spurious failure. However, I was not able to reliably reproduce the failure locally without a delay. So, I can tell you that with the proposed fix, I was able to get 1k successful runs of the test, but that was also true with the original code before. But analytically, this seems to be pretty clearly what was going on, and so I feel confident enough to resolve this issue. Note also that this is a test only issue.

This fixes #3292.