### PR TITLE
Remove FDB Binaries Cache

### DIFF
--- a/actions/setup-fdb/action.yml
+++ b/actions/setup-fdb/action.yml
@@ -15,22 +15,15 @@ runs:
       run: |
         echo "client_deb=foundationdb-clients_${{ inputs.fdb_version }}-1_amd64.deb" >> "${GITHUB_OUTPUT}"
         echo "server_deb=foundationdb-server_${{ inputs.fdb_version }}-1_amd64.deb" >> "${GITHUB_OUTPUT}"
-    - name: Check FDB Binaries Cache
-      id: cache_fdb
-      uses: actions/cache@v5.0.4
-      with:
-        path: ~/.fdb-cache
-        key: ${{ runner.os }}-fdb-debs-${{ inputs.fdb_version }}
     - name: Download FDB Binaries
-      if: steps.cache_fdb.outputs.cache-hit != 'true'
       shell: bash
       run: |
-        mkdir -p ~/.fdb-cache
-        wget -O ~/.fdb-cache/${{ steps.fdb_filenames.outputs.client_deb }} -nv https://github.com/apple/foundationdb/releases/download/${{ inputs.fdb_version }}/${{ steps.fdb_filenames.outputs.client_deb }}
-        wget -O ~/.fdb-cache/${{ steps.fdb_filenames.outputs.server_deb }} -nv https://github.com/apple/foundationdb/releases/download/${{ inputs.fdb_version }}/${{ steps.fdb_filenames.outputs.server_deb }}
+        mkdir -p ~/.fdb-bin
+        wget -O ~/.fdb-bin/${{ steps.fdb_filenames.outputs.client_deb }} -nv https://github.com/apple/foundationdb/releases/download/${{ inputs.fdb_version }}/${{ steps.fdb_filenames.outputs.client_deb }}
+        wget -O ~/.fdb-bin/${{ steps.fdb_filenames.outputs.server_deb }} -nv https://github.com/apple/foundationdb/releases/download/${{ inputs.fdb_version }}/${{ steps.fdb_filenames.outputs.server_deb }}
     - name: Install FDB Server
       shell: bash
-      run: sudo dpkg -i ~/.fdb-cache/${{ steps.fdb_filenames.outputs.client_deb }} ~/.fdb-cache/${{ steps.fdb_filenames.outputs.server_deb }}
+      run: sudo dpkg -i ~/.fdb-bin/${{ steps.fdb_filenames.outputs.client_deb }} ~/.fdb-bin/${{ steps.fdb_filenames.outputs.server_deb }}
     - name: Stop default fdb
       shell: bash
       run: sudo service foundationdb stop


### PR DESCRIPTION
With the upgrade to actions/cache@v5.0.4 this started issuing notices in the builds:
> Failed to restore:

Looking at the logs in more detail, I see this wrapped around the FDB cache:
```
Cache hit for: Linux-fdb-debs-7.3.42
Warning: Failed to restore:
Cache not found for input keys: Linux-fdb-debs-7.3.42
```

It seems weird that it says it got a cache hit, but then failed to restore. That being said, it takes 1 second to get the binaries, so I'm concluding it makes more sense to just remove the caching and noise, rather than try to debug it.