### PR TITLE
Update actions dependencies to not depend on Node 20

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -403,4 +403,4 @@ jobs:
         shell: bash
         run: echo "${{ needs.get-update-type.outputs.update-type }}"
       - name: Deploy Documentation
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -381,7 +381,7 @@ jobs:
       - name: Upload Documentation
         if: needs.get-update-type.outputs.update-type == 'BUILD'
         id: doc_upload
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5.0.0
         with:
           path: docs/sphinx/.out/html/
 


### PR DESCRIPTION
This updates two additional dependencies that were not used by PRB (which were mostly fixed by https://github.com/FoundationDB/fdb-record-layer/pull/4068), only release:

## [Update actions/upload-pages-artifact v3 -> v5.0.0](https://github.com/FoundationDB/fdb-record-layer/commit/710bf21eb63e77e2855607da4d68b5825b40dc76)
https://github.com/actions/upload-pages-artifact/releases

Most notably, there is a change and the pages no longer include
hidden files (starting with "."). I tested generating the sphinx
docs locally, and the only hidden file in there is ".buildinfo",
which, according to itself:

> This file records the configuration used when building these files.
> When it is not found, a full rebuild will be done.

So I think we should be ok to lose that file when creating pages.

## [Update actions/deploy-pages v4 -> v5.0.0](https://github.com/FoundationDB/fdb-record-layer/commit/58de591be5743921ffcbb3fdb4e3b3dc3a61b61e)
https://github.com/actions/deploy-pages/releases

This does not appear to have any problematic changes. It briefly
required different permissions, but that was fixed before v5