### PR TITLE
Introduce custom mechanism for exposing coverage information

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -162,13 +162,13 @@ jobs:
           comment-type: summary
           min-coverage-overall: 75
           min-coverage-changed-files: 80
-      - name: Get Changed Files
+      - name: Get PR Diff
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh pr diff ${{ github.event.pull_request.number }} --name-only > changed_files.txt
+          gh pr diff ${{ github.event.pull_request.number }} > pr_diff.patch
       - name: Annotate Coverage
         run: |
           python3 build/coverage_annotations.py \
             --report .out/reports/jacoco/codeCoverageReport/codeCoverageReport.xml \
-            --changed-files changed_files.txt
+            --diff pr_diff.patch

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -111,8 +111,9 @@ jobs:
     needs: [tests, other-tests]
     runs-on: ubuntu-latest
     permissions:
-      checks: read
+      checks: write
       contents: read
+      pull-requests: read
     timeout-minutes: 10
     steps:
       - name: Checkout HEAD sources
@@ -161,3 +162,13 @@ jobs:
           comment-type: summary
           min-coverage-overall: 75
           min-coverage-changed-files: 80
+      - name: Get Changed Files
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr diff ${{ github.event.pull_request.number }} --name-only > changed_files.txt
+      - name: Annotate Coverage
+        run: |
+          python3 build/coverage_annotations.py \
+            --report .out/reports/jacoco/codeCoverageReport/codeCoverageReport.xml \
+            --changed-files changed_files.txt

--- a/build/coverage_annotations.py
+++ b/build/coverage_annotations.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+
+#
+# coverage_annotations.py
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Parse a JaCoCo XML coverage report and emit GitHub Actions annotations
+for uncovered and partially-covered lines in files changed by a pull request.
+
+Usage:
+    python build/coverage_annotations.py \
+        --report .out/reports/jacoco/codeCoverageReport/codeCoverageReport.xml \
+        --changed-files changed_files.txt \
+        [--max-annotations 50] \
+        [--source-prefix 'src/main/java/']
+
+The script outputs GitHub Actions workflow commands (::warning, ::notice) that
+appear as inline annotations on the PR "Files changed" tab.
+"""
+
+import argparse
+import os
+import sys
+import xml.etree.ElementTree as ET
+
+DEFAULT_SOURCE_PREFIXES = ['src/main/java/']
+DEFAULT_MAX_ANNOTATIONS = 50
+JAVA_EXTENSIONS = {'.java'}
+
+
+class LineCoverage:
+    """Coverage data for a single source line."""
+
+    __slots__ = ('line_number', 'missed_instructions', 'covered_instructions',
+                 'missed_branches', 'covered_branches')
+
+    def __init__(self, line_number, missed_instructions, covered_instructions,
+                 missed_branches, covered_branches):
+        self.line_number = line_number
+        self.missed_instructions = missed_instructions
+        self.covered_instructions = covered_instructions
+        self.missed_branches = missed_branches
+        self.covered_branches = covered_branches
+
+    @property
+    def is_uncovered(self):
+        """Line has executable code but nothing was executed."""
+        return self.covered_instructions == 0 and self.missed_instructions > 0
+
+    @property
+    def is_partial_branch(self):
+        """Line was executed but some branches were not taken."""
+        return (self.covered_instructions > 0
+                and self.missed_branches > 0
+                and self.covered_branches > 0)
+
+    @property
+    def status(self):
+        if self.is_uncovered:
+            return 'uncovered'
+        elif self.is_partial_branch:
+            return 'partial'
+        else:
+            return 'covered'
+
+
+class AnnotationRange:
+    """A range of consecutive lines with the same coverage status."""
+
+    __slots__ = ('start_line', 'end_line', 'status', 'total_missed_instructions',
+                 'covered_branches', 'total_branches')
+
+    def __init__(self, start_line, end_line, status, total_missed_instructions=0,
+                 covered_branches=0, total_branches=0):
+        self.start_line = start_line
+        self.end_line = end_line
+        self.status = status
+        self.total_missed_instructions = total_missed_instructions
+        self.covered_branches = covered_branches
+        self.total_branches = total_branches
+
+    @property
+    def message(self):
+        if self.status == 'uncovered':
+            return 'Not covered by tests'
+        elif self.status == 'partial':
+            return (f'Partial branch coverage '
+                    f'({self.covered_branches}/{self.total_branches} branches covered)')
+        return ''
+
+
+def repo_path_to_jacoco_key(repo_path, prefixes=None):
+    """
+    Convert a repo-relative file path to a JaCoCo coverage key.
+
+    Example:
+        'fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/Foo.java'
+        -> 'com/apple/foundationdb/record/Foo.java'
+
+    Returns None if the path doesn't match any known source prefix.
+    """
+    if prefixes is None:
+        prefixes = DEFAULT_SOURCE_PREFIXES
+    for prefix in prefixes:
+        idx = repo_path.find(prefix)
+        if idx != -1:
+            return repo_path[idx + len(prefix):]
+    return None
+
+
+def parse_jacoco_report(report_path):
+    """
+    Parse a JaCoCo XML report and return coverage data indexed by source file key.
+
+    Returns:
+        dict mapping 'package/path/FileName.java' -> list of LineCoverage
+    """
+    tree = ET.parse(report_path)
+    root = tree.getroot()
+
+    coverage_data = {}
+    for package in root.findall('.//package'):
+        package_name = package.get('name')
+        for sourcefile in package.findall('sourcefile'):
+            filename = sourcefile.get('name')
+            file_key = f"{package_name}/{filename}"
+            lines = []
+            for line in sourcefile.findall('line'):
+                lines.append(LineCoverage(
+                    line_number=int(line.get('nr')),
+                    missed_instructions=int(line.get('mi')),
+                    covered_instructions=int(line.get('ci')),
+                    missed_branches=int(line.get('mb')),
+                    covered_branches=int(line.get('cb')),
+                ))
+            coverage_data[file_key] = lines
+    return coverage_data
+
+
+def read_changed_files(changed_files_path):
+    """Read a file containing one repo-relative path per line."""
+    with open(changed_files_path) as f:
+        return [line.strip() for line in f if line.strip()]
+
+
+def filter_source_files(file_paths):
+    """Filter to only Java source files."""
+    return [p for p in file_paths if os.path.splitext(p)[1] in JAVA_EXTENSIONS]
+
+
+def group_consecutive_lines(lines):
+    """
+    Group consecutive lines with the same coverage status into AnnotationRanges.
+
+    Only groups 'uncovered' and 'partial' lines (covered lines are ignored).
+    Consecutive means line numbers differ by exactly 1 and have the same status.
+    """
+    # Filter to only lines that need annotations
+    notable_lines = [l for l in lines if l.status in ('uncovered', 'partial')]
+    if not notable_lines:
+        return []
+
+    # Sort by line number
+    notable_lines.sort(key=lambda l: l.line_number)
+
+    ranges = []
+    current_start = notable_lines[0]
+    current_end = notable_lines[0]
+    current_status = notable_lines[0].status
+    missed_instr = notable_lines[0].missed_instructions
+    cov_branches = notable_lines[0].covered_branches
+    tot_branches = notable_lines[0].covered_branches + notable_lines[0].missed_branches
+
+    for line in notable_lines[1:]:
+        if (line.status == current_status
+                and line.line_number == current_end.line_number + 1):
+            # Extend the current range
+            current_end = line
+            missed_instr += line.missed_instructions
+            cov_branches += line.covered_branches
+            tot_branches += line.covered_branches + line.missed_branches
+        else:
+            # Emit the current range and start a new one
+            ranges.append(AnnotationRange(
+                start_line=current_start.line_number,
+                end_line=current_end.line_number,
+                status=current_status,
+                total_missed_instructions=missed_instr,
+                covered_branches=cov_branches,
+                total_branches=tot_branches,
+            ))
+            current_start = line
+            current_end = line
+            current_status = line.status
+            missed_instr = line.missed_instructions
+            cov_branches = line.covered_branches
+            tot_branches = line.covered_branches + line.missed_branches
+
+    # Emit the last range
+    ranges.append(AnnotationRange(
+        start_line=current_start.line_number,
+        end_line=current_end.line_number,
+        status=current_status,
+        total_missed_instructions=missed_instr,
+        covered_branches=cov_branches,
+        total_branches=tot_branches,
+    ))
+    return ranges
+
+
+def format_annotation(repo_path, annotation_range):
+    """Format a single GitHub Actions workflow command for an annotation."""
+    level = 'warning' if annotation_range.status == 'uncovered' else 'notice'
+    location = f'file={repo_path},line={annotation_range.start_line}'
+    if annotation_range.end_line > annotation_range.start_line:
+        location += f',endLine={annotation_range.end_line}'
+    message = annotation_range.message
+    return f'::{level} {location}::{message}'
+
+
+def generate_annotations(coverage_data, changed_files, source_prefixes, max_annotations):
+    """
+    Generate annotation strings for changed files based on coverage data.
+
+    Returns:
+        tuple of (list of annotation strings, int of remaining annotations not emitted)
+    """
+    annotations = []
+    total_skipped = 0
+
+    for repo_path in changed_files:
+        jacoco_key = repo_path_to_jacoco_key(repo_path, source_prefixes)
+        if jacoco_key is None:
+            continue
+
+        lines = coverage_data.get(jacoco_key)
+        if lines is None:
+            continue
+
+        ranges = group_consecutive_lines(lines)
+        for r in ranges:
+            if len(annotations) >= max_annotations:
+                total_skipped += 1
+            else:
+                annotations.append(format_annotation(repo_path, r))
+
+    return annotations, total_skipped
+
+
+def main(argv):
+    """Main entry point for the coverage annotations script."""
+    parser = argparse.ArgumentParser(
+        prog='coverage_annotations',
+        description='Emit GitHub Actions annotations for uncovered lines in changed files'
+    )
+    parser.add_argument('--report', required=True,
+                        help='Path to JaCoCo codeCoverageReport XML file')
+    parser.add_argument('--changed-files', required=True,
+                        help='Path to file listing changed files (one per line)')
+    parser.add_argument('--max-annotations', type=int, default=DEFAULT_MAX_ANNOTATIONS,
+                        help=f'Maximum number of annotations to emit (default: {DEFAULT_MAX_ANNOTATIONS})')
+    parser.add_argument('--source-prefix', action='append', default=None,
+                        help='Source path prefixes to strip '
+                             '(default: src/main/java/). '
+                             'Can be specified multiple times.')
+    args = parser.parse_args(argv)
+
+    source_prefixes = args.source_prefix if args.source_prefix else DEFAULT_SOURCE_PREFIXES
+
+    # Validate inputs
+    if not os.path.isfile(args.report):
+        print(f'::error ::Coverage report not found: {args.report}', file=sys.stderr)
+        sys.exit(1)
+
+    if not os.path.isfile(args.changed_files):
+        print(f'::error ::Changed files list not found: {args.changed_files}', file=sys.stderr)
+        sys.exit(1)
+
+    # Parse inputs
+    coverage_data = parse_jacoco_report(args.report)
+    changed_files = read_changed_files(args.changed_files)
+    source_files = filter_source_files(changed_files)
+
+    if not source_files:
+        print('No Java source files in the changed files list. Nothing to annotate.')
+        return
+
+    if not coverage_data:
+        print('Coverage report contains no data. Nothing to annotate.')
+        return
+
+    # Generate and emit annotations
+    annotations, skipped = generate_annotations(
+        coverage_data, source_files, source_prefixes, args.max_annotations
+    )
+
+    for annotation in annotations:
+        print(annotation)
+
+    if skipped > 0:
+        print(f'::notice ::Coverage annotations truncated at {args.max_annotations}. '
+              f'{skipped} more uncovered regions not shown.')
+
+    # Summary
+    matched_files = sum(
+        1 for f in source_files
+        if repo_path_to_jacoco_key(f, source_prefixes) in coverage_data
+    )
+    print(f'\nProcessed {len(source_files)} source file(s), '
+          f'{matched_files} with coverage data, '
+          f'{len(annotations)} annotation(s) emitted.',
+          file=sys.stderr)
+
+
+if __name__ == '__main__':
+    main(sys.argv[1:])

--- a/build/coverage_annotations.py
+++ b/build/coverage_annotations.py
@@ -212,9 +212,12 @@ def format_percentage(covered, total):
     return f'{pct:.1f}% ({covered}/{total} lines)'
 
 
-def format_file_annotation(repo_path, file_coverage, changed_coverage):
+def format_file_annotation(repo_path, file_coverage, changed_coverage, first_changed_line):
     """
     Format a single GitHub Actions annotation for a file's coverage summary.
+
+    The annotation is placed one line above the first changed line so it appears
+    as a header above the changes in the PR diff view.
 
     Returns the annotation string, or None if there's nothing to report.
     """
@@ -224,8 +227,9 @@ def format_file_annotation(repo_path, file_coverage, changed_coverage):
     file_pct_str = format_percentage(file_covered, file_total)
     changed_pct_str = format_percentage(changed_covered, changed_total)
 
+    annotation_line = max(1, first_changed_line - 1)
     message = f'File coverage: {file_pct_str} | Changed lines: {changed_pct_str}'
-    return f'::notice file={repo_path},line=1::{message}'
+    return f'::notice file={repo_path},line={annotation_line}::{message}'
 
 
 def generate_annotations(coverage_data, diff_data, source_prefixes):
@@ -252,8 +256,10 @@ def generate_annotations(coverage_data, diff_data, source_prefixes):
 
         file_coverage = compute_file_coverage(lines)
         changed_coverage = compute_changed_lines_coverage(lines, changed_line_numbers)
+        first_changed_line = min(changed_line_numbers)
 
-        annotation = format_file_annotation(repo_path, file_coverage, changed_coverage)
+        annotation = format_file_annotation(
+            repo_path, file_coverage, changed_coverage, first_changed_line)
         if annotation:
             annotations.append(annotation)
 

--- a/build/coverage_annotations.py
+++ b/build/coverage_annotations.py
@@ -22,27 +22,33 @@
 
 """
 Parse a JaCoCo XML coverage report and emit GitHub Actions annotations
-for uncovered and partially-covered lines in files changed by a pull request.
+showing per-file coverage summaries for files changed by a pull request.
+
+For each changed Java file, emits a single annotation with:
+  - Overall file line coverage percentage
+  - Line coverage percentage for the changed lines only
 
 Usage:
     python build/coverage_annotations.py \
         --report .out/reports/jacoco/codeCoverageReport/codeCoverageReport.xml \
-        --changed-files changed_files.txt \
-        [--max-annotations 50] \
+        --diff pr_diff.patch \
         [--source-prefix 'src/main/java/']
 
-The script outputs GitHub Actions workflow commands (::warning, ::notice) that
+The script outputs GitHub Actions workflow commands (::notice) that
 appear as inline annotations on the PR "Files changed" tab.
 """
 
 import argparse
 import os
+import re
 import sys
 import xml.etree.ElementTree as ET
 
 DEFAULT_SOURCE_PREFIXES = ['src/main/java/']
-DEFAULT_MAX_ANNOTATIONS = 50
 JAVA_EXTENSIONS = {'.java'}
+
+# Matches a unified diff hunk header: @@ -old_start[,old_count] +new_start[,new_count] @@
+HUNK_HEADER_RE = re.compile(r'^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@')
 
 
 class LineCoverage:
@@ -60,50 +66,14 @@ class LineCoverage:
         self.covered_branches = covered_branches
 
     @property
-    def is_uncovered(self):
-        """Line has executable code but nothing was executed."""
-        return self.covered_instructions == 0 and self.missed_instructions > 0
+    def is_covered(self):
+        """Line has executable code and at least some was executed."""
+        return self.covered_instructions > 0
 
     @property
-    def is_partial_branch(self):
-        """Line was executed but some branches were not taken."""
-        return (self.covered_instructions > 0
-                and self.missed_branches > 0
-                and self.covered_branches > 0)
-
-    @property
-    def status(self):
-        if self.is_uncovered:
-            return 'uncovered'
-        elif self.is_partial_branch:
-            return 'partial'
-        else:
-            return 'covered'
-
-
-class AnnotationRange:
-    """A range of consecutive lines with the same coverage status."""
-
-    __slots__ = ('start_line', 'end_line', 'status', 'total_missed_instructions',
-                 'covered_branches', 'total_branches')
-
-    def __init__(self, start_line, end_line, status, total_missed_instructions=0,
-                 covered_branches=0, total_branches=0):
-        self.start_line = start_line
-        self.end_line = end_line
-        self.status = status
-        self.total_missed_instructions = total_missed_instructions
-        self.covered_branches = covered_branches
-        self.total_branches = total_branches
-
-    @property
-    def message(self):
-        if self.status == 'uncovered':
-            return 'Not covered by tests'
-        elif self.status == 'partial':
-            return (f'Partial branch coverage '
-                    f'({self.covered_branches}/{self.total_branches} branches covered)')
-        return ''
+    def is_executable(self):
+        """Line has executable code (covered or not)."""
+        return self.missed_instructions > 0 or self.covered_instructions > 0
 
 
 def repo_path_to_jacoco_key(repo_path, prefixes=None):
@@ -154,98 +124,124 @@ def parse_jacoco_report(report_path):
     return coverage_data
 
 
-def read_changed_files(changed_files_path):
-    """Read a file containing one repo-relative path per line."""
-    with open(changed_files_path) as f:
-        return [line.strip() for line in f if line.strip()]
-
-
-def filter_source_files(file_paths):
-    """Filter to only Java source files."""
-    return [p for p in file_paths if os.path.splitext(p)[1] in JAVA_EXTENSIONS]
-
-
-def group_consecutive_lines(lines):
+def parse_diff(diff_path):
     """
-    Group consecutive lines with the same coverage status into AnnotationRanges.
-
-    Only groups 'uncovered' and 'partial' lines (covered lines are ignored).
-    Consecutive means line numbers differ by exactly 1 and have the same status.
-    """
-    # Filter to only lines that need annotations
-    notable_lines = [l for l in lines if l.status in ('uncovered', 'partial')]
-    if not notable_lines:
-        return []
-
-    # Sort by line number
-    notable_lines.sort(key=lambda l: l.line_number)
-
-    ranges = []
-    current_start = notable_lines[0]
-    current_end = notable_lines[0]
-    current_status = notable_lines[0].status
-    missed_instr = notable_lines[0].missed_instructions
-    cov_branches = notable_lines[0].covered_branches
-    tot_branches = notable_lines[0].covered_branches + notable_lines[0].missed_branches
-
-    for line in notable_lines[1:]:
-        if (line.status == current_status
-                and line.line_number == current_end.line_number + 1):
-            # Extend the current range
-            current_end = line
-            missed_instr += line.missed_instructions
-            cov_branches += line.covered_branches
-            tot_branches += line.covered_branches + line.missed_branches
-        else:
-            # Emit the current range and start a new one
-            ranges.append(AnnotationRange(
-                start_line=current_start.line_number,
-                end_line=current_end.line_number,
-                status=current_status,
-                total_missed_instructions=missed_instr,
-                covered_branches=cov_branches,
-                total_branches=tot_branches,
-            ))
-            current_start = line
-            current_end = line
-            current_status = line.status
-            missed_instr = line.missed_instructions
-            cov_branches = line.covered_branches
-            tot_branches = line.covered_branches + line.missed_branches
-
-    # Emit the last range
-    ranges.append(AnnotationRange(
-        start_line=current_start.line_number,
-        end_line=current_end.line_number,
-        status=current_status,
-        total_missed_instructions=missed_instr,
-        covered_branches=cov_branches,
-        total_branches=tot_branches,
-    ))
-    return ranges
-
-
-def format_annotation(repo_path, annotation_range):
-    """Format a single GitHub Actions workflow command for an annotation."""
-    level = 'warning' if annotation_range.status == 'uncovered' else 'notice'
-    location = f'file={repo_path},line={annotation_range.start_line}'
-    if annotation_range.end_line > annotation_range.start_line:
-        location += f',endLine={annotation_range.end_line}'
-    message = annotation_range.message
-    return f'::{level} {location}::{message}'
-
-
-def generate_annotations(coverage_data, changed_files, source_prefixes, max_annotations):
-    """
-    Generate annotation strings for changed files based on coverage data.
+    Parse a unified diff and return the set of added line numbers per file.
 
     Returns:
-        tuple of (list of annotation strings, int of remaining annotations not emitted)
+        dict mapping repo-relative file path -> set of added/modified line numbers
+    """
+    changed_lines = {}
+    current_file = None
+    current_line = 0
+
+    with open(diff_path) as f:
+        for raw_line in f:
+            line = raw_line.rstrip('\n')
+
+            # Detect file header: +++ b/path/to/file.java
+            if line.startswith('+++ b/'):
+                current_file = line[6:]  # strip '+++ b/'
+                if current_file not in changed_lines:
+                    changed_lines[current_file] = set()
+                continue
+
+            # Detect hunk header
+            hunk_match = HUNK_HEADER_RE.match(line)
+            if hunk_match:
+                current_line = int(hunk_match.group(1))
+                continue
+
+            if current_file is None:
+                continue
+
+            # Inside a hunk: track line numbers
+            if line.startswith('+'):
+                # This is an added/modified line
+                changed_lines[current_file].add(current_line)
+                current_line += 1
+            elif line.startswith('-'):
+                # Removed line - doesn't affect new file line numbering
+                pass
+            else:
+                # Context line (or "\ No newline at end of file")
+                if not line.startswith('\\'):
+                    current_line += 1
+
+    return changed_lines
+
+
+def compute_file_coverage(lines):
+    """
+    Compute overall line coverage for a file.
+
+    Returns:
+        tuple of (covered_lines, total_executable_lines)
+    """
+    executable = [l for l in lines if l.is_executable]
+    covered = [l for l in executable if l.is_covered]
+    return len(covered), len(executable)
+
+
+def compute_changed_lines_coverage(lines, changed_line_numbers):
+    """
+    Compute line coverage for only the changed lines in a file.
+
+    Returns:
+        tuple of (covered_changed, total_executable_changed)
+    """
+    line_map = {l.line_number: l for l in lines}
+    executable_changed = 0
+    covered_changed = 0
+
+    for line_num in changed_line_numbers:
+        line = line_map.get(line_num)
+        if line is not None and line.is_executable:
+            executable_changed += 1
+            if line.is_covered:
+                covered_changed += 1
+
+    return covered_changed, executable_changed
+
+
+def format_percentage(covered, total):
+    """Format a coverage percentage string."""
+    if total == 0:
+        return 'N/A (no executable lines)'
+    pct = (covered / total) * 100
+    return f'{pct:.1f}% ({covered}/{total} lines)'
+
+
+def format_file_annotation(repo_path, file_coverage, changed_coverage):
+    """
+    Format a single GitHub Actions annotation for a file's coverage summary.
+
+    Returns the annotation string, or None if there's nothing to report.
+    """
+    file_covered, file_total = file_coverage
+    changed_covered, changed_total = changed_coverage
+
+    file_pct_str = format_percentage(file_covered, file_total)
+    changed_pct_str = format_percentage(changed_covered, changed_total)
+
+    message = f'File coverage: {file_pct_str} | Changed lines: {changed_pct_str}'
+    return f'::notice file={repo_path},line=1::{message}'
+
+
+def generate_annotations(coverage_data, diff_data, source_prefixes):
+    """
+    Generate one annotation per changed file with coverage summary.
+
+    Returns:
+        list of annotation strings
     """
     annotations = []
-    total_skipped = 0
 
-    for repo_path in changed_files:
+    for repo_path, changed_line_numbers in sorted(diff_data.items()):
+        # Only process Java files
+        if os.path.splitext(repo_path)[1] not in JAVA_EXTENSIONS:
+            continue
+
         jacoco_key = repo_path_to_jacoco_key(repo_path, source_prefixes)
         if jacoco_key is None:
             continue
@@ -254,28 +250,26 @@ def generate_annotations(coverage_data, changed_files, source_prefixes, max_anno
         if lines is None:
             continue
 
-        ranges = group_consecutive_lines(lines)
-        for r in ranges:
-            if len(annotations) >= max_annotations:
-                total_skipped += 1
-            else:
-                annotations.append(format_annotation(repo_path, r))
+        file_coverage = compute_file_coverage(lines)
+        changed_coverage = compute_changed_lines_coverage(lines, changed_line_numbers)
 
-    return annotations, total_skipped
+        annotation = format_file_annotation(repo_path, file_coverage, changed_coverage)
+        if annotation:
+            annotations.append(annotation)
+
+    return annotations
 
 
 def main(argv):
     """Main entry point for the coverage annotations script."""
     parser = argparse.ArgumentParser(
         prog='coverage_annotations',
-        description='Emit GitHub Actions annotations for uncovered lines in changed files'
+        description='Emit GitHub Actions annotations with per-file coverage summaries'
     )
     parser.add_argument('--report', required=True,
                         help='Path to JaCoCo codeCoverageReport XML file')
-    parser.add_argument('--changed-files', required=True,
-                        help='Path to file listing changed files (one per line)')
-    parser.add_argument('--max-annotations', type=int, default=DEFAULT_MAX_ANNOTATIONS,
-                        help=f'Maximum number of annotations to emit (default: {DEFAULT_MAX_ANNOTATIONS})')
+    parser.add_argument('--diff', required=True,
+                        help='Path to unified diff file (e.g., from gh pr diff)')
     parser.add_argument('--source-prefix', action='append', default=None,
                         help='Source path prefixes to strip '
                              '(default: src/main/java/). '
@@ -289,17 +283,16 @@ def main(argv):
         print(f'::error ::Coverage report not found: {args.report}', file=sys.stderr)
         sys.exit(1)
 
-    if not os.path.isfile(args.changed_files):
-        print(f'::error ::Changed files list not found: {args.changed_files}', file=sys.stderr)
+    if not os.path.isfile(args.diff):
+        print(f'::error ::Diff file not found: {args.diff}', file=sys.stderr)
         sys.exit(1)
 
     # Parse inputs
     coverage_data = parse_jacoco_report(args.report)
-    changed_files = read_changed_files(args.changed_files)
-    source_files = filter_source_files(changed_files)
+    diff_data = parse_diff(args.diff)
 
-    if not source_files:
-        print('No Java source files in the changed files list. Nothing to annotate.')
+    if not diff_data:
+        print('No changed files found in diff. Nothing to annotate.')
         return
 
     if not coverage_data:
@@ -307,25 +300,13 @@ def main(argv):
         return
 
     # Generate and emit annotations
-    annotations, skipped = generate_annotations(
-        coverage_data, source_files, source_prefixes, args.max_annotations
-    )
+    annotations = generate_annotations(coverage_data, diff_data, source_prefixes)
 
     for annotation in annotations:
         print(annotation)
 
-    if skipped > 0:
-        print(f'::notice ::Coverage annotations truncated at {args.max_annotations}. '
-              f'{skipped} more uncovered regions not shown.')
-
     # Summary
-    matched_files = sum(
-        1 for f in source_files
-        if repo_path_to_jacoco_key(f, source_prefixes) in coverage_data
-    )
-    print(f'\nProcessed {len(source_files)} source file(s), '
-          f'{matched_files} with coverage data, '
-          f'{len(annotations)} annotation(s) emitted.',
+    print(f'\n{len(annotations)} file(s) annotated with coverage data.',
           file=sys.stderr)
 
 

--- a/build/coverage_annotations.py
+++ b/build/coverage_annotations.py
@@ -246,6 +246,10 @@ def generate_annotations(coverage_data, diff_data, source_prefixes):
         if os.path.splitext(repo_path)[1] not in JAVA_EXTENSIONS:
             continue
 
+        # Skip files with only deletions (no added/modified lines)
+        if not changed_line_numbers:
+            continue
+
         jacoco_key = repo_path_to_jacoco_key(repo_path, source_prefixes)
         if jacoco_key is None:
             continue

--- a/build/test_coverage_annotations.py
+++ b/build/test_coverage_annotations.py
@@ -421,6 +421,13 @@ class TestGenerateAnnotations(unittest.TestCase):
         annotations = generate_annotations(self.coverage_data, diff_data, None)
         self.assertEqual(len(annotations), 0)
 
+    def test_skips_files_with_only_deletions(self):
+        diff_data = {
+            'fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/FDBRecordStore.java': set(),
+        }
+        annotations = generate_annotations(self.coverage_data, diff_data, None)
+        self.assertEqual(len(annotations), 0)
+
     def test_annotation_contains_coverage_data(self):
         diff_data = {
             'fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/FDBRecordStore.java': {12, 13, 14},

--- a/build/test_coverage_annotations.py
+++ b/build/test_coverage_annotations.py
@@ -348,18 +348,29 @@ class TestFormatFileAnnotation(unittest.TestCase):
             'module/src/main/java/com/example/Foo.java',
             (8, 10),
             (2, 3),
+            first_changed_line=15,
         )
         self.assertEqual(
             result,
-            '::notice file=module/src/main/java/com/example/Foo.java,line=1::'
+            '::notice file=module/src/main/java/com/example/Foo.java,line=14::'
             'File coverage: 80.0% (8/10 lines) | Changed lines: 66.7% (2/3 lines)'
         )
+
+    def test_annotation_line_does_not_go_below_1(self):
+        result = format_file_annotation(
+            'module/src/main/java/com/example/Foo.java',
+            (8, 10),
+            (2, 3),
+            first_changed_line=1,
+        )
+        self.assertIn('line=1', result)
 
     def test_no_executable_changed_lines(self):
         result = format_file_annotation(
             'module/src/main/java/com/example/Foo.java',
             (8, 10),
             (0, 0),
+            first_changed_line=5,
         )
         self.assertIn('N/A (no executable lines)', result)
 

--- a/build/test_coverage_annotations.py
+++ b/build/test_coverage_annotations.py
@@ -1,0 +1,432 @@
+#!/usr/bin/env python3
+
+#
+# test_coverage_annotations.py
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Unit tests for coverage_annotations.py"""
+
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(__file__))
+from coverage_annotations import (
+    AnnotationRange,
+    LineCoverage,
+    filter_source_files,
+    format_annotation,
+    generate_annotations,
+    group_consecutive_lines,
+    parse_jacoco_report,
+    repo_path_to_jacoco_key,
+)
+
+SAMPLE_JACOCO_XML = """\
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!DOCTYPE report PUBLIC "-//JACOCO//DTD Report 1.1//EN" "report.dtd">
+<report name="Code Coverage Report">
+  <package name="com/apple/foundationdb/record">
+    <sourcefile name="FDBRecordStore.java">
+      <line nr="10" mi="0" ci="3" mb="0" cb="0"/>
+      <line nr="11" mi="0" ci="2" mb="0" cb="0"/>
+      <line nr="12" mi="4" ci="0" mb="0" cb="0"/>
+      <line nr="13" mi="3" ci="0" mb="0" cb="0"/>
+      <line nr="14" mi="2" ci="0" mb="0" cb="0"/>
+      <line nr="15" mi="0" ci="5" mb="1" cb="3"/>
+      <line nr="20" mi="0" ci="1" mb="0" cb="0"/>
+      <line nr="21" mi="6" ci="0" mb="0" cb="0"/>
+      <counter type="INSTRUCTION" missed="15" covered="11"/>
+      <counter type="LINE" missed="4" covered="4"/>
+      <counter type="BRANCH" missed="1" covered="3"/>
+    </sourcefile>
+    <sourcefile name="AllCovered.java">
+      <line nr="5" mi="0" ci="2" mb="0" cb="0"/>
+      <line nr="6" mi="0" ci="3" mb="0" cb="2"/>
+      <counter type="INSTRUCTION" missed="0" covered="5"/>
+      <counter type="LINE" missed="0" covered="2"/>
+    </sourcefile>
+  </package>
+  <package name="com/apple/foundationdb/record/query">
+    <sourcefile name="QueryPlanner.java">
+      <line nr="100" mi="5" ci="0" mb="0" cb="0"/>
+      <line nr="101" mi="0" ci="4" mb="2" cb="2"/>
+      <line nr="102" mi="0" ci="3" mb="0" cb="0"/>
+      <counter type="INSTRUCTION" missed="5" covered="7"/>
+      <counter type="LINE" missed="1" covered="2"/>
+      <counter type="BRANCH" missed="2" covered="2"/>
+    </sourcefile>
+  </package>
+</report>
+"""
+
+
+class TestRepoPathToJacocoKey(unittest.TestCase):
+    """Tests for repo_path_to_jacoco_key()"""
+
+    def test_standard_java_path(self):
+        path = 'fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/FDBRecordStore.java'
+        result = repo_path_to_jacoco_key(path)
+        self.assertEqual(result, 'com/apple/foundationdb/record/FDBRecordStore.java')
+
+    def test_nested_module_path(self):
+        path = 'fdb-relational-layer/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/Foo.java'
+        result = repo_path_to_jacoco_key(path)
+        self.assertEqual(result, 'com/apple/foundationdb/relational/Foo.java')
+
+    def test_no_match(self):
+        path = 'fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/TestFoo.java'
+        result = repo_path_to_jacoco_key(path, ['src/main/java/'])
+        self.assertIsNone(result)
+
+    def test_non_java_file(self):
+        path = 'build.gradle'
+        result = repo_path_to_jacoco_key(path)
+        self.assertIsNone(result)
+
+    def test_custom_prefix(self):
+        path = 'module/src/main/java/com/example/Bar.java'
+        result = repo_path_to_jacoco_key(path, ['src/main/java/'])
+        self.assertEqual(result, 'com/example/Bar.java')
+
+    def test_extensions_module(self):
+        path = 'fdb-extensions/src/main/java/com/apple/foundationdb/async/AsyncUtil.java'
+        result = repo_path_to_jacoco_key(path)
+        self.assertEqual(result, 'com/apple/foundationdb/async/AsyncUtil.java')
+
+
+class TestLineCoverage(unittest.TestCase):
+    """Tests for LineCoverage classification."""
+
+    def test_uncovered(self):
+        line = LineCoverage(10, missed_instructions=4, covered_instructions=0,
+                           missed_branches=0, covered_branches=0)
+        self.assertTrue(line.is_uncovered)
+        self.assertFalse(line.is_partial_branch)
+        self.assertEqual(line.status, 'uncovered')
+
+    def test_fully_covered(self):
+        line = LineCoverage(10, missed_instructions=0, covered_instructions=3,
+                           missed_branches=0, covered_branches=0)
+        self.assertFalse(line.is_uncovered)
+        self.assertFalse(line.is_partial_branch)
+        self.assertEqual(line.status, 'covered')
+
+    def test_fully_covered_with_branches(self):
+        line = LineCoverage(10, missed_instructions=0, covered_instructions=3,
+                           missed_branches=0, covered_branches=4)
+        self.assertFalse(line.is_uncovered)
+        self.assertFalse(line.is_partial_branch)
+        self.assertEqual(line.status, 'covered')
+
+    def test_partial_branch(self):
+        line = LineCoverage(10, missed_instructions=0, covered_instructions=5,
+                           missed_branches=2, covered_branches=2)
+        self.assertFalse(line.is_uncovered)
+        self.assertTrue(line.is_partial_branch)
+        self.assertEqual(line.status, 'partial')
+
+    def test_uncovered_with_branches(self):
+        # Line not executed at all, so branches also not covered
+        line = LineCoverage(10, missed_instructions=4, covered_instructions=0,
+                           missed_branches=2, covered_branches=0)
+        self.assertTrue(line.is_uncovered)
+        self.assertFalse(line.is_partial_branch)
+        self.assertEqual(line.status, 'uncovered')
+
+
+class TestGroupConsecutiveLines(unittest.TestCase):
+    """Tests for group_consecutive_lines()"""
+
+    def test_empty_list(self):
+        self.assertEqual(group_consecutive_lines([]), [])
+
+    def test_all_covered(self):
+        lines = [
+            LineCoverage(1, 0, 3, 0, 0),
+            LineCoverage(2, 0, 2, 0, 0),
+        ]
+        self.assertEqual(group_consecutive_lines(lines), [])
+
+    def test_single_uncovered(self):
+        lines = [LineCoverage(10, 4, 0, 0, 0)]
+        ranges = group_consecutive_lines(lines)
+        self.assertEqual(len(ranges), 1)
+        self.assertEqual(ranges[0].start_line, 10)
+        self.assertEqual(ranges[0].end_line, 10)
+        self.assertEqual(ranges[0].status, 'uncovered')
+
+    def test_consecutive_uncovered_grouped(self):
+        lines = [
+            LineCoverage(10, 4, 0, 0, 0),
+            LineCoverage(11, 3, 0, 0, 0),
+            LineCoverage(12, 2, 0, 0, 0),
+        ]
+        ranges = group_consecutive_lines(lines)
+        self.assertEqual(len(ranges), 1)
+        self.assertEqual(ranges[0].start_line, 10)
+        self.assertEqual(ranges[0].end_line, 12)
+        self.assertEqual(ranges[0].status, 'uncovered')
+
+    def test_non_consecutive_separate_ranges(self):
+        lines = [
+            LineCoverage(10, 4, 0, 0, 0),
+            LineCoverage(12, 3, 0, 0, 0),  # gap at line 11
+        ]
+        ranges = group_consecutive_lines(lines)
+        self.assertEqual(len(ranges), 2)
+        self.assertEqual(ranges[0].start_line, 10)
+        self.assertEqual(ranges[0].end_line, 10)
+        self.assertEqual(ranges[1].start_line, 12)
+        self.assertEqual(ranges[1].end_line, 12)
+
+    def test_mixed_status_splits(self):
+        lines = [
+            LineCoverage(10, 4, 0, 0, 0),   # uncovered
+            LineCoverage(11, 0, 3, 2, 2),    # partial
+            LineCoverage(12, 5, 0, 0, 0),    # uncovered
+        ]
+        ranges = group_consecutive_lines(lines)
+        self.assertEqual(len(ranges), 3)
+        self.assertEqual(ranges[0].status, 'uncovered')
+        self.assertEqual(ranges[1].status, 'partial')
+        self.assertEqual(ranges[2].status, 'uncovered')
+
+    def test_covered_lines_interspersed(self):
+        lines = [
+            LineCoverage(10, 0, 3, 0, 0),   # covered - ignored
+            LineCoverage(11, 4, 0, 0, 0),   # uncovered
+            LineCoverage(12, 3, 0, 0, 0),   # uncovered
+            LineCoverage(13, 0, 5, 0, 0),   # covered - ignored
+            LineCoverage(14, 2, 0, 0, 0),   # uncovered
+        ]
+        ranges = group_consecutive_lines(lines)
+        self.assertEqual(len(ranges), 2)
+        self.assertEqual(ranges[0].start_line, 11)
+        self.assertEqual(ranges[0].end_line, 12)
+        self.assertEqual(ranges[1].start_line, 14)
+        self.assertEqual(ranges[1].end_line, 14)
+
+    def test_partial_branch_range(self):
+        lines = [
+            LineCoverage(5, 0, 3, 1, 3),    # partial
+            LineCoverage(6, 0, 2, 2, 2),    # partial
+        ]
+        ranges = group_consecutive_lines(lines)
+        self.assertEqual(len(ranges), 1)
+        self.assertEqual(ranges[0].start_line, 5)
+        self.assertEqual(ranges[0].end_line, 6)
+        self.assertEqual(ranges[0].status, 'partial')
+        self.assertEqual(ranges[0].covered_branches, 5)
+        self.assertEqual(ranges[0].total_branches, 8)
+
+
+class TestParseJacocoReport(unittest.TestCase):
+    """Tests for parse_jacoco_report()"""
+
+    def setUp(self):
+        self.xml_file = tempfile.NamedTemporaryFile(
+            mode='w', suffix='.xml', delete=False)
+        self.xml_file.write(SAMPLE_JACOCO_XML)
+        self.xml_file.close()
+
+    def tearDown(self):
+        os.unlink(self.xml_file.name)
+
+    def test_parses_packages_and_files(self):
+        data = parse_jacoco_report(self.xml_file.name)
+        self.assertIn('com/apple/foundationdb/record/FDBRecordStore.java', data)
+        self.assertIn('com/apple/foundationdb/record/AllCovered.java', data)
+        self.assertIn('com/apple/foundationdb/record/query/QueryPlanner.java', data)
+
+    def test_line_count(self):
+        data = parse_jacoco_report(self.xml_file.name)
+        self.assertEqual(len(data['com/apple/foundationdb/record/FDBRecordStore.java']), 8)
+        self.assertEqual(len(data['com/apple/foundationdb/record/AllCovered.java']), 2)
+        self.assertEqual(len(data['com/apple/foundationdb/record/query/QueryPlanner.java']), 3)
+
+    def test_line_data_correct(self):
+        data = parse_jacoco_report(self.xml_file.name)
+        lines = data['com/apple/foundationdb/record/FDBRecordStore.java']
+        # Line 10: covered (ci=3, mi=0)
+        self.assertEqual(lines[0].line_number, 10)
+        self.assertEqual(lines[0].status, 'covered')
+        # Line 12: uncovered (ci=0, mi=4)
+        self.assertEqual(lines[2].line_number, 12)
+        self.assertEqual(lines[2].status, 'uncovered')
+        # Line 15: partial branch (ci=5, mb=1, cb=3)
+        self.assertEqual(lines[5].line_number, 15)
+        self.assertEqual(lines[5].status, 'partial')
+
+
+class TestFilterSourceFiles(unittest.TestCase):
+    """Tests for filter_source_files()"""
+
+    def test_filters_java_files(self):
+        files = [
+            'module/src/main/java/com/example/Foo.java',
+            'module/src/main/java/com/example/Bar.java',
+            'module/build.gradle',
+            'README.md',
+            'module/src/main/proto/record.proto',
+        ]
+        result = filter_source_files(files)
+        self.assertEqual(result, [
+            'module/src/main/java/com/example/Foo.java',
+            'module/src/main/java/com/example/Bar.java',
+        ])
+
+    def test_empty_list(self):
+        self.assertEqual(filter_source_files([]), [])
+
+
+class TestFormatAnnotation(unittest.TestCase):
+    """Tests for format_annotation()"""
+
+    def test_single_line_warning(self):
+        r = AnnotationRange(start_line=10, end_line=10, status='uncovered')
+        result = format_annotation('module/src/main/java/com/example/Foo.java', r)
+        self.assertEqual(
+            result,
+            '::warning file=module/src/main/java/com/example/Foo.java,line=10::Not covered by tests'
+        )
+
+    def test_multi_line_warning(self):
+        r = AnnotationRange(start_line=10, end_line=14, status='uncovered')
+        result = format_annotation('module/src/main/java/com/example/Foo.java', r)
+        self.assertEqual(
+            result,
+            '::warning file=module/src/main/java/com/example/Foo.java,line=10,endLine=14::Not covered by tests'
+        )
+
+    def test_partial_branch_notice(self):
+        r = AnnotationRange(start_line=15, end_line=15, status='partial',
+                           covered_branches=3, total_branches=4)
+        result = format_annotation('module/src/main/java/com/example/Foo.java', r)
+        self.assertEqual(
+            result,
+            '::notice file=module/src/main/java/com/example/Foo.java,line=15::'
+            'Partial branch coverage (3/4 branches covered)'
+        )
+
+
+class TestGenerateAnnotations(unittest.TestCase):
+    """Tests for generate_annotations()"""
+
+    def setUp(self):
+        self.xml_file = tempfile.NamedTemporaryFile(
+            mode='w', suffix='.xml', delete=False)
+        self.xml_file.write(SAMPLE_JACOCO_XML)
+        self.xml_file.close()
+        self.coverage_data = parse_jacoco_report(self.xml_file.name)
+
+    def tearDown(self):
+        os.unlink(self.xml_file.name)
+
+    def test_generates_annotations_for_changed_file(self):
+        changed_files = [
+            'fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/FDBRecordStore.java'
+        ]
+        annotations, skipped = generate_annotations(
+            self.coverage_data, changed_files, None, 50)
+        # Should have annotations for uncovered lines 12-14, partial line 15, uncovered line 21
+        self.assertGreater(len(annotations), 0)
+        self.assertEqual(skipped, 0)
+        # Check that we have both warnings and notices
+        warnings = [a for a in annotations if a.startswith('::warning')]
+        notices = [a for a in annotations if a.startswith('::notice')]
+        self.assertGreater(len(warnings), 0)
+        self.assertGreater(len(notices), 0)
+
+    def test_no_annotations_for_covered_file(self):
+        changed_files = [
+            'fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/AllCovered.java'
+        ]
+        annotations, skipped = generate_annotations(
+            self.coverage_data, changed_files, None, 50)
+        self.assertEqual(len(annotations), 0)
+        self.assertEqual(skipped, 0)
+
+    def test_no_annotations_for_unknown_file(self):
+        changed_files = [
+            'fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/Unknown.java'
+        ]
+        annotations, skipped = generate_annotations(
+            self.coverage_data, changed_files, None, 50)
+        self.assertEqual(len(annotations), 0)
+        self.assertEqual(skipped, 0)
+
+    def test_max_annotations_respected(self):
+        changed_files = [
+            'fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/FDBRecordStore.java',
+            'fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/QueryPlanner.java',
+        ]
+        annotations, skipped = generate_annotations(
+            self.coverage_data, changed_files, None, 2)
+        self.assertEqual(len(annotations), 2)
+        self.assertGreater(skipped, 0)
+
+    def test_non_matching_path_skipped(self):
+        changed_files = [
+            'fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/TestFoo.java'
+        ]
+        annotations, skipped = generate_annotations(
+            self.coverage_data, changed_files, None, 50)
+        self.assertEqual(len(annotations), 0)
+
+
+class TestEndToEnd(unittest.TestCase):
+    """End-to-end tests using main() with captured output."""
+
+    def setUp(self):
+        self.xml_file = tempfile.NamedTemporaryFile(
+            mode='w', suffix='.xml', delete=False)
+        self.xml_file.write(SAMPLE_JACOCO_XML)
+        self.xml_file.close()
+
+        self.changed_file = tempfile.NamedTemporaryFile(
+            mode='w', suffix='.txt', delete=False)
+        self.changed_file.write(
+            'fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/FDBRecordStore.java\n'
+            'build.gradle\n'
+            'README.md\n'
+        )
+        self.changed_file.close()
+
+    def tearDown(self):
+        os.unlink(self.xml_file.name)
+        os.unlink(self.changed_file.name)
+
+    def test_main_runs_without_error(self):
+        from io import StringIO
+        from unittest.mock import patch
+
+        with patch('sys.stdout', new_callable=StringIO) as mock_out:
+            from coverage_annotations import main
+            main(['--report', self.xml_file.name,
+                  '--changed-files', self.changed_file.name])
+
+        output = mock_out.getvalue()
+        self.assertIn('::warning', output)
+        self.assertIn('FDBRecordStore.java', output)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/build/test_coverage_annotations.py
+++ b/build/test_coverage_annotations.py
@@ -29,12 +29,13 @@ import unittest
 
 sys.path.insert(0, os.path.dirname(__file__))
 from coverage_annotations import (
-    AnnotationRange,
     LineCoverage,
-    filter_source_files,
-    format_annotation,
+    compute_changed_lines_coverage,
+    compute_file_coverage,
+    format_file_annotation,
+    format_percentage,
     generate_annotations,
-    group_consecutive_lines,
+    parse_diff,
     parse_jacoco_report,
     repo_path_to_jacoco_key,
 )
@@ -77,6 +78,43 @@ SAMPLE_JACOCO_XML = """\
 </report>
 """
 
+SAMPLE_DIFF = """\
+diff --git a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/FDBRecordStore.java b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/FDBRecordStore.java
+index abc1234..def5678 100644
+--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/FDBRecordStore.java
++++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/FDBRecordStore.java
+@@ -10,4 +10,6 @@ public class FDBRecordStore {
+     existing line
++    added line on 11
++    added line on 12
+     existing line
++    added line on 14
+ }
+@@ -19,3 +21,4 @@ public class FDBRecordStore {
+     existing line
++    added line on 22
+     existing line
+"""
+
+SAMPLE_DIFF_MULTIPLE_FILES = """\
+diff --git a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/FDBRecordStore.java b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/FDBRecordStore.java
+--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/FDBRecordStore.java
++++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/FDBRecordStore.java
+@@ -11,2 +11,4 @@ public class FDBRecordStore {
+     existing line
++    new line 12
++    new line 13
+     existing line
+diff --git a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/QueryPlanner.java b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/QueryPlanner.java
+--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/QueryPlanner.java
++++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/QueryPlanner.java
+@@ -99,3 +99,5 @@ public class QueryPlanner {
+     existing line
++    new line 100
++    new line 101
+     existing line
+"""
+
 
 class TestRepoPathToJacocoKey(unittest.TestCase):
     """Tests for repo_path_to_jacoco_key()"""
@@ -91,7 +129,7 @@ class TestRepoPathToJacocoKey(unittest.TestCase):
         result = repo_path_to_jacoco_key(path)
         self.assertEqual(result, 'com/apple/foundationdb/relational/Foo.java')
 
-    def test_no_match(self):
+    def test_no_match_test_source(self):
         path = 'fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/TestFoo.java'
         result = repo_path_to_jacoco_key(path, ['src/main/java/'])
         self.assertIsNone(result)
@@ -115,216 +153,215 @@ class TestRepoPathToJacocoKey(unittest.TestCase):
 class TestLineCoverage(unittest.TestCase):
     """Tests for LineCoverage classification."""
 
+    def test_covered(self):
+        line = LineCoverage(10, missed_instructions=0, covered_instructions=3,
+                           missed_branches=0, covered_branches=0)
+        self.assertTrue(line.is_covered)
+        self.assertTrue(line.is_executable)
+
     def test_uncovered(self):
         line = LineCoverage(10, missed_instructions=4, covered_instructions=0,
                            missed_branches=0, covered_branches=0)
-        self.assertTrue(line.is_uncovered)
-        self.assertFalse(line.is_partial_branch)
-        self.assertEqual(line.status, 'uncovered')
+        self.assertFalse(line.is_covered)
+        self.assertTrue(line.is_executable)
 
-    def test_fully_covered(self):
-        line = LineCoverage(10, missed_instructions=0, covered_instructions=3,
-                           missed_branches=0, covered_branches=0)
-        self.assertFalse(line.is_uncovered)
-        self.assertFalse(line.is_partial_branch)
-        self.assertEqual(line.status, 'covered')
-
-    def test_fully_covered_with_branches(self):
-        line = LineCoverage(10, missed_instructions=0, covered_instructions=3,
-                           missed_branches=0, covered_branches=4)
-        self.assertFalse(line.is_uncovered)
-        self.assertFalse(line.is_partial_branch)
-        self.assertEqual(line.status, 'covered')
-
-    def test_partial_branch(self):
+    def test_partial_branch_is_covered(self):
         line = LineCoverage(10, missed_instructions=0, covered_instructions=5,
                            missed_branches=2, covered_branches=2)
-        self.assertFalse(line.is_uncovered)
-        self.assertTrue(line.is_partial_branch)
-        self.assertEqual(line.status, 'partial')
+        self.assertTrue(line.is_covered)
+        self.assertTrue(line.is_executable)
 
-    def test_uncovered_with_branches(self):
-        # Line not executed at all, so branches also not covered
-        line = LineCoverage(10, missed_instructions=4, covered_instructions=0,
-                           missed_branches=2, covered_branches=0)
-        self.assertTrue(line.is_uncovered)
-        self.assertFalse(line.is_partial_branch)
-        self.assertEqual(line.status, 'uncovered')
+    def test_no_instructions(self):
+        line = LineCoverage(10, missed_instructions=0, covered_instructions=0,
+                           missed_branches=0, covered_branches=0)
+        self.assertFalse(line.is_covered)
+        self.assertFalse(line.is_executable)
 
 
-class TestGroupConsecutiveLines(unittest.TestCase):
-    """Tests for group_consecutive_lines()"""
+class TestParseDiff(unittest.TestCase):
+    """Tests for parse_diff()"""
 
-    def test_empty_list(self):
-        self.assertEqual(group_consecutive_lines([]), [])
+    def _write_diff(self, content):
+        f = tempfile.NamedTemporaryFile(mode='w', suffix='.patch', delete=False)
+        f.write(content)
+        f.close()
+        return f.name
+
+    def test_parses_added_lines(self):
+        path = self._write_diff(SAMPLE_DIFF)
+        try:
+            result = parse_diff(path)
+            file_path = 'fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/FDBRecordStore.java'
+            self.assertIn(file_path, result)
+            # Hunk 1: starts at line 10, context line (11), +line(12), +line(13), context(14), +line(15)
+            # Wait, let me trace through:
+            # @@ -10,4 +10,6 @@ -> new file starts at line 10
+            #  "    existing line"  -> context, line 10, current_line becomes 11
+            # "+    added line on 11" -> added, line 11, current_line becomes 12
+            # "+    added line on 12" -> added, line 12, current_line becomes 13
+            #  "    existing line"  -> context, line 13, current_line becomes 14
+            # "+    added line on 14" -> added, line 14
+            # Hunk 2: @@ -19,3 +21,4 @@ -> new file starts at line 21
+            #  "    existing line"  -> context, line 21, current_line becomes 22
+            # "+    added line on 22" -> added, line 22
+            #  "    existing line"  -> context, line 23
+            self.assertIn(11, result[file_path])
+            self.assertIn(12, result[file_path])
+            self.assertIn(14, result[file_path])
+            self.assertIn(22, result[file_path])
+            # Context lines should NOT be in the set
+            self.assertNotIn(10, result[file_path])
+            self.assertNotIn(13, result[file_path])
+        finally:
+            os.unlink(path)
+
+    def test_parses_multiple_files(self):
+        path = self._write_diff(SAMPLE_DIFF_MULTIPLE_FILES)
+        try:
+            result = parse_diff(path)
+            self.assertEqual(len(result), 2)
+            self.assertIn(
+                'fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/FDBRecordStore.java',
+                result)
+            self.assertIn(
+                'fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/QueryPlanner.java',
+                result)
+        finally:
+            os.unlink(path)
+
+    def test_empty_diff(self):
+        path = self._write_diff('')
+        try:
+            result = parse_diff(path)
+            self.assertEqual(result, {})
+        finally:
+            os.unlink(path)
+
+    def test_non_java_files_included_in_parse(self):
+        """parse_diff returns all files; filtering happens later."""
+        diff = """\
+diff --git a/build.gradle b/build.gradle
+--- a/build.gradle
++++ b/build.gradle
+@@ -1,2 +1,3 @@
+ existing
++new line
+ existing
+"""
+        path = self._write_diff(diff)
+        try:
+            result = parse_diff(path)
+            self.assertIn('build.gradle', result)
+        finally:
+            os.unlink(path)
+
+
+class TestComputeFileCoverage(unittest.TestCase):
+    """Tests for compute_file_coverage()"""
+
+    def test_mixed_coverage(self):
+        lines = [
+            LineCoverage(10, 0, 3, 0, 0),   # covered
+            LineCoverage(11, 0, 2, 0, 0),   # covered
+            LineCoverage(12, 4, 0, 0, 0),   # uncovered
+            LineCoverage(13, 3, 0, 0, 0),   # uncovered
+            LineCoverage(14, 2, 0, 0, 0),   # uncovered
+            LineCoverage(15, 0, 5, 1, 3),   # covered (has instructions covered)
+            LineCoverage(20, 0, 1, 0, 0),   # covered
+            LineCoverage(21, 6, 0, 0, 0),   # uncovered
+        ]
+        covered, total = compute_file_coverage(lines)
+        self.assertEqual(total, 8)
+        self.assertEqual(covered, 4)
 
     def test_all_covered(self):
         lines = [
-            LineCoverage(1, 0, 3, 0, 0),
-            LineCoverage(2, 0, 2, 0, 0),
+            LineCoverage(5, 0, 2, 0, 0),
+            LineCoverage(6, 0, 3, 0, 2),
         ]
-        self.assertEqual(group_consecutive_lines(lines), [])
+        covered, total = compute_file_coverage(lines)
+        self.assertEqual(total, 2)
+        self.assertEqual(covered, 2)
 
-    def test_single_uncovered(self):
-        lines = [LineCoverage(10, 4, 0, 0, 0)]
-        ranges = group_consecutive_lines(lines)
-        self.assertEqual(len(ranges), 1)
-        self.assertEqual(ranges[0].start_line, 10)
-        self.assertEqual(ranges[0].end_line, 10)
-        self.assertEqual(ranges[0].status, 'uncovered')
+    def test_empty_file(self):
+        covered, total = compute_file_coverage([])
+        self.assertEqual(total, 0)
+        self.assertEqual(covered, 0)
 
-    def test_consecutive_uncovered_grouped(self):
+
+class TestComputeChangedLinesCoverage(unittest.TestCase):
+    """Tests for compute_changed_lines_coverage()"""
+
+    def test_some_changed_lines_covered(self):
         lines = [
-            LineCoverage(10, 4, 0, 0, 0),
-            LineCoverage(11, 3, 0, 0, 0),
-            LineCoverage(12, 2, 0, 0, 0),
+            LineCoverage(10, 0, 3, 0, 0),   # covered
+            LineCoverage(11, 0, 2, 0, 0),   # covered
+            LineCoverage(12, 4, 0, 0, 0),   # uncovered
+            LineCoverage(13, 3, 0, 0, 0),   # uncovered
         ]
-        ranges = group_consecutive_lines(lines)
-        self.assertEqual(len(ranges), 1)
-        self.assertEqual(ranges[0].start_line, 10)
-        self.assertEqual(ranges[0].end_line, 12)
-        self.assertEqual(ranges[0].status, 'uncovered')
+        # Changed lines 10, 12, 13
+        covered, total = compute_changed_lines_coverage(lines, {10, 12, 13})
+        self.assertEqual(total, 3)   # all 3 are executable
+        self.assertEqual(covered, 1)  # only line 10 is covered
 
-    def test_non_consecutive_separate_ranges(self):
+    def test_changed_lines_not_executable(self):
         lines = [
-            LineCoverage(10, 4, 0, 0, 0),
-            LineCoverage(12, 3, 0, 0, 0),  # gap at line 11
+            LineCoverage(10, 0, 3, 0, 0),
         ]
-        ranges = group_consecutive_lines(lines)
-        self.assertEqual(len(ranges), 2)
-        self.assertEqual(ranges[0].start_line, 10)
-        self.assertEqual(ranges[0].end_line, 10)
-        self.assertEqual(ranges[1].start_line, 12)
-        self.assertEqual(ranges[1].end_line, 12)
+        # Line 5 is changed but not in coverage data (comment/blank)
+        covered, total = compute_changed_lines_coverage(lines, {5})
+        self.assertEqual(total, 0)
+        self.assertEqual(covered, 0)
 
-    def test_mixed_status_splits(self):
-        lines = [
-            LineCoverage(10, 4, 0, 0, 0),   # uncovered
-            LineCoverage(11, 0, 3, 2, 2),    # partial
-            LineCoverage(12, 5, 0, 0, 0),    # uncovered
-        ]
-        ranges = group_consecutive_lines(lines)
-        self.assertEqual(len(ranges), 3)
-        self.assertEqual(ranges[0].status, 'uncovered')
-        self.assertEqual(ranges[1].status, 'partial')
-        self.assertEqual(ranges[2].status, 'uncovered')
-
-    def test_covered_lines_interspersed(self):
-        lines = [
-            LineCoverage(10, 0, 3, 0, 0),   # covered - ignored
-            LineCoverage(11, 4, 0, 0, 0),   # uncovered
-            LineCoverage(12, 3, 0, 0, 0),   # uncovered
-            LineCoverage(13, 0, 5, 0, 0),   # covered - ignored
-            LineCoverage(14, 2, 0, 0, 0),   # uncovered
-        ]
-        ranges = group_consecutive_lines(lines)
-        self.assertEqual(len(ranges), 2)
-        self.assertEqual(ranges[0].start_line, 11)
-        self.assertEqual(ranges[0].end_line, 12)
-        self.assertEqual(ranges[1].start_line, 14)
-        self.assertEqual(ranges[1].end_line, 14)
-
-    def test_partial_branch_range(self):
-        lines = [
-            LineCoverage(5, 0, 3, 1, 3),    # partial
-            LineCoverage(6, 0, 2, 2, 2),    # partial
-        ]
-        ranges = group_consecutive_lines(lines)
-        self.assertEqual(len(ranges), 1)
-        self.assertEqual(ranges[0].start_line, 5)
-        self.assertEqual(ranges[0].end_line, 6)
-        self.assertEqual(ranges[0].status, 'partial')
-        self.assertEqual(ranges[0].covered_branches, 5)
-        self.assertEqual(ranges[0].total_branches, 8)
+    def test_no_changed_lines(self):
+        lines = [LineCoverage(10, 0, 3, 0, 0)]
+        covered, total = compute_changed_lines_coverage(lines, set())
+        self.assertEqual(total, 0)
+        self.assertEqual(covered, 0)
 
 
-class TestParseJacocoReport(unittest.TestCase):
-    """Tests for parse_jacoco_report()"""
+class TestFormatPercentage(unittest.TestCase):
+    """Tests for format_percentage()"""
 
-    def setUp(self):
-        self.xml_file = tempfile.NamedTemporaryFile(
-            mode='w', suffix='.xml', delete=False)
-        self.xml_file.write(SAMPLE_JACOCO_XML)
-        self.xml_file.close()
+    def test_normal_percentage(self):
+        result = format_percentage(3, 4)
+        self.assertEqual(result, '75.0% (3/4 lines)')
 
-    def tearDown(self):
-        os.unlink(self.xml_file.name)
+    def test_full_coverage(self):
+        result = format_percentage(10, 10)
+        self.assertEqual(result, '100.0% (10/10 lines)')
 
-    def test_parses_packages_and_files(self):
-        data = parse_jacoco_report(self.xml_file.name)
-        self.assertIn('com/apple/foundationdb/record/FDBRecordStore.java', data)
-        self.assertIn('com/apple/foundationdb/record/AllCovered.java', data)
-        self.assertIn('com/apple/foundationdb/record/query/QueryPlanner.java', data)
+    def test_zero_coverage(self):
+        result = format_percentage(0, 5)
+        self.assertEqual(result, '0.0% (0/5 lines)')
 
-    def test_line_count(self):
-        data = parse_jacoco_report(self.xml_file.name)
-        self.assertEqual(len(data['com/apple/foundationdb/record/FDBRecordStore.java']), 8)
-        self.assertEqual(len(data['com/apple/foundationdb/record/AllCovered.java']), 2)
-        self.assertEqual(len(data['com/apple/foundationdb/record/query/QueryPlanner.java']), 3)
-
-    def test_line_data_correct(self):
-        data = parse_jacoco_report(self.xml_file.name)
-        lines = data['com/apple/foundationdb/record/FDBRecordStore.java']
-        # Line 10: covered (ci=3, mi=0)
-        self.assertEqual(lines[0].line_number, 10)
-        self.assertEqual(lines[0].status, 'covered')
-        # Line 12: uncovered (ci=0, mi=4)
-        self.assertEqual(lines[2].line_number, 12)
-        self.assertEqual(lines[2].status, 'uncovered')
-        # Line 15: partial branch (ci=5, mb=1, cb=3)
-        self.assertEqual(lines[5].line_number, 15)
-        self.assertEqual(lines[5].status, 'partial')
+    def test_no_executable_lines(self):
+        result = format_percentage(0, 0)
+        self.assertEqual(result, 'N/A (no executable lines)')
 
 
-class TestFilterSourceFiles(unittest.TestCase):
-    """Tests for filter_source_files()"""
+class TestFormatFileAnnotation(unittest.TestCase):
+    """Tests for format_file_annotation()"""
 
-    def test_filters_java_files(self):
-        files = [
+    def test_basic_annotation(self):
+        result = format_file_annotation(
             'module/src/main/java/com/example/Foo.java',
-            'module/src/main/java/com/example/Bar.java',
-            'module/build.gradle',
-            'README.md',
-            'module/src/main/proto/record.proto',
-        ]
-        result = filter_source_files(files)
-        self.assertEqual(result, [
+            (8, 10),
+            (2, 3),
+        )
+        self.assertEqual(
+            result,
+            '::notice file=module/src/main/java/com/example/Foo.java,line=1::'
+            'File coverage: 80.0% (8/10 lines) | Changed lines: 66.7% (2/3 lines)'
+        )
+
+    def test_no_executable_changed_lines(self):
+        result = format_file_annotation(
             'module/src/main/java/com/example/Foo.java',
-            'module/src/main/java/com/example/Bar.java',
-        ])
-
-    def test_empty_list(self):
-        self.assertEqual(filter_source_files([]), [])
-
-
-class TestFormatAnnotation(unittest.TestCase):
-    """Tests for format_annotation()"""
-
-    def test_single_line_warning(self):
-        r = AnnotationRange(start_line=10, end_line=10, status='uncovered')
-        result = format_annotation('module/src/main/java/com/example/Foo.java', r)
-        self.assertEqual(
-            result,
-            '::warning file=module/src/main/java/com/example/Foo.java,line=10::Not covered by tests'
+            (8, 10),
+            (0, 0),
         )
-
-    def test_multi_line_warning(self):
-        r = AnnotationRange(start_line=10, end_line=14, status='uncovered')
-        result = format_annotation('module/src/main/java/com/example/Foo.java', r)
-        self.assertEqual(
-            result,
-            '::warning file=module/src/main/java/com/example/Foo.java,line=10,endLine=14::Not covered by tests'
-        )
-
-    def test_partial_branch_notice(self):
-        r = AnnotationRange(start_line=15, end_line=15, status='partial',
-                           covered_branches=3, total_branches=4)
-        result = format_annotation('module/src/main/java/com/example/Foo.java', r)
-        self.assertEqual(
-            result,
-            '::notice file=module/src/main/java/com/example/Foo.java,line=15::'
-            'Partial branch coverage (3/4 branches covered)'
-        )
+        self.assertIn('N/A (no executable lines)', result)
 
 
 class TestGenerateAnnotations(unittest.TestCase):
@@ -340,56 +377,49 @@ class TestGenerateAnnotations(unittest.TestCase):
     def tearDown(self):
         os.unlink(self.xml_file.name)
 
-    def test_generates_annotations_for_changed_file(self):
-        changed_files = [
-            'fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/FDBRecordStore.java'
-        ]
-        annotations, skipped = generate_annotations(
-            self.coverage_data, changed_files, None, 50)
-        # Should have annotations for uncovered lines 12-14, partial line 15, uncovered line 21
-        self.assertGreater(len(annotations), 0)
-        self.assertEqual(skipped, 0)
-        # Check that we have both warnings and notices
-        warnings = [a for a in annotations if a.startswith('::warning')]
-        notices = [a for a in annotations if a.startswith('::notice')]
-        self.assertGreater(len(warnings), 0)
-        self.assertGreater(len(notices), 0)
-
-    def test_no_annotations_for_covered_file(self):
-        changed_files = [
-            'fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/AllCovered.java'
-        ]
-        annotations, skipped = generate_annotations(
-            self.coverage_data, changed_files, None, 50)
-        self.assertEqual(len(annotations), 0)
-        self.assertEqual(skipped, 0)
-
-    def test_no_annotations_for_unknown_file(self):
-        changed_files = [
-            'fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/Unknown.java'
-        ]
-        annotations, skipped = generate_annotations(
-            self.coverage_data, changed_files, None, 50)
-        self.assertEqual(len(annotations), 0)
-        self.assertEqual(skipped, 0)
-
-    def test_max_annotations_respected(self):
-        changed_files = [
-            'fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/FDBRecordStore.java',
-            'fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/QueryPlanner.java',
-        ]
-        annotations, skipped = generate_annotations(
-            self.coverage_data, changed_files, None, 2)
+    def test_generates_one_annotation_per_file(self):
+        diff_data = {
+            'fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/FDBRecordStore.java': {12, 13},
+            'fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/QueryPlanner.java': {100},
+        }
+        annotations = generate_annotations(self.coverage_data, diff_data, None)
         self.assertEqual(len(annotations), 2)
-        self.assertGreater(skipped, 0)
+        # Each should be a ::notice
+        for a in annotations:
+            self.assertTrue(a.startswith('::notice'))
 
-    def test_non_matching_path_skipped(self):
-        changed_files = [
-            'fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/TestFoo.java'
-        ]
-        annotations, skipped = generate_annotations(
-            self.coverage_data, changed_files, None, 50)
+    def test_skips_non_java_files(self):
+        diff_data = {
+            'build.gradle': {1, 2, 3},
+            'README.md': {5},
+        }
+        annotations = generate_annotations(self.coverage_data, diff_data, None)
         self.assertEqual(len(annotations), 0)
+
+    def test_skips_files_without_coverage(self):
+        diff_data = {
+            'fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/Unknown.java': {10},
+        }
+        annotations = generate_annotations(self.coverage_data, diff_data, None)
+        self.assertEqual(len(annotations), 0)
+
+    def test_skips_test_files(self):
+        diff_data = {
+            'fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/FDBRecordStoreTest.java': {10},
+        }
+        annotations = generate_annotations(self.coverage_data, diff_data, None)
+        self.assertEqual(len(annotations), 0)
+
+    def test_annotation_contains_coverage_data(self):
+        diff_data = {
+            'fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/FDBRecordStore.java': {12, 13, 14},
+        }
+        annotations = generate_annotations(self.coverage_data, diff_data, None)
+        self.assertEqual(len(annotations), 1)
+        # File has 8 executable lines, 4 covered -> 50%
+        self.assertIn('50.0%', annotations[0])
+        # Changed lines 12, 13, 14 are all uncovered -> 0%
+        self.assertIn('0.0%', annotations[0])
 
 
 class TestEndToEnd(unittest.TestCase):
@@ -401,18 +431,14 @@ class TestEndToEnd(unittest.TestCase):
         self.xml_file.write(SAMPLE_JACOCO_XML)
         self.xml_file.close()
 
-        self.changed_file = tempfile.NamedTemporaryFile(
-            mode='w', suffix='.txt', delete=False)
-        self.changed_file.write(
-            'fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/FDBRecordStore.java\n'
-            'build.gradle\n'
-            'README.md\n'
-        )
-        self.changed_file.close()
+        self.diff_file = tempfile.NamedTemporaryFile(
+            mode='w', suffix='.patch', delete=False)
+        self.diff_file.write(SAMPLE_DIFF)
+        self.diff_file.close()
 
     def tearDown(self):
         os.unlink(self.xml_file.name)
-        os.unlink(self.changed_file.name)
+        os.unlink(self.diff_file.name)
 
     def test_main_runs_without_error(self):
         from io import StringIO
@@ -421,11 +447,13 @@ class TestEndToEnd(unittest.TestCase):
         with patch('sys.stdout', new_callable=StringIO) as mock_out:
             from coverage_annotations import main
             main(['--report', self.xml_file.name,
-                  '--changed-files', self.changed_file.name])
+                  '--diff', self.diff_file.name])
 
         output = mock_out.getvalue()
-        self.assertIn('::warning', output)
+        self.assertIn('::notice', output)
         self.assertIn('FDBRecordStore.java', output)
+        self.assertIn('File coverage:', output)
+        self.assertIn('Changed lines:', output)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This introduces a new mechanism to our pull request builds to add annotations to the diff indicating the coverage of the changed file.
You can see an example of this in: https://github.com/FoundationDB/fdb-record-layer/pull/4147 OR #4164 (same changes but at different points in the history)

 To each modified java file, it adds an annotation above the first changed line indicating the total coverage for that file, and the coverage of the modified lines.
We already have teamscale validating that no methods are completely uncovered, but hopefully this will provide some additional information that could expose situations where a code change is under-covered. Further information would need to be gathered by looking at the report directly.

Note: We currently also use https://github.com/Madrapps/jacoco-report which adds similar information to the build, but, we never got the commenting back to the PR to work, and it runs on Node 20, which is no longer going to be supported. This PR does not remove that dependency, but that will probably come later.