### PR TITLE
`LuceneIndexMaintenanceTest.concurrentMix`is flaky - resolve deadlock

### DIFF
--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTestDataModel.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTestDataModel.java
@@ -555,9 +555,9 @@ public class LuceneIndexTestDataModel {
     private CompletableFuture<Void> updateRecord(final FDBRecordStore recordStore,
                                                  Tuple primaryKey,
                                                  Function<Message, Message> updateMessage) {
-        return recordStore.loadRecordAsync(primaryKey).thenAccept(existingRecord -> {
-            recordStore.saveRecord(updateMessage.apply(existingRecord.getRecord()));
-        });
+        return recordStore.loadRecordAsync(primaryKey).thenCompose(existingRecord ->
+                recordStore.saveRecordAsync(updateMessage.apply(existingRecord.getRecord()))
+                        .thenApply(rec -> null));
     }
 
     /**


### PR DESCRIPTION
The `LuceneIndexMaintenanceTest.concurrentMix` test is flaky - seeing `TimeoutException` in PRBs for the `!synthetic` and `MULTIPLE` configuration.
Analysis (see below) suggested that the `forkJoinPool` is deadlocked (the test limits it to size of 3) when there are calls that cause the `agilityContext` to flush a transaction to FDB.
Changed the `LuceneIndexTestDataModel` to issue `saveAsync` within a `thenCompose` instead of `save`.
Tested locally by increasing the `recordCount` to force more writes to the DB and could verify reproduction before the fix and none after.

Resolves #3769

[Analysis.md](https://github.com/user-attachments/files/27063448/distributed-spinning-pascal.md)
