### PR TITLE
Fix infinite `RecursiveCursor` out-of-band behavior

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/RecursiveCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/RecursiveCursor.java
@@ -331,7 +331,14 @@ public final class RecursiveCursor<T> implements RecordCursor<RecursiveCursor.Re
         } else {
             final NoNextReason noNextReason = childResult.getNoNextReason();
             if (noNextReason.isOutOfBand()) {
-                final RecordCursorContinuation continuation = buildContinuation(depth + 1);
+                final RecordCursorContinuation continuation;
+                // For preorder traversal with an un-emitted parent, build the continuation at the parent
+                // depth so resumption emits it before descending.
+                if (node.emitPending && isPreorder) {
+                    continuation = buildContinuation(depth);
+                } else {
+                    continuation = buildContinuation(depth + 1);
+                }
                 lastResult = RecordCursorResult.withoutNextValue(continuation, noNextReason);
                 return AsyncUtil.READY_FALSE;
             }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/RecursiveCursor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/cursors/RecursiveCursor.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2015-2024 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import com.apple.foundationdb.record.RecordCursorResult;
 import com.apple.foundationdb.record.RecordCursorStartContinuation;
 import com.apple.foundationdb.record.RecordCursorVisitor;
 import com.apple.foundationdb.tuple.ByteArrayUtil2;
+import com.google.common.base.Verify;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.ZeroCopyByteString;
@@ -330,14 +331,7 @@ public final class RecursiveCursor<T> implements RecordCursor<RecursiveCursor.Re
         } else {
             final NoNextReason noNextReason = childResult.getNoNextReason();
             if (noNextReason.isOutOfBand()) {
-                final RecordCursorContinuation continuation;
-                if (node.emitPending) {
-                    // Stop before parent.
-                    continuation = buildContinuation(depth - 1);
-                } else {
-                    // Stop before child.
-                    continuation = buildContinuation(depth);
-                }
+                final RecordCursorContinuation continuation = buildContinuation(depth + 1);
                 lastResult = RecordCursorResult.withoutNextValue(continuation, noNextReason);
                 return AsyncUtil.READY_FALSE;
             }
@@ -390,7 +384,9 @@ public final class RecursiveCursor<T> implements RecordCursor<RecursiveCursor.Re
         nodes.add(childNode);
     }
 
+    @Nonnull
     private RecordCursorContinuation buildContinuation(int depth) {
+        Verify.verify(depth > 0);
         final List<RecordCursorContinuation> continuations = new ArrayList<>(depth);
         final List<byte[]> checkValues = checkValueFunction == null ? null : new ArrayList<>(depth - 1);
         for (int i = 0; i < depth; i++) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreTestBase.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreTestBase.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2015-2018 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -116,6 +116,15 @@ public abstract class FDBRecordStoreTestBase extends FDBRecordStoreConcurrentTes
         recordStore = recordStoreQueryPlannerPair.getLeft();
         planner = recordStoreQueryPlannerPair.getRight();
         return recordStoreQueryPlannerPair;
+    }
+
+    protected Pair<FDBRecordStore, QueryPlanner> createOrOpenRecordStoreWithSingletonPipeline(@Nonnull FDBRecordContext context,
+                                                                                              @Nonnull RecordMetaDataProvider metaData) {
+        recordStore = getStoreBuilder(context, metaData, path)
+                .setPipelineSizer(ignored -> 1)
+                .createOrOpen();
+        planner = setupPlanner(recordStore, null);
+        return Pair.of(recordStore, planner);
     }
 
     public FDBRecordStore openSimpleRecordStore(FDBRecordContext context, @Nullable RecordMetaDataHook hook, @Nonnull FormatVersion formatVersion) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/RecursiveQueriesTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/RecursiveQueriesTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -158,6 +158,46 @@ class RecursiveQueriesTest extends TempTableTestBase {
                 210L, 20L,
                 250L, 50L
          );
+    }
+
+    /**
+     * Wide hierarchy with depth 5 and ~100 nodes per level (401 nodes total).
+     * <pre>
+     * {@code
+     *                              1
+     *         ┌────────┬─── ... ───┼─── ... ───┬────────┐
+     *       1001     1002        1010         1099     1100
+     *      /|..\    /|..\       /|..\
+     *  2001..2010 2011..2020  2091..2100      (90 leaves)
+     *   /|..\
+     * 3001..3010  ...                         (90 leaves)
+     *  /|..\
+     * 4001..4010  ...                         (90 leaves)
+     * }
+     * </pre>
+     * Each of the first 10 parents at a level has 10 children; the remaining 90 are leaves.
+     */
+    @Nonnull
+    private static Map<Long, Long> wideHierarchy() {
+        final var builder = ImmutableMap.<Long, Long>builder();
+        builder.put(1L, -1L);
+        // Level 1: 100 children of root
+        for (long i = 0; i < 100; i++) {
+            builder.put(1001L + i, 1L);
+        }
+        // Level 2: 100 children spread across 10 parents from level 1
+        for (long i = 0; i < 100; i++) {
+            builder.put(2001L + i, 1001L + (i % 10));
+        }
+        // Level 3: 100 children spread across 10 parents from level 2
+        for (long i = 0; i < 100; i++) {
+            builder.put(3001L + i, 2001L + (i % 10));
+        }
+        // Level 4: 100 children spread across 10 parents from level 3
+        for (long i = 0; i < 100; i++) {
+            builder.put(4001L + i, 3001L + (i % 10));
+        }
+        return builder.build();
     }
 
     /**
@@ -333,6 +373,110 @@ class RecursiveQueriesTest extends TempTableTestBase {
         Assumptions.assumeTrue(isUseCascadesPlanner());
         var result = descendantsOfAcrossContinuations(hierarchy, initial, successiveRowLimits, false, traversalStrategy);
         assertEquals(expectedResult, result);
+    }
+
+    static Stream<Arguments> descendantsWithScanLimitParameters() {
+        return Stream.of(
+                Arguments.of(wideHierarchy(), ImmutableMap.of(1L, -1L), 2, PREORDER),
+                Arguments.of(wideHierarchy(), ImmutableMap.of(1L, -1L), 5, PREORDER),
+                Arguments.of(wideHierarchy(), ImmutableMap.of(1L, -1L), 2, POSTORDER),
+                Arguments.of(wideHierarchy(), ImmutableMap.of(1L, -1L), 5, POSTORDER),
+                Arguments.of(wideHierarchy(), ImmutableMap.of(1L, -1L), 2, LEVEL),
+                Arguments.of(wideHierarchy(), ImmutableMap.of(1L, -1L), 5, LEVEL)
+        );
+    }
+
+    @DualPlannerTest(planner = DualPlannerTest.Planner.CASCADES)
+    @ParameterizedTest(name = "descendants of {1} with scanLimit={2} and {3} traversal match full result")
+    @MethodSource("descendantsWithScanLimitParameters")
+    void descendantsWithScanLimitOutOfBand(Map<Long, Long> hierarchy, Map<Long, Long> initial, int scanLimit,
+                                           RecursiveUnionExpression.TraversalStrategy traversalStrategy) {
+        Assumptions.assumeTrue(isUseCascadesPlanner());
+
+        final var hierarchyUnderTest = Hierarchy.fromEdges(hierarchy);
+        final int depth = hierarchyUnderTest.calculateDepth();
+        final int maxLevelSize = hierarchyUnderTest.calculateMaxLevelSize();
+        final List<Long> expectedDescendants = hierarchyUnderTest.calculateDescendants(traversalStrategy);
+        final List<Long> traversalWithScanLimitResult = descendantsWithScanLimit(hierarchy, initial, scanLimit, depth,
+                maxLevelSize, traversalStrategy);
+        assertEquals(expectedDescendants, traversalWithScanLimitResult);
+
+        //
+        // verify hierarchy traversal with scan limit against unbound traversal
+        //
+        var traversalResult = descendantsOf(hierarchy, initial, traversalStrategy);
+        assertEquals(traversalResult, traversalWithScanLimitResult);
+    }
+
+    @Nonnull
+    private List<Long> descendantsWithScanLimit(@Nonnull final Map<Long, Long> hierarchy,
+                                                @Nonnull final Map<Long, Long> initial,
+                                                int scanLimit,
+                                                int depth,
+                                                int maxLevelSize,
+                                                @Nonnull final RecursiveUnionExpression.TraversalStrategy traversalStrategy) {
+
+        final BiFunction<Quantifier.ForEach, Quantifier.ForEach, QueryPredicate> predicate = (hierarchyScanQun, ttSelectQun) -> {
+            final var idField = getIdField(ttSelectQun);
+            final var parentField = getParentField(hierarchyScanQun);
+            return new ValuePredicate(parentField, new Comparisons.ValueComparison(Comparisons.Type.EQUALS, idField));
+        };
+
+        final RecordQueryPlan plan;
+        // First transaction: set up data and plan the query.
+        try (FDBRecordContext context = openContext()) {
+            setupRecordStoreMetadata(context);
+            for (final var entry : hierarchy.entrySet()) {
+                saveHierarchyEdge(entry.getKey(), entry.getValue());
+            }
+            final var seedingTempTableAlias = CorrelationIdentifier.of("Seeding");
+            final var insertTempTableAlias = CorrelationIdentifier.of("Insert");
+            final var scanTempTableAlias = CorrelationIdentifier.of("Scan");
+            plan = createAndOptimizeHierarchyQuery(seedingTempTableAlias, insertTempTableAlias, scanTempTableAlias, predicate, traversalStrategy);
+            context.commit();
+        }
+
+        final var seedingTempTableAlias = CorrelationIdentifier.of("Seeding");
+        final var allResults = new ArrayList<Long>();
+        byte[] continuation = null;
+        // Resume loop: each iteration opens a new transaction with a fresh scan limit.
+        do {
+            try (FDBRecordContext context = openContext()) {
+                setupRecordStoreMetadata(context);
+                final var seedingTempTable = tempTableInstance();
+                initial.forEach((id, parent) -> seedingTempTable.add(queryResult(id, parent)));
+                var evaluationContext = setUpPlanContext(plan, seedingTempTableAlias, seedingTempTable);
+
+                final var executeProperties = ExecuteProperties.newBuilder()
+                        .setScannedRecordsLimit(scanLimit)
+                        .build();
+
+                try (RecordCursorIterator<QueryResult> cursor = plan.executePlan(
+                        recordStore, evaluationContext, continuation, executeProperties).asIterator()) {
+                    while (cursor.hasNext()) {
+                        Message message = Verify.verifyNotNull(cursor.next()).getMessage();
+
+                        final int scannedRecords = executeProperties.getState().getRecordsScanned();
+                        if (traversalStrategy == POSTORDER || traversalStrategy == PREORDER) {
+                            //
+                            // the number of scanned records must not exceed the depth of the hierarchy
+                            // it looks like we may over scan by few more elements sometimes, which is presumably
+                            // related to the cursor's next semantics, add an overscan tolerance of 4.
+                            //
+                            org.assertj.core.api.Assertions.assertThat(scannedRecords).isLessThanOrEqualTo(depth + 4);
+                        } else {
+                            Verify.verify(traversalStrategy == LEVEL);
+                            org.assertj.core.api.Assertions.assertThat(scannedRecords).isLessThanOrEqualTo(maxLevelSize);
+                        }
+
+                        allResults.add(asIdParent(message).getKey());
+                    }
+                    continuation = cursor.getContinuation();
+                }
+            }
+        } while (continuation != null);
+
+        return allResults;
     }
 
     @Nonnull
@@ -907,7 +1051,7 @@ class RecursiveQueriesTest extends TempTableTestBase {
         builder.addIndex("SimpleHierarchicalRecord", "parentIdIdx", concat(field("parent"), field("id")));
         builder.addIndex("SimpleHierarchicalRecord", "idParentIdx", concat(field("id"), field("parent")));
         RecordMetaData metaData = builder.getRecordMetaData();
-        createOrOpenRecordStore(context, metaData);
+        createOrOpenRecordStoreWithSingletonPipeline(context, metaData);
     }
 
     private void saveHierarchyEdge(@Nonnull Long key, @Nonnull Long value) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/RecursiveQueriesTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/RecursiveQueriesTest.java
@@ -375,14 +375,21 @@ class RecursiveQueriesTest extends TempTableTestBase {
         assertEquals(expectedResult, result);
     }
 
+    @Nonnull
     static Stream<Arguments> descendantsWithScanLimitParameters() {
         return Stream.of(
-                Arguments.of(wideHierarchy(), ImmutableMap.of(1L, -1L), 2, PREORDER),
-                Arguments.of(wideHierarchy(), ImmutableMap.of(1L, -1L), 5, PREORDER),
-                Arguments.of(wideHierarchy(), ImmutableMap.of(1L, -1L), 2, POSTORDER),
-                Arguments.of(wideHierarchy(), ImmutableMap.of(1L, -1L), 5, POSTORDER),
-                Arguments.of(wideHierarchy(), ImmutableMap.of(1L, -1L), 2, LEVEL),
-                Arguments.of(wideHierarchy(), ImmutableMap.of(1L, -1L), 5, LEVEL)
+                Arguments.of(wideHierarchy(), ImmutableMap.of(1L, -1L), 2, PREORDER, true),
+                Arguments.of(wideHierarchy(), ImmutableMap.of(1L, -1L), 5, PREORDER, true),
+                Arguments.of(wideHierarchy(), ImmutableMap.of(1L, -1L), 2, POSTORDER, true),
+                Arguments.of(wideHierarchy(), ImmutableMap.of(1L, -1L), 5, POSTORDER, true),
+                Arguments.of(wideHierarchy(), ImmutableMap.of(1L, -1L), 2, LEVEL, true),
+                Arguments.of(wideHierarchy(), ImmutableMap.of(1L, -1L), 5, LEVEL, true),
+                Arguments.of(sampleHierarchy(), ImmutableMap.of(1L, -1L), 25, PREORDER, false),
+                Arguments.of(sampleHierarchy(), ImmutableMap.of(1L, -1L), 25, PREORDER, false),
+                Arguments.of(sampleHierarchy(), ImmutableMap.of(1L, -1L), 25, POSTORDER, false),
+                Arguments.of(sampleHierarchy(), ImmutableMap.of(1L, -1L), 25, POSTORDER, false),
+                Arguments.of(sampleHierarchy(), ImmutableMap.of(1L, -1L), 25, LEVEL, false),
+                Arguments.of(sampleHierarchy(), ImmutableMap.of(1L, -1L), 25, LEVEL, false)
         );
     }
 
@@ -390,7 +397,8 @@ class RecursiveQueriesTest extends TempTableTestBase {
     @ParameterizedTest(name = "descendants of {1} with scanLimit={2} and {3} traversal match full result")
     @MethodSource("descendantsWithScanLimitParameters")
     void descendantsWithScanLimitOutOfBand(Map<Long, Long> hierarchy, Map<Long, Long> initial, int scanLimit,
-                                           RecursiveUnionExpression.TraversalStrategy traversalStrategy) {
+                                           RecursiveUnionExpression.TraversalStrategy traversalStrategy,
+                                           boolean useSecondaryIndexes) {
         Assumptions.assumeTrue(isUseCascadesPlanner());
 
         final var hierarchyUnderTest = Hierarchy.fromEdges(hierarchy);
@@ -398,7 +406,7 @@ class RecursiveQueriesTest extends TempTableTestBase {
         final int maxLevelSize = hierarchyUnderTest.calculateMaxLevelSize();
         final List<Long> expectedDescendants = hierarchyUnderTest.calculateDescendants(traversalStrategy);
         final List<Long> traversalWithScanLimitResult = descendantsWithScanLimit(hierarchy, initial, scanLimit, depth,
-                maxLevelSize, traversalStrategy);
+                maxLevelSize, useSecondaryIndexes, traversalStrategy);
         assertEquals(expectedDescendants, traversalWithScanLimitResult);
 
         //
@@ -414,7 +422,8 @@ class RecursiveQueriesTest extends TempTableTestBase {
                                                 int scanLimit,
                                                 int depth,
                                                 int maxLevelSize,
-                                                @Nonnull final RecursiveUnionExpression.TraversalStrategy traversalStrategy) {
+                                                boolean useSecondaryIndexes,
+                                                @Nonnull final RecursiveUnionExpression.TraversalStrategy traversalStrategy ) {
 
         final BiFunction<Quantifier.ForEach, Quantifier.ForEach, QueryPredicate> predicate = (hierarchyScanQun, ttSelectQun) -> {
             final var idField = getIdField(ttSelectQun);
@@ -425,7 +434,7 @@ class RecursiveQueriesTest extends TempTableTestBase {
         final RecordQueryPlan plan;
         // First transaction: set up data and plan the query.
         try (FDBRecordContext context = openContext()) {
-            setupRecordStoreMetadata(context);
+            setupRecordStoreMetadata(context, useSecondaryIndexes);
             for (final var entry : hierarchy.entrySet()) {
                 saveHierarchyEdge(entry.getKey(), entry.getValue());
             }
@@ -455,18 +464,23 @@ class RecursiveQueriesTest extends TempTableTestBase {
                         recordStore, evaluationContext, continuation, executeProperties).asIterator()) {
                     while (cursor.hasNext()) {
                         Message message = Verify.verifyNotNull(cursor.next()).getMessage();
-
                         final int scannedRecords = executeProperties.getState().getRecordsScanned();
-                        if (traversalStrategy == POSTORDER || traversalStrategy == PREORDER) {
-                            //
-                            // the number of scanned records must not exceed the depth of the hierarchy
-                            // it looks like we may over scan by few more elements sometimes, which is presumably
-                            // related to the cursor's next semantics, add an overscan tolerance of 4.
-                            //
-                            org.assertj.core.api.Assertions.assertThat(scannedRecords).isLessThanOrEqualTo(depth + 4);
-                        } else {
-                            Verify.verify(traversalStrategy == LEVEL);
-                            org.assertj.core.api.Assertions.assertThat(scannedRecords).isLessThanOrEqualTo(maxLevelSize);
+                        //
+                        // only verify the number of scans when using an efficient index and these scans are point scans
+                        // that align more or less nicely with the topology of the hierarchy.
+                        //
+                        if (useSecondaryIndexes) {
+                            if (traversalStrategy == POSTORDER || traversalStrategy == PREORDER) {
+                                //
+                                // the number of scanned records must not exceed the depth of the hierarchy
+                                // it looks like we may over scan by few more elements sometimes, which is presumably
+                                // related to the cursor's next semantics, add an overscan tolerance of 4.
+                                //
+                                org.assertj.core.api.Assertions.assertThat(scannedRecords).isLessThanOrEqualTo(depth + 4);
+                            } else {
+                                Verify.verify(traversalStrategy == LEVEL);
+                                org.assertj.core.api.Assertions.assertThat(scannedRecords).isLessThanOrEqualTo(maxLevelSize);
+                            }
                         }
 
                         allResults.add(asIdParent(message).getKey());
@@ -1046,10 +1060,16 @@ class RecursiveQueriesTest extends TempTableTestBase {
     }
 
     private void setupRecordStoreMetadata(@Nonnull final FDBRecordContext context) {
+        setupRecordStoreMetadata(context, true);
+    }
+
+    private void setupRecordStoreMetadata(@Nonnull final FDBRecordContext context, boolean withSecondaryIndexes) {
         RecordMetaDataBuilder builder = RecordMetaData.newBuilder().setRecords(TestHierarchiesProto.getDescriptor());
         builder.getRecordType("SimpleHierarchicalRecord").setPrimaryKey(field("id"));
-        builder.addIndex("SimpleHierarchicalRecord", "parentIdIdx", concat(field("parent"), field("id")));
-        builder.addIndex("SimpleHierarchicalRecord", "idParentIdx", concat(field("id"), field("parent")));
+        if (withSecondaryIndexes) {
+            builder.addIndex("SimpleHierarchicalRecord", "parentIdIdx", concat(field("parent"), field("id")));
+            builder.addIndex("SimpleHierarchicalRecord", "idParentIdx", concat(field("id"), field("parent")));
+        }
         RecordMetaData metaData = builder.getRecordMetaData();
         createOrOpenRecordStoreWithSingletonPipeline(context, metaData);
     }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/TempTableTestBase.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/TempTableTestBase.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -86,7 +86,7 @@ public abstract class TempTableTestBase extends FDBRecordStoreQueryTestBase {
     @BeforeEach
     void setupPlanner() {
         try (FDBRecordContext context = openContext()) {
-            openNestedRecordStore(context);
+            openSimpleRecordStoreWithSingletonPipeline(context);
         }
     }
 
@@ -524,6 +524,46 @@ public abstract class TempTableTestBase extends FDBRecordStoreQueryTestBase {
         private Hierarchy(@Nonnull final Map<Long, Long> edges) {
             this.edges = edges;
             this.reverseLookup = Suppliers.memoize(this::calculateReverseLookup);
+        }
+
+        /**
+         * Calculates the depth of the hierarchy, defined as the number of edges on the longest
+         * path from the root to any leaf.
+         *
+         * @return the maximum depth of the hierarchy
+         */
+        public int calculateDepth() {
+            int maxDepth = 0;
+            for (final var vertex : edges.keySet()) {
+                int depth = 0;
+                var current = vertex;
+                while (edges.get(current) != null && edges.get(current) != SENTINEL) {
+                    depth++;
+                    current = edges.get(current);
+                }
+                maxDepth = Math.max(maxDepth, depth);
+            }
+            return maxDepth;
+        }
+
+        /**
+         * Calculates the maximum number of nodes at any single level in the hierarchy.
+         * Level 0 is the root, level 1 is its children, etc.
+         *
+         * @return the maximum width (number of nodes) across all levels
+         */
+        public int calculateMaxLevelSize() {
+            final var levelCounts = new java.util.HashMap<Integer, Integer>();
+            for (final var vertex : edges.keySet()) {
+                int depth = 0;
+                var current = vertex;
+                while (edges.get(current) != null && edges.get(current) != SENTINEL) {
+                    depth++;
+                    current = edges.get(current);
+                }
+                levelCounts.merge(depth, 1, Integer::sum);
+            }
+            return levelCounts.values().stream().mapToInt(Integer::intValue).max().orElse(0);
         }
 
         @Nonnull


### PR DESCRIPTION
 When `recursionLoop()` encountered an out-of-band stop, it built the continuation at `depth - 1` (postorder) or `depth` (preorder before first emit), discarding the child cursor's scan progress. On resume, `addChildNode` would create a fresh node with a START continuation, causing the child cursor to re-scan from the beginning and hit the same limit indefinitely.

This fixes #4135.