### PR TITLE
Create IndexGeneralAttributes

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexGeneralAttributes.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexGeneralAttributes.java
@@ -49,11 +49,4 @@ public final class IndexGeneralAttributes {
     public boolean isOptimizedForMutualIndexing() {
         return optimizedForMutualIndexing;
     }
-
-    @Override
-    public String toString() {
-        return "IndexAttributes[" +
-                "optimizedForMutualIndexing=" + optimizedForMutualIndexing + ']';
-    }
-
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexGeneralAttributes.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexGeneralAttributes.java
@@ -1,0 +1,59 @@
+/*
+ * indexGeneralAttributes.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb;
+
+import com.apple.foundationdb.annotation.API;
+
+
+/**
+ * Provide general information and guidelines for the index.
+ */
+@API(API.Status.EXPERIMENTAL)
+public final class IndexGeneralAttributes {
+    public static final IndexGeneralAttributes DEFAULT = new IndexGeneralAttributes(true);
+    private final boolean optimizedForMutualIndexing;
+
+    /**
+     * Create a new set of index attributes.
+     *
+     * @param optimizedForMutualIndexing whether the index type is optimized for mutual indexing.
+     */
+    public IndexGeneralAttributes(boolean optimizedForMutualIndexing) {
+        this.optimizedForMutualIndexing = optimizedForMutualIndexing;
+    }
+
+    /**
+     * Predict if the indexing process goes through a bottleneck (like a semaphore or a single item that will cause a
+     * conflict for concurrent transactions). If false, mutual indexing may be inefficient.
+     *
+     * @return true unless not optimized to mutual indexing
+     */
+    public boolean isOptimizedForMutualIndexing() {
+        return optimizedForMutualIndexing;
+    }
+
+    @Override
+    public String toString() {
+        return "IndexAttributes[" +
+                "optimizedForMutualIndexing=" + optimizedForMutualIndexing + ']';
+    }
+
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexGeneralAttributes.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexGeneralAttributes.java
@@ -28,7 +28,6 @@ import com.apple.foundationdb.annotation.API;
  */
 @API(API.Status.EXPERIMENTAL)
 public final class IndexGeneralAttributes {
-    public static final IndexGeneralAttributes DEFAULT = new IndexGeneralAttributes(true);
     private final boolean optimizedForMutualIndexing;
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexGeneralAttributes.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexGeneralAttributes.java
@@ -41,7 +41,10 @@ public final class IndexGeneralAttributes {
 
     /**
      * Predict if the indexing process goes through a bottleneck (like a semaphore or a single item that will cause a
-     * conflict for concurrent transactions). If false, mutual indexing may be inefficient.
+     * conflict for concurrent transactions). This returns {@code true} if it can be expected that N concurrent workers
+     * will take 1/Nth the time to build using mutual indexing. This returns {@code false} if the index maintenance does
+     * not play well with concurrent writes, and N workers will take approximately the same time as building without
+     * concurrency.
      *
      * @return true unless not optimized to mutual indexing
      */

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexMaintainerFactory.java
@@ -116,4 +116,15 @@ public interface IndexMaintainerFactory {
     default Iterable<MatchCandidate> createMatchCandidates(@Nonnull RecordMetaData metaData, @Nonnull Index index, boolean reverse) {
         return Collections.emptyList();
     }
+
+    /**
+     * Get the {@link IndexGeneralAttributes} for this factory's index type. The attributes provide general information
+     * and guidelines about the index.
+     *
+     * @return the index attributes for this factory's index type
+     */
+    @Nonnull
+    default IndexGeneralAttributes getIndexGeneralAttributes() {
+        return IndexGeneralAttributes.DEFAULT;
+    }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexMaintainerFactory.java
@@ -118,13 +118,14 @@ public interface IndexMaintainerFactory {
     }
 
     /**
-     * Get the {@link IndexGeneralAttributes} for this factory's index type. The attributes provide general information
+     * Get the {@link IndexGeneralAttributes} for the given index. The attributes provide general information
      * and guidelines about the index.
      *
-     * @return the index attributes for this factory's index type
+     * @param index the index to get attributes for
+     * @return the index attributes for this index
      */
     @Nonnull
-    default IndexGeneralAttributes getIndexGeneralAttributes() {
-        return IndexGeneralAttributes.DEFAULT;
+    default IndexGeneralAttributes getIndexGeneralAttributes(@Nonnull Index index) {
+        return new IndexGeneralAttributes(true);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexMaintainerFactory.java
@@ -126,6 +126,6 @@ public interface IndexMaintainerFactory {
      */
     @Nonnull
     default IndexGeneralAttributes getIndexGeneralAttributes(@Nonnull Index index) {
-        return new IndexGeneralAttributes(true);
+        return new IndexGeneralAttributes(false);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexMaintainerFactory.java
@@ -117,6 +117,8 @@ public interface IndexMaintainerFactory {
         return Collections.emptyList();
     }
 
+    IndexGeneralAttributes DEFAULT_GENERAL_ATTRIBUTES = new IndexGeneralAttributes(false);
+
     /**
      * Get the {@link IndexGeneralAttributes} for the given index. The attributes provide general information
      * and guidelines about the index.
@@ -126,6 +128,6 @@ public interface IndexMaintainerFactory {
      */
     @Nonnull
     default IndexGeneralAttributes getIndexGeneralAttributes(@Nonnull Index index) {
-        return new IndexGeneralAttributes(false);
+        return DEFAULT_GENERAL_ATTRIBUTES;
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexMaintainerFactory.java
@@ -49,6 +49,8 @@ import java.util.Collections;
  */
 @API(API.Status.UNSTABLE)
 public interface IndexMaintainerFactory {
+    IndexGeneralAttributes DEFAULT_GENERAL_ATTRIBUTES = new IndexGeneralAttributes(false);
+
     /**
      * Get the index types supported by this factory.
      * @return a collection of strings of index types supported by this factory
@@ -116,8 +118,6 @@ public interface IndexMaintainerFactory {
     default Iterable<MatchCandidate> createMatchCandidates(@Nonnull RecordMetaData metaData, @Nonnull Index index, boolean reverse) {
         return Collections.emptyList();
     }
-
-    IndexGeneralAttributes DEFAULT_GENERAL_ATTRIBUTES = new IndexGeneralAttributes(false);
 
     /**
      * Get the {@link IndexGeneralAttributes} for the given index. The attributes provide general information

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/AtomicMutationIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/AtomicMutationIndexMaintainerFactory.java
@@ -73,6 +73,7 @@ public class AtomicMutationIndexMaintainerFactory implements IndexMaintainerFact
             IndexTypes.MAX_EVER_VERSION,
             IndexTypes.MIN_EVER, IndexTypes.MAX_EVER
     };
+    private static final IndexGeneralAttributes GENERAL_ATTRIBUTES = new IndexGeneralAttributes(true);
 
     @Override
     @Nonnull
@@ -166,8 +167,6 @@ public class AtomicMutationIndexMaintainerFactory implements IndexMaintainerFact
             return ImmutableList.of();
         }
     }
-
-    private static final IndexGeneralAttributes GENERAL_ATTRIBUTES = new IndexGeneralAttributes(true);
 
     @Nonnull
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/AtomicMutationIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/AtomicMutationIndexMaintainerFactory.java
@@ -31,6 +31,7 @@ import com.apple.foundationdb.record.metadata.MetaDataValidator;
 import com.apple.foundationdb.record.metadata.RecordType;
 import com.apple.foundationdb.record.metadata.expressions.GroupingKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
+import com.apple.foundationdb.record.provider.foundationdb.IndexGeneralAttributes;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainer;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerFactory;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerState;
@@ -164,5 +165,11 @@ public class AtomicMutationIndexMaintainerFactory implements IndexMaintainerFact
         } else {
             return ImmutableList.of();
         }
+    }
+
+    @Nonnull
+    @Override
+    public IndexGeneralAttributes getIndexGeneralAttributes(@Nonnull final Index index) {
+        return new IndexGeneralAttributes(true);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/AtomicMutationIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/AtomicMutationIndexMaintainerFactory.java
@@ -167,9 +167,11 @@ public class AtomicMutationIndexMaintainerFactory implements IndexMaintainerFact
         }
     }
 
+    private static final IndexGeneralAttributes GENERAL_ATTRIBUTES = new IndexGeneralAttributes(true);
+
     @Nonnull
     @Override
     public IndexGeneralAttributes getIndexGeneralAttributes(@Nonnull final Index index) {
-        return new IndexGeneralAttributes(true);
+        return GENERAL_ATTRIBUTES;
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/BitmapValueIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/BitmapValueIndexMaintainerFactory.java
@@ -121,9 +121,11 @@ public class BitmapValueIndexMaintainerFactory implements IndexMaintainerFactory
                 MatchCandidateExpansion.expandIndexMatchCandidate(info, false, null, expansionVisitor));
     }
 
+    private static final IndexGeneralAttributes GENERAL_ATTRIBUTES = new IndexGeneralAttributes(true);
+
     @Nonnull
     @Override
     public IndexGeneralAttributes getIndexGeneralAttributes(@Nonnull final Index index) {
-        return new IndexGeneralAttributes(true);
+        return GENERAL_ATTRIBUTES;
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/BitmapValueIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/BitmapValueIndexMaintainerFactory.java
@@ -30,6 +30,7 @@ import com.apple.foundationdb.record.metadata.MetaDataValidator;
 import com.apple.foundationdb.record.metadata.RecordType;
 import com.apple.foundationdb.record.metadata.expressions.GroupingKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
+import com.apple.foundationdb.record.provider.foundationdb.IndexGeneralAttributes;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainer;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerFactory;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerState;
@@ -118,5 +119,11 @@ public class BitmapValueIndexMaintainerFactory implements IndexMaintainerFactory
         final ExpansionVisitor<?> expansionVisitor = new BitmapAggregateIndexExpansionVisitor(info.getIndex(), info.getIndexedRecordTypes());
         return MatchCandidateExpansion.optionalToIterable(
                 MatchCandidateExpansion.expandIndexMatchCandidate(info, false, null, expansionVisitor));
+    }
+
+    @Nonnull
+    @Override
+    public IndexGeneralAttributes getIndexGeneralAttributes(@Nonnull final Index index) {
+        return new IndexGeneralAttributes(true);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/BitmapValueIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/BitmapValueIndexMaintainerFactory.java
@@ -54,6 +54,7 @@ import java.util.List;
 public class BitmapValueIndexMaintainerFactory implements IndexMaintainerFactory {
     @Nonnull
     private static final List<String> TYPES = Collections.singletonList(IndexTypes.BITMAP_VALUE);
+    private static final IndexGeneralAttributes GENERAL_ATTRIBUTES = new IndexGeneralAttributes(true);
 
     @Override
     @Nonnull
@@ -120,8 +121,6 @@ public class BitmapValueIndexMaintainerFactory implements IndexMaintainerFactory
         return MatchCandidateExpansion.optionalToIterable(
                 MatchCandidateExpansion.expandIndexMatchCandidate(info, false, null, expansionVisitor));
     }
-
-    private static final IndexGeneralAttributes GENERAL_ATTRIBUTES = new IndexGeneralAttributes(true);
 
     @Nonnull
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/MultidimensionalIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/MultidimensionalIndexMaintainerFactory.java
@@ -51,6 +51,7 @@ import java.util.Set;
 @API(API.Status.EXPERIMENTAL)
 public class MultidimensionalIndexMaintainerFactory implements IndexMaintainerFactory {
     static final String[] TYPES = { IndexTypes.MULTIDIMENSIONAL};
+    private static final IndexGeneralAttributes GENERAL_ATTRIBUTES = new IndexGeneralAttributes(false);
 
     @Override
     @Nonnull
@@ -198,8 +199,6 @@ public class MultidimensionalIndexMaintainerFactory implements IndexMaintainerFa
     public IndexMaintainer getIndexMaintainer(@Nonnull final IndexMaintainerState state) {
         return new MultidimensionalIndexMaintainer(state);
     }
-
-    private static final IndexGeneralAttributes GENERAL_ATTRIBUTES = new IndexGeneralAttributes(false);
 
     @Nonnull
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/MultidimensionalIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/MultidimensionalIndexMaintainerFactory.java
@@ -33,6 +33,7 @@ import com.apple.foundationdb.record.metadata.expressions.DimensionsKeyExpressio
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.KeyWithValueExpression;
 import com.apple.foundationdb.record.metadata.expressions.ThenKeyExpression;
+import com.apple.foundationdb.record.provider.foundationdb.IndexGeneralAttributes;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainer;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerFactory;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerState;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/MultidimensionalIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/MultidimensionalIndexMaintainerFactory.java
@@ -198,4 +198,12 @@ public class MultidimensionalIndexMaintainerFactory implements IndexMaintainerFa
     public IndexMaintainer getIndexMaintainer(@Nonnull final IndexMaintainerState state) {
         return new MultidimensionalIndexMaintainer(state);
     }
+
+    private static final IndexGeneralAttributes GENERAL_ATTRIBUTES = new IndexGeneralAttributes(false);
+
+    @Nonnull
+    @Override
+    public IndexGeneralAttributes getIndexGeneralAttributes(@Nonnull final Index index) {
+        return GENERAL_ATTRIBUTES;
+    }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/NoOpIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/NoOpIndexMaintainerFactory.java
@@ -62,9 +62,11 @@ public class NoOpIndexMaintainerFactory implements IndexMaintainerFactory {
         return new NoOpIndexMaintainer(state);
     }
 
+    private static final IndexGeneralAttributes GENERAL_ATTRIBUTES = new IndexGeneralAttributes(true);
+
     @Nonnull
     @Override
     public IndexGeneralAttributes getIndexGeneralAttributes(@Nonnull final Index index) {
-        return new IndexGeneralAttributes(true);
+        return GENERAL_ATTRIBUTES;
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/NoOpIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/NoOpIndexMaintainerFactory.java
@@ -39,6 +39,8 @@ import java.util.Collections;
 @AutoService(IndexMaintainerFactory.class)
 @API(API.Status.UNSTABLE)
 public class NoOpIndexMaintainerFactory implements IndexMaintainerFactory {
+    private static final IndexGeneralAttributes GENERAL_ATTRIBUTES = new IndexGeneralAttributes(true);
+
     @Nonnull
     @Override
     public Iterable<String> getIndexTypes() {
@@ -61,8 +63,6 @@ public class NoOpIndexMaintainerFactory implements IndexMaintainerFactory {
     public IndexMaintainer getIndexMaintainer(@Nonnull IndexMaintainerState state) {
         return new NoOpIndexMaintainer(state);
     }
-
-    private static final IndexGeneralAttributes GENERAL_ATTRIBUTES = new IndexGeneralAttributes(true);
 
     @Nonnull
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/NoOpIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/NoOpIndexMaintainerFactory.java
@@ -24,6 +24,7 @@ import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.IndexValidator;
 import com.apple.foundationdb.record.metadata.MetaDataValidator;
+import com.apple.foundationdb.record.provider.foundationdb.IndexGeneralAttributes;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainer;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerFactory;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerState;
@@ -59,5 +60,11 @@ public class NoOpIndexMaintainerFactory implements IndexMaintainerFactory {
     @Override
     public IndexMaintainer getIndexMaintainer(@Nonnull IndexMaintainerState state) {
         return new NoOpIndexMaintainer(state);
+    }
+
+    @Nonnull
+    @Override
+    public IndexGeneralAttributes getIndexGeneralAttributes(@Nonnull final Index index) {
+        return new IndexGeneralAttributes(true);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/PermutedMinMaxIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/PermutedMinMaxIndexMaintainerFactory.java
@@ -110,9 +110,11 @@ public class PermutedMinMaxIndexMaintainerFactory implements IndexMaintainerFact
         return resultBuilder.build();
     }
 
+    private static final IndexGeneralAttributes GENERAL_ATTRIBUTES = new IndexGeneralAttributes(true);
+
     @Nonnull
     @Override
     public IndexGeneralAttributes getIndexGeneralAttributes(@Nonnull final Index index) {
-        return new IndexGeneralAttributes(true);
+        return GENERAL_ATTRIBUTES;
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/PermutedMinMaxIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/PermutedMinMaxIndexMaintainerFactory.java
@@ -53,6 +53,7 @@ public class PermutedMinMaxIndexMaintainerFactory implements IndexMaintainerFact
     static final String[] TYPES = {
         IndexTypes.PERMUTED_MIN, IndexTypes.PERMUTED_MAX
     };
+    private static final IndexGeneralAttributes GENERAL_ATTRIBUTES = new IndexGeneralAttributes(true);
 
     @Override
     @Nonnull
@@ -109,8 +110,6 @@ public class PermutedMinMaxIndexMaintainerFactory implements IndexMaintainerFact
 
         return resultBuilder.build();
     }
-
-    private static final IndexGeneralAttributes GENERAL_ATTRIBUTES = new IndexGeneralAttributes(true);
 
     @Nonnull
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/PermutedMinMaxIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/PermutedMinMaxIndexMaintainerFactory.java
@@ -30,6 +30,7 @@ import com.apple.foundationdb.record.metadata.IndexValidator;
 import com.apple.foundationdb.record.metadata.MetaDataException;
 import com.apple.foundationdb.record.metadata.MetaDataValidator;
 import com.apple.foundationdb.record.metadata.expressions.GroupingKeyExpression;
+import com.apple.foundationdb.record.provider.foundationdb.IndexGeneralAttributes;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainer;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerFactory;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerState;
@@ -107,5 +108,11 @@ public class PermutedMinMaxIndexMaintainerFactory implements IndexMaintainerFact
                 .ifPresent(resultBuilder::add);
 
         return resultBuilder.build();
+    }
+
+    @Nonnull
+    @Override
+    public IndexGeneralAttributes getIndexGeneralAttributes(@Nonnull final Index index) {
+        return new IndexGeneralAttributes(true);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankIndexMaintainerFactory.java
@@ -52,6 +52,7 @@ import java.util.Set;
 @API(API.Status.UNSTABLE)
 public class RankIndexMaintainerFactory implements IndexMaintainerFactory {
     static final String[] TYPES = { IndexTypes.RANK };
+    private static final IndexGeneralAttributes GENERAL_ATTRIBUTES = new IndexGeneralAttributes(true);
 
     @Override
     @Nonnull
@@ -123,8 +124,6 @@ public class RankIndexMaintainerFactory implements IndexMaintainerFactory {
 
         return resultBuilder.build();
     }
-
-    private static final IndexGeneralAttributes GENERAL_ATTRIBUTES = new IndexGeneralAttributes(true);
 
     @Nonnull
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankIndexMaintainerFactory.java
@@ -30,6 +30,7 @@ import com.apple.foundationdb.record.metadata.IndexTypes;
 import com.apple.foundationdb.record.metadata.IndexValidator;
 import com.apple.foundationdb.record.metadata.MetaDataException;
 import com.apple.foundationdb.record.metadata.MetaDataValidator;
+import com.apple.foundationdb.record.provider.foundationdb.IndexGeneralAttributes;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainer;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerFactory;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerState;
@@ -121,5 +122,11 @@ public class RankIndexMaintainerFactory implements IndexMaintainerFactory {
                 .ifPresent(resultBuilder::add);
 
         return resultBuilder.build();
+    }
+
+    @Nonnull
+    @Override
+    public IndexGeneralAttributes getIndexGeneralAttributes(@Nonnull final Index index) {
+        return new IndexGeneralAttributes(true);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankIndexMaintainerFactory.java
@@ -124,9 +124,11 @@ public class RankIndexMaintainerFactory implements IndexMaintainerFactory {
         return resultBuilder.build();
     }
 
+    private static final IndexGeneralAttributes GENERAL_ATTRIBUTES = new IndexGeneralAttributes(true);
+
     @Nonnull
     @Override
     public IndexGeneralAttributes getIndexGeneralAttributes(@Nonnull final Index index) {
-        return new IndexGeneralAttributes(true);
+        return GENERAL_ATTRIBUTES;
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/SlidingWindowIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/SlidingWindowIndexMaintainerFactory.java
@@ -66,6 +66,8 @@ import java.util.Collection;
 @API(API.Status.EXPERIMENTAL)
 public class SlidingWindowIndexMaintainerFactory implements IndexMaintainerFactory {
 
+    private static final IndexGeneralAttributes GENERAL_ATTRIBUTES = new IndexGeneralAttributes(false);
+
     @Nonnull
     private final IndexMaintainerFactory delegateFactory;
 
@@ -145,8 +147,6 @@ public class SlidingWindowIndexMaintainerFactory implements IndexMaintainerFacto
                                                            @Nonnull Index index, boolean reverse) {
         return delegateFactory.createMatchCandidates(metaData, index, reverse);
     }
-
-    private static final IndexGeneralAttributes GENERAL_ATTRIBUTES = new IndexGeneralAttributes(false);
 
     @Nonnull
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/SlidingWindowIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/SlidingWindowIndexMaintainerFactory.java
@@ -31,6 +31,7 @@ import com.apple.foundationdb.record.metadata.IndexValidator;
 import com.apple.foundationdb.record.metadata.MetaDataException;
 import com.apple.foundationdb.record.metadata.MetaDataValidator;
 import com.apple.foundationdb.record.metadata.RecordType;
+import com.apple.foundationdb.record.provider.foundationdb.IndexGeneralAttributes;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainer;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerFactory;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerState;
@@ -143,6 +144,14 @@ public class SlidingWindowIndexMaintainerFactory implements IndexMaintainerFacto
     public Iterable<MatchCandidate> createMatchCandidates(@Nonnull RecordMetaData metaData,
                                                            @Nonnull Index index, boolean reverse) {
         return delegateFactory.createMatchCandidates(metaData, index, reverse);
+    }
+
+    private static final IndexGeneralAttributes GENERAL_ATTRIBUTES = new IndexGeneralAttributes(false);
+
+    @Nonnull
+    @Override
+    public IndexGeneralAttributes getIndexGeneralAttributes(@Nonnull final Index index) {
+        return GENERAL_ATTRIBUTES;
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexMaintainerFactory.java
@@ -31,6 +31,7 @@ import com.apple.foundationdb.record.metadata.MetaDataValidator;
 import com.apple.foundationdb.record.metadata.RecordType;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.provider.common.text.TextTokenizer;
+import com.apple.foundationdb.record.provider.foundationdb.IndexGeneralAttributes;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainer;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerFactory;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerState;
@@ -52,6 +53,8 @@ import java.util.Set;
 public class TextIndexMaintainerFactory implements IndexMaintainerFactory {
     @Nonnull
     private static final List<String> TYPES = Collections.singletonList(IndexTypes.TEXT);
+    @Nonnull
+    private static final IndexGeneralAttributes TEXT_INDEX_ATTRIBUTES = new IndexGeneralAttributes(false);
     @Nonnull
     private static final Set<String> TEXT_OPTIONS = ImmutableSet.of(
             IndexOptions.TEXT_TOKENIZER_NAME_OPTION,
@@ -196,5 +199,11 @@ public class TextIndexMaintainerFactory implements IndexMaintainerFactory {
     @Override
     public IndexMaintainer getIndexMaintainer(@Nonnull IndexMaintainerState state) {
         return new TextIndexMaintainer(state);
+    }
+
+    @Nonnull
+    @Override
+    public IndexGeneralAttributes getIndexGeneralAttributes() {
+        return TEXT_INDEX_ATTRIBUTES;
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexMaintainerFactory.java
@@ -203,7 +203,7 @@ public class TextIndexMaintainerFactory implements IndexMaintainerFactory {
 
     @Nonnull
     @Override
-    public IndexGeneralAttributes getIndexGeneralAttributes() {
+    public IndexGeneralAttributes getIndexGeneralAttributes(@Nonnull final Index index) {
         return TEXT_INDEX_ATTRIBUTES;
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexMaintainerFactory.java
@@ -54,8 +54,6 @@ public class TextIndexMaintainerFactory implements IndexMaintainerFactory {
     @Nonnull
     private static final List<String> TYPES = Collections.singletonList(IndexTypes.TEXT);
     @Nonnull
-    private static final IndexGeneralAttributes TEXT_INDEX_ATTRIBUTES = new IndexGeneralAttributes(false);
-    @Nonnull
     private static final Set<String> TEXT_OPTIONS = ImmutableSet.of(
             IndexOptions.TEXT_TOKENIZER_NAME_OPTION,
             IndexOptions.TEXT_TOKENIZER_VERSION_OPTION,
@@ -199,11 +197,5 @@ public class TextIndexMaintainerFactory implements IndexMaintainerFactory {
     @Override
     public IndexMaintainer getIndexMaintainer(@Nonnull IndexMaintainerState state) {
         return new TextIndexMaintainer(state);
-    }
-
-    @Nonnull
-    @Override
-    public IndexGeneralAttributes getIndexGeneralAttributes(@Nonnull final Index index) {
-        return TEXT_INDEX_ATTRIBUTES;
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexMaintainerFactory.java
@@ -60,6 +60,7 @@ public class TextIndexMaintainerFactory implements IndexMaintainerFactory {
             IndexOptions.TEXT_OMIT_POSITIONS_OPTION,
             IndexOptions.TEXT_ADD_AGGRESSIVE_CONFLICT_RANGES_OPTION
     );
+    private static final IndexGeneralAttributes GENERAL_ATTRIBUTES = new IndexGeneralAttributes(false);
 
     /**
      * A list containing only the name of the "{@value IndexTypes#TEXT}" index type.
@@ -198,8 +199,6 @@ public class TextIndexMaintainerFactory implements IndexMaintainerFactory {
     public IndexMaintainer getIndexMaintainer(@Nonnull IndexMaintainerState state) {
         return new TextIndexMaintainer(state);
     }
-
-    private static final IndexGeneralAttributes GENERAL_ATTRIBUTES = new IndexGeneralAttributes(false);
 
     @Nonnull
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexMaintainerFactory.java
@@ -198,4 +198,12 @@ public class TextIndexMaintainerFactory implements IndexMaintainerFactory {
     public IndexMaintainer getIndexMaintainer(@Nonnull IndexMaintainerState state) {
         return new TextIndexMaintainer(state);
     }
+
+    private static final IndexGeneralAttributes GENERAL_ATTRIBUTES = new IndexGeneralAttributes(false);
+
+    @Nonnull
+    @Override
+    public IndexGeneralAttributes getIndexGeneralAttributes(@Nonnull final Index index) {
+        return GENERAL_ATTRIBUTES;
+    }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/ValueIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/ValueIndexMaintainerFactory.java
@@ -26,6 +26,7 @@ import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.IndexTypes;
 import com.apple.foundationdb.record.metadata.IndexValidator;
 import com.apple.foundationdb.record.metadata.MetaDataValidator;
+import com.apple.foundationdb.record.provider.foundationdb.IndexGeneralAttributes;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainer;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerFactory;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerState;
@@ -73,5 +74,11 @@ public class ValueIndexMaintainerFactory implements IndexMaintainerFactory {
     @Override
     public Iterable<MatchCandidate> createMatchCandidates(@Nonnull final RecordMetaData metaData, @Nonnull final Index index, final boolean reverse) {
         return MatchCandidateExpansion.expandValueIndexMatchCandidate(metaData, index, reverse);
+    }
+
+    @Nonnull
+    @Override
+    public IndexGeneralAttributes getIndexGeneralAttributes(@Nonnull final Index index) {
+        return new IndexGeneralAttributes(true);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/ValueIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/ValueIndexMaintainerFactory.java
@@ -44,6 +44,7 @@ import java.util.Arrays;
 @API(API.Status.UNSTABLE)
 public class ValueIndexMaintainerFactory implements IndexMaintainerFactory {
     static final String[] TYPES = { IndexTypes.VALUE };
+    private static final IndexGeneralAttributes GENERAL_ATTRIBUTES = new IndexGeneralAttributes(true);
 
     @Override
     @Nonnull
@@ -75,8 +76,6 @@ public class ValueIndexMaintainerFactory implements IndexMaintainerFactory {
     public Iterable<MatchCandidate> createMatchCandidates(@Nonnull final RecordMetaData metaData, @Nonnull final Index index, final boolean reverse) {
         return MatchCandidateExpansion.expandValueIndexMatchCandidate(metaData, index, reverse);
     }
-
-    private static final IndexGeneralAttributes GENERAL_ATTRIBUTES = new IndexGeneralAttributes(true);
 
     @Nonnull
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/ValueIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/ValueIndexMaintainerFactory.java
@@ -76,9 +76,11 @@ public class ValueIndexMaintainerFactory implements IndexMaintainerFactory {
         return MatchCandidateExpansion.expandValueIndexMatchCandidate(metaData, index, reverse);
     }
 
+    private static final IndexGeneralAttributes GENERAL_ATTRIBUTES = new IndexGeneralAttributes(true);
+
     @Nonnull
     @Override
     public IndexGeneralAttributes getIndexGeneralAttributes(@Nonnull final Index index) {
-        return new IndexGeneralAttributes(true);
+        return GENERAL_ATTRIBUTES;
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VectorIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VectorIndexMaintainerFactory.java
@@ -32,6 +32,7 @@ import com.apple.foundationdb.record.metadata.MetaDataException;
 import com.apple.foundationdb.record.metadata.MetaDataValidator;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.KeyWithValueExpression;
+import com.apple.foundationdb.record.provider.foundationdb.IndexGeneralAttributes;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainer;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerFactory;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerState;
@@ -54,6 +55,8 @@ import java.util.function.Function;
 @API(API.Status.EXPERIMENTAL)
 public class VectorIndexMaintainerFactory implements IndexMaintainerFactory {
     static final String[] TYPES = { IndexTypes.VECTOR };
+    @Nonnull
+    private static final IndexGeneralAttributes VECTOR_INDEX_ATTRIBUTES = new IndexGeneralAttributes(false);
 
     @Override
     @Nonnull
@@ -80,6 +83,12 @@ public class VectorIndexMaintainerFactory implements IndexMaintainerFactory {
         final ExpansionVisitor<?> expansionVisitor = new VectorIndexExpansionVisitor(info.getIndex(), info.getIndexedRecordTypes());
         return MatchCandidateExpansion.optionalToIterable(
                 MatchCandidateExpansion.expandIndexMatchCandidate(info, false, info.getCommonPrimaryKeyForTypes(), expansionVisitor));
+    }
+
+    @Nonnull
+    @Override
+    public IndexGeneralAttributes getIndexGeneralAttributes() {
+        return VECTOR_INDEX_ATTRIBUTES;
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VectorIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VectorIndexMaintainerFactory.java
@@ -55,6 +55,7 @@ import java.util.function.Function;
 @API(API.Status.EXPERIMENTAL)
 public class VectorIndexMaintainerFactory implements IndexMaintainerFactory {
     static final String[] TYPES = { IndexTypes.VECTOR };
+    private static final IndexGeneralAttributes GENERAL_ATTRIBUTES = new IndexGeneralAttributes(false);
 
     @Override
     @Nonnull
@@ -82,8 +83,6 @@ public class VectorIndexMaintainerFactory implements IndexMaintainerFactory {
         return MatchCandidateExpansion.optionalToIterable(
                 MatchCandidateExpansion.expandIndexMatchCandidate(info, false, info.getCommonPrimaryKeyForTypes(), expansionVisitor));
     }
-
-    private static final IndexGeneralAttributes GENERAL_ATTRIBUTES = new IndexGeneralAttributes(false);
 
     @Nonnull
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VectorIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VectorIndexMaintainerFactory.java
@@ -32,6 +32,7 @@ import com.apple.foundationdb.record.metadata.MetaDataException;
 import com.apple.foundationdb.record.metadata.MetaDataValidator;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.KeyWithValueExpression;
+import com.apple.foundationdb.record.provider.foundationdb.IndexGeneralAttributes;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainer;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerFactory;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerState;
@@ -80,6 +81,14 @@ public class VectorIndexMaintainerFactory implements IndexMaintainerFactory {
         final ExpansionVisitor<?> expansionVisitor = new VectorIndexExpansionVisitor(info.getIndex(), info.getIndexedRecordTypes());
         return MatchCandidateExpansion.optionalToIterable(
                 MatchCandidateExpansion.expandIndexMatchCandidate(info, false, info.getCommonPrimaryKeyForTypes(), expansionVisitor));
+    }
+
+    private static final IndexGeneralAttributes GENERAL_ATTRIBUTES = new IndexGeneralAttributes(false);
+
+    @Nonnull
+    @Override
+    public IndexGeneralAttributes getIndexGeneralAttributes(@Nonnull final Index index) {
+        return GENERAL_ATTRIBUTES;
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VectorIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VectorIndexMaintainerFactory.java
@@ -87,7 +87,7 @@ public class VectorIndexMaintainerFactory implements IndexMaintainerFactory {
 
     @Nonnull
     @Override
-    public IndexGeneralAttributes getIndexGeneralAttributes() {
+    public IndexGeneralAttributes getIndexGeneralAttributes(@Nonnull final Index index) {
         return VECTOR_INDEX_ATTRIBUTES;
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VectorIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VectorIndexMaintainerFactory.java
@@ -32,7 +32,6 @@ import com.apple.foundationdb.record.metadata.MetaDataException;
 import com.apple.foundationdb.record.metadata.MetaDataValidator;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.KeyWithValueExpression;
-import com.apple.foundationdb.record.provider.foundationdb.IndexGeneralAttributes;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainer;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerFactory;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerState;
@@ -55,8 +54,6 @@ import java.util.function.Function;
 @API(API.Status.EXPERIMENTAL)
 public class VectorIndexMaintainerFactory implements IndexMaintainerFactory {
     static final String[] TYPES = { IndexTypes.VECTOR };
-    @Nonnull
-    private static final IndexGeneralAttributes VECTOR_INDEX_ATTRIBUTES = new IndexGeneralAttributes(false);
 
     @Override
     @Nonnull
@@ -83,12 +80,6 @@ public class VectorIndexMaintainerFactory implements IndexMaintainerFactory {
         final ExpansionVisitor<?> expansionVisitor = new VectorIndexExpansionVisitor(info.getIndex(), info.getIndexedRecordTypes());
         return MatchCandidateExpansion.optionalToIterable(
                 MatchCandidateExpansion.expandIndexMatchCandidate(info, false, info.getCommonPrimaryKeyForTypes(), expansionVisitor));
-    }
-
-    @Nonnull
-    @Override
-    public IndexGeneralAttributes getIndexGeneralAttributes(@Nonnull final Index index) {
-        return VECTOR_INDEX_ATTRIBUTES;
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VersionIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VersionIndexMaintainerFactory.java
@@ -26,6 +26,7 @@ import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.IndexTypes;
 import com.apple.foundationdb.record.metadata.IndexValidator;
 import com.apple.foundationdb.record.metadata.MetaDataValidator;
+import com.apple.foundationdb.record.provider.foundationdb.IndexGeneralAttributes;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainer;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerFactory;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerState;
@@ -75,5 +76,11 @@ public class VersionIndexMaintainerFactory implements IndexMaintainerFactory {
     @Override
     public Iterable<MatchCandidate> createMatchCandidates(@Nonnull final RecordMetaData metaData, @Nonnull final Index index, final boolean reverse) {
         return MatchCandidateExpansion.expandValueIndexMatchCandidate(metaData, index, reverse);
+    }
+
+    @Nonnull
+    @Override
+    public IndexGeneralAttributes getIndexGeneralAttributes(@Nonnull final Index index) {
+        return new IndexGeneralAttributes(true);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VersionIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VersionIndexMaintainerFactory.java
@@ -44,6 +44,7 @@ import java.util.Arrays;
 @API(API.Status.EXPERIMENTAL)
 public class VersionIndexMaintainerFactory implements IndexMaintainerFactory {
     static final String[] TYPES = { IndexTypes.VERSION };
+    private static final IndexGeneralAttributes GENERAL_ATTRIBUTES = new IndexGeneralAttributes(true);
 
     @Override
     @Nonnull
@@ -77,8 +78,6 @@ public class VersionIndexMaintainerFactory implements IndexMaintainerFactory {
     public Iterable<MatchCandidate> createMatchCandidates(@Nonnull final RecordMetaData metaData, @Nonnull final Index index, final boolean reverse) {
         return MatchCandidateExpansion.expandValueIndexMatchCandidate(metaData, index, reverse);
     }
-
-    private static final IndexGeneralAttributes GENERAL_ATTRIBUTES = new IndexGeneralAttributes(true);
 
     @Nonnull
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VersionIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VersionIndexMaintainerFactory.java
@@ -78,9 +78,11 @@ public class VersionIndexMaintainerFactory implements IndexMaintainerFactory {
         return MatchCandidateExpansion.expandValueIndexMatchCandidate(metaData, index, reverse);
     }
 
+    private static final IndexGeneralAttributes GENERAL_ATTRIBUTES = new IndexGeneralAttributes(true);
+
     @Nonnull
     @Override
     public IndexGeneralAttributes getIndexGeneralAttributes(@Nonnull final Index index) {
-        return new IndexGeneralAttributes(true);
+        return GENERAL_ATTRIBUTES;
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowLeaderboardIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowLeaderboardIndexMaintainerFactory.java
@@ -25,6 +25,7 @@ import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.IndexTypes;
 import com.apple.foundationdb.record.metadata.IndexValidator;
 import com.apple.foundationdb.record.metadata.MetaDataValidator;
+import com.apple.foundationdb.record.provider.foundationdb.IndexGeneralAttributes;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainer;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerFactory;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerState;
@@ -64,5 +65,11 @@ public class TimeWindowLeaderboardIndexMaintainerFactory implements IndexMaintai
     @Nonnull
     public IndexMaintainer getIndexMaintainer(@Nonnull IndexMaintainerState state) {
         return new TimeWindowLeaderboardIndexMaintainer(state);
+    }
+
+    @Nonnull
+    @Override
+    public IndexGeneralAttributes getIndexGeneralAttributes(@Nonnull final Index index) {
+        return new IndexGeneralAttributes(true);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowLeaderboardIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowLeaderboardIndexMaintainerFactory.java
@@ -41,6 +41,7 @@ import java.util.Arrays;
 @API(API.Status.EXPERIMENTAL)
 public class TimeWindowLeaderboardIndexMaintainerFactory implements IndexMaintainerFactory {
     static final String[] TYPES = { IndexTypes.TIME_WINDOW_LEADERBOARD };
+    private static final IndexGeneralAttributes GENERAL_ATTRIBUTES = new IndexGeneralAttributes(true);
 
     @Override
     @Nonnull
@@ -66,8 +67,6 @@ public class TimeWindowLeaderboardIndexMaintainerFactory implements IndexMaintai
     public IndexMaintainer getIndexMaintainer(@Nonnull IndexMaintainerState state) {
         return new TimeWindowLeaderboardIndexMaintainer(state);
     }
-
-    private static final IndexGeneralAttributes GENERAL_ATTRIBUTES = new IndexGeneralAttributes(true);
 
     @Nonnull
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowLeaderboardIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/leaderboard/TimeWindowLeaderboardIndexMaintainerFactory.java
@@ -67,9 +67,11 @@ public class TimeWindowLeaderboardIndexMaintainerFactory implements IndexMaintai
         return new TimeWindowLeaderboardIndexMaintainer(state);
     }
 
+    private static final IndexGeneralAttributes GENERAL_ATTRIBUTES = new IndexGeneralAttributes(true);
+
     @Nonnull
     @Override
     public IndexGeneralAttributes getIndexGeneralAttributes(@Nonnull final Index index) {
-        return new IndexGeneralAttributes(true);
+        return GENERAL_ATTRIBUTES;
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMutualTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMutualTest.java
@@ -36,6 +36,11 @@ import com.apple.foundationdb.record.metadata.IndexOptions;
 import com.apple.foundationdb.record.metadata.IndexTypes;
 import com.apple.foundationdb.record.metadata.expressions.EmptyKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.GroupingKeyExpression;
+import com.apple.foundationdb.record.provider.foundationdb.indexes.AtomicMutationIndexMaintainerFactory;
+import com.apple.foundationdb.record.provider.foundationdb.indexes.MultidimensionalIndexMaintainerFactory;
+import com.apple.foundationdb.record.provider.foundationdb.indexes.RankIndexMaintainerFactory;
+import com.apple.foundationdb.record.provider.foundationdb.indexes.ValueIndexMaintainerFactory;
+import com.apple.foundationdb.record.provider.foundationdb.indexes.VersionIndexMaintainerFactory;
 import com.apple.foundationdb.tuple.Tuple;
 import com.apple.test.BooleanSource;
 import com.apple.test.Tags;
@@ -1768,6 +1773,21 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
                         .build())
                 .build()) {
             assertThrows(RecordCoreException.class, indexBuilder::buildIndex);
+        }
+    }
+
+    @Test
+    void standardIndexAttributesOptimizedForMutualIndexing() {
+        List<IndexMaintainerFactory> factories = List.of(
+                new ValueIndexMaintainerFactory(),
+                new AtomicMutationIndexMaintainerFactory(),
+                new VersionIndexMaintainerFactory(),
+                new MultidimensionalIndexMaintainerFactory(),
+                new RankIndexMaintainerFactory()
+        );
+        for (IndexMaintainerFactory factory : factories) {
+            assertTrue(factory.getIndexGeneralAttributes().isOptimizedForMutualIndexing(),
+                    factory.getClass().getSimpleName() + " should be optimized for mutual indexing");
         }
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMutualTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMutualTest.java
@@ -34,6 +34,7 @@ import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.IndexOptions;
 import com.apple.foundationdb.record.metadata.IndexTypes;
+import com.apple.foundationdb.record.metadata.IndexValidator;
 import com.apple.foundationdb.record.metadata.expressions.EmptyKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.GroupingKeyExpression;
 import com.apple.foundationdb.record.provider.foundationdb.indexes.AtomicMutationIndexMaintainerFactory;
@@ -50,6 +51,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -1788,5 +1790,32 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
             assertTrue(factory.getIndexGeneralAttributes(index).isOptimizedForMutualIndexing(),
                     factory.getClass().getSimpleName() + " should be optimized for mutual indexing");
         }
+    }
+
+    @Test
+    void defaultIndexGeneralAttributesNotOptimizedForMutualIndexing() {
+        // Check a generic index maintainer factory that doesn't implement getIndexGeneralAttributes
+        final Index index = new Index("test", "field");
+        // Anonymous implementation that doesn't override getIndexGeneralAttributes
+        IndexMaintainerFactory factory = new IndexMaintainerFactory() {
+            @Nonnull
+            @Override
+            public Iterable<String> getIndexTypes() {
+                return List.of("test");
+            }
+
+            @Nonnull
+            @Override
+            public IndexValidator getIndexValidator(final Index index) {
+                return new IndexValidator(index);
+            }
+
+            @Nonnull
+            @Override
+            public IndexMaintainer getIndexMaintainer(@Nonnull final IndexMaintainerState state) {
+                throw new UnsupportedOperationException();
+            }
+        };
+        assertFalse(factory.getIndexGeneralAttributes(index).isOptimizedForMutualIndexing());
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMutualTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMutualTest.java
@@ -37,7 +37,6 @@ import com.apple.foundationdb.record.metadata.IndexTypes;
 import com.apple.foundationdb.record.metadata.expressions.EmptyKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.GroupingKeyExpression;
 import com.apple.foundationdb.record.provider.foundationdb.indexes.AtomicMutationIndexMaintainerFactory;
-import com.apple.foundationdb.record.provider.foundationdb.indexes.MultidimensionalIndexMaintainerFactory;
 import com.apple.foundationdb.record.provider.foundationdb.indexes.RankIndexMaintainerFactory;
 import com.apple.foundationdb.record.provider.foundationdb.indexes.ValueIndexMaintainerFactory;
 import com.apple.foundationdb.record.provider.foundationdb.indexes.VersionIndexMaintainerFactory;
@@ -1783,7 +1782,6 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
                 new ValueIndexMaintainerFactory(),
                 new AtomicMutationIndexMaintainerFactory(),
                 new VersionIndexMaintainerFactory(),
-                new MultidimensionalIndexMaintainerFactory(),
                 new RankIndexMaintainerFactory()
         );
         for (IndexMaintainerFactory factory : factories) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMutualTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMutualTest.java
@@ -1778,6 +1778,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
 
     @Test
     void standardIndexAttributesOptimizedForMutualIndexing() {
+        final Index index = new Index("test", "field");
         List<IndexMaintainerFactory> factories = List.of(
                 new ValueIndexMaintainerFactory(),
                 new AtomicMutationIndexMaintainerFactory(),
@@ -1786,7 +1787,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
                 new RankIndexMaintainerFactory()
         );
         for (IndexMaintainerFactory factory : factories) {
-            assertTrue(factory.getIndexGeneralAttributes().isOptimizedForMutualIndexing(),
+            assertTrue(factory.getIndexGeneralAttributes(index).isOptimizedForMutualIndexing(),
                     factory.getClass().getSimpleName() + " should be optimized for mutual indexing");
         }
     }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexTest.java
@@ -183,6 +183,7 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -3262,5 +3263,11 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
         long endTime = System.nanoTime();
         LOGGER.info("performed 1000 parallel insertions in {} seconds.", (endTime - startTime) * 1e-9);
         printUsage();
+    }
+
+    @Test
+    void textIndexAttributesNotOptimizedForMutualIndexing() {
+        final TextIndexMaintainerFactory factory = new TextIndexMaintainerFactory();
+        assertFalse(factory.getIndexGeneralAttributes().isOptimizedForMutualIndexing());
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexTest.java
@@ -50,6 +50,7 @@ import com.apple.foundationdb.record.logging.TestLogMessageKeys;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.IndexOptions;
 import com.apple.foundationdb.record.metadata.IndexTypes;
+import com.apple.foundationdb.record.metadata.Key;
 import com.apple.foundationdb.record.metadata.MetaDataException;
 import com.apple.foundationdb.record.metadata.RecordTypeBuilder;
 import com.apple.foundationdb.record.metadata.expressions.EmptyKeyExpression;
@@ -3268,6 +3269,7 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
     @Test
     void textIndexAttributesNotOptimizedForMutualIndexing() {
         final TextIndexMaintainerFactory factory = new TextIndexMaintainerFactory();
-        assertFalse(factory.getIndexGeneralAttributes(new Index("test", "field")).isOptimizedForMutualIndexing());
+        final Index textIndex = new Index("test", Key.Expressions.field("field"), IndexTypes.TEXT);
+        assertFalse(factory.getIndexGeneralAttributes(textIndex).isOptimizedForMutualIndexing());
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexTest.java
@@ -3268,6 +3268,6 @@ public class TextIndexTest extends FDBRecordStoreTestBase {
     @Test
     void textIndexAttributesNotOptimizedForMutualIndexing() {
         final TextIndexMaintainerFactory factory = new TextIndexMaintainerFactory();
-        assertFalse(factory.getIndexGeneralAttributes().isOptimizedForMutualIndexing());
+        assertFalse(factory.getIndexGeneralAttributes(new Index("test", "field")).isOptimizedForMutualIndexing());
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VectorIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VectorIndexTest.java
@@ -567,4 +567,10 @@ class VectorIndexTest extends VectorIndexTestBase {
                             assertThat((double)recallCounter / k).isGreaterThan(0.9));
         }
     }
+
+    @Test
+    void vectorIndexAttributesNotOptimizedForMutualIndexing() {
+        final VectorIndexMaintainerFactory factory = new VectorIndexMaintainerFactory();
+        Assertions.assertThat(factory.getIndexGeneralAttributes().isOptimizedForMutualIndexing()).isFalse();
+    }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VectorIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VectorIndexTest.java
@@ -571,6 +571,6 @@ class VectorIndexTest extends VectorIndexTestBase {
     @Test
     void vectorIndexAttributesNotOptimizedForMutualIndexing() {
         final VectorIndexMaintainerFactory factory = new VectorIndexMaintainerFactory();
-        Assertions.assertThat(factory.getIndexGeneralAttributes().isOptimizedForMutualIndexing()).isFalse();
+        Assertions.assertThat(factory.getIndexGeneralAttributes(new Index("test", "field")).isOptimizedForMutualIndexing()).isFalse();
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VectorIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VectorIndexTest.java
@@ -37,6 +37,7 @@ import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.IndexOptions;
 import com.apple.foundationdb.record.metadata.IndexTypes;
 import com.apple.foundationdb.record.metadata.IndexValidator;
+import com.apple.foundationdb.record.metadata.Key;
 import com.apple.foundationdb.record.metadata.MetaDataException;
 import com.apple.foundationdb.record.metadata.MetaDataValidator;
 import com.apple.foundationdb.record.metadata.expressions.KeyWithValueExpression;
@@ -571,6 +572,7 @@ class VectorIndexTest extends VectorIndexTestBase {
     @Test
     void vectorIndexAttributesNotOptimizedForMutualIndexing() {
         final VectorIndexMaintainerFactory factory = new VectorIndexMaintainerFactory();
-        Assertions.assertThat(factory.getIndexGeneralAttributes(new Index("test", "field")).isOptimizedForMutualIndexing()).isFalse();
+        final Index vectorIndex = new Index("test", Key.Expressions.field("field"), IndexTypes.VECTOR);
+        Assertions.assertThat(factory.getIndexGeneralAttributes(vectorIndex).isOptimizedForMutualIndexing()).isFalse();
     }
 }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainerFactory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainerFactory.java
@@ -23,6 +23,7 @@ package com.apple.foundationdb.record.lucene;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.IndexValidator;
+import com.apple.foundationdb.record.provider.foundationdb.IndexGeneralAttributes;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainer;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerFactory;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerState;
@@ -42,6 +43,8 @@ public class LuceneIndexMaintainerFactory implements IndexMaintainerFactory {
 
     @Nonnull
     private static final List<String> TYPES = Collections.singletonList(LuceneIndexTypes.LUCENE);
+    @Nonnull
+    private static final IndexGeneralAttributes LUCENE_INDEX_ATTRIBUTES = new IndexGeneralAttributes(false);
 
     @Override
     public Iterable<String> getIndexTypes() {
@@ -58,5 +61,11 @@ public class LuceneIndexMaintainerFactory implements IndexMaintainerFactory {
     @Nonnull
     public IndexMaintainer getIndexMaintainer(@Nonnull final IndexMaintainerState state) {
         return new LuceneIndexMaintainer(state, state.context.getExecutor());
+    }
+
+    @Override
+    @Nonnull
+    public IndexGeneralAttributes getIndexGeneralAttributes() {
+        return LUCENE_INDEX_ATTRIBUTES;
     }
 }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainerFactory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainerFactory.java
@@ -43,6 +43,7 @@ public class LuceneIndexMaintainerFactory implements IndexMaintainerFactory {
 
     @Nonnull
     private static final List<String> TYPES = Collections.singletonList(LuceneIndexTypes.LUCENE);
+    private static final IndexGeneralAttributes GENERAL_ATTRIBUTES = new IndexGeneralAttributes(false);
 
     @Override
     public Iterable<String> getIndexTypes() {
@@ -60,8 +61,6 @@ public class LuceneIndexMaintainerFactory implements IndexMaintainerFactory {
     public IndexMaintainer getIndexMaintainer(@Nonnull final IndexMaintainerState state) {
         return new LuceneIndexMaintainer(state, state.context.getExecutor());
     }
-
-    private static final IndexGeneralAttributes GENERAL_ATTRIBUTES = new IndexGeneralAttributes(false);
 
     @Nonnull
     @Override

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainerFactory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainerFactory.java
@@ -23,6 +23,7 @@ package com.apple.foundationdb.record.lucene;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.IndexValidator;
+import com.apple.foundationdb.record.provider.foundationdb.IndexGeneralAttributes;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainer;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerFactory;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerState;
@@ -58,5 +59,13 @@ public class LuceneIndexMaintainerFactory implements IndexMaintainerFactory {
     @Nonnull
     public IndexMaintainer getIndexMaintainer(@Nonnull final IndexMaintainerState state) {
         return new LuceneIndexMaintainer(state, state.context.getExecutor());
+    }
+
+    private static final IndexGeneralAttributes GENERAL_ATTRIBUTES = new IndexGeneralAttributes(false);
+
+    @Nonnull
+    @Override
+    public IndexGeneralAttributes getIndexGeneralAttributes(@Nonnull final Index index) {
+        return GENERAL_ATTRIBUTES;
     }
 }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainerFactory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainerFactory.java
@@ -65,7 +65,7 @@ public class LuceneIndexMaintainerFactory implements IndexMaintainerFactory {
 
     @Override
     @Nonnull
-    public IndexGeneralAttributes getIndexGeneralAttributes() {
+    public IndexGeneralAttributes getIndexGeneralAttributes(@Nonnull final Index index) {
         return LUCENE_INDEX_ATTRIBUTES;
     }
 }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainerFactory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainerFactory.java
@@ -23,7 +23,6 @@ package com.apple.foundationdb.record.lucene;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.IndexValidator;
-import com.apple.foundationdb.record.provider.foundationdb.IndexGeneralAttributes;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainer;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerFactory;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerState;
@@ -43,8 +42,6 @@ public class LuceneIndexMaintainerFactory implements IndexMaintainerFactory {
 
     @Nonnull
     private static final List<String> TYPES = Collections.singletonList(LuceneIndexTypes.LUCENE);
-    @Nonnull
-    private static final IndexGeneralAttributes LUCENE_INDEX_ATTRIBUTES = new IndexGeneralAttributes(false);
 
     @Override
     public Iterable<String> getIndexTypes() {
@@ -61,11 +58,5 @@ public class LuceneIndexMaintainerFactory implements IndexMaintainerFactory {
     @Nonnull
     public IndexMaintainer getIndexMaintainer(@Nonnull final IndexMaintainerState state) {
         return new LuceneIndexMaintainer(state, state.context.getExecutor());
-    }
-
-    @Override
-    @Nonnull
-    public IndexGeneralAttributes getIndexGeneralAttributes(@Nonnull final Index index) {
-        return LUCENE_INDEX_ATTRIBUTES;
     }
 }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
@@ -6299,6 +6299,12 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
         }
     }
 
+    @Test
+    void luceneIndexAttributesNotOptimizedForMutualIndexing() {
+        final LuceneIndexMaintainerFactory factory = new LuceneIndexMaintainerFactory();
+        assertFalse(factory.getIndexGeneralAttributes().isOptimizedForMutualIndexing());
+    }
+
     /**
      * A version of the tests that runs with the new version of asyncToSync.
      */

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
@@ -6302,7 +6302,8 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
     @Test
     void luceneIndexAttributesNotOptimizedForMutualIndexing() {
         final LuceneIndexMaintainerFactory factory = new LuceneIndexMaintainerFactory();
-        assertFalse(factory.getIndexGeneralAttributes(new Index("test", "field")).isOptimizedForMutualIndexing());
+        final Index luceneIndex = new Index("test", field("field"), LuceneIndexTypes.LUCENE);
+        assertFalse(factory.getIndexGeneralAttributes(luceneIndex).isOptimizedForMutualIndexing());
     }
 
     /**

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
@@ -6302,7 +6302,7 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
     @Test
     void luceneIndexAttributesNotOptimizedForMutualIndexing() {
         final LuceneIndexMaintainerFactory factory = new LuceneIndexMaintainerFactory();
-        assertFalse(factory.getIndexGeneralAttributes().isOptimizedForMutualIndexing());
+        assertFalse(factory.getIndexGeneralAttributes(new Index("test", "field")).isOptimizedForMutualIndexing());
     }
 
     /**

--- a/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileIndexMaintainerFactory.java
+++ b/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileIndexMaintainerFactory.java
@@ -58,10 +58,12 @@ public class GeophileIndexMaintainerFactory implements IndexMaintainerFactory {
         return new GeophileIndexMaintainer(state);
     }
 
+    private static final IndexGeneralAttributes GENERAL_ATTRIBUTES = new IndexGeneralAttributes(true);
+
     @Nonnull
     @Override
     public IndexGeneralAttributes getIndexGeneralAttributes(@Nonnull final Index index) {
-        return new IndexGeneralAttributes(true);
+        return GENERAL_ATTRIBUTES;
     }
 
 }

--- a/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileIndexMaintainerFactory.java
+++ b/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileIndexMaintainerFactory.java
@@ -39,6 +39,7 @@ import java.util.Arrays;
 @API(API.Status.UNSTABLE)
 public class GeophileIndexMaintainerFactory implements IndexMaintainerFactory {
     static final String[] TYPES = { GeophileIndexTypes.SPATIAL_GEOPHILE};
+    private static final IndexGeneralAttributes GENERAL_ATTRIBUTES = new IndexGeneralAttributes(true);
 
     @Override
     @Nonnull
@@ -57,8 +58,6 @@ public class GeophileIndexMaintainerFactory implements IndexMaintainerFactory {
     public IndexMaintainer getIndexMaintainer(@Nonnull IndexMaintainerState state) {
         return new GeophileIndexMaintainer(state);
     }
-
-    private static final IndexGeneralAttributes GENERAL_ATTRIBUTES = new IndexGeneralAttributes(true);
 
     @Nonnull
     @Override

--- a/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileIndexMaintainerFactory.java
+++ b/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileIndexMaintainerFactory.java
@@ -23,6 +23,7 @@ package com.apple.foundationdb.record.spatial.geophile;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.IndexValidator;
+import com.apple.foundationdb.record.provider.foundationdb.IndexGeneralAttributes;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainer;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerFactory;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerState;
@@ -55,6 +56,12 @@ public class GeophileIndexMaintainerFactory implements IndexMaintainerFactory {
     @Override
     public IndexMaintainer getIndexMaintainer(@Nonnull IndexMaintainerState state) {
         return new GeophileIndexMaintainer(state);
+    }
+
+    @Nonnull
+    @Override
+    public IndexGeneralAttributes getIndexGeneralAttributes(@Nonnull final Index index) {
+        return new IndexGeneralAttributes(true);
     }
 
 }


### PR DESCRIPTION
Create IndexGeneralAttributes - an object returned by the index maintainer factory that provides general information and guidelines for a given index

The object is returned by the maintainer factory (and not the index maintainer) to support fast operation in cases that the user wishes to make a quick decision without invoking a maintainer.

The first implemented item is isOptimizedForMutualIndexing() - which can support mutual indexing automation.