### PR TITLE
Resolve Gradle 9 deprecation warnings

### DIFF
--- a/fdb-relational-jdbc/fdb-relational-jdbc.gradle
+++ b/fdb-relational-jdbc/fdb-relational-jdbc.gradle
@@ -21,7 +21,6 @@
 import org.yaml.snakeyaml.Yaml
 
 plugins {
-    alias(libs.plugins.serviceloader)
     alias(libs.plugins.shadow)
 }
 
@@ -62,10 +61,6 @@ if (fdbEnvironmentYamlFile.exists()) {
             task.environment(FDB_CLUSTER_FILE: firstClusterFile)
         }
     }
-}
-
-serviceLoader {
-    serviceInterface 'java.sql.Driver'
 }
 
 jar {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -154,10 +154,9 @@ test-compileOnly = [ "autoService", "jsr305" ]
 
 download = { id = "de.undercouch.download", version = "5.6.0" }
 gitversion = { id = "com.palantir.git-version", version = "3.1.0" }
-jmh = { id = "me.champeau.jmh", version = "0.7.2" }
+jmh = { id = "me.champeau.jmh", version = "0.7.3" }
 nexus = { id = "io.github.gradle-nexus.publish-plugin", version = "2.0.0" }
 protobuf = { id = "com.google.protobuf", version = "0.9.4" }
-serviceloader = { id = "com.github.harbby.gradle.serviceloader", version = "1.1.8" }
 shadow = { id = "com.gradleup.shadow", version = "8.3.5" }
 spotbugs = { id = "com.github.spotbugs", version = "6.1.3" }
 versions = { id = "com.github.ben-manes.versions", version = "0.52.0" }


### PR DESCRIPTION
The warning “Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0” is caused by two third-party plugins:

* `me.champeau.jmh` version 0.7.2 uses the deprecated Groovy space-assignment syntax internally. This warning is resolved by updating to version 0.7.3, which switches to `=` assignment.

* `com.github.harbby.gradle.serviceloader` version 1.1.8 calls `Task.project` at execution time, which is incompatible with the configuration cache and not yet fixed in the latest version 1.1.9.  The plugin seems to be barely maintained. However, it is currently used only to generate the `META-INF/services/java.sql.Driver` manifest for a single driver implementation (the `JDBCRelationalDriver`), and that exact manifest file is already committed under `src/main/resources`. So the plugin is actually superfluous and we can remove it entirely.