### PR TITLE
Move temporary function defaults into AbstractMetadataOperationsFactory

### DIFF
--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/catalog/TransactionBoundDatabase.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/catalog/TransactionBoundDatabase.java
@@ -27,20 +27,15 @@ import com.apple.foundationdb.relational.api.Options;
 import com.apple.foundationdb.relational.api.RelationalConnection;
 import com.apple.foundationdb.relational.api.Transaction;
 import com.apple.foundationdb.relational.api.TransactionManager;
-import com.apple.foundationdb.relational.api.ddl.ConstantAction;
 import com.apple.foundationdb.relational.api.ddl.MetadataOperationsFactory;
 import com.apple.foundationdb.relational.api.ddl.NoOpQueryFactory;
 import com.apple.foundationdb.relational.api.exceptions.ErrorCode;
 import com.apple.foundationdb.relational.api.exceptions.RelationalException;
-import com.apple.foundationdb.relational.api.metadata.SchemaTemplate;
 import com.apple.foundationdb.relational.recordlayer.AbstractDatabase;
 import com.apple.foundationdb.relational.recordlayer.EmbeddedRelationalConnection;
 import com.apple.foundationdb.relational.recordlayer.HollowTransactionManager;
 import com.apple.foundationdb.relational.recordlayer.RecordStoreAndRecordContextTransaction;
 import com.apple.foundationdb.relational.recordlayer.ddl.AbstractMetadataOperationsFactory;
-import com.apple.foundationdb.relational.recordlayer.ddl.CreateTemporaryFunctionConstantAction;
-import com.apple.foundationdb.relational.recordlayer.ddl.DropTemporaryFunctionConstantAction;
-import com.apple.foundationdb.relational.recordlayer.metadata.RecordLayerInvokedRoutine;
 import com.apple.foundationdb.relational.recordlayer.query.cache.RelationalPlanCache;
 import com.apple.foundationdb.relational.recordlayer.storage.BackingRecordStore;
 import com.apple.foundationdb.relational.recordlayer.storage.BackingStore;
@@ -69,18 +64,6 @@ public class TransactionBoundDatabase extends AbstractDatabase {
     URI uri;
 
     private static final MetadataOperationsFactory onlyTemporaryFunctionOperationsFactory = new AbstractMetadataOperationsFactory() {
-        @Nonnull
-        @Override
-        public ConstantAction getCreateTemporaryFunctionConstantAction(@Nonnull final SchemaTemplate template, final boolean throwIfExists,
-                                                                       @Nonnull final RecordLayerInvokedRoutine invokedRoutine) {
-            return new CreateTemporaryFunctionConstantAction(template, throwIfExists, invokedRoutine);
-        }
-
-        @Nonnull
-        @Override
-        public ConstantAction getDropTemporaryFunctionConstantAction(final boolean throwIfNotExists, @Nonnull final String temporaryFunctionName) {
-            return new DropTemporaryFunctionConstantAction(throwIfNotExists, temporaryFunctionName);
-        }
     };
 
     public TransactionBoundDatabase(@Nonnull URI uri, @Nonnull Options options, @Nullable RelationalPlanCache planCache,

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ddl/AbstractMetadataOperationsFactory.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ddl/AbstractMetadataOperationsFactory.java
@@ -73,13 +73,13 @@ public abstract class AbstractMetadataOperationsFactory implements MetadataOpera
     @Override
     public ConstantAction getCreateTemporaryFunctionConstantAction(@Nonnull final SchemaTemplate template, boolean throwIfExists,
                                                                    @Nonnull final RecordLayerInvokedRoutine invokedRoutine) {
-        return NoOpMetadataOperationsFactory.INSTANCE.getCreateTemporaryFunctionConstantAction(template, throwIfExists, invokedRoutine);
+        return new CreateTemporaryFunctionConstantAction(template, throwIfExists, invokedRoutine);
     }
 
     @Nonnull
     @Override
     public ConstantAction getDropTemporaryFunctionConstantAction(boolean throwIfNotExists,
                                                                  @Nonnull final String temporaryFunctionName) {
-        return NoOpMetadataOperationsFactory.INSTANCE.getDropTemporaryFunctionConstantAction(throwIfNotExists, temporaryFunctionName);
+        return new DropTemporaryFunctionConstantAction(throwIfNotExists, temporaryFunctionName);
     }
 }

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/ddl/MetadataOperationsFactoryTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/ddl/MetadataOperationsFactoryTests.java
@@ -56,12 +56,10 @@ public class MetadataOperationsFactoryTests {
         final var mockedSchemaTemplate = Mockito.mock(SchemaTemplate.class);
         return Stream.of(
                 Arguments.of((Function<MetadataOperationsFactory, ConstantAction>)factory -> factory.getCreateSchemaConstantAction(dummyURI, dummyString, dummyString, Options.NONE)),
-                Arguments.of((Function<MetadataOperationsFactory, ConstantAction>)factory -> factory.getCreateTemporaryFunctionConstantAction(mockedSchemaTemplate, dummyBoolean, Mockito.mock(RecordLayerInvokedRoutine.class))),
                 Arguments.of((Function<MetadataOperationsFactory, ConstantAction>)factory -> factory.getCreateDatabaseConstantAction(dummyURI, Options.NONE)),
                 Arguments.of((Function<MetadataOperationsFactory, ConstantAction>)factory -> factory.getSaveSchemaTemplateConstantAction(mockedSchemaTemplate, Options.NONE)),
                 Arguments.of((Function<MetadataOperationsFactory, ConstantAction>)factory -> factory.getDropSchemaConstantAction(dummyURI, dummyString, Options.NONE)),
                 Arguments.of((Function<MetadataOperationsFactory, ConstantAction>)factory -> factory.getDropSchemaTemplateConstantAction(dummyString, dummyBoolean, Options.NONE)),
-                Arguments.of((Function<MetadataOperationsFactory, ConstantAction>)factory -> factory.getDropTemporaryFunctionConstantAction(dummyBoolean, dummyString)),
                 Arguments.of((Function<MetadataOperationsFactory, ConstantAction>)factory -> factory.getDropDatabaseConstantAction(dummyURI, dummyBoolean, Options.NONE))
         );
     }


### PR DESCRIPTION
Move the default implementations of `getCreateTemporaryFunctionConstantAction` and `getDropTemporaryFunctionConstantAction` from `TransactionBoundDatabase`'s anonymous subclass into `AbstractMetadataOperationsFactory`, so any subclass gets them for free without having to override.