### PR TITLE
Make `RelationalExpression#equalsWithoutChildren()` compare the result values where necessary

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryDeletePlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryDeletePlan.java
@@ -165,7 +165,10 @@ public class RecordQueryDeletePlan extends AbstractRelationalExpressionWithChild
         if (this == other) {
             return true;
         }
-        return getClass() == other.getClass();
+        if (getClass() != other.getClass()) {
+            return false;
+        }
+        return semanticEqualsForResults(other, equivalences);
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryFetchFromPartialRecordPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryFetchFromPartialRecordPlan.java
@@ -229,7 +229,9 @@ public class RecordQueryFetchFromPartialRecordPlan extends AbstractRelationalExp
         if (getClass() != otherExpression.getClass()) {
             return false;
         }
-
+        if (!semanticEqualsForResults(otherExpression, equivalences)) {
+            return false;
+        }
         final var otherFetchPlan = (RecordQueryFetchFromPartialRecordPlan)otherExpression;
         return fetchIndexRecords == otherFetchPlan.fetchIndexRecords;
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryFilterPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryFilterPlan.java
@@ -153,6 +153,9 @@ public class RecordQueryFilterPlan extends RecordQueryFilterPlanBase {
         if (getClass() != otherExpression.getClass()) {
             return false;
         }
+        if (!semanticEqualsForResults(otherExpression, equivalencesMap)) {
+            return false;
+        }
         final RecordQueryFilterPlan otherPlan = (RecordQueryFilterPlan)otherExpression;
         return conjunctedFilter.equals(otherPlan.getConjunctedFilter());
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryInJoinPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryInJoinPlan.java
@@ -209,6 +209,9 @@ public abstract class RecordQueryInJoinPlan extends AbstractRelationalExpression
         if (getClass() != otherExpression.getClass()) {
             return false;
         }
+        if (!semanticEqualsForResults(otherExpression, equivalencesMap)) {
+            return false;
+        }
         final RecordQueryInJoinPlan other = (RecordQueryInJoinPlan)otherExpression;
         return inSource.equals(other.inSource);
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryInUnionPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryInUnionPlan.java
@@ -283,6 +283,9 @@ public abstract class RecordQueryInUnionPlan extends AbstractRelationalExpressio
         if (getClass() != otherExpression.getClass()) {
             return false;
         }
+        if (!semanticEqualsForResults(otherExpression, equivalencesMap)) {
+            return false;
+        }
         final RecordQueryInUnionPlan other = (RecordQueryInUnionPlan)otherExpression;
         return inSources.equals(other.inSources) && comparisonKeyFunction.equals(other.comparisonKeyFunction);
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryPredicatesFilterPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryPredicatesFilterPlan.java
@@ -180,6 +180,9 @@ public class RecordQueryPredicatesFilterPlan extends RecordQueryFilterPlanBase i
             return false;
         }
         final var otherPlan = (RecordQueryPredicatesFilterPlan)otherExpression;
+        if (!semanticEqualsForResults(otherPlan, equivalencesMap)) {
+            return false;
+        }
         final var otherPredicates = otherPlan.getPredicates();
         if (predicates.size() != otherPredicates.size()) {
             return false;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryRecursiveLevelUnionPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryRecursiveLevelUnionPlan.java
@@ -284,6 +284,9 @@ public class RecordQueryRecursiveLevelUnionPlan extends AbstractRelationalExpres
         if (!(otherExpression instanceof RecordQueryRecursiveLevelUnionPlan)) {
             return false;
         }
+        if (!semanticEqualsForResults(otherExpression, equivalences)) {
+            return false;
+        }
 
         final var otherRecursiveUnionQueryPlan = (RecordQueryRecursiveLevelUnionPlan)otherExpression;
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnorderedDistinctPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnorderedDistinctPlan.java
@@ -182,6 +182,9 @@ public class RecordQueryUnorderedDistinctPlan extends AbstractRelationalExpressi
         if (getClass() != otherExpression.getClass()) {
             return false;
         }
+        if (!semanticEqualsForResults(otherExpression, equivalencesMap)) {
+            return false;
+        }
         return comparisonKey.equals(((RecordQueryUnorderedDistinctPlan)otherExpression).comparisonKey);
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnorderedPrimaryKeyDistinctPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryUnorderedPrimaryKeyDistinctPlan.java
@@ -165,7 +165,10 @@ public class RecordQueryUnorderedPrimaryKeyDistinctPlan extends AbstractRelation
         if (this == otherExpression) {
             return true;
         }
-        return (getClass() == otherExpression.getClass());
+        if (getClass() != otherExpression.getClass()) {
+            return false;
+        }
+        return semanticEqualsForResults(otherExpression, equivalencesMap);
     }
 
     @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryDeletePlanTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryDeletePlanTest.java
@@ -1,0 +1,72 @@
+/*
+ * RecordQueryDeletePlanTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.plans;
+
+import com.apple.foundationdb.record.query.plan.ScanComparisons;
+import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
+import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
+import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
+import com.apple.foundationdb.record.query.plan.cascades.Reference;
+import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
+import com.google.common.collect.ImmutableSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RecordQueryDeletePlanTest {
+
+    private static RecordQueryDeletePlan deletePlanOver(final Type flowedType,
+                                                        final CorrelationIdentifier alias) {
+        final var scan = new RecordQueryScanPlan(ImmutableSet.of("R"), flowedType, null,
+                ScanComparisons.EMPTY, false, false);
+        return RecordQueryDeletePlan.deletePlan(Quantifier.physical(Reference.plannedOf(scan), alias));
+    }
+
+    private static Type recordTypeWith(final Type.TypeCode fieldType) {
+        return Type.Record.fromFields(false, List.of(
+                Type.Record.Field.of(Type.primitiveType(fieldType), Optional.of("a"))));
+    }
+
+    @Test
+    void equalsWithoutChildrenReturnsFalseWhenResultValuesDiffer() {
+        final var typeLong = recordTypeWith(Type.TypeCode.LONG);
+        final var deletePlan1 = deletePlanOver(typeLong, CorrelationIdentifier.of("q1"));
+        final var deletePlan2 = deletePlanOver(typeLong, CorrelationIdentifier.of("q2"));
+
+        assertFalse(deletePlan1.equalsWithoutChildren(deletePlan2, AliasMap.emptyMap()));
+        assertFalse(deletePlan2.equalsWithoutChildren(deletePlan1, AliasMap.emptyMap()));
+    }
+
+    @Test
+    void equalsWithoutChildrenReturnsTrueWhenResultValuesMatch() {
+        final var typeLong = recordTypeWith(Type.TypeCode.LONG);
+        final var alias = CorrelationIdentifier.of("q");
+        final var deletePlan1 = deletePlanOver(typeLong, alias);
+        final var deletePlan2 = deletePlanOver(typeLong, alias);
+
+        assertTrue(deletePlan1.equalsWithoutChildren(deletePlan2, AliasMap.emptyMap()));
+        assertTrue(deletePlan1.equalsWithoutChildren(deletePlan1, AliasMap.emptyMap()));
+    }
+}


### PR DESCRIPTION
This change adds  `semanticEqualsForResults(…)` comparisons to any `RelationalExpression#equalsWithoutChildren()` implementations that were missing it. Without this comparison, the Cascades memoizer will unify plans that differ (_only_) in their result value or type, which is incorrect. See Issue https://github.com/FoundationDB/fdb-record-layer/issues/4184 for details.

This change does not adjust the `hashCodeWithoutChildren()` methods likewise, as this is not strictly necessary. Leaving these methods untouched avoids needless plan changes (since the hashes are used as a tie-breaker in the cost model).

The potentially incorrect memoization prior to this change can trigger a sanity-check in `Reference.insertUnchecked()`, if enabled. Note though that in production the sanity-checks are disabled, so a violation would have gone undetected there.

Testing:
* Existing test coverage.
* Add missing `equals…()` coverage for `RecordQueryDeletePlan`.

Fixes https://github.com/FoundationDB/fdb-record-layer/issues/4184.