### PR TITLE
Bump Python deps with reported CVEs

### DIFF
--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -5,15 +5,15 @@ certifi==2024.7.4
 charset-normalizer==3.3.2
 docutils==0.21.2
 furo==2024.8.6
-idna==3.7
+idna==3.15
 imagesize==1.4.1
-Jinja2==3.1.4
+Jinja2==3.1.6
 MarkupSafe==2.1.5
 myst-parser==4.0.0
 packaging==24.1
-Pygments==2.18.0
+Pygments==2.20.0
 railroad-diagrams==3.0.1
-requests==2.32.3
+requests==2.33.0
 snowballstemmer==2.2.0
 soupsieve==2.5
 sphinx==8.1.3
@@ -25,4 +25,4 @@ sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==2.0.0
 sphinxcontrib-serializinghtml==2.0.0
 tomli==2.0.1
-urllib3==2.6.0
+urllib3==2.7.0

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,3 +1,3 @@
 PyGithub==1.55
-black==24.3.0
+black==26.3.1
 pylint==2.15.7


### PR DESCRIPTION
Reported by Dependabot alerts:

- \`urllib3\` 2.6.0 → 2.7.0
- \`black\` 24.3.0 → 26.3.1
- \`Jinja2\` 3.1.4 → 3.1.6
- \`requests\` 2.32.3 → 2.33.0
- \`idna\` 3.7 → 3.15
- \`Pygments\` 2.18.0 → 2.20.0