### PR TITLE
Replace PartiQL references with SQL++

### DIFF
--- a/docs/sphinx/source/ReleaseNotes.md
+++ b/docs/sphinx/source/ReleaseNotes.md
@@ -46,7 +46,7 @@ Mixed mode testing run against the following previous versions:
 * Fix the NULL result of `field()` key expressions with fan-type `Concatenate` - [PR #4130](https://github.com/FoundationDB/fdb-record-layer/pull/4130)
 <h4> New Features </h4>
 
-* Implement the PartiQL “AT” construct for unnesting with ordinality - [PR #4112](https://github.com/FoundationDB/fdb-record-layer/pull/4112)
+* Implement the SQL++ “AT” construct for unnesting with ordinality - [PR #4112](https://github.com/FoundationDB/fdb-record-layer/pull/4112)
 * Support CARDINALITY() in indexes - [PR #4100](https://github.com/FoundationDB/fdb-record-layer/pull/4100)
 <h4> Bug Fixes </h4>
 

--- a/docs/sphinx/source/reference/Subqueries.rst
+++ b/docs/sphinx/source/reference/Subqueries.rst
@@ -40,7 +40,7 @@ A subquery that references columns from the outer query:
 Array Unnesting
 ---------------
 
-FDB supports PartiQL-style array unnesting:
+FDB supports SQL++-style array unnesting:
 
 .. code-block:: sql
 
@@ -124,10 +124,10 @@ Use a correlated subquery as a derived table:
 
 The subquery ``(SELECT * FROM r WHERE r.idr = a.x)`` is correlated because it references ``a.x`` from the outer query.
 
-Array Unnesting with PartiQL
+Array Unnesting with SQL++
 -----------------------------
 
-Unnest an array column using PartiQL syntax:
+Unnest an array column using SQL++ syntax:
 
 .. code-block:: sql
 

--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/RelationalStatement.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/api/RelationalStatement.java
@@ -35,7 +35,7 @@ import java.sql.SQLWarning;
  * <dl>
  *     <dt><span class="strong"> Query Language</span></dt>
  *     <dd>
- *         The Query language used by Relational is a subset of the <a href="https://partiql.org">PartiQL Spec</a>.
+ *         The Query language used by Relational is a subset of <a href="https://arxiv.org/pdf/1405.3631">SQL++</a>.
  *     </dd>
  *     <dt><span class="strong"> Direct Access</span></dt>
  *     <dd>

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/api/ddl/IndexTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/api/ddl/IndexTest.java
@@ -340,10 +340,10 @@ public class IndexTest {
     }
 
     /**
-     * Scalar array unnesting via PartiQL syntax: STRING ARRAY, INDEX…AS syntax.
+     * Scalar array unnesting via SQL++ syntax: STRING ARRAY, INDEX…AS syntax.
      */
     @Test
-    void createIndexOnScalarStringArrayPartiQL() throws Exception {
+    void createIndexOnScalarStringArraySqlPlusPlus() throws Exception {
         final String stmt = "CREATE SCHEMA TEMPLATE test_template " +
                 "CREATE TABLE T(p BIGINT, items STRING ARRAY, PRIMARY KEY (p)) " +
                 "CREATE INDEX mv1 AS SELECT item FROM T AS t, t.items AS item ORDER BY item";
@@ -351,11 +351,11 @@ public class IndexTest {
     }
 
     /**
-     * Scalar array unnesting via PartiQL syntax: STRING ARRAY, VIEW + INDEX…ON syntax.
+     * Scalar array unnesting via SQL++ syntax: STRING ARRAY, VIEW + INDEX…ON syntax.
      */
     @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
     @Test
-    void createIndexOnScalarStringArrayPartiQLUsingView() throws Exception {
+    void createIndexOnScalarStringArraySqlPlusPlusUsingView() throws Exception {
         final String stmt = "CREATE SCHEMA TEMPLATE test_template " +
                 "CREATE TABLE T(p BIGINT, items STRING ARRAY, PRIMARY KEY (p)) " +
                 "CREATE VIEW v1 AS SELECT item FROM T AS t, t.items AS item " +
@@ -364,10 +364,10 @@ public class IndexTest {
     }
 
     /**
-     * Scalar array unnesting via PartiQL syntax: INTEGER ARRAY (different scalar type).
+     * Scalar array unnesting via SQL++ syntax: INTEGER ARRAY (different scalar type).
      */
     @Test
-    void createIndexOnScalarIntegerArrayPartiQL() throws Exception {
+    void createIndexOnScalarIntegerArraySqlPlusPlus() throws Exception {
         final String stmt = "CREATE SCHEMA TEMPLATE test_template " +
                 "CREATE TABLE T(p BIGINT, nums INTEGER ARRAY, PRIMARY KEY (p)) " +
                 "CREATE INDEX mv1 AS SELECT num FROM T AS t, t.nums AS num ORDER BY num";
@@ -375,11 +375,11 @@ public class IndexTest {
     }
 
     /**
-     * Scalar array unnesting via PartiQL syntax: array element + table column, ordered by (item, p).
+     * Scalar array unnesting via SQL++ syntax: array element + table column, ordered by (item, p).
      */
     @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
     @Test
-    void createIndexOnScalarArrayPartiQLAndConcat() throws Exception {
+    void createIndexOnScalarArraySqlPlusPlusAndConcat() throws Exception {
         final String stmt = "CREATE SCHEMA TEMPLATE test_template " +
                 "CREATE TABLE T(p BIGINT, items STRING ARRAY, PRIMARY KEY (p)) " +
                 "CREATE INDEX mv1 AS SELECT item, t.p FROM T AS t, t.items AS item ORDER BY item, t.p";
@@ -387,11 +387,11 @@ public class IndexTest {
     }
 
     /**
-     * Scalar array unnesting via PartiQL syntax: array element + table column, ordered by (p, item).
+     * Scalar array unnesting via SQL++ syntax: array element + table column, ordered by (p, item).
      */
     @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
     @Test
-    void createIndexOnScalarArrayPartiQLAndConcatDifferentOrder() throws Exception {
+    void createIndexOnScalarArraySqlPlusPlusAndConcatDifferentOrder() throws Exception {
         final String stmt = "CREATE SCHEMA TEMPLATE test_template " +
                 "CREATE TABLE T(p BIGINT, items STRING ARRAY, PRIMARY KEY (p)) " +
                 "CREATE INDEX mv1 AS SELECT t.p, item FROM T AS t, t.items AS item ORDER BY t.p, item";

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/StandardQueryTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/StandardQueryTests.java
@@ -559,7 +559,7 @@ public class StandardQueryTests {
     }
 
     @Test
-    void partiqlNestingWorks() throws Exception {
+    void sqlPlusPlusNestingWorks() throws Exception {
         final String schema = "CREATE TYPE AS STRUCT A ( b B )" +
                 " CREATE TYPE AS STRUCT B ( c C )" +
                 " CREATE TYPE AS STRUCT C ( d D )" +
@@ -611,7 +611,7 @@ public class StandardQueryTests {
     }
 
     @Test
-    void partiqlNestingWorksWithRepeatedLeaf() throws Exception {
+    void sqlPlusPlusNestingWorksWithRepeatedLeaf() throws Exception {
         final String schema = "CREATE TYPE AS STRUCT A ( b B )" +
                 " CREATE TYPE AS STRUCT B ( c C )" +
                 " CREATE TYPE AS STRUCT C ( d D )" +
@@ -656,7 +656,7 @@ public class StandardQueryTests {
     }
 
     @Test
-    void partiqlAccessingNestedFieldWithInnerRepeatedFieldsFails() throws Exception {
+    void sqlPlusPlusAccessingNestedFieldWithInnerRepeatedFieldsFails() throws Exception {
         final String schema = "CREATE TYPE AS STRUCT A ( b B )" +
                 " CREATE TYPE AS STRUCT B ( c C )" +
                 " CREATE TYPE AS STRUCT C ( d D )" +

--- a/yaml-tests/src/test/resources/array-join-at.yamsql
+++ b/yaml-tests/src/test/resources/array-join-at.yamsql
@@ -20,7 +20,7 @@
 options:
   supported_version: 4.12.3.0
 ---
-# Comprehensive integration tests for the PartiQL AT construct.
+# Comprehensive integration tests for the SQL++ AT construct.
 schema_template:
   CREATE TABLE T1 ("id" BIGINT, "arr1" INTEGER ARRAY NULL, "arr1_nn" INTEGER ARRAY NOT NULL, PRIMARY KEY ("id"))
   CREATE TABLE T2 ("id" BIGINT, "arr1" INTEGER ARRAY,      "arr2"    INTEGER ARRAY,          PRIMARY KEY ("id"))
@@ -89,7 +89,7 @@ test_block:
           {id: 2, val: 203, at: 3}]
     -
       # It is allowed to leave out the AS alias completely, keeping only the AT part. This way the elements themselves
-      # cannot be accessed, only their indexes. Although this is not possible with pure PartiQL or with the UNNEST()
+      # cannot be accessed, only their indexes. Although this is not possible with pure SQL++ or with the UNNEST()
       # construct in standard SQL, we do not prohibit this case.
       - query: SELECT "id", "at" FROM T1, T1."arr1" AT "at"
       - explain: "SCAN([IS T1]) | FLATMAP q0 -> { EXPLODE q0.arr1 WITH ORDINALITY AS q1 RETURN (q0.id AS id, q1._1 AS at) }"

--- a/yaml-tests/src/test/resources/arrays-unnesting.yamsql
+++ b/yaml-tests/src/test/resources/arrays-unnesting.yamsql
@@ -109,7 +109,7 @@ test_block:
       - query: SELECT "items" FROM "T1_indexed" ORDER BY "items"
       - error: "0AF00"  # "Cascades planner could not plan query"
     -
-      # Unnesting the array using PartiQL-style unnesting.
+      # Unnesting the array using SQL++-style unnesting.
       - query: SELECT "id", "item" FROM "T1_indexed" AS "row", "row"."items" AS "item"
       - explain: "SCAN([IS T1_indexed]) | FLATMAP q0 -> { EXPLODE q0.items AS q1 RETURN (q0.id AS id, q1 AS item) }"
       - unorderedResult: [
@@ -123,9 +123,9 @@ test_block:
           {id: 3, item: 'f'}]
     -
       # Unnesting the array using a lateral/correlated subquery.
-      # Notice the difference to PartiQL-style unnesting, where "item" binds directly to an array item.
+      # Notice the difference to SQL++-style unnesting, where "item" binds directly to an array item.
       # Here the subquery packs each array item into a tuple, produces a stream of tuples, and binds SQ to each tuple.
-      # The planner is able to produce the same EXPLODE plan as for PartiQL-style unnesting.
+      # The planner is able to produce the same EXPLODE plan as for SQL++-style unnesting.
       - query: SELECT "id", SQ."item" FROM "T1_indexed" AS "row", (SELECT "item" FROM "row"."items" AS "item") AS SQ
       - explain: "SCAN([IS T1_indexed]) | FLATMAP q0 -> { EXPLODE q0.items AS q1 RETURN (q0.id AS id, q1 AS item) }"
       - unorderedResult: [

--- a/yaml-tests/src/test/resources/documentation-queries/subqueries-documentation-queries.yamsql
+++ b/yaml-tests/src/test/resources/documentation-queries/subqueries-documentation-queries.yamsql
@@ -34,7 +34,7 @@ test_block:
                           {x: 2, idr: 2, nr: [{f: 21}, {f: 22}, {f: 23}]},
                           {x: 3, idr: 3, nr: [{f: 31}, {f: 32}, {f: 33}]}]
 
-    # Array Unnesting with PartiQL
+    # Array Unnesting with SQL++
     -
       - query: SELECT idr FROM r, r.nr AS NEST WHERE NEST.f = 23
       - result: [{idr: 2}]

--- a/yaml-tests/src/test/resources/subquery-tests.yamsql
+++ b/yaml-tests/src/test/resources/subquery-tests.yamsql
@@ -51,11 +51,11 @@ test_block:
       - explain: "SCAN([IS A, EQUALS promote(@c14 AS INT)]) | MAP (_.X AS X) | DEFAULT NULL | FILTER _ NOT_NULL | FLATMAP q0 -> { SCAN([IS X]) AS q1 RETURN (q1.IDX AS IDX) }"
       - result: [{4}, {5}, {6}]
     -
-      # PartiQL resolution.
+      # SQL++ resolution.
       - query: select idr from r, r.nr as NEST where NEST.f = 23;
       - result: [{2}]
     -
-      # PartiQL resolution, another flavour (TODO check whether this still use the IR index).
+      # SQL++ resolution, another flavour (TODO check whether this still use the IR index).
       - query: select idr from r, (select * from r.nr) as NEST where NEST.f = 23;
       - result: [{2}]
     -


### PR DESCRIPTION
Array unnesting, the `AT` construct, and dot-path navigation originate from the [SQL++ spec](https://arxiv.org/pdf/1405.3631). PartiQL is one implementation of SQL++ — better to reference the language itself.