### PR TITLE
Remove jacoco-report from our pull_request builds

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -152,16 +152,6 @@ jobs:
           name: coverage-report
           path: |
             ${{ github.workspace }}/.out/reports/jacoco/codeCoverageReport/
-      - name: Add Coverage Summary
-        # v1.7.2
-        uses: madrapps/jacoco-report@50d3aff4548aa991e6753342d9ba291084e63848
-        with:
-          paths: |
-            ${{ github.workspace }}/.out/reports/jacoco/codeCoverageReport/codeCoverageReport.xml
-          token: ${{ secrets.GITHUB_TOKEN }}
-          comment-type: summary
-          min-coverage-overall: 75
-          min-coverage-changed-files: 80
       - name: Get PR Diff
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This removes the summary that noted the coverage as part of PRB. madrapps/jacoco-report does not have a version that is compatible with node 24, and node 20 support is going away shortly.

This has been replaced by teamscale, and a custom coverage reporting.