### PR TITLE
`testConcurrentMixedOperations` is flaky

### DIFF
--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/PendingWriteQueueIntegrationTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/PendingWriteQueueIntegrationTest.java
@@ -816,10 +816,13 @@ public class PendingWriteQueueIntegrationTest extends FDBRecordStoreTestBase {
                 snooze(10); // increase the chances of concurrency
                 commit(context);
             }
-            if (threadId == 2 && withMerge) {
-                mergeIndexNow(schemaSetup, index);
-            }
         });
+
+        // Merge the index outside the loop, as the merge will clear the pending writes flag and may cause conflicts
+        // on the index
+        if (withMerge) {
+            mergeIndexNow(schemaSetup, index);
+        }
 
         // Verify operation counts
         assertEquals(10, insertCount.get());  // 5 threads * 2 inserts


### PR DESCRIPTION
The `testConcurrentMixedOperations` test shows `Conflict` errors in CI. This is likely due to the `mergeNow` happening (in thread number 2) before the other threads have finished their run. This would remove the `merge` flag and cause the other threads to save documents to the index concurrently, causing a conflict.

Resolves #4131
