### PR TITLE
Disallow the STRAIGHT_JOIN and NATURAL JOIN variants

### DIFF
--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/BaseVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/BaseVisitor.java
@@ -27,6 +27,7 @@ import com.apple.foundationdb.record.util.pair.NonnullPair;
 import com.apple.foundationdb.relational.api.ddl.DdlQueryFactory;
 import com.apple.foundationdb.relational.api.ddl.MetadataOperationsFactory;
 import com.apple.foundationdb.relational.api.exceptions.ErrorCode;
+import com.apple.foundationdb.relational.api.exceptions.RelationalException;
 import com.apple.foundationdb.relational.api.metadata.DataType;
 import com.apple.foundationdb.relational.generated.RelationalParser;
 import com.apple.foundationdb.relational.generated.RelationalParserBaseVisitor;
@@ -765,7 +766,7 @@ public class BaseVisitor extends RelationalParserBaseVisitor<Object> implements 
     @Nonnull
     @Override
     public Object visitStraightJoin(@Nonnull RelationalParser.StraightJoinContext ctx) {
-        return visitChildren(ctx);
+        throw new RelationalException("STRAIGHT_JOIN is not supported", ErrorCode.UNSUPPORTED_QUERY).toUncheckedWrappedException();
     }
 
     @Nonnull
@@ -777,7 +778,7 @@ public class BaseVisitor extends RelationalParserBaseVisitor<Object> implements 
     @Nonnull
     @Override
     public Object visitNaturalJoin(@Nonnull RelationalParser.NaturalJoinContext ctx) {
-        return visitChildren(ctx);
+        throw new RelationalException("NATURAL JOIN is not supported", ErrorCode.UNSUPPORTED_QUERY).toUncheckedWrappedException();
     }
 
     @Nonnull

--- a/yaml-tests/src/test/resources/join-tests.yamsql
+++ b/yaml-tests/src/test/resources/join-tests.yamsql
@@ -505,4 +505,19 @@ test_block:
       - query: select * from jua join (select * from jub join jud using(c1)) as X using (c1);
       - explain: "SCAN([IS JUD]) | FLATMAP q0 -> { SCAN([IS JUB, EQUALS q0.C1]) | FLATMAP q1 -> { SCAN([IS JUA, EQUALS q1.C1]) AS q2 RETURN (q2 AS _0, q1 AS _1) } AS q3 RETURN (q3._0.C1 AS C1, q3._0.C2 AS C2, q3._0.C5 AS _2, q3._1.C3 AS C3, q3._1.C5 AS _4, q0.C4 AS C4, q0.C5 AS _6) }"
       - result: [{!pos 1: 1, !pos 2: 2, !pos 3: 5, !pos 4: 3, !pos 5: 5, !pos 6: 4, !pos 7: 5}]
+    -
+      # NATURAL JOIN (inner) is not yet supported.`
+      - query: SELECT * FROM emp e NATURAL JOIN dept d;
+      - supported_version: !current_version
+      - error: '0AF00'  # UNSUPPORTED_QUERY
+    -
+      # NATURAL LEFT JOIN is not yet supported.
+      - query: SELECT * FROM emp e NATURAL LEFT JOIN dept d;
+      - supported_version: !current_version
+      - error: '0AF00'  # UNSUPPORTED_QUERY
+    -
+      # STRAIGHT_JOIN is not yet supported.
+      - query: SELECT * FROM emp e STRAIGHT_JOIN dept d ON e.dept_id = d.id;
+      - supported_version: !current_version
+      - error: '0AF00'  # UNSUPPORTED_QUERY
 ...


### PR DESCRIPTION
These join variants are present in the grammar but not implemented. They were previously not blocked with errors and instead silently produced wrong results.

Testing:
* Add small negative tests to `join-tests.yamsql`.