### PR TITLE
Support per-version variants to `schema_template` in .yamsql tests

### DIFF
--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/CustomYamlConstructor.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/CustomYamlConstructor.java
@@ -58,6 +58,7 @@ public class CustomYamlConstructor extends SafeConstructor {
         requireLineNumber.add(PreambleBlock.OPTIONS);
         requireLineNumber.add(SetupBlock.SETUP_BLOCK);
         requireLineNumber.add(SetupBlock.SchemaTemplateBlock.SCHEMA_TEMPLATE_BLOCK);
+        requireLineNumber.add(SetupBlock.SchemaTemplateBlock.SCHEMA_TEMPLATE_VARIANT_DEFINITION);
         requireLineNumber.add(TransactionSetupsBlock.TRANSACTION_SETUP);
         requireLineNumber.add(TestBlock.TEST_BLOCK);
         requireLineNumber.add(IncludeBlock.INCLUDE);

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/Block.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/Block.java
@@ -41,10 +41,10 @@ import java.util.List;
  *   <tr><td>{@code schema_template}</td><td>{@link SetupBlock} (SchemaTemplateBlock)</td>
  *       <td>Declarative schema creation from DDL statements. The framework creates a temporary database and schema
  *       automatically, and cleans them up after all blocks execute. Referenced by 1-based index in
- *       {@code connect}. The value can also be a list of multiple {@code schema_template} sub-entries each gated by
- *       {@code initialVersionAtLeast} or {@code initialVersionLessThan}. In that case the variant whose version range
- *       contains the initial version of the catalog connection is the one whose DDL is executed, and the defined
- *       ranges must comprehensively cover {@code [MIN, MAX)}.</td></tr>
+ *       {@code connect}. The value can also be a list of any number of variants, each holding a {@code definition}
+ *       body and gated by {@code initialVersionAtLeast} or {@code initialVersionLessThan} (or both). In that case the
+ *       variant whose version range contains the initial version of the catalog connection is the one whose DDL is
+ *       executed. The variants must be mutually exclusive and must comprehensively cover all possible versions.</td></tr>
  *   <tr><td>{@code setup}</td><td>{@link SetupBlock} (ManualSetupBlock)</td>
  *       <td>Arbitrary SQL steps for environment setup/teardown. Supports {@code connect} (integer index, {@code 0}
  *       for catalog, or full JDBC URI) and {@code steps} (list of queries).</td></tr>

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/Block.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/Block.java
@@ -41,7 +41,10 @@ import java.util.List;
  *   <tr><td>{@code schema_template}</td><td>{@link SetupBlock} (SchemaTemplateBlock)</td>
  *       <td>Declarative schema creation from DDL statements. The framework creates a temporary database and schema
  *       automatically, and cleans them up after all blocks execute. Referenced by 1-based index in
- *       {@code connect}.</td></tr>
+ *       {@code connect}. The value can also be a list of multiple {@code schema_template} sub-entries each gated by
+ *       {@code initialVersionAtLeast} or {@code initialVersionLessThan}. In that case the variant whose version range
+ *       contains the initial version of the catalog connection is the one whose DDL is executed, and the defined
+ *       ranges must comprehensively cover {@code [MIN, MAX)}.</td></tr>
  *   <tr><td>{@code setup}</td><td>{@link SetupBlock} (ManualSetupBlock)</td>
  *       <td>Arbitrary SQL steps for environment setup/teardown. Supports {@code connect} (integer index, {@code 0}
  *       for catalog, or full JDBC URI) and {@code steps} (list of queries).</td></tr>

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/SetupBlock.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/SetupBlock.java
@@ -29,8 +29,12 @@ import com.apple.foundationdb.relational.yamltests.YamlConnection;
 import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
 import com.apple.foundationdb.relational.yamltests.command.Command;
 import com.apple.foundationdb.relational.yamltests.command.QueryCommand;
+import com.apple.foundationdb.relational.yamltests.server.SemanticVersion;
+import com.apple.foundationdb.relational.yamltests.server.SemanticVersionRanges;
 
 import com.apple.foundationdb.relational.yamltests.ConnectionTarget;
+
+import com.google.common.collect.Range;
 
 import javax.annotation.Nonnull;
 import java.sql.SQLException;
@@ -39,8 +43,10 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 /**
  * Implementation of block that serves the purpose of creating the 'environment' needed to run the {@link TestBlock}
@@ -129,31 +135,136 @@ public class SetupBlock extends ConnectedBlock {
 
         static final String DOMAIN = "/FRL";
         public static final String SCHEMA_TEMPLATE_BLOCK = "schema_template";
+        public static final String INITIAL_VERSION_AT_LEAST = "initialVersionAtLeast";
+        public static final String INITIAL_VERSION_LESS_THAN = "initialVersionLessThan";
 
         @Nonnull
         private List<Block> finalizingBlocks;
 
+
+        /**
+         * A {@code schema_template} variant specified in the .yamsql file.
+         *
+         * @param range  the semantic version range associated with this variant
+         * @param createSchemaTemplateSql  the {@code CREATE SCHEMA TEMPLATE} body
+         */
+        private record Variant(@Nonnull Range<SemanticVersion> range, @Nonnull String createSchemaTemplateSql) {
+        }
+
+        /**
+         * A resolved {@link Variant} holding the {@link QueryCommand} to execute.
+         */
+        private record VariantCommands(@Nonnull Range<SemanticVersion> range, @Nonnull QueryCommand command) {
+        }
+
         public static List<Block> parse(@Nonnull final YamlReference reference, @Nonnull Object document, @Nonnull YamlExecutionContext executionContext) {
             try {
-                final var identifier = "YAML_" + UUID.randomUUID().toString().toUpperCase(Locale.ROOT).replace("-", "").substring(0, 16);
-                final var schemaTemplateName = identifier + "_TEMPLATE";
-                final var databasePath = DOMAIN + "/" + identifier + "_DB";
-                final var schemaName = identifier + "_SCHEMA";
-                final var steps = new ArrayList<String>();
-                steps.add("DROP SCHEMA TEMPLATE IF EXISTS " + schemaTemplateName);
-                steps.add("CREATE SCHEMA TEMPLATE " + schemaTemplateName + " " + Matchers.string(document, "schema template description"));
-                steps.add("DROP DATABASE IF EXISTS " + databasePath);
-                steps.add("CREATE DATABASE " + databasePath);
-                steps.add("CREATE SCHEMA " + databasePath + "/" + schemaName + " WITH TEMPLATE " + schemaTemplateName);
-                final var executables = new ArrayList<Consumer<YamlConnection>>();
-                for (final var step : steps) {
-                    final var resolvedCommand = QueryCommand.withQueryString(reference, step, executionContext);
-                    executables.add(resolvedCommand::execute);
-                }
+                final String identifier = "YAML_" + UUID.randomUUID().toString().toUpperCase(Locale.ROOT).replace("-", "").substring(0, 16);
+                final String schemaTemplateName = identifier + "_TEMPLATE";
+                final String databasePath = DOMAIN + "/" + identifier + "_DB";
+                final String schemaName = identifier + "_SCHEMA";
+
+                final List<Consumer<YamlConnection>> executables = new ArrayList<>();
+
+                // Pre-steps: Wipe anything left over from a prior run.
+                executables.add(asExecutable("DROP SCHEMA TEMPLATE IF EXISTS " + schemaTemplateName, reference, executionContext));
+                executables.add(asExecutable("DROP DATABASE IF EXISTS " + databasePath, reference, executionContext));
+
+                // Parse the list of variants, depending on which `schema_template` syntax is used.
+                final List<Variant> variants = (document instanceof List)
+                                               ? parseVariantList(document, reference, schemaTemplateName)
+                                               : parseSingleVariant(document, schemaTemplateName);
+
+                // Build the main CREATE SCHEMA TEMPLATE step. This is a special executable that inspects the initial
+                // version of the connection at execution time and chooses the matching CREATE SCHEMA TEMPLATE to run.
+                final List<VariantCommands> variantCommands = variants.stream()
+                        .map(variant -> new VariantCommands(variant.range,
+                                QueryCommand.withQueryString(reference, variant.createSchemaTemplateSql, executionContext)))
+                        .toList();
+                executables.add(connection -> {
+                    final SemanticVersion initialVersion = connection.getInitialVersion();
+                    final VariantCommands chosen = variantCommands.stream()
+                            .filter(v -> v.range.contains(initialVersion))
+                            .findFirst()
+                            .orElseThrow(() -> new IllegalStateException(
+                                    "No schema_template variant matches initial version " + initialVersion + " at " + reference));
+                    chosen.command.execute(connection);
+                });
+
+                // Post-steps: Create the database and the schema based on the chosen template.
+                executables.add(asExecutable("CREATE DATABASE " + databasePath, reference, executionContext));
+                executables.add(asExecutable("CREATE SCHEMA " + databasePath + "/" + schemaName + " WITH TEMPLATE " + schemaTemplateName, reference, executionContext));
+
                 executionContext.registerConnectionURI(reference.getResource(), "jdbc:embed:" + databasePath + "?schema=" + schemaName);
                 return List.of(new SchemaTemplateBlock(reference, schemaTemplateName, databasePath, executables, executionContext));
             } catch (Exception e) {
                 throw YamlExecutionContext.wrapContext(e, () -> "‼️ Error parsing the schema_template block at " + reference, SCHEMA_TEMPLATE_BLOCK, reference);
+            }
+        }
+
+        @Nonnull
+        private static Consumer<YamlConnection> asExecutable(@Nonnull String step, @Nonnull YamlReference reference,
+                                                             @Nonnull YamlExecutionContext executionContext) {
+            return QueryCommand.withQueryString(reference, step, executionContext)::execute;
+        }
+
+        @Nonnull
+        private static String buildCreateSchemaTemplateSql(final String schemaTemplateName, final String body) {
+            return "CREATE SCHEMA TEMPLATE " + schemaTemplateName + " " + body;
+        }
+
+        @Nonnull
+        private static List<Variant> parseSingleVariant(@Nonnull Object document, @Nonnull String schemaTemplateName) {
+            final String body = Matchers.string(document, "schema template description");
+            return List.of(new Variant(SemanticVersionRanges.all(),
+                    buildCreateSchemaTemplateSql(schemaTemplateName, body)));
+        }
+
+        @Nonnull
+        private static List<Variant> parseVariantList(@Nonnull Object document, @Nonnull YamlReference reference, @Nonnull String schemaTemplateName) {
+            final List<?> rawVariants = Matchers.arrayList(document, "schema_template variants");
+            Assert.thatUnchecked(!rawVariants.isEmpty(), "schema_template list form must declare at least one variant");
+            final List<Variant> parsed = new ArrayList<>(rawVariants.size());
+            for (final Object raw : rawVariants) {
+                final Map<?, ?> variantMap = CustomYamlConstructor.LinedObject.unlineKeys(Matchers.map(raw, "schema_template variant"));
+                final Object templateObj = variantMap.get(SCHEMA_TEMPLATE_BLOCK);
+                Assert.thatUnchecked(templateObj != null, "schema_template variant requires a '" + SCHEMA_TEMPLATE_BLOCK + "' key");
+                final String template = Matchers.string(templateObj, "schema_template variant template");
+                final Range<SemanticVersion> range = parseVariantRange(variantMap);
+                parsed.add(new Variant(range, buildCreateSchemaTemplateSql(schemaTemplateName, template)));
+            }
+            validateVariantCoverage(parsed, reference);
+            return parsed;
+        }
+
+        @Nonnull
+        private static Range<SemanticVersion> parseVariantRange(@Nonnull Map<?, ?> variantMap) {
+            final boolean hasAtLeast = variantMap.containsKey(INITIAL_VERSION_AT_LEAST);
+            final boolean hasLessThan = variantMap.containsKey(INITIAL_VERSION_LESS_THAN);
+            if (!hasAtLeast && !hasLessThan) {
+                return SemanticVersionRanges.all();
+            }
+            SemanticVersion lowerBound = SemanticVersion.min();
+            SemanticVersion upperBound = SemanticVersion.max();
+            if (hasAtLeast) {
+                lowerBound = PreambleBlock.parseVersion(variantMap.get(INITIAL_VERSION_AT_LEAST));
+            }
+            if (hasLessThan) {
+                upperBound = PreambleBlock.parseVersion(variantMap.get(INITIAL_VERSION_LESS_THAN));
+            }
+            Assert.thatUnchecked(lowerBound.compareTo(upperBound) < 0,
+                    "schema_template_by_version variant has empty version range [" + lowerBound + ", " + upperBound + ")");
+            return Range.closedOpen(lowerBound, upperBound);
+        }
+
+        private static void validateVariantCoverage(@Nonnull List<Variant> variants, @Nonnull YamlReference reference) {
+            final Set<Range<SemanticVersion>> uncovered = SemanticVersionRanges.uncovered(
+                    variants.stream().map(Variant::range).collect(Collectors.toList()));
+            if (!uncovered.isEmpty()) {
+                final IllegalArgumentException e = new IllegalArgumentException(
+                        "schema_template variants do not cover the complete set of versions; missing: " + uncovered);
+                throw YamlExecutionContext.wrapContext(e,
+                        () -> "‼️ Non-comprehensive schema_template variants at " + reference, SCHEMA_TEMPLATE_BLOCK, reference);
             }
         }
 

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/SetupBlock.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/SetupBlock.java
@@ -135,6 +135,7 @@ public class SetupBlock extends ConnectedBlock {
 
         static final String DOMAIN = "/FRL";
         public static final String SCHEMA_TEMPLATE_BLOCK = "schema_template";
+        public static final String SCHEMA_TEMPLATE_VARIANT_DEFINITION = "definition";
         public static final String INITIAL_VERSION_AT_LEAST = "initialVersionAtLeast";
         public static final String INITIAL_VERSION_LESS_THAN = "initialVersionLessThan";
 
@@ -145,10 +146,13 @@ public class SetupBlock extends ConnectedBlock {
         /**
          * A {@code schema_template} variant specified in the .yamsql file.
          *
+         * @param reference  the location of this variant in the source .yamsql file
          * @param range  the semantic version range associated with this variant
-         * @param createSchemaTemplateSql  the {@code CREATE SCHEMA TEMPLATE} body
+         * @param createSchemaTemplateSql  the {@code CREATE SCHEMA TEMPLATE} statement built from the variant’s
+         *                                 {@code definition} body
          */
-        private record Variant(@Nonnull Range<SemanticVersion> range, @Nonnull String createSchemaTemplateSql) {
+        private record Variant(@Nonnull YamlReference reference, @Nonnull Range<SemanticVersion> range,
+                               @Nonnull String createSchemaTemplateSql) {
         }
 
         /**
@@ -173,13 +177,13 @@ public class SetupBlock extends ConnectedBlock {
                 // Parse the list of variants, depending on which `schema_template` syntax is used.
                 final List<Variant> variants = (document instanceof List)
                                                ? parseVariantList(document, reference, schemaTemplateName)
-                                               : parseSingleVariant(document, schemaTemplateName);
+                                               : parseSingleVariant(document, reference, schemaTemplateName);
 
                 // Build the main CREATE SCHEMA TEMPLATE step. This is a special executable that inspects the initial
                 // version of the connection at execution time and chooses the matching CREATE SCHEMA TEMPLATE to run.
                 final List<VariantCommands> variantCommands = variants.stream()
                         .map(variant -> new VariantCommands(variant.range,
-                                QueryCommand.withQueryString(reference, variant.createSchemaTemplateSql, executionContext)))
+                                QueryCommand.withQueryString(variant.reference, variant.createSchemaTemplateSql, executionContext)))
                         .toList();
                 executables.add(connection -> {
                     final SemanticVersion initialVersion = connection.getInitialVersion();
@@ -214,9 +218,10 @@ public class SetupBlock extends ConnectedBlock {
         }
 
         @Nonnull
-        private static List<Variant> parseSingleVariant(@Nonnull Object document, @Nonnull String schemaTemplateName) {
+        private static List<Variant> parseSingleVariant(@Nonnull Object document, @Nonnull YamlReference reference,
+                                                        @Nonnull String schemaTemplateName) {
             final String body = Matchers.string(document, "schema template description");
-            return List.of(new Variant(SemanticVersionRanges.all(),
+            return List.of(new Variant(reference, SemanticVersionRanges.all(),
                     buildCreateSchemaTemplateSql(schemaTemplateName, body)));
         }
 
@@ -226,15 +231,25 @@ public class SetupBlock extends ConnectedBlock {
             Assert.thatUnchecked(!rawVariants.isEmpty(), "schema_template list form must declare at least one variant");
             final List<Variant> parsed = new ArrayList<>(rawVariants.size());
             for (final Object raw : rawVariants) {
-                final Map<?, ?> variantMap = CustomYamlConstructor.LinedObject.unlineKeys(Matchers.map(raw, "schema_template variant"));
-                final Object templateObj = variantMap.get(SCHEMA_TEMPLATE_BLOCK);
-                Assert.thatUnchecked(templateObj != null, "schema_template variant requires a '" + SCHEMA_TEMPLATE_BLOCK + "' key");
-                final String template = Matchers.string(templateObj, "schema_template variant template");
+                final Map<?, ?> rawVariantMap = Matchers.map(raw, "schema_template variant");
+                final YamlReference variantReference = reference.getResource().withLineNumber(extractVariantLineNumber(rawVariantMap, reference));
+                final Map<?, ?> variantMap = CustomYamlConstructor.LinedObject.unlineKeys(rawVariantMap);
+                final Object definitionObj = variantMap.get(SCHEMA_TEMPLATE_VARIANT_DEFINITION);
+                Assert.thatUnchecked(definitionObj != null, "schema_template variant requires a '" + SCHEMA_TEMPLATE_VARIANT_DEFINITION + "' key");
+                final String definition = Matchers.string(definitionObj, "schema_template variant definition");
                 final Range<SemanticVersion> range = parseVariantRange(variantMap);
-                parsed.add(new Variant(range, buildCreateSchemaTemplateSql(schemaTemplateName, template)));
+                parsed.add(new Variant(variantReference, range, buildCreateSchemaTemplateSql(schemaTemplateName, definition)));
             }
-            validateVariantCoverage(parsed, reference);
+            validateVariants(parsed, reference);
             return parsed;
+        }
+
+        private static int extractVariantLineNumber(@Nonnull Map<?, ?> rawVariantMap, @Nonnull YamlReference outerReference) {
+            return rawVariantMap.keySet().stream()
+                    .filter(CustomYamlConstructor.LinedObject.class::isInstance)
+                    .mapToInt(k -> ((CustomYamlConstructor.LinedObject) k).getLineNumber())
+                    .min()
+                    .orElse(outerReference.getLineNumber());
         }
 
         @Nonnull
@@ -257,9 +272,20 @@ public class SetupBlock extends ConnectedBlock {
             return Range.closedOpen(lowerBound, upperBound);
         }
 
-        private static void validateVariantCoverage(@Nonnull List<Variant> variants, @Nonnull YamlReference reference) {
-            final Set<Range<SemanticVersion>> uncovered = SemanticVersionRanges.uncovered(
-                    variants.stream().map(Variant::range).collect(Collectors.toList()));
+        private static void validateVariants(@Nonnull List<Variant> variants, @Nonnull YamlReference reference) {
+            final List<Range<SemanticVersion>> ranges = variants.stream().map(Variant::range).collect(Collectors.toList());
+
+            // Check for overlapping ranges.
+            final Set<Range<SemanticVersion>> overlapping = SemanticVersionRanges.overlapping(ranges);
+            if (!overlapping.isEmpty()) {
+                final IllegalArgumentException e = new IllegalArgumentException(
+                        "schema_template variants have overlapping version ranges: " + overlapping);
+                throw YamlExecutionContext.wrapContext(e,
+                        () -> "‼️ Overlapping schema_template variants at " + reference, SCHEMA_TEMPLATE_BLOCK, reference);
+            }
+
+            // Check for uncovered ranges.
+            final Set<Range<SemanticVersion>> uncovered = SemanticVersionRanges.uncovered(ranges);
             if (!uncovered.isEmpty()) {
                 final IllegalArgumentException e = new IllegalArgumentException(
                         "schema_template variants do not cover the complete set of versions; missing: " + uncovered);

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryConfig.java
@@ -32,12 +32,11 @@ import com.apple.foundationdb.relational.yamltests.block.PreambleBlock;
 import com.apple.foundationdb.relational.yamltests.command.queryconfigs.CheckExplainConfig;
 import com.apple.foundationdb.relational.yamltests.command.queryconfigs.CheckResultMetadataConfig;
 import com.apple.foundationdb.relational.yamltests.server.SemanticVersion;
+import com.apple.foundationdb.relational.yamltests.server.SemanticVersionRanges;
 import com.apple.foundationdb.relational.yamltests.server.SupportedVersionCheck;
 import com.apple.foundationdb.tuple.ByteArrayUtil2;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Range;
-import com.google.common.collect.RangeSet;
-import com.google.common.collect.TreeRangeSet;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
@@ -50,6 +49,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.apple.foundationdb.relational.yamltests.command.QueryCommand.reportTestFailure;
 
@@ -513,15 +513,12 @@ public abstract class QueryConfig {
         // Validate that the results check each version comprehensively by making sure the set of
         // covered ranges spans the range [MIN_VERSION, MAX_VERSION)
         if (configs.stream().anyMatch(config -> config instanceof QueryConfig.InitialVersionCheckConfig)) {
-            // Creating an interval set including each covered range
-            RangeSet<SemanticVersion> rangeSet = TreeRangeSet.create();
-            configs.stream().filter(config -> config instanceof QueryConfig.InitialVersionCheckConfig)
-                    .map(config -> (QueryConfig.InitialVersionCheckConfig)config)
-                    .forEach(config -> rangeSet.add(Range.closedOpen(config.getMinVersion(), config.getMaxVersion())));
-            // Get the set of uncovered ranges that span over [MIN_VERSION, MAX_VERSION)
-            Set<Range<SemanticVersion>> uncovered = rangeSet.complement()
-                    .subRangeSet(Range.closedOpen(SemanticVersion.min(), SemanticVersion.max()))
-                    .asRanges();
+            List<Range<SemanticVersion>> ranges = configs.stream()
+                    .filter(config -> config instanceof QueryConfig.InitialVersionCheckConfig)
+                    .map(config -> (QueryConfig.InitialVersionCheckConfig) config)
+                    .map(config -> Range.closedOpen(config.getMinVersion(), config.getMaxVersion()))
+                    .toList();
+            Set<Range<SemanticVersion>> uncovered = SemanticVersionRanges.uncovered(ranges);
             if (!uncovered.isEmpty()) {
                 IllegalArgumentException e = new IllegalArgumentException("Test case does not cover complete set of versions as it is missing: " + uncovered);
                 throw YamlExecutionContext.wrapContext(e, () -> "‼️ Non-comprehensive test case found at " + reference, "config", reference);

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryConfig.java
@@ -49,7 +49,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static com.apple.foundationdb.relational.yamltests.command.QueryCommand.reportTestFailure;
 

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/SemanticVersionRanges.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/SemanticVersionRanges.java
@@ -1,0 +1,76 @@
+/*
+ * SemanticVersionRanges.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.relational.yamltests.server;
+
+import com.google.common.collect.Range;
+import com.google.common.collect.RangeSet;
+import com.google.common.collect.TreeRangeSet;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+import java.util.Set;
+
+/**
+ * Helpers shared by yamsql directives that gate execution on the initial version of the connection, in particular
+ * {@code initialVersionAtLeast} and {@code initialVersionLessThan}.
+ */
+public final class SemanticVersionRanges {
+
+    private SemanticVersionRanges() {
+    }
+
+    /**
+     * Returns the {@code [v, MAX)} range, meaning versions {@code v} and above.
+     * Mirrors the {@code initialVersionAtLeast} directive.
+     */
+    @Nonnull
+    public static Range<SemanticVersion> atLeast(@Nonnull SemanticVersion v) {
+        return Range.closedOpen(v, SemanticVersion.max());
+    }
+
+    /**
+     * The {@code [MIN, v)} range, meaning versions strictly below {@code v}.
+     * Mirrors the {@code initialVersionLessThan} directive.
+     */
+    @Nonnull
+    public static Range<SemanticVersion> lessThan(@Nonnull SemanticVersion v) {
+        return Range.closedOpen(SemanticVersion.min(), v);
+    }
+
+    /**
+     * The full {@code [MIN, MAX)} range. This is the implicit range for an entry that declares no version constraint.
+     */
+    @Nonnull
+    public static Range<SemanticVersion> all() {
+        return Range.closedOpen(SemanticVersion.min(), SemanticVersion.max());
+    }
+
+    /**
+     * Returns the sub-ranges of {@code [MIN, MAX)} that are not covered by any of the supplied ranges. An empty
+     * result means the supplied ranges comprehensively cover every possible version.
+     */
+    @Nonnull
+    public static Set<Range<SemanticVersion>> uncovered(@Nonnull Collection<Range<SemanticVersion>> ranges) {
+        RangeSet<SemanticVersion> rangeSet = TreeRangeSet.create();
+        ranges.forEach(rangeSet::add);
+        return rangeSet.complement().subRangeSet(all()).asRanges();
+    }
+}

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/SemanticVersionRanges.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/SemanticVersionRanges.java
@@ -26,6 +26,8 @@ import com.google.common.collect.TreeRangeSet;
 
 import javax.annotation.Nonnull;
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -72,5 +74,27 @@ public final class SemanticVersionRanges {
         RangeSet<SemanticVersion> rangeSet = TreeRangeSet.create();
         ranges.forEach(rangeSet::add);
         return rangeSet.complement().subRangeSet(all()).asRanges();
+    }
+
+    /**
+     * Returns the pairwise non-empty intersections of the supplied ranges, i.e. the regions where two or more ranges
+     * overlap. An empty result means the supplied ranges are mutually exclusive.
+     */
+    @Nonnull
+    public static Set<Range<SemanticVersion>> overlapping(@Nonnull List<Range<SemanticVersion>> ranges) {
+        final Set<Range<SemanticVersion>> overlaps = new HashSet<>();
+        for (int i = 0; i < ranges.size(); i++) {
+            for (int j = i + 1; j < ranges.size(); j++) {
+                final Range<SemanticVersion> a = ranges.get(i);
+                final Range<SemanticVersion> b = ranges.get(j);
+                if (a.isConnected(b)) {
+                    final Range<SemanticVersion> intersection = a.intersection(b);
+                    if (!intersection.isEmpty()) {
+                        overlaps.add(intersection);
+                    }
+                }
+            }
+        }
+        return overlaps;
     }
 }

--- a/yaml-tests/src/test/java/InitialVersionTest.java
+++ b/yaml-tests/src/test/java/InitialVersionTest.java
@@ -94,6 +94,7 @@ public class InitialVersionTest {
                 "mid-query",
                 "non-exhaustive-versions",
                 "non-exhaustive-current-version",
+                "non-exhaustive-schema-template-variants",
                 "wrong-result-at-least",
                 "wrong-result-less-than",
                 "wrong-count-at-least",
@@ -116,7 +117,8 @@ public class InitialVersionTest {
     static Stream<String> shouldPass() {
         return Stream.of(
                 "less-than-version-tests",
-                "at-least-version-tests"
+                "at-least-version-tests",
+                "schema-template-variants"
         );
     }
 
@@ -131,6 +133,7 @@ public class InitialVersionTest {
                 "mid-query",
                 "non-exhaustive-versions",
                 "non-exhaustive-current-version",
+                "non-exhaustive-schema-template-variants",
                 "wrong-result-at-least",
                 "wrong-count-at-least",
                 "wrong-unordered-at-least",
@@ -149,6 +152,7 @@ public class InitialVersionTest {
         return Stream.of(
                 "at-least-current-version",
                 "at-least-version-tests",
+                "schema-template-variants",
                 "wrong-result-less-than",
                 "wrong-count-less-than",
                 "wrong-unordered-less-than",

--- a/yaml-tests/src/test/java/InitialVersionTest.java
+++ b/yaml-tests/src/test/java/InitialVersionTest.java
@@ -91,10 +91,13 @@ public class InitialVersionTest {
                 "do-not-allow-max-rows-in-at-least",
                 "do-not-allow-max-rows-in-less-than",
                 "explain-after-version",
+                "malformed-version-schema-template-variants",
                 "mid-query",
+                "missing-version-tag-schema-template-variants",
                 "non-exhaustive-versions",
                 "non-exhaustive-current-version",
                 "non-exhaustive-schema-template-variants",
+                "overlapping-schema-template-variants",
                 "wrong-result-at-least",
                 "wrong-result-less-than",
                 "wrong-count-at-least",
@@ -118,7 +121,8 @@ public class InitialVersionTest {
         return Stream.of(
                 "less-than-version-tests",
                 "at-least-version-tests",
-                "schema-template-variants"
+                "schema-template-variants",
+                "multiple-schema-template-variants"
         );
     }
 
@@ -130,10 +134,13 @@ public class InitialVersionTest {
 
     static Stream<String> shouldFailOnCurrent() {
         return Stream.of(
+                "malformed-version-schema-template-variants",
                 "mid-query",
+                "missing-version-tag-schema-template-variants",
                 "non-exhaustive-versions",
                 "non-exhaustive-current-version",
                 "non-exhaustive-schema-template-variants",
+                "overlapping-schema-template-variants",
                 "wrong-result-at-least",
                 "wrong-count-at-least",
                 "wrong-unordered-at-least",
@@ -153,6 +160,7 @@ public class InitialVersionTest {
                 "at-least-current-version",
                 "at-least-version-tests",
                 "schema-template-variants",
+                "multiple-schema-template-variants",
                 "wrong-result-less-than",
                 "wrong-count-less-than",
                 "wrong-unordered-less-than",

--- a/yaml-tests/src/test/resources/initial-version/malformed-version-schema-template-variants.yamsql
+++ b/yaml-tests/src/test/resources/initial-version/malformed-version-schema-template-variants.yamsql
@@ -1,5 +1,5 @@
 #
-# schema-template-variants.yamsql
+# malformed-version-schema-template-variants.yamsql
 #
 # This source file is part of the FoundationDB open source project
 #
@@ -18,23 +18,19 @@
 # limitations under the License.
 
 ---
-# Exercises the multiple-variants form of `schema_template`. The fixed test version is 3.0.18.0, so the
-# `initialVersionAtLeast: 3.0.18.0` variant is the one that should run; the other variant declares a different column
-# so that an incorrect variant selection would surface as a query-time failure.
+# The second variant’s `initialVersionAtLeast` is not a parseable version, so the parser rejects the file at parse
+# time when building the version range.
 schema_template:
-    - initialVersionLessThan: "3.0.18.0"
+    - initialVersionLessThan: "3.0.0.0"
       definition: |
-          create table t1(id bigint, col_old bigint, primary key(id))
-    - initialVersionAtLeast: "3.0.18.0"
+          CREATE TABLE T1 (id BIGINT, PRIMARY KEY (id))
+    - initialVersionAtLeast: "not.a.real.version"
       definition: |
-          create table t1(id bigint, col_new bigint, primary key(id))
+          CREATE TABLE T1 (id BIGINT, PRIMARY KEY (id))
 ---
 test_block:
   preset: single_repetition_ordered
   tests:
     -
-      - query: insert into t1 values (1, 2)
-      - count: 1
-    -
-      - query: select col_new from t1
-      - result: [{col_new: !l 2}]
+      - query: SELECT * FROM T1
+      - result: []

--- a/yaml-tests/src/test/resources/initial-version/missing-version-tag-schema-template-variants.yamsql
+++ b/yaml-tests/src/test/resources/initial-version/missing-version-tag-schema-template-variants.yamsql
@@ -1,5 +1,5 @@
 #
-# schema-template-variants.yamsql
+# missing-version-tag-schema-template-variants.yamsql
 #
 # This source file is part of the FoundationDB open source project
 #
@@ -18,23 +18,18 @@
 # limitations under the License.
 
 ---
-# Exercises the multiple-variants form of `schema_template`. The fixed test version is 3.0.18.0, so the
-# `initialVersionAtLeast: 3.0.18.0` variant is the one that should run; the other variant declares a different column
-# so that an incorrect variant selection would surface as a query-time failure.
+# The second variant declares no version key, so its range defaults to [MIN, MAX). That overlaps with the first
+# variant's [MIN, 3.0.0.0), and the parser rejects the file at parse time via the overlap check.
 schema_template:
-    - initialVersionLessThan: "3.0.18.0"
+    - initialVersionLessThan: "3.0.0.0"
       definition: |
-          create table t1(id bigint, col_old bigint, primary key(id))
-    - initialVersionAtLeast: "3.0.18.0"
-      definition: |
-          create table t1(id bigint, col_new bigint, primary key(id))
+          CREATE TABLE T1 (id BIGINT, PRIMARY KEY (id))
+    - definition: |
+          CREATE TABLE T1 (id BIGINT, PRIMARY KEY (id))
 ---
 test_block:
   preset: single_repetition_ordered
   tests:
     -
-      - query: insert into t1 values (1, 2)
-      - count: 1
-    -
-      - query: select col_new from t1
-      - result: [{col_new: !l 2}]
+      - query: SELECT * FROM T1
+      - result: []

--- a/yaml-tests/src/test/resources/initial-version/multiple-schema-template-variants.yamsql
+++ b/yaml-tests/src/test/resources/initial-version/multiple-schema-template-variants.yamsql
@@ -1,0 +1,45 @@
+#
+# multiple-schema-template-variants.yamsql
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2021-2026 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+# Exercises a `schema_template` list with three variants. The middle variant uses both `initialVersionAtLeast` and
+# `initialVersionLessThan` to bound a closed-open range; the low and high variants use a single bound each. All three
+# variants define T1 identically, so this test passes regardless of which variant is selected. The goal is to verify
+# that the parser, validator, and runtime selector all handle more than two variants.
+schema_template:
+    - initialVersionLessThan: "1.0.0.0"
+      definition: |
+          CREATE TABLE T1 (id BIGINT, PRIMARY KEY (id))
+    - initialVersionAtLeast: "1.0.0.0"
+      initialVersionLessThan: "100.0.0.0"
+      definition: |
+          CREATE TABLE T1 (id BIGINT, PRIMARY KEY (id))
+    - initialVersionAtLeast: "100.0.0.0"
+      definition: |
+          CREATE TABLE T1 (id BIGINT, PRIMARY KEY (id))
+---
+test_block:
+  preset: single_repetition_ordered
+  tests:
+    -
+      - query: INSERT INTO T1 VALUES (1)
+      - count: 1
+    -
+      - query: SELECT id FROM T1
+      - result: [{id: !l 1}]

--- a/yaml-tests/src/test/resources/initial-version/non-exhaustive-schema-template-variants.yamsql
+++ b/yaml-tests/src/test/resources/initial-version/non-exhaustive-schema-template-variants.yamsql
@@ -1,0 +1,33 @@
+#
+# non-exhaustive-schema-template-variants.yamsql
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2021-2026 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+# The `schema_template` variants here leave [MIN, 3.1.0.0) uncovered, so the file should fail at parse time regardless
+# of the version under test.
+schema_template:
+    - initialVersionAtLeast: "3.1.0.0"
+      schema_template: |
+          create table t1(id bigint, primary key(id))
+---
+test_block:
+  preset: single_repetition_ordered
+  tests:
+    -
+      - query: select * from t1
+      - result: []

--- a/yaml-tests/src/test/resources/initial-version/non-exhaustive-schema-template-variants.yamsql
+++ b/yaml-tests/src/test/resources/initial-version/non-exhaustive-schema-template-variants.yamsql
@@ -22,7 +22,7 @@
 # of the version under test.
 schema_template:
     - initialVersionAtLeast: "3.1.0.0"
-      schema_template: |
+      definition: |
           create table t1(id bigint, primary key(id))
 ---
 test_block:

--- a/yaml-tests/src/test/resources/initial-version/overlapping-schema-template-variants.yamsql
+++ b/yaml-tests/src/test/resources/initial-version/overlapping-schema-template-variants.yamsql
@@ -1,5 +1,5 @@
 #
-# schema-template-variants.yamsql
+# overlapping-schema-template-variants.yamsql
 #
 # This source file is part of the FoundationDB open source project
 #
@@ -18,23 +18,19 @@
 # limitations under the License.
 
 ---
-# Exercises the multiple-variants form of `schema_template`. The fixed test version is 3.0.18.0, so the
-# `initialVersionAtLeast: 3.0.18.0` variant is the one that should run; the other variant declares a different column
-# so that an incorrect variant selection would surface as a query-time failure.
+# The two `schema_template` variants here both match versions in [3.0.0.0, 3.1.0.0), so the file should fail at
+# parse time regardless of the version under test.
 schema_template:
-    - initialVersionLessThan: "3.0.18.0"
+    - initialVersionLessThan: "3.1.0.0"
       definition: |
-          create table t1(id bigint, col_old bigint, primary key(id))
-    - initialVersionAtLeast: "3.0.18.0"
+          CREATE TABLE T (id BIGINT, PRIMARY KEY (id))
+    - initialVersionAtLeast: "3.0.0.0"
       definition: |
-          create table t1(id bigint, col_new bigint, primary key(id))
+          CREATE TABLE T (id BIGINT, PRIMARY KEY (id))
 ---
 test_block:
   preset: single_repetition_ordered
   tests:
     -
-      - query: insert into t1 values (1, 2)
-      - count: 1
-    -
-      - query: select col_new from t1
-      - result: [{col_new: !l 2}]
+      - query: SELECT * FROM T
+      - result: []

--- a/yaml-tests/src/test/resources/initial-version/schema-template-variants.yamsql
+++ b/yaml-tests/src/test/resources/initial-version/schema-template-variants.yamsql
@@ -1,0 +1,40 @@
+#
+# schema-template-variants.yamsql
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2021-2026 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+# Exercises the multiple-variants form of `schema_template`. The fixed test version is 3.0.18.0, so the
+# `initialVersionAtLeast: 3.0.18.0` variant is the one that should run; the other variant declares a different column
+# so that an incorrect variant selection would surface as a query-time failure.
+schema_template:
+    - initialVersionLessThan: "3.0.18.0"
+      schema_template: |
+          create table t1(id bigint, col_old bigint, primary key(id))
+    - initialVersionAtLeast: "3.0.18.0"
+      schema_template: |
+          create table t1(id bigint, col_new bigint, primary key(id))
+---
+test_block:
+  preset: single_repetition_ordered
+  tests:
+    -
+      - query: insert into t1 values (1, 2)
+      - count: 1
+    -
+      - query: select col_new from t1
+      - result: [{col_new: !l 2}]


### PR DESCRIPTION
As an alternative to a single string body, the `schema_template` block now accepts a list of variants. Each variant carries a [min, max) version range specified by the existing `initialVersionAtLeast` and `initialVersionLessThan` tags in addition to the actual `schema_template` body. At execute time the variant whose version range contains the initial version of the catalog connection is picked as the one to execute. Variant ranges must comprehensively cover [MIN, MAX), validated at parse time.

The use case is to allow a single yamsql file to be tested across server versions when the DDL syntax differs somewhat, such as when a release changes the syntax of a DDL construct.

Testing:
* `schema-template-variants.yamsql` exercises variant selection by initial version.
* `non-exhaustive-schema-template-variants.yamsql` exercises the check for comprehensive version coverage.