### PR TITLE
Update OperationsTest.testBasicInsertRingSearch expectation based on nightly runs

### DIFF
--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/OperationsTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/OperationsTest.java
@@ -449,7 +449,7 @@ class OperationsTest implements BaseTest {
                 TimeUnit.NANOSECONDS.toMillis(endTs - beginTs),
                 onReadListener.getNodeCountByLayer(), onReadListener.getBytesReadByLayer(),
                 String.format(Locale.ROOT, "%.2f", recall * 100.0d));
-        assertThat(recall).isGreaterThan(0.9);
+        assertThat(recall).isGreaterThan(0.8);
     }
 
     @ParameterizedTest


### PR DESCRIPTION
The nightly runs routinely see values between 0.8 and 0.9, so I am decreasing the expectation.
It's possible that 0.85 would also work, but the historical information is a bit hard to parse, I know there's a lot of 0.9 (exactly), and 0.8666666. 