### PR TITLE
Disallow CREATE INDEX on ARRAY fields with implicit fan-out

### DIFF
--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/ddl/MaterializedViewIndexGenerator.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/ddl/MaterializedViewIndexGenerator.java
@@ -570,7 +570,7 @@ public final class MaterializedViewIndexGenerator {
         final var exprConstituents = childrenMap.entrySet().stream().map(nodeEntry -> {
             final FieldValue.ResolvedAccessor accessor = nodeEntry.getKey();
             final FieldValueTrieNode node = nodeEntry.getValue();
-            final KeyExpression expr = toFieldKeyExpression(accessor.getField());
+            final KeyExpression expr = toFieldKeyExpression(accessor);
             if (node.getChildrenMap() != null) {
                 final FieldKeyExpression fieldExpr = Assert.castUnchecked(expr, FieldKeyExpression.class);
                 return fieldExpr.nest(toKeyExpression(node, orderingFunctions));
@@ -756,8 +756,8 @@ public final class MaterializedViewIndexGenerator {
     @Nonnull
     private KeyExpression toKeyExpression(@Nonnull Iterator<FieldValue.ResolvedAccessor> resolvedAccessors) {
         Assert.thatUnchecked(resolvedAccessors.hasNext(), "cannot resolve empty list");
-        final Type.Record.Field field = resolvedAccessors.next().getField();
-        final KeyExpression expression = toFieldKeyExpression(field);
+        final FieldValue.ResolvedAccessor accessor = resolvedAccessors.next();
+        final KeyExpression expression = toFieldKeyExpression(accessor);
         if (resolvedAccessors.hasNext()) {
             KeyExpression childExpression = toKeyExpression(resolvedAccessors);
             final FieldKeyExpression fieldExpression = Assert.castUnchecked(expression, FieldKeyExpression.class);
@@ -780,8 +780,13 @@ public final class MaterializedViewIndexGenerator {
     }
 
     @Nonnull
-    private static KeyExpression toFieldKeyExpression(@Nonnull Type.Record.Field fieldType) {
+    private static KeyExpression toFieldKeyExpression(@Nonnull FieldValue.ResolvedAccessor accessor) {
+        final Type.Record.Field fieldType = accessor.getField();
         Assert.notNullUnchecked(fieldType.getFieldStorageName());
+        Assert.thatUnchecked(!fieldType.getFieldType().isArray() || (accessor instanceof AnnotatedAccessor),
+                ErrorCode.UNSUPPORTED_OPERATION,
+                "Unsupported index definition, cannot create index on array field '" +
+                fieldType.getFieldName() + "' without unnesting");
         final var fanType = fieldType.getFieldType().getTypeCode() == Type.TypeCode.ARRAY ?
                 KeyExpression.FanType.FanOut :
                 KeyExpression.FanType.None;

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/api/ddl/IndexTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/api/ddl/IndexTest.java
@@ -1185,6 +1185,23 @@ public class IndexTest {
     }
 
     @Test
+    void createIndexOnArrayFieldWithoutUnnestingIsDisallowed() throws Exception {
+        final String stmt = "CREATE SCHEMA TEMPLATE test_template " +
+                "CREATE TABLE T (p BIGINT, items STRING ARRAY, PRIMARY KEY (p))" +
+                "CREATE INDEX MV1 AS SELECT items FROM T";
+        shouldFailWith(stmt, ErrorCode.UNSUPPORTED_OPERATION, "cannot create index on array field");
+    }
+
+    @Test
+    void createIndexNavigatingThroughArrayWithoutUnnestingIsDisallowed() throws Exception {
+        final String stmt = "CREATE SCHEMA TEMPLATE test_template " +
+                "CREATE TYPE AS STRUCT A(x BIGINT) " +
+                "CREATE TABLE T (p BIGINT, a A ARRAY, PRIMARY KEY (p))" +
+                "CREATE INDEX MV1 AS SELECT a.x FROM T";
+        shouldFailWith(stmt, ErrorCode.UNDEFINED_COLUMN, "A.X");
+    }
+
+    @Test
     void createIndexWithOrderByMixedDirection() throws Exception {
         final String stmt = "CREATE SCHEMA TEMPLATE test_template " +
                 "CREATE TABLE T1(col1 bigint, col2 bigint, col3 bigint, primary key(col1)) " +

--- a/yaml-tests/src/test/resources/in-predicate.yamsql
+++ b/yaml-tests/src/test/resources/in-predicate.yamsql
@@ -18,12 +18,22 @@
 # limitations under the License.
 ---
 schema_template:
-    create type as struct ts(sa bigint, sb bigint)
-    create type as struct fruit_type(name string, color string)
-    create table ta(a bigint, b bigint, c double, d boolean, e string, f ts, primary key(a))
-    create index f1 as select f.sa, f.sb from ta order by f.sa, f.sb
-    create table array_table(id bigint, fruits string array, numbers bigint array, fruit_records fruit_type array, primary key(id))
-    create index fruits as select fruits from array_table
+  - initialVersionLessThan: "4.12.1.0"
+    definition: |
+      create type as struct ts(sa bigint, sb bigint)
+      create type as struct fruit_type(name string, color string)
+      create table ta(a bigint, b bigint, c double, d boolean, e string, f ts, primary key(a))
+      create index f1 as select f.sa, f.sb from ta order by f.sa, f.sb
+      create table array_table(id bigint, fruits string array, numbers bigint array, fruit_records fruit_type array, primary key(id))
+      create index fruits as select fruits from array_table
+  - initialVersionAtLeast: "4.12.1.0"
+    definition: |
+      create type as struct ts(sa bigint, sb bigint)
+      create type as struct fruit_type(name string, color string)
+      create table ta(a bigint, b bigint, c double, d boolean, e string, f ts, primary key(a))
+      create index f1 as select f.sa, f.sb from ta order by f.sa, f.sb
+      create table array_table(id bigint, fruits string array, numbers bigint array, fruit_records fruit_type array, primary key(id))
+      create index fruits as select "fruit" from array_table as t, t.fruits as "fruit"
 ---
 setup:
   steps:

--- a/yaml-tests/src/test/resources/valid-identifiers.yamsql
+++ b/yaml-tests/src/test/resources/valid-identifiers.yamsql
@@ -21,69 +21,134 @@ options:
     supported_version: 4.8.15.0
 ---
 schema_template:
-    create type as struct "nested.type$level2" ("level2$field.1" bigint, "level2$field.2" bigint)
-    create type as struct "nested.type$level1" ("level1$field.1" "nested.type$level2", "level1$field.2" "nested.type$level2")
-    create table "foo.table$nested" (id bigint, "level0.field1" "nested.type$level1", primary key(id))
-    create index "foo.table$nested.idx" as select "level0.field1"."level1$field.1"."level2$field.1" from "foo.table$nested" order by "level0.field1"."level1$field.1"."level2$field.1"
-
-    create type as struct "nested.repeated.type$level2" ("level2$array.field.1" bigint, "level2$field.2" bigint)
-    create type as struct "nested.repeated.type$level1" ("level1$field.1" "nested.repeated.type$level2" array, "level1$field.2" "nested.type$level2", "level1$field.3" bigint)
-    create table "foo.table$nested.repeated" (id bigint, "level0.field1" "nested.repeated.type$level1" array, primary key(id))
-    create index "foo.table$nested.repeated.idx.field.1.3"   as select "nested$level1"."level1$field.3"                  from "foo.table$nested.repeated" as "level0$t", "level0$t"."level0.field1" AS "nested$level1"
-    create index "foo.table$nested.repeated.idx.field.1.2.1" as select "nested$level1"."level1$field.2"."level2$field.1" from "foo.table$nested.repeated" as "level0$t", "level0$t"."level0.field1" AS "nested$level1"
-    create index "foo.table$nested.repeated.idx.field.1.1.1" as select "nested$level2"."level2$array.field.1"            from "foo.table$nested.repeated" as "level0$t", "level0$t"."level0.field1" AS "nested$level1", "nested$level1"."level1$field.1" AS "nested$level2"
-
-    create table "foo.table$repeated" (id bigint, "field.0$array" bigint array, "field.1$array" string array, primary key (id))
-    create index "foo.table$repeated.1" as select t."field.0$array" from "foo.table$repeated" AS t
-    create index "foo.table$repeated.2" as select t."field.1$array" from "foo.table$repeated" AS t
-
-    create type as struct "foo.struct"(S1 bigint, S2 bigint)
-    create table "foo.tableA"("foo.tableA.A1" bigint, "foo.tableA.A2" bigint, "foo.tableA.A3" bigint, primary key("foo.tableA.A1"))
-    create index "foo.tableA.idx" as select "foo.tableA.A1", "foo.tableA.A2", "foo.tableA.A3" FROM "foo.tableA" order by "foo.tableA.A1", "foo.tableA.A2", "foo.tableA.A3"
-    create index "foo.tableA.idx2" as select sum("foo.tableA.A1") FROM "foo.tableA" group by "foo.tableA.A2"
-    create index "foo.tableA.idx3" as select "foo.tableA.A2" FROM "foo.tableA" order by "foo.tableA.A2"
-
-    create table "foo.tableB"("foo.tableB.B1" bigint, "foo.tableB.B2" bigint, "foo.tableB.B3" "foo.struct", primary key("foo.tableB.B1"))
-
-    create table "foo$tableC"("foo$tableC$C1" bigint, "foo$tableC$C2" bigint, "foo$tableC$C3" bigint, primary key("foo$tableC$C1"))
-    create index "foo$tableC$idx" as select "foo$tableC$C1", "foo$tableC$C2", "foo$tableC$C3" FROM "foo$tableC" order by "foo$tableC$C1", "foo$tableC$C2", "foo$tableC$C3"
-    create index "foo$tableC$idx2" as select sum("foo$tableC$C1") FROM "foo$tableC" group by "foo$tableC$C2"
-
-    create table "__foo__tableD"("__foo__tableD$D1" bigint, "__foo__tableD$D2" bigint, "__foo__tableD$D3" bigint, primary key("__foo__tableD$D1"))
-    create index "__foo__tableD$idx" as select "__foo__tableD$D1", "__foo__tableD$D2", "__foo__tableD$D3" FROM "__foo__tableD" order by "__foo__tableD$D1", "__foo__tableD$D2", "__foo__tableD$D3"
-    create index "__foo__tableD$idx2" as select sum("__foo__tableD$D1") FROM "__foo__tableD" group by "__foo__tableD$D2"
-
-    create table "foo.tableE"("foo.tableE.E1" bigint, "foo.tableE.E2" bigint array, "foo.tableE.E3" "foo.struct", primary key("foo.tableE.E1"))
-
-    create function "$yay" (in "_1$blah" bigint)
-       as select "foo.tableE"."foo.tableE.E1" as "_$x.id" from "foo.tableE" where "foo.tableE"."foo.tableE.E3".S1 = "_1$blah"
-    create function "__2yay" (in "_2$blah" bigint)
-       as select "foo.tableE"."foo.tableE.E1" as "_$y.id" from "foo.tableE" where "foo.tableE"."foo.tableE.E3".S1 = "_2$blah"
-    create function "नमस्त" (in "x.y" bigint)
-       as select "foo.tableE"."foo.tableE.E1" as "_$z.id" from "foo.tableE" where "foo.tableE"."foo.tableE.E3".S1 = "x.y"
-
-    create function "alpha__f" (in "__in__foo.struct" TYPE "foo.struct") RETURNS bigint AS "__in__foo.struct".S1
-    create function "βήτα__f" (in "__in__foo.struct" TYPE "foo.struct") RETURNS bigint AS "__in__foo.struct".S2
-
-    create view "$yay__view"
-       as select "foo.tableE"."foo.tableE.E1" as "_$x.id" from "foo.tableE" where "foo.tableE"."foo.tableE.E3".S1 = 4
-    create view "__2yay__view"
-       as select "foo.tableE"."foo.tableE.E1" as "_$y.id" from "foo.tableE" where "foo.tableE"."foo.tableE.E3".S1 = 5
-    create view "வணக்கம்"
-       as select "foo.tableE"."foo.tableE.E1" as "_$z.id" from "foo.tableE" where "foo.tableE"."foo.tableE.E3".S1 = 6
-
-    create table "my$adjacency$list"("me" bigint, "my__parent" bigint, primary key("me"))
-    create function "__$func1" ( in "__$func1$A" bigint, in "__$func1$B" bigint )
-       as select "me" as "__A", "my__parent" as "__B" from "my$adjacency$list" where "me" < "__$func1$A" and "my$adjacency$list"."my__parent" = "__$func1$B"
-    create function "__$func2" ( "__$func2$A" bigint )
-       as select "me" as "__A", "my__parent" as "__B" from "my$adjacency$list" where "me" = "__$func2$A"
-    create function "__$func3" ( in "__$func3$A" bigint, in "__$func3$B" bigint, in "__$func3$C" bigint) as select "__..f1"."__A", "__..f1"."__B", "__..f2"."__A", "__..f2"."__B" from "__$func1"("__$func3$A", "__$func3$B") "__..f1", "__$func2"("__$func3$C") "__..f2"
-
-    create type as enum "foo.enum"('A', 'B$C', 'C.D', 'E__F', '__G$H')
-    create table "foo.enum.type"("enum_type.id" bigint, "enum_type.enum__1" "foo.enum", "enum_type.enum__2" "foo.enum", primary key ("enum_type.id"))
-
-    create index "foo.enum.type$enum__1" as select "enum_type.enum__1" from "foo.enum.type"
-
+  - initialVersionLessThan: "4.12.1.0"
+    definition: |
+      create type as struct "nested.type$level2" ("level2$field.1" bigint, "level2$field.2" bigint)
+      create type as struct "nested.type$level1" ("level1$field.1" "nested.type$level2", "level1$field.2" "nested.type$level2")
+      create table "foo.table$nested" (id bigint, "level0.field1" "nested.type$level1", primary key(id))
+      create index "foo.table$nested.idx" as select "level0.field1"."level1$field.1"."level2$field.1" from "foo.table$nested" order by "level0.field1"."level1$field.1"."level2$field.1"
+      
+      create type as struct "nested.repeated.type$level2" ("level2$array.field.1" bigint, "level2$field.2" bigint)
+      create type as struct "nested.repeated.type$level1" ("level1$field.1" "nested.repeated.type$level2" array, "level1$field.2" "nested.type$level2", "level1$field.3" bigint)
+      create table "foo.table$nested.repeated" (id bigint, "level0.field1" "nested.repeated.type$level1" array, primary key(id))
+      create index "foo.table$nested.repeated.idx.field.1.3"   as select "nested$level1"."level1$field.3"                  from "foo.table$nested.repeated" as "level0$t", "level0$t"."level0.field1" AS "nested$level1"
+      create index "foo.table$nested.repeated.idx.field.1.2.1" as select "nested$level1"."level1$field.2"."level2$field.1" from "foo.table$nested.repeated" as "level0$t", "level0$t"."level0.field1" AS "nested$level1"
+      create index "foo.table$nested.repeated.idx.field.1.1.1" as select "nested$level2"."level2$array.field.1"            from "foo.table$nested.repeated" as "level0$t", "level0$t"."level0.field1" AS "nested$level1", "nested$level1"."level1$field.1" AS "nested$level2"
+      
+      create table "foo.table$repeated" (id bigint, "field.0$array" bigint array, "field.1$array" string array, primary key (id))
+      create index "foo.table$repeated.1" as select t."field.0$array" from "foo.table$repeated" AS t
+      create index "foo.table$repeated.2" as select t."field.1$array" from "foo.table$repeated" AS t
+      
+      create type as struct "foo.struct"(S1 bigint, S2 bigint)
+      create table "foo.tableA"("foo.tableA.A1" bigint, "foo.tableA.A2" bigint, "foo.tableA.A3" bigint, primary key("foo.tableA.A1"))
+      create index "foo.tableA.idx" as select "foo.tableA.A1", "foo.tableA.A2", "foo.tableA.A3" FROM "foo.tableA" order by "foo.tableA.A1", "foo.tableA.A2", "foo.tableA.A3"
+      create index "foo.tableA.idx2" as select sum("foo.tableA.A1") FROM "foo.tableA" group by "foo.tableA.A2"
+      create index "foo.tableA.idx3" as select "foo.tableA.A2" FROM "foo.tableA" order by "foo.tableA.A2"
+      
+      create table "foo.tableB"("foo.tableB.B1" bigint, "foo.tableB.B2" bigint, "foo.tableB.B3" "foo.struct", primary key("foo.tableB.B1"))
+      
+      create table "foo$tableC"("foo$tableC$C1" bigint, "foo$tableC$C2" bigint, "foo$tableC$C3" bigint, primary key("foo$tableC$C1"))
+      create index "foo$tableC$idx" as select "foo$tableC$C1", "foo$tableC$C2", "foo$tableC$C3" FROM "foo$tableC" order by "foo$tableC$C1", "foo$tableC$C2", "foo$tableC$C3"
+      create index "foo$tableC$idx2" as select sum("foo$tableC$C1") FROM "foo$tableC" group by "foo$tableC$C2"
+      
+      create table "__foo__tableD"("__foo__tableD$D1" bigint, "__foo__tableD$D2" bigint, "__foo__tableD$D3" bigint, primary key("__foo__tableD$D1"))
+      create index "__foo__tableD$idx" as select "__foo__tableD$D1", "__foo__tableD$D2", "__foo__tableD$D3" FROM "__foo__tableD" order by "__foo__tableD$D1", "__foo__tableD$D2", "__foo__tableD$D3"
+      create index "__foo__tableD$idx2" as select sum("__foo__tableD$D1") FROM "__foo__tableD" group by "__foo__tableD$D2"
+      
+      create table "foo.tableE"("foo.tableE.E1" bigint, "foo.tableE.E2" bigint array, "foo.tableE.E3" "foo.struct", primary key("foo.tableE.E1"))
+      
+      create function "$yay" (in "_1$blah" bigint)
+         as select "foo.tableE"."foo.tableE.E1" as "_$x.id" from "foo.tableE" where "foo.tableE"."foo.tableE.E3".S1 = "_1$blah"
+      create function "__2yay" (in "_2$blah" bigint)
+         as select "foo.tableE"."foo.tableE.E1" as "_$y.id" from "foo.tableE" where "foo.tableE"."foo.tableE.E3".S1 = "_2$blah"
+      create function "नमस्त" (in "x.y" bigint)
+         as select "foo.tableE"."foo.tableE.E1" as "_$z.id" from "foo.tableE" where "foo.tableE"."foo.tableE.E3".S1 = "x.y"
+      
+      create function "alpha__f" (in "__in__foo.struct" TYPE "foo.struct") RETURNS bigint AS "__in__foo.struct".S1
+      create function "βήτα__f" (in "__in__foo.struct" TYPE "foo.struct") RETURNS bigint AS "__in__foo.struct".S2
+      
+      create view "$yay__view"
+         as select "foo.tableE"."foo.tableE.E1" as "_$x.id" from "foo.tableE" where "foo.tableE"."foo.tableE.E3".S1 = 4
+      create view "__2yay__view"
+         as select "foo.tableE"."foo.tableE.E1" as "_$y.id" from "foo.tableE" where "foo.tableE"."foo.tableE.E3".S1 = 5
+      create view "வணக்கம்"
+         as select "foo.tableE"."foo.tableE.E1" as "_$z.id" from "foo.tableE" where "foo.tableE"."foo.tableE.E3".S1 = 6
+      
+      create table "my$adjacency$list"("me" bigint, "my__parent" bigint, primary key("me"))
+      create function "__$func1" ( in "__$func1$A" bigint, in "__$func1$B" bigint )
+         as select "me" as "__A", "my__parent" as "__B" from "my$adjacency$list" where "me" < "__$func1$A" and "my$adjacency$list"."my__parent" = "__$func1$B"
+      create function "__$func2" ( "__$func2$A" bigint )
+         as select "me" as "__A", "my__parent" as "__B" from "my$adjacency$list" where "me" = "__$func2$A"
+      create function "__$func3" ( in "__$func3$A" bigint, in "__$func3$B" bigint, in "__$func3$C" bigint) as select "__..f1"."__A", "__..f1"."__B", "__..f2"."__A", "__..f2"."__B" from "__$func1"("__$func3$A", "__$func3$B") "__..f1", "__$func2"("__$func3$C") "__..f2"
+      
+      create type as enum "foo.enum"('A', 'B$C', 'C.D', 'E__F', '__G$H')
+      create table "foo.enum.type"("enum_type.id" bigint, "enum_type.enum__1" "foo.enum", "enum_type.enum__2" "foo.enum", primary key ("enum_type.id"))
+      
+      create index "foo.enum.type$enum__1" as select "enum_type.enum__1" from "foo.enum.type"
+  - initialVersionAtLeast: "4.12.1.0"
+    definition: |
+      create type as struct "nested.type$level2" ("level2$field.1" bigint, "level2$field.2" bigint)
+      create type as struct "nested.type$level1" ("level1$field.1" "nested.type$level2", "level1$field.2" "nested.type$level2")
+      create table "foo.table$nested" (id bigint, "level0.field1" "nested.type$level1", primary key(id))
+      create index "foo.table$nested.idx" as select "level0.field1"."level1$field.1"."level2$field.1" from "foo.table$nested" order by "level0.field1"."level1$field.1"."level2$field.1"
+      
+      create type as struct "nested.repeated.type$level2" ("level2$array.field.1" bigint, "level2$field.2" bigint)
+      create type as struct "nested.repeated.type$level1" ("level1$field.1" "nested.repeated.type$level2" array, "level1$field.2" "nested.type$level2", "level1$field.3" bigint)
+      create table "foo.table$nested.repeated" (id bigint, "level0.field1" "nested.repeated.type$level1" array, primary key(id))
+      create index "foo.table$nested.repeated.idx.field.1.3"   as select "nested$level1"."level1$field.3"                  from "foo.table$nested.repeated" as "level0$t", "level0$t"."level0.field1" AS "nested$level1"
+      create index "foo.table$nested.repeated.idx.field.1.2.1" as select "nested$level1"."level1$field.2"."level2$field.1" from "foo.table$nested.repeated" as "level0$t", "level0$t"."level0.field1" AS "nested$level1"
+      create index "foo.table$nested.repeated.idx.field.1.1.1" as select "nested$level2"."level2$array.field.1"            from "foo.table$nested.repeated" as "level0$t", "level0$t"."level0.field1" AS "nested$level1", "nested$level1"."level1$field.1" AS "nested$level2"
+      
+      create table "foo.table$repeated" (id bigint, "field.0$array" bigint array, "field.1$array" string array, primary key (id))
+      create index "foo.table$repeated.1" as select "e" from "foo.table$repeated" AS t, t."field.0$array" as "e"
+      create index "foo.table$repeated.2" as select "e" from "foo.table$repeated" AS t, t."field.1$array" as "e"
+      
+      create type as struct "foo.struct"(S1 bigint, S2 bigint)
+      create table "foo.tableA"("foo.tableA.A1" bigint, "foo.tableA.A2" bigint, "foo.tableA.A3" bigint, primary key("foo.tableA.A1"))
+      create index "foo.tableA.idx" as select "foo.tableA.A1", "foo.tableA.A2", "foo.tableA.A3" FROM "foo.tableA" order by "foo.tableA.A1", "foo.tableA.A2", "foo.tableA.A3"
+      create index "foo.tableA.idx2" as select sum("foo.tableA.A1") FROM "foo.tableA" group by "foo.tableA.A2"
+      create index "foo.tableA.idx3" as select "foo.tableA.A2" FROM "foo.tableA" order by "foo.tableA.A2"
+      
+      create table "foo.tableB"("foo.tableB.B1" bigint, "foo.tableB.B2" bigint, "foo.tableB.B3" "foo.struct", primary key("foo.tableB.B1"))
+      
+      create table "foo$tableC"("foo$tableC$C1" bigint, "foo$tableC$C2" bigint, "foo$tableC$C3" bigint, primary key("foo$tableC$C1"))
+      create index "foo$tableC$idx" as select "foo$tableC$C1", "foo$tableC$C2", "foo$tableC$C3" FROM "foo$tableC" order by "foo$tableC$C1", "foo$tableC$C2", "foo$tableC$C3"
+      create index "foo$tableC$idx2" as select sum("foo$tableC$C1") FROM "foo$tableC" group by "foo$tableC$C2"
+      
+      create table "__foo__tableD"("__foo__tableD$D1" bigint, "__foo__tableD$D2" bigint, "__foo__tableD$D3" bigint, primary key("__foo__tableD$D1"))
+      create index "__foo__tableD$idx" as select "__foo__tableD$D1", "__foo__tableD$D2", "__foo__tableD$D3" FROM "__foo__tableD" order by "__foo__tableD$D1", "__foo__tableD$D2", "__foo__tableD$D3"
+      create index "__foo__tableD$idx2" as select sum("__foo__tableD$D1") FROM "__foo__tableD" group by "__foo__tableD$D2"
+      
+      create table "foo.tableE"("foo.tableE.E1" bigint, "foo.tableE.E2" bigint array, "foo.tableE.E3" "foo.struct", primary key("foo.tableE.E1"))
+      
+      create function "$yay" (in "_1$blah" bigint)
+         as select "foo.tableE"."foo.tableE.E1" as "_$x.id" from "foo.tableE" where "foo.tableE"."foo.tableE.E3".S1 = "_1$blah"
+      create function "__2yay" (in "_2$blah" bigint)
+         as select "foo.tableE"."foo.tableE.E1" as "_$y.id" from "foo.tableE" where "foo.tableE"."foo.tableE.E3".S1 = "_2$blah"
+      create function "नमस्त" (in "x.y" bigint)
+         as select "foo.tableE"."foo.tableE.E1" as "_$z.id" from "foo.tableE" where "foo.tableE"."foo.tableE.E3".S1 = "x.y"
+      
+      create function "alpha__f" (in "__in__foo.struct" TYPE "foo.struct") RETURNS bigint AS "__in__foo.struct".S1
+      create function "βήτα__f" (in "__in__foo.struct" TYPE "foo.struct") RETURNS bigint AS "__in__foo.struct".S2
+      
+      create view "$yay__view"
+         as select "foo.tableE"."foo.tableE.E1" as "_$x.id" from "foo.tableE" where "foo.tableE"."foo.tableE.E3".S1 = 4
+      create view "__2yay__view"
+         as select "foo.tableE"."foo.tableE.E1" as "_$y.id" from "foo.tableE" where "foo.tableE"."foo.tableE.E3".S1 = 5
+      create view "வணக்கம்"
+         as select "foo.tableE"."foo.tableE.E1" as "_$z.id" from "foo.tableE" where "foo.tableE"."foo.tableE.E3".S1 = 6
+      
+      create table "my$adjacency$list"("me" bigint, "my__parent" bigint, primary key("me"))
+      create function "__$func1" ( in "__$func1$A" bigint, in "__$func1$B" bigint )
+         as select "me" as "__A", "my__parent" as "__B" from "my$adjacency$list" where "me" < "__$func1$A" and "my$adjacency$list"."my__parent" = "__$func1$B"
+      create function "__$func2" ( "__$func2$A" bigint )
+         as select "me" as "__A", "my__parent" as "__B" from "my$adjacency$list" where "me" = "__$func2$A"
+      create function "__$func3" ( in "__$func3$A" bigint, in "__$func3$B" bigint, in "__$func3$C" bigint) as select "__..f1"."__A", "__..f1"."__B", "__..f2"."__A", "__..f2"."__B" from "__$func1"("__$func3$A", "__$func3$B") "__..f1", "__$func2"("__$func3$C") "__..f2"
+      
+      create type as enum "foo.enum"('A', 'B$C', 'C.D', 'E__F', '__G$H')
+      create table "foo.enum.type"("enum_type.id" bigint, "enum_type.enum__1" "foo.enum", "enum_type.enum__2" "foo.enum", primary key ("enum_type.id"))
+      
+      create index "foo.enum.type$enum__1" as select "enum_type.enum__1" from "foo.enum.type"
 ---
 setup:
   steps:

--- a/yaml-tests/src/test/resources/versions-tests.yamsql
+++ b/yaml-tests/src/test/resources/versions-tests.yamsql
@@ -19,35 +19,68 @@
 
 ---
 schema_template:
-    create table t1(id bigint, col1 bigint, col2 bigint, primary key(id))
-    create index i1 as select col1 from t1
-    create index t1_version_index as select "__ROW_VERSION" from t1
-    create index grouped_version_index as select col1, "__ROW_VERSION" from t1 order by col1, "__ROW_VERSION"
-
-    create table t2(id bigint, col1 bigint, col2 string, primary key (id))
-    create index t2_col2 as select col2 from t2
-
-    create table t3(id bigint, col1 string, col2 bigint, primary key (id))
-    create index t3_version_with_col1 as select "__ROW_VERSION", col1 from t3 order by "__ROW_VERSION"
-
-    create table unindexed_t(id bigint, col1 bigint, col2 string, primary key(id))
-
-    create table t4(id bigint, col1 string, col2 bigint, col3 bigint, col4 bigint array, primary key (id))
-    create index t4_col2 as select col2 from t4
-    create index t4_col2_col4 as select col2, col4 from t4 order by col2, col4
-    create index t4_col3_version as select col3, "__ROW_VERSION" from t4 order by col3, "__ROW_VERSION"
-    create index t4_col4_version as select col4, "__ROW_VERSION" from t4 order by col4, "__ROW_VERSION"
-
-    create function t1_v(in x bigint) as select "__ROW_VERSION", id, col1, col2 from t1 where col1 = x
-    create function t2_v(in x bigint) as select "__ROW_VERSION", id, col1, col2 from t2 where col1 = x
-    create function t3_v(in x bigint) as select "__ROW_VERSION", id, col1, col2 from t3 where col2 = x
-    create function t4_v(in x bigint) as select "__ROW_VERSION", id, col1, col2 from t3 where col2 = x
-    create function unindexed_t_v(in x bigint) as select "__ROW_VERSION", id, col1, col2 from unindexed_t where col1 = x
-
-    create function t3_by_col1(in x string) as select "__ROW_VERSION" AS version, (t3.*) as r from t3 where t3.col1 = x
-    create function t4_by_col1(in x string) as select "__ROW_VERSION" AS version, (t4.*) as r from t4 where t4.col1 = x
-
-    with options (store_row_versions=true)
+  - initialVersionLessThan: "4.12.1.0"
+    definition: |
+      create table t1(id bigint, col1 bigint, col2 bigint, primary key(id))
+      create index i1 as select col1 from t1
+      create index t1_version_index as select "__ROW_VERSION" from t1
+      create index grouped_version_index as select col1, "__ROW_VERSION" from t1 order by col1, "__ROW_VERSION"
+      
+      create table t2(id bigint, col1 bigint, col2 string, primary key (id))
+      create index t2_col2 as select col2 from t2
+      
+      create table t3(id bigint, col1 string, col2 bigint, primary key (id))
+      create index t3_version_with_col1 as select "__ROW_VERSION", col1 from t3 order by "__ROW_VERSION"
+      
+      create table unindexed_t(id bigint, col1 bigint, col2 string, primary key(id))
+      
+      create table t4(id bigint, col1 string, col2 bigint, col3 bigint, col4 bigint array, primary key (id))
+      create index t4_col2 as select col2 from t4
+      create index t4_col2_col4 as select col2, col4 from t4 order by col2, col4
+      create index t4_col3_version as select col3, "__ROW_VERSION" from t4 order by col3, "__ROW_VERSION"
+      create index t4_col4_version as select col4, "__ROW_VERSION" from t4 order by col4, "__ROW_VERSION"
+      
+      create function t1_v(in x bigint) as select "__ROW_VERSION", id, col1, col2 from t1 where col1 = x
+      create function t2_v(in x bigint) as select "__ROW_VERSION", id, col1, col2 from t2 where col1 = x
+      create function t3_v(in x bigint) as select "__ROW_VERSION", id, col1, col2 from t3 where col2 = x
+      create function t4_v(in x bigint) as select "__ROW_VERSION", id, col1, col2 from t3 where col2 = x
+      create function unindexed_t_v(in x bigint) as select "__ROW_VERSION", id, col1, col2 from unindexed_t where col1 = x
+      
+      create function t3_by_col1(in x string) as select "__ROW_VERSION" AS version, (t3.*) as r from t3 where t3.col1 = x
+      create function t4_by_col1(in x string) as select "__ROW_VERSION" AS version, (t4.*) as r from t4 where t4.col1 = x
+      
+      with options (store_row_versions=true)
+  - initialVersionAtLeast: "4.12.1.0"
+    definition: |
+      create table t1(id bigint, col1 bigint, col2 bigint, primary key(id))
+      create index i1 as select col1 from t1
+      create index t1_version_index as select "__ROW_VERSION" from t1
+      create index grouped_version_index as select col1, "__ROW_VERSION" from t1 order by col1, "__ROW_VERSION"
+      
+      create table t2(id bigint, col1 bigint, col2 string, primary key (id))
+      create index t2_col2 as select col2 from t2
+      
+      create table t3(id bigint, col1 string, col2 bigint, primary key (id))
+      create index t3_version_with_col1 as select "__ROW_VERSION", col1 from t3 order by "__ROW_VERSION"
+      
+      create table unindexed_t(id bigint, col1 bigint, col2 string, primary key(id))
+      
+      create table t4(id bigint, col1 string, col2 bigint, col3 bigint, col4 bigint array, primary key (id))
+      create index t4_col2 as select col2 from t4
+      create index t4_col2_col4 as select t.col2, "e" from t4 as t, t.col4 as "e" order by t.col2, "e"
+      create index t4_col3_version as select col3, "__ROW_VERSION" from t4 order by col3, "__ROW_VERSION"
+      create index t4_col4_version as select "e", "__ROW_VERSION" from t4 as t, t.col4 as "e" order by "e", "__ROW_VERSION"
+      
+      create function t1_v(in x bigint) as select "__ROW_VERSION", id, col1, col2 from t1 where col1 = x
+      create function t2_v(in x bigint) as select "__ROW_VERSION", id, col1, col2 from t2 where col1 = x
+      create function t3_v(in x bigint) as select "__ROW_VERSION", id, col1, col2 from t3 where col2 = x
+      create function t4_v(in x bigint) as select "__ROW_VERSION", id, col1, col2 from t3 where col2 = x
+      create function unindexed_t_v(in x bigint) as select "__ROW_VERSION", id, col1, col2 from unindexed_t where col1 = x
+      
+      create function t3_by_col1(in x string) as select "__ROW_VERSION" AS version, (t3.*) as r from t3 where t3.col1 = x
+      create function t4_by_col1(in x string) as select "__ROW_VERSION" AS version, (t4.*) as r from t4 where t4.col1 = x
+      
+      with options (store_row_versions=true)
 ---
 setup:
   steps:


### PR DESCRIPTION
Previously, `CREATE INDEX … AS SELECT <array> FROM …` on an ARRAY column was allowed and silently introduced an implicit fan-out in the index key expression, which is inadvertent and potentially surprising behavior. Similarly, navigating through an ARRAY of STRUCT without explicit unnesting (as in `SELECT <array>.<field> FROM T`) would also produce an implicit fan-out index. Example:

```
CREATE TABLE "vendors" ("id" BIGINT, "fruits" STRING ARRAY, PRIMARY KEY ("id"))
CREATE INDEX "fruits" AS SELECT "fruits" FROM "vendors"
-- Full key expression:
-- [Field {'fruits' None}/Field {'values' FanOut}, RecordTypeKey, Field{'id' None}]
```

With this change we disallow such implicit unnesting. Explicit unnesting (as documented under “SQL Reference › Indexes”) remains possible.

* Make `toFieldKeyExpression()` in the index generator reject ARRAY-typed fields unless they originate from an explicit unnesting operation (`ExplodeExpression`). This applies to both supported index syntaxes, `CREATE INDEX … AS SELECT` and `CREATE INDEX … ON`.

Testing:
* Adjust `in-predicate.yamsql`, `valid-identifiers.yamsql`, and `versions-tests.yamsql` to use explicit unnesting in CREATE INDEX.

Fixes #4103.