### PR TITLE
Lucene queries with special characters test

### DIFF
--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneQueryTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneQueryTest.java
@@ -435,8 +435,9 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
         }
     }
 
-    @Test
-    void testQueryWithSpecialCharacters() {
+    @ParameterizedTest
+    @BooleanSource("quotes")
+    void testQueryWithSpecialCharacters(boolean quotes) {
         try (FDBRecordContext context = openContext()) {
             openRecordStore(context);
             TestRecordsTextProto.SimpleDocument document1 = TestRecordsTextProto.SimpleDocument.newBuilder()
@@ -470,12 +471,17 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
                     .build();
             recordStore.saveRecord(document5);
 
-            assertPrimaryKeys("text:never", false, Set.of(1L, 2L, 3L, 4L, 5L));
-            assertPrimaryKeys("text:nev\\*er", false, Set.of(2L, 4L));
-            assertPrimaryKeys("text:nev\\:er", false, Set.of(3L));
-            assertPrimaryKeys("text:nev\\\"er", false, Set.of(2L, 4L));
-            assertPrimaryKeys("text:nev'er", false, Set.of(5L));
+            assertPrimaryKeys(quote(quotes, "never"), false, Set.of(1L, 2L, 3L, 4L, 5L));
+            assertPrimaryKeys(quote(quotes, "nev\\*er"), false, Set.of(2L, 4L));
+            assertPrimaryKeys(quote(quotes, "nev\\:er"), false, Set.of(3L));
+            assertPrimaryKeys(quote(quotes, "nev\\\"er"), false, Set.of(2L, 4L));
+            assertPrimaryKeys(quote(quotes, "nev'er"), false, Set.of(5L));
         }
+    }
+
+    @Nonnull
+    private static String quote(final boolean quotes, final String term) {
+        return "text:" + (quotes ? "\"" + term + "\"" : term);
     }
 
     /**

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneQueryTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneQueryTest.java
@@ -435,6 +435,49 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
         }
     }
 
+    @Test
+    void testQueryWithSpecialCharacters() {
+        try (FDBRecordContext context = openContext()) {
+            openRecordStore(context);
+            TestRecordsTextProto.SimpleDocument document1 = TestRecordsTextProto.SimpleDocument.newBuilder()
+                    .setDocId(1L)
+                    .setGroup(1)
+                    .setText("Never, never give up")
+                    .build();
+            recordStore.saveRecord(document1);
+            TestRecordsTextProto.SimpleDocument document2 = TestRecordsTextProto.SimpleDocument.newBuilder()
+                    .setDocId(2L)
+                    .setGroup(1)
+                    .setText("Never, nev*er give up")
+                    .build();
+            recordStore.saveRecord(document2);
+            TestRecordsTextProto.SimpleDocument document3 = TestRecordsTextProto.SimpleDocument.newBuilder()
+                    .setDocId(3L)
+                    .setGroup(1)
+                    .setText("Never, nev:er give up")
+                    .build();
+            recordStore.saveRecord(document3);
+            TestRecordsTextProto.SimpleDocument document4 = TestRecordsTextProto.SimpleDocument.newBuilder()
+                    .setDocId(4L)
+                    .setGroup(1)
+                    .setText("Never, nev\"er give up")
+                    .build();
+            recordStore.saveRecord(document4);
+            TestRecordsTextProto.SimpleDocument document5 = TestRecordsTextProto.SimpleDocument.newBuilder()
+                    .setDocId(5L)
+                    .setGroup(1)
+                    .setText("Never, nev'er give up")
+                    .build();
+            recordStore.saveRecord(document5);
+
+            assertPrimaryKeys("text:never", false, Set.of(1L, 2L, 3L, 4L, 5L));
+            assertPrimaryKeys("text:nev\\*er", false, Set.of(2L, 4L));
+            assertPrimaryKeys("text:nev\\:er", false, Set.of(3L));
+            assertPrimaryKeys("text:nev\\\"er", false, Set.of(2L, 4L));
+            assertPrimaryKeys("text:nev\'er", false, Set.of(5L));
+        }
+    }
+
     /**
      * Test that lucene doesn't break whene there's unicode in the text.
      * <p>

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneQueryTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneQueryTest.java
@@ -474,7 +474,7 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
             assertPrimaryKeys("text:nev\\*er", false, Set.of(2L, 4L));
             assertPrimaryKeys("text:nev\\:er", false, Set.of(3L));
             assertPrimaryKeys("text:nev\\\"er", false, Set.of(2L, 4L));
-            assertPrimaryKeys("text:nev\'er", false, Set.of(5L));
+            assertPrimaryKeys("text:nev'er", false, Set.of(5L));
         }
     }
 


### PR DESCRIPTION
Create a test that shows the behavior of Lucene queries with special characters (", *, :, ') in them
This is to illustrate the proper query syntax for distinguishing the character as a literal from its special behavior.

Resolves #4126

 