### PR TITLE
Queue size in metadata

### DIFF
--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
@@ -75,6 +75,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
+import com.apple.foundationdb.record.util.pair.ImmutablePair;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -583,13 +584,24 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
         try {
             try (IndexReader indexReader = directoryManager.getIndexReader(groupingKey, partitionId)) {
                 final FDBDirectory directory = getDirectory(groupingKey, partitionId);
-                final CompletableFuture<Integer> fieldInfosFuture = directory.getFieldInfosCount();
-                return directory.getAllAsync()
-                        .thenCombine(fieldInfosFuture, (fileList, fieldInfosCount) ->
+                final CompletableFuture<Map<String, FDBLuceneFileReference>> filesFuture =
+                        directory.getAllAsync();
+                final CompletableFuture<Integer> fieldInfosFuture =
+                        directory.getFieldInfosCount();
+                final CompletableFuture<Long> queueSizeFuture =
+                        directoryManager.getPendingWriteQueue(groupingKey, partitionId)
+                                        .getQueueSize(state.context);
+                return filesFuture.thenCombine(
+                        fieldInfosFuture.thenCombine(queueSizeFuture,
+                                (fieldInfosCount, queueSize) ->
+                                        ImmutablePair.of(fieldInfosCount,
+                                                queueSize != null ? queueSize : 0L)),
+                        (fileList, fieldInfosAndQueueSize) ->
                                 new LuceneMetadataInfo.LuceneInfo(
                                         indexReader.numDocs(),
-                                        fieldInfosCount,
-                                        toLuceneFileInfo(fileList)));
+                                        fieldInfosAndQueueSize.getLeft(),
+                                        toLuceneFileInfo(fileList),
+                                        fieldInfosAndQueueSize.getRight()));
             }
         } catch (IOException e) {
             return CompletableFuture.failedFuture(e);

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
@@ -75,7 +75,6 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
-import com.apple.foundationdb.record.util.pair.ImmutablePair;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -591,17 +590,14 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
                 final CompletableFuture<Long> queueSizeFuture =
                         directoryManager.getPendingWriteQueue(groupingKey, partitionId)
                                         .getQueueSize(state.context);
-                return filesFuture.thenCombine(
-                        fieldInfosFuture.thenCombine(queueSizeFuture,
-                                (fieldInfosCount, queueSize) ->
-                                        ImmutablePair.of(fieldInfosCount,
-                                                queueSize != null ? queueSize : 0L)),
-                        (fileList, fieldInfosAndQueueSize) ->
-                                new LuceneMetadataInfo.LuceneInfo(
-                                        indexReader.numDocs(),
-                                        fieldInfosAndQueueSize.getLeft(),
-                                        toLuceneFileInfo(fileList),
-                                        fieldInfosAndQueueSize.getRight()));
+                return filesFuture.thenCompose(fileList ->
+                        fieldInfosFuture.thenCompose(fieldInfosCount ->
+                                queueSizeFuture.thenApply(queueSize ->
+                                        new LuceneMetadataInfo.LuceneInfo(
+                                                indexReader.numDocs(),
+                                                fieldInfosCount,
+                                                toLuceneFileInfo(fileList),
+                                                queueSize != null ? queueSize : 0L))));
             }
         } catch (IOException e) {
             return CompletableFuture.failedFuture(e);

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneMetadataInfo.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneMetadataInfo.java
@@ -72,6 +72,7 @@ public class LuceneMetadataInfo extends IndexOperationResult {
         private final int fieldInfoCount;
         @Nullable
         private final List<LuceneFileInfo> detailedFileInfos;
+        private final long pendingWritesQueueSize;
 
         @API(API.Status.DEPRECATED)
         public LuceneInfo(final int documentCount, final Collection<String> files, final int fieldInfoCount) {
@@ -79,15 +80,24 @@ public class LuceneMetadataInfo extends IndexOperationResult {
             this.files = files;
             this.fieldInfoCount = fieldInfoCount;
             this.detailedFileInfos = null;
+            this.pendingWritesQueueSize = 0;
         }
 
         public LuceneInfo(final int documentCount,
                           final int fieldInfoCount,
                           @Nonnull final List<LuceneFileInfo> detailedFileInfos) {
+            this(documentCount, fieldInfoCount, detailedFileInfos, 0);
+        }
+
+        public LuceneInfo(final int documentCount,
+                          final int fieldInfoCount,
+                          @Nonnull final List<LuceneFileInfo> detailedFileInfos,
+                          final long pendingWritesQueueSize) {
             this.documentCount = documentCount;
             this.files = detailedFileInfos.stream().map(LuceneFileInfo::getName).collect(Collectors.toList());
             this.fieldInfoCount = fieldInfoCount;
             this.detailedFileInfos = Collections.unmodifiableList(detailedFileInfos);
+            this.pendingWritesQueueSize = pendingWritesQueueSize;
         }
 
         /**
@@ -126,6 +136,15 @@ public class LuceneMetadataInfo extends IndexOperationResult {
             return detailedFileInfos;
         }
 
+        /**
+         * The size of the pending writes queue for this partition.
+         * A value of {@code 0} means the queue is empty or has never been initialised.
+         * @return the number of entries currently in the pending writes queue
+         */
+        public long getPendingWritesQueueSize() {
+            return pendingWritesQueueSize;
+        }
+
         @Override
         public boolean equals(final Object o) {
             if (this == o) {
@@ -137,13 +156,14 @@ public class LuceneMetadataInfo extends IndexOperationResult {
             final LuceneInfo that = (LuceneInfo)o;
             return documentCount == that.documentCount &&
                     fieldInfoCount == that.fieldInfoCount &&
+                    pendingWritesQueueSize == that.pendingWritesQueueSize &&
                     Objects.equals(files, that.files) &&
                     Objects.equals(detailedFileInfos, that.detailedFileInfos);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(documentCount, files, fieldInfoCount, detailedFileInfos);
+            return Objects.hash(documentCount, files, fieldInfoCount, detailedFileInfos, pendingWritesQueueSize);
         }
     }
 

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexGetMetadataInfoTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexGetMetadataInfoTest.java
@@ -234,27 +234,69 @@ public class LuceneIndexGetMetadataInfoTest extends FDBRecordStoreTestBase {
                 new LuceneMetadataInfo.LuceneFileInfo("file1.txt", 1L, 100L),
                 new LuceneMetadataInfo.LuceneFileInfo("file2.txt", 2L, 200L)
         );
-        final LuceneMetadataInfo.LuceneInfo info1 = new LuceneMetadataInfo.LuceneInfo(10, 5, detailedFiles1);
-        final LuceneMetadataInfo.LuceneInfo info2 = new LuceneMetadataInfo.LuceneInfo(10, 5, detailedFiles1Copy);
-        final LuceneMetadataInfo.LuceneInfo info3 = new LuceneMetadataInfo.LuceneInfo(15, 5, detailedFiles1);
-        final LuceneMetadataInfo.LuceneInfo info4 = new LuceneMetadataInfo.LuceneInfo(10, 3, detailedFiles1);
-        final LuceneMetadataInfo.LuceneInfo info5 = new LuceneMetadataInfo.LuceneInfo(10, 5, detailedFiles2);
+        final LuceneMetadataInfo.LuceneInfo info1 = new LuceneMetadataInfo.LuceneInfo(10, 5, detailedFiles1, 1);
+        final LuceneMetadataInfo.LuceneInfo info2 = new LuceneMetadataInfo.LuceneInfo(10, 5, detailedFiles1Copy, 1);
+        final LuceneMetadataInfo.LuceneInfo info3 = new LuceneMetadataInfo.LuceneInfo(15, 5, detailedFiles1, 1);
+        final LuceneMetadataInfo.LuceneInfo info4 = new LuceneMetadataInfo.LuceneInfo(10, 3, detailedFiles1, 1);
+        final LuceneMetadataInfo.LuceneInfo info5 = new LuceneMetadataInfo.LuceneInfo(10, 5, detailedFiles2, 1);
+        final LuceneMetadataInfo.LuceneInfo info6 = new LuceneMetadataInfo.LuceneInfo(10, 5, detailedFiles1, 2);
 
         // Test equals
         assertEquals(info1, info2);
         assertNotEquals(info1, info3);
         assertNotEquals(info1, info4);
         assertNotEquals(info1, info5);
+        assertNotEquals(info1, info6);
 
         // Test hashCode consistency
         assertEquals(info1.hashCode(), info2.hashCode());
         assertNotEquals(info1.hashCode(), info3.hashCode());
         assertNotEquals(info1.hashCode(), info4.hashCode());
         assertNotEquals(info1.hashCode(), info5.hashCode());
+        assertNotEquals(info1.hashCode(), info6.hashCode());
 
         // Test reflexivity
         assertEquals(info1, info1);
         assertEquals(info1.hashCode(), info1.hashCode());
+    }
+
+    @Test
+    void getMetadataWithNonZeroQueueSize() {
+        final LuceneIndexTestDataModel dataModel = new LuceneIndexTestDataModel.Builder(234097L, this::getStoreBuilder, pathManager)
+                .setIsGrouped(false)
+                .setEnablePendingWriteQueueDuringMerge(true)
+                .build();
+
+        // Save an initial batch of records directly to Lucene (no merge indicator yet)
+        try (FDBRecordContext context = openContext()) {
+            dataModel.saveRecords(3, context, 0);
+            commit(context);
+        }
+
+        // Activate the pending-write queue by simulating an ongoing merge
+        try (FDBRecordContext context = openContext()) {
+            dataModel.setOngoingMergeIndicator(context, null, null);
+            commit(context);
+        }
+
+        // Save records while the merge indicator is set - writes go to the queue instead of directly to Lucene
+        try (FDBRecordContext context = openContext()) {
+            dataModel.saveRecords(3, context, 0);
+            commit(context);
+        }
+
+        // Queue has pending entries - metadata should report a non-zero queue size
+        final LuceneMetadataInfo result = getLuceneMetadataInfo(false, Tuple.from(), dataModel, null);
+        assertThat(result.getLuceneInfo().get(0).getPendingWritesQueueSize(), Matchers.equalTo(3L));
+
+        // Merge drains the queue
+        try (FDBRecordContext context = openContext()) {
+            dataModel.explicitMergeIndex(context, timer);
+        }
+
+        // After merge the queue is empty - metadata should report zero
+        final LuceneMetadataInfo result2 = getLuceneMetadataInfo(false, Tuple.from(), dataModel, null);
+        assertEquals(0L, result2.getLuceneInfo().get(0).getPendingWritesQueueSize());
     }
 
     private static void assertPartitionInfosHaveCorrectFromTo(

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexGetMetadataInfoTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexGetMetadataInfoTest.java
@@ -86,6 +86,7 @@ public class LuceneIndexGetMetadataInfoTest extends FDBRecordStoreTestBase {
                 assertThat(luceneInfo.getFiles(), Matchers.hasSize(segmentCountToFileCount(isGrouped ? 1 : 5)));
                 assertThat(luceneInfo.getDetailedFileInfos(), Matchers.hasSize(segmentCountToFileCount(isGrouped ? 1 : 5)));
                 assertEquals(1, luceneInfo.getFieldInfoCount());
+                assertEquals(0, luceneInfo.getPendingWritesQueueSize());
             }
         }
     }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
@@ -1403,7 +1403,7 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
         AtomicInteger updates = new AtomicInteger(0);
         AtomicInteger deletes = new AtomicInteger(0);
         AtomicInteger saves = new AtomicInteger(0);
-        concurrentTestWithinTransaction(false, (dataModel, recordStore) ->
+        concurrentTestWithinTransaction(isSynthetic, (dataModel, recordStore) ->
                         RecordCursor.fromList(dataModel.recordsUnderTest())
                                 .mapPipelined(record -> {
                                     switch (step.incrementAndGet() % 3) {
@@ -1422,7 +1422,7 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
                                 .asList().join(),
                 (inserted, actual) -> assertEquals(inserted + saves.get() - deletes.get(), actual),
                 noopConsumer(),
-                PartitionCount.MULTIPLE);
+                partitionCount);
     }
 
     private void concurrentTestWithinTransaction(boolean isSynthetic,
@@ -1471,7 +1471,7 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
                 .build();
 
         final int repartitionCount = 10;
-        final int recordsPerIteration = 100;
+        final int recordsPerIteration = 10;
         final int loopCount = 40;
 
         final RecordLayerPropertyStorage contextProps = RecordLayerPropertyStorage.newBuilder()

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
@@ -1403,7 +1403,7 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
         AtomicInteger updates = new AtomicInteger(0);
         AtomicInteger deletes = new AtomicInteger(0);
         AtomicInteger saves = new AtomicInteger(0);
-        concurrentTestWithinTransaction(isSynthetic, (dataModel, recordStore) ->
+        concurrentTestWithinTransaction(false, (dataModel, recordStore) ->
                         RecordCursor.fromList(dataModel.recordsUnderTest())
                                 .mapPipelined(record -> {
                                     switch (step.incrementAndGet() % 3) {
@@ -1422,7 +1422,7 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
                                 .asList().join(),
                 (inserted, actual) -> assertEquals(inserted + saves.get() - deletes.get(), actual),
                 noopConsumer(),
-                partitionCount);
+                PartitionCount.MULTIPLE);
     }
 
     private void concurrentTestWithinTransaction(boolean isSynthetic,
@@ -1471,7 +1471,7 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
                 .build();
 
         final int repartitionCount = 10;
-        final int recordsPerIteration = 10;
+        final int recordsPerIteration = 100;
         final int loopCount = 40;
 
         final RecordLayerPropertyStorage contextProps = RecordLayerPropertyStorage.newBuilder()

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTestDataModel.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTestDataModel.java
@@ -25,6 +25,8 @@ import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.RecordMetaDataBuilder;
 import com.apple.foundationdb.record.ScanProperties;
 import com.apple.foundationdb.record.TestRecordsGroupedParentChildProto;
+import com.apple.foundationdb.record.lucene.directory.FDBDirectory;
+import com.apple.foundationdb.record.lucene.directory.FDBDirectoryManager;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.IndexPredicate;
 import com.apple.foundationdb.record.metadata.JoinedRecordTypeBuilder;
@@ -35,6 +37,7 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStore;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoredRecord;
+import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerState;
 import com.apple.foundationdb.record.provider.foundationdb.OnlineIndexScrubber;
 import com.apple.foundationdb.record.provider.foundationdb.OnlineIndexer;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpacePath;
@@ -404,6 +407,25 @@ public class LuceneIndexTestDataModel {
         }
     }
 
+    /**
+     * Sets the "ongoing merge" indicator for the given partition, activating the pending-write queue so that
+     * subsequent record saves are routed to the queue rather than written directly to Lucene.
+     * The caller is responsible for committing the context after this call.
+     *
+     * @param context the open record context to use
+     * @param groupingKey the grouping key for the partition, or {@code null} for non-grouped indexes
+     * @param partitionId the partition id, or {@code null} for non-partitioned indexes
+     */
+    public void setOngoingMergeIndicator(@Nonnull final FDBRecordContext context,
+                                         @Nullable final Tuple groupingKey,
+                                         @Nullable final Integer partitionId) {
+        FDBRecordStore store = Objects.requireNonNull(schemaSetup.apply(context));
+        final IndexMaintainerState state = new IndexMaintainerState(store, index, store.getIndexMaintenanceFilter());
+        final FDBDirectoryManager directoryManager = FDBDirectoryManager.getManager(state);
+        final FDBDirectory directory = directoryManager.getDirectory(groupingKey, partitionId);
+        directory.setOngoingMergeIndicator();
+    }
+
     public long findMissingIndexEntries(final FDBRecordContext context, @Nullable FDBStoreTimer timer) {
         FDBRecordStore recordStore = Objects.requireNonNull(schemaSetup.apply(context));
         try (OnlineIndexScrubber indexBuilder = OnlineIndexScrubber.newBuilder()
@@ -452,6 +474,7 @@ public class LuceneIndexTestDataModel {
         boolean isSynthetic;
         boolean primaryKeySegmentIndexEnabled = true;
         int partitionHighWatermark;
+        boolean enablePendingWriteQueueDuringMerge = true;
         @Nullable
         private Index index;
         @Nullable
@@ -486,6 +509,12 @@ public class LuceneIndexTestDataModel {
 
         public Builder setPartitionHighWatermark(final int partitionHighWatermark) {
             this.partitionHighWatermark = partitionHighWatermark;
+            metadata = null;
+            return this;
+        }
+
+        public Builder setEnablePendingWriteQueueDuringMerge(final boolean enablePendingWriteQueueDuringMerge) {
+            this.enablePendingWriteQueueDuringMerge = enablePendingWriteQueueDuringMerge;
             metadata = null;
             return this;
         }
@@ -537,6 +566,10 @@ public class LuceneIndexTestDataModel {
             if (partitionHighWatermark > 0) {
                 options.put(LuceneIndexOptions.INDEX_PARTITION_BY_FIELD_NAME, isSynthetic ? "parent.timestamp" : "timestamp");
                 options.put(LuceneIndexOptions.INDEX_PARTITION_HIGH_WATERMARK, String.valueOf(partitionHighWatermark));
+            }
+            if (enablePendingWriteQueueDuringMerge) {
+                options.put(LuceneIndexOptions.ENABLE_PENDING_WRITE_QUEUE_DURING_MERGE, "true");
+                options.put(LuceneIndexOptions.PENDING_WRITE_QUEUE_INCARNATION_ENABLED, "true");
             }
             return options;
         }


### PR DESCRIPTION
Add the PendingWritesQueue size to the Lucene index metadata.
This will allow the queue size to be returned via an API, for visibility and monitoring.
The index size is already available through the Directory Manager, so all it takes is to add it to the metadata structure.

Resolves #4180 