### PR TITLE
Fix Sphinx doc warnings in CREATE INDEX

### DIFF
--- a/docs/sphinx/source/reference/sql_commands/DDL/CREATE/INDEX.rst
+++ b/docs/sphinx/source/reference/sql_commands/DDL/CREATE/INDEX.rst
@@ -704,4 +704,3 @@ See Also
 
 - :ref:`create-schema-template` - Schema template definition
 - :ref:`index_definition` - Detailed index definition and limitations
-- :ref:`CREATE VIEW <create-view>` - Creating views for use with INDEX ON

--- a/docs/sphinx/source/reference/sql_commands/DDL/CREATE/SCHEMA_TEMPLATE.rst
+++ b/docs/sphinx/source/reference/sql_commands/DDL/CREATE/SCHEMA_TEMPLATE.rst
@@ -1,8 +1,8 @@
+.. _create-schema-template:
+
 ======================
 CREATE SCHEMA TEMPLATE
 ======================
-
-.. _create-schema-template:
 
 A schema template is a predefined structure that defines the set of ``TABLE`` and ``INDEX`` definitions. This can then
 used as a blueprint to create ``SCHEMA`` in a database. See: :doc:`../../../Databases_Schemas_SchemaTemplates` for more

--- a/fdb-relational-core/src/main/antlr/RelationalParser.g4
+++ b/fdb-relational-core/src/main/antlr/RelationalParser.g4
@@ -244,7 +244,7 @@ dropTempFunction
     ;
 
 setLocalVariable
-    : SET LOCAL varName=uid ('=' | ':=') varValue=constant
+    : SET LOCAL varName=uid '=' varValue=constant
     ;
 
 viewDefinition

--- a/fdb-relational-core/src/main/antlr/RelationalParser.g4
+++ b/fdb-relational-core/src/main/antlr/RelationalParser.g4
@@ -59,7 +59,6 @@ ddlStatement
     | dropStatement
     | createTempFunction
     | dropTempFunction
-    | setLocalVariable
     ;
 
 transactionStatement
@@ -241,10 +240,6 @@ createTempFunction
 
 dropTempFunction
     : DROP TEMPORARY FUNCTION (IF EXISTS)? schemaQualifiedRoutineName=fullId
-    ;
-
-setLocalVariable
-    : SET LOCAL varName=uid '=' varValue=constant
     ;
 
 viewDefinition
@@ -657,7 +652,8 @@ showStatement
     ;
 
 setStatement
-    : SET charSet (charsetName | DEFAULT)          #setCharset
+    : SET LOCAL varName=uid '=' varValue=constant                                #setLocalVariable
+    | SET charSet (charsetName | DEFAULT)          #setCharset
     | SET NAMES
         (charsetName (COLLATE collationName)? | DEFAULT)                        #setNames
     | setTransactionStatement                                                   #setTransaction

--- a/fdb-relational-core/src/main/antlr/RelationalParser.g4
+++ b/fdb-relational-core/src/main/antlr/RelationalParser.g4
@@ -59,6 +59,7 @@ ddlStatement
     | dropStatement
     | createTempFunction
     | dropTempFunction
+    | setLocalVariable
     ;
 
 transactionStatement
@@ -240,6 +241,10 @@ createTempFunction
 
 dropTempFunction
     : DROP TEMPORARY FUNCTION (IF EXISTS)? schemaQualifiedRoutineName=fullId
+    ;
+
+setLocalVariable
+    : SET LOCAL varName=uid ('=' | ':=') varValue=constant
     ;
 
 viewDefinition
@@ -667,7 +672,7 @@ setStatement
 // details
 
 variableClause
-    : LOCAL_ID | ( ('@' '@')? (GLOBAL | SESSION | LOCAL)  )? uid
+    : LOCAL_ID | ( ('@' '@')? (GLOBAL | SESSION)  )? uid
     ;
 
 //    Other administrative statements
@@ -1241,6 +1246,7 @@ expressionAtom
     | fullColumnName                                                                      #fullColumnNameExpressionAtom // done
     | functionCall                                                                        #functionCallExpressionAtom // done
     | preparedStatementParameter                                                          #preparedStatementParameterAtom // done
+    | variableRef                                                                         #variableRefAtom // done
     | recordConstructor                                                                   #recordConstructorExpressionAtom // done
     | arrayConstructor                                                                    #arrayConstructorExpressionAtom // done
     | base=expressionAtom LEFT_SQUARE_BRACKET index=expressionAtom RIGHT_SQUARE_BRACKET   #subscriptExpression // done
@@ -1258,6 +1264,10 @@ inList
 preparedStatementParameter
     : QUESTION
     | NAMED_PARAMETER
+    ;
+
+variableRef
+    : LOCAL_ID
     ;
 
 unaryOperator

--- a/fdb-relational-core/src/main/antlr/RelationalParser.g4
+++ b/fdb-relational-core/src/main/antlr/RelationalParser.g4
@@ -657,22 +657,13 @@ showStatement
     ;
 
 setStatement
-    : SET variableClause ('=' | ':=') expression
-      (',' variableClause ('=' | ':=') expression)*                             #setVariable
-    | SET charSet (charsetName | DEFAULT)          #setCharset
+    : SET charSet (charsetName | DEFAULT)          #setCharset
     | SET NAMES
         (charsetName (COLLATE collationName)? | DEFAULT)                        #setNames
     | setTransactionStatement                                                   #setTransaction
     | setAutocommitStatement                                                    #setAutocommit
     | SET fullId ('=' | ':=') expression
       (',' fullId ('=' | ':=') expression)*                                     #setNewValueInsideTrigger
-    ;
-
-
-// details
-
-variableClause
-    : LOCAL_ID | ( ('@' '@')? (GLOBAL | SESSION)  )? uid
     ;
 
 //    Other administrative statements

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/Transaction.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/Transaction.java
@@ -68,7 +68,7 @@ public interface Transaction extends AutoCloseable {
     /**
      * Sets a transaction-scoped local variable. The variable lives for the duration of this transaction only.
      *
-     * @param name  the variable name (case-insensitive; stored in upper-case)
+     * @param name  the variable name (caller is responsible for normalization)
      * @param value the variable value
      */
     void setLocalVariable(@Nonnull String name, @Nullable Object value);

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/Transaction.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/Transaction.java
@@ -25,6 +25,8 @@ import com.apple.foundationdb.relational.api.exceptions.RelationalException;
 import com.apple.foundationdb.relational.api.metadata.SchemaTemplate;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Map;
 import java.util.Optional;
 
 public interface Transaction extends AutoCloseable {
@@ -62,6 +64,22 @@ public interface Transaction extends AutoCloseable {
      * Unsets the bound schema template, if one exists.
      */
     void unsetBoundSchemaTemplate();
+
+    /**
+     * Sets a transaction-scoped local variable. The variable lives for the duration of this transaction only.
+     *
+     * @param name  the variable name (case-insensitive; stored in upper-case)
+     * @param value the variable value
+     */
+    void setLocalVariable(@Nonnull String name, @Nullable Object value);
+
+    /**
+     * Returns an immutable snapshot of all local variables set in this transaction.
+     *
+     * @return map from variable name to value; empty if no variables have been set
+     */
+    @Nonnull
+    Map<String, Object> getLocalVariables();
 
     @Override
     void close() throws RelationalException;

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/Transaction.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/Transaction.java
@@ -74,7 +74,7 @@ public interface Transaction extends AutoCloseable {
     void setLocalVariable(@Nonnull String name, @Nullable Object value);
 
     /**
-     * Returns an immutable snapshot of all local variables set in this transaction.
+     * Returns an unmodifiable view of all local variables set in this transaction.
      *
      * @return map from variable name to value; empty if no variables have been set
      */

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/ddl/MetadataOperationsFactory.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/ddl/MetadataOperationsFactory.java
@@ -25,6 +25,7 @@ import com.apple.foundationdb.relational.api.metadata.SchemaTemplate;
 import com.apple.foundationdb.relational.recordlayer.metadata.RecordLayerInvokedRoutine;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import java.net.URI;
 
@@ -54,4 +55,7 @@ public interface MetadataOperationsFactory {
 
     @Nonnull
     ConstantAction getDropTemporaryFunctionConstantAction(boolean throwIfNotExists, @Nonnull String temporaryFunctionName);
+
+    @Nonnull
+    ConstantAction getSetLocalVariableConstantAction(@Nonnull String name, @Nullable Object value);
 }

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/EmbeddedRelationalPreparedStatement.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/EmbeddedRelationalPreparedStatement.java
@@ -36,7 +36,6 @@ import com.apple.foundationdb.relational.util.Assert;
 import javax.annotation.Nonnull;
 import java.sql.Array;
 import java.sql.SQLException;
-import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/EmbeddedRelationalPreparedStatement.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/EmbeddedRelationalPreparedStatement.java
@@ -218,13 +218,26 @@ public class EmbeddedRelationalPreparedStatement extends AbstractEmbeddedStateme
     @Override
     @Nonnull
     PlanContext createPlanContext(@Nonnull final FDBRecordStoreBase<?> store, @Nonnull final Options options) throws RelationalException {
+        final var localVars = conn.getTransaction().getLocalVariables();
+        final var mergedNamed = localVars.isEmpty() ? namedParameters : mergeNamedParams(namedParameters, localVars);
         return PlanContext.builder()
                 .fromRecordStore(store, options)
                 .fromDatabase(conn.getRecordLayerDatabase())
                 .withMetricsCollector(Assert.notNullUnchecked(conn.getMetricCollector()))
-                .withPreparedParameters(PreparedParams.of(parameters, namedParameters))
+                .withPreparedParameters(PreparedParams.of(parameters, mergedNamed))
                 .withSchemaTemplate(conn.getTransaction().getBoundSchemaTemplateMaybe().orElse(conn.getSchemaTemplate()))
                 .build();
+    }
+
+    private static Map<String, Object> mergeNamedParams(Map<String, Object> explicit, Map<String, Object> vars) {
+        final var merged = new java.util.HashMap<>(vars);
+        for (final var entry : explicit.entrySet()) {
+            Assert.thatUnchecked(!merged.containsKey(entry.getKey()) || merged.get(entry.getKey()) == explicit.get(entry.getKey()),
+                    ErrorCode.INVALID_PARAMETER,
+                    () -> "Parameter name '" + entry.getKey() + "' conflicts with a local variable of the same name");
+            merged.put(entry.getKey(), entry.getValue());
+        }
+        return merged;
     }
 
     @Override

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/EmbeddedRelationalPreparedStatement.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/EmbeddedRelationalPreparedStatement.java
@@ -36,6 +36,7 @@ import com.apple.foundationdb.relational.util.Assert;
 import javax.annotation.Nonnull;
 import java.sql.Array;
 import java.sql.SQLException;
+import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
@@ -230,9 +231,9 @@ public class EmbeddedRelationalPreparedStatement extends AbstractEmbeddedStateme
     }
 
     private static Map<String, Object> mergeNamedParams(Map<String, Object> explicit, Map<String, Object> vars) {
-        final var merged = new java.util.HashMap<>(vars);
+        final var merged = new HashMap<>(vars);
         for (final var entry : explicit.entrySet()) {
-            Assert.thatUnchecked(!merged.containsKey(entry.getKey()) || merged.get(entry.getKey()) == explicit.get(entry.getKey()),
+            Assert.thatUnchecked(!merged.containsKey(entry.getKey()),
                     ErrorCode.INVALID_PARAMETER,
                     () -> "Parameter name '" + entry.getKey() + "' conflicts with a local variable of the same name");
             merged.put(entry.getKey(), entry.getValue());

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/EmbeddedRelationalPreparedStatement.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/EmbeddedRelationalPreparedStatement.java
@@ -226,6 +226,7 @@ public class EmbeddedRelationalPreparedStatement extends AbstractEmbeddedStateme
                 .fromDatabase(conn.getRecordLayerDatabase())
                 .withMetricsCollector(Assert.notNullUnchecked(conn.getMetricCollector()))
                 .withPreparedParameters(PreparedParams.of(parameters, mergedNamed))
+                .withLocalVariables(localVars)
                 .withSchemaTemplate(conn.getTransaction().getBoundSchemaTemplateMaybe().orElse(conn.getSchemaTemplate()))
                 .build();
     }

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/EmbeddedRelationalPreparedStatement.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/EmbeddedRelationalPreparedStatement.java
@@ -220,26 +220,14 @@ public class EmbeddedRelationalPreparedStatement extends AbstractEmbeddedStateme
     @Nonnull
     PlanContext createPlanContext(@Nonnull final FDBRecordStoreBase<?> store, @Nonnull final Options options) throws RelationalException {
         final var localVars = conn.getTransaction().getLocalVariables();
-        final var mergedNamed = localVars.isEmpty() ? namedParameters : mergeNamedParams(namedParameters, localVars);
         return PlanContext.builder()
                 .fromRecordStore(store, options)
                 .fromDatabase(conn.getRecordLayerDatabase())
                 .withMetricsCollector(Assert.notNullUnchecked(conn.getMetricCollector()))
-                .withPreparedParameters(PreparedParams.of(parameters, mergedNamed))
+                .withPreparedParameters(PreparedParams.of(parameters, namedParameters))
                 .withLocalVariables(localVars)
                 .withSchemaTemplate(conn.getTransaction().getBoundSchemaTemplateMaybe().orElse(conn.getSchemaTemplate()))
                 .build();
-    }
-
-    private static Map<String, Object> mergeNamedParams(Map<String, Object> explicit, Map<String, Object> vars) {
-        final var merged = new HashMap<>(vars);
-        for (final var entry : explicit.entrySet()) {
-            Assert.thatUnchecked(!merged.containsKey(entry.getKey()),
-                    ErrorCode.INVALID_PARAMETER,
-                    () -> "Parameter name '" + entry.getKey() + "' conflicts with a local variable of the same name");
-            merged.put(entry.getKey(), entry.getValue());
-        }
-        return merged;
     }
 
     @Override

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/EmbeddedRelationalStatement.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/EmbeddedRelationalStatement.java
@@ -68,6 +68,7 @@ public class EmbeddedRelationalStatement extends AbstractEmbeddedStatement imple
                 .withMetricsCollector(Assert.notNullUnchecked(conn.getMetricCollector()))
                 .withSchemaTemplate(conn.getTransaction().getBoundSchemaTemplateMaybe().orElse(conn.getSchemaTemplate()))
                 .withPreparedParameters(params)
+                .withLocalVariables(localVars)
                 .build();
     }
 

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/EmbeddedRelationalStatement.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/EmbeddedRelationalStatement.java
@@ -35,6 +35,7 @@ import com.apple.foundationdb.relational.api.RelationalStruct;
 import com.apple.foundationdb.relational.api.exceptions.ErrorCode;
 import com.apple.foundationdb.relational.api.exceptions.RelationalException;
 import com.apple.foundationdb.relational.recordlayer.query.PlanContext;
+import com.apple.foundationdb.relational.recordlayer.query.PreparedParams;
 import com.apple.foundationdb.relational.recordlayer.util.ExceptionUtil;
 import com.apple.foundationdb.relational.util.Assert;
 import com.apple.foundationdb.relational.util.Supplier;
@@ -59,11 +60,14 @@ public class EmbeddedRelationalStatement extends AbstractEmbeddedStatement imple
     @Override
     @Nonnull
     PlanContext createPlanContext(@Nonnull final FDBRecordStoreBase<?> store, @Nonnull final Options options) throws RelationalException {
+        final var localVars = conn.getTransaction().getLocalVariables();
+        final var params = localVars.isEmpty() ? PreparedParams.empty() : PreparedParams.ofNamed(localVars);
         return PlanContext.builder()
                 .fromRecordStore(store, options)
                 .fromDatabase(conn.getRecordLayerDatabase())
                 .withMetricsCollector(Assert.notNullUnchecked(conn.getMetricCollector()))
                 .withSchemaTemplate(conn.getTransaction().getBoundSchemaTemplateMaybe().orElse(conn.getSchemaTemplate()))
+                .withPreparedParameters(params)
                 .build();
     }
 

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/RecordContextTransaction.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/RecordContextTransaction.java
@@ -34,8 +34,12 @@ import com.apple.foundationdb.relational.api.metadata.SchemaTemplate;
 import com.apple.foundationdb.relational.recordlayer.util.ExceptionUtil;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -100,6 +104,25 @@ public class RecordContextTransaction implements Transaction {
         context.removeFromSession(SchemaTemplate.class.toString(), SchemaTemplate.class);
     }
 
+    @SuppressWarnings("unchecked")
+    @Override
+    public void setLocalVariable(@Nonnull String name, @Nullable Object value) {
+        Map<String, Object> vars = context.getInSession(LocalVariables.SESSION_KEY, Map.class);
+        if (vars == null) {
+            context.putInSessionIfAbsent(LocalVariables.SESSION_KEY, new LinkedHashMap<String, Object>());
+            vars = context.getInSession(LocalVariables.SESSION_KEY, Map.class);
+        }
+        vars.put(name, value);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Nonnull
+    @Override
+    public Map<String, Object> getLocalVariables() {
+        Map<String, Object> vars = context.getInSession(LocalVariables.SESSION_KEY, Map.class);
+        return vars != null ? Collections.unmodifiableMap(vars) : Map.of();
+    }
+
     @Override
     public void close() throws RelationalException {
         abort();
@@ -132,5 +155,9 @@ public class RecordContextTransaction implements Transaction {
 
     public FDBRecordContext getContext() {
         return context;
+    }
+
+    private static final class LocalVariables {
+        static final String SESSION_KEY = LocalVariables.class.getName();
     }
 }

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/RecordStoreAndRecordContextTransaction.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/RecordStoreAndRecordContextTransaction.java
@@ -33,6 +33,8 @@ import com.apple.foundationdb.relational.recordlayer.query.cache.QueryCacheKey;
 import com.google.protobuf.Message;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -85,6 +87,17 @@ public class RecordStoreAndRecordContextTransaction implements Transaction {
     @Override
     public void unsetBoundSchemaTemplate() {
         transaction.unsetBoundSchemaTemplate();
+    }
+
+    @Override
+    public void setLocalVariable(@Nonnull String name, @Nullable Object value) {
+        transaction.setLocalVariable(name, value);
+    }
+
+    @Nonnull
+    @Override
+    public Map<String, Object> getLocalVariables() {
+        return transaction.getLocalVariables();
     }
 
     @Override

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ddl/AbstractMetadataOperationsFactory.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ddl/AbstractMetadataOperationsFactory.java
@@ -27,6 +27,7 @@ import com.apple.foundationdb.relational.api.metadata.SchemaTemplate;
 import com.apple.foundationdb.relational.recordlayer.metadata.RecordLayerInvokedRoutine;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.net.URI;
 
 /**
@@ -81,5 +82,11 @@ public abstract class AbstractMetadataOperationsFactory implements MetadataOpera
     public ConstantAction getDropTemporaryFunctionConstantAction(boolean throwIfNotExists,
                                                                  @Nonnull final String temporaryFunctionName) {
         return NoOpMetadataOperationsFactory.INSTANCE.getDropTemporaryFunctionConstantAction(throwIfNotExists, temporaryFunctionName);
+    }
+
+    @Nonnull
+    @Override
+    public ConstantAction getSetLocalVariableConstantAction(@Nonnull String name, @Nullable Object value) {
+        return NoOpMetadataOperationsFactory.INSTANCE.getSetLocalVariableConstantAction(name, value);
     }
 }

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ddl/AbstractMetadataOperationsFactory.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ddl/AbstractMetadataOperationsFactory.java
@@ -87,6 +87,6 @@ public abstract class AbstractMetadataOperationsFactory implements MetadataOpera
     @Nonnull
     @Override
     public ConstantAction getSetLocalVariableConstantAction(@Nonnull String name, @Nullable Object value) {
-        return NoOpMetadataOperationsFactory.INSTANCE.getSetLocalVariableConstantAction(name, value);
+        return new SetLocalVariableConstantAction(name, value);
     }
 }

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ddl/NoOpMetadataOperationsFactory.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ddl/NoOpMetadataOperationsFactory.java
@@ -30,6 +30,7 @@ import com.apple.foundationdb.relational.api.metadata.SchemaTemplate;
 import com.apple.foundationdb.relational.recordlayer.metadata.RecordLayerInvokedRoutine;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.net.URI;
 
 @API(API.Status.EXPERIMENTAL)
@@ -86,6 +87,12 @@ public final class NoOpMetadataOperationsFactory implements MetadataOperationsFa
     @Nonnull
     @Override
     public ConstantAction getDropSchemaTemplateConstantAction(@Nonnull String templateId, boolean throwIfDoesNotExist, @Nonnull Options options) {
+        return NoOpConstantAction.INSTANCE;
+    }
+
+    @Nonnull
+    @Override
+    public ConstantAction getSetLocalVariableConstantAction(@Nonnull String name, @Nullable Object value) {
         return NoOpConstantAction.INSTANCE;
     }
 

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ddl/RecordLayerMetadataOperationsFactory.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ddl/RecordLayerMetadataOperationsFactory.java
@@ -32,6 +32,7 @@ import com.apple.foundationdb.relational.recordlayer.RecordLayerConfig;
 import com.apple.foundationdb.relational.recordlayer.metadata.RecordLayerInvokedRoutine;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.net.URI;
 
 @API(API.Status.EXPERIMENTAL)
@@ -102,6 +103,12 @@ public class RecordLayerMetadataOperationsFactory implements MetadataOperationsF
     public ConstantAction getDropTemporaryFunctionConstantAction(boolean throwIfNotExists,
                                                                  @Nonnull final String temporaryFunctionName) {
         return new DropTemporaryFunctionConstantAction(throwIfNotExists, temporaryFunctionName);
+    }
+
+    @Nonnull
+    @Override
+    public ConstantAction getSetLocalVariableConstantAction(@Nonnull String name, @Nullable Object value) {
+        return new SetLocalVariableConstantAction(name, value);
     }
 
     public static class Builder {

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ddl/SetLocalVariableConstantAction.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ddl/SetLocalVariableConstantAction.java
@@ -1,0 +1,47 @@
+/*
+ * SetLocalVariableConstantAction.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.relational.recordlayer.ddl;
+
+import com.apple.foundationdb.relational.api.Transaction;
+import com.apple.foundationdb.relational.api.ddl.ConstantAction;
+import com.apple.foundationdb.relational.api.exceptions.RelationalException;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class SetLocalVariableConstantAction implements ConstantAction {
+
+    @Nonnull
+    private final String name;
+
+    @Nullable
+    private final Object value;
+
+    public SetLocalVariableConstantAction(@Nonnull String name, @Nullable Object value) {
+        this.name = name;
+        this.value = value;
+    }
+
+    @Override
+    public void execute(@Nonnull Transaction txn) throws RelationalException {
+        txn.setLocalVariable(name, value);
+    }
+}

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/RecordLayerInvokedRoutine.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/RecordLayerInvokedRoutine.java
@@ -23,12 +23,15 @@ package com.apple.foundationdb.relational.recordlayer.metadata;
 import com.apple.foundationdb.record.query.plan.cascades.UserDefinedFunction;
 import com.apple.foundationdb.relational.api.metadata.InvokedRoutine;
 import com.apple.foundationdb.relational.recordlayer.query.PreparedParams;
-import com.apple.foundationdb.relational.recordlayer.util.MemoizedFunction;
 import com.apple.foundationdb.relational.util.Assert;
+import com.google.common.collect.ImmutableMap;
 
 import javax.annotation.Nonnull;
+import java.util.AbstractMap;
+import java.util.Map;
 import java.util.Objects;
-import java.util.function.Function;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiFunction;
 
 public class RecordLayerInvokedRoutine implements InvokedRoutine {
 
@@ -47,7 +50,7 @@ public class RecordLayerInvokedRoutine implements InvokedRoutine {
     private final boolean isTemporary;
 
     @Nonnull
-    private final Function<Boolean, UserDefinedFunction> userDefinedFunctionProvider;
+    private final BiFunction<Boolean, Map<String, Object>, UserDefinedFunction> userDefinedFunctionProvider;
 
     @Nonnull
     private final UserDefinedFunction serializableFunction;
@@ -57,15 +60,30 @@ public class RecordLayerInvokedRoutine implements InvokedRoutine {
                                      @Nonnull final String name,
                                      @Nonnull final PreparedParams preparedParams,
                                      boolean isTemporary,
-                                     @Nonnull final Function<Boolean, UserDefinedFunction> userDefinedFunctionProvider,
+                                     @Nonnull final BiFunction<Boolean, Map<String, Object>, UserDefinedFunction> userDefinedFunctionProvider,
                                      @Nonnull final UserDefinedFunction serializableFunction) {
         this.description = description;
         this.normalizedDescription = normalizedDescription;
         this.name = name;
         this.preparedParams = preparedParams;
         this.isTemporary = isTemporary;
-        this.userDefinedFunctionProvider = MemoizedFunction.memoize(userDefinedFunctionProvider::apply);
+        this.userDefinedFunctionProvider = memoize(userDefinedFunctionProvider);
         this.serializableFunction = serializableFunction;
+    }
+
+    // Memoizes by (isCaseSensitive, ImmutableMap snapshot of localVars) so that:
+    // - the same function instance is reused when local variables haven't changed (preserving the
+    //   assertSame guarantee that plan-sharing relies on), and
+    // - a new compilation is triggered when local variable values change (fixing the stale-value
+    //   bug that existed when the old memoization keyed only on isCaseSensitive).
+    @Nonnull
+    private static BiFunction<Boolean, Map<String, Object>, UserDefinedFunction> memoize(
+            @Nonnull final BiFunction<Boolean, Map<String, Object>, UserDefinedFunction> fn) {
+        final var cache = new ConcurrentHashMap<Map.Entry<Boolean, ImmutableMap<String, Object>>, UserDefinedFunction>();
+        return (isCaseSensitive, localVars) -> {
+            final var key = new AbstractMap.SimpleImmutableEntry<>(isCaseSensitive, ImmutableMap.copyOf(localVars));
+            return cache.computeIfAbsent(key, k -> fn.apply(k.getKey(), k.getValue()));
+        };
     }
 
     @Nonnull
@@ -86,7 +104,7 @@ public class RecordLayerInvokedRoutine implements InvokedRoutine {
     }
 
     @Nonnull
-    public Function<Boolean, UserDefinedFunction> getUserDefinedFunctionProvider() {
+    public BiFunction<Boolean, Map<String, Object>, UserDefinedFunction> getUserDefinedFunctionProvider() {
         return userDefinedFunctionProvider;
     }
 
@@ -149,7 +167,7 @@ public class RecordLayerInvokedRoutine implements InvokedRoutine {
         private String normalizedDescription;
         private PreparedParams preparedParams;
         private String name;
-        private Function<Boolean, UserDefinedFunction> userDefinedFunctionProvider;
+        private BiFunction<Boolean, Map<String, Object>, UserDefinedFunction> userDefinedFunctionProvider;
         private UserDefinedFunction serializableFunction;
         private boolean isTemporary;
 
@@ -175,7 +193,7 @@ public class RecordLayerInvokedRoutine implements InvokedRoutine {
         }
 
         @Nonnull
-        public Builder withUserDefinedFunctionProvider(@Nonnull final Function<Boolean, UserDefinedFunction> userDefinedFunctionProvider) {
+        public Builder withUserDefinedFunctionProvider(@Nonnull final BiFunction<Boolean, Map<String, Object>, UserDefinedFunction> userDefinedFunctionProvider) {
             this.userDefinedFunctionProvider = userDefinedFunctionProvider;
             return this;
         }

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/serde/RecordMetadataDeserializer.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/serde/RecordMetadataDeserializer.java
@@ -48,6 +48,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -147,10 +148,10 @@ public class RecordMetadataDeserializer {
 
     @Nonnull
     @VisibleForTesting
-    protected static Function<Boolean, UserDefinedFunction> getSqlFunctionCompiler(@Nonnull final String name,
+    protected static BiFunction<Boolean, Map<String, Object>, UserDefinedFunction> getSqlFunctionCompiler(@Nonnull final String name,
                                                                                    @Nonnull final Supplier<RecordLayerSchemaTemplate> metadata,
                                                                                    @Nonnull final String functionBody) {
-        return isCaseSensitive -> RoutineParser.sqlFunctionParser(metadata.get()).parseFunction(functionBody, isCaseSensitive);
+        return (isCaseSensitive, localVars) -> RoutineParser.sqlFunctionParser(metadata.get()).parseFunction(functionBody, isCaseSensitive);
     }
 
     @Nonnull
@@ -180,7 +181,7 @@ public class RecordMetadataDeserializer {
         return RecordLayerInvokedRoutine.newBuilder()
                 .setName(name)
                 .setDescription(body)
-                .withUserDefinedFunctionProvider(ignored -> userDefinedScalarFunction)
+                .withUserDefinedFunctionProvider((ignored, localVars) -> userDefinedScalarFunction)
                 .withSerializableFunction(userDefinedScalarFunction);
     }
 

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/AstNormalizer.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/AstNormalizer.java
@@ -128,6 +128,13 @@ public final class AstNormalizer extends RelationalParserBaseVisitor<Object> {
     @Nonnull
     private final PreparedParams preparedStatementParameters;
 
+    private boolean insideTempFunctionBody = false;
+
+    // True when processing the original CREATE TEMPORARY FUNCTION statement; false during
+    // re-normalization of function bodies at query execution time. When false, missing local
+    // variables inside function bodies are an error (UNDEFINED_PARAMETER), not a placeholder.
+    private final boolean deferMissingVarsInFunctionBodies;
+
     @Nonnull
     private final Set<NormalizationResult.QueryCachingFlags> queryCachingFlags;
 
@@ -149,7 +156,8 @@ public final class AstNormalizer extends RelationalParserBaseVisitor<Object> {
     }
 
     private AstNormalizer(@Nonnull final PreparedParams preparedStatementParameters, boolean caseSensitive,
-                          @Nonnull final PlanHashable.PlanHashMode currentPlanHashMode, boolean forExplain) {
+                          @Nonnull final PlanHashable.PlanHashMode currentPlanHashMode, boolean forExplain,
+                          boolean deferMissingVarsInFunctionBodies) {
         parameterHash = Hashing.murmur3_32_fixed().newHasher().putInt("ParameterHash".hashCode());
         parameterHashSupplier = Suppliers.memoize(() -> parameterHash.hash().asInt())::get;
         sqlCanonicalizer = new StringBuilder();
@@ -161,6 +169,7 @@ public final class AstNormalizer extends RelationalParserBaseVisitor<Object> {
         queryCachingFlags = EnumSet.noneOf(NormalizationResult.QueryCachingFlags.class);
         queryOptions = Options.builder();
         this.caseSensitive = caseSensitive;
+        this.deferMissingVarsInFunctionBodies = deferMissingVarsInFunctionBodies;
     }
 
     @Override
@@ -190,13 +199,27 @@ public final class AstNormalizer extends RelationalParserBaseVisitor<Object> {
     public Object visitCreateTempFunction(final RelationalParser.CreateTempFunctionContext ctx) {
         final var functionName = SemanticAnalyzer.normalizeString(ctx.tempSqlInvokedFunction().functionSpecification().schemaQualifiedRoutineName.getText(), caseSensitive);
         queryHasherContextBuilder.getLiteralsBuilder().setScope(functionName);
-        return visitChildren(ctx);
+        insideTempFunctionBody = true;
+        try {
+            return visitChildren(ctx);
+        } finally {
+            insideTempFunctionBody = false;
+        }
     }
 
     @Override
     public Object visitVariableRef(@Nonnull RelationalParser.VariableRefContext ctx) {
         final var rawName = ctx.LOCAL_ID().getText().substring(1); // strip leading '@'
         final var varName = Assert.notNullUnchecked(SemanticAnalyzer.normalizeString(rawName, caseSensitive));
+        if (insideTempFunctionBody && deferMissingVarsInFunctionBodies && !preparedStatementParameters.containsNamedParam(varName)) {
+            // Variable not yet set; emit a named-parameter placeholder so the canonical form is
+            // deterministic. The actual value is injected via withExecutionContext at call time.
+            if (allowTokenAddition) {
+                sqlCanonicalizer.append("?").append(varName).append(" ");
+                parameterHash.putInt("?".concat(varName).hashCode());
+            }
+            return null;
+        }
         final var value = preparedStatementParameters.namedParamValue(varName);
         processNamedParameter(value, varName, ctx.LOCAL_ID().getSymbol().getTokenIndex());
         return value;
@@ -605,7 +628,7 @@ public final class AstNormalizer extends RelationalParserBaseVisitor<Object> {
                                                    boolean caseSensitive,
                                                    @Nonnull final PlanHashable.PlanHashMode currentPlanHashMode,
                                                    @Nonnull final String query) throws RelationalException {
-        final var astNormalizer = new AstNormalizer(preparedStatementParameters, caseSensitive, currentPlanHashMode, parseTreeInfo.getQueryType() == ParseTreeInfo.QueryType.DESCRIBE_QUERY);
+        final var astNormalizer = new AstNormalizer(preparedStatementParameters, caseSensitive, currentPlanHashMode, parseTreeInfo.getQueryType() == ParseTreeInfo.QueryType.DESCRIBE_QUERY, true);
         astNormalizer.visit(parseTreeInfo.getRootContext());
         final var recordLayerSchemaTemplate = Assert.castUnchecked(schemaTemplate, RecordLayerSchemaTemplate.class);
 
@@ -627,9 +650,9 @@ public final class AstNormalizer extends RelationalParserBaseVisitor<Object> {
                     continue;
                 }
                 final var recordLayerRoutine = (RecordLayerInvokedRoutine)temporaryRoutine;
-                final var functionAstResult = normalizeAst(schemaTemplate,
+                final var functionAstResult = normalizeFunctionBody(schemaTemplate,
                         QueryParser.parse(recordLayerRoutine.getDescription()),
-                        recordLayerRoutine.getPreparedParams(),
+                        preparedStatementParameters,
                         userVersion,
                         plannerConfiguration,
                         caseSensitive,
@@ -638,6 +661,33 @@ public final class AstNormalizer extends RelationalParserBaseVisitor<Object> {
                 astNormalizer.queryHasherContextBuilder.getLiteralsBuilder().importLiterals(functionAstResult.queryExecutionContext.getLiterals());
             }
         }
+        return new NormalizationResult(
+                recordLayerSchemaTemplate.getName(),
+                QueryCacheKey.of(astNormalizer.getCanonicalSqlString(), getQuerySpecificPlannerConfig(plannerConfiguration, astNormalizer.getQueryOptions()),
+                        recordLayerSchemaTemplate.getTransactionBoundMetadataAsString(),
+                        recordLayerSchemaTemplate.getVersion(), userVersion),
+                astNormalizer.getQueryExecutionParameters(),
+                parseTreeInfo.getRootContext(),
+                astNormalizer.getQueryCachingFlags(),
+                astNormalizer.getQueryOptions(),
+                query);
+    }
+
+    // Re-normalizes a temporary function body during query execution. Unlike the outer normalizeAst,
+    // this does NOT defer missing local variables — if a variable referenced in the function body is
+    // absent from preparedStatementParameters, UNDEFINED_PARAMETER is thrown at invocation time.
+    private static NormalizationResult normalizeFunctionBody(@Nonnull final SchemaTemplate schemaTemplate,
+                                                              @Nonnull final ParseTreeInfoImpl parseTreeInfo,
+                                                              @Nonnull final PreparedParams preparedStatementParameters,
+                                                              int userVersion,
+                                                              @Nonnull final PlannerConfiguration plannerConfiguration,
+                                                              boolean caseSensitive,
+                                                              @Nonnull final PlanHashable.PlanHashMode currentPlanHashMode,
+                                                              @Nonnull final String query) throws RelationalException {
+        final var astNormalizer = new AstNormalizer(preparedStatementParameters, caseSensitive, currentPlanHashMode,
+                parseTreeInfo.getQueryType() == ParseTreeInfo.QueryType.DESCRIBE_QUERY, false);
+        astNormalizer.visit(parseTreeInfo.getRootContext());
+        final var recordLayerSchemaTemplate = Assert.castUnchecked(schemaTemplate, RecordLayerSchemaTemplate.class);
         return new NormalizationResult(
                 recordLayerSchemaTemplate.getName(),
                 QueryCacheKey.of(astNormalizer.getCanonicalSqlString(), getQuerySpecificPlannerConfig(plannerConfiguration, astNormalizer.getQueryOptions()),

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/AstNormalizer.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/AstNormalizer.java
@@ -128,6 +128,9 @@ public final class AstNormalizer extends RelationalParserBaseVisitor<Object> {
     @Nonnull
     private final PreparedParams preparedStatementParameters;
 
+    @Nonnull
+    private final Map<String, Object> localVariables;
+
     private boolean insideTempFunctionBody = false;
 
     // True when processing the original CREATE TEMPORARY FUNCTION statement; false during
@@ -155,7 +158,9 @@ public final class AstNormalizer extends RelationalParserBaseVisitor<Object> {
         literalNodes.put(RelationalParser.NegativeDecimalConstantContext.class, context -> ParseHelpers.parseDecimal(context.getText()));
     }
 
-    private AstNormalizer(@Nonnull final PreparedParams preparedStatementParameters, boolean caseSensitive,
+    private AstNormalizer(@Nonnull final PreparedParams preparedStatementParameters,
+                          @Nonnull final Map<String, Object> localVariables,
+                          boolean caseSensitive,
                           @Nonnull final PlanHashable.PlanHashMode currentPlanHashMode, boolean forExplain,
                           boolean deferMissingVarsInFunctionBodies) {
         parameterHash = Hashing.murmur3_32_fixed().newHasher().putInt("ParameterHash".hashCode());
@@ -164,6 +169,7 @@ public final class AstNormalizer extends RelationalParserBaseVisitor<Object> {
         // needed to collect information that guide query execution (explain flag, continuation string, offset int, and limit int).
         queryHasherContextBuilder = NormalizedQueryExecutionContext.newBuilder().setPlanHashMode(currentPlanHashMode).setForExplain(forExplain);
         this.preparedStatementParameters = preparedStatementParameters;
+        this.localVariables = localVariables;
         allowTokenAddition = true;
         allowLiteralAddition = true;
         queryCachingFlags = EnumSet.noneOf(NormalizationResult.QueryCachingFlags.class);
@@ -174,7 +180,7 @@ public final class AstNormalizer extends RelationalParserBaseVisitor<Object> {
 
     private AstNormalizer(@Nonnull final PreparedParams preparedStatementParameters, boolean caseSensitive,
                           @Nonnull final PlanHashable.PlanHashMode currentPlanHashMode, boolean forExplain) {
-        this(preparedStatementParameters, caseSensitive, currentPlanHashMode, forExplain, false);
+        this(preparedStatementParameters, Map.of(), caseSensitive, currentPlanHashMode, forExplain, false);
     }
 
     @Override
@@ -216,18 +222,35 @@ public final class AstNormalizer extends RelationalParserBaseVisitor<Object> {
     public Object visitVariableRef(@Nonnull RelationalParser.VariableRefContext ctx) {
         final var rawName = ctx.LOCAL_ID().getText().substring(1); // strip leading '@'
         final var varName = Assert.notNullUnchecked(SemanticAnalyzer.normalizeString(rawName, caseSensitive));
-        if (insideTempFunctionBody && deferMissingVarsInFunctionBodies && !preparedStatementParameters.containsNamedParam(varName)) {
+        if (insideTempFunctionBody && deferMissingVarsInFunctionBodies && !localVariables.containsKey(varName)) {
             // Variable not yet set; emit a named-parameter placeholder so the canonical form is
             // deterministic. The actual value is injected via withExecutionContext at call time.
             if (allowTokenAddition) {
-                sqlCanonicalizer.append("?").append(varName).append(" ");
-                parameterHash.putInt("?".concat(varName).hashCode());
+                sqlCanonicalizer.append("@").append(varName).append(" ");
+                parameterHash.putInt("@".concat(varName).hashCode());
             }
             return null;
         }
-        final var value = preparedStatementParameters.namedParamValue(varName);
-        processNamedParameter(value, varName, ctx.LOCAL_ID().getSymbol().getTokenIndex());
+        Assert.thatUnchecked(localVariables.containsKey(varName), ErrorCode.UNDEFINED_PARAMETER,
+                () -> "No value found for parameter " + varName);
+        final var value = localVariables.get(varName);
+        processLocalVariableRef(value, varName, ctx.LOCAL_ID().getSymbol().getTokenIndex());
         return value;
+    }
+
+    private void processLocalVariableRef(@Nullable final Object literal, @Nonnull final String varName,
+                                         final int tokenIndex) {
+        if (allowLiteralAddition) {
+            queryHasherContextBuilder.getLiteralsBuilder()
+                    .addLiteral(Type.any(), literal, null, varName, tokenIndex);
+        }
+        if (allowTokenAddition) {
+            final String canonicalName = "@" + varName;
+            sqlCanonicalizer.append(canonicalName).append(" ");
+            // Hash only the variable name — the value is injected at execution time via the
+            // QueryExecutionContext, allowing the same plan to be reused across different values.
+            parameterHash.putInt(canonicalName.hashCode());
+        }
     }
 
     @Override
@@ -353,6 +376,14 @@ public final class AstNormalizer extends RelationalParserBaseVisitor<Object> {
     @Override
     public Object visitAdministrationStatement(@Nonnull RelationalParser.AdministrationStatementContext ctx) {
         queryCachingFlags.add(NormalizationResult.QueryCachingFlags.IS_ADMIN_STATEMENT);
+        return visitChildren(ctx);
+    }
+
+    @Override
+    public Object visitSetLocalVariable(@Nonnull RelationalParser.SetLocalVariableContext ctx) {
+        // SET LOCAL embeds the literal value in ProceduralPlan.action, which withExecutionContext
+        // cannot update. Mark it as DDL so the plan cache is bypassed.
+        queryCachingFlags.add(NormalizationResult.QueryCachingFlags.IS_DDL_STATEMENT);
         return visitChildren(ctx);
     }
 
@@ -648,7 +679,7 @@ public final class AstNormalizer extends RelationalParserBaseVisitor<Object> {
                                                     @Nonnull final PlanHashable.PlanHashMode currentPlanHashMode,
                                                     @Nonnull final String query,
                                                     @Nonnull final Map<String, Object> localVariables) throws RelationalException {
-        final var astNormalizer = new AstNormalizer(preparedStatementParameters, caseSensitive, currentPlanHashMode, parseTreeInfo.getQueryType() == ParseTreeInfo.QueryType.DESCRIBE_QUERY, true);
+        final var astNormalizer = new AstNormalizer(preparedStatementParameters, localVariables, caseSensitive, currentPlanHashMode, parseTreeInfo.getQueryType() == ParseTreeInfo.QueryType.DESCRIBE_QUERY, true);
         astNormalizer.visit(parseTreeInfo.getRootContext());
         final var recordLayerSchemaTemplate = Assert.castUnchecked(schemaTemplate, RecordLayerSchemaTemplate.class);
 
@@ -671,13 +702,12 @@ public final class AstNormalizer extends RelationalParserBaseVisitor<Object> {
                 }
                 final var recordLayerRoutine = (RecordLayerInvokedRoutine)temporaryRoutine;
                 // For the function body cache-key normalization: use the CREATE-time ?param bindings from
-                // the routine itself, merged with SELECT-time @var bindings. This preserves the function
-                // body’s own prepared-statement semantics while allowing local variables to resolve.
-                final var bodyParams = PreparedParams.withAdditionalNamed(
-                        recordLayerRoutine.getPreparedParams(), localVariables);
+                // the routine itself, and pass SELECT-time @var bindings separately so they resolve as
+                // local variables rather than named parameters.
                 final var functionAstResult = normalizeFunctionBody(schemaTemplate,
                         QueryParser.parse(recordLayerRoutine.getDescription()),
-                        bodyParams,
+                        recordLayerRoutine.getPreparedParams(),
+                        localVariables,
                         userVersion,
                         plannerConfiguration,
                         caseSensitive,
@@ -704,12 +734,13 @@ public final class AstNormalizer extends RelationalParserBaseVisitor<Object> {
     private static NormalizationResult normalizeFunctionBody(@Nonnull final SchemaTemplate schemaTemplate,
                                                               @Nonnull final ParseTreeInfoImpl parseTreeInfo,
                                                               @Nonnull final PreparedParams preparedStatementParameters,
+                                                              @Nonnull final Map<String, Object> localVariables,
                                                               int userVersion,
                                                               @Nonnull final PlannerConfiguration plannerConfiguration,
                                                               boolean caseSensitive,
                                                               @Nonnull final PlanHashable.PlanHashMode currentPlanHashMode,
                                                               @Nonnull final String query) throws RelationalException {
-        final var astNormalizer = new AstNormalizer(preparedStatementParameters, caseSensitive, currentPlanHashMode,
+        final var astNormalizer = new AstNormalizer(preparedStatementParameters, localVariables, caseSensitive, currentPlanHashMode,
                 parseTreeInfo.getQueryType() == ParseTreeInfo.QueryType.DESCRIBE_QUERY, false);
         astNormalizer.visit(parseTreeInfo.getRootContext());
         final var recordLayerSchemaTemplate = Assert.castUnchecked(schemaTemplate, RecordLayerSchemaTemplate.class);

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/AstNormalizer.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/AstNormalizer.java
@@ -172,6 +172,11 @@ public final class AstNormalizer extends RelationalParserBaseVisitor<Object> {
         this.deferMissingVarsInFunctionBodies = deferMissingVarsInFunctionBodies;
     }
 
+    private AstNormalizer(@Nonnull final PreparedParams preparedStatementParameters, boolean caseSensitive,
+                          @Nonnull final PlanHashable.PlanHashMode currentPlanHashMode, boolean forExplain) {
+        this(preparedStatementParameters, caseSensitive, currentPlanHashMode, forExplain, false);
+    }
+
     @Override
     public Void visitChildren(@Nonnull RuleNode node) {
         if (literalNodes.containsKey(node.getClass())) {
@@ -614,7 +619,8 @@ public final class AstNormalizer extends RelationalParserBaseVisitor<Object> {
                         context.getPlannerConfiguration(),
                         isCaseSensitive,
                         currentPlanHashMode,
-                        query
+                        query,
+                        context.getLocalVariables()
                 ));
     }
 
@@ -628,6 +634,20 @@ public final class AstNormalizer extends RelationalParserBaseVisitor<Object> {
                                                    boolean caseSensitive,
                                                    @Nonnull final PlanHashable.PlanHashMode currentPlanHashMode,
                                                    @Nonnull final String query) throws RelationalException {
+        return normalizeAst(schemaTemplate, parseTreeInfo, preparedStatementParameters, userVersion,
+                plannerConfiguration, caseSensitive, currentPlanHashMode, query, Map.of());
+    }
+
+    @Nonnull
+    private static NormalizationResult normalizeAst(@Nonnull final SchemaTemplate schemaTemplate,
+                                                    @Nonnull final ParseTreeInfoImpl parseTreeInfo,
+                                                    @Nonnull final PreparedParams preparedStatementParameters,
+                                                    int userVersion,
+                                                    @Nonnull final PlannerConfiguration plannerConfiguration,
+                                                    boolean caseSensitive,
+                                                    @Nonnull final PlanHashable.PlanHashMode currentPlanHashMode,
+                                                    @Nonnull final String query,
+                                                    @Nonnull final Map<String, Object> localVariables) throws RelationalException {
         final var astNormalizer = new AstNormalizer(preparedStatementParameters, caseSensitive, currentPlanHashMode, parseTreeInfo.getQueryType() == ParseTreeInfo.QueryType.DESCRIBE_QUERY, true);
         astNormalizer.visit(parseTreeInfo.getRootContext());
         final var recordLayerSchemaTemplate = Assert.castUnchecked(schemaTemplate, RecordLayerSchemaTemplate.class);
@@ -650,9 +670,14 @@ public final class AstNormalizer extends RelationalParserBaseVisitor<Object> {
                     continue;
                 }
                 final var recordLayerRoutine = (RecordLayerInvokedRoutine)temporaryRoutine;
+                // For the function body cache-key normalization: use the CREATE-time ?param bindings from
+                // the routine itself, merged with SELECT-time @var bindings. This preserves the function
+                // body’s own prepared-statement semantics while allowing local variables to resolve.
+                final var bodyParams = PreparedParams.withAdditionalNamed(
+                        recordLayerRoutine.getPreparedParams(), localVariables);
                 final var functionAstResult = normalizeFunctionBody(schemaTemplate,
                         QueryParser.parse(recordLayerRoutine.getDescription()),
-                        preparedStatementParameters,
+                        bodyParams,
                         userVersion,
                         plannerConfiguration,
                         caseSensitive,

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/AstNormalizer.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/AstNormalizer.java
@@ -194,6 +194,15 @@ public final class AstNormalizer extends RelationalParserBaseVisitor<Object> {
     }
 
     @Override
+    public Object visitVariableRef(@Nonnull RelationalParser.VariableRefContext ctx) {
+        final var rawName = ctx.LOCAL_ID().getText().substring(1); // strip leading '@'
+        final var varName = Assert.notNullUnchecked(SemanticAnalyzer.normalizeString(rawName, caseSensitive));
+        final var value = preparedStatementParameters.namedParamValue(varName);
+        processNamedParameter(value, varName, ctx.LOCAL_ID().getSymbol().getTokenIndex());
+        return value;
+    }
+
+    @Override
     public Value visitUid(@Nonnull RelationalParser.UidContext ctx) {
         String uid = SemanticAnalyzer.normalizeString(ctx.getText(), caseSensitive);
         sqlCanonicalizer.append("\"").append(uid).append("\"").append(" ");

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/LogicalOperator.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/LogicalOperator.java
@@ -68,6 +68,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -211,7 +212,7 @@ public class LogicalOperator {
                     () -> String.format(Locale.ROOT,
                             "AT clause requires an array-typed column, but '%s' is a function",
                             identifier));
-            return semanticAnalyzer.resolveTableFunction(identifier, Expressions.empty(), false)
+            return semanticAnalyzer.resolveTableFunction(identifier, Expressions.empty(), false, Map.of())
                     .withNewSharedReferenceAndAlias(alias);
         } else {
             final var correlatedField = semanticAnalyzer.resolveCorrelatedIdentifier(identifier,

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/MutablePlanGenerationContext.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/MutablePlanGenerationContext.java
@@ -62,6 +62,7 @@ import java.util.Optional;
 import java.util.function.Supplier;
 
 import static com.apple.foundationdb.relational.api.exceptions.ErrorCode.DATATYPE_MISMATCH;
+import static com.apple.foundationdb.relational.api.exceptions.ErrorCode.UNDEFINED_PARAMETER;
 
 /**
  * Context keeping state related to plan generation, it also captures execution-specific attributes that influences
@@ -478,6 +479,14 @@ public class MutablePlanGenerationContext implements QueryExecutionContext {
             duplicateLiteralMaybe.ifPresent(prev -> addEqualityConstraint(prev.getConstantId(), literal.getConstantId(), literalValue.getResultType()));
             constantObjectValues.add(ConstantObjectValue.of(Quantifier.constant(), literal.getConstantId(), literalValue.getResultType()));
         }
+    }
+
+    @Nonnull
+    public Value processLocalVariable(@Nonnull String varName, int tokenIndex) {
+        Assert.thatUnchecked(localVariables.containsKey(varName), UNDEFINED_PARAMETER,
+                () -> "No value found for parameter " + varName);
+        final var value = localVariables.get(varName);
+        return processPreparedStatementParameter(value, getObjectType(value), null, varName, tokenIndex);
     }
 
     @Nonnull

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/MutablePlanGenerationContext.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/MutablePlanGenerationContext.java
@@ -57,6 +57,7 @@ import java.sql.Struct;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
 
@@ -70,6 +71,9 @@ import static com.apple.foundationdb.relational.api.exceptions.ErrorCode.DATATYP
 public class MutablePlanGenerationContext implements QueryExecutionContext {
     @Nonnull
     private PreparedParams preparedParams;
+
+    @Nonnull
+    private Map<String, Object> localVariables = Map.of();
 
     @Nonnull
     private final Literals.Builder literalsBuilder;
@@ -291,6 +295,15 @@ public class MutablePlanGenerationContext implements QueryExecutionContext {
 
     public void setPreparedParams(@Nonnull PreparedParams newParams) {
         this.preparedParams = newParams;
+    }
+
+    @Nonnull
+    public Map<String, Object> getLocalVariables() {
+        return localVariables;
+    }
+
+    public void setLocalVariables(@Nonnull Map<String, Object> localVariables) {
+        this.localVariables = localVariables;
     }
 
 

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/MutablePlanGenerationContext.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/MutablePlanGenerationContext.java
@@ -69,7 +69,7 @@ import static com.apple.foundationdb.relational.api.exceptions.ErrorCode.DATATYP
 @API(API.Status.EXPERIMENTAL)
 public class MutablePlanGenerationContext implements QueryExecutionContext {
     @Nonnull
-    private final PreparedParams preparedParams;
+    private PreparedParams preparedParams;
 
     @Nonnull
     private final Literals.Builder literalsBuilder;
@@ -289,6 +289,11 @@ public class MutablePlanGenerationContext implements QueryExecutionContext {
         return preparedParams;
     }
 
+    public void setPreparedParams(@Nonnull PreparedParams newParams) {
+        this.preparedParams = newParams;
+    }
+
+
     public void startArrayLiteral() {
         literalsBuilder.startArrayLiteral();
     }
@@ -467,6 +472,14 @@ public class MutablePlanGenerationContext implements QueryExecutionContext {
         final var value = preparedParams.namedParamValue(param);
         //TODO type should probably be Type.any() instead of null
         return processPreparedStatementParameter(value, getObjectType(value), null, param, tokenIndex);
+    }
+
+    @Nonnull
+    public Value processNamedPreparedParamDeferred(@Nonnull String param, int tokenIndex) {
+        // With SELECT-time PreparedParams injected via BaseVisitor.TVFUNCTION_COMPILATION_PARAMS,
+        // the variable will be present when the plan is compiled. If it is still missing here,
+        // normalization already threw UNDEFINED_PARAMETER, so we should not reach this point.
+        return processNamedPreparedParam(param, tokenIndex);
     }
 
     @Nonnull

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/MutablePlanGenerationContext.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/MutablePlanGenerationContext.java
@@ -488,14 +488,6 @@ public class MutablePlanGenerationContext implements QueryExecutionContext {
     }
 
     @Nonnull
-    public Value processNamedPreparedParamDeferred(@Nonnull String param, int tokenIndex) {
-        // With SELECT-time PreparedParams injected via BaseVisitor.TVFUNCTION_COMPILATION_PARAMS,
-        // the variable will be present when the plan is compiled. If it is still missing here,
-        // normalization already threw UNDEFINED_PARAMETER, so we should not reach this point.
-        return processNamedPreparedParam(param, tokenIndex);
-    }
-
-    @Nonnull
     public Value processUnnamedPreparedParam(int tokenIndex) {
         // TODO (Make prepared statement parameters stateless)
         final int currentUnnamedParameterIndex = preparedParams.currentUnnamedParamIndex();

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/PlanContext.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/PlanContext.java
@@ -37,6 +37,7 @@ import com.google.common.annotations.VisibleForTesting;
 
 import javax.annotation.Nonnull;
 import java.net.URI;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -66,6 +67,9 @@ public final class PlanContext {
 
     private final boolean isCaseSensitive;
 
+    @Nonnull
+    private final Map<String, Object> localVariables;
+
     /**
      * Creates a new instance of {@link PlanContext} needed for generating plans.
      *
@@ -90,7 +94,8 @@ public final class PlanContext {
                         @Nonnull URI dbUri,
                         @Nonnull PreparedParams preparedStatementParameters,
                         final int userVersion,
-                        boolean isCaseSensitive) {
+                        boolean isCaseSensitive,
+                        @Nonnull Map<String, Object> localVariables) {
         this.metaData = metaData;
         this.metricCollector = metricCollector;
         this.schemaTemplate = schemaTemplate;
@@ -101,6 +106,7 @@ public final class PlanContext {
         this.preparedStatementParameters = preparedStatementParameters;
         this.userVersion = userVersion;
         this.isCaseSensitive = isCaseSensitive;
+        this.localVariables = localVariables;
     }
 
     @Nonnull
@@ -149,6 +155,11 @@ public final class PlanContext {
     }
 
     @Nonnull
+    public Map<String, Object> getLocalVariables() {
+        return localVariables;
+    }
+
+    @Nonnull
     public SchemaTemplate getSchemaTemplate() {
         return schemaTemplate;
     }
@@ -183,6 +194,8 @@ public final class PlanContext {
         private PreparedParams preparedStatementParameters;
 
         private boolean isCaseSensitive;
+
+        private Map<String, Object> localVariables = Map.of();
 
         private Builder() {
         }
@@ -252,6 +265,12 @@ public final class PlanContext {
         }
 
         @Nonnull
+        public Builder withLocalVariables(@Nonnull Map<String, Object> localVariables) {
+            this.localVariables = localVariables;
+            return this;
+        }
+
+        @Nonnull
         private static Optional<Set<String>> getReadableIndexes(@Nonnull RecordMetaData metaData,
                                                                 @Nonnull RecordStoreState storeState) {
             // (yhatem) we should cache this somewhere, or embed it in the caching logic of the {@code FDBRecordStoreBase#createOrOpen}.
@@ -298,7 +317,7 @@ public final class PlanContext {
         public PlanContext build() throws RelationalException {
             verify();
             return new PlanContext(metaData, metricCollector, schemaTemplate, plannerConfiguration, metadataOperationsFactory,
-                    ddlQueryFactory, dbUri, preparedStatementParameters, userVersion, isCaseSensitive);
+                    ddlQueryFactory, dbUri, preparedStatementParameters, userVersion, isCaseSensitive, localVariables);
         }
 
         @Nonnull
@@ -318,6 +337,7 @@ public final class PlanContext {
                     .withPlannerConfiguration(planContext.plannerConfiguration)
                     .withUserVersion(planContext.userVersion)
                     .withPreparedParameters(planContext.preparedStatementParameters)
+                    .withLocalVariables(planContext.localVariables)
                     .isCaseSensitive(planContext.isCaseSensitive);
         }
     }

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/PlanGenerator.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/PlanGenerator.java
@@ -244,6 +244,7 @@ public final class PlanGenerator {
 
         final var planGenerationContext = new MutablePlanGenerationContext(planContext.getPreparedStatementParameters(),
                 currentPlanHashMode, ast.getQuery(), ast.getQueryCacheKey().getCanonicalQueryString(), parameterHash);
+        planGenerationContext.setLocalVariables(planContext.getLocalVariables());
         planGenerationContext.setForExplain(ast.getQueryExecutionContext().isForExplain());
         final var metadata = Assert.castUnchecked(planContext.getSchemaTemplate(), RecordLayerSchemaTemplate.class);
         try (var ignored = new PlannerEventStatsCollector.DefaultStatsCollectorController()) {

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/PreparedParams.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/PreparedParams.java
@@ -83,6 +83,10 @@ public final class PreparedParams {
         return namedParams.get(name);
     }
 
+    public boolean containsNamedParam(@Nonnull String name) {
+        return namedParams.containsKey(name);
+    }
+
     public boolean isEmpty() {
         return this.namedParams.isEmpty() && this.unnamedParams.isEmpty();
     }

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/PreparedParams.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/PreparedParams.java
@@ -125,4 +125,21 @@ public final class PreparedParams {
             return new PreparedParams(other.unnamedParams, other.namedParams);
         }
     }
+
+    /**
+     * Returns a new {@link PreparedParams} that is identical to {@code base} but with the entries in
+     * {@code additionalNamed} added to (or overriding) its named-parameter map.  Used to inject local
+     * variable bindings into a function body's compilation context while keeping the CREATE-time
+     * positional / named parameters unchanged.
+     */
+    @Nonnull
+    public static PreparedParams withAdditionalNamed(@Nonnull PreparedParams base,
+                                                     @Nonnull Map<String, Object> additionalNamed) {
+        if (additionalNamed.isEmpty()) {
+            return base;
+        }
+        final var merged = new java.util.HashMap<>(base.namedParams);
+        merged.putAll(additionalNamed);
+        return new PreparedParams(base.unnamedParams, merged, base.nextParam);
+    }
 }

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/SemanticAnalyzer.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/SemanticAnalyzer.java
@@ -959,7 +959,7 @@ public class SemanticAnalyzer {
         Assert.thatUnchecked(functionCatalog.containsFunction(functionName), ErrorCode.UNSUPPORTED_QUERY,
                 () -> String.format(Locale.ROOT, "Unsupported operator %s", functionName));
 
-        final var builtInFunction = functionCatalog.lookupFunction(functionName, arguments);
+        final var builtInFunction = functionCatalog.lookupFunction(functionName, arguments, Map.of());
         processFunctionSideEffects(builtInFunction);
 
         final var argumentList = ImmutableList.<Expression>builderWithExpectedSize(arguments.size() + 1).addAll(arguments);
@@ -1131,10 +1131,10 @@ public class SemanticAnalyzer {
      */
     @Nonnull
     public LogicalOperator resolveTableFunction(@Nonnull final Identifier functionName, @Nonnull final Expressions arguments,
-                                                boolean flattenSingleItemRecords) {
+                                                boolean flattenSingleItemRecords, @Nonnull final Map<String, Object> localVariables) {
         Assert.thatUnchecked(functionCatalog.containsFunction(functionName.getName()), ErrorCode.UNDEFINED_FUNCTION,
                 () -> String.format(Locale.ROOT, "Unknown function %s", functionName));
-        final var tableFunction = functionCatalog.lookupFunction(functionName.getName(), arguments);
+        final var tableFunction = functionCatalog.lookupFunction(functionName.getName(), arguments, localVariables);
         if (tableFunction instanceof BuiltInFunction) {
             Assert.thatUnchecked(tableFunction instanceof BuiltInTableFunction, functionName + " is not a table-valued function");
         }

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/functions/SqlFunctionCatalog.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/functions/SqlFunctionCatalog.java
@@ -28,6 +28,7 @@ import com.apple.foundationdb.relational.recordlayer.metadata.RecordLayerSchemaT
 import com.apple.foundationdb.relational.recordlayer.query.Expressions;
 
 import javax.annotation.Nonnull;
+import java.util.Map;
 import java.util.stream.StreamSupport;
 
 import static java.util.stream.Collectors.toList;
@@ -46,7 +47,8 @@ public interface SqlFunctionCatalog {
      * @return the function instance.
      */
     @Nonnull
-    CatalogedFunction lookupFunction(@Nonnull String name, @Nonnull Expressions arguments);
+    CatalogedFunction lookupFunction(@Nonnull String name, @Nonnull Expressions arguments,
+                                     @Nonnull Map<String, Object> localVariables);
 
     /**
      * Checks whether a function exists in the catalog. Note that invoking this method shall not trigger compiling

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/functions/SqlFunctionCatalogImpl.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/functions/SqlFunctionCatalogImpl.java
@@ -34,6 +34,7 @@ import com.google.common.collect.ImmutableMap;
 
 import javax.annotation.Nonnull;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -50,14 +51,15 @@ final class SqlFunctionCatalogImpl implements SqlFunctionCatalog {
     private final UserDefinedFunctionCatalog userDefinedFunctionCatalog;
 
     private SqlFunctionCatalogImpl(boolean isCaseSensitive) {
-        this.userDefinedFunctionCatalog = new UserDefinedFunctionCatalog(isCaseSensitive);
+        this.userDefinedFunctionCatalog = new UserDefinedFunctionCatalog();
     }
 
     @Nonnull
     @Override
-    public CatalogedFunction lookupFunction(@Nonnull final String name, @Nonnull final Expressions arguments) {
+    public CatalogedFunction lookupFunction(@Nonnull final String name, @Nonnull final Expressions arguments,
+                                            @Nonnull final Map<String, Object> localVariables) {
         final var builtInFunctionMaybe = lookupBuiltInFunction(name, arguments);
-        final var userDefinedFunctionMaybe = lookupUserDefinedFunction(name, arguments);
+        final var userDefinedFunctionMaybe = lookupUserDefinedFunction(name, arguments, localVariables);
         if (builtInFunctionMaybe.isPresent() && userDefinedFunctionMaybe.isPresent()) {
             // this should never happen.
             Assert.failUnchecked(ErrorCode.INTERNAL_ERROR, "multiple definition of '" + name + "' found in the catalog");
@@ -84,8 +86,9 @@ final class SqlFunctionCatalogImpl implements SqlFunctionCatalog {
 
     @Nonnull
     private Optional<? extends CatalogedFunction> lookupUserDefinedFunction(@Nonnull final String name,
-                                                                            @Nonnull final Expressions expressions) {
-        return userDefinedFunctionCatalog.lookup(name, expressions);
+                                                                            @Nonnull final Expressions expressions,
+                                                                            @Nonnull final Map<String, Object> localVariables) {
+        return userDefinedFunctionCatalog.lookup(name, expressions, localVariables);
     }
 
     @Override
@@ -100,7 +103,7 @@ final class SqlFunctionCatalogImpl implements SqlFunctionCatalog {
     }
 
     public void registerUserDefinedFunction(@Nonnull final String functionName,
-                                            @Nonnull final Function<Boolean, ? extends UserDefinedFunction> functionSupplier) {
+                                            @Nonnull final Function<Map<String, Object>, ? extends UserDefinedFunction> functionSupplier) {
         userDefinedFunctionCatalog.registerFunction(functionName, functionSupplier);
     }
 
@@ -167,7 +170,7 @@ final class SqlFunctionCatalogImpl implements SqlFunctionCatalog {
         metadata.getInvokedRoutines().forEach(func ->
                 functionCatalog.registerUserDefinedFunction(
                         Assert.notNullUnchecked(func.getName()),
-                        func.getUserDefinedFunctionProvider()));
+                        localVars -> func.getUserDefinedFunctionProvider().apply(isCaseSensitive, localVars)));
         return functionCatalog;
     }
 }

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/functions/UserDefinedFunctionCatalog.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/functions/UserDefinedFunctionCatalog.java
@@ -38,17 +38,14 @@ import java.util.function.Function;
 final class UserDefinedFunctionCatalog {
 
     @Nonnull
-    private final Map<String, Function<Boolean, ? extends UserDefinedFunction>> functionsMap;
+    private final Map<String, Function<Map<String, Object>, ? extends UserDefinedFunction>> functionsMap;
 
-    private final boolean isCaseSensitive;
-
-    UserDefinedFunctionCatalog(boolean isCaseSensitive) {
-        this.isCaseSensitive = isCaseSensitive;
+    UserDefinedFunctionCatalog() {
         this.functionsMap = new LinkedHashMap<>();
     }
 
     void registerFunction(@Nonnull final String functionName,
-                          @Nonnull final Function<Boolean, ? extends UserDefinedFunction> function) {
+                          @Nonnull final Function<Map<String, Object>, ? extends UserDefinedFunction> function) {
         functionsMap.put(functionName, function);
     }
 
@@ -57,14 +54,15 @@ final class UserDefinedFunctionCatalog {
     }
 
     @Nonnull
-    public Optional<? extends CatalogedFunction> lookup(@Nonnull final String functionName, Expressions arguments) {
+    public Optional<? extends CatalogedFunction> lookup(@Nonnull final String functionName, Expressions arguments,
+                                                        @Nonnull Map<String, Object> localVariables) {
         final var functionSupplier = functionsMap.get(functionName);
         if (functionSupplier == null) {
             return Optional.empty();
         }
 
         // lazy-compile the function
-        final var function = functionSupplier.apply(isCaseSensitive);
+        final var function = functionSupplier.apply(localVariables);
 
         // either all arguments are named, or none is named.
         // I think partial naming is supported in SQL standard, but we do not support that at the moment.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/BaseVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/BaseVisitor.java
@@ -51,6 +51,7 @@ import com.apple.foundationdb.relational.recordlayer.query.QueryPlan;
 import com.apple.foundationdb.relational.recordlayer.query.SemanticAnalyzer;
 import com.apple.foundationdb.relational.recordlayer.query.functions.CompiledSqlFunction;
 import com.apple.foundationdb.relational.recordlayer.query.functions.SqlFunctionCatalog;
+import com.apple.foundationdb.relational.recordlayer.query.PreparedParams;
 import com.apple.foundationdb.relational.util.Assert;
 import org.antlr.v4.runtime.tree.ParseTree;
 
@@ -61,6 +62,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+
 /**
  * This class is a composition of different, specialized AST visitors. It holds that visitation and some other
  * cross-functional state.
@@ -68,6 +70,14 @@ import java.util.Set;
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 @API(API.Status.EXPERIMENTAL)
 public class BaseVisitor extends RelationalParserBaseVisitor<Object> implements TypedVisitor {
+
+    /**
+     * Carries the SELECT-time {@link PreparedParams} into the memoized lambda that compiles a temporary
+     * function body, so that local variable refs inside the body resolve to their actual runtime types
+     * (not to the empty CREATE-time params).  Set in {@link #resolveTableValuedFunction} and cleared
+     * after each TVF lookup completes.
+     */
+    static final ThreadLocal<PreparedParams> TVFUNCTION_COMPILATION_PARAMS = new ThreadLocal<>();
 
     private final boolean caseSensitive;
 
@@ -82,6 +92,8 @@ public class BaseVisitor extends RelationalParserBaseVisitor<Object> implements 
 
     @Nonnull
     protected Optional<LogicalPlanFragment> currentPlanFragment;
+
+    private boolean deferMissingLocalVars = false;
 
     @Nonnull
     private final ExpressionVisitor expressionVisitor;
@@ -133,6 +145,14 @@ public class BaseVisitor extends RelationalParserBaseVisitor<Object> implements 
     @Nonnull
     public MutablePlanGenerationContext getPlanGenerationContext() {
         return mutablePlanGenerationContext;
+    }
+
+    public void setDeferMissingLocalVars(boolean defer) {
+        this.deferMissingLocalVars = defer;
+    }
+
+    public boolean isDeferMissingLocalVars() {
+        return deferMissingLocalVars;
     }
 
     @Nonnull
@@ -234,7 +254,12 @@ public class BaseVisitor extends RelationalParserBaseVisitor<Object> implements 
 
     @Nonnull
     public LogicalOperator resolveTableValuedFunction(@Nonnull Identifier functionName, @Nonnull Expressions arguments) {
-        return getSemanticAnalyzer().resolveTableFunction(functionName, arguments, true);
+        TVFUNCTION_COMPILATION_PARAMS.set(mutablePlanGenerationContext.getPreparedParams());
+        try {
+            return getSemanticAnalyzer().resolveTableFunction(functionName, arguments, true);
+        } finally {
+            TVFUNCTION_COMPILATION_PARAMS.remove();
+        }
     }
 
     @Override

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/BaseVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/BaseVisitor.java
@@ -71,15 +71,6 @@ import java.util.Set;
 @API(API.Status.EXPERIMENTAL)
 public class BaseVisitor extends RelationalParserBaseVisitor<Object> implements TypedVisitor {
 
-    /**
-     * Carries the SELECT-time local variable bindings into the memoized lambda that compiles a temporary
-     * function body, so that local variable refs inside the body resolve to their actual runtime types.
-     * Set in {@link #resolveTableValuedFunction} and cleared after each TVF lookup completes.
-     * Only local variables (@var) are carried, never prepared-statement parameters (?param), so the
-     * CREATE-time ?param bindings in the function body are preserved as-is.
-     */
-    static final ThreadLocal<Map<String, Object>> TVFUNCTION_COMPILATION_PARAMS = new ThreadLocal<>();
-
     private final boolean caseSensitive;
 
     @Nonnull
@@ -93,8 +84,6 @@ public class BaseVisitor extends RelationalParserBaseVisitor<Object> implements 
 
     @Nonnull
     protected Optional<LogicalPlanFragment> currentPlanFragment;
-
-    private boolean deferMissingLocalVars = false;
 
     @Nonnull
     private final ExpressionVisitor expressionVisitor;
@@ -146,14 +135,6 @@ public class BaseVisitor extends RelationalParserBaseVisitor<Object> implements 
     @Nonnull
     public MutablePlanGenerationContext getPlanGenerationContext() {
         return mutablePlanGenerationContext;
-    }
-
-    public void setDeferMissingLocalVars(boolean defer) {
-        this.deferMissingLocalVars = defer;
-    }
-
-    public boolean isDeferMissingLocalVars() {
-        return deferMissingLocalVars;
     }
 
     @Nonnull
@@ -255,12 +236,8 @@ public class BaseVisitor extends RelationalParserBaseVisitor<Object> implements 
 
     @Nonnull
     public LogicalOperator resolveTableValuedFunction(@Nonnull Identifier functionName, @Nonnull Expressions arguments) {
-        TVFUNCTION_COMPILATION_PARAMS.set(mutablePlanGenerationContext.getLocalVariables());
-        try {
-            return getSemanticAnalyzer().resolveTableFunction(functionName, arguments, true);
-        } finally {
-            TVFUNCTION_COMPILATION_PARAMS.remove();
-        }
+        return getSemanticAnalyzer().resolveTableFunction(functionName, arguments, true,
+                mutablePlanGenerationContext.getLocalVariables());
     }
 
     @Override

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/BaseVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/BaseVisitor.java
@@ -58,7 +58,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.net.URI;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/BaseVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/BaseVisitor.java
@@ -981,12 +981,6 @@ public class BaseVisitor extends RelationalParserBaseVisitor<Object> implements 
 
     @Nonnull
     @Override
-    public Object visitSetVariable(@Nonnull RelationalParser.SetVariableContext ctx) {
-        return visitChildren(ctx);
-    }
-
-    @Nonnull
-    @Override
     public Object visitSetCharset(@Nonnull RelationalParser.SetCharsetContext ctx) {
         return visitChildren(ctx);
     }
@@ -1012,12 +1006,6 @@ public class BaseVisitor extends RelationalParserBaseVisitor<Object> implements 
     @Nonnull
     @Override
     public Object visitSetNewValueInsideTrigger(@Nonnull RelationalParser.SetNewValueInsideTriggerContext ctx) {
-        return visitChildren(ctx);
-    }
-
-    @Nonnull
-    @Override
-    public Object visitVariableClause(@Nonnull RelationalParser.VariableClauseContext ctx) {
         return visitChildren(ctx);
     }
 

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/BaseVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/BaseVisitor.java
@@ -474,11 +474,6 @@ public class BaseVisitor extends RelationalParserBaseVisitor<Object> implements 
     }
 
     @Override
-    public Expression visitVariableRef(final RelationalParser.VariableRefContext ctx) {
-        return expressionVisitor.visitVariableRef(ctx);
-    }
-
-    @Override
     public Expression visitVariableRefAtom(final RelationalParser.VariableRefAtomContext ctx) {
         return expressionVisitor.visitVariableRefAtom(ctx);
     }

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/BaseVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/BaseVisitor.java
@@ -59,6 +59,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.net.URI;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -72,12 +73,13 @@ import java.util.Set;
 public class BaseVisitor extends RelationalParserBaseVisitor<Object> implements TypedVisitor {
 
     /**
-     * Carries the SELECT-time {@link PreparedParams} into the memoized lambda that compiles a temporary
-     * function body, so that local variable refs inside the body resolve to their actual runtime types
-     * (not to the empty CREATE-time params).  Set in {@link #resolveTableValuedFunction} and cleared
-     * after each TVF lookup completes.
+     * Carries the SELECT-time local variable bindings into the memoized lambda that compiles a temporary
+     * function body, so that local variable refs inside the body resolve to their actual runtime types.
+     * Set in {@link #resolveTableValuedFunction} and cleared after each TVF lookup completes.
+     * Only local variables (@var) are carried, never prepared-statement parameters (?param), so the
+     * CREATE-time ?param bindings in the function body are preserved as-is.
      */
-    static final ThreadLocal<PreparedParams> TVFUNCTION_COMPILATION_PARAMS = new ThreadLocal<>();
+    static final ThreadLocal<Map<String, Object>> TVFUNCTION_COMPILATION_PARAMS = new ThreadLocal<>();
 
     private final boolean caseSensitive;
 
@@ -254,7 +256,7 @@ public class BaseVisitor extends RelationalParserBaseVisitor<Object> implements 
 
     @Nonnull
     public LogicalOperator resolveTableValuedFunction(@Nonnull Identifier functionName, @Nonnull Expressions arguments) {
-        TVFUNCTION_COMPILATION_PARAMS.set(mutablePlanGenerationContext.getPreparedParams());
+        TVFUNCTION_COMPILATION_PARAMS.set(mutablePlanGenerationContext.getLocalVariables());
         try {
             return getSemanticAnalyzer().resolveTableFunction(functionName, arguments, true);
         } finally {

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/BaseVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/BaseVisitor.java
@@ -51,7 +51,6 @@ import com.apple.foundationdb.relational.recordlayer.query.QueryPlan;
 import com.apple.foundationdb.relational.recordlayer.query.SemanticAnalyzer;
 import com.apple.foundationdb.relational.recordlayer.query.functions.CompiledSqlFunction;
 import com.apple.foundationdb.relational.recordlayer.query.functions.SqlFunctionCatalog;
-import com.apple.foundationdb.relational.recordlayer.query.PreparedParams;
 import com.apple.foundationdb.relational.util.Assert;
 import org.antlr.v4.runtime.tree.ParseTree;
 

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/BaseVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/BaseVisitor.java
@@ -443,6 +443,21 @@ public class BaseVisitor extends RelationalParserBaseVisitor<Object> implements 
     }
 
     @Override
+    public ProceduralPlan visitSetLocalVariable(final RelationalParser.SetLocalVariableContext ctx) {
+        return ddlVisitor.visitSetLocalVariable(ctx);
+    }
+
+    @Override
+    public Expression visitVariableRef(final RelationalParser.VariableRefContext ctx) {
+        return expressionVisitor.visitVariableRef(ctx);
+    }
+
+    @Override
+    public Expression visitVariableRefAtom(final RelationalParser.VariableRefAtomContext ctx) {
+        return expressionVisitor.visitVariableRefAtom(ctx);
+    }
+
+    @Override
     public CompiledSqlFunction visitTempSqlInvokedFunction(final RelationalParser.TempSqlInvokedFunctionContext ctx) {
         return ddlVisitor.visitTempSqlInvokedFunction(ctx);
     }

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DdlVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DdlVisitor.java
@@ -29,6 +29,8 @@ import com.apple.foundationdb.record.query.plan.cascades.RawSqlFunction;
 import com.apple.foundationdb.record.query.plan.cascades.UserDefinedFunction;
 import com.apple.foundationdb.record.query.plan.cascades.UserDefinedMacroFunction;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.LogicalSortExpression;
+import com.apple.foundationdb.record.query.plan.cascades.values.LiteralValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.NullValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.PromoteValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.QuantifiedObjectValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.ThrowsValue;
@@ -607,27 +609,12 @@ public final class DdlVisitor extends DelegatingVisitor<BaseVisitor> {
     @Override
     public ProceduralPlan visitSetLocalVariable(@Nonnull RelationalParser.SetLocalVariableContext ctx) {
         final var varName = getDelegate().normalizeString(ctx.varName.getText());
-        final var value = evalConstant(ctx.varValue);
+        final var expr = getDelegate().getPlanGenerationContext().withDisabledLiteralProcessing(
+                () -> Assert.castUnchecked(visit(ctx.varValue), Expression.class));
+        final var underlying = expr.getUnderlying();
+        final Object value = underlying instanceof NullValue ? null
+                : Assert.castUnchecked(underlying, LiteralValue.class).getLiteralValue();
         return ProceduralPlan.of(metadataOperationsFactory.getSetLocalVariableConstantAction(varName, value));
-    }
-
-    @Nullable
-    private Object evalConstant(@Nonnull RelationalParser.ConstantContext ctx) {
-        if (ctx instanceof RelationalParser.StringConstantContext) {
-            return SemanticAnalyzer.normalizeString(ctx.getText(), false);
-        } else if (ctx instanceof RelationalParser.DecimalConstantContext) {
-            return ParseHelpers.parseDecimal(ctx.getText());
-        } else if (ctx instanceof RelationalParser.NegativeDecimalConstantContext) {
-            return ParseHelpers.parseDecimal(ctx.getText());
-        } else if (ctx instanceof RelationalParser.BooleanConstantContext) {
-            return ((RelationalParser.BooleanConstantContext) ctx).booleanLiteral().FALSE() == null;
-        } else if (ctx instanceof RelationalParser.NullConstantContext) {
-            return null;
-        } else {
-            Assert.failUnchecked(ErrorCode.UNSUPPORTED_QUERY,
-                    "Unsupported constant type for SET LOCAL: " + ctx.getText());
-            return null; // unreachable
-        }
     }
 
     @Override

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DdlVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DdlVisitor.java
@@ -526,19 +526,16 @@ public final class DdlVisitor extends DelegatingVisitor<BaseVisitor> {
             // delay the compilation of table-valued temporary functions for later
             return builder
                     .withUserDefinedFunctionProvider(ignore -> {
-                        // Merge SELECT-time local variable bindings (set by resolveTableValuedFunction via
-                        // thread-local) into the CREATE-time PreparedParams so that @var refs inside the
-                        // body resolve to their current values. We add (not replace) so that ?param
-                        // bindings already present from the CREATE-time context are preserved.
+                        // Inject SELECT-time local variable bindings (set by resolveTableValuedFunction via
+                        // thread-local) so that @var refs inside the body resolve to their current values.
                         final var localVarsMap = BaseVisitor.TVFUNCTION_COMPILATION_PARAMS.get();
                         if (localVarsMap != null && !localVarsMap.isEmpty()) {
-                            final var prev = getDelegate().getPlanGenerationContext().getPreparedParams();
-                            final var merged = PreparedParams.withAdditionalNamed(prev, localVarsMap);
-                            getDelegate().getPlanGenerationContext().setPreparedParams(merged);
+                            final var prev = getDelegate().getPlanGenerationContext().getLocalVariables();
+                            getDelegate().getPlanGenerationContext().setLocalVariables(localVarsMap);
                             try {
                                 return visitSqlInvokedFunction(functionSpecCtx, bodyCtx, isTemporary);
                             } finally {
-                                getDelegate().getPlanGenerationContext().setPreparedParams(prev);
+                                getDelegate().getPlanGenerationContext().setLocalVariables(prev);
                             }
                         }
                         return visitSqlInvokedFunction(functionSpecCtx, bodyCtx, isTemporary);

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DdlVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DdlVisitor.java
@@ -523,7 +523,22 @@ public final class DdlVisitor extends DelegatingVisitor<BaseVisitor> {
         if (!isScalar && isTemporary) {
             // delay the compilation of table-valued temporary functions for later
             return builder
-                    .withUserDefinedFunctionProvider(ignore -> visitSqlInvokedFunction(functionSpecCtx, bodyCtx, isTemporary))
+                    .withUserDefinedFunctionProvider(ignore -> {
+                        // Use SELECT-time PreparedParams (set by resolveTableValuedFunction via thread-local)
+                        // so that local variable refs inside the body resolve to their actual types,
+                        // not to the empty CREATE-time params.
+                        final var selectTimeParams = BaseVisitor.TVFUNCTION_COMPILATION_PARAMS.get();
+                        if (selectTimeParams != null) {
+                            final var prev = getDelegate().getPlanGenerationContext().getPreparedParams();
+                            getDelegate().getPlanGenerationContext().setPreparedParams(selectTimeParams);
+                            try {
+                                return visitSqlInvokedFunction(functionSpecCtx, bodyCtx, isTemporary);
+                            } finally {
+                                getDelegate().getPlanGenerationContext().setPreparedParams(prev);
+                            }
+                        }
+                        return visitSqlInvokedFunction(functionSpecCtx, bodyCtx, isTemporary);
+                    })
                     .withSerializableFunction(new RawSqlFunction(functionName, functionDefinition))
                     .build();
         } else {
@@ -682,7 +697,12 @@ public final class DdlVisitor extends DelegatingVisitor<BaseVisitor> {
             parametersCorrelation.ifPresent(quantifier -> fragment.addOperator(LogicalOperator.newUnnamedOperator(
                     Expressions.fromQuantifier(quantifier), quantifier)));
             if (isTemporary) {
-                body = Assert.castUnchecked(visit(bodyCtx), LogicalOperator.class);
+                getDelegate().setDeferMissingLocalVars(true);
+                try {
+                    body = Assert.castUnchecked(visit(bodyCtx), LogicalOperator.class);
+                } finally {
+                    getDelegate().setDeferMissingLocalVars(false);
+                }
             } else {
                 body = getDelegate().getPlanGenerationContext().withDisabledLiteralProcessing(() ->
                         Assert.castUnchecked(visit(bodyCtx), LogicalOperator.class));

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DdlVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DdlVisitor.java
@@ -52,7 +52,6 @@ import com.apple.foundationdb.relational.recordlayer.query.Expressions;
 import com.apple.foundationdb.relational.recordlayer.query.Identifier;
 import com.apple.foundationdb.relational.recordlayer.query.LogicalOperator;
 import com.apple.foundationdb.relational.recordlayer.query.LogicalOperators;
-import com.apple.foundationdb.relational.recordlayer.query.ParseHelpers;
 import com.apple.foundationdb.relational.recordlayer.query.PreparedParams;
 import com.apple.foundationdb.relational.recordlayer.query.ProceduralPlan;
 import com.apple.foundationdb.relational.recordlayer.query.QueryParser;

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DdlVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DdlVisitor.java
@@ -50,6 +50,7 @@ import com.apple.foundationdb.relational.recordlayer.query.Expressions;
 import com.apple.foundationdb.relational.recordlayer.query.Identifier;
 import com.apple.foundationdb.relational.recordlayer.query.LogicalOperator;
 import com.apple.foundationdb.relational.recordlayer.query.LogicalOperators;
+import com.apple.foundationdb.relational.recordlayer.query.ParseHelpers;
 import com.apple.foundationdb.relational.recordlayer.query.PreparedParams;
 import com.apple.foundationdb.relational.recordlayer.query.ProceduralPlan;
 import com.apple.foundationdb.relational.recordlayer.query.QueryParser;
@@ -584,6 +585,32 @@ public final class DdlVisitor extends DelegatingVisitor<BaseVisitor> {
         final var functionName = visitFullId(ctx.schemaQualifiedRoutineName).toString();
         var throwIfNotExists = ctx.IF() == null && ctx.EXISTS() == null;
         return ProceduralPlan.of(metadataOperationsFactory.getDropTemporaryFunctionConstantAction(throwIfNotExists, functionName));
+    }
+
+    @Override
+    public ProceduralPlan visitSetLocalVariable(@Nonnull RelationalParser.SetLocalVariableContext ctx) {
+        final var varName = getDelegate().normalizeString(ctx.varName.getText());
+        final var value = evalConstant(ctx.varValue);
+        return ProceduralPlan.of(metadataOperationsFactory.getSetLocalVariableConstantAction(varName, value));
+    }
+
+    @Nullable
+    private Object evalConstant(@Nonnull RelationalParser.ConstantContext ctx) {
+        if (ctx instanceof RelationalParser.StringConstantContext) {
+            return SemanticAnalyzer.normalizeString(ctx.getText(), false);
+        } else if (ctx instanceof RelationalParser.DecimalConstantContext) {
+            return ParseHelpers.parseDecimal(ctx.getText());
+        } else if (ctx instanceof RelationalParser.NegativeDecimalConstantContext) {
+            return ParseHelpers.parseDecimal(ctx.getText());
+        } else if (ctx instanceof RelationalParser.BooleanConstantContext) {
+            return ((RelationalParser.BooleanConstantContext) ctx).booleanLiteral().FALSE() == null;
+        } else if (ctx instanceof RelationalParser.NullConstantContext) {
+            return null;
+        } else {
+            Assert.failUnchecked(ErrorCode.UNSUPPORTED_QUERY,
+                    "Unsupported constant type for SET LOCAL: " + ctx.getText());
+            return null; // unreachable
+        }
     }
 
     @Override

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DdlVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DdlVisitor.java
@@ -524,13 +524,15 @@ public final class DdlVisitor extends DelegatingVisitor<BaseVisitor> {
             // delay the compilation of table-valued temporary functions for later
             return builder
                     .withUserDefinedFunctionProvider(ignore -> {
-                        // Use SELECT-time PreparedParams (set by resolveTableValuedFunction via thread-local)
-                        // so that local variable refs inside the body resolve to their actual types,
-                        // not to the empty CREATE-time params.
-                        final var selectTimeParams = BaseVisitor.TVFUNCTION_COMPILATION_PARAMS.get();
-                        if (selectTimeParams != null) {
+                        // Merge SELECT-time local variable bindings (set by resolveTableValuedFunction via
+                        // thread-local) into the CREATE-time PreparedParams so that @var refs inside the
+                        // body resolve to their current values. We add (not replace) so that ?param
+                        // bindings already present from the CREATE-time context are preserved.
+                        final var localVarsMap = BaseVisitor.TVFUNCTION_COMPILATION_PARAMS.get();
+                        if (localVarsMap != null && !localVarsMap.isEmpty()) {
                             final var prev = getDelegate().getPlanGenerationContext().getPreparedParams();
-                            getDelegate().getPlanGenerationContext().setPreparedParams(selectTimeParams);
+                            final var merged = PreparedParams.withAdditionalNamed(prev, localVarsMap);
+                            getDelegate().getPlanGenerationContext().setPreparedParams(merged);
                             try {
                                 return visitSqlInvokedFunction(functionSpecCtx, bodyCtx, isTemporary);
                             } finally {

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DdlVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DdlVisitor.java
@@ -523,12 +523,10 @@ public final class DdlVisitor extends DelegatingVisitor<BaseVisitor> {
         if (!isScalar && isTemporary) {
             // delay the compilation of table-valued temporary functions for later
             return builder
-                    .withUserDefinedFunctionProvider(ignore -> {
-                        // Merge SELECT-time local variable bindings (set by resolveTableValuedFunction via
-                        // thread-local) into the CREATE-time PreparedParams so that @var refs inside the
-                        // body resolve to their current values. We add (not replace) so that ?param
-                        // bindings already present from the CREATE-time context are preserved.
-                        final var localVarsMap = BaseVisitor.TVFUNCTION_COMPILATION_PARAMS.get();
+                    .withUserDefinedFunctionProvider((ignore, localVarsMap) -> {
+                        // Merge SELECT-time local variable bindings into the CREATE-time PreparedParams so that
+                        // @var refs inside the body resolve to their current values. We add (not replace) so
+                        // that ?param bindings already present from the CREATE-time context are preserved.
                         if (localVarsMap != null && !localVarsMap.isEmpty()) {
                             final var prev = getDelegate().getPlanGenerationContext().getPreparedParams();
                             final var merged = PreparedParams.withAdditionalNamed(prev, localVarsMap);
@@ -545,7 +543,7 @@ public final class DdlVisitor extends DelegatingVisitor<BaseVisitor> {
                     .build();
         } else {
             final var userDefinedFunction = visitSqlInvokedFunction(functionSpecCtx, bodyCtx, isTemporary);
-            builder.withUserDefinedFunctionProvider(ignore -> userDefinedFunction);
+            builder.withUserDefinedFunctionProvider((ignore, localVars) -> userDefinedFunction);
             if (isScalar) {
                 return builder.withSerializableFunction(userDefinedFunction).build();
             } else {
@@ -699,12 +697,7 @@ public final class DdlVisitor extends DelegatingVisitor<BaseVisitor> {
             parametersCorrelation.ifPresent(quantifier -> fragment.addOperator(LogicalOperator.newUnnamedOperator(
                     Expressions.fromQuantifier(quantifier), quantifier)));
             if (isTemporary) {
-                getDelegate().setDeferMissingLocalVars(true);
-                try {
-                    body = Assert.castUnchecked(visit(bodyCtx), LogicalOperator.class);
-                } finally {
-                    getDelegate().setDeferMissingLocalVars(false);
-                }
+                body = Assert.castUnchecked(visit(bodyCtx), LogicalOperator.class);
             } else {
                 body = getDelegate().getPlanGenerationContext().withDisabledLiteralProcessing(() ->
                         Assert.castUnchecked(visit(bodyCtx), LogicalOperator.class));

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DelegatingVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DelegatingVisitor.java
@@ -300,6 +300,21 @@ public class DelegatingVisitor<D extends TypedVisitor> implements TypedVisitor {
     }
 
     @Override
+    public ProceduralPlan visitSetLocalVariable(final RelationalParser.SetLocalVariableContext ctx) {
+        return getDelegate().visitSetLocalVariable(ctx);
+    }
+
+    @Override
+    public Object visitVariableRef(final RelationalParser.VariableRefContext ctx) {
+        return getDelegate().visitVariableRef(ctx);
+    }
+
+    @Override
+    public Object visitVariableRefAtom(final RelationalParser.VariableRefAtomContext ctx) {
+        return getDelegate().visitVariableRefAtom(ctx);
+    }
+
+    @Override
     public Object visitViewDefinition(final RelationalParser.ViewDefinitionContext ctx) {
         return getDelegate().visitViewDefinition(ctx);
     }

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DelegatingVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DelegatingVisitor.java
@@ -300,6 +300,16 @@ public class DelegatingVisitor<D extends TypedVisitor> implements TypedVisitor {
     }
 
     @Override
+    public Object visitViewDefinition(final RelationalParser.ViewDefinitionContext ctx) {
+        return getDelegate().visitViewDefinition(ctx);
+    }
+
+    @Override
+    public CompiledSqlFunction visitTempSqlInvokedFunction(final RelationalParser.TempSqlInvokedFunctionContext ctx) {
+        return getDelegate().visitTempSqlInvokedFunction(ctx);
+    }
+
+    @Override
     public ProceduralPlan visitSetLocalVariable(final RelationalParser.SetLocalVariableContext ctx) {
         return getDelegate().visitSetLocalVariable(ctx);
     }
@@ -312,16 +322,6 @@ public class DelegatingVisitor<D extends TypedVisitor> implements TypedVisitor {
     @Override
     public Object visitVariableRefAtom(final RelationalParser.VariableRefAtomContext ctx) {
         return getDelegate().visitVariableRefAtom(ctx);
-    }
-
-    @Override
-    public Object visitViewDefinition(final RelationalParser.ViewDefinitionContext ctx) {
-        return getDelegate().visitViewDefinition(ctx);
-    }
-
-    @Override
-    public CompiledSqlFunction visitTempSqlInvokedFunction(final RelationalParser.TempSqlInvokedFunctionContext ctx) {
-        return getDelegate().visitTempSqlInvokedFunction(ctx);
     }
 
     @Override

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DelegatingVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DelegatingVisitor.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.relational.recordlayer.query.visitors;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.relational.util.ExcludeFromJacocoGeneratedReport;
 import com.apple.foundationdb.record.query.plan.cascades.UserDefinedFunction;
 import com.apple.foundationdb.record.query.plan.cascades.predicates.CompatibleTypeEvolutionPredicate;
 import com.apple.foundationdb.record.util.pair.NonnullPair;
@@ -310,16 +311,19 @@ public class DelegatingVisitor<D extends TypedVisitor> implements TypedVisitor {
     }
 
     @Override
+    @ExcludeFromJacocoGeneratedReport
     public ProceduralPlan visitSetLocalVariable(final RelationalParser.SetLocalVariableContext ctx) {
         return getDelegate().visitSetLocalVariable(ctx);
     }
 
     @Override
+    @ExcludeFromJacocoGeneratedReport
     public Object visitVariableRef(final RelationalParser.VariableRefContext ctx) {
         return getDelegate().visitVariableRef(ctx);
     }
 
     @Override
+    @ExcludeFromJacocoGeneratedReport
     public Object visitVariableRefAtom(final RelationalParser.VariableRefAtomContext ctx) {
         return getDelegate().visitVariableRefAtom(ctx);
     }

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DelegatingVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DelegatingVisitor.java
@@ -857,12 +857,6 @@ public class DelegatingVisitor<D extends TypedVisitor> implements TypedVisitor {
 
     @Nonnull
     @Override
-    public Object visitSetVariable(@Nonnull RelationalParser.SetVariableContext ctx) {
-        return getDelegate().visitSetVariable(ctx);
-    }
-
-    @Nonnull
-    @Override
     public Object visitSetCharset(@Nonnull RelationalParser.SetCharsetContext ctx) {
         return getDelegate().visitSetCharset(ctx);
     }
@@ -889,12 +883,6 @@ public class DelegatingVisitor<D extends TypedVisitor> implements TypedVisitor {
     @Override
     public Object visitSetNewValueInsideTrigger(@Nonnull RelationalParser.SetNewValueInsideTriggerContext ctx) {
         return getDelegate().visitSetNewValueInsideTrigger(ctx);
-    }
-
-    @Nonnull
-    @Override
-    public Object visitVariableClause(@Nonnull RelationalParser.VariableClauseContext ctx) {
-        return getDelegate().visitVariableClause(ctx);
     }
 
     @Nonnull

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DelegatingVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DelegatingVisitor.java
@@ -21,7 +21,6 @@
 package com.apple.foundationdb.relational.recordlayer.query.visitors;
 
 import com.apple.foundationdb.annotation.API;
-import com.apple.foundationdb.relational.util.ExcludeFromJacocoGeneratedReport;
 import com.apple.foundationdb.record.query.plan.cascades.UserDefinedFunction;
 import com.apple.foundationdb.record.query.plan.cascades.predicates.CompatibleTypeEvolutionPredicate;
 import com.apple.foundationdb.record.util.pair.NonnullPair;
@@ -311,19 +310,16 @@ public class DelegatingVisitor<D extends TypedVisitor> implements TypedVisitor {
     }
 
     @Override
-    @ExcludeFromJacocoGeneratedReport
     public ProceduralPlan visitSetLocalVariable(final RelationalParser.SetLocalVariableContext ctx) {
         return getDelegate().visitSetLocalVariable(ctx);
     }
 
     @Override
-    @ExcludeFromJacocoGeneratedReport
     public Object visitVariableRef(final RelationalParser.VariableRefContext ctx) {
         return getDelegate().visitVariableRef(ctx);
     }
 
     @Override
-    @ExcludeFromJacocoGeneratedReport
     public Object visitVariableRefAtom(final RelationalParser.VariableRefAtomContext ctx) {
         return getDelegate().visitVariableRefAtom(ctx);
     }

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/ExpressionVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/ExpressionVisitor.java
@@ -478,6 +478,23 @@ public final class ExpressionVisitor extends DelegatingVisitor<BaseVisitor> {
 
     @Nonnull
     @Override
+    public Expression visitVariableRefAtom(@Nonnull RelationalParser.VariableRefAtomContext ctx) {
+        return visitVariableRef(ctx.variableRef());
+    }
+
+    @Nonnull
+    @Override
+    public Expression visitVariableRef(@Nonnull RelationalParser.VariableRefContext ctx) {
+        final var rawName = ctx.LOCAL_ID().getText().substring(1); // strip leading '@'
+        final var varName = getDelegate().normalizeString(rawName);
+        final var tokenIndex = ctx.LOCAL_ID().getSymbol().getTokenIndex();
+        final var value = getDelegate().getPlanGenerationContext().processNamedPreparedParam(varName, tokenIndex);
+        final var type = DataTypeUtils.toRelationalType(value.getResultType());
+        return Expression.ofUnnamed(type, value);
+    }
+
+    @Nonnull
+    @Override
     public Expression visitPreparedStatementParameter(@Nonnull RelationalParser.PreparedStatementParameterContext ctx) {
         final var tokenIndex = ctx.getStart().getTokenIndex();
         final Value value;

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/ExpressionVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/ExpressionVisitor.java
@@ -488,12 +488,7 @@ public final class ExpressionVisitor extends DelegatingVisitor<BaseVisitor> {
         final var rawName = ctx.LOCAL_ID().getText().substring(1); // strip leading '@'
         final var varName = getDelegate().normalizeString(rawName);
         final var tokenIndex = ctx.LOCAL_ID().getSymbol().getTokenIndex();
-        final Value value;
-        if (getDelegate().isDeferMissingLocalVars()) {
-            value = getDelegate().getPlanGenerationContext().processNamedPreparedParamDeferred(varName, tokenIndex);
-        } else {
-            value = getDelegate().getPlanGenerationContext().processNamedPreparedParam(varName, tokenIndex);
-        }
+        final Value value = getDelegate().getPlanGenerationContext().processNamedPreparedParam(varName, tokenIndex);
         final var type = DataTypeUtils.toRelationalType(value.getResultType());
         return Expression.ofUnnamed(type, value);
     }

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/ExpressionVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/ExpressionVisitor.java
@@ -488,7 +488,12 @@ public final class ExpressionVisitor extends DelegatingVisitor<BaseVisitor> {
         final var rawName = ctx.LOCAL_ID().getText().substring(1); // strip leading '@'
         final var varName = getDelegate().normalizeString(rawName);
         final var tokenIndex = ctx.LOCAL_ID().getSymbol().getTokenIndex();
-        final var value = getDelegate().getPlanGenerationContext().processNamedPreparedParam(varName, tokenIndex);
+        final Value value;
+        if (getDelegate().isDeferMissingLocalVars()) {
+            value = getDelegate().getPlanGenerationContext().processNamedPreparedParamDeferred(varName, tokenIndex);
+        } else {
+            value = getDelegate().getPlanGenerationContext().processNamedPreparedParam(varName, tokenIndex);
+        }
         final var type = DataTypeUtils.toRelationalType(value.getResultType());
         return Expression.ofUnnamed(type, value);
     }

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/ExpressionVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/ExpressionVisitor.java
@@ -488,12 +488,7 @@ public final class ExpressionVisitor extends DelegatingVisitor<BaseVisitor> {
         final var rawName = ctx.LOCAL_ID().getText().substring(1); // strip leading '@'
         final var varName = getDelegate().normalizeString(rawName);
         final var tokenIndex = ctx.LOCAL_ID().getSymbol().getTokenIndex();
-        final Value value;
-        if (getDelegate().isDeferMissingLocalVars()) {
-            value = getDelegate().getPlanGenerationContext().processNamedPreparedParamDeferred(varName, tokenIndex);
-        } else {
-            value = getDelegate().getPlanGenerationContext().processNamedPreparedParam(varName, tokenIndex);
-        }
+        final Value value = getDelegate().getPlanGenerationContext().processLocalVariable(varName, tokenIndex);
         final var type = DataTypeUtils.toRelationalType(value.getResultType());
         return Expression.ofUnnamed(type, value);
     }

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/TypedVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/TypedVisitor.java
@@ -496,10 +496,6 @@ public interface TypedVisitor extends RelationalParserVisitor<Object> {
 
     @Nonnull
     @Override
-    Object visitSetVariable(@Nonnull RelationalParser.SetVariableContext ctx);
-
-    @Nonnull
-    @Override
     Object visitSetCharset(@Nonnull RelationalParser.SetCharsetContext ctx);
 
     @Nonnull
@@ -517,10 +513,6 @@ public interface TypedVisitor extends RelationalParserVisitor<Object> {
     @Nonnull
     @Override
     Object visitSetNewValueInsideTrigger(@Nonnull RelationalParser.SetNewValueInsideTriggerContext ctx);
-
-    @Nonnull
-    @Override
-    Object visitVariableClause(@Nonnull RelationalParser.VariableClauseContext ctx);
 
     @Nonnull
     @Override

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/TypedVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/TypedVisitor.java
@@ -200,6 +200,15 @@ public interface TypedVisitor extends RelationalParserVisitor<Object> {
     ProceduralPlan visitDropTempFunction(RelationalParser.DropTempFunctionContext ctx);
 
     @Override
+    ProceduralPlan visitSetLocalVariable(RelationalParser.SetLocalVariableContext ctx);
+
+    @Override
+    Object visitVariableRef(RelationalParser.VariableRefContext ctx);
+
+    @Override
+    Object visitVariableRefAtom(RelationalParser.VariableRefAtomContext ctx);
+
+    @Override
     CompiledSqlFunction visitTempSqlInvokedFunction(RelationalParser.TempSqlInvokedFunctionContext ctx);
 
     @Override

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/TransactionBoundDatabaseTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/TransactionBoundDatabaseTest.java
@@ -536,6 +536,29 @@ public class TransactionBoundDatabaseTest {
         }
     }
 
+    @Test
+    void localVariableDelegationInRecordStoreAndRecordContextTransaction() throws RelationalException, SQLException {
+        final var embeddedConnection = connRule.getUnderlyingEmbeddedConnection();
+        try (FDBRecordContext context = createNewContext(embeddedConnection)) {
+            try (Transaction transaction = createRecordStoreAndRecordContextTransaction(embeddedConnection, context)) {
+                Assertions.assertThat(transaction.getLocalVariables()).isEmpty();
+
+                transaction.setLocalVariable("foo", "bar");
+                transaction.setLocalVariable("count", 42L);
+
+                final var vars = transaction.getLocalVariables();
+                Assertions.assertThat(vars).containsEntry("foo", "bar");
+                Assertions.assertThat(vars).containsEntry("count", 42L);
+                Assertions.assertThat(vars).hasSize(2);
+
+                transaction.setLocalVariable("foo", "updated");
+                Assertions.assertThat(transaction.getLocalVariables()).containsEntry("foo", "updated");
+
+                context.commit();
+            }
+        }
+    }
+
     private Transaction createRecordStoreAndRecordContextTransaction(@Nonnull final EmbeddedRelationalConnection embeddedConnection,
                                                                      @Nonnull final FDBRecordContext context) throws SQLException, RelationalException {
         final FDBRecordStore store = getStore(embeddedConnection);

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/TransactionBoundDatabaseTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/TransactionBoundDatabaseTest.java
@@ -121,6 +121,27 @@ public class TransactionBoundDatabaseTest {
     }
 
     @Test
+    void setLocalVariableViaTransactionBoundDatabase() throws RelationalException, SQLException {
+        final var embeddedConnection = connRule.getUnderlyingEmbeddedConnection();
+        withTransactionBoundConnection(embeddedConnection, Options.NONE, (KeySpace) null, conn -> {
+            try (RelationalStatement stmt = conn.createStatement()) {
+                stmt.executeInsert("RESTAURANT", EmbeddedRelationalStruct.newBuilder()
+                        .addLong("REST_NO", 77)
+                        .addString("NAME", "transbound-place")
+                        .build());
+            }
+            try (RelationalStatement stmt = conn.createStatement()) {
+                stmt.execute("SET LOCAL target_no = 77");
+                try (RelationalResultSet rs = stmt.executeQuery("SELECT NAME FROM RESTAURANT WHERE REST_NO = @target_no")) {
+                    Assertions.assertThat(rs.next()).isTrue();
+                    Assertions.assertThat(rs.getString("NAME")).isEqualTo("transbound-place");
+                    Assertions.assertThat(rs.next()).isFalse();
+                }
+            }
+        });
+    }
+
+    @Test
     void selectWithIncludedPlanCache() throws RelationalException, SQLException {
         final var embeddedConnection = connRule.getUnderlyingEmbeddedConnection();
 

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/ddl/MetadataOperationsFactoryTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/ddl/MetadataOperationsFactoryTests.java
@@ -84,7 +84,7 @@ public class MetadataOperationsFactoryTests {
     void createTemporaryFunctionOperationDoesNotChangeInvokedRoutine() throws RelationalException {
         final var mockedInvokedRoutine = Mockito.mock(RecordLayerInvokedRoutine.class);
         final var mockedUdf = Mockito.mock(UserDefinedFunction.class);
-        when(mockedInvokedRoutine.getUserDefinedFunctionProvider()).thenReturn((ignore) -> mockedUdf);
+        when(mockedInvokedRoutine.getUserDefinedFunctionProvider()).thenReturn((ignore, localVars) -> mockedUdf);
         when(mockedInvokedRoutine.getName()).thenReturn("routine1");
         final var schemaTemplate = RecordLayerSchemaTemplate.newBuilder()
                 .setName("TestSchemaTemplate")

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/metadata/SchemaTemplateSerDeTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/metadata/SchemaTemplateSerDeTests.java
@@ -71,6 +71,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -583,7 +584,7 @@ public class SchemaTemplateSerDeTests {
                 .setName(funcName)
                 .setDescription(funcDescription)
                 .setTemporary(true)
-                .withUserDefinedFunctionProvider(ignored -> new CompiledFunctionStub())
+                .withUserDefinedFunctionProvider((ignored, localVars) -> new CompiledFunctionStub())
                 .withSerializableFunction(new RawSqlFunction(funcName, funcDescription))
                 .build());
 
@@ -627,7 +628,7 @@ public class SchemaTemplateSerDeTests {
             schemaTemplateBuilder.addInvokedRoutine(RecordLayerInvokedRoutine.newBuilder()
                     .setName(functionName)
                     .setDescription(functionDescription)
-                    .withUserDefinedFunctionProvider(igored -> new CompiledFunctionStub())
+                    .withUserDefinedFunctionProvider((igored, localVars) -> new CompiledFunctionStub())
                     .withSerializableFunction(new RawSqlFunction(functionName, functionDescription))
                     .build());
         }
@@ -1035,11 +1036,11 @@ public class SchemaTemplateSerDeTests {
             final List<RecordLayerInvokedRoutine> invokedRoutines = schemaBuilder.getInvokedRoutines();
             for (RecordLayerInvokedRoutine routine : invokedRoutines) {
                 final String name = routine.getName();
-                final Function<Boolean, UserDefinedFunction> provider = routine.getUserDefinedFunctionProvider();
+                final BiFunction<Boolean, Map<String, Object>, UserDefinedFunction> provider = routine.getUserDefinedFunctionProvider();
                 final RecordLayerInvokedRoutine.Builder routineBuilder = routine.toBuilder();
-                routineBuilder.withUserDefinedFunctionProvider(isCaseSensitive -> {
+                routineBuilder.withUserDefinedFunctionProvider((isCaseSensitive, localVars) -> {
                     invocationsCount.merge(name, 1, Integer::sum);
-                    return provider.apply(isCaseSensitive);
+                    return provider.apply(isCaseSensitive, localVars);
                 });
                 schemaBuilder.removeInvokedRoutine(name);
                 schemaBuilder.addInvokedRoutine(routineBuilder.build());

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/metadata/SchemaTemplateSerDeTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/metadata/SchemaTemplateSerDeTests.java
@@ -72,7 +72,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/AstNormalizerTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/AstNormalizerTests.java
@@ -408,7 +408,7 @@ public class AstNormalizerTests {
                         .setDescription(functionDdl)
                         .setNormalizedDescription(canonicalFunctionDdl)
                         // invoking the compiled routine should only happen during plan generation.
-                        .withUserDefinedFunctionProvider(ignored -> new CompiledSqlFunction("", List.of(), List.of(),
+                        .withUserDefinedFunctionProvider((ignored, localVars) -> new CompiledSqlFunction("", List.of(), List.of(),
                                 List.of(), Optional.empty(), null, Literals.empty()) {
                             @Nonnull
                             @Override

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/DelegatingVisitorTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/DelegatingVisitorTest.java
@@ -583,7 +583,7 @@ public class DelegatingVisitorTest {
     void visitSetLocalVariableTest() {
         final TypedVisitor baseVisitor = Mockito.mock(TypedVisitor.class);
         final DelegatingVisitor<TypedVisitor> delegating = new DelegatingVisitor<>(baseVisitor);
-        final RelationalParser.SetLocalVariableContext context = new RelationalParser.SetLocalVariableContext(null, -1);
+        final RelationalParser.SetLocalVariableContext context = new RelationalParser.SetLocalVariableContext(new RelationalParser.SetStatementContext(null, -1));
         final ProceduralPlan plan = ProceduralPlan.of(Mockito.mock(ConstantAction.class));
         Mockito.when(baseVisitor.visitSetLocalVariable(context)).thenReturn(plan);
         final ProceduralPlan result = delegating.visitSetLocalVariable(context);

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/DelegatingVisitorTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/DelegatingVisitorTest.java
@@ -35,6 +35,7 @@ import com.apple.foundationdb.relational.recordlayer.metadata.RecordLayerTable;
 import com.apple.foundationdb.relational.recordlayer.query.visitors.BaseVisitor;
 import com.apple.foundationdb.relational.recordlayer.query.visitors.DelegatingVisitor;
 import com.apple.foundationdb.relational.recordlayer.query.visitors.TypedVisitor;
+import com.apple.foundationdb.relational.api.ddl.ConstantAction;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.assertj.core.api.Assertions;
@@ -579,13 +580,36 @@ public class DelegatingVisitorTest {
     }
 
     @Test
-    void visitIncarnationOption() {
+    void visitSetLocalVariableTest() {
         final TypedVisitor baseVisitor = Mockito.mock(TypedVisitor.class);
         final DelegatingVisitor<TypedVisitor> delegating = new DelegatingVisitor<>(baseVisitor);
-        final RelationalParser.IncarnationOptionContext context = new RelationalParser.IncarnationOptionContext(null, -1);
+        final RelationalParser.SetLocalVariableContext context = new RelationalParser.SetLocalVariableContext(null, -1);
+        final ProceduralPlan plan = ProceduralPlan.of(Mockito.mock(ConstantAction.class));
+        Mockito.when(baseVisitor.visitSetLocalVariable(context)).thenReturn(plan);
+        final ProceduralPlan result = delegating.visitSetLocalVariable(context);
+        Assertions.assertThat(result).isSameAs(plan);
+    }
+
+    @Test
+    void visitVariableRefTest() {
+        final TypedVisitor baseVisitor = Mockito.mock(TypedVisitor.class);
+        final DelegatingVisitor<TypedVisitor> delegating = new DelegatingVisitor<>(baseVisitor);
+        final RelationalParser.VariableRefContext context = new RelationalParser.VariableRefContext(null, -1);
         final Object mockResult = new Object();
-        Mockito.when(baseVisitor.visitIncarnationOption(context)).thenReturn(mockResult);
-        final Object result = delegating.visitIncarnationOption(context);
+        Mockito.when(baseVisitor.visitVariableRef(context)).thenReturn(mockResult);
+        final Object result = delegating.visitVariableRef(context);
+        Assertions.assertThat(result).isSameAs(mockResult);
+    }
+
+    @Test
+    void visitVariableRefAtomTest() {
+        final TypedVisitor baseVisitor = Mockito.mock(TypedVisitor.class);
+        final DelegatingVisitor<TypedVisitor> delegating = new DelegatingVisitor<>(baseVisitor);
+        final RelationalParser.VariableRefAtomContext context = new RelationalParser.VariableRefAtomContext(new RelationalParser.ExpressionAtomContext());
+        final Object mockResult = new Object();
+        Mockito.when(baseVisitor.visitVariableRefAtom(context)).thenReturn(mockResult);
+        final Object result = delegating.visitVariableRefAtom(context);
         Assertions.assertThat(result).isSameAs(mockResult);
     }
 }
+

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/LocalVariableTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/LocalVariableTests.java
@@ -1,0 +1,470 @@
+/*
+ * LocalVariableTests.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.relational.recordlayer.query;
+
+import com.apple.foundationdb.relational.api.Options;
+import com.apple.foundationdb.relational.api.exceptions.ErrorCode;
+import com.apple.foundationdb.relational.recordlayer.EmbeddedRelationalConnection;
+import com.apple.foundationdb.relational.recordlayer.EmbeddedRelationalExtension;
+import com.apple.foundationdb.relational.recordlayer.LogAppenderRule;
+import com.apple.foundationdb.relational.recordlayer.Utils;
+import com.apple.foundationdb.relational.utils.Ddl;
+import com.apple.foundationdb.relational.utils.RelationalAssertions;
+import com.apple.foundationdb.relational.utils.ResultSetAssert;
+import org.apache.logging.log4j.Level;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.net.URI;
+import java.sql.SQLException;
+
+/**
+ * Tests for transaction-scoped local variables (SET LOCAL / @variable).
+ */
+public class LocalVariableTests {
+
+    @RegisterExtension
+    @Order(0)
+    public final EmbeddedRelationalExtension relationalExtension = new EmbeddedRelationalExtension();
+
+    public LocalVariableTests() {
+        Utils.enableCascadesDebugger();
+    }
+
+    @Test
+    void setLocalStringVariableAndRead() throws Exception {
+        final String schemaTemplate = "create table t1(pk bigint, name string, primary key(pk))";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/LV")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            try (var stmt = ddl.setSchemaAndGetConnection().createStatement()) {
+                stmt.executeUpdate("insert into t1 values (1, 'alice'), (2, 'bob'), (3, 'carol')");
+            }
+            final var conn = ddl.getConnection();
+            conn.setAutoCommit(false);
+            try (var stmt = conn.createStatement()) {
+                stmt.execute("set local myname = 'bob'");
+                try (var rs = stmt.executeQuery("select pk, name from t1 where name = @myname")) {
+                    ResultSetAssert.assertThat(rs).hasNextRow().isRowExactly(2L, "bob").hasNoNextRow();
+                }
+            }
+            conn.rollback();
+        }
+    }
+
+    @Test
+    void setLocalLongVariableAndFilter() throws Exception {
+        final String schemaTemplate = "create table t2(pk bigint, val bigint, primary key(pk))";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/LV")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            try (var stmt = ddl.setSchemaAndGetConnection().createStatement()) {
+                stmt.executeUpdate("insert into t2 values (1, 10), (2, 20), (3, 30), (4, 40)");
+            }
+            final var conn = ddl.getConnection();
+            conn.setAutoCommit(false);
+            try (var stmt = conn.createStatement()) {
+                stmt.execute("set local target = 20");
+                try (var rs = stmt.executeQuery("select pk from t2 where val = @target")) {
+                    ResultSetAssert.assertThat(rs).hasNextRow().isRowExactly(2L).hasNoNextRow();
+                }
+            }
+            conn.rollback();
+        }
+    }
+
+    @Test
+    void variableNotVisibleInNextTransaction() throws Exception {
+        final String schemaTemplate = "create table t3(pk bigint, val bigint, primary key(pk))";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/LV")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            final var conn = ddl.setSchemaAndGetConnection();
+            conn.setAutoCommit(false);
+
+            // Set variable in first transaction
+            try (var stmt = conn.createStatement()) {
+                stmt.execute("set local x = 42");
+            }
+            conn.commit();
+
+            // New transaction — variable must not be visible
+            conn.unwrap(EmbeddedRelationalConnection.class).createNewTransaction();
+            conn.setAutoCommit(false);
+            try (var stmt = conn.createStatement()) {
+                RelationalAssertions.assertThrowsSqlException(
+                        () -> stmt.executeQuery("select @x from t3"))
+                        .hasErrorCode(ErrorCode.UNDEFINED_PARAMETER);
+            }
+            conn.rollback();
+        }
+    }
+
+    @Test
+    void undefinedVariableThrows() throws Exception {
+        final String schemaTemplate = "create table t4(pk bigint, primary key(pk))";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/LV")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            final var conn = ddl.setSchemaAndGetConnection();
+            conn.setAutoCommit(false);
+            try (var stmt = conn.createStatement()) {
+                RelationalAssertions.assertThrowsSqlException(
+                        () -> stmt.executeQuery("select @undefined from t4"))
+                        .hasErrorCode(ErrorCode.UNDEFINED_PARAMETER);
+            }
+            conn.rollback();
+        }
+    }
+
+    @Test
+    void planCacheReusedForDifferentValues() throws Exception {
+        final String schemaTemplate = "create table t5(pk bigint, val bigint, primary key(pk))";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/LV")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            try (var stmt = ddl.setSchemaAndGetConnection().createStatement()) {
+                stmt.executeUpdate("insert into t5 values (1, 100), (2, 200), (3, 300)");
+            }
+            final var conn = ddl.getConnection();
+
+            // First value
+            conn.setAutoCommit(false);
+            try (var stmt = conn.createStatement()) {
+                stmt.execute("set local v = 100");
+                try (var rs = stmt.executeQuery("select pk from t5 where val = @v")) {
+                    ResultSetAssert.assertThat(rs).hasNextRow().isRowExactly(1L).hasNoNextRow();
+                }
+            }
+            conn.commit();
+
+            // Second value in a new transaction — same plan should be reused
+            conn.unwrap(EmbeddedRelationalConnection.class).createNewTransaction();
+            conn.setAutoCommit(false);
+            try (var stmt = conn.createStatement()) {
+                stmt.execute("set local v = 200");
+                try (var rs = stmt.executeQuery("select pk from t5 where val = @v")) {
+                    ResultSetAssert.assertThat(rs).hasNextRow().isRowExactly(2L).hasNoNextRow();
+                }
+            }
+            conn.rollback();
+        }
+    }
+
+    @Test
+    void setLocalBooleanVariable() throws Exception {
+        final String schemaTemplate = "create table t6(pk bigint, active boolean, primary key(pk))";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/LV")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            try (var stmt = ddl.setSchemaAndGetConnection().createStatement()) {
+                stmt.executeUpdate("insert into t6 values (1, true), (2, false), (3, true)");
+            }
+            final var conn = ddl.getConnection();
+            conn.setAutoCommit(false);
+            try (var stmt = conn.createStatement()) {
+                stmt.execute("set local flag = true");
+                try (var rs = stmt.executeQuery("select pk from t6 where active = @flag")) {
+                    ResultSetAssert.assertThat(rs)
+                            .hasNextRow().isRowExactly(1L)
+                            .hasNextRow().isRowExactly(3L)
+                            .hasNoNextRow();
+                }
+            }
+            conn.rollback();
+        }
+    }
+
+    @Test
+    void variableOverwriteIsVisible() throws Exception {
+        final String schemaTemplate = "create table t7(pk bigint, val bigint, primary key(pk))";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/LV")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            try (var stmt = ddl.setSchemaAndGetConnection().createStatement()) {
+                stmt.executeUpdate("insert into t7 values (1, 10), (2, 20), (3, 30)");
+            }
+            final var conn = ddl.getConnection();
+            conn.setAutoCommit(false);
+            try (var stmt = conn.createStatement()) {
+                stmt.execute("set local x = 10");
+                stmt.execute("set local x = 20");
+                try (var rs = stmt.executeQuery("select pk from t7 where val = @x")) {
+                    ResultSetAssert.assertThat(rs).hasNextRow().isRowExactly(2L).hasNoNextRow();
+                }
+            }
+            conn.rollback();
+        }
+    }
+
+    @Test
+    void caseSensitiveVariableNames() throws Exception {
+        final String schemaTemplate = "create table t8(pk bigint, val bigint, primary key(pk))";
+        try (var ddl = Ddl.builder()
+                .database(URI.create("/TEST/LVCS"))
+                .relationalExtension(relationalExtension)
+                .withOption(Options.Name.CASE_SENSITIVE_IDENTIFIERS, true)
+                .schemaTemplate(schemaTemplate)
+                .build()) {
+            try (var stmt = ddl.setSchemaAndGetConnection().createStatement()) {
+                stmt.executeUpdate("insert into t8 values (1, 10), (2, 20)");
+            }
+            final var conn = ddl.getConnection();
+            conn.setAutoCommit(false);
+            try (var stmt = conn.createStatement()) {
+                // Quoted variable name "myVar" stores the key with case preserved
+                stmt.execute("set local \"myVar\" = 10");
+                // @"myVar" resolves to 'myVar' — same key → found
+                try (var rs = stmt.executeQuery("select pk from t8 where val = @\"myVar\"")) {
+                    ResultSetAssert.assertThat(rs).hasNextRow().isRowExactly(1L).hasNoNextRow();
+                }
+                // @myvar is an unquoted identifier; with caseSensitive=true, it preserves
+                // the literal case from the input ('myvar' != 'myVar') → undefined
+                RelationalAssertions.assertThrowsSqlException(
+                        () -> stmt.executeQuery("select pk from t8 where val = @myvar"))
+                        .hasErrorCode(ErrorCode.UNDEFINED_PARAMETER);
+            }
+            conn.rollback();
+        }
+    }
+
+    @Test
+    void variableNotVisibleAfterAutoCommit() throws Exception {
+        final String schemaTemplate = "create table t9(pk bigint, val bigint, primary key(pk))";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/LV")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            final var conn = ddl.setSchemaAndGetConnection();
+            // autoCommit=true: the SET LOCAL statement auto-commits its transaction; the
+            // variable disappears before the next statement runs in its own new transaction.
+            conn.setAutoCommit(true);
+            try (var stmt = conn.createStatement()) {
+                stmt.execute("set local x = 99");
+            }
+            try (var stmt = conn.createStatement()) {
+                RelationalAssertions.assertThrowsSqlException(
+                        () -> stmt.executeQuery("select pk from t9 where pk = @x"))
+                        .hasErrorCode(ErrorCode.UNDEFINED_PARAMETER);
+            }
+        }
+    }
+
+    @Test
+    void variableAndPreparedParamCoexist() throws Exception {
+        final String schemaTemplate = "create table t10(pk bigint, val bigint, primary key(pk))";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/LV")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            try (var stmt = ddl.setSchemaAndGetConnection().createStatement()) {
+                stmt.executeUpdate("insert into t10 values (1, 100), (2, 100), (3, 200)");
+            }
+            final var conn = ddl.getConnection();
+            conn.setAutoCommit(false);
+            try (var stmt = conn.createStatement()) {
+                stmt.execute("set local valfilter = 100");
+            }
+            // Mix a local variable (@valfilter) with a positional prepared parameter (?)
+            try (var ps = conn.prepareStatement("select pk from t10 where val = @valfilter and pk = ?")) {
+                ps.setLong(1, 1L);
+                try (var rs = ps.executeQuery()) {
+                    ResultSetAssert.assertThat(rs).hasNextRow().isRowExactly(1L).hasNoNextRow();
+                }
+            }
+            conn.rollback();
+        }
+    }
+
+    @Test
+    void negativeValueVariable() throws Exception {
+        final String schemaTemplate = "create table t11(pk bigint, delta bigint, primary key(pk))";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/LV")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            try (var stmt = ddl.setSchemaAndGetConnection().createStatement()) {
+                stmt.executeUpdate("insert into t11 values (1, -10), (2, 5), (3, -10)");
+            }
+            final var conn = ddl.getConnection();
+            conn.setAutoCommit(false);
+            try (var stmt = conn.createStatement()) {
+                stmt.execute("set local threshold = -10");
+                try (var rs = stmt.executeQuery("select pk from t11 where delta = @threshold")) {
+                    ResultSetAssert.assertThat(rs)
+                            .hasNextRow().isRowExactly(1L)
+                            .hasNextRow().isRowExactly(3L)
+                            .hasNoNextRow();
+                }
+            }
+            conn.rollback();
+        }
+    }
+
+    @Test
+    void planCacheHitVerifiedByLog() throws Exception {
+        final String schemaTemplate = "create table t12(pk bigint, val bigint, primary key(pk))";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/LV")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            try (var stmt = ddl.setSchemaAndGetConnection().createStatement()) {
+                stmt.executeUpdate("insert into t12 values (1, 10), (2, 20), (3, 30)");
+            }
+            final var conn = ddl.getConnection();
+            try (var logAppender = LogAppenderRule.of("LocalVariableTests", PlanGenerator.class, Level.INFO)) {
+                // First execution — cache miss expected
+                conn.setAutoCommit(false);
+                try (var stmt = conn.createStatement()) {
+                    stmt.execute("set local v = 10");
+                    try (var rs = stmt.executeQuery("select pk from t12 where val = @v options (log query)")) {
+                        ResultSetAssert.assertThat(rs).hasNextRow().isRowExactly(1L).hasNoNextRow();
+                    }
+                }
+                conn.commit();
+                Assertions.assertTrue(logAppender.lastMessageIsCacheMiss(), "first execution should be a cache miss");
+
+                // Second execution with a different value — same plan structure, cache hit expected
+                conn.unwrap(EmbeddedRelationalConnection.class).createNewTransaction();
+                conn.setAutoCommit(false);
+                try (var stmt = conn.createStatement()) {
+                    stmt.execute("set local v = 20");
+                    try (var rs = stmt.executeQuery("select pk from t12 where val = @v options (log query)")) {
+                        ResultSetAssert.assertThat(rs).hasNextRow().isRowExactly(2L).hasNoNextRow();
+                    }
+                }
+                conn.rollback();
+                Assertions.assertTrue(logAppender.lastMessageIsCacheHit(), "second execution should be a cache hit");
+            }
+        }
+    }
+
+    @Test
+    void schemaTemplateFunctionWithVariableInBody() throws Exception {
+        // The TVF takes an explicit parameter and is called with @var as the argument.
+        // This tests the interaction between local variables and schema-template TVFs.
+        // Note: using @var directly inside a TVF body requires lazy compilation support
+        // (separate work item); passing @var at the call site works today.
+        final String schemaTemplate =
+                "create table schfoo(pk bigint, name string, primary key(pk)) " +
+                "create function find_names(in target string) as select pk, name from schfoo where name = target";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/LV")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            try (var stmt = ddl.setSchemaAndGetConnection().createStatement()) {
+                stmt.executeUpdate("insert into schfoo values (1, 'alice'), (2, 'bob'), (3, 'carol')");
+            }
+            final var conn = ddl.getConnection();
+
+            // Without setting @varname: call fails with UNDEFINED_PARAMETER
+            conn.setAutoCommit(false);
+            try (var stmt = conn.createStatement()) {
+                RelationalAssertions.assertThrowsSqlException(
+                        () -> stmt.executeQuery("select pk, name from find_names(target => @varname)"))
+                        .hasErrorCode(ErrorCode.UNDEFINED_PARAMETER);
+            }
+            conn.rollback();
+
+            // Set @varname = 'alice' → only alice is returned
+            conn.unwrap(EmbeddedRelationalConnection.class).createNewTransaction();
+            conn.setAutoCommit(false);
+            try (var stmt = conn.createStatement()) {
+                stmt.execute("set local varname = 'alice'");
+                try (var rs = stmt.executeQuery("select pk, name from find_names(target => @varname)")) {
+                    ResultSetAssert.assertThat(rs).hasNextRow().isRowExactly(1L, "alice").hasNoNextRow();
+                }
+            }
+            conn.commit();
+
+            // Set @varname = 'bob' → only bob is returned (different value, same function call site)
+            conn.unwrap(EmbeddedRelationalConnection.class).createNewTransaction();
+            conn.setAutoCommit(false);
+            try (var stmt = conn.createStatement()) {
+                stmt.execute("set local varname = 'bob'");
+                try (var rs = stmt.executeQuery("select pk, name from find_names(target => @varname)")) {
+                    ResultSetAssert.assertThat(rs).hasNextRow().isRowExactly(2L, "bob").hasNoNextRow();
+                }
+            }
+            conn.rollback();
+        }
+    }
+
+    @Test
+    void filteredIndexSelectedByVariableWithPlanCacheConstraints() throws Exception {
+        // Schema: table with a boolean column, a filtered index covering only active=true rows,
+        // and a schema-template TVF that accepts the filter as a parameter.
+        // The TVF is called with @filter as the argument so the Cascades planner generates a
+        // constraint-based plan bundle:
+        //   - when @filter=true  → filtered-index plan variant is used
+        //   - when @filter=false → full-scan plan variant is used
+        // Verified via plan-cache hit/miss log messages.
+        final String schemaTemplate =
+                "create table schbar(pk bigint, active boolean, val bigint, primary key(pk)) " +
+                "create index idx_active as select pk, val from schbar where active = true order by pk " +
+                "create function active_items(in active_filter boolean) as select pk, val from schbar where active = active_filter";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/LV")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            try (var stmt = ddl.setSchemaAndGetConnection().createStatement()) {
+                stmt.executeUpdate("insert into schbar values (1, true, 10), (2, false, 20), (3, true, 30)");
+            }
+            final var conn = ddl.getConnection();
+
+            try (var logAppender = LogAppenderRule.of("LocalVariableTests_idx", PlanGenerator.class, Level.INFO)) {
+
+                // --- first call: @filter = true ---
+                // active_filter = true satisfies the filtered index predicate active = true
+                // → filtered-index plan is selected; first time seeing this query → cache miss.
+                conn.setAutoCommit(false);
+                try (var stmt = conn.createStatement()) {
+                    stmt.execute("set local filter = true");
+                    try (var rs = stmt.executeQuery("select pk, val from active_items(active_filter => @filter) options (log query)")) {
+                        ResultSetAssert.assertThat(rs)
+                                .hasNextRow().isRowExactly(1L, 10L)
+                                .hasNextRow().isRowExactly(3L, 30L)
+                                .hasNoNextRow();
+                    }
+                }
+                conn.commit();
+                Assertions.assertTrue(logAppender.lastMessageIsCacheMiss(), "first call (filter=true) should be a cache miss");
+
+                // --- second call: @filter = true again ---
+                // Same constraint satisfied → same plan variant → cache hit.
+                conn.unwrap(EmbeddedRelationalConnection.class).createNewTransaction();
+                conn.setAutoCommit(false);
+                try (var stmt = conn.createStatement()) {
+                    stmt.execute("set local filter = true");
+                    try (var rs = stmt.executeQuery("select pk, val from active_items(active_filter => @filter) options (log query)")) {
+                        ResultSetAssert.assertThat(rs)
+                                .hasNextRow().isRowExactly(1L, 10L)
+                                .hasNextRow().isRowExactly(3L, 30L)
+                                .hasNoNextRow();
+                    }
+                }
+                conn.commit();
+                Assertions.assertTrue(logAppender.lastMessageIsCacheHit(), "second call (filter=true) should be a cache hit");
+
+                // --- third call: @filter = false ---
+                // active_filter = false does NOT satisfy the filtered index predicate active = true
+                // → full-scan plan variant required; constraint violated → cache miss (new plan stored).
+                conn.unwrap(EmbeddedRelationalConnection.class).createNewTransaction();
+                conn.setAutoCommit(false);
+                try (var stmt = conn.createStatement()) {
+                    stmt.execute("set local filter = false");
+                    try (var rs = stmt.executeQuery("select pk, val from active_items(active_filter => @filter) options (log query)")) {
+                        ResultSetAssert.assertThat(rs)
+                                .hasNextRow().isRowExactly(2L, 20L)
+                                .hasNoNextRow();
+                    }
+                }
+                conn.commit();
+                Assertions.assertTrue(logAppender.lastMessageIsCacheMiss(), "call with filter=false should be a cache miss (different plan variant)");
+
+                // --- fourth call: @filter = false again ---
+                // Same full-scan plan variant → cache hit.
+                conn.unwrap(EmbeddedRelationalConnection.class).createNewTransaction();
+                conn.setAutoCommit(false);
+                try (var stmt = conn.createStatement()) {
+                    stmt.execute("set local filter = false");
+                    try (var rs = stmt.executeQuery("select pk, val from active_items(active_filter => @filter) options (log query)")) {
+                        ResultSetAssert.assertThat(rs)
+                                .hasNextRow().isRowExactly(2L, 20L)
+                                .hasNoNextRow();
+                    }
+                }
+                conn.rollback();
+                Assertions.assertTrue(logAppender.lastMessageIsCacheHit(), "fourth call (filter=false again) should be a cache hit");
+            }
+        }
+    }
+}

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/LocalVariableTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/LocalVariableTests.java
@@ -22,6 +22,7 @@ package com.apple.foundationdb.relational.recordlayer.query;
 
 import com.apple.foundationdb.relational.api.Options;
 import com.apple.foundationdb.relational.api.exceptions.ErrorCode;
+import com.apple.foundationdb.relational.recordlayer.ContinuationImpl;
 import com.apple.foundationdb.relational.recordlayer.EmbeddedRelationalConnection;
 import com.apple.foundationdb.relational.recordlayer.EmbeddedRelationalExtension;
 import com.apple.foundationdb.relational.recordlayer.LogAppenderRule;
@@ -36,6 +37,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.net.URI;
+import java.util.Base64;
 
 /**
  * Tests for transaction-scoped local variables (SET LOCAL / @variable).
@@ -469,36 +471,28 @@ public class LocalVariableTests {
 
     @Test
     void variableInTempFunctionBodyResolvesAtCallTime() throws Exception {
-        // @body_var referenced directly inside a temp TVF body requires the variable to exist
-        // at CREATE TEMPORARY FUNCTION time (AstNormalizer resolves it then), but the function
-        // uses a live reference to the transaction's local-variable map, so it always reflects
-        // the current value of @body_var at the time the function is called.
+        // @body_var directly inside a temp TVF body is resolved at invocation time, not at CREATE
+        // TEMPORARY FUNCTION time. The function can be created before the variable exists; the error
+        // surfaces only if @body_var is still absent when the function is actually called.
         final String schemaTemplate = "create table tvfbody(pk bigint, name string, primary key(pk))";
         try (var ddl = Ddl.builder().database(URI.create("/TEST/LV")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
             try (var stmt = ddl.setSchemaAndGetConnection().createStatement()) {
                 stmt.executeUpdate("insert into tvfbody values (1, 'alice'), (2, 'bob'), (3, 'carol')");
             }
             final var conn = ddl.getConnection();
-
-            // --- attempt 1: CREATE before @body_var is set → fails at normalization time ---
             conn.setAutoCommit(false);
             try (var stmt = conn.createStatement()) {
-                RelationalAssertions.assertThrowsSqlException(
-                        () -> stmt.execute("create temporary function find_by_body_var() on commit drop function " +
-                                "as select pk, name from tvfbody where name = @body_var"))
-                        .hasErrorCode(ErrorCode.UNDEFINED_PARAMETER);
-            }
-            conn.rollback();
-
-            // --- attempt 2: set @body_var BEFORE creating the function → CREATE succeeds ---
-            conn.unwrap(EmbeddedRelationalConnection.class).createNewTransaction();
-            conn.setAutoCommit(false);
-            try (var stmt = conn.createStatement()) {
-                stmt.execute("set local body_var = 'alice'");
+                // CREATE succeeds even though @body_var is not set yet
                 stmt.execute("create temporary function find_by_body_var() on commit drop function " +
                         "as select pk, name from tvfbody where name = @body_var");
 
-                // first call: @body_var = 'alice' → returns only alice
+                // calling before @body_var is set → UNDEFINED_PARAMETER at invocation time
+                RelationalAssertions.assertThrowsSqlException(
+                        () -> stmt.executeQuery("select pk, name from find_by_body_var()"))
+                        .hasErrorCode(ErrorCode.UNDEFINED_PARAMETER);
+
+                // set @body_var = 'alice' → first call returns alice
+                stmt.execute("set local body_var = 'alice'");
                 try (var rs = stmt.executeQuery("select pk, name from find_by_body_var()")) {
                     ResultSetAssert.assertThat(rs).hasNextRow().isRowExactly(1L, "alice").hasNoNextRow();
                 }
@@ -553,6 +547,48 @@ public class LocalVariableTests {
                             .hasNextRow().isRowExactly(2L)
                             .hasNextRow().isRowExactly(3L)
                             .hasNoNextRow();
+                }
+            }
+            conn.rollback();
+        }
+    }
+
+    @Test
+    void variableValueCapturedInContinuation() throws Exception {
+        // Verifies that the value bound to a local variable at the time a query is first executed
+        // is captured in the continuation, just like a bound prepared-statement parameter.
+        // Changing the variable after the first page is fetched must NOT affect the continuation.
+        final String schemaTemplate = "create table conttbl(pk bigint, name string, primary key(pk))";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/LV")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            try (var stmt = ddl.setSchemaAndGetConnection().createStatement()) {
+                stmt.executeUpdate("insert into conttbl values (1, 'alice'), (2, 'bob'), (3, 'carol'), (4, 'dave'), (5, 'eve')");
+            }
+            final var conn = ddl.getConnection();
+            conn.setAutoCommit(false);
+            try (var stmt = conn.createStatement()) {
+                // Filter: pk >= @min_pk  (= 2 → rows 2,3,4,5)
+                stmt.execute("set local min_pk = 2");
+                stmt.setMaxRows(2);
+                // First page: rows 2 and 3
+                final byte[] continuationBytes;
+                try (var rs = stmt.executeQuery("select pk, name from conttbl where pk >= @min_pk")) {
+                    ResultSetAssert.assertThat(rs)
+                            .hasNextRow().isRowExactly(2L, "bob")
+                            .hasNextRow().isRowExactly(3L, "carol")
+                            .hasNoNextRow();
+                    continuationBytes = rs.getContinuation().serialize();
+                }
+                // Change @min_pk to a different value — the continuation must ignore this
+                stmt.execute("set local min_pk = 99");
+                stmt.setMaxRows(10);
+                // Resume via continuation: should still see rows 4 and 5 (original binding min_pk=2)
+                final String encoded = Base64.getEncoder().encodeToString(continuationBytes);
+                try (var rs = stmt.executeQuery("EXECUTE CONTINUATION B64'" + encoded + "'")) {
+                    ResultSetAssert.assertThat(rs)
+                            .hasNextRow().isRowExactly(4L, "dave")
+                            .hasNextRow().isRowExactly(5L, "eve")
+                            .hasNoNextRow();
+                    Assertions.assertTrue(rs.getContinuation().atEnd(), "continuation should be at end after last row");
                 }
             }
             conn.rollback();

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/LocalVariableTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/LocalVariableTests.java
@@ -36,7 +36,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.net.URI;
-import java.sql.SQLException;
 
 /**
  * Tests for transaction-scoped local variables (SET LOCAL / @variable).

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/LocalVariableTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/LocalVariableTests.java
@@ -468,6 +468,52 @@ public class LocalVariableTests {
     }
 
     @Test
+    void variableInTempFunctionBodyResolvesAtCallTime() throws Exception {
+        // @body_var referenced directly inside a temp TVF body requires the variable to exist
+        // at CREATE TEMPORARY FUNCTION time (AstNormalizer resolves it then), but the function
+        // uses a live reference to the transaction's local-variable map, so it always reflects
+        // the current value of @body_var at the time the function is called.
+        final String schemaTemplate = "create table tvfbody(pk bigint, name string, primary key(pk))";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/LV")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            try (var stmt = ddl.setSchemaAndGetConnection().createStatement()) {
+                stmt.executeUpdate("insert into tvfbody values (1, 'alice'), (2, 'bob'), (3, 'carol')");
+            }
+            final var conn = ddl.getConnection();
+
+            // --- attempt 1: CREATE before @body_var is set → fails at normalization time ---
+            conn.setAutoCommit(false);
+            try (var stmt = conn.createStatement()) {
+                RelationalAssertions.assertThrowsSqlException(
+                        () -> stmt.execute("create temporary function find_by_body_var() on commit drop function " +
+                                "as select pk, name from tvfbody where name = @body_var"))
+                        .hasErrorCode(ErrorCode.UNDEFINED_PARAMETER);
+            }
+            conn.rollback();
+
+            // --- attempt 2: set @body_var BEFORE creating the function → CREATE succeeds ---
+            conn.unwrap(EmbeddedRelationalConnection.class).createNewTransaction();
+            conn.setAutoCommit(false);
+            try (var stmt = conn.createStatement()) {
+                stmt.execute("set local body_var = 'alice'");
+                stmt.execute("create temporary function find_by_body_var() on commit drop function " +
+                        "as select pk, name from tvfbody where name = @body_var");
+
+                // first call: @body_var = 'alice' → returns only alice
+                try (var rs = stmt.executeQuery("select pk, name from find_by_body_var()")) {
+                    ResultSetAssert.assertThat(rs).hasNextRow().isRowExactly(1L, "alice").hasNoNextRow();
+                }
+
+                // overwrite @body_var to 'bob' → same function now returns bob (live reference)
+                stmt.execute("set local body_var = 'bob'");
+                try (var rs = stmt.executeQuery("select pk, name from find_by_body_var()")) {
+                    ResultSetAssert.assertThat(rs).hasNextRow().isRowExactly(2L, "bob").hasNoNextRow();
+                }
+            }
+            conn.rollback();
+        }
+    }
+
+    @Test
     void tempFunctionAndLocalVariableCoexist() throws Exception {
         // Verifies that SET LOCAL and CREATE TEMPORARY FUNCTION are independent:
         // - the temp function survives a SET LOCAL in the same transaction

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/LocalVariableTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/LocalVariableTests.java
@@ -466,4 +466,50 @@ public class LocalVariableTests {
             }
         }
     }
+
+    @Test
+    void tempFunctionAndLocalVariableCoexist() throws Exception {
+        // Verifies that SET LOCAL and CREATE TEMPORARY FUNCTION are independent:
+        // - the temp function survives a SET LOCAL in the same transaction
+        // - the local variable survives a CREATE TEMPORARY FUNCTION in the same transaction
+        // - both can be used together in the same query (variable passed as a function argument)
+        final String schemaTemplate = "create table coexist(pk bigint, val bigint, primary key(pk))";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/LV")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            try (var stmt = ddl.setSchemaAndGetConnection().createStatement()) {
+                stmt.executeUpdate("insert into coexist values (1, 10), (2, 20), (3, 30)");
+            }
+            final var conn = ddl.getConnection();
+            conn.setAutoCommit(false);
+            try (var stmt = conn.createStatement()) {
+                // Create a temp function, then set a variable — function must still work
+                stmt.execute("create temporary function find_val(in threshold bigint) on commit drop function as select pk from coexist where val > threshold");
+                stmt.execute("set local limit_val = 15");
+
+                // Temp function still works after SET LOCAL
+                try (var rs = stmt.executeQuery("select pk from find_val(threshold => 15)")) {
+                    ResultSetAssert.assertThat(rs)
+                            .hasNextRow().isRowExactly(2L)
+                            .hasNextRow().isRowExactly(3L)
+                            .hasNoNextRow();
+                }
+
+                // Local variable still works after CREATE TEMPORARY FUNCTION
+                try (var rs = stmt.executeQuery("select pk from coexist where val > @limit_val")) {
+                    ResultSetAssert.assertThat(rs)
+                            .hasNextRow().isRowExactly(2L)
+                            .hasNextRow().isRowExactly(3L)
+                            .hasNoNextRow();
+                }
+
+                // Both together: variable as argument to the temp function
+                try (var rs = stmt.executeQuery("select pk from find_val(threshold => @limit_val)")) {
+                    ResultSetAssert.assertThat(rs)
+                            .hasNextRow().isRowExactly(2L)
+                            .hasNextRow().isRowExactly(3L)
+                            .hasNoNextRow();
+                }
+            }
+            conn.rollback();
+        }
+    }
 }

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/LocalVariableTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/LocalVariableTests.java
@@ -22,7 +22,6 @@ package com.apple.foundationdb.relational.recordlayer.query;
 
 import com.apple.foundationdb.relational.api.Options;
 import com.apple.foundationdb.relational.api.exceptions.ErrorCode;
-import com.apple.foundationdb.relational.recordlayer.ContinuationImpl;
 import com.apple.foundationdb.relational.recordlayer.EmbeddedRelationalConnection;
 import com.apple.foundationdb.relational.recordlayer.EmbeddedRelationalExtension;
 import com.apple.foundationdb.relational.recordlayer.LogAppenderRule;

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/TemporaryFunctionTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/TemporaryFunctionTests.java
@@ -65,6 +65,7 @@ import org.mockito.Mockito;
 import javax.annotation.Nonnull;
 import java.net.URI;
 import java.sql.SQLException;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -271,7 +272,7 @@ public class TemporaryFunctionTests {
         Assertions.assertTrue(invokedRoutineMaybe.isPresent());
         Assertions.assertTrue(invokedRoutineMaybe.get().isTemporary());
         Assertions.assertInstanceOf(RecordLayerInvokedRoutine.class, invokedRoutineMaybe.get());
-        return ((RecordLayerInvokedRoutine) invokedRoutineMaybe.get()).getUserDefinedFunctionProvider().apply(true);
+        return ((RecordLayerInvokedRoutine) invokedRoutineMaybe.get()).getUserDefinedFunctionProvider().apply(true, Map.of());
     }
 
     @Test

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/utils/InMemoryTransactionManager.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/utils/InMemoryTransactionManager.java
@@ -29,6 +29,7 @@ import org.apache.commons.lang3.NotImplementedException;
 
 import javax.annotation.Nonnull;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -57,6 +58,7 @@ public class InMemoryTransactionManager implements TransactionManager {
     private static final class TestTransaction implements Transaction {
         private final long txnId;
         private final TransactionManager txnManager;
+        private final Map<String, Object> localVariables = new LinkedHashMap<>();
 
         private TestTransaction(long txnId, TransactionManager txnManager) {
             this.txnId = txnId;
@@ -87,6 +89,17 @@ public class InMemoryTransactionManager implements TransactionManager {
         @Override
         public void unsetBoundSchemaTemplate() {
             throw new NotImplementedException("method is not implemented");
+        }
+
+        @Override
+        public void setLocalVariable(@Nonnull String name, Object value) {
+            localVariables.put(name, value);
+        }
+
+        @Nonnull
+        @Override
+        public Map<String, Object> getLocalVariables() {
+            return java.util.Collections.unmodifiableMap(localVariables);
         }
 
         @Override


### PR DESCRIPTION
Fix two Sphinx build warnings in the CREATE INDEX doc:

- Move `.. _create-schema-template:` label before the section title in `SCHEMA_TEMPLATE.rst` so Sphinx can resolve the cross-reference title
- Remove broken `create-view` reference (no corresponding page exists)