### PR TITLE
Extract resolveAcrossFragments helper in SemanticAnalyzer

### DIFF
--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/SemanticAnalyzer.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/SemanticAnalyzer.java
@@ -87,6 +87,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -369,23 +370,51 @@ public class SemanticAnalyzer {
     @Nonnull
     public Expression resolveIdentifier(@Nonnull Identifier identifier,
                                         @Nonnull LogicalPlanFragment planFragment) {
-        // search throw all visible plan fragments:
-        // - in each plan fragment, search operators left to right.
-        // - if identifier is not resolve, go to parent plan fragment.
-        LogicalPlanFragment currentPlanFragment = planFragment;
-        var resolvedMaybe = resolveIdentifierMaybe(identifier, currentPlanFragment.getLogicalOperators());
-        if (resolvedMaybe.isPresent()) {
-            return resolvedMaybe.get();
+        // Column resolution takes priority over table-row resolution across all visible fragments.
+        var resolved = resolveAcrossFragments(identifier, planFragment, this::resolveIdentifierMaybe);
+        if (resolved.isPresent()) {
+            return resolved.get();
         }
-        while (currentPlanFragment.hasParent()) {
-            currentPlanFragment = currentPlanFragment.getParent();
-            resolvedMaybe = resolveIdentifierMaybe(identifier, currentPlanFragment.getLogicalOperators());
-            if (resolvedMaybe.isPresent()) {
-                return resolvedMaybe.get();
-            }
+        // Fallback: if the identifier names a table or alias in scope, return the full row as a struct.
+        // This makes SELECT FOO FROM FOO equivalent to SELECT (*) FROM FOO when no column named FOO exists.
+        resolved = resolveAcrossFragments(identifier, planFragment, this::resolveAsTableRowMaybe);
+        if (resolved.isPresent()) {
+            return resolved.get();
         }
         Assert.failUnchecked(ErrorCode.UNDEFINED_COLUMN, String.format(Locale.ROOT, "Attempting to query non existing column %s", identifier));
         return null; // unreachable.
+    }
+
+    @Nonnull
+    private Optional<Expression> resolveAcrossFragments(
+            @Nonnull Identifier identifier,
+            @Nonnull LogicalPlanFragment planFragment,
+            @Nonnull BiFunction<Identifier, LogicalOperators, Optional<Expression>> resolver) {
+        LogicalPlanFragment current = planFragment;
+        Optional<Expression> result = resolver.apply(identifier, current.getLogicalOperators());
+        if (result.isPresent()) {
+            return result;
+        }
+        while (current.hasParent()) {
+            current = current.getParent();
+            result = resolver.apply(identifier, current.getLogicalOperators());
+            if (result.isPresent()) {
+                return result;
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Nonnull
+    private Optional<Expression> resolveAsTableRowMaybe(@Nonnull Identifier identifier,
+                                                         @Nonnull LogicalOperators operators) {
+        final boolean matchesTableName = Streams.stream(operators.forEachOnly())
+                .anyMatch(op -> op.getName().isPresent() && op.getName().get().equals(identifier));
+        if (!matchesTableName) {
+            return Optional.empty();
+        }
+        final var star = expandStar(Optional.of(identifier), operators);
+        return Optional.of(Expression.of(star.getUnderlying(), identifier));
     }
 
     @Nonnull


### PR DESCRIPTION
## Summary

- Extracts a `resolveAcrossFragments` traversal helper in `SemanticAnalyzer` that walks up the `LogicalPlanFragment` parent chain applying a pluggable resolver function
- Also adds `resolveAsTableRowMaybe` so that an unqualified identifier matching a table/alias name falls back to returning the full row as a struct (bringing `SELECT FOO FROM FOO` parity)
- Foundational refactor for cross-schema query support (PRs 2-7 build on this helper to resolve `schema.table` references across plan fragments)

## Stacking

This is PR 1 of 7 in the cross-schema join series. Each PR targets the previous PR's branch and is independently reviewable.

| # | Branch | Topic |
|---|--------|-------|
| **1** | `cross-schema/pr1` ← `main` | SemanticAnalyzer cross-schema resolution helper |
| 2 | `cross-schema/pr2` ← `cross-schema/pr1` | Plan-cache key for multi-schema queries |
| 3 | `cross-schema/pr3` ← `cross-schema/pr2` | Record Layer store-binding infrastructure |
| 4 | `cross-schema/pr4` ← `cross-schema/pr3` | Secondary-store wiring into execution context |
| 5 | `cross-schema/pr5` ← `cross-schema/pr4` | Type-namespace collision avoidance + catalog metadata |
| 6 | `cross-schema/pr6` ← `cross-schema/pr5` | Java integration tests |
| 7 | `cross-schema/pr7` ← `cross-schema/pr6` | YAML integration tests + documentation |

## Test plan

- [ ] Existing `SemanticAnalyzerTest` suite passes
- [ ] `table-as-column-tests.yamsql` continues to pass
- [ ] No regression in single-schema query paths