### PR TITLE
Make `PullUpNullOnEmptyRule` duplicate the Select predicates correctly

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PullUpNullOnEmptyRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PullUpNullOnEmptyRule.java
@@ -38,18 +38,17 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
 
 /**
  * A rewrite rule that splits a {@link SelectExpression} expression that ranges over a child with a {@link Quantifier}
- * that has {@code null-on-empty} semantics into two parts:
+ * that has null-on-empty semantics into two parts:
  * <ol>
- *     <li> a lower {@link SelectExpression} expression that ranges over the old child with a normal {@link Quantifier},
- *     i.e. one without {@code null-on-empty} semantics.
- *     <li> an upper {@link SelectExpression} expression that ranges over the lower the {@link SelectExpression} with a
- *     {@link Quantifier} that has {@code null-on-empty} semantics, and the same set of predicates as contained by the
- *     lower {@link SelectExpression}.
+ *     <li>A lower {@code SelectExpression} that ranges over the old child with a normal quantifier, i.e., one without
+ *     null-on-empty semantics.
+ *     <li>An upper {@code SelectExpression} that ranges over the lower select with a quantifier that has null-on-empty
+ *     semantics, and the same set of predicates as the lower select.
  * </ol>
- * The purpose of this rewrite rule is to create a variation that has a better chance of matching an index (since the lower
- * {@link SelectExpression} has a normal {@link Quantifier}), the purpose of the upper {@link SelectExpression} is to reapply
- * the predicates on top of its {@link Quantifier} with {@code null-on-empty} giving them a chance of acting on any {@code null}s
- * produced by this quantifier, which guarantees semantic equivalency.
+ * The purpose of this rewrite rule is to create a variation that has a better chance of matching an index, since the
+ * lower select has a normal quantifier. The purpose of the upper select is to reapply the predicates on top of its
+ * quantifier with null-on-empty, giving them a chance of acting on any {@code null}s produced by this quantifier,
+ * which guarantees semantic equivalency.
  */
 public class PullUpNullOnEmptyRule extends ExplorationCascadesRule<SelectExpression> {
 
@@ -95,10 +94,13 @@ public class PullUpNullOnEmptyRule extends ExplorationCascadesRule<SelectExpress
                 .addAllPredicates(selectExpression.getPredicates())
                 .build().buildSimpleSelectOverQuantifier(newChildrenQuantifier));
 
-        // Create the upper select expression.
+        // Create the upper select expression. The predicates are duplicated on top of the null-on-empty quantifier
+        // (as well as pushed down into the lower `SelectExpression`), so that predicates that filter out the null
+        // rows produced by `null-on-empty` are still applied correctly.
         final var topLevelSelectQuantifier = Quantifier.forEachBuilder().from(quantifier).build(newSelectExpression);
         final var topLevelSelectExpression = GraphExpansion.builder()
                 .addQuantifier(topLevelSelectQuantifier)
+                .addAllPredicates(selectExpression.getPredicates())
                 .build().buildSelectWithResultValue(selectExpression.getResultValue());
 
         call.yieldExploratoryExpression(topLevelSelectExpression);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/rules/PullUpNullOnEmptyRuleTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/rules/PullUpNullOnEmptyRuleTest.java
@@ -1,0 +1,103 @@
+/*
+ * PullUpNullOnEmptyRuleTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.cascades.rules;
+
+import com.apple.foundationdb.record.query.plan.cascades.GraphExpansion;
+import com.apple.foundationdb.record.query.plan.cascades.PlannerPhase;
+import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
+import com.apple.foundationdb.record.query.plan.cascades.Reference;
+import com.apple.foundationdb.record.query.plan.cascades.RuleTestHelper;
+import com.apple.foundationdb.record.query.plan.cascades.debug.Debugger;
+import com.apple.foundationdb.record.query.plan.cascades.debug.DebuggerWithSymbolTables;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.SelectExpression;
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+
+import static com.apple.foundationdb.record.provider.foundationdb.query.FDBQueryGraphTestHelpers.fieldPredicate;
+import static com.apple.foundationdb.record.provider.foundationdb.query.FDBQueryGraphTestHelpers.forEachWithNullOnEmpty;
+import static com.apple.foundationdb.record.provider.foundationdb.query.FDBQueryGraphTestHelpers.selectWithPredicates;
+import static com.apple.foundationdb.record.query.plan.cascades.RuleTestHelper.EQUALS_42;
+import static com.apple.foundationdb.record.query.plan.cascades.RuleTestHelper.GREATER_THAN_HELLO;
+import static com.apple.foundationdb.record.query.plan.cascades.RuleTestHelper.baseT;
+
+/**
+ * Tests of the {@link PullUpNullOnEmptyRule}.
+ */
+class PullUpNullOnEmptyRuleTest {
+    @Nonnull
+    private static final RuleTestHelper testHelper = new RuleTestHelper(new PullUpNullOnEmptyRule(), PlannerPhase.PLANNING);
+
+    @BeforeEach
+    void setUp() {
+        Debugger.setDebugger(DebuggerWithSymbolTables.withSanityChecks());
+        Debugger.setup();
+    }
+
+    /**
+     * Tests the rule against the following (pseudo) query:
+     * <pre>{@code
+     * SELECT b, c FROM (SELECT a, b, c FROM T WHERE b > 'hello') OR ELSE NULL WHERE a = 42
+     * }</pre>
+     * <p>The rule splits the outer select into a lower select (over a normal quantifier) and an upper select (over the
+     * null-on-empty quantifier). After the rewrite, the predicate {@code a = 42} must be attached to both the lower
+     * select and the upper select.
+     */
+    @Test
+    void pullUpReappliesPredicatesAboveNullOnEmpty() {
+        final Quantifier baseQun = baseT();
+        final SelectExpression innerSelect = selectWithPredicates(baseQun,
+                ImmutableList.of("a", "b", "c"),
+                fieldPredicate(baseQun, "b", GREATER_THAN_HELLO));
+        final Quantifier noeQun = forEachWithNullOnEmpty(innerSelect);
+        final SelectExpression outer = selectWithPredicates(noeQun,
+                ImmutableList.of("b", "c"),
+                fieldPredicate(noeQun, "a", EQUALS_42));
+
+        // Build the expected pulled-up structure. The lower select has a normal ForEach that re-uses the alias of the
+        // original null-on-empty quantifier (so that the predicate, which references that alias, continues to resolve).
+        // The upper select has a null-on-empty quantifier (cloned from the original) and *also* carries the predicate.
+        final Quantifier baseQun2 = baseT();
+        final SelectExpression innerSelect2 = selectWithPredicates(baseQun2,
+                ImmutableList.of("a", "b", "c"),
+                fieldPredicate(baseQun2, "b", GREATER_THAN_HELLO));
+        final Quantifier.ForEach expectedLowerQun = Quantifier.forEachBuilder()
+                .withAlias(noeQun.getAlias())
+                .build(Reference.initialOf(innerSelect2));
+        final SelectExpression expectedLower = GraphExpansion.builder()
+                .addQuantifier(expectedLowerQun)
+                .addPredicate(fieldPredicate(expectedLowerQun, "a", EQUALS_42))
+                .build()
+                .buildSimpleSelectOverQuantifier(expectedLowerQun);
+        final Quantifier.ForEach expectedTopQun = Quantifier.forEachBuilder()
+                .from((Quantifier.ForEach)noeQun)
+                .build(Reference.initialOf(expectedLower));
+        final SelectExpression expectedTop = GraphExpansion.builder()
+                .addQuantifier(expectedTopQun)
+                .addPredicate(fieldPredicate(expectedTopQun, "a", EQUALS_42))
+                .build()
+                .buildSelectWithResultValue(outer.getResultValue());
+
+        testHelper.assertYields(outer, expectedTop);
+    }
+}


### PR DESCRIPTION
`PullUpNullOnEmptyRule` splits a `SelectExpression` featuring a null-on-empty quantifier into two selects. However, it assigns the predicates only to the lower select. To be correct, it needs to apply them to the upper `SelectExpression` as well (“to act on any nulls produced by this quantifier”, as the Javadoc comment on the rule already says). Without this bugfix, WHERE predicates may get incorrectly pushed past the null-on-empty boundary.

Testing:
* Introduce `PullUpNullOnEmptyRuleTest` and add a regression test.

Fixes #4148.