### PR TITLE
Revert "Disallow CREATE INDEX on ARRAY fields with implicit fan-out (#4104)"

### DIFF
--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/ddl/MaterializedViewIndexGenerator.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/ddl/MaterializedViewIndexGenerator.java
@@ -570,7 +570,7 @@ public final class MaterializedViewIndexGenerator {
         final var exprConstituents = childrenMap.entrySet().stream().map(nodeEntry -> {
             final FieldValue.ResolvedAccessor accessor = nodeEntry.getKey();
             final FieldValueTrieNode node = nodeEntry.getValue();
-            final KeyExpression expr = toFieldKeyExpression(accessor);
+            final KeyExpression expr = toFieldKeyExpression(accessor.getField());
             if (node.getChildrenMap() != null) {
                 final FieldKeyExpression fieldExpr = Assert.castUnchecked(expr, FieldKeyExpression.class);
                 return fieldExpr.nest(toKeyExpression(node, orderingFunctions));
@@ -756,8 +756,8 @@ public final class MaterializedViewIndexGenerator {
     @Nonnull
     private KeyExpression toKeyExpression(@Nonnull Iterator<FieldValue.ResolvedAccessor> resolvedAccessors) {
         Assert.thatUnchecked(resolvedAccessors.hasNext(), "cannot resolve empty list");
-        final FieldValue.ResolvedAccessor accessor = resolvedAccessors.next();
-        final KeyExpression expression = toFieldKeyExpression(accessor);
+        final Type.Record.Field field = resolvedAccessors.next().getField();
+        final KeyExpression expression = toFieldKeyExpression(field);
         if (resolvedAccessors.hasNext()) {
             KeyExpression childExpression = toKeyExpression(resolvedAccessors);
             final FieldKeyExpression fieldExpression = Assert.castUnchecked(expression, FieldKeyExpression.class);
@@ -780,13 +780,8 @@ public final class MaterializedViewIndexGenerator {
     }
 
     @Nonnull
-    private static KeyExpression toFieldKeyExpression(@Nonnull FieldValue.ResolvedAccessor accessor) {
-        final Type.Record.Field fieldType = accessor.getField();
+    private static KeyExpression toFieldKeyExpression(@Nonnull Type.Record.Field fieldType) {
         Assert.notNullUnchecked(fieldType.getFieldStorageName());
-        Assert.thatUnchecked(!fieldType.getFieldType().isArray() || (accessor instanceof AnnotatedAccessor),
-                ErrorCode.UNSUPPORTED_OPERATION,
-                "Unsupported index definition, cannot create index on array field '" +
-                fieldType.getFieldName() + "' without unnesting");
         final var fanType = fieldType.getFieldType().getTypeCode() == Type.TypeCode.ARRAY ?
                 KeyExpression.FanType.FanOut :
                 KeyExpression.FanType.None;

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/api/ddl/IndexTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/api/ddl/IndexTest.java
@@ -1185,23 +1185,6 @@ public class IndexTest {
     }
 
     @Test
-    void createIndexOnArrayFieldWithoutUnnestingIsDisallowed() throws Exception {
-        final String stmt = "CREATE SCHEMA TEMPLATE test_template " +
-                "CREATE TABLE T (p BIGINT, items STRING ARRAY, PRIMARY KEY (p))" +
-                "CREATE INDEX MV1 AS SELECT items FROM T";
-        shouldFailWith(stmt, ErrorCode.UNSUPPORTED_OPERATION, "cannot create index on array field");
-    }
-
-    @Test
-    void createIndexNavigatingThroughArrayWithoutUnnestingIsDisallowed() throws Exception {
-        final String stmt = "CREATE SCHEMA TEMPLATE test_template " +
-                "CREATE TYPE AS STRUCT A(x BIGINT) " +
-                "CREATE TABLE T (p BIGINT, a A ARRAY, PRIMARY KEY (p))" +
-                "CREATE INDEX MV1 AS SELECT a.x FROM T";
-        shouldFailWith(stmt, ErrorCode.UNDEFINED_COLUMN, "A.X");
-    }
-
-    @Test
     void createIndexWithOrderByMixedDirection() throws Exception {
         final String stmt = "CREATE SCHEMA TEMPLATE test_template " +
                 "CREATE TABLE T1(col1 bigint, col2 bigint, col3 bigint, primary key(col1)) " +

--- a/yaml-tests/src/test/resources/in-predicate.yamsql
+++ b/yaml-tests/src/test/resources/in-predicate.yamsql
@@ -23,7 +23,7 @@ schema_template:
     create table ta(a bigint, b bigint, c double, d boolean, e string, f ts, primary key(a))
     create index f1 as select f.sa, f.sb from ta order by f.sa, f.sb
     create table array_table(id bigint, fruits string array, numbers bigint array, fruit_records fruit_type array, primary key(id))
-    create index fruits as select "fruit" from array_table as t, t.fruits as "fruit"
+    create index fruits as select fruits from array_table
 ---
 setup:
   steps:

--- a/yaml-tests/src/test/resources/valid-identifiers.yamsql
+++ b/yaml-tests/src/test/resources/valid-identifiers.yamsql
@@ -34,8 +34,8 @@ schema_template:
     create index "foo.table$nested.repeated.idx.field.1.1.1" as select "nested$level2"."level2$array.field.1"            from "foo.table$nested.repeated" as "level0$t", "level0$t"."level0.field1" AS "nested$level1", "nested$level1"."level1$field.1" AS "nested$level2"
 
     create table "foo.table$repeated" (id bigint, "field.0$array" bigint array, "field.1$array" string array, primary key (id))
-    create index "foo.table$repeated.1" as select "e" from "foo.table$repeated" AS t, t."field.0$array" as "e"
-    create index "foo.table$repeated.2" as select "e" from "foo.table$repeated" AS t, t."field.1$array" as "e"
+    create index "foo.table$repeated.1" as select t."field.0$array" from "foo.table$repeated" AS t
+    create index "foo.table$repeated.2" as select t."field.1$array" from "foo.table$repeated" AS t
 
     create type as struct "foo.struct"(S1 bigint, S2 bigint)
     create table "foo.tableA"("foo.tableA.A1" bigint, "foo.tableA.A2" bigint, "foo.tableA.A3" bigint, primary key("foo.tableA.A1"))

--- a/yaml-tests/src/test/resources/versions-tests.yamsql
+++ b/yaml-tests/src/test/resources/versions-tests.yamsql
@@ -34,9 +34,9 @@ schema_template:
 
     create table t4(id bigint, col1 string, col2 bigint, col3 bigint, col4 bigint array, primary key (id))
     create index t4_col2 as select col2 from t4
-    create index t4_col2_col4 as select t.col2, "e" from t4 as t, t.col4 as "e" order by t.col2, "e"
+    create index t4_col2_col4 as select col2, col4 from t4 order by col2, col4
     create index t4_col3_version as select col3, "__ROW_VERSION" from t4 order by col3, "__ROW_VERSION"
-    create index t4_col4_version as select "e", "__ROW_VERSION" from t4 as t, t.col4 as "e" order by "e", "__ROW_VERSION"
+    create index t4_col4_version as select col4, "__ROW_VERSION" from t4 order by col4, "__ROW_VERSION"
 
     create function t1_v(in x bigint) as select "__ROW_VERSION", id, col1, col2 from t1 where col1 = x
     create function t2_v(in x bigint) as select "__ROW_VERSION", id, col1, col2 from t2 where col1 = x


### PR DESCRIPTION
Revert PR #4104. Since the new syntax used in the tests was introduced only recently with PR #4106, its usage causes nightly tests to fail against versions older than 4.12.1.0.

This reverts commit 655e989e382fe045ba2f67fd9e2ae56091ed6efe.