### PR TITLE
Reduce yaml-tests log verbosity

### DIFF
--- a/yaml-tests/yaml-tests.gradle
+++ b/yaml-tests/yaml-tests.gradle
@@ -305,6 +305,11 @@ def copyTempLogs = tasks.register("copyTempLogs", Copy) {
 }
 
 tasks.withType(Test).configureEach {
+    // Override the global debug-level log4j config; yaml-tests has its own tuned config
+    systemProperty('log4j2.configurationFile', project.file('src/test/resources/log4j2-test.properties').toURI())
+}
+
+tasks.withType(Test).configureEach {
     if (project.hasProperty("tests.ci") || project.hasProperty("tests.saveServerLogs")) {
         systemProperties['tests.saveServerLogs'] = "true"
         finalizedBy(copyTempLogs)


### PR DESCRIPTION
`testing.gradle` globally sets `log4j2.configurationFile` to the root `log4j-test.properties` (`rootLogger.level=debug`), which overrides the yaml-tests module's own `log4j2-test.properties`. That module config correctly sets `rootLogger.level=OFF` and only enables `INFO` for the `com.apple.foundationdb.relational.yamltests` package — but it was never being used.

This adds a `tasks.withType(Test).configureEach` block in `yaml-tests.gradle` to re-point `log4j2.configurationFile` to the module-specific config, restoring the intended quiet logging for all yaml test tasks.