### PR TITLE
Fix the NULL result of `field()` key expressions with fan-type `Concatenate`

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/FieldKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/FieldKeyExpression.java
@@ -44,15 +44,56 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * Take keys from a record field.
- * If <code>fieldName</code> is a <code>repeated</code> field, then <code>FanType.Concatenate</code> turns all the
- * field values into a single <code>Key.Evaluated</code>. If <code>FanType.FanOut</code>, there is one (singleton)
- * <code>Key.Evaluated</code> for each repeated value. If this is evaluated on the <code>null</code> record, then
- * it will the same value as if it were evaluated on a record where the field is either unset (in the case of scalar
- * fields) or empty (in the case of repeated fields). In particular, if <code>FanType.None</code>, then this returns
- * a single <code>Key.Evaluated</code> containing <code>null</code>; if <code>FanType.FanOut</code>, then
- * this returns no <code>Key.Evaluated</code>s; and if <code>FanType.Concatenate</code>, then this returns a single
- * <code>Key.Evaluated</code> containing the empty list.
+ * A {@code field()} key expression.
+ *
+ * <p>The {@code field()} expression takes keys from a record field specified by name. Besides the field name, it
+ * carries two properties that control the behavior for {@code optional} or {@code repeated} fields:
+ * <ul>
+ * <li>The fan type ({@link com.apple.foundationdb.record.metadata.expressions.KeyExpression.FanType FanType}).</li>
+ * <li>The null standin ({@link Key.Evaluated.NullStandin NullStandin}).</li>
+ * </ul>
+ *
+ * <p>If the field is singular and {@code required}, the fan type is irrelevant and must be set to {@code None}.
+ * In this case, {@code field()} always yields a single {@link Key.Evaluated} holding the scalar value.
+ *
+ * <p>If the field is singular and marked as {@code optional}, the fan type must be set to {@code None} (like for
+ * {@code required} fields), and the {@code NullStandin} property drives the behavior in the “absent” case where the
+ * field is not set on the processed message:
+ * <ul>
+ * <li>For {@code NULL} and {@code NULL_UNIQUE}, the {@code field()} expression yields a single {@code Key.Evaluated}
+ *     carrying the standin, which represents an indexable null value in this case.
+ * <li>For {@code NOT_NULL}, it substitutes the default value of the Protobuf type, such as 0 or {@code ""}.
+ * </ul>
+ *
+ * <p>If the field is {@code repeated}, the fan type comes into play and must be set to either {@code FanOut} or
+ * {@code Concatenate}:
+ * <ul>
+ * <li>For {@code FanOut}, the {@code field()} expression yields one {@code Key.Evaluated} per element of the repeated
+ *     field.
+ * <li>For {@code Concatenate}, it yields a single {@code Key.Evaluated} holding the entire repeated field as a
+ *     {@link java.util.List List} object.
+ * </ul>
+ * Note that a {@code repeated} field cannot be “absent” in the sense of {@code optional}. If the {@code repeated} field
+ * has 0 repetitions, {@code FanOut} will yield nothing while {@code Concatenate} will yield a single key holding an
+ * empty list (since the empty list is the proto default for a repeated field).
+ *
+ * <p>A {@code field()} expression may also be evaluated on a message that itself is {@code null}. In this case, the
+ * result depending on the fan type and the null standin is as follows:
+ * <ul>
+ * <li>For a singular field and fan type {@code None}, the {@code field()} expression yields a single key carrying the
+ *     {@code NullStandin}.
+ *     (TODO <a href="https://github.com/FoundationDB/fdb-record-layer/issues/4141/">Issue [#4141](#4141)</a>: NOT_NULL is currently returned as-is in this case instead of the proto default value.)
+ * <li>For a repeated field and fan type {@code FanOut}, it yields no entries.
+ * <li>For a repeated field and fan type {@code Concatenate}, if the standin is {@code NOT_NULL}, it behaves “as if 0
+ *     repetitions” and yields a single entry holding the empty list. Otherwise, it behaves like {@code None} and emits
+ *     a single key carrying the null standin.
+ * </ul>
+ * One common scenario where the message will be {@code null} is when the {@code field()} expression is the child
+ * of a {@link NestingKeyExpression nest()} key expression, and the parent field evaluates to null.
+ * For example, in the expression {@code field("array1").nest(field("values", Concatenate))}, if {@code array1} is an
+ * {@code optional} field that is absent, then the outer {@code field("array1")} will yield its null standin and
+ * {@code nest()} will funnel that as a {@code null} message to the inner {@code field("values", …)} expression,
+ * which will in turn yield its null standin.
  */
 @API(API.Status.UNSTABLE)
 public class FieldKeyExpression extends BaseKeyExpression implements AtomKeyExpression, KeyExpressionWithoutChildren {
@@ -174,13 +215,26 @@ public class FieldKeyExpression extends BaseKeyExpression implements AtomKeyExpr
         }
     }
 
+    /**
+     * Evaluates the case where no value can be extracted for this field. This method is called from
+     * {@link #evaluateMessage} in three cases:
+     * <ul>
+     * <li>The input {@code message} is {@code null}.
+     * <li>The {@code fieldDescriptor} is {@code null} (meaning the field does not exist, i.e., incorrect metadata).
+     * <li>For a singular (non-{@code repeated}), {@code optional} field when that field is absent on the message, and
+     *     the {@link #nullStandin} is not {@code NOT_NULL} (i.e., the type-default substitution does not apply).
+     * </ul>
+     * See {@link FieldKeyExpression} for a detailed explanation of the semantics.
+     */
     private List<Key.Evaluated> getNullResult() {
-        // As opposed to default value, in order to get indexable NULL.
         switch (fanType) {
             case FanOut:
                 return Collections.emptyList();
             case Concatenate:
-                return Collections.singletonList(Key.Evaluated.scalar(Collections.emptyList()));
+                Key.Evaluated result = (nullStandin == Key.Evaluated.NullStandin.NOT_NULL)
+                                       ? Key.Evaluated.scalar(Collections.emptyList())
+                                       : Key.Evaluated.scalar(nullStandin);
+                return Collections.singletonList(result);
             case None:
                 return Collections.singletonList(Key.Evaluated.scalar(nullStandin));
             default:

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/NestingKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/NestingKeyExpression.java
@@ -38,12 +38,17 @@ import java.util.stream.Collectors;
 
 /**
  * A key expression within a nested subrecord.
- * If the parent field is repeated, then the parent field must have fan type <code>FanType.FanOut</code>.
- * In that case, this will return the nested expression evaluated against every subrecord (possibly returning
- * no <code>Key.Evaluated</code>s if the parent field is empty). If the parent field is not repeated and not set,
- * then this will evaluate the nested expression on the <code>null</code> record. This should return the same
- * result as if the field were set to the empty message. If this expression is evaluated on the <code>null</code>
- * record, then it will evaluate the same as if the parent field is unset or empty (depending on the fan type).
+ *
+ * <p>If the parent field is {@code repeated}, then the parent {@code field()} expression must have fan type
+ * {@code FanType.FanOut}. In that case, this will return the nested expression evaluated against every subrecord
+ * (possibly returning no <code>Key.Evaluated</code> entries at all if the parent field is empty).
+ *
+ * <p>If the parent field is singular (not {@code repeated}) and {@code optional} and not set, then this will evaluate
+ * the nested expression on the <code>null</code> record. See {@link FieldKeyExpression} for the exact semantics in this
+ * scenario.
+ *
+ * <p>If this expression is evaluated on the <code>null</code> record, then it will evaluate the same as if the parent
+ * field is unset or empty (depending on the fan type).
  */
 @API(API.Status.UNSTABLE)
 public class NestingKeyExpression extends BaseKeyExpression implements KeyExpressionWithChild, AtomKeyExpression {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/KeyExpressionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/KeyExpressionTest.java
@@ -339,9 +339,11 @@ public class KeyExpressionTest {
         assertFalse(expression.createsDuplicates());
         assertEquals(Collections.singletonList(scalar(Arrays.asList("Boxes", "Bowls"))),
                 evaluate(expression, plantsBoxesAndBowls));
+        // `repeat_me` has 0 repetitions: Concatenate yields the empty list.
         assertEquals(Collections.singletonList(scalar(Collections.emptyList())),
                 evaluate(expression, emptyScalar));
-        assertEquals(Collections.singletonList(scalar(Collections.emptyList())),
+        // Null record: Concatenate propagates the field’s null standin (here NULL, by default).
+        assertEquals(Collections.singletonList(scalar(NULL)),
                 evaluate(expression, null));
     }
 
@@ -353,9 +355,11 @@ public class KeyExpressionTest {
         assertFalse(expression.createsDuplicates());
         assertEquals(Collections.singletonList(Key.Evaluated.concatenate("Plants", Arrays.asList("Boxes", "Bowls"))),
                 evaluate(expression, plantsBoxesAndBowls));
+        // Both fields unset: The scalar `field` yields the NULL standin; concatenate yields the empty list.
         assertEquals(Collections.singletonList(Key.Evaluated.concatenate(NULL, Collections.emptyList())),
                 evaluate(expression, emptyScalar));
-        assertEquals(Collections.singletonList(Key.Evaluated.concatenate(NULL, Collections.emptyList())),
+        // Null record: Both parts propagate their null standin (by default NULL) and yield NULL.
+        assertEquals(Collections.singletonList(Key.Evaluated.concatenate(NULL, NULL)),
                 evaluate(expression, null));
     }
 
@@ -524,7 +528,7 @@ public class KeyExpressionTest {
         // For the parent, NOT_NULL substitutes an empty sub-message; the child then sees a set-but-empty message,
         // so the child’s NOT_NULL substitutes the proto default "".
         // NULL/NULL_UNIQUE on the parent funnel null to the child, which then takes its own null path; and for
-        // `None`, `getNullResult()` emits the standin verbatim, so the child NOT_NULL yields the NOT_NULL
+        // `FanType.None`, `getNullResult()` emits the standin verbatim, so the child NOT_NULL yields the NOT_NULL
         // sentinel rather than "".
         // TODO Issue #4141: This seems to be a bug; the NOT_NULL standin is not supposed to be emitted as is.
         final NestSingularSingularCase expr3 = (parentStandin, childStandin, expected) ->
@@ -697,6 +701,8 @@ public class KeyExpressionTest {
         final var emptyList = Collections.emptyList();
         final var emptyListEntry = ImmutableList.of(scalar(emptyList));
         final ImmutableList<Key.Evaluated> noEntry = ImmutableList.of();
+        final var nullEntry = ImmutableList.of(scalar(NULL));
+        final var nullUniqueEntry = ImmutableList.of(scalar(NULL_UNIQUE));
 
         // Case: Parent present, child present.
         //
@@ -755,17 +761,16 @@ public class KeyExpressionTest {
         // Case: Parent absent (but on a non-null record)
         //
         // The `emptyNested` record has `nesty` absent. On the parent, the NOT_NULL standin effectively substitutes an
-        // empty sub-message, so the child sees 0 repetitions and goes through its repeated-field branch. For parent
-        // NULL/NULL_UNIQUE the parent funnels a `null` record to the child, which then takes its own null path; for
-        // both Concatenate and FanOut, `getNullResult()` does not consult the child standin either, so the child standin
-        // has no observable effect. FanOut yields no entries; Concatenate yields a single entry holding the empty list.
+        // empty sub-message, so the child sees 0 repetitions; whereas NULL/NULL_UNIQUE funnel a `null` record to the
+        // child, which then takes its own null path. For `FanOut` both code branches collapse to [], so we get no entry
+        // at all. For Concatenate the child standin has an observable effect only when the parent funnels null.
         final NestSingularRepeatedCase expr3 = (parentStandin, childStandin, childFanType, expected) ->
                 assertEquals(expected, evaluate(buildNestSingularRepeatedExpr(parentStandin, childStandin, childFanType), emptyNested));
-        expr3.verify(NULL,        NULL,        Concatenate, emptyListEntry);
-        expr3.verify(NULL,        NULL_UNIQUE, Concatenate, emptyListEntry);
+        expr3.verify(NULL,        NULL,        Concatenate, nullEntry);
+        expr3.verify(NULL,        NULL_UNIQUE, Concatenate, nullUniqueEntry);
         expr3.verify(NULL,        NOT_NULL,    Concatenate, emptyListEntry);
-        expr3.verify(NULL_UNIQUE, NULL,        Concatenate, emptyListEntry);
-        expr3.verify(NULL_UNIQUE, NULL_UNIQUE, Concatenate, emptyListEntry);
+        expr3.verify(NULL_UNIQUE, NULL,        Concatenate, nullEntry);
+        expr3.verify(NULL_UNIQUE, NULL_UNIQUE, Concatenate, nullUniqueEntry);
         expr3.verify(NULL_UNIQUE, NOT_NULL,    Concatenate, emptyListEntry);
         expr3.verify(NOT_NULL,    NULL,        Concatenate, emptyListEntry);
         expr3.verify(NOT_NULL,    NULL_UNIQUE, Concatenate, emptyListEntry);
@@ -783,20 +788,19 @@ public class KeyExpressionTest {
         // Case: Null record
         //
         // The parent standin doesn’t matter, as `FieldKeyExpression` short-circuits on `message == null` before
-        // consulting the parent standin. The child standin doesn’t matter either: for both Concatenate and FanOut,
-        // `getNullResult()` does not consult the standin. FanOut yields no entries; Concatenate yields a single entry
-        // holding the empty list.
+        // consulting the parent standin. Only the child’s null standin matters. For `FanOut` the null code path yields
+        // no entries regardless of the child standin.
         final NestSingularRepeatedCase expr4 = (parentStandin, childStandin, childFanType, expected) ->
                 assertEquals(expected,
                         evaluate(buildNestSingularRepeatedExpr(parentStandin, childStandin, childFanType), null));
-        expr4.verify(NULL,        NULL,        Concatenate, emptyListEntry);
-        expr4.verify(NULL,        NULL_UNIQUE, Concatenate, emptyListEntry);
+        expr4.verify(NULL,        NULL,        Concatenate, nullEntry);
+        expr4.verify(NULL,        NULL_UNIQUE, Concatenate, nullUniqueEntry);
         expr4.verify(NULL,        NOT_NULL,    Concatenate, emptyListEntry);
-        expr4.verify(NULL_UNIQUE, NULL,        Concatenate, emptyListEntry);
-        expr4.verify(NULL_UNIQUE, NULL_UNIQUE, Concatenate, emptyListEntry);
+        expr4.verify(NULL_UNIQUE, NULL,        Concatenate, nullEntry);
+        expr4.verify(NULL_UNIQUE, NULL_UNIQUE, Concatenate, nullUniqueEntry);
         expr4.verify(NULL_UNIQUE, NOT_NULL,    Concatenate, emptyListEntry);
-        expr4.verify(NOT_NULL,    NULL,        Concatenate, emptyListEntry);
-        expr4.verify(NOT_NULL,    NULL_UNIQUE, Concatenate, emptyListEntry);
+        expr4.verify(NOT_NULL,    NULL,        Concatenate, nullEntry);
+        expr4.verify(NOT_NULL,    NULL_UNIQUE, Concatenate, nullUniqueEntry);
         expr4.verify(NOT_NULL,    NOT_NULL,    Concatenate, emptyListEntry);
         expr4.verify(NULL,        NULL,        FanOut,      noEntry);
         expr4.verify(NULL,        NULL_UNIQUE, FanOut,      noEntry);


### PR DESCRIPTION
This change makes `FieldKeyExpression#getNullResult()` propagate the null stand-in for fan-type `Concatenate` instead of unconditionally returning an empty-list key. We consider this to be the more appropriate behavior in the `message == null` scenario, and desirable for alignment with SQL semantics. For a detailed discussion, please refer to Issue #4129.

This is a **breaking change** that impacts index data. It changes the evaluated keys for `field()` expressions if

1. the expression is of the form `field(…, «fan-type», «standin»)`,
2. the referenced field is a `repeated` field,
3. the «fan-type» is `Concatenate`;
3. the «standin» is `NULL` or `NULL_UNIQUE`;
4. the expression is evaluated against a null message (`message == null`).

In this specific case the `field()` expression will now yield the «standin» (`NULL` or `NULL_UNIQUE`). Deployed indexes will have persisted a `scalar(emptyList)` instead and should be rebuilt.

Note that if «standin» is `NOT_NULL`, an empty-list key will be returned just as before. Users depending on the old behavior can therefore opt into it by specifying `NOT_NULL`.

Resolves #4129.