### PR TITLE
Disallow `.*` star expansion on unnested scalar arrays

### DIFF
--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/SemanticAnalyzer.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/SemanticAnalyzer.java
@@ -303,25 +303,48 @@ public class SemanticAnalyzer {
         return resolveIdentifier(identifier, operators);
     }
 
+    /**
+     * Expands a SQL {@code *} (star) expression into the corresponding set of column expressions. Three forms are
+     * supported: an unqualified {@code *} (expanding to all columns of all tables in scope), {@code T.*} (expanding
+     * to the columns of table {@code T}), and {@code T.A.*} (expanding the fields of a struct-typed column {@code A}).
+     * Raises {@link ErrorCode#INVALID_COLUMN_REFERENCE} when the qualifier does not refer to a record/struct type,
+     * e.g. when unnesting a scalar array.
+     *
+     * @param optionalQualifier the optional qualifier preceding the {@code *}, or {@link Optional#empty()} for an
+     * unqualified {@code *}
+     * @param operators the logical operators in scope for resolving the qualifier
+     *
+     * @return a {@link Star} expression capturing the expansion
+     */
     @Nonnull
     public Star expandStar(@Nonnull Optional<Identifier> optionalQualifier,
                            @Nonnull LogicalOperators operators) {
         final var forEachOperators = operators.forEachOnly();
+
         // Case 1: no qualifier, e.g. SELECT * FROM T, R;
         if (optionalQualifier.isEmpty()) {
             final var expansion = forEachOperators.getExpressions().nonEphemeralVisible();
             return Star.overQuantifiers(Optional.empty(), Streams.stream(forEachOperators).map(LogicalOperator::getQuantifier)
                     .map(Quantifier::getFlowedObjectValue).collect(ImmutableList.toImmutableList()), "unknown", expansion);
         }
+
         // Case 2: qualifying a table, e.g. SELECT T.* FROM T, R;
         final var qualifier = optionalQualifier.get();
         final var logicalTableMaybe = Streams.stream(forEachOperators)
                 .filter(table -> table.getName().isPresent() && table.getName().get().equals(qualifier))
                 .findFirst();
         if (logicalTableMaybe.isPresent()) {
-            return Star.overQuantifier(optionalQualifier, logicalTableMaybe.get().getQuantifier().getFlowedObjectValue(),
-                    qualifier.getName(), logicalTableMaybe.get().getOutput().nonEphemeralVisible());
+            final LogicalOperator logicalTable = logicalTableMaybe.get();
+            // Star can only be expanded on a record (struct) type. Examples of non-record qualifier types are scalars
+            // (e.g., when unnesting a scalar array, as in `SELECT integer.* FROM T, T.integer_array AS integer`)
+            // as well as VECTOR, ENUM, and UUID.
+            Assert.thatUnchecked(logicalTable.getQuantifier().getFlowedObjectType().isRecord(),
+                    ErrorCode.INVALID_COLUMN_REFERENCE,
+                    () -> String.format(Locale.ROOT, "attempt to expand non-struct column %s", qualifier));
+            return Star.overQuantifier(optionalQualifier, logicalTable.getQuantifier().getFlowedObjectValue(),
+                    qualifier.getName(), logicalTable.getOutput().nonEphemeralVisible());
         }
+
         // Case 2.1: represents a rare case where a logical operator contains a mix of columns that are qualified
         // differently.
         // This mostly happens when the logical operator encompasses an internal modeling strategy
@@ -333,6 +356,7 @@ public class SemanticAnalyzer {
         if (!individualReferencedColumns.isEmpty()) {
             return Star.overIndividualExpressions(optionalQualifier, "unknown", individualReferencedColumns);
         }
+
         // Case 3: qualifying a column inside a table, e.g. SELECT T.A.* FROM T, R;
         // TODO this is currently not supported as per parsing rules TODO (Expand nested struct fields)
         final var expression = resolveIdentifier(qualifier, forEachOperators);

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@
 #
 
 rootProject.name=fdb-record-layer
-version=4.11.1.0
+version=4.12.0.0
 releaseBuild=false
 
 # this should be false for release branches (i.e. if there is no -SNAPSHOT on the above version)

--- a/yaml-tests/src/test/resources/arrays-unnesting.yamsql
+++ b/yaml-tests/src/test/resources/arrays-unnesting.yamsql
@@ -46,6 +46,8 @@ schema_template:
   CREATE TYPE AS STRUCT "Struct" ("integer" INTEGER)
   CREATE TABLE T3 ("id" BIGINT, "structs" "Struct" ARRAY, "integers" INTEGER ARRAY, PRIMARY KEY ("id"))
 
+  CREATE TABLE T4 ("id" BIGINT, "vectors" VECTOR(3, FLOAT) ARRAY, PRIMARY KEY ("id"))
+
   CREATE TYPE AS STRUCT "restaurant_review" ("reviewer" STRING, "rating" BIGINT)
   CREATE TABLE "restaurant" ("rest_no" BIGINT, "name" STRING, "reviews" "restaurant_review" ARRAY, PRIMARY KEY ("rest_no"))
   CREATE INDEX "mv" AS SELECT SQ."rating" FROM "restaurant" AS RR, (SELECT "rating" FROM RR."reviews") SQ
@@ -154,9 +156,21 @@ test_block:
       - unorderedResult: [{1, 101}, {1, 102}, {2, 201}, {2, 202}]
     -
       # Unnesting an ARRAY of scalars (integers) directly.
-      # TODO Issue #4102: The `"integer".*` star expansion should not be permitted here.
+      # The `"integer".*` syntax is disallowed because "integer" is a scalar here, not a STRUCT.
       - query: SELECT "id", "integer".* FROM T3, T3."integers" AS "integer"
-      - unorderedResult: [{1, 101}, {1, 102}, {2, 201}, {2, 202}]
+      - error: "42F10"
+    -
+      # Same `.*` rejection as above, but here the array comes from a table function rather than a base-table column.
+      - query: SELECT "b".* FROM (SELECT "a" FROM VALUES ([1, 2, 3, 4]) AS T("a")) AS "sq", "sq"."a" AS "b"
+      - error: "42F10"
+    -
+      # Wrapping the unnested scalar into a one-field struct lifts it back into a record type, so `.*` expansion is allowed.
+      - query: SELECT "b".* FROM (SELECT "a" FROM VALUES ([1, 2, 3, 4]) AS T("a")) AS "sq", (SELECT ("x") AS wrapped FROM "sq"."a" AS "x") AS "b"
+      - result: [{wrapped: {1}}, {wrapped: {2}}, {wrapped: {3}}, {wrapped: {4}}]
+    -
+      # Same .* rejection as above, but on an unnested VECTOR element. VECTOR has no fields to expand.
+      - query: SELECT "id", "v".* FROM T4, T4."vectors" AS "v"
+      - error: "42F10"
     -
       # Unnest the ARRAY of integers via a subquery and wrap each integer into a tuple with a `( … )` expression.
       # Note: As an alternative to the `AS "wrapped_int"` we might write `AS SQ ("wrapped_int")`, but this is not


### PR DESCRIPTION
This change fixes a small gap in the type checks for star expansion.
Case 2 in `SemanticAnalyzer#expandStar()` allowed star expansion for
any qualifier that matches some FROM-clause quantifier, regardless of
the type of that quantifier. When the quantifier was not of a record
type, `Star.overQuantifier()` would silently wrap the scalar in a
single-field `RecordConstructorValue` and produce a valid but unintended
result. For example, when unnesting a scalar array,
```
SELECT integer.* FROM T, T.integer_array AS integer
```
the scalar integer was treated as if it were a one-element struct.
We now raise a INVALID_COLUMN_REFERENCE error in this case, consistent
with Case 3.

We also bump the minor version, as this is a (mildly) breaking change.

Fixes https://github.com/FoundationDB/fdb-record-layer/issues/4102.