### PR TITLE
Add function key expressions for computing record size and ternary expressions

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/SerializedSizeFunctionKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/SerializedSizeFunctionKeyExpression.java
@@ -1,0 +1,107 @@
+/*
+ * SerializedSizeFunctionKeyExpression.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.metadata.expressions;
+
+import com.apple.foundationdb.record.ObjectPlanHash;
+import com.apple.foundationdb.record.PlanHashable;
+import com.apple.foundationdb.record.metadata.Key;
+import com.apple.foundationdb.record.provider.foundationdb.FDBIndexableRecord;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecord;
+import com.apple.foundationdb.record.query.plan.cascades.values.Value;
+import com.google.auto.service.AutoService;
+import com.google.protobuf.Message;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+
+public final class SerializedSizeFunctionKeyExpression extends FunctionKeyExpression {
+    public static final String FUNCTION_NAME = "serialized_size";
+    @Nonnull
+    private static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("Serialized-Size-Function-Key-Expression");
+
+    private SerializedSizeFunctionKeyExpression(@Nonnull final KeyExpression arguments) {
+        super(FUNCTION_NAME, arguments);
+    }
+
+    @Nonnull
+    @Override
+    public <M extends Message> List<Key.Evaluated> evaluateFunction(@Nullable final FDBRecord<M> record, @Nullable final Message message, @Nonnull final Key.Evaluated arguments) {
+        return List.of(Key.Evaluated.scalar(extractSize(record)));
+    }
+
+    private long extractSize(@Nullable FDBRecord<?> rec) {
+        if (rec instanceof FDBIndexableRecord<?> indexableRecord) {
+            return indexableRecord.getValueSize();
+        }
+        return 0L;
+    }
+
+    @Override
+    public int getMinArguments() {
+        return 0;
+    }
+
+    @Override
+    public int getMaxArguments() {
+        return 0;
+    }
+
+    @Nonnull
+    @Override
+    public Value toValue(@Nonnull final List<? extends Value> argumentValues) {
+        return resolveAndEncapsulateFunction(getName(), argumentValues);
+    }
+
+    @Override
+    public boolean createsDuplicates() {
+        return false;
+    }
+
+    @Override
+    public int getColumnSize() {
+        return 1;
+    }
+
+    @Override
+    public int planHash(@Nonnull final PlanHashMode hashMode) {
+        return PlanHashable.objectsPlanHash(hashMode, BASE_HASH, getName(), getArguments());
+    }
+
+    @AutoService(FunctionKeyExpression.Factory.class)
+    public static final class Factory implements FunctionKeyExpression.Factory {
+        private static final List<FunctionKeyExpression.Builder> builders = List.of(
+                new Builder(FUNCTION_NAME) {
+                    @Nonnull
+                    @Override
+                    public FunctionKeyExpression build(@Nonnull final KeyExpression arguments) {
+                        return new SerializedSizeFunctionKeyExpression(arguments);
+                    }
+                }
+        );
+
+        @Nonnull
+        @Override
+        public List<Builder> getBuilders() {
+            return builders;
+        }
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/TernaryFunctionKeyExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/expressions/TernaryFunctionKeyExpression.java
@@ -1,0 +1,142 @@
+/*
+ * TernaryFunctionKeyExpression.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.metadata.expressions;
+
+import com.apple.foundationdb.record.ObjectPlanHash;
+import com.apple.foundationdb.record.PlanHashable;
+import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.logging.LogMessageKeys;
+import com.apple.foundationdb.record.metadata.Key;
+import com.apple.foundationdb.record.metadata.MetaDataException;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecord;
+import com.apple.foundationdb.record.query.plan.cascades.values.Value;
+import com.google.auto.service.AutoService;
+import com.google.protobuf.Message;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+
+public final class TernaryFunctionKeyExpression extends FunctionKeyExpression {
+    @Nonnull
+    public static final String FUNCTION_NAME = "if";
+    @Nonnull
+    private static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("Ternary-Function-Key-Expression");
+
+    private final int columnSize;
+
+    public TernaryFunctionKeyExpression(@Nonnull KeyExpression arguments, int columnSize) {
+        super(FUNCTION_NAME, arguments);
+        this.columnSize = columnSize;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Nonnull
+    @Override
+    public <M extends Message> List<Key.Evaluated> evaluateFunction(@Nullable final FDBRecord<M> record, @Nullable final Message message, @Nonnull final Key.Evaluated arguments) {
+        final Object condition = arguments.getObject(0);
+        if (condition == null) {
+            return List.of();
+        } else if (condition instanceof List<?> listCondition) {
+            final Object conditionValue = listCondition.get(0);
+            if (conditionValue == null) {
+                return List.of();
+            } else if (conditionValue instanceof Boolean booleanCondition) {
+                Object resultObject = booleanCondition ? arguments.getObject(1) : arguments.getObject(2);
+                if (resultObject instanceof List<?> resultList) {
+                    return List.of(Key.Evaluated.concatenate((List<Object>) resultList));
+                } else {
+                    return List.of(Key.Evaluated.scalar(resultObject));
+                }
+            } else {
+                throw new RecordCoreException("Unable to evaluate ternary function as condition is non-Boolean");
+            }
+        } else {
+            throw new RecordCoreException("Unable to evaluate ternary function as condition is non-Boolean");
+        }
+    }
+
+    @Override
+    public int getMinArguments() {
+        return 3;
+    }
+
+    @Override
+    public int getMaxArguments() {
+        return 3;
+    }
+
+    @Nonnull
+    @Override
+    public Value toValue(@Nonnull final List<? extends Value> argumentValues) {
+        return resolveAndEncapsulateFunction(getName(), argumentValues);
+    }
+
+    @Override
+    public boolean createsDuplicates() {
+        return arguments.createsDuplicates();
+    }
+
+    @Override
+    public int getColumnSize() {
+        return columnSize;
+    }
+
+    @Override
+    public int planHash(@Nonnull final PlanHashMode hashMode) {
+        return PlanHashable.objectsPlanHash(hashMode, BASE_HASH, getName(), getArguments());
+    }
+
+    @AutoService(FunctionKeyExpression.Factory.class)
+    public static final class Factory implements FunctionKeyExpression.Factory {
+        private static final List<FunctionKeyExpression.Builder> builders = List.of(
+                new Builder(FUNCTION_NAME) {
+                    @Nonnull
+                    @Override
+                    public FunctionKeyExpression build(@Nonnull final KeyExpression arguments) {
+                        if (arguments instanceof ListKeyExpression listArguments) {
+                            final List<KeyExpression> children = listArguments.getChildren();
+                            if (children.size() != 3) {
+                                throw new MetaDataException("cannot create ternary expression over non-three number of children")
+                                        .addLogInfo(LogMessageKeys.KEY_EXPRESSION, arguments);
+                            }
+                            final KeyExpression leftExpression = children.get(1);
+                            final KeyExpression rightExpression = children.get(2);
+                            if (leftExpression.getColumnSize() != rightExpression.getColumnSize()) {
+                                throw new MetaDataException("left and right arguments of ternary expression must have the same result column sizes")
+                                        .addLogInfo(LogMessageKeys.KEY_EXPRESSION, arguments);
+                            }
+                            return new TernaryFunctionKeyExpression(arguments, leftExpression.getColumnSize());
+                        } else {
+                            throw new MetaDataException("cannot create ternary expression over non-list expression arguments")
+                                    .addLogInfo(LogMessageKeys.KEY_EXPRESSION, arguments);
+                        }
+                    }
+                }
+        );
+
+        @Nonnull
+        @Override
+        public List<Builder> getBuilders() {
+            return builders;
+        }
+    }
+}

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/expressions/SerializedSizeFunctionKeyExpressionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/expressions/SerializedSizeFunctionKeyExpressionTest.java
@@ -1,0 +1,136 @@
+/*
+ * SerializedSizeKeyExpressionTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.metadata.expressions;
+
+import com.apple.foundationdb.record.IndexEntry;
+import com.apple.foundationdb.record.IndexScanType;
+import com.apple.foundationdb.record.RecordMetaData;
+import com.apple.foundationdb.record.ScanProperties;
+import com.apple.foundationdb.record.TestRecords1Proto;
+import com.apple.foundationdb.record.TupleRange;
+import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.metadata.Key;
+import com.apple.foundationdb.record.provider.foundationdb.FDBIndexableRecord;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreTestBase;
+import com.apple.foundationdb.record.provider.foundationdb.FDBStoredRecord;
+import com.apple.foundationdb.tuple.Tuple;
+import com.apple.foundationdb.tuple.TupleHelpers;
+import com.google.protobuf.Message;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SerializedSizeFunctionKeyExpressionTest extends FDBRecordStoreTestBase {
+    private static final KeyExpression expression = FunctionKeyExpression.create(SerializedSizeFunctionKeyExpression.FUNCTION_NAME, Key.Expressions.empty());
+
+    static {
+        assertThat(expression)
+                .isInstanceOf(SerializedSizeFunctionKeyExpression.class);
+        assertThat(expression.getColumnSize())
+                .isOne();
+    }
+
+    private static <M extends Message> FDBIndexableRecord<M> createIndexable(@Nonnull M message) {
+        final RecordMetaData metaData = RecordMetaData.build(message.getDescriptorForType().getFile());
+        return FDBStoredRecord.<M>newBuilder()
+                .setRecordType(metaData.getRecordType(message.getDescriptorForType().getName()))
+                .setRecord(message)
+                .setPrimaryKey(TupleHelpers.EMPTY)
+                .setValueSize(message.getSerializedSize())
+                .build();
+    }
+
+    @Test
+    void evalOnNull() {
+        assertThat(expression.evaluateSingleton(null))
+                .isEqualTo(Key.Evaluated.scalar(0L));
+    }
+
+    @Test
+    void evalOnEmpty() {
+        assertThat(expression.evaluateSingleton(createIndexable(TestRecords1Proto.MyOtherRecord.getDefaultInstance())))
+                .isEqualTo(Key.Evaluated.scalar(0L));
+    }
+
+    @Test
+    void evalOnRecord() {
+        final Message message = TestRecords1Proto.MySimpleRecord.newBuilder()
+                .setStrValueIndexed("str_value")
+                .setNumValue2(42)
+                .build();
+        assertThat(expression.evaluateSingleton(createIndexable(message)))
+                .isEqualTo(Key.Evaluated.scalar((long) message.getSerializedSize()));
+    }
+
+    @Test
+    void maintainValueIndexOnSize() throws Exception {
+        final Index serializedSizeIndex = new Index("serializedSize", expression);
+
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, metaData -> metaData.addUniversalIndex(serializedSizeIndex));
+
+            final List<IndexEntry> beforeInsert = recordStore.scanIndex(serializedSizeIndex, IndexScanType.BY_VALUE, TupleRange.ALL, null, ScanProperties.FORWARD_SCAN)
+                    .asList()
+                    .get();
+            assertThat(beforeInsert)
+                    .isEmpty();
+
+            TestRecords1Proto.MySimpleRecord record1 = TestRecords1Proto.MySimpleRecord.newBuilder()
+                    .setRecNo(1066L)
+                    .setStrValueIndexed("hello")
+                    .setNumValue3Indexed(42)
+                    .build();
+            recordStore.saveRecord(record1);
+
+            TestRecords1Proto.MyOtherRecord record2 = TestRecords1Proto.MyOtherRecord.newBuilder()
+                    .setRecNo(1415L)
+                    .setNumValue3Indexed(42)
+                    .build();
+            recordStore.saveRecord(record2);
+
+            final List<IndexEntry> afterInsert = recordStore.scanIndex(serializedSizeIndex, IndexScanType.BY_VALUE, TupleRange.ALL, null, ScanProperties.FORWARD_SCAN)
+                    .asList()
+                    .get();
+            assertThat(afterInsert)
+                    .hasSize(2);
+            assertThat(afterInsert.get(0).getKey().getLong(0))
+                    .isEqualTo(TestRecords1Proto.RecordTypeUnion.newBuilder().setMyOtherRecord(record2).build().getSerializedSize() + 13L);
+            assertThat(afterInsert.get(1).getKey().getLong(0))
+                    .isEqualTo(TestRecords1Proto.RecordTypeUnion.newBuilder().setMySimpleRecord(record1).build().getSerializedSize() + 13L);
+
+            recordStore.deleteRecord(Tuple.from(record2.getRecNo()));
+
+            final List<IndexEntry> afterDelete = recordStore.scanIndex(serializedSizeIndex, IndexScanType.BY_VALUE, TupleRange.ALL, null, ScanProperties.FORWARD_SCAN)
+                    .asList()
+                    .get();
+            assertThat(afterDelete)
+                    .hasSize(1);
+            assertThat(afterDelete.get(0).getKey().getLong(0))
+                    .isEqualTo(TestRecords1Proto.RecordTypeUnion.newBuilder().setMySimpleRecord(record1).build().getSerializedSize() + 13L);
+
+            commit(context);
+        }
+    }
+}

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/expressions/TernaryFunctionKeyExpressionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/expressions/TernaryFunctionKeyExpressionTest.java
@@ -1,0 +1,94 @@
+/*
+ * TernaryFunctionKeyExpressionTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.metadata.expressions;
+
+import com.apple.foundationdb.record.metadata.Key;
+import com.apple.foundationdb.record.metadata.MetaDataException;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecord;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Tests of the {@link TernaryFunctionKeyExpression}.
+ */
+class TernaryFunctionKeyExpressionTest {
+    @Nonnull
+    private static FunctionKeyExpression create(@Nonnull KeyExpression condition, @Nonnull KeyExpression trueExpression, @Nonnull KeyExpression falseExpression) {
+        FunctionKeyExpression keyExpression = Key.Expressions.function(TernaryFunctionKeyExpression.FUNCTION_NAME,
+                Key.Expressions.list(condition, trueExpression, falseExpression));
+        assertThat(keyExpression)
+                .isInstanceOf(TernaryFunctionKeyExpression.class);
+        assertThat(keyExpression.getColumnSize())
+                .isEqualTo(trueExpression.getColumnSize())
+                .isEqualTo(falseExpression.getColumnSize());
+        assertThat(keyExpression.createsDuplicates())
+                .isEqualTo(condition.createsDuplicates() || trueExpression.createsDuplicates() || falseExpression.createsDuplicates());
+        return keyExpression;
+    }
+
+    private static void evaluateTrueAndFalse(@Nonnull KeyExpression trueExpr, @Nonnull KeyExpression falseExpr, @Nullable FDBRecord<?> record) {
+        KeyExpression trueTernary = create(Key.Expressions.value(true), trueExpr, falseExpr);
+        assertThat(trueTernary.evaluate(record))
+                .containsExactlyInAnyOrderElementsOf(trueExpr.evaluate(record));
+        KeyExpression falseTernary = create(Key.Expressions.value(false), trueExpr, falseExpr);
+        assertThat(falseTernary.evaluate(record))
+                .containsExactlyInAnyOrderElementsOf(falseExpr.evaluate(record));
+    }
+
+    @Test
+    void basicOnLiteralsTest() {
+        KeyExpression trueExpr = create(Key.Expressions.value(true), Key.Expressions.value(3L), Key.Expressions.value(4L));
+        assertThat(trueExpr.evaluateSingleton(null))
+                .isEqualTo(Key.Evaluated.scalar(3L));
+
+        KeyExpression falseExpr = create(Key.Expressions.value(false), Key.Expressions.value(3L), Key.Expressions.value(4L));
+        assertThat(falseExpr.evaluateSingleton(null))
+                .isEqualTo(Key.Evaluated.scalar(4L));
+
+        evaluateTrueAndFalse(Key.Expressions.value("foo"), Key.Expressions.value("bar"), null);
+    }
+
+    @Test
+    void twoColumnResult() {
+        final KeyExpression trueExpr = Key.Expressions.concat(Key.Expressions.value("hello"), Key.Expressions.value(1L));
+        final KeyExpression falseExpr = Key.Expressions.concat(Key.Expressions.value("goodbye"), Key.Expressions.value(2L));
+
+        assertThat(create(Key.Expressions.value(true), trueExpr, falseExpr).evaluateSingleton(null))
+                .isEqualTo(Key.Evaluated.concatenate("hello", 1L));
+
+        assertThat(create(Key.Expressions.value(false), trueExpr, falseExpr).evaluateSingleton(null))
+                .isEqualTo(Key.Evaluated.concatenate("goodbye", 2L));
+
+        evaluateTrueAndFalse(trueExpr, falseExpr, null);
+    }
+
+    @Test
+    void mixedColumnSize() {
+        assertThatCode(() -> create(Key.Expressions.field("blah"), Key.Expressions.field("one"), Key.Expressions.concatenateFields("two", "three")))
+                .isInstanceOf(MetaDataException.class)
+                .hasMessageContaining("left and right arguments of ternary expression must have the same result column sizes");
+    }
+}


### PR DESCRIPTION
This adds a few new useful function key expressions to allow users to specify more complicated ideas through key expressions.

The first is a record size function key expression. It behaves a bit like the `VersionKeyExpression` in that it doesn't really take arguments, and it returns a value (the serialized size) that comes from the `FDBRecord` rather than the non-record inputs into the expression.

The second is a ternary function key expression. It allows the user to define expressions like `a.bool_field ? <expr1> : <expr2>`. It would prepare us for some what more complicated expressions like `a.x < 10 ? <expr1> : <expr2>`. You could also theoretically implement a coaelsce function on top of it (`x IS NULL ? y : x` for `coalesce(x, y)`), but you are limited by the set of expressions that could actually be Booleans.