### PR TITLE
Allow ErrorCode enum names in yamsql error directives

### DIFF
--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryConfig.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.relational.yamltests.command;
 
 import com.apple.foundationdb.relational.api.RelationalResultSet;
+import com.apple.foundationdb.relational.api.exceptions.ErrorCode;
 import com.apple.foundationdb.relational.recordlayer.ErrorCapturingResultSet;
 import com.apple.foundationdb.relational.util.Assert;
 import com.apple.foundationdb.relational.yamltests.CustomYamlConstructor;
@@ -242,6 +243,7 @@ public abstract class QueryConfig {
     }
 
     private static QueryConfig getCheckErrorConfig(@Nullable Object value, @Nonnull final YamlReference reference) {
+        final String expectedCode = resolveErrorCode(value, reference);
         return new QueryConfig(QUERY_CONFIG_ERROR, value, reference) {
 
             @Override
@@ -269,13 +271,49 @@ public abstract class QueryConfig {
             @Override
             void checkErrorInternal(@Nonnull SQLException e, @Nonnull String queryDescription) {
                 logger.debug("⛳️ Checking error code resulted from executing '{}'", queryDescription);
-                if (!e.getSQLState().equals(getVal())) {
-                    reportTestFailure("‼️ expecting '" + getVal() + "' error code, got '" + e.getSQLState() + "' instead at " + getReference() + "!", e);
+                final String actualCode = e.getSQLState();
+                if (!actualCode.equals(expectedCode)) {
+                    reportTestFailure("‼️ expecting '" + formatErrorCode(expectedCode) + "' error code, got '" + formatErrorCode(actualCode) + "' instead at " + getReference() + "!", e);
                 } else {
-                    logger.debug("✅ error codes '{}' match!", getVal());
+                    logger.debug("✅ error codes '{}' match!", expectedCode);
                 }
             }
         };
+    }
+
+    /**
+     * Resolves an error value from a yamsql file to a 5-character SQLSTATE code.
+     * Accepts either a raw 5-character SQLSTATE code (e.g. {@code "42601"}) or an
+     * {@link ErrorCode} enum name (e.g. {@code "SYNTAX_ERROR"}) for readability.
+     */
+    private static String resolveErrorCode(@Nullable Object value, @Nonnull YamlReference reference) {
+        if (value == null) {
+            return null;
+        }
+        final String str = value.toString();
+        if (str.length() == 5) {
+            return str;
+        }
+        try {
+            return ErrorCode.valueOf(str).getErrorCode();
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("'" + str + "' is not a valid ErrorCode enum name or a 5-character SQLSTATE code at " + reference);
+        }
+    }
+
+    /**
+     * Formats a 5-character SQLSTATE code for display. If the code maps to a known
+     * {@link ErrorCode}, returns {@code "ENUM_NAME (code)"}; otherwise returns the raw code.
+     */
+    private static String formatErrorCode(@Nullable String code) {
+        if (code == null) {
+            return "null";
+        }
+        final ErrorCode errorCode = ErrorCode.get(code);
+        if (errorCode == ErrorCode.UNKNOWN) {
+            return code;
+        }
+        return errorCode.name() + " (" + code + ")";
     }
 
     private static QueryConfig getCheckCountConfig(@Nullable Object value, @Nonnull final YamlReference reference) {

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryConfig.java
@@ -297,7 +297,7 @@ public abstract class QueryConfig {
         try {
             return ErrorCode.valueOf(str).getErrorCode();
         } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("'" + str + "' is not a valid ErrorCode enum name or a 5-character SQLSTATE code at " + reference);
+            throw new IllegalArgumentException("'" + str + "' is not a valid ErrorCode enum name or a 5-character SQLSTATE code at " + reference, e);
         }
     }
 

--- a/yaml-tests/src/test/resources/aggregate-empty-table.yamsql
+++ b/yaml-tests/src/test/resources/aggregate-empty-table.yamsql
@@ -51,19 +51,19 @@ test_block:
       - result: [{0}]
     -
       - query: select count(*) from T1 where col1 = 0 group by col1;
-      - error: "0AF00"
+      - error: UNSUPPORTED_QUERY
     -
       - query: select count(*) from T1 where col1 > 0 group by col1;
-      - error: "0AF00"
+      - error: UNSUPPORTED_QUERY
     -
       - query: select count(*) from T1 group by col1;
-      - error: "0AF00"
+      - error: UNSUPPORTED_QUERY
     -
       - query: select count(*) from T1 where col1 = 0 group by col1;
-      - error: "0AF00"
+      - error: UNSUPPORTED_QUERY
     -
       - query: select count(*) from T1 where col1 > 0 group by col1;
-      - error: "0AF00"
+      - error: UNSUPPORTED_QUERY
     -
       - query: select count(*) from T2;
       - explain: "AISCAN(T2_I1 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
@@ -143,19 +143,19 @@ test_block:
       - result: [{0}]
     -
       - query: select count(col2) from T1 where col1 = 0 group by col1;
-      - error: "0AF00"
+      - error: UNSUPPORTED_QUERY
     -
       - query: select count(col2) from T1 where col1 > 0 group by col1;
-      - error: "0AF00"
+      - error: UNSUPPORTED_QUERY
     -
       - query: select count(col2) from T1 group by col1;
-      - error: "0AF00"
+      - error: UNSUPPORTED_QUERY
     -
       - query: select count(col2) from T1 where col1 = 0 group by col1;
-      - error: "0AF00"
+      - error: UNSUPPORTED_QUERY
     -
       - query: select count(col2) from T1 where col1 > 0 group by col1;
-      - error: "0AF00"
+      - error: UNSUPPORTED_QUERY
     -
       - query: select count(col2) from T2;
       - explain: "AISCAN(T2_I3 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
@@ -272,7 +272,7 @@ test_block:
       - result: [{!null _}]
     -
       - query: select sum(col1) from T2 where col1 = 0 group by col2;
-      - error: "0AF00"
+      - error: UNSUPPORTED_QUERY
     -
       - query: select sum(col1) from T2 where col2 = 0 group by col2;
       - explain: "AISCAN(T2_I6 [EQUALS promote(@c10 AS LONG)] BY_GROUP -> [_0: KEY:[0], _1: VALUE:[0]]) | MAP (_._1 AS _0)"
@@ -280,7 +280,7 @@ test_block:
       - result: []
     -
       - query: select sum(col1) from T2 where col1 > 0 group by col2;
-      - error: "0AF00"
+      - error: UNSUPPORTED_QUERY
     -
       - query: select sum(col1) from T2 where col2 > 0 group by col2;
       - explain: "AISCAN(T2_I6 [[GREATER_THAN promote(@c10 AS LONG)]] BY_GROUP -> [_0: KEY:[0], _1: VALUE:[0]]) | MAP (_._1 AS _0)"
@@ -374,19 +374,19 @@ test_block:
       - result: [{0}]
     -
       - query: select count(*) from T1 where col1 = 0 group by col1;
-      - error: "0AF00"
+      - error: UNSUPPORTED_QUERY
     -
       - query: select count(*) from T1 where col1 > 0 group by col1;
-      - error: "0AF00"
+      - error: UNSUPPORTED_QUERY
     -
       - query: select count(*) from T1 group by col1;
-      - error: "0AF00"
+      - error: UNSUPPORTED_QUERY
     -
       - query: select count(*) from T1 where col1 = 0 group by col1;
-      - error: "0AF00"
+      - error: UNSUPPORTED_QUERY
     -
       - query: select count(*) from T1 where col1 > 0 group by col1;
-      - error: "0AF00"
+      - error: UNSUPPORTED_QUERY
     -
       - query: select count(*) from T2;
       - explain: "AISCAN(T2_I1 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
@@ -450,19 +450,19 @@ test_block:
       - result: [{0}]
     -
       - query: select count(col2) from T1 where col1 = 0 group by col1;
-      - error: "0AF00"
+      - error: UNSUPPORTED_QUERY
     -
       - query: select count(col2) from T1 where col1 > 0 group by col1;
-      - error: "0AF00"
+      - error: UNSUPPORTED_QUERY
     -
       - query: select count(col2) from T1 group by col1;
-      - error: "0AF00"
+      - error: UNSUPPORTED_QUERY
     -
       - query: select count(col2) from T1 where col1 = 0 group by col1;
-      - error: "0AF00"
+      - error: UNSUPPORTED_QUERY
     -
       - query: select count(col2) from T1 where col1 > 0 group by col1;
-      - error: "0AF00"
+      - error: UNSUPPORTED_QUERY
     -
       - query: select count(col2) from T2;
       - explain: "AISCAN(T2_I3 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
@@ -577,14 +577,14 @@ test_block:
       - result: [{!l 0}]
     -
       - query: select sum(col1) from T2 where col1 = 0 group by col2;
-      - error: "0AF00"
+      - error: UNSUPPORTED_QUERY
     -
       - query: select sum(col1) from T2 where col2 = 0 group by col2;
       - resultMetadata: [{_0: BIGINT}]
       - result: []
     -
       - query: select sum(col1) from T2 where col1 > 0 group by col2;
-      - error: "0AF00"
+      - error: UNSUPPORTED_QUERY
 #    -
 #      # TODO ([POST] Enhance SUM aggregate index to disambiguate null results and 0 results)
 #      - query: select sum(col1) from T2 where col2 > 0 group by col2;

--- a/yaml-tests/src/test/resources/aggregate-index-tests.yamsql
+++ b/yaml-tests/src/test/resources/aggregate-index-tests.yamsql
@@ -381,7 +381,7 @@ test_block:
       - query: select b, c, d, e, max(x) from t5 where a = 0 group by a, b, c, d, e order by b, max(x), c, d, e
       - explain: "AISCAN(MV16 [EQUALS promote(@c18 AS LONG)] BY_GROUP -> [_0: KEY:[0], _1: KEY:[1], _2: KEY:[3], _3: KEY:[4], _4: KEY:[5], _5: KEY:[2]]) | MAP (_._1 AS B, _._2 AS C, _._3 AS D, _._4 AS E, _._5 AS _4)"
       - initialVersionLessThan: 4.3.5.0
-      - error: "0AF00"
+      - error: UNSUPPORTED_QUERY
       - initialVersionAtLeast: 4.3.5.0
       - resultMetadata: [{B: STRING}, {C: BIGINT}, {D: BIGINT}, {E: STRING}, {_4: BIGINT}]
       - result: [
@@ -412,7 +412,7 @@ test_block:
       - query: select b, c, d, e, min(x) from t5 where a = 0 group by a, b, c, d, e order by b, min(x), c, d, e
       - explain: "AISCAN(MV17 [EQUALS promote(@c18 AS LONG)] BY_GROUP -> [_0: KEY:[0], _1: KEY:[1], _2: KEY:[3], _3: KEY:[4], _4: KEY:[5], _5: KEY:[2]]) | MAP (_._1 AS B, _._2 AS C, _._3 AS D, _._4 AS E, _._5 AS _4)"
       - initialVersionLessThan: 4.3.5.0
-      - error: "0AF00"
+      - error: UNSUPPORTED_QUERY
       - initialVersionAtLeast: 4.3.5.0
       - resultMetadata: [{B: STRING}, {C: BIGINT}, {D: BIGINT}, {E: STRING}, {_4: BIGINT}]
       - result: [
@@ -443,7 +443,7 @@ test_block:
       - query: select b, c, d, e, max(x) from t5 where a = 0 group by a, b, c, d, e order by b, c, max(x), d, e
       - explain: "AISCAN(MV18 [EQUALS promote(@c18 AS LONG)] BY_GROUP -> [_0: KEY:[0], _1: KEY:[1], _2: KEY:[2], _3: KEY:[4], _4: KEY:[5], _5: KEY:[3]]) | MAP (_._1 AS B, _._2 AS C, _._3 AS D, _._4 AS E, _._5 AS _4)"
       - initialVersionLessThan: 4.3.5.0
-      - error: "0AF00"
+      - error: UNSUPPORTED_QUERY
       - initialVersionAtLeast: 4.3.5.0
       - resultMetadata: [{B: STRING}, {C: BIGINT}, {D: BIGINT}, {E: STRING}, {_4: BIGINT}]
       - result: [
@@ -474,7 +474,7 @@ test_block:
       - query: select b, c, d, e, min(x) from t5 where a = 0 group by a, b, c, d, e order by b, c, min(x), d, e
       - explain: "AISCAN(MV19 [EQUALS promote(@c18 AS LONG)] BY_GROUP -> [_0: KEY:[0], _1: KEY:[1], _2: KEY:[2], _3: KEY:[4], _4: KEY:[5], _5: KEY:[3]]) | MAP (_._1 AS B, _._2 AS C, _._3 AS D, _._4 AS E, _._5 AS _4)"
       - initialVersionLessThan: 4.3.5.0
-      - error: "0AF00"
+      - error: UNSUPPORTED_QUERY
       - initialVersionAtLeast: 4.3.5.0
       - resultMetadata: [{B: STRING}, {C: BIGINT}, {D: BIGINT}, {E: STRING}, {_4: BIGINT}]
       - result: [
@@ -583,7 +583,7 @@ test_block:
       - query: select b, c, d, e, max(x) from t5 where a = 0 group by a, b, c, d, e having b IN ('foo', 'bar') and d IN (1, 2) order by max(x), c, e
       - explain: "[IN arrayDistinct(@c33)] INUNION q0 -> { [IN arrayDistinct(promote(@c41 AS ARRAY(LONG)))] INUNION q1 -> { AISCAN(MV16 [EQUALS promote(@c18 AS LONG), EQUALS q0] BY_GROUP -> [_0: KEY:[0], _1: KEY:[1], _2: KEY:[3], _3: KEY:[4], _4: KEY:[5], _5: KEY:[2]]) | FILTER _._3 EQUALS q1 | MAP (_._1 AS B, _._2 AS C, _._3 AS D, _._4 AS E, _._5 AS _4) } COMPARE BY (_._4, _.C, _.E, _.D) } COMPARE BY (_._4, _.C, _.E, _.B)"
       - initialVersionLessThan: 4.3.5.0
-      - error: "0AF00"
+      - error: UNSUPPORTED_QUERY
       - initialVersionAtLeast: 4.3.5.0
       - resultMetadata: [{B: STRING}, {C: BIGINT}, {D: BIGINT}, {E: STRING}, {_4: BIGINT}]
       - result: [
@@ -600,7 +600,7 @@ test_block:
       - query: select b, c, d, e, min(x) from t5 where a = 0 group by a, b, c, d, e having b IN ('foo', 'bar') and d IN (1, 2) order by min(x), c, e
       - explain: "[IN arrayDistinct(@c33)] INUNION q0 -> { [IN arrayDistinct(promote(@c41 AS ARRAY(LONG)))] INUNION q1 -> { AISCAN(MV17 [EQUALS promote(@c18 AS LONG), EQUALS q0] BY_GROUP -> [_0: KEY:[0], _1: KEY:[1], _2: KEY:[3], _3: KEY:[4], _4: KEY:[5], _5: KEY:[2]]) | FILTER _._3 EQUALS q1 | MAP (_._1 AS B, _._2 AS C, _._3 AS D, _._4 AS E, _._5 AS _4) } COMPARE BY (_._4, _.C, _.E, _.D) } COMPARE BY (_._4, _.C, _.E, _.B)"
       - initialVersionLessThan: 4.3.5.0
-      - error: "0AF00"
+      - error: UNSUPPORTED_QUERY
       - initialVersionAtLeast: 4.3.5.0
       - resultMetadata: [{B: STRING}, {C: BIGINT}, {D: BIGINT}, {E: STRING}, {_4: BIGINT}]
       - result: [
@@ -688,7 +688,7 @@ test_block:
       # Even though the aggregate index will be rolled-up to col2 because of the implicit grouping produced by the equality
       # predicate, it is not possible to reference it in the projected columns.
       - query: select col2, sum(col3) as s from T2 where col2 = 2
-      - error: "42803"
+      - error: GROUPING_ERROR
     -
       # A sum aggregate that matches no records should return null
       - query: select sum(col3) as s from T2 where col2 = 90

--- a/yaml-tests/src/test/resources/array-join-at.yamsql
+++ b/yaml-tests/src/test/resources/array-join-at.yamsql
@@ -165,7 +165,7 @@ test_block:
     -
       # Applying AT to a normal table source item (that does not produce an array) is invalid.
       - query: SELECT "id", "at" FROM T1 AT "at"
-      - error: "42809" # "AT clause requires an array-typed column, but 'T1' is a table"
+      - error: WRONG_OBJECT_TYPE
     -
       # Unnesting two arrays from the same row, with AT on both, in a cross-product manner.
       # Notice the ordinals are independent; each `at2` restarts at 1 for each element of the outer array.
@@ -196,11 +196,11 @@ test_block:
     -
       # Unnesting the same array twice, but with the same AS alias assigned both.
       - query: SELECT T2."id", "val", "at1", "at2" FROM T2, T2."arr1" AS "val" AT "at1", T2."arr1" AS "val" AT "at2"
-      - error: "42702"  # "Ambiguous reference val"
+      - error: AMBIGUOUS_COLUMN
     -
       # Unnesting the same array twice, but with the same AT alias on both.
       - query: SELECT T2."id", "at", "val1", "val2" FROM T2, T2."arr1" AS "val1" AT "at", T2."arr1" AS "val2" AT "at"
-      - error: "42702"  # "Ambiguous reference at"
+      - error: AMBIGUOUS_COLUMN
     -
       # An AT variable can be used within the subscript [] operator to access another array. This enables “parallel”
       # unnesting of two arrays within the same row.
@@ -274,11 +274,11 @@ test_block:
     -
       # Applying AT to a common table expression is invalid (CTE is not an array).
       - query: WITH "cte" AS (SELECT * FROM T1) SELECT "id" FROM "cte" AT "at"
-      - error: "42809"
+      - error: WRONG_OBJECT_TYPE
     -
       # ORDER BY on the AT ordinal cannot be planned without and index.
       - query: SELECT "id", "val", "at" FROM T1, T1."arr1_nn" AS "val" AT "at" WHERE T1."id" = 2 ORDER BY "at" DESC
-      - error: "0AF00"
+      - error: UNSUPPORTED_QUERY
     -
       # STRING array with AT via VALUES. Verifies ordinals also work with non-integer element types.
       - query: SELECT "val", "at"

--- a/yaml-tests/src/test/resources/arrays-cardinality.yamsql
+++ b/yaml-tests/src/test/resources/arrays-cardinality.yamsql
@@ -56,10 +56,10 @@ test_block:
   tests:
     - # Incorrect argument type: Passing a non-array (here: INTEGER) raises error 22000.
       - query: SELECT CARDINALITY("id") FROM "dummy"
-      - error: "22000"
+      - error: CANNOT_CONVERT_TYPE
     - # Incorrect argument type (constant case)
       - query: SELECT CARDINALITY(1) FROM "dummy"
-      - error: "22000"
+      - error: CANNOT_CONVERT_TYPE
     - # NULL argument array (constant case): NULL gets mapped to NULL.
       - query: SELECT CARDINALITY(CAST(NULL AS INTEGER ARRAY)) FROM "tab1" WHERE "id" = 1
       - resultMetadata: [{_0: INTEGER}]

--- a/yaml-tests/src/test/resources/arrays-operators.yamsql
+++ b/yaml-tests/src/test/resources/arrays-operators.yamsql
@@ -235,7 +235,7 @@ test_block:
     -
       # Comparison of an INTEGER ARRAY field to [], casted to an ARRAY type that is not compatible with INTEGER ARRAY.
       - query: SELECT * FROM T1 WHERE "arr" = CAST([] AS STRING ARRAY)
-      - error: "42804"
+      - error: DATATYPE_MISMATCH
     -
       # Comparison of a nullable ARRAY field to [], casted to the correct type.
       - query: SELECT "pk" FROM T1 WHERE "arr" = CAST([] AS INTEGER ARRAY)
@@ -268,8 +268,8 @@ test_block:
       # Comparison of an INTEGER ARRAY to a constant BIGINT ARRAY. The INTEGER ARRAY could be promoted to a BIGINT ARRAY
       # but this is not yet supported.
       - query: SELECT "pk" FROM T1 WHERE "arr" = CAST([1] AS BIGINT ARRAY)
-      - error: "42804"
+      - error: DATATYPE_MISMATCH
     - # Some more constant comparisons of different but promotable ARRAY types. This is not yet supported.
       - query: SELECT 1I = 1L, [1I] = [1L] FROM "dummy"
-      - error: "42804"
+      - error: DATATYPE_MISMATCH
 ...

--- a/yaml-tests/src/test/resources/arrays-unnesting.yamsql
+++ b/yaml-tests/src/test/resources/arrays-unnesting.yamsql
@@ -103,11 +103,11 @@ test_block:
     -
       # ORDER BY on the array is not possible without an index.
       - query: SELECT "items" FROM T1 ORDER BY "items"
-      - error: "0AF00"  # "Cascades planner could not plan query"
+      - error: UNSUPPORTED_QUERY
     -
       # Likewise on the `T1_indexed` table; the `T1_index` does not match.
       - query: SELECT "items" FROM "T1_indexed" ORDER BY "items"
-      - error: "0AF00"  # "Cascades planner could not plan query"
+      - error: UNSUPPORTED_QUERY
     -
       # Unnesting the array using PartiQL-style unnesting.
       - query: SELECT "id", "item" FROM "T1_indexed" AS "row", "row"."items" AS "item"
@@ -141,11 +141,11 @@ test_block:
       # Same query but with an added `ORDER BY "item"`.
       # TODO Issue #3896: The `T1_index` is not leveraged here.
       - query: SELECT SQ."item" FROM "T1_indexed" AS "row", (SELECT "item" FROM "row"."items" AS "item") AS SQ ORDER BY SQ."item"
-      - error: "0AF00"  # "Cascades planner could not plan query"
+      - error: UNSUPPORTED_QUERY
     -
       # Same ORDER BY on the array, but on the view-indexed table.
       - query: SELECT "items" FROM "T2" ORDER BY "items"
-      - error: "0AF00"  # "Cascades planner could not plan query"
+      - error: UNSUPPORTED_QUERY
     -
       # Example query from the SQL reference (`Indexes.rst`, section "Indexes on nested fields").
       - query: SELECT SQ."rating" FROM "restaurant" AS RR, (SELECT "rating" FROM RR."reviews") SQ
@@ -158,11 +158,11 @@ test_block:
       # Unnesting an ARRAY of scalars (integers) directly.
       # The `"integer".*` syntax is disallowed because "integer" is a scalar here, not a STRUCT.
       - query: SELECT "id", "integer".* FROM T3, T3."integers" AS "integer"
-      - error: "42F10"
+      - error: INVALID_COLUMN_REFERENCE
     -
       # Same `.*` rejection as above, but here the array comes from a table function rather than a base-table column.
       - query: SELECT "b".* FROM (SELECT "a" FROM VALUES ([1, 2, 3, 4]) AS T("a")) AS "sq", "sq"."a" AS "b"
-      - error: "42F10"
+      - error: INVALID_COLUMN_REFERENCE
     -
       # Wrapping the unnested scalar into a one-field struct lifts it back into a record type, so `.*` expansion is allowed.
       - query: SELECT "b".* FROM (SELECT "a" FROM VALUES ([1, 2, 3, 4]) AS T("a")) AS "sq", (SELECT ("x") AS wrapped FROM "sq"."a" AS "x") AS "b"
@@ -170,7 +170,7 @@ test_block:
     -
       # Same .* rejection as above, but on an unnested VECTOR element. VECTOR has no fields to expand.
       - query: SELECT "id", "v".* FROM T4, T4."vectors" AS "v"
-      - error: "42F10"
+      - error: INVALID_COLUMN_REFERENCE
     -
       # Unnest the ARRAY of integers via a subquery and wrap each integer into a tuple with a `( … )` expression.
       # Note: As an alternative to the `AS "wrapped_int"` we might write `AS SQ ("wrapped_int")`, but this is not

--- a/yaml-tests/src/test/resources/arrays.yamsql
+++ b/yaml-tests/src/test/resources/arrays.yamsql
@@ -40,7 +40,7 @@ test_block:
       # Attempting to insert a NULL value into a not-nullable ARRAY column.
       - query: INSERT INTO A_NOT_NULL VALUES (0, NULL)
       - supported_version: 4.11.1.0
-      - error: "XX000"
+      - error: INTERNAL_ERROR
     -
       # INSERT + basic SELECT for a not-nullable INTEGER ARRAY.
       - query: INSERT INTO A_NOT_NULL VALUES (0, []), (1, [1]), (2, [1, 2])

--- a/yaml-tests/src/test/resources/between.yamsql
+++ b/yaml-tests/src/test/resources/between.yamsql
@@ -99,15 +99,15 @@ test_block:
     -
       - query: select * from t1 WHERE col1 BETWEEN 10 AND 'a'
       - initialVersionLessThan: 4.11.1.0
-      - error: "XX000"
+      - error: INTERNAL_ERROR
       - initialVersionAtLeast: 4.11.1.0
-      - error: "42804"
+      - error: DATATYPE_MISMATCH
     -
       - query: select * from t1 WHERE 'a' BETWEEN 10 AND 20
       - initialVersionLessThan: 4.11.1.0
-      - error: "XX000"
+      - error: INTERNAL_ERROR
       - initialVersionAtLeast: 4.11.1.0
-      - error: "42804"
+      - error: DATATYPE_MISMATCH
 ---
 test_block:
   name: between-compatible-types

--- a/yaml-tests/src/test/resources/bitmap-aggregate-index.yamsql
+++ b/yaml-tests/src/test/resources/bitmap-aggregate-index.yamsql
@@ -60,7 +60,7 @@ test_block:
       - initialVersionLessThan: 4.10.1.0
       - unorderedResult: [{BITMAP: xStartsWith_1250'060000c', 'OFFSET':0}, {BITMAP: xStartsWith_1250'02', 'OFFSET':10000}]
       - initialVersionAtLeast: 4.10.1.0
-      - error: "42702"
+      - error: AMBIGUOUS_COLUMN
     -
       - query: SELECT bitmap_construct_agg(bitmap_bit_position(id)) as bitmap, category, bitmap_bucket_offset(id) as offset FROM T1 GROUP BY bitmap_bucket_offset(id), category, bitmap_bucket_offset(id)
       - initialVersionLessThan: 4.10.1.0
@@ -68,7 +68,7 @@ test_block:
                           {BITMAP: xStartsWith_1250'02', 'CATEGORY': 'hello', 'OFFSET':10000},
                           {BITMAP: xStartsWith_1250'0400008', 'CATEGORY': 'world', 'OFFSET':0}]
       - initialVersionAtLeast: 4.10.1.0
-      - error: "42702"
+      - error: AMBIGUOUS_COLUMN
     -
       - query: SELECT bitmap_construct_agg(bitmap_bit_position(id)) as bitmap, bitmap_bucket_offset(id) as offset FROM T2 GROUP BY bitmap_bucket_offset(id)
       - explain: "ISCAN(AGG_INDEX_1 <,>) | MAP (_ AS _0) | AGG (bitmap_construct_agg_l((_._0.ID) bitmap_bit_position 10000) AS _0) GROUP BY ((_._0.ID) bitmap_bucket_offset 10000 AS _0) | MAP (_._1._0 AS BITMAP, _._0._0 AS OFFSET)"

--- a/yaml-tests/src/test/resources/bytes.yamsql
+++ b/yaml-tests/src/test/resources/bytes.yamsql
@@ -33,13 +33,13 @@ test_block:
       - result: [ { x'deadbeef'}, { x'cafe' }, { !null } ]
     -
       - query: select x'0' from lb where a = 1
-      - error: 22F03
+      - error: INVALID_BINARY_REPRESENTATION
     -
       - query: select x'ABCDMN' from lb where a = 1
-      - error: 22F03
+      - error: INVALID_BINARY_REPRESENTATION
     -
       - query: select b64'***' from lb where a = 1
-      - error: 22F03
+      - error: INVALID_BINARY_REPRESENTATION
     -
       - query: select a from lb where b = x'cafe'
       - result: [ { 2 } ]

--- a/yaml-tests/src/test/resources/case-sensitivity.yamsql
+++ b/yaml-tests/src/test/resources/case-sensitivity.yamsql
@@ -83,7 +83,7 @@ test_block:
                           {ID: 2, COL1: 10, COL2: 2, X: 2, Y: 'bar'}]
     -
       - query: select * from table1
-      - error: "42F01"
+      - error: UNDEFINED_TABLE
     -
       - query: select * from TABLE2
       - unorderedResult: [{A: 10, B: 'blah'},
@@ -112,10 +112,10 @@ test_block:
   tests:
     -
       - query: with c1 as (select col1, col2 from Table1) select col1, col2 from c1
-      - error: "42F01"
+      - error: UNDEFINED_TABLE
     -
       - query: with c1 as (select col1, col2 from "Table1") select col1, col2 from c1
-      - error: "42703"
+      - error: UNDEFINED_COLUMN
     -
       - query: with c1 as (select "col1", "col2" from "Table1") select "col1", "col2" from c1
       - unorderedResult: [{COL1: 10, COL2: 1},

--- a/yaml-tests/src/test/resources/case-when.yamsql
+++ b/yaml-tests/src/test/resources/case-when.yamsql
@@ -97,5 +97,5 @@ test_block:
                   { A1: 3, A2: 6666, A3: 30 } ]
     -
       - query: update A set A2 = case when A2 = 4444 then 1 else 2.2 end
-      - error: "22000"
+      - error: CANNOT_CONVERT_TYPE
 ...

--- a/yaml-tests/src/test/resources/cast-tests.yamsql
+++ b/yaml-tests/src/test/resources/cast-tests.yamsql
@@ -46,7 +46,7 @@ test_block:
       - result: [{[]}]
     -
       - query: select [] from test_cast where id = 1
-      - error: "XXXXX"
+      - error: UNKNOWN
     -
       # Array casting: INT array to DOUBLE array
       - query: select CAST([1, 2, 3] AS DOUBLE ARRAY) from test_cast where id = 1
@@ -113,11 +113,11 @@ test_block:
     -
       # Array casting: Invalid string to number conversion (should error)
       - query: select CAST(['invalid', 'not_a_number'] AS INTEGER ARRAY) from test_cast where id = 1
-      - error: "22F3H"
+      - error: INVALID_CAST
     -
       # Array casting: Mixed valid/invalid strings (should error on first invalid)
       - query: select CAST(['42', 'invalid'] AS INTEGER ARRAY) from test_cast where id = 1
-      - error: "22F3H"
+      - error: INVALID_CAST
     -
       - query: select CAST(num_col AS STRING) as casted_value from test_cast where id = 1
       - explain: "SCAN([IS TEST_CAST, EQUALS promote(@c14 AS LONG)]) | MAP (CAST(_.NUM_COL AS STRING) AS CASTED_VALUE)"
@@ -176,14 +176,14 @@ test_block:
     -
       # LONG to INT overflow (should throw error)
       - query: select CAST(9223372036854775807 AS INTEGER) as overflow_test from test_cast where id = 1
-      - error: "22F3H"
+      - error: INVALID_CAST
 
     # Cast null
     -
       - query: select cast(null as integer) as a, cast(null as bigint) as b, cast(null as string) as c, cast(null as double) as d, cast(null as boolean) as e, cast(null as string) as f from values (1), (2) as X(X)
       - explain: "EXPLODE array((@c57 AS X), (@c61 AS X)) | MAP (CAST(NULL AS INT) AS A, CAST(NULL AS LONG) AS B, CAST(NULL AS STRING) AS C, CAST(NULL AS DOUBLE) AS D, CAST(NULL AS BOOLEAN) AS E, CAST(NULL AS STRING) AS F)"
       - initialVersionLessThan: 4.9.6.0
-      - error: 'XXXXX'
+      - error: UNKNOWN
       - initialVersionAtLeast: 4.9.6.0
       - result: [
           { A: !null _, B: !null _, C: !null _, D: !null _, E: !null _, F: !null _ },
@@ -195,7 +195,7 @@ test_block:
       - supported_version: 4.9.1.0
       - explain: "EXPLODE array((@c10 AS X), (@c14 AS X)) | MAP (CAST(NULL AS UUID) AS _0)"
       - initialVersionLessThan: 4.9.6.0
-      - error: 'XXXXX'
+      - error: UNKNOWN
       - initialVersionAtLeast: 4.9.6.0
       - result: [{ !null _ }, { !null _ }]
     -
@@ -222,7 +222,7 @@ test_block:
       - query: select cast(null as integer array) as a, cast(null as bigint array) as b, cast(null as string array) as c, cast(null as double array) as d, cast(null as boolean array) as e, cast(null as string array) as f from values (1), (2) as X(X)
       - explain: "EXPLODE array((@c63 AS X), (@c67 AS X)) | MAP (CAST(NULL AS ARRAY(INT)) AS A, CAST(NULL AS ARRAY(LONG)) AS B, CAST(NULL AS ARRAY(STRING)) AS C, CAST(NULL AS ARRAY(DOUBLE)) AS D, CAST(NULL AS ARRAY(BOOLEAN)) AS E, CAST(NULL AS ARRAY(STRING)) AS F)"
       - initialVersionLessThan: 4.9.6.0
-      - error: 'XXXXX'
+      - error: UNKNOWN
       - initialVersionAtLeast: 4.9.6.0
       - result: [
           { A: !null _, B: !null _, C: !null _, D: !null _, E: !null _, F: !null _, },
@@ -234,7 +234,7 @@ test_block:
       - supported_version: 4.9.1.0
       - explain: "EXPLODE array((@c11 AS X), (@c15 AS X)) | MAP (CAST(NULL AS ARRAY(UUID)) AS _0)"
       - initialVersionLessThan: 4.9.6.0
-      - error: 'XXXXX'
+      - error: UNKNOWN
       - initialVersionAtLeast: 4.9.6.0
       - result: [{ !null _ }, { !null _ }]
     -
@@ -242,7 +242,7 @@ test_block:
       - query: select cast(null as float array) from values (1), (2) as X(X)
       - explain: "EXPLODE array((@c11 AS X), (@c15 AS X)) | MAP (CAST(NULL AS ARRAY(FLOAT)) AS _0)"
       - initialVersionLessThan: 4.9.6.0
-      - error: 'XXXXX'
+      - error: UNKNOWN
       - initialVersionAtLeast: 4.9.6.0
       - result: [{ !null _ }, { !null _ }]
     -
@@ -250,14 +250,14 @@ test_block:
       - query: select cast(null as bytes array) from values (1), (2) as X(X)
       - explain: "EXPLODE array((@c11 AS X), (@c15 AS X)) | MAP (CAST(NULL AS ARRAY(BYTES)) AS _0)"
       - initialVersionLessThan: 4.9.6.0
-      - error: 'XXXXX'
+      - error: UNKNOWN
       - initialVersionAtLeast: 4.9.6.0
       - result: [{ !null _ }, { !null _ }]
     -
       - query: select cast(null as vector(10, half) array) as a, cast(null as vector(15, float) array) as b, cast(null as vector(30, double) array) as c from values (1), (2) as X(X)
       - explain: "EXPLODE array((@c48 AS X), (@c52 AS X)) | MAP (CAST(NULL AS ARRAY(VECTOR(16, 10))) AS A, CAST(NULL AS ARRAY(VECTOR(32, 15))) AS B, CAST(NULL AS ARRAY(VECTOR(64, 30))) AS C)"
       - initialVersionLessThan: 4.9.6.0
-      - error: 'XXXXX'
+      - error: UNKNOWN
       - initialVersionAtLeast: 4.9.6.0
       - result: [
           { A: !null _, B: !null _, C: !null _ },

--- a/yaml-tests/src/test/resources/create-drop.yamsql
+++ b/yaml-tests/src/test/resources/create-drop.yamsql
@@ -39,10 +39,10 @@ test_block:
   tests:
     -
       - query: drop schema template temp
-      - error: "42F55"
+      - error: UNKNOWN_SCHEMA_TEMPLATE
     -
       - query: drop database /frl/DB
-      - error: "42F63"
+      - error: UNKNOWN_DATABASE
 ---
 setup:
   connect: "jdbc:embed:/__SYS?schema=CATALOG"

--- a/yaml-tests/src/test/resources/cte.yamsql
+++ b/yaml-tests/src/test/resources/cte.yamsql
@@ -88,15 +88,15 @@ test_block:
     -
       - query: with c1(w, z) as (select id, col1 from t1), c2(a, b) as (with c3(A, B) as (select id, col1 from c1 where id in (1, 2)) select * from c3) select * from c1,c2
       - initialVersionAtLeast: 4.10.1.0
-      - error: "42703"
+      - error: UNDEFINED_COLUMN
       - initialVersionLessThan: 4.10.1.0
-      - error: "42F01"
+      - error: UNDEFINED_TABLE
     -
       - query: with c1(w, z, x1, x2, x3, x4) as (select id, col1 from t1) select * from c1
-      - error: "42F10"
+      - error: INVALID_COLUMN_REFERENCE
     -
       - query: with c1(w, z) as (select id, col1 from t1), c1(a, b) as (select id, col1 from t1 where id in (1, 2)) select * from c1
-      - error: "42712"
+      - error: DUPLICATE_ALIAS
     -
       - query: with c1(w, z) as (select id, col1 from t1), c2(a, b) as (with c1(A, B) as (select id, col1 from t1 where id in (1, 2)) select * from c1) select * from c1,c2
       - unorderedResult: [{W: 1, Z: 10, A: 1, B: 10},
@@ -109,10 +109,10 @@ test_block:
                           {W: 7, Z: 20, A: 2, B: 10}]
     -
       - query: with c1(w, z) as (select id, col1 from t1) select col2 from c1
-      - error: "42703"
+      - error: UNDEFINED_COLUMN
     -
       - query: with c1(w, z) as (select id, col1 from t1) select col1 from c1
-      - error: "42703"
+      - error: UNDEFINED_COLUMN
     -
       - query: select col1 from t1 where col2 < 3
       - explain: "COVERING(I1 [[LESS_THAN promote(@c7 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], ID: KEY:[3]]) | MAP (_.COL1 AS COL1)"

--- a/yaml-tests/src/test/resources/documentation-queries/cast-documentation-queries.yamsql
+++ b/yaml-tests/src/test/resources/documentation-queries/cast-documentation-queries.yamsql
@@ -50,7 +50,7 @@ test_block:
     -
       - query: SELECT CAST(null AS string) AS null_string FROM data WHERE id = 1
       - initialVersionLessThan: 4.9.6.0
-      - error: 'XXXXX'
+      - error: UNKNOWN
       - initialVersionAtLeast: 4.9.6.0
       - result: [{null_string: !null _ }]
     -
@@ -65,9 +65,9 @@ test_block:
     # Invalid Conversions - String to Integer Error
     -
       - query: SELECT CAST(str_value AS INTEGER) FROM data WHERE id = 2
-      - error: "22F3H"
+      - error: INVALID_CAST
 
     # Range Overflow - BIGINT to INT Error
     -
       - query: SELECT CAST(9223372036854775807 AS INTEGER) FROM numbers WHERE id = 1
-      - error: "22F3H"
+      - error: INVALID_CAST

--- a/yaml-tests/src/test/resources/documentation-queries/vector-documentation-queries.yamsql
+++ b/yaml-tests/src/test/resources/documentation-queries/vector-documentation-queries.yamsql
@@ -106,20 +106,20 @@ test_block:
     # Test CAST errors - Array must match vector dimension (documentation example)
     -
       - query: SELECT CAST([1.0, 2.0, 3.0, 4.0] AS VECTOR(3, FLOAT)) FROM embeddings WHERE id = 1
-      - error: "22F3H"
+      - error: INVALID_CAST
 
     -
       - query: SELECT CAST([1.0, 2.0] AS VECTOR(3, DOUBLE)) FROM embeddings WHERE id = 1
-      - error: "22F3H"
+      - error: INVALID_CAST
 
     # Test CAST errors - Only numeric arrays can be cast to vectors (documentation example)
     -
       - query: SELECT CAST(['a', 'b', 'c'] AS VECTOR(3, FLOAT)) FROM embeddings WHERE id = 1
-      - error: "22F3H"
+      - error: INVALID_CAST
 
     -
       - query: SELECT CAST([true, false, true] AS VECTOR(3, HALF)) FROM embeddings WHERE id = 1
-      - error: "22F3H"
+      - error: INVALID_CAST
 
     # Vectors in Struct Fields - Insert vector within struct (documentation example)
     # Note: Using YAML DSL syntax for inserts as CAST expressions don't work with prepared statements

--- a/yaml-tests/src/test/resources/documentation-queries/window-function-documentation-queries.yamsql
+++ b/yaml-tests/src/test/resources/documentation-queries/window-function-documentation-queries.yamsql
@@ -51,7 +51,7 @@ test_block:
                     PARTITION BY zone, bookshelf
                     ORDER BY euclidean_distance(embedding, !! !v16 [1.0, 0.0, 0.0] !!) ASC
                 ) <= 1
-      - error: "42F21"
+      - error: WINDOWING_ERROR
 
     # Basic K-Nearest Neighbor Search using QUALIFY (documentation example)
     -

--- a/yaml-tests/src/test/resources/enum.yamsql
+++ b/yaml-tests/src/test/resources/enum.yamsql
@@ -142,15 +142,15 @@ test_block:
     -
       - query: SELECT * From TABLE_A where "mood" = 'NOT_A_VALID_MOOD'
       - initialVersionAtLeast: 4.7.3.0
-      - error: "XX000"
+      - error: INTERNAL_ERROR
       - initialVersionLessThan: 4.7.3.0
-      - error: "XXXXX"
+      - error: UNKNOWN
     -
       - query: SELECT * From TABLE_A where "mood" < 'NOT_A_VALID_MOOD'
       - initialVersionAtLeast: 4.7.3.0
-      - error: "XX000"
+      - error: INTERNAL_ERROR
       - initialVersionLessThan: 4.7.3.0
-      - error: "XXXXX"
+      - error: UNKNOWN
 
     -
       - query: SELECT * From TABLE_B where "mood" = 'CONFUSED'

--- a/yaml-tests/src/test/resources/functions.yamsql
+++ b/yaml-tests/src/test/resources/functions.yamsql
@@ -44,10 +44,10 @@ test_block:
       - result: [{_0: true, _1: true, _2: !null _, false}]
     -
       - query: select greatest(a5, a5) from A
-      - error: '22F00'
+      - error: INVALID_ARGUMENT_FOR_FUNCTION
     -
       - query: select greatest(a6, a6) from A
-      - error: '22F00'
+      - error: INVALID_ARGUMENT_FOR_FUNCTION
       # Note: the following query has been disabled since July 2023
 #    -
 #      - query: select greatest(a7, 0), greatest(a7, 1), greatest(a7, 2), greatest(a7, null) from A
@@ -57,7 +57,7 @@ test_block:
       - result: [{_0: 1.0, _1: 1.0, _2: 2.0, !null _}]
     -
       - query: select greatest(a9, '0'), greatest(a9, '1'), greatest(a9, '2'), greatest(a9, null) from A
-      - error: '22000'
+      - error: CANNOT_CONVERT_TYPE
     -
       - query: select greatest(a1, a2, a8), greatest(1, 2, 3.0, 4, 5) from A
       - result: [{_0: 1.0, _1: 5.0}]
@@ -75,10 +75,10 @@ test_block:
       - result: [{_0: false, _1: true, _2: !null _, _3: false, _4: true}]
     -
       - query: select least(a5, a5) from A
-      - error: '22F00'
+      - error: INVALID_ARGUMENT_FOR_FUNCTION
     -
       - query: select least(a6, a6) from A
-      - error: '22F00'
+      - error: INVALID_ARGUMENT_FOR_FUNCTION
       # Note: the following query has been disabled since July 2023
 #    -
 #      - query: select least(a7, 0), least(a7, 1), least(a7, 2), least(a7, null) from A
@@ -88,7 +88,7 @@ test_block:
       - result: [{_0: 0.0, _1: 1.0, _2: 1.0, !null _}]
     -
       - query: select least(a9, '0'), least(a9, '1'), least(a9, '2'), least(a9, null) from A
-      - error: '22000'
+      - error: CANNOT_CONVERT_TYPE
     -
       - query: select least(a1, a2, a8), least(1, 2, 3.0, 4, 5) from A
       - result: [{_0: 1.0, _1: 1.0}]

--- a/yaml-tests/src/test/resources/groupby-tests.yamsql
+++ b/yaml-tests/src/test/resources/groupby-tests.yamsql
@@ -72,13 +72,13 @@ test_block:
 #      - result: [{!l 210}]
     -
       - query: select * from T1 group by col1;
-      - error: "42803"
+      - error: GROUPING_ERROR
     -
       - query: select ID from T1 group by col1;
-      - error: "42803"
+      - error: GROUPING_ERROR
     -
       - query: select BLA from T1 group by col1;
-      - error: "42703"
+      - error: UNDEFINED_COLUMN
     -
       - query: select col1 from T1 group by col1;
       - result: [{COL1: !l 10}, {COL1: !l 20}]
@@ -145,10 +145,10 @@ test_block:
       - result: [{!l 3, 3.0}, {!l 9, 9.5}]
     -
       - query: select MAX(x.col2) from (select col1 from t1) as x group by x.col1;
-      - error: "42703"
+      - error: UNDEFINED_COLUMN
     -
       - query: select X.col2 from (select  col1, col2 from t1) as x group by x.col1;
-      - error: "42803"
+      - error: GROUPING_ERROR
     -
       - query: select MAX(x.col2) from (select col1,col2 from t1) as x;
       - explain: "ISCAN(I1 <,>) | MAP ((_.COL1 AS COL1, _.COL2 AS COL2) AS _0) | AGG (max_l(_._0.COL2) AS _0) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS _0)"
@@ -170,7 +170,7 @@ test_block:
       - result: [{!l 20}, {!l 30}]
     -
       - query: select x.col1 + x.col2 from (select col1, col2 from t1) as x group by x.col1;
-      - error: "42803"
+      - error: GROUPING_ERROR
     -
       - query: select x.col1 + x.col1 from (select col1, col2 from t1) as x group by x.col1;
       - result: [{!l 20}, {!l 40}]
@@ -190,7 +190,7 @@ test_block:
       - result: [{!l 13}]
     -
       - query: select x from t1 group by col1 as x, col2 as x;
-      - error: "42702"
+      - error: AMBIGUOUS_COLUMN
     -
       - query: SELECT COUNT(*) from T1 WHERE col1 = 20 or col2 = 5
       - explain: "ISCAN(I1 <,>) | FILTER _.COL1 EQUALS promote(@c10 AS LONG) OR _.COL2 EQUALS promote(@c14 AS LONG) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"

--- a/yaml-tests/src/test/resources/in-predicate.yamsql
+++ b/yaml-tests/src/test/resources/in-predicate.yamsql
@@ -71,7 +71,7 @@ test_block:
     -
       # LONG value matched against empty IN list
       - query: select a, b from ta where b in ()
-      - error: "42601"
+      - error: SYNTAX_ERROR
     -
       # LONG value matched against IN list with no matches
       - query: select a, b from ta where b in (10, 33, 66)
@@ -119,7 +119,7 @@ test_block:
     -
       # _ matched against IN list containing NULL value
       - query: select a, b from ta where b in (1, null, 2, 1, 3, null)
-      - error: "42809"
+      - error: WRONG_OBJECT_TYPE
     -
       # DOUBLE value matched against IN list of DOUBLE values
       - query: select a, c from ta where c in (4.56, 3.45, 2.34)
@@ -185,13 +185,13 @@ test_block:
       # `NOT IN` with incompatible types
       - query: select a, e from ta where e not in ('foo' , 35)
       - initialVersionAtLeast: 4.5.13.0
-      - error: "42804"
+      - error: DATATYPE_MISMATCH
       - initialVersionLessThan: 4.5.13.0
-      - error: "42601"
+      - error: SYNTAX_ERROR
     -
       # Values of incompatible types in the IN list
       - query: select a, e from ta where e in ('foo' , 35 + 4)
-      - error: "22000"
+      - error: CANNOT_CONVERT_TYPE
     -
       # constant LONG value matched against IN list of LONG values
       - query: select a, e from ta where 1 in (2, 3)
@@ -285,29 +285,29 @@ test_block:
         # clear whether we want to support it as it would probably
         # make plan lookup in the cache much more expensive.
         - query: select a, b from ta where b in (1, 3.0, 5, 7.0)
-        - error: "XX000"
+        - error: INTERNAL_ERROR
       -
         # Values of incompatible types in the IN list
         - query: select a, e from ta where e in ('foo' , 35)
-        - error: "XX000"
+        - error: INTERNAL_ERROR
       -
         # Values of incompatible types in the IN list
         - query: select a, e from ta where e in (35, '23')
-        - error: "XX000"
+        - error: INTERNAL_ERROR
       -
         # Values of incompatible types in the IN list
         - query: select a, e from ta where e in (true, 75.34)
-        - error: "XX000"
+        - error: INTERNAL_ERROR
       -
         # Left type (STRING) is not compatible with right type (type of the IN List)
         - query: select a, e from ta where e in (35, 75.34)
-        - error: "XX000"
+        - error: INTERNAL_ERROR
       -
         # Left type (STRING) is not compatible with right type (type of the IN List)
         - query: select a, e from ta where e in (35.34, 32)
-        - error: "XX000"
+        - error: INTERNAL_ERROR
       -
         # Complex (STRUCT) left type matched against IN list
         - query: select a, e from ta where f in (34, 23)
-        - error: "22000"
+        - error: CANNOT_CONVERT_TYPE
 ...

--- a/yaml-tests/src/test/resources/index-ddl.yamsql
+++ b/yaml-tests/src/test/resources/index-ddl.yamsql
@@ -221,10 +221,10 @@ test_block:
     # Test UNIQUE constraint violations on profession column - should fail when attempting to insert duplicate professions
     -
       - query: INSERT INTO customers_materialized_view VALUES (5, 'David', 'david@example.com', 28, 'Boston', 'USA', 'Engineer')
-      - error: "23505"
+      - error: UNIQUE_CONSTRAINT_VIOLATION
     -
       - query: INSERT INTO customers_index_on_table VALUES (5, 'David', 'david@example.com', 28, 'Boston', 'USA', 'Engineer')
-      - error: "23505"
+      - error: UNIQUE_CONSTRAINT_VIOLATION
     # Test that different professions still work
     -
       - query: INSERT INTO customers_materialized_view VALUES (5, 'David', 'david@example.com', 28, 'Boston', 'USA', 'Architect')

--- a/yaml-tests/src/test/resources/initial-version/at-least-current-version.yamsql
+++ b/yaml-tests/src/test/resources/initial-version/at-least-current-version.yamsql
@@ -48,4 +48,4 @@ test_block:
       - initialVersionLessThan: !current_version
       - result: []
       - initialVersionAtLeast: !current_version
-      - error: '42601'
+      - error: SYNTAX_ERROR

--- a/yaml-tests/src/test/resources/initial-version/at-least-version-tests.yamsql
+++ b/yaml-tests/src/test/resources/initial-version/at-least-version-tests.yamsql
@@ -66,4 +66,4 @@ test_block:
       - initialVersionLessThan: 3.0.17.0
       - result: []
       - initialVersionAtLeast: 3.0.17.0
-      - error: '42601'
+      - error: SYNTAX_ERROR

--- a/yaml-tests/src/test/resources/initial-version/less-than-version-tests.yamsql
+++ b/yaml-tests/src/test/resources/initial-version/less-than-version-tests.yamsql
@@ -70,7 +70,7 @@ test_block:
     -
       - query: SHOULD ERROR;
       - initialVersionLessThan: 3.0.19.0
-      - error: '42601'
+      - error: SYNTAX_ERROR
       - initialVersionAtLeast: 3.0.19.0
       - unorderedResult: []
 

--- a/yaml-tests/src/test/resources/inserts-updates-deletes.yamsql
+++ b/yaml-tests/src/test/resources/inserts-updates-deletes.yamsql
@@ -110,13 +110,13 @@ test_block:
       - query: insert into A(A1, A2, A3) values (4);
       - initialVersionLessThan: 4.1.5.0
       # Used to get an internal error prior to: https://github.com/FoundationDB/fdb-record-layer/pull/3070
-      - error: "XXXXX"
+      - error: UNKNOWN
       - initialVersionAtLeast: 4.1.5.0
-      - error: "42601"
+      - error: SYNTAX_ERROR
     -
       # Case where not all values are provided of A. Fails as not all columns (from the schema template) can be matched
       - query: insert into A values (4);
-      - error: "22000"
+      - error: CANNOT_CONVERT_TYPE
     -
       # Case when the number of values is more than the number of columns specified.
       - query: insert into A(A1, A2, A3) values (5, 6, 7, 8, 9);
@@ -124,7 +124,7 @@ test_block:
       # Used to ignore extra column prior to: https://github.com/FoundationDB/fdb-record-layer/pull/3070
       - count: 1
       - initialVersionAtLeast: 4.1.5.0
-      - error: "42601"
+      - error: SYNTAX_ERROR
     -
       # Case when a nullable column's value is not provided
       - query: insert into A(A1, A3) values (6, 7);

--- a/yaml-tests/src/test/resources/join-tests.yamsql
+++ b/yaml-tests/src/test/resources/join-tests.yamsql
@@ -207,7 +207,7 @@ test_block:
     -
       # ambiguous sub select fails if top-level select refers to one of the columns
       - query: select name from (select dept.name, project.name from emp, dept, project where emp.dept_id = dept.id and project.emp_id = emp.id) X;
-      - error: "42702"
+      - error: AMBIGUOUS_COLUMN
     -
       # inner join version of previous
       - query: select dept.name, project.name from project inner join emp on emp.id = project.emp_id inner join dept on emp.dept_id = dept.id;
@@ -376,12 +376,12 @@ test_block:
       # inner join with using: ambiguity left
       - query: select * from jua join jub using(c1) join jud using(c5);
       - supported_version: 4.10.4.0
-      - error: "42702"
+      - error: AMBIGUOUS_COLUMN
     -
       # inner join with using: ambiguity right
       - query: select * from jua join (select * from jub join jud using(c5)) as r using(c1);
       - supported_version: 4.10.4.0
-      - error: "42702"
+      - error: AMBIGUOUS_COLUMN
     -
       # inner join with using: muli using
       - query: select * from jua join jub using(c1, c5);
@@ -557,15 +557,15 @@ test_block:
       # NATURAL JOIN (inner) is not yet supported.`
       - query: SELECT * FROM emp e NATURAL JOIN dept d;
       - supported_version: 4.12.2.0
-      - error: '0AF00'  # UNSUPPORTED_QUERY
+      - error: UNSUPPORTED_QUERY
     -
       # NATURAL LEFT JOIN is not yet supported.
       - query: SELECT * FROM emp e NATURAL LEFT JOIN dept d;
       - supported_version: 4.12.2.0
-      - error: '0AF00'  # UNSUPPORTED_QUERY
+      - error: UNSUPPORTED_QUERY
     -
       # STRAIGHT_JOIN is not yet supported.
       - query: SELECT * FROM emp e STRAIGHT_JOIN dept d ON e.dept_id = d.id;
       - supported_version: 4.12.2.0
-      - error: '0AF00'  # UNSUPPORTED_QUERY
+      - error: UNSUPPORTED_QUERY
 ...

--- a/yaml-tests/src/test/resources/join-with-order-by-tests.yamsql
+++ b/yaml-tests/src/test/resources/join-with-order-by-tests.yamsql
@@ -211,7 +211,7 @@ test_block:
                 order by x.a2 desc
       - explain: "ISCAN(t1$a1_a2 [EQUALS promote(@c9 AS LONG)] REVERSE) | FLATMAP q0 -> { COVERING(t2$b1_b3 [EQUALS promote(@c9 AS LONG)] -> [b1: KEY:[0], b3: KEY:[1], id: KEY:[2]]) | FILTER q0.a3 EQUALS _.b3 | FETCH AS q1 RETURN ((q1.__ROW_VERSION AS __ROW_VERSION, q1.id AS id, q1.b1 AS b1, q1.b2 AS b2, q1.b3 AS b3) AS _0, q0.a2 AS a2) } | MAP (_._0 AS _0)"
       - initialVersionLessThan: 4.10.5.0
-      - error: 'XX000'
+      - error: INTERNAL_ERROR
       - initialVersionAtLeast: 4.10.5.0
       - result: [
           { { '__ROW_VERSION': !not_null _, id: 2003, b1: 1, b2: 18, b3: "b" } },
@@ -248,7 +248,7 @@ test_block:
                 order by x.the_a2 desc
       - explain: "ISCAN(t1$a1_a2 [EQUALS promote(@c9 AS LONG)] REVERSE) | FLATMAP q0 -> { COVERING(t2$b1_b3 [EQUALS promote(@c9 AS LONG)] -> [b1: KEY:[0], b3: KEY:[1], id: KEY:[2]]) | FILTER q0.a3 EQUALS _.b3 | FETCH AS q1 RETURN ((q1.__ROW_VERSION AS __ROW_VERSION, q1.id AS id, q1.b1 AS b1, q1.b2 AS b2, q1.b3 AS b3, q1.b2 AS the_b2) AS _0, q0.a2 AS the_a2) } | MAP (_._0 AS _0)"
       - initialVersionLessThan: 4.10.5.0
-      - error: 'XX000'
+      - error: INTERNAL_ERROR
       - initialVersionAtLeast: 4.10.5.0
       - result: [
           { { '__ROW_VERSION': !not_null _, id: 2003, b1: 1, b2: 18, b3: "b", the_b2: 18 } },
@@ -360,7 +360,7 @@ test_block:
                  from t1, t2
                  where t1.a1 = 1 and t2.b1 = 1
                  order by t1.a2, t2.b3
-      - error: '0AF00'
+      - error: UNSUPPORTED_QUERY
     -
       # This should be possible to plan, but it requires noting that if the outer is on t2 and ordered by t2.b3,
       # then the join is executed with an equality predicate on t1.a3, and thus the order is satisfied
@@ -368,7 +368,7 @@ test_block:
                  from t1, t2
                  where t1.a1 = 1 and t2.b1 = 1 and t1.a3 = t2.b3
                  order by t2.b3, t1.a3
-      - error: '0AF00'
+      - error: UNSUPPORTED_QUERY
     -
       - query: select (t1.*), (t3.*)
                  from t1, t3
@@ -434,7 +434,7 @@ test_block:
                 order by t3.c3 desc
       # This can't be planned because it can't figure out that m has max cardinality 1 (coming from the fact that the group by columns are all equality bound by the having)
       # See: https://github.com/FoundationDB/fdb-record-layer/issues/3975
-      - error: '0AF00'
+      - error: UNSUPPORTED_QUERY
     -
       - query: select t1.*
                  from t1, (select max(t1.a2) as maxA2 from t1 where t1.a1 = 1) as m
@@ -546,7 +546,7 @@ test_block:
       # This should be possible to plan, as there is an equality predicate on t1.id, so we should be able to freely
       # introduce it into the ordering
       # See: https://github.com/FoundationDB/fdb-record-layer/issues/3974
-      - error: '0AF00'
+      - error: UNSUPPORTED_QUERY
     -
       - query: select (t1.*), (t2.*)
                  from t1, t2
@@ -555,7 +555,7 @@ test_block:
       # This should be possible to plan, as the fact that the max cardinality on the t1 quantifier should allow us to move
       # the order around as we want
       # See: https://github.com/FoundationDB/fdb-record-layer/issues/3974
-      - error: '0AF00'
+      - error: UNSUPPORTED_QUERY
     -
       - query: select (t1.*), (t3.*)
                  from t1, t3
@@ -601,7 +601,7 @@ test_block:
       # will give us the right order, as the index scan on t3$c1_c2 produces distinct elements. However, this
       # fails as we are unable to parlay the uniqueness constraint into a distinct ordering
       # See: https://github.com/FoundationDB/fdb-record-layer/issues/3976
-      - error: '0AF00'
+      - error: UNSUPPORTED_QUERY
 
     #
     # Ternary joins. Assert that we can get joins with three constituents and an order by correct.
@@ -837,5 +837,5 @@ test_block:
                 where c.aRef = a.id
                 order by x1 desc, a.a2 asc
       # Error: VerifyException when translating the ordering part. Needs more analysis
-      - error: 'XX000'
+      - error: INTERNAL_ERROR
 ...

--- a/yaml-tests/src/test/resources/large-record-fails.yamsql
+++ b/yaml-tests/src/test/resources/large-record-fails.yamsql
@@ -28,5 +28,5 @@ test_block:
     -
       - query: insert into T1 values
           (1,  !! !randomStr seed 123234 length 1000000 !!)
-      - error: "XXXXX"
+      - error: UNKNOWN
 ...

--- a/yaml-tests/src/test/resources/maxRows.yamsql
+++ b/yaml-tests/src/test/resources/maxRows.yamsql
@@ -41,7 +41,7 @@ test_block:
       # maxRows value is negative
       - query: select ta.* from ta;
       - maxRows: -27525
-      - error: "22023"
+      - error: INVALID_PARAMETER
     -
       # maxRows value 1
       - query: select ta.* from ta;
@@ -96,7 +96,7 @@ test_block:
     -
       # limit value offset value is not supported
       - query: select ta.* from ta LIMIT 2 OFFSET 2;
-      - error: "0AF00"
+      - error: UNSUPPORTED_QUERY
 #    -
 #      # offset value is negative
 #      - query: select ta.* from ta LIMIT 2 OFFSET -27525;
@@ -138,15 +138,15 @@ test_block:
     -
       # limit not supported as it was replaced by maxRows for now
       - query: select * from ta limit 5
-      - error: "0AF00"
+      - error: UNSUPPORTED_QUERY
     -
       # limit clause when from has a nested statement
       - query: select p.* from (select ta.* from ta where ta.a > 5 limit 1) as p;
-      - error: "0AF00"
+      - error: UNSUPPORTED_QUERY
     -
       # limit clause when where has existential statement
       - query: select p.* FROM ta as p where exists (select * from ta where ta.a = p.a limit 1);
-      - error: "0AF00"
+      - error: UNSUPPORTED_QUERY
     -
       # limit clause with continuation
       - query: select ta.* from ta;

--- a/yaml-tests/src/test/resources/orderby.yamsql
+++ b/yaml-tests/src/test/resources/orderby.yamsql
@@ -109,7 +109,7 @@ test_block:
   tests:
     -
       - query: select b, c from t1 order by b, b
-      - error: "42701"
+      - error: COLUMN_ALREADY_EXISTS
     -
       # Simple ordering on 1 variable
       - query: select b, c from t1 order by b
@@ -179,15 +179,15 @@ test_block:
     -
       # Simple ordering on 2 variable, arbitrary ordering exception
       - query: select c, b from t1 order by c, b desc;
-      - error: 0AF00
+      - error: UNSUPPORTED_QUERY
     -
       # Simple ordering on 2 variable, arbitrary ordering exception
       - query: select c, b from t1 order by c asc, b desc;
-      - error: 0AF00
+      - error: UNSUPPORTED_QUERY
     -
       # Simple ordering on 2 variable, arbitrary ordering exception
       - query: select c, b from t1 order by c desc, b;
-      - error: 0AF00
+      - error: UNSUPPORTED_QUERY
     -
       # Simple ordering on 2 variable, point filter on outer
       - query: select c, b from t1 where c = 8 order by c, b;
@@ -237,11 +237,11 @@ test_block:
     -
       # Ordering in nested select is not allowed
       - query: select b from t1, (select * from t1 order by b) as n
-      - error: "0A000"
+      - error: UNSUPPORTED_OPERATION
     -
       # Ordering in nested select is not allowed
       - query: select b from t1 where exists (select * from t1 order by b limit 1)
-      - error: "0AF00"
+      - error: UNSUPPORTED_QUERY
     -
       # Ordering by a non projected column
       - query: select c from t1 order by b
@@ -274,7 +274,7 @@ test_block:
     -
       # Ordering by a ambiguous projected column
       - query: select q as "nested", q.a as "ordered", q.b as "ordered" from t2 order by "ordered"
-      - error: "42702"
+      - error: AMBIGUOUS_COLUMN
     -
       # Ordering by a ambiguous projected column in subquery
       - query: select (T.*) from (select q as "nested", q.a as "ordered" from t2) as T order by "ordered"
@@ -291,12 +291,12 @@ test_block:
       # Ordering by a column in table function that has been projected in multiple ways
       - query: select (*) from t2_func_2() order by "ordered"
       # This should probably return AMBIGUOUS_COLUMN, but currently it returns UNKNOWN_COLUMN.
-      - error: "42703"
+      - error: UNDEFINED_COLUMN
     -
       # qualification on order by clause is currently not supported entirely
       - query: select (q as "nested", q.a as "ordered") as "st" from t2 order by "st"."ordered"
       - supported_version: 4.10.1.0
-      - error: "42703"
+      - error: UNDEFINED_COLUMN
     -
       # Ordering by a column in table function that has been projected in multiple ways
       - query: select (*) from t2_func_3() order by "ordered2", "ordered1"

--- a/yaml-tests/src/test/resources/primary-key-tests.yamsql
+++ b/yaml-tests/src/test/resources/primary-key-tests.yamsql
@@ -30,7 +30,7 @@ test_block:
       - query: INSERT INTO T1
            VALUES ((1, 2, 3, 4), 5),
                   ((1, 2, 30, 40), 50)
-      - error: "23505"
+      - error: UNIQUE_CONSTRAINT_VIOLATION
     -
       - query: SELECT COUNT(*) FROM T1
       - explain: "SCAN([IS T1]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"

--- a/yaml-tests/src/test/resources/pseudo-field-clash.yamsql
+++ b/yaml-tests/src/test/resources/pseudo-field-clash.yamsql
@@ -258,7 +258,7 @@ test_block:
                 WHERE t2.id = t1.id AND t3.id = t1.id
       - explain: "SCAN([IS T1]) | FLATMAP q0 -> { SCAN([IS T3, EQUALS q0.ID]) | FLATMAP q1 -> { SCAN([IS T2, EQUALS q0.ID]) AS q2 RETURN (q2 AS _0, q1 AS _1) } AS q3 RETURN ((q0.ID AS ID, q0.COL1 AS COL1, q0.__ROW_VERSION AS __ROW_VERSION) AS _0, (q3._0.ID AS ID, q3._0.COL1 AS COL1, q3._0.__ROW_VERSION AS __ROW_VERSION) AS _1, (q3._1.ID AS ID, q3._1.COL1 AS COL1, q3._1.COL2 AS COL2, q3._1.__ROW_VERSION AS __ROW_VERSION) AS _2) }"
       - initialVersionLessThan: 4.10.1.0
-      - error: 'XXXXX'
+      - error: UNKNOWN
       - initialVersionAtLeast: 4.10.1.0
       - unorderedResult: [
           { { ID: 1, COL1: "a", '__ROW_VERSION': x'0000' }, { ID: 1, COL1: 10, '__ROW_VERSION': "aa" }, { ID: 1, COL1: 10, COL2: "aa", '__ROW_VERSION': !not_null _ } },

--- a/yaml-tests/src/test/resources/select-a-star.yamsql
+++ b/yaml-tests/src/test/resources/select-a-star.yamsql
@@ -53,7 +53,7 @@ test_block:
       - result: [{A1: 1 , 10, 1}, {A1: 2, 10, 2}, {A1: 3, 10, 3}]
     -
       - query: select A.* from A group by A1;
-      - error: "42803"
+      - error: GROUPING_ERROR
     -
       - query: select * from A, B where A.A1 = B.B1;
       - result: [{A1: 1 , A2: 10, A3: 1, B1: 1, B2: 20, B3: {4, 40}},
@@ -76,7 +76,7 @@ test_block:
                  {B1: 3, B2: 20, B3: {6, 60}, A1: 3, A2: 10, A3: 3}]
     -
       - query: select A.*, B.* from A, B where A.A1 = B.B1 group by A1;
-      - error: "42803"
+      - error: GROUPING_ERROR
     -
       - query: select B1 from B where exists (select A.*, B1 from A group by A1,A2,A3);
       - explain: "SCAN([IS B]) | FLATMAP q0 -> { ISCAN(A_IDX <,>) | MAP (_ AS _0) | AGG () GROUP BY (_._0.A1 AS _0, _._0.A2 AS _1, _._0.A3 AS _2) | MAP (_._0._0 AS A1, _._0._1 AS A2, _._0._2 AS A3, q0.B1 AS B1) | DEFAULT NULL | FILTER _ NOT_NULL AS q0 RETURN (q0.B1 AS B1) }"
@@ -90,15 +90,15 @@ test_block:
     -
       # Not yet supported
       - query: select B.B3.* from B;
-      - error: "42601"
+      - error: SYNTAX_ERROR
     -
       # Should never be supported
       - query: select B.*.S1 from B;
-      - error: "42601"
+      - error: SYNTAX_ERROR
     -
       # Ambiguous column A1 (error code is now correct).
       - query: select A1 from (select A.*, A.* from A) as nested
-      - error: "42702"
+      - error: AMBIGUOUS_COLUMN
 #    -
 #      - query: select A.*, SUM(B1) from A, B where A.A1 = B.B1 group by A1, A2, A3;
 #      - result: [{A1: 1 , A2: 10, A3: 1, 1},

--- a/yaml-tests/src/test/resources/semantic-search-advanced-metrics.yamsql
+++ b/yaml-tests/src/test/resources/semantic-search-advanced-metrics.yamsql
@@ -183,22 +183,22 @@ test_block:
           select docId, title from multiTypePartitionDocs
           where zoneId = !! 3 !! and bookshelf = 'fiction'
           qualify row_number() over (partition by zoneId, bookshelf order by dot_product_distance(embedding, !! !v16 [0.0, 0.1, 0.9] !!) desc) <= !! 2 !!
-      - error: "0AF01"
+      - error: UNSUPPORTED_SORT
     -
       - query:
           select docId, title from multiTypePartitionDocs
           where zoneId = !! 3 !! and bookshelf = 'fiction'
           qualify row_number() over (partition by zoneId, bookshelf order by dot_product_distance(embedding, !! !v16 [0.0, 0.1, 0.9] !!) desc nulls first) <= !! 2 !!
-      - error: "0AF01"
+      - error: UNSUPPORTED_SORT
     -
       - query:
           select docId, title from multiTypePartitionDocs
           where zoneId = !! 3 !! and bookshelf = 'fiction'
           qualify row_number() over (partition by zoneId, bookshelf order by dot_product_distance(embedding, !! !v16 [0.0, 0.1, 0.9] !!) desc nulls last) <= !! 2 !!
-      - error: "0AF01"
+      - error: UNSUPPORTED_SORT
     -
       - query:
           select docId, title from multiTypePartitionDocs
           where zoneId = !! 3 !! and bookshelf = 'fiction'
           qualify row_number() over (partition by zoneId, bookshelf order by dot_product_distance(embedding, !! !v16 [0.0, 0.1, 0.9] !!) nulls last) <= !! 2 !!
-      - error: "0AF01"
+      - error: UNSUPPORTED_SORT

--- a/yaml-tests/src/test/resources/semantic-search.yamsql
+++ b/yaml-tests/src/test/resources/semantic-search.yamsql
@@ -105,7 +105,7 @@ test_block:
           select docId, title, euclidean_distance(embedding, !! !v16 [1.0, 0.0, 0.0] !!) from documents
           where zone = 'zone1' and bookshelf = 'fiction'
           and row_number() over (partition by zone, bookshelf order by euclidean_distance(embedding, !! !v16 [1.0, 0.0, 0.0] !!) asc) <= 1
-      - error: "42F21"
+      - error: WINDOWING_ERROR
     -
       - query:
           select docId, euclidean_distance(embedding, !! !v16 [1.0, 0.0, 0.0] !!) from documents
@@ -262,7 +262,7 @@ test_block:
           join documents d2 on d2.zone = d1.zone and d2.bookshelf = 'science'
           where r.zone = 'zone1'
           qualify row_number() over (partition by d2.zone, d2.bookshelf order by manhattan_distance(d2.embedding, d1.embedding) asc options ef_search = 100) < 2
-      - error: "0AF00"
+      - error: UNSUPPORTED_QUERY
 # Test HNSW index with mixed-type partition columns (bigint and string)
     -
       - query:
@@ -326,25 +326,25 @@ test_block:
           select docId, title from multiTypePartitionDocs
           where zoneId = !! 2 !! and bookshelf = 'fiction'
           qualify row_number() over (partition by zoneId, bookshelf order by euclidean_distance(embedding, !! !v16 [0.0, 0.1, 0.9] !!) desc) <= !! 2 !!
-      - error: "0AF01"
+      - error: UNSUPPORTED_SORT
     -
       - query:
           select docId, title from multiTypePartitionDocs
           where zoneId = !! 2 !! and bookshelf = 'fiction'
           qualify row_number() over (partition by zoneId, bookshelf order by euclidean_distance(embedding, !! !v16 [0.0, 0.1, 0.9] !!) desc nulls first) <= !! 2 !!
-      - error: "0AF01"
+      - error: UNSUPPORTED_SORT
     -
       - query:
           select docId, title from multiTypePartitionDocs
           where zoneId = !! 2 !! and bookshelf = 'fiction'
           qualify row_number() over (partition by zoneId, bookshelf order by euclidean_distance(embedding, !! !v16 [0.0, 0.1, 0.9] !!) desc nulls last) <= !! 2 !!
-      - error: "0AF01"
+      - error: UNSUPPORTED_SORT
     -
       - query:
           select docId, title from multiTypePartitionDocs
           where zoneId = !! 2 !! and bookshelf = 'fiction'
           qualify row_number() over (partition by zoneId, bookshelf order by euclidean_distance(embedding, !! !v16 [0.0, 0.1, 0.9] !!) nulls last) <= !! 2 !!
-      - error: "0AF01"
+      - error: UNSUPPORTED_SORT
 ---
 test_block:
   preset: single_repetition_ordered

--- a/yaml-tests/src/test/resources/serialization-options.yamsql
+++ b/yaml-tests/src/test/resources/serialization-options.yamsql
@@ -58,7 +58,7 @@ test_block:
   tests:
     -
       - query: SELECT * FROM t
-      - error: "XXF01"
+      - error: DESERIALIZATION_FAILURE
 ---
 test_block:
   name: read-wrong-key
@@ -69,7 +69,7 @@ test_block:
   tests:
     -
       - query: SELECT * FROM t
-      - error: "XXF01"
+      - error: DESERIALIZATION_FAILURE
 ---
 test_block:
   name: write-without-encryption
@@ -87,7 +87,7 @@ test_block:
       - unorderedResult: [{S: 'xyz'}]
     -
       - query: SELECT s FROM t WHERE id = 1
-      - error: "XXF01"
+      - error: DESERIALIZATION_FAILURE
 ---
 test_block:
   name: write-unencrypted

--- a/yaml-tests/src/test/resources/showcasing-tests.yamsql
+++ b/yaml-tests/src/test/resources/showcasing-tests.yamsql
@@ -128,7 +128,7 @@ test_block:
       # incorrect, this should throw SYNTAX_ERROR error whose SQL state is 42601
       # the `query` command has a configuration `error` implemented to check that.
       - query: selec * from t1;
-      - error: "42601"
+      - error: SYNTAX_ERROR  # equivalent to: error: "42601"
 
     # ------------------------------------------------------------------
     # Result checking with partial matching (!ignore, !l tags)

--- a/yaml-tests/src/test/resources/sparse-index-tests.yamsql
+++ b/yaml-tests/src/test/resources/sparse-index-tests.yamsql
@@ -117,10 +117,10 @@ test_block:
       - result: [{ID: 1}, {ID: 2}, {ID: 3}, {ID: 4}]
     -
       - query: select id from t1 use index (i1)
-      - error: "0AF00"
+      - error: UNSUPPORTED_QUERY
     -
       - query: select id from t1 use index (i2)
-      - error: "0AF00"
+      - error: UNSUPPORTED_QUERY
     -
       - query: select id from t1
       # Without a predicate matching any of these sparse indexes, this needs to fall back to a scan

--- a/yaml-tests/src/test/resources/sql-functions.yamsql
+++ b/yaml-tests/src/test/resources/sql-functions.yamsql
@@ -168,19 +168,19 @@ test_block:
       - result: [{100, 'a'}]
     -
       - query: select col1, col2 from f1('b', 103);
-      - error: "42883"
+      - error: UNDEFINED_FUNCTION
     -
       - query: select col1, col2 from f1(102, 103);
-      - error: "42883"
+      - error: UNDEFINED_FUNCTION
     -
       - query: select col1, col2 from f1(103);
-      - error: "42883"
+      - error: UNDEFINED_FUNCTION
     -
       - query: select col1, col2 from f1(103);
-      - error: "42883"
+      - error: UNDEFINED_FUNCTION
     -
       - query: select col1, col2 from f1(a => 103, a => 104);
-      - error: "42601"
+      - error: SYNTAX_ERROR
 ---
 test_block:
   name: parenthesis-less-function-calls
@@ -192,6 +192,6 @@ test_block:
       - result: [{101, 'b'}, {102, 'b'}]
     -
       - query: select * from f1;
-      - error: '42883'
+      - error: UNDEFINED_FUNCTION
 
 ...

--- a/yaml-tests/src/test/resources/table-functions.yamsql
+++ b/yaml-tests/src/test/resources/table-functions.yamsql
@@ -79,16 +79,16 @@ test_block:
       - result: [{ID: 1}, {ID: 2}, {ID: 3}]
     -
       - query: select * from range(-1)
-      - error: XXXXX
+      - error: UNKNOWN
     -
       - query: select * from range(-1, 4)
-      - error: XXXXX
+      - error: UNKNOWN
     -
       - query: select * from range(1, 4, -1)
-      - error: XXXXX
+      - error: UNKNOWN
     -
       - query: select * from range(1, 4, 0)
-      - error: XXXXX
+      - error: UNKNOWN
     -
       - query: select * from range(0, 12, 5)
       - result: [{ID: 0}, {ID: 5}, {ID: 10}]

--- a/yaml-tests/src/test/resources/union-empty-tables.yamsql
+++ b/yaml-tests/src/test/resources/union-empty-tables.yamsql
@@ -90,11 +90,11 @@ test_block:
       - unorderedResult: []
     -
       - query: select col1, col2 from t1 union all select col1 from t1
-      - error: "42F64"
+      - error: UNION_INCORRECT_COLUMN_COUNT
     -
       - query: select col1, col2 from t1 union select col1 from t1
-      - error: "0AF00"
+      - error: UNSUPPORTED_QUERY
     -
       - query: select col1, col2 from t1 union all select a, b from t5
-      - error: "42F65"
+      - error: UNION_INCOMPATIBLE_COLUMNS
 ...

--- a/yaml-tests/src/test/resources/union.yamsql
+++ b/yaml-tests/src/test/resources/union.yamsql
@@ -167,13 +167,13 @@ test_block:
       - result: [{1}, {2}, {6}, {7}]
     -
       - query: select col1, col2 from t1 union all select col1 from t1
-      - error: "42F64"
+      - error: UNION_INCORRECT_COLUMN_COUNT
     -
       - query: select col1, col2 from t1 union select col1 from t1
-      - error: "0AF00"
+      - error: UNSUPPORTED_QUERY
     -
       - query: select col1, col2 from t1 union all select a, b from t5
-      - error: "42F65"
+      - error: UNION_INCOMPATIBLE_COLUMNS
     -
       - query: select sum(Y) as S from (select count(*) as Y from t6 union all select count(*) from t7) as X
       - explain: "AISCAN(MV11 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS Y) ⊎ AISCAN(MV12 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0) | MAP (_ AS _0) | AGG (sum_l(_._0.Y) AS _0) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS S)"

--- a/yaml-tests/src/test/resources/user-defined-macro-function-tests.yamsql
+++ b/yaml-tests/src/test/resources/user-defined-macro-function-tests.yamsql
@@ -206,5 +206,5 @@ test_block:
     -
       # wrong function name
       - query: select zz(r) from nested group by z(r)
-      - error: "0AF00"
+      - error: UNSUPPORTED_QUERY
 ...

--- a/yaml-tests/src/test/resources/uuid-non-prepared.yamsql
+++ b/yaml-tests/src/test/resources/uuid-non-prepared.yamsql
@@ -127,7 +127,7 @@ test_block:
                           {8, !null _}]
     -
       - query: select * from ta where b is not null order by b
-      - error: '0AF00'
+      - error: UNSUPPORTED_QUERY
 ---
 test_block:
   name: uuid-as-a-primary-key

--- a/yaml-tests/src/test/resources/uuid-prepared.yamsql
+++ b/yaml-tests/src/test/resources/uuid-prepared.yamsql
@@ -131,7 +131,7 @@ test_block:
                           {8, !null _}]
     -
       - query: select * from ta where b is not null order by b
-      - error: '0AF00'
+      - error: UNSUPPORTED_QUERY
 ---
 test_block:
   options:

--- a/yaml-tests/src/test/resources/valid-identifiers.yamsql
+++ b/yaml-tests/src/test/resources/valid-identifiers.yamsql
@@ -290,15 +290,15 @@ test_block:
     -
       # with select element alias prefixed with .
       - query: select "foo.tableA"."foo.tableA.A1" AS ".__." from "foo.tableA";
-      - error: "42602"
+      - error: INVALID_NAME
     -
       # with select element alias prefixed with $
       - query: select "foo.tableA"."foo.tableA.A1" AS "$__." from "foo.tableA";
-      - error: "42602"
+      - error: INVALID_NAME
     -
       # with select element alias with non-supported characters
       - query: select "foo.tableA"."foo.tableA.A1" AS "उपनाम" from "foo.tableA";
-      - error: "42602"
+      - error: INVALID_NAME
     -
       # multi-level CTEs
       - query: with "A$_$__$$" as (with "A$__$" as (select "foo.tableA.A1" as "A$" from "foo.tableA") select * from "A$__$") select * from "A$_$__$$"
@@ -614,46 +614,46 @@ test_block:
       # invalid table name
       - query: create schema template test_template_with_invalid_identifiers
                create table "$yay"(id2 bigint, col6 s2 ARRAY, primary key(id2))
-      - error: "42602"
+      - error: INVALID_NAME
     -
       # invalid table name
       - query: create schema template test_template_with_invalid_identifiers
                create table "नमस्ते"(id2 bigint, col6 s2 ARRAY, primary key(id2))
-      - error: "42602"
+      - error: INVALID_NAME
     -
       # invalid column name
       - query: create schema template test_template_with_invalid_identifiers
                create table T1("$yay" bigint, col6 s2 ARRAY, primary key(id2))
-      - error: "42602"
+      - error: INVALID_NAME
     -
       # invalid column name
       - query: create schema template test_template_with_invalid_identifiers
                create table T1("नमस्ते" bigint, col6 s2 ARRAY, primary key(id2))
-      - error: "42602"
+      - error: INVALID_NAME
     -
       # invalid struct name
       - query: create schema template test_template_with_invalid_identifiers
                CREATE TYPE AS STRUCT "$yay"(S1 bigint, S2 bigint)
                create table T1(id2 bigint, col6 "$yay", primary key(id2))
-      - error: "42602"
+      - error: INVALID_NAME
     -
       # invalid struct name
       - query: create schema template test_template_with_invalid_identifiers
                CREATE TYPE AS STRUCT "नमस्ते"(S1 bigint, S2 bigint)
                create table T1(id2 bigint, col6 "नमस्ते", primary key(id2))
-      - error: "42602"
+      - error: INVALID_NAME
     -
       # invalid function argument
       - query: create schema template test_template_with_invalid_identifiers
                create table T1(id2 bigint, id3 bigint, primary key(id2))
                create function func (in "$yay" bigint) as SELECT id3 from T1 where id2 > "$yay"
-      - error: "42602"
+      - error: INVALID_NAME
     -
       # invalid function argument
       - query: create schema template test_template_with_invalid_identifiers
                create table T1(id2 bigint, id3 bigint, primary key(id2))
                create function func (in "नमस्ते" bigint) as SELECT id3 from T1 where id2 > "नमस्ते"
-      - error: "42602"
+      - error: INVALID_NAME
 ---
 setup:
   connect: "jdbc:embed:/__SYS?schema=CATALOG"

--- a/yaml-tests/src/test/resources/vector.yamsql
+++ b/yaml-tests/src/test/resources/vector.yamsql
@@ -195,19 +195,19 @@ test_block:
       - initialVersionAtLeast: 4.8.12.0
       - result: [{200, !null _}]
       - initialVersionLessThan: 4.8.12.0
-      - error: "XXXXX"
+      - error: UNKNOWN
     -
       - query: select * from tFloatVector where a = 200
       - initialVersionAtLeast: 4.8.12.0
       - result: [{200, !null _}]
       - initialVersionLessThan: 4.8.12.0
-      - error: "XXXXX"
+      - error: UNKNOWN
     -
       - query: select * from tDoubleVector where a = 200
       - initialVersionAtLeast: 4.8.12.0
       - result: [{200, !null _}]
       - initialVersionLessThan: 4.8.12.0
-      - error: "XXXXX"
+      - error: UNKNOWN
     # IS NULL tests for NULL vectors
     -
       - query: select b is null from tHalfVector where a = 200
@@ -413,123 +413,123 @@ test_block:
     # STRING array to vector should fail
     -
       - query: select cast(['a', 'b', 'c'] as VECTOR(3, FLOAT)) from tDoubleVector where a = 100
-      - error: "22F3H"
+      - error: INVALID_CAST
     # BOOLEAN array to vector should fail
     -
       - query: select cast([true, false, true] as VECTOR(3, HALF)) from tDoubleVector where a = 100
-      - error: "22F3H"
+      - error: INVALID_CAST
     # Mismatched dimensions should fail (array has 4 elements, vector expects 3)
     -
       - query: select cast([1.0, 2.0, 3.0, 4.0] as VECTOR(3, FLOAT)) from tDoubleVector where a = 100
-      - error: "22F3H"
+      - error: INVALID_CAST
     # Mismatched dimensions should fail (array has 2 elements, vector expects 3)
     -
       - query: select cast([1.0, 2.0] as VECTOR(3, DOUBLE)) from tDoubleVector where a = 100
-      - error: "22F3H"
+      - error: INVALID_CAST
     # Tests for attempting to insert vectors of different precision / size
     # Wrong number of dimensions - HALF vector with 2 dimensions into table expecting 3
     -
       - query: insert into tHalfVector values (400, !! !v16 [1.1, 2.2] !!)
       - initialVersionAtLeast: 4.8.12.0
-      - error: "22000"
+      - error: CANNOT_CONVERT_TYPE
       - initialVersionLessThan: 4.8.12.0
       - count: 1
     # Wrong number of dimensions - HALF vector with 4 dimensions into table expecting 3
     -
       - query: insert into tHalfVector values (401, !! !v16 [1.1, 2.2, 3.3, 4.4] !!)
       - initialVersionAtLeast: 4.8.12.0
-      - error: "22000"
+      - error: CANNOT_CONVERT_TYPE
       - initialVersionLessThan: 4.8.12.0
       - count: 1
     # Wrong number of dimensions - FLOAT vector with 2 dimensions into table expecting 3
     -
       - query: insert into tFloatVector values (402, !! !v32 [1.1, 2.2] !!)
       - initialVersionAtLeast: 4.8.12.0
-      - error: "22000"
+      - error: CANNOT_CONVERT_TYPE
       - initialVersionLessThan: 4.8.12.0
       - count: 1
     # Wrong number of dimensions - FLOAT vector with 4 dimensions into table expecting 3
     -
       - query: insert into tFloatVector values (403, !! !v32 [1.1, 2.2, 3.3, 4.4] !!)
       - initialVersionAtLeast: 4.8.12.0
-      - error: "22000"
+      - error: CANNOT_CONVERT_TYPE
       - initialVersionLessThan: 4.8.12.0
       - count: 1
     # Wrong number of dimensions - DOUBLE vector with 2 dimensions into table expecting 3
     -
       - query: insert into tDoubleVector values (404, !! !v64 [1.1, 2.2] !!)
       - initialVersionAtLeast: 4.8.12.0
-      - error: "22000"
+      - error: CANNOT_CONVERT_TYPE
       - initialVersionLessThan: 4.8.12.0
       - count: 1
     # Wrong number of dimensions - DOUBLE vector with 4 dimensions into table expecting 3
     -
       - query: insert into tDoubleVector values (405, !! !v64 [1.1, 2.2, 3.3, 4.4] !!)
       - initialVersionAtLeast: 4.8.12.0
-      - error: "22000"
+      - error: CANNOT_CONVERT_TYPE
       - initialVersionLessThan: 4.8.12.0
       - count: 1
     # Wrong precision - FLOAT vector into HALF table
     -
       - query: insert into tHalfVector values (406, !! !v32 [1.1, 2.2, 3.3] !!)
       - initialVersionAtLeast: 4.8.12.0
-      - error: "22000"
+      - error: CANNOT_CONVERT_TYPE
       - initialVersionLessThan: 4.8.12.0
       - count: 1
     # Wrong precision - DOUBLE vector into HALF table
     -
       - query: insert into tHalfVector values (407, !! !v64 [1.1, 2.2, 3.3] !!)
       - initialVersionAtLeast: 4.8.12.0
-      - error: "22000"
+      - error: CANNOT_CONVERT_TYPE
       - initialVersionLessThan: 4.8.12.0
       - count: 1
     # Wrong precision - HALF vector into FLOAT table
     -
       - query: insert into tFloatVector values (408, !! !v16 [1.1, 2.2, 3.3] !!)
       - initialVersionAtLeast: 4.8.12.0
-      - error: "22000"
+      - error: CANNOT_CONVERT_TYPE
       - initialVersionLessThan: 4.8.12.0
       - count: 1
     # Wrong precision - DOUBLE vector into FLOAT table
     -
       - query: insert into tFloatVector values (409, !! !v64 [1.1, 2.2, 3.3] !!)
       - initialVersionAtLeast: 4.8.12.0
-      - error: "22000"
+      - error: CANNOT_CONVERT_TYPE
       - initialVersionLessThan: 4.8.12.0
       - count: 1
     # Wrong precision - HALF vector into DOUBLE table
     -
       - query: insert into tDoubleVector values (410, !! !v16 [1.1, 2.2, 3.3] !!)
       - initialVersionAtLeast: 4.8.12.0
-      - error: "22000"
+      - error: CANNOT_CONVERT_TYPE
       - initialVersionLessThan: 4.8.12.0
       - count: 1
     # Wrong precision - FLOAT vector into DOUBLE table
     -
       - query: insert into tDoubleVector values (411, !! !v32 [1.1, 2.2, 3.3] !!)
       - initialVersionAtLeast: 4.8.12.0
-      - error: "22000"
+      - error: CANNOT_CONVERT_TYPE
       - initialVersionLessThan: 4.8.12.0
       - count: 1
     # Wrong number of dimensions - HALF vector with 1 dimension into table expecting 3
     -
       - query: insert into tHalfVector values (412, !! !v16 [1.1] !!)
       - initialVersionAtLeast: 4.8.12.0
-      - error: "22000"
+      - error: CANNOT_CONVERT_TYPE
       - initialVersionLessThan: 4.8.12.0
       - count: 1
     # Wrong number of dimensions - FLOAT vector with 5 dimensions into table expecting 3
     -
       - query: insert into tFloatVector values (413, !! !v32 [1.1, 2.2, 3.3, 4.4, 5.5] !!)
       - initialVersionAtLeast: 4.8.12.0
-      - error: "22000"
+      - error: CANNOT_CONVERT_TYPE
       - initialVersionLessThan: 4.8.12.0
       - count: 1
     # Wrong number of dimensions - DOUBLE vector with 0 dimensions into table expecting 3
     -
       - query: insert into tDoubleVector values (414, !! !v64 [] !!)
       - initialVersionAtLeast: 4.8.12.0
-      - error: "22000"
+      - error: CANNOT_CONVERT_TYPE
       - initialVersionLessThan: 4.8.12.0
       - count: 1
     # Tests for tWithStruct (struct with HALF vector field)

--- a/yaml-tests/src/test/resources/versions-tests.yamsql
+++ b/yaml-tests/src/test/resources/versions-tests.yamsql
@@ -285,9 +285,9 @@ test_block:
       - query: select "__ROW_VERSION" from (select * from t1) a;
       - supported_version: 4.9.1.0
       - initialVersionLessThan: 4.10.1.0
-      - error: 'XXXXX'
+      - error: UNKNOWN
       - initialVersionAtLeast: 4.10.1.0
-      - error: '42703'
+      - error: UNDEFINED_COLUMN
     -
       # Do not include __ROW_VERSION (as a pseudo-column) in nested (*) without identifier
       - query: select (*) from t1 where col1 = 10;
@@ -563,17 +563,17 @@ test_block:
     -
       - query: select "__ROW_VERSION", t1.id, t2.id
                  from t1, t2
-      - error: '42702'
+      - error: AMBIGUOUS_COLUMN
     -
       - query: select t1.id, t2.id
                  from t1, t2
                  order by "__ROW_VERSION"
-      - error: '42702'
+      - error: AMBIGUOUS_COLUMN
     -
       - query: select t1.id, t2.id
                  from t1, t2
                  where "__ROW_VERSION" is not null
-      - error: '42702'
+      - error: AMBIGUOUS_COLUMN
     -
       # Reference row version without a qualifier. Only one of the two sides of the join should surface the row version, though
       # so this shouldn't be ambiguous. Ideally, we'd assert that it came from the correct side, but barring that, we can inspect
@@ -585,7 +585,7 @@ test_block:
       - initialVersionLessThan: 4.10.1.0
       # Prior to 4.10.1.0, we did not keep track of which quantifiers actually had the version, so this would default to
       # assuming that the row version column was ambiguous
-      - error: '42702'
+      - error: AMBIGUOUS_COLUMN
       - initialVersionAtLeast: 4.10.1.0
       - unorderedResult: [
           { '__ROW_VERSION': !not_null _, { ID: 1, COL1: 10, COL2: 1 }, { ID:  1, COL1: 1, COL2: 'a' } },
@@ -786,7 +786,7 @@ test_block:
            where A.col2 = B.col1 AND B.col1 = C.col1
       - explain: "ISCAN(T3_VERSION_WITH_COL1 <,>) | FILTER _.COL2 EQUALS promote(@c27 AS LONG) | FLATMAP q0 -> { ISCAN(T3_VERSION_WITH_COL1 <,>) | FILTER _.COL2 EQUALS promote(@c27 AS LONG) AND q0.COL1 EQUALS _.COL1 | FLATMAP q1 -> { ISCAN(T2_COL2 [EQUALS q0.COL1]) | FILTER _.COL1 EQUALS promote(@c27 AS LONG) AS q2 RETURN (q2 AS _0, q1 AS _1) } AS q3 RETURN ((q3._0.__ROW_VERSION AS __ROW_VERSION, q3._0.ID AS ID, q3._0.COL1 AS COL1, q3._0.COL2 AS COL2) AS A, (q0.__ROW_VERSION AS __ROW_VERSION, q0.ID AS ID, q0.COL1 AS COL1, q0.COL2 AS COL2) AS B, (q3._1.__ROW_VERSION AS __ROW_VERSION, q3._1.ID AS ID, q3._1.COL1 AS COL1, q3._1.COL2 AS COL2) AS C) }"
       - initialVersionLessThan: 4.10.1.0
-      - error: 'XXXXX'
+      - error: UNKNOWN
       - initialVersionAtLeast: 4.10.1.0
       - unorderedResult: [
           { A: { '__ROW_VERSION': !not_null _, ID: 4, COL1: 2, COL2: 'b' }, B: { '__ROW_VERSION': !not_null _, ID: 4, COL1: 'b', COL2: 2 }, C: { '__ROW_VERSION': !not_null _, ID: 4, COL1: 'b', COL2: 2 } },


### PR DESCRIPTION
Yamsql `error:` directives now accept `ErrorCode` enum names (e.g. `SYNTAX_ERROR`) in addition to raw SQLSTATE codes. Failure messages show `NAME (code)` on both sides. All yamsql files updated; `showcasing-tests.yamsql` demonstrates both forms.