### PR TITLE
Fix Sphinx doc warnings in CREATE INDEX

### DIFF
--- a/docs/sphinx/source/reference/sql_commands/DDL/CREATE/INDEX.rst
+++ b/docs/sphinx/source/reference/sql_commands/DDL/CREATE/INDEX.rst
@@ -704,4 +704,3 @@ See Also
 
 - :ref:`create-schema-template` - Schema template definition
 - :ref:`index_definition` - Detailed index definition and limitations
-- :ref:`CREATE VIEW <create-view>` - Creating views for use with INDEX ON

--- a/docs/sphinx/source/reference/sql_commands/DDL/CREATE/SCHEMA_TEMPLATE.rst
+++ b/docs/sphinx/source/reference/sql_commands/DDL/CREATE/SCHEMA_TEMPLATE.rst
@@ -1,8 +1,8 @@
+.. _create-schema-template:
+
 ======================
 CREATE SCHEMA TEMPLATE
 ======================
-
-.. _create-schema-template:
 
 A schema template is a predefined structure that defines the set of ``TABLE`` and ``INDEX`` definitions. This can then
 used as a blueprint to create ``SCHEMA`` in a database. See: :doc:`../../../Databases_Schemas_SchemaTemplates` for more


### PR DESCRIPTION
Fix two Sphinx build warnings in the CREATE INDEX doc:

- Move `.. _create-schema-template:` label before the section title in `SCHEMA_TEMPLATE.rst` so Sphinx can resolve the cross-reference title
- Remove broken `create-view` reference (no corresponding page exists)