### PR TITLE
Handle binary files in diffs for coverage_annotations

### DIFF
--- a/build/coverage_annotations.py
+++ b/build/coverage_annotations.py
@@ -135,7 +135,13 @@ def parse_diff(diff_path):
     current_file = None
     current_line = 0
 
-    with open(diff_path) as f:
+    # Use errors='replace' so the parser tolerates diffs that contain non-UTF-8
+    # bytes inside hunk content. This happens when git classifies a fixture file
+    # (e.g. a .binpb binary protobuf) as text and emits a regular textual diff
+    # whose hunk lines include raw binary bytes. We never need to decode that
+    # content faithfully -- non-Java paths are filtered out in
+    # generate_annotations() -- but the file must decode without raising.
+    with open(diff_path, encoding='utf-8', errors='replace') as f:
         for raw_line in f:
             line = raw_line.rstrip('\n')
 

--- a/build/test_coverage_annotations.py
+++ b/build/test_coverage_annotations.py
@@ -255,6 +255,57 @@ diff --git a/build.gradle b/build.gradle
         finally:
             os.unlink(path)
 
+    def test_diff_with_non_utf8_bytes(self):
+        """parse_diff tolerates raw non-UTF-8 bytes embedded in hunk content.
+
+        Reproduces the failure mode where `gh pr diff` emits a textual diff for
+        a binary-protobuf (.binpb) fixture: git classifies it as text, so the
+        patch contains real binary bytes (e.g. \\xc8, \\xff) inline. The script
+        must keep parsing and still extract changed lines for the .java entries.
+        """
+        # Build the diff as bytes so we can embed real non-UTF-8 sequences.
+        diff_bytes = (
+            b'diff --git a/yaml-tests/src/test/resources/foo.binpb '
+            b'b/yaml-tests/src/test/resources/foo.binpb\n'
+            b'--- a/yaml-tests/src/test/resources/foo.binpb\n'
+            b'+++ b/yaml-tests/src/test/resources/foo.binpb\n'
+            b'@@ -1,3 +1,3 @@\n'
+            b'-\xc8\x17\n'
+            b'+\xff\x17\n'
+            b' 9\n'
+            b'-\x15agg-empty-table-tests\x12 EXPLAIN select\n'
+            b'+\x15agg-empty-table-tests\x12 EXPLAIN insert\n'
+            b'diff --git a/fdb-record-layer-core/src/main/java/com/apple/'
+            b'foundationdb/record/FDBRecordStore.java '
+            b'b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/'
+            b'record/FDBRecordStore.java\n'
+            b'--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/'
+            b'record/FDBRecordStore.java\n'
+            b'+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/'
+            b'record/FDBRecordStore.java\n'
+            b'@@ -10,2 +10,3 @@\n'
+            b' existing line\n'
+            b'+added line on 11\n'
+            b' existing line\n'
+        )
+        f = tempfile.NamedTemporaryFile(mode='wb', suffix='.patch', delete=False)
+        f.write(diff_bytes)
+        f.close()
+        try:
+            # Must not raise UnicodeDecodeError.
+            result = parse_diff(f.name)
+
+            java_path = ('fdb-record-layer-core/src/main/java/com/apple/'
+                         'foundationdb/record/FDBRecordStore.java')
+            self.assertIn(java_path, result)
+            # The +line in the java hunk lands on new-file line 11.
+            self.assertIn(11, result[java_path])
+            # The binpb file is present (parse_diff doesn't filter); content
+            # filtering happens later in generate_annotations().
+            self.assertIn('yaml-tests/src/test/resources/foo.binpb', result)
+        finally:
+            os.unlink(f.name)
+
 
 class TestComputeFileCoverage(unittest.TestCase):
     """Tests for compute_file_coverage()"""


### PR DESCRIPTION
The .binbp files used for metrics are sometimes interpreted as text by GitHub and their content is rendered in the diff (and we haven't found a way to override that).
When coverage_annotations.py read it as utf-8 it could fail due to invalid sequences. This changes that to errors which should be fine because our java files should always be utf-8, and are the only files we actually care about here.

I tested this locally (beyond the new tests) by fetching a problematic PR: 
```
gh pr diff --repo FoundationDB/fdb-record-layer 4174 > pr_diff.patch
```

And calling `parse_diff` on it.