### PR TITLE
Add RecordQueryStoreBindingPlan and cross-schema store binding in planner rules

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/EvaluationContext.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/EvaluationContext.java
@@ -21,8 +21,10 @@
 package com.apple.foundationdb.record;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.typing.TypeRepository;
+import com.google.common.collect.ImmutableMap;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -44,7 +46,10 @@ public class EvaluationContext {
     @Nonnull
     private final TypeRepository typeRepository;
 
-    public static final EvaluationContext EMPTY = new EvaluationContext(Bindings.EMPTY_BINDINGS, TypeRepository.EMPTY_SCHEMA);
+    @Nonnull
+    private final ImmutableMap<String, FDBRecordStoreBase<?>> auxiliaryStores;
+
+    public static final EvaluationContext EMPTY = new EvaluationContext(Bindings.EMPTY_BINDINGS, TypeRepository.EMPTY_SCHEMA, ImmutableMap.of());
 
     /**
      * Get an empty evaluation context.
@@ -55,9 +60,11 @@ public class EvaluationContext {
         return EMPTY;
     }
 
-    private EvaluationContext(@Nonnull Bindings bindings, @Nonnull TypeRepository typeRepository) {
+    private EvaluationContext(@Nonnull Bindings bindings, @Nonnull TypeRepository typeRepository,
+                              @Nonnull ImmutableMap<String, FDBRecordStoreBase<?>> auxiliaryStores) {
         this.bindings = bindings;
         this.typeRepository = typeRepository;
+        this.auxiliaryStores = auxiliaryStores;
     }
 
     /**
@@ -68,7 +75,7 @@ public class EvaluationContext {
      */
     @Nonnull
     public static EvaluationContext forBindings(@Nonnull Bindings bindings) {
-        return new EvaluationContext(bindings, TypeRepository.EMPTY_SCHEMA);
+        return new EvaluationContext(bindings, TypeRepository.EMPTY_SCHEMA, ImmutableMap.of());
     }
 
     /**
@@ -80,12 +87,18 @@ public class EvaluationContext {
      */
     @Nonnull
     public static EvaluationContext forBindingsAndTypeRepository(@Nonnull Bindings bindings, @Nonnull TypeRepository typeRepository) {
-        return new EvaluationContext(bindings, typeRepository);
+        return new EvaluationContext(bindings, typeRepository, ImmutableMap.of());
+    }
+
+    @Nonnull
+    public static EvaluationContext forBindingsAndTypeRepository(@Nonnull Bindings bindings, @Nonnull TypeRepository typeRepository,
+                                                                 @Nonnull ImmutableMap<String, FDBRecordStoreBase<?>> auxiliaryStores) {
+        return new EvaluationContext(bindings, typeRepository, auxiliaryStores);
     }
 
     @Nonnull
     public static EvaluationContext forTypeRepository(@Nonnull TypeRepository typeRepository) {
-        return new EvaluationContext(Bindings.EMPTY_BINDINGS, typeRepository);
+        return new EvaluationContext(Bindings.EMPTY_BINDINGS, typeRepository, ImmutableMap.of());
     }
 
     /**
@@ -97,7 +110,7 @@ public class EvaluationContext {
      */
     @Nonnull
     public static EvaluationContext forBinding(@Nonnull String bindingName, @Nullable Object value) {
-        return new EvaluationContext(Bindings.newBuilder().set(bindingName, value).build(), TypeRepository.EMPTY_SCHEMA);
+        return new EvaluationContext(Bindings.newBuilder().set(bindingName, value).build(), TypeRepository.EMPTY_SCHEMA, ImmutableMap.of());
     }
 
     /**
@@ -198,6 +211,31 @@ public class EvaluationContext {
     }
 
     /**
+     * Returns the auxiliary store bound to the given schema name, or {@code null} if no such
+     * store has been injected. Used by {@code RecordQueryStoreBindingPlan} to redirect execution
+     * to a secondary schema's record store.
+     *
+     * @param schemaName the name of the secondary schema
+     * @return the bound store, or {@code null}
+     */
+    @Nullable
+    public FDBRecordStoreBase<?> getAuxiliaryStore(@Nonnull final String schemaName) {
+        return auxiliaryStores.get(schemaName);
+    }
+
+    /**
+     * Returns a new {@link EvaluationContext} identical to this one except that the given
+     * auxiliary stores are injected. Existing bindings and type repository are preserved.
+     *
+     * @param stores map from schema name to pre-opened record store
+     * @return new context with auxiliary stores
+     */
+    @Nonnull
+    public EvaluationContext withAuxiliaryStores(@Nonnull final ImmutableMap<String, FDBRecordStoreBase<?>> stores) {
+        return new EvaluationContext(bindings, typeRepository, stores);
+    }
+
+    /**
      * Construct a builder from this context. This allows the user to create
      * a new <code>EvaluationContext</code> that has all of the same data
      * as the current context except for a few modifications expressed as
@@ -232,7 +270,10 @@ public class EvaluationContext {
      */
     @Nonnull
     public EvaluationContext withBinding(@Nonnull String bindingName, @Nullable Object value) {
-        return childBuilder().setBinding(bindingName, value).build(typeRepository);
+        return new EvaluationContext(
+                bindings.childBuilder().set(bindingName, value).build(),
+                typeRepository,
+                auxiliaryStores);
     }
 
     /**
@@ -248,6 +289,6 @@ public class EvaluationContext {
      * @return a new <code>EvaluationContext</code> with the new binding
      */
     public EvaluationContext withBinding(final Bindings.Internal type, @Nonnull CorrelationIdentifier alias, @Nullable Object value) {
-        return childBuilder().setBinding(type.bindingName(alias.getId()), value).build(typeRepository);
+        return withBinding(type.bindingName(alias.getId()), value);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/EvaluationContextBuilder.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/EvaluationContextBuilder.java
@@ -21,8 +21,10 @@
 package com.apple.foundationdb.record;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.typing.TypeRepository;
+import com.google.common.collect.ImmutableMap;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -37,12 +39,15 @@ import javax.annotation.Nullable;
 public class EvaluationContextBuilder {
     @Nonnull
     protected final Bindings.Builder bindings;
+    @Nonnull
+    protected ImmutableMap<String, FDBRecordStoreBase<?>> auxiliaryStores;
 
     /**
      * Create an empty builder.
      */
     protected EvaluationContextBuilder() {
         this.bindings = Bindings.newBuilder();
+        this.auxiliaryStores = ImmutableMap.of();
     }
 
     /**
@@ -54,6 +59,7 @@ public class EvaluationContextBuilder {
      */
     protected EvaluationContextBuilder(@Nonnull EvaluationContext original) {
         this.bindings = original.getBindings().childBuilder();
+        this.auxiliaryStores = ImmutableMap.of();
     }
 
     /**
@@ -116,6 +122,6 @@ public class EvaluationContextBuilder {
      */
     @Nonnull
     public EvaluationContext build(@Nonnull final TypeRepository typeRepository) {
-        return EvaluationContext.forBindingsAndTypeRepository(bindings.build(), typeRepository);
+        return EvaluationContext.forBindingsAndTypeRepository(bindings.build(), typeRepository, auxiliaryStores);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CascadesPlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CascadesPlanner.java
@@ -61,6 +61,7 @@ import com.apple.foundationdb.record.query.plan.cascades.matching.structure.Bind
 import com.apple.foundationdb.record.query.plan.cascades.matching.structure.PlannerBindings;
 import com.apple.foundationdb.record.query.plan.cascades.matching.structure.ReferenceMatchers;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
+import com.apple.foundationdb.record.util.pair.NonnullPair;
 import com.google.common.base.Suppliers;
 import com.google.common.base.Verify;
 import com.google.common.collect.Iterables;
@@ -71,6 +72,7 @@ import javax.annotation.Nonnull;
 import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.Deque;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -384,6 +386,38 @@ public class CascadesPlanner implements QueryPlanner {
                                     rootReference,
                                     allowedIndexesOptional,
                                     indexQueryabilityFilter
+                            ),
+                    evaluationContext);
+            final var plan = resultOrFail();
+            final var constraints = QueryPlanConstraint.collectConstraints(plan);
+            return new QueryPlanResult(plan,
+                    QueryPlanInfo.newBuilder()
+                            .put(QueryPlanInfoKeys.CONSTRAINTS, constraints)
+                            .put(QueryPlanInfoKeys.STATS_MAPS,
+                                    PlannerEventStatsCollector.flatMapCollector(PlannerEventStatsCollector::getStatsMaps)
+                                            .orElse(null))
+                            .build());
+        } finally {
+            PlannerEventListeners.dispatchOnDone();
+        }
+    }
+
+    public QueryPlanResult planGraph(@Nonnull final Supplier<Reference> referenceSupplier,
+                                     @Nonnull final Optional<Collection<String>> allowedIndexesOptional,
+                                     @Nonnull final IndexQueryabilityFilter indexQueryabilityFilter,
+                                     @Nonnull final EvaluationContext evaluationContext,
+                                     @Nonnull final Map<SchemaIdentifier, NonnullPair<RecordMetaData, RecordStoreState>> additionalSchemas) {
+        try {
+            planPartial(referenceSupplier,
+                    rootReference ->
+                            MetaDataPlanContext.forRootReferenceWithAdditionalSchemas(configuration,
+                                    metaData,
+                                    recordStoreState,
+                                    matchCandidateRegistry,
+                                    rootReference,
+                                    allowedIndexesOptional,
+                                    indexQueryabilityFilter,
+                                    additionalSchemas
                             ),
                     evaluationContext);
             final var plan = resultOrFail();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MetaDataPlanContext.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MetaDataPlanContext.java
@@ -61,16 +61,32 @@ public class MetaDataPlanContext implements PlanContext {
     @Nonnull
     private final Set<MatchCandidate> matchCandidates;
 
+    @Nonnull
+    private final Map<MatchCandidate, SchemaIdentifier> matchCandidateSchemaMap;
+
     private MetaDataPlanContext(@Nonnull final RecordQueryPlannerConfiguration plannerConfiguration,
                                 @Nonnull final Set<MatchCandidate> matchCandidates) {
+        this(plannerConfiguration, matchCandidates, Map.of());
+    }
+
+    private MetaDataPlanContext(@Nonnull final RecordQueryPlannerConfiguration plannerConfiguration,
+                                @Nonnull final Set<MatchCandidate> matchCandidates,
+                                @Nonnull final Map<MatchCandidate, SchemaIdentifier> matchCandidateSchemaMap) {
         this.plannerConfiguration = plannerConfiguration;
         this.matchCandidates = ImmutableSet.copyOf(matchCandidates);
+        this.matchCandidateSchemaMap = Map.copyOf(matchCandidateSchemaMap);
     }
 
     @Nonnull
     @Override
     public RecordQueryPlannerConfiguration getPlannerConfiguration() {
         return plannerConfiguration;
+    }
+
+    @Nonnull
+    @Override
+    public SchemaIdentifier getSchemaIdForMatchCandidate(@Nonnull final MatchCandidate candidate) {
+        return matchCandidateSchemaMap.getOrDefault(candidate, SchemaIdentifier.current());
     }
 
     @Nullable
@@ -211,21 +227,28 @@ public class MetaDataPlanContext implements PlanContext {
             @Nonnull final Map<SchemaIdentifier, NonnullPair<RecordMetaData, RecordStoreState>> additionalSchemas) {
         final var queriedRecordTypeNames = recordTypes().evaluate(rootReference);
         final ImmutableSet.Builder<MatchCandidate> allCandidates = ImmutableSet.builder();
+        final Map<MatchCandidate, SchemaIdentifier> schemaMap = new java.util.LinkedHashMap<>();
 
-        if (!queriedRecordTypeNames.isEmpty()) {
+        final var primaryTypeNames = queriedRecordTypeNames.stream()
+                .filter(name -> metaData.getRecordTypes().containsKey(name))
+                .collect(ImmutableSet.toImmutableSet());
+        if (!primaryTypeNames.isEmpty()) {
             allCandidates.addAll(buildMatchCandidates(metaData, recordStoreState, matchCandidateRegistry,
-                    queriedRecordTypeNames, allowedIndexesOptional, indexQueryabilityFilter));
+                    primaryTypeNames, allowedIndexesOptional, indexQueryabilityFilter));
         }
 
-        for (final NonnullPair<RecordMetaData, RecordStoreState> schemaEntry : additionalSchemas.values()) {
-            final RecordMetaData secondaryMetaData = schemaEntry.getLeft();
-            final RecordStoreState secondaryState = schemaEntry.getRight();
+        for (final Map.Entry<SchemaIdentifier, NonnullPair<RecordMetaData, RecordStoreState>> entry : additionalSchemas.entrySet()) {
+            final SchemaIdentifier schemaId = entry.getKey();
+            final RecordMetaData secondaryMetaData = entry.getValue().getLeft();
+            final RecordStoreState secondaryState = entry.getValue().getRight();
             final Set<String> allTypes = secondaryMetaData.getRecordTypes().keySet();
-            allCandidates.addAll(buildMatchCandidates(secondaryMetaData, secondaryState, matchCandidateRegistry,
-                    allTypes, allowedIndexesOptional, indexQueryabilityFilter));
+            final ImmutableSet<MatchCandidate> secondaryCandidates = buildMatchCandidates(secondaryMetaData, secondaryState, matchCandidateRegistry,
+                    allTypes, allowedIndexesOptional, indexQueryabilityFilter);
+            allCandidates.addAll(secondaryCandidates);
+            secondaryCandidates.forEach(c -> schemaMap.put(c, schemaId));
         }
 
-        return new MetaDataPlanContext(plannerConfiguration, allCandidates.build());
+        return new MetaDataPlanContext(plannerConfiguration, allCandidates.build(), schemaMap);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MetaDataPlanContext.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MetaDataPlanContext.java
@@ -31,6 +31,7 @@ import com.apple.foundationdb.record.provider.foundationdb.IndexMatchCandidateRe
 import com.apple.foundationdb.record.query.IndexQueryabilityFilter;
 import com.apple.foundationdb.record.query.RecordQuery;
 import com.apple.foundationdb.record.query.plan.RecordQueryPlannerConfiguration;
+import com.apple.foundationdb.record.util.pair.NonnullPair;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 
@@ -39,6 +40,7 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -179,6 +181,61 @@ public class MetaDataPlanContext implements PlanContext {
             return new MetaDataPlanContext(plannerConfiguration, ImmutableSet.of());
         }
 
+        return new MetaDataPlanContext(plannerConfiguration,
+                buildMatchCandidates(metaData, recordStoreState, matchCandidateRegistry,
+                        queriedRecordTypeNames, allowedIndexesOptional, indexQueryabilityFilter));
+    }
+
+    /**
+     * Build a plan context pooling match candidates from the primary schema and all additional schemas.
+     * Used when a query references tables from more than one schema.
+     *
+     * @param plannerConfiguration planner configuration
+     * @param metaData primary schema metadata
+     * @param recordStoreState primary schema store state
+     * @param matchCandidateRegistry registry for match candidates
+     * @param rootReference root reference of the query
+     * @param allowedIndexesOptional optional set of allowed index names
+     * @param indexQueryabilityFilter filter for queryable indexes
+     * @param additionalSchemas map from secondary schema identifier to (metadata, store state) pair
+     * @return a plan context with match candidates from all schemas
+     */
+    public static PlanContext forRootReferenceWithAdditionalSchemas(
+            @Nonnull final RecordQueryPlannerConfiguration plannerConfiguration,
+            @Nonnull final RecordMetaData metaData,
+            @Nonnull final RecordStoreState recordStoreState,
+            @Nonnull final IndexMatchCandidateRegistry matchCandidateRegistry,
+            @Nonnull final Reference rootReference,
+            @Nonnull final Optional<Collection<String>> allowedIndexesOptional,
+            @Nonnull final IndexQueryabilityFilter indexQueryabilityFilter,
+            @Nonnull final Map<SchemaIdentifier, NonnullPair<RecordMetaData, RecordStoreState>> additionalSchemas) {
+        final var queriedRecordTypeNames = recordTypes().evaluate(rootReference);
+        final ImmutableSet.Builder<MatchCandidate> allCandidates = ImmutableSet.builder();
+
+        if (!queriedRecordTypeNames.isEmpty()) {
+            allCandidates.addAll(buildMatchCandidates(metaData, recordStoreState, matchCandidateRegistry,
+                    queriedRecordTypeNames, allowedIndexesOptional, indexQueryabilityFilter));
+        }
+
+        for (final NonnullPair<RecordMetaData, RecordStoreState> schemaEntry : additionalSchemas.values()) {
+            final RecordMetaData secondaryMetaData = schemaEntry.getLeft();
+            final RecordStoreState secondaryState = schemaEntry.getRight();
+            final Set<String> allTypes = secondaryMetaData.getRecordTypes().keySet();
+            allCandidates.addAll(buildMatchCandidates(secondaryMetaData, secondaryState, matchCandidateRegistry,
+                    allTypes, allowedIndexesOptional, indexQueryabilityFilter));
+        }
+
+        return new MetaDataPlanContext(plannerConfiguration, allCandidates.build());
+    }
+
+    @Nonnull
+    private static ImmutableSet<MatchCandidate> buildMatchCandidates(
+            @Nonnull final RecordMetaData metaData,
+            @Nonnull final RecordStoreState recordStoreState,
+            @Nonnull final IndexMatchCandidateRegistry matchCandidateRegistry,
+            @Nonnull final Set<String> queriedRecordTypeNames,
+            @Nonnull final Optional<Collection<String>> allowedIndexesOptional,
+            @Nonnull final IndexQueryabilityFilter indexQueryabilityFilter) {
         final var queriedRecordTypes =
                 queriedRecordTypeNames.stream().map(metaData::getRecordType).collect(Collectors.toList());
         final var indexList = Lists.<Index>newArrayList();
@@ -218,6 +275,6 @@ public class MetaDataPlanContext implements PlanContext {
                     .ifPresent(matchCandidatesBuilder::add);
         }
 
-        return new MetaDataPlanContext(plannerConfiguration, matchCandidatesBuilder.build());
+        return matchCandidatesBuilder.build();
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PlanContext.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PlanContext.java
@@ -53,6 +53,18 @@ public interface PlanContext {
     @Nonnull
     Set<MatchCandidate> getMatchCandidates();
 
+    /**
+     * Returns the {@link SchemaIdentifier} for a match candidate, or {@link SchemaIdentifier#current()} if the
+     * candidate belongs to the primary (current) schema.
+     *
+     * @param candidate a match candidate
+     * @return the schema identifier for the candidate
+     */
+    @Nonnull
+    default SchemaIdentifier getSchemaIdForMatchCandidate(@Nonnull MatchCandidate candidate) {
+        return SchemaIdentifier.current();
+    }
+
     @Nonnull
     static PlanContext emptyContext() {
         return EMPTY_CONTEXT;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/SchemaIdentifier.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/SchemaIdentifier.java
@@ -1,0 +1,93 @@
+/*
+ * SchemaIdentifier.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.cascades;
+
+import com.apple.foundationdb.annotation.API;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Objects;
+
+/**
+ * Identifies a schema (record store) within a query plan. A {@code null} schema name means "the
+ * schema of the current connection" — the default for single-schema queries.
+ *
+ * <p>Used to tag scan expressions ({@link com.apple.foundationdb.record.query.plan.cascades.expressions.FullUnorderedScanExpression},
+ * {@link com.apple.foundationdb.record.query.plan.cascades.expressions.LogicalTypeFilterExpression})
+ * so that {@code ImplementNestedLoopJoinRule} can detect when both sides of a join belong to
+ * different schemas and wrap the inner side in a {@code RecordQueryStoreBindingPlan}.
+ */
+@API(API.Status.EXPERIMENTAL)
+public final class SchemaIdentifier {
+
+    private static final SchemaIdentifier CURRENT = new SchemaIdentifier(null);
+
+    @Nullable
+    private final String schemaName;
+
+    private SchemaIdentifier(@Nullable final String schemaName) {
+        this.schemaName = schemaName;
+    }
+
+    /** Returns the singleton representing the current connection's schema. */
+    @Nonnull
+    public static SchemaIdentifier current() {
+        return CURRENT;
+    }
+
+    /** Returns a {@code SchemaIdentifier} for the named schema. */
+    @Nonnull
+    public static SchemaIdentifier of(@Nonnull final String schemaName) {
+        return new SchemaIdentifier(schemaName);
+    }
+
+    /** Returns {@code true} if this identifier represents the current connection schema. */
+    public boolean isCurrentSchema() {
+        return schemaName == null;
+    }
+
+    /** Returns the schema name, or {@code null} if this is the current connection schema. */
+    @Nullable
+    public String getSchemaName() {
+        return schemaName;
+    }
+
+    @Override
+    public boolean equals(final Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+        return Objects.equals(schemaName, ((SchemaIdentifier) other).schemaName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(schemaName);
+    }
+
+    @Override
+    public String toString() {
+        return schemaName == null ? "<current>" : schemaName;
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/explain/ExplainPlanVisitor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/explain/ExplainPlanVisitor.java
@@ -73,6 +73,7 @@ import com.apple.foundationdb.record.query.plan.plans.RecordQueryScanPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryScoreForRankPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQuerySelectorPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryStreamingAggregationPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryStoreBindingPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryTableFunctionPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryTextIndexPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryTypeFilterPlan;
@@ -611,6 +612,13 @@ public class ExplainPlanVisitor extends ExplainTokens implements RecordQueryPlan
                                 .stream()
                                 .map(recordType -> new ExplainTokens().addIdentifier(recordType))
                                 .iterator());
+    }
+
+    @Nonnull
+    @Override
+    public ExplainTokens visitStoreBindingPlan(@Nonnull final RecordQueryStoreBindingPlan storeBindingPlan) {
+        visit(storeBindingPlan.getChild());
+        return pipe().addKeyword("STORE_BIND").addWhitespace().addToString(storeBindingPlan.getSchemaId().toString());
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/FullUnorderedScanExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/FullUnorderedScanExpression.java
@@ -23,6 +23,7 @@ package com.apple.foundationdb.record.query.plan.cascades.expressions;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.EvaluationContext;
 import com.apple.foundationdb.record.query.plan.cascades.AccessHints;
+import com.apple.foundationdb.record.query.plan.cascades.SchemaIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.ComparisonRange;
 import com.apple.foundationdb.record.query.plan.cascades.Compensation;
@@ -74,10 +75,18 @@ public class FullUnorderedScanExpression extends AbstractRelationalExpressionWit
     @Nonnull
     final AccessHints accessHints;
 
+    @Nonnull
+    private final SchemaIdentifier schemaId;
+
     public FullUnorderedScanExpression(@Nonnull final Set<String> recordTypes, @Nonnull final Type flowedType, @Nonnull final AccessHints accessHints) {
+        this(recordTypes, flowedType, accessHints, SchemaIdentifier.current());
+    }
+
+    public FullUnorderedScanExpression(@Nonnull final Set<String> recordTypes, @Nonnull final Type flowedType, @Nonnull final AccessHints accessHints, @Nonnull final SchemaIdentifier schemaId) {
         this.recordTypes = ImmutableSet.copyOf(recordTypes);
         this.flowedType = flowedType;
         this.accessHints = accessHints;
+        this.schemaId = schemaId;
     }
 
     @Nonnull
@@ -88,6 +97,11 @@ public class FullUnorderedScanExpression extends AbstractRelationalExpressionWit
     @Nonnull
     public AccessHints getAccessHints() {
         return accessHints;
+    }
+
+    @Nonnull
+    public SchemaIdentifier getSchemaId() {
+        return schemaId;
     }
 
     @Nonnull
@@ -114,7 +128,7 @@ public class FullUnorderedScanExpression extends AbstractRelationalExpressionWit
                                                              final boolean shouldSimplifyValues,
                                                              @Nonnull final List<? extends Quantifier> translatedQuantifiers) {
         Verify.verify(translatedQuantifiers.isEmpty());
-        // this is ok as there are no new quantifiers
+        // schemaId is not correlation-dependent; return this unchanged
         return this;
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/LogicalTypeFilterExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/LogicalTypeFilterExpression.java
@@ -35,6 +35,7 @@ import com.apple.foundationdb.record.query.plan.cascades.PartialMatch;
 import com.apple.foundationdb.record.query.plan.cascades.PredicateMultiMap;
 import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
 import com.apple.foundationdb.record.query.plan.cascades.Quantifiers;
+import com.apple.foundationdb.record.query.plan.cascades.SchemaIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.ValueEquivalence;
 import com.apple.foundationdb.record.query.plan.cascades.explain.Attribute;
 import com.apple.foundationdb.record.query.plan.cascades.explain.NodeInfo;
@@ -84,13 +85,17 @@ public class LogicalTypeFilterExpression extends AbstractRelationalExpressionWit
     private final Quantifier innerQuantifier;
     @Nonnull
     private final Type resultType;
+    @Nonnull
+    private final SchemaIdentifier schemaId;
 
     private LogicalTypeFilterExpression(@Nonnull QueryPredicate recordTypePredicate, @Nonnull Set<String> recordTypes,
-                                        @Nonnull Quantifier innerQuantifier, @Nonnull Type resultType) {
+                                        @Nonnull Quantifier innerQuantifier, @Nonnull Type resultType,
+                                        @Nonnull SchemaIdentifier schemaId) {
         this.recordTypePredicate = recordTypePredicate;
         this.recordTypes = ImmutableSet.copyOf(recordTypes);
         this.innerQuantifier = innerQuantifier;
         this.resultType = resultType;
+        this.schemaId = schemaId;
     }
 
     @Nonnull
@@ -116,6 +121,11 @@ public class LogicalTypeFilterExpression extends AbstractRelationalExpressionWit
         return recordTypePredicate;
     }
 
+    @Nonnull
+    public SchemaIdentifier getSchemaId() {
+        return schemaId;
+    }
+
     @Override
     public int getRelationalChildCount() {
         return 1;
@@ -139,7 +149,7 @@ public class LogicalTypeFilterExpression extends AbstractRelationalExpressionWit
                                                              @Nonnull final List<? extends Quantifier> translatedQuantifiers) {
         final var translatedPredicates = recordTypePredicate.translateCorrelations(translationMap, shouldSimplifyValues);
         return new LogicalTypeFilterExpression(translatedPredicates, getRecordTypes(), Iterables.getOnlyElement(translatedQuantifiers),
-                resultType);
+                resultType, schemaId);
     }
 
     @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
@@ -438,6 +448,15 @@ public class LogicalTypeFilterExpression extends AbstractRelationalExpressionWit
                                                                 @Nonnull final Quantifier innerQuantifier,
                                                                 @Nonnull final Type resultType,
                                                                 @Nullable final CorrelationIdentifier recordTypeKeyParameterAlias) {
+        return forMatchCandidate(recordTypes, innerQuantifier, resultType, recordTypeKeyParameterAlias, SchemaIdentifier.current());
+    }
+
+    @Nonnull
+    public static LogicalTypeFilterExpression forMatchCandidate(@Nonnull final Set<String> recordTypes,
+                                                                @Nonnull final Quantifier innerQuantifier,
+                                                                @Nonnull final Type resultType,
+                                                                @Nullable final CorrelationIdentifier recordTypeKeyParameterAlias,
+                                                                @Nonnull final SchemaIdentifier schemaId) {
         final var value = new RecordTypeValue(QuantifiedObjectValue.of(innerQuantifier));
         final var rangeConstraints = recordTypeNamesToRangeConstraints(recordTypes);
 
@@ -452,7 +471,7 @@ public class LogicalTypeFilterExpression extends AbstractRelationalExpressionWit
             predicate = PredicateWithValueAndRanges.ofRanges(value, rangeConstraints);
         }
 
-        return new LogicalTypeFilterExpression(predicate, recordTypes, innerQuantifier, resultType);
+        return new LogicalTypeFilterExpression(predicate, recordTypes, innerQuantifier, resultType, schemaId);
     }
 
     /**
@@ -467,11 +486,19 @@ public class LogicalTypeFilterExpression extends AbstractRelationalExpressionWit
     public static LogicalTypeFilterExpression of(@Nonnull final Set<String> recordTypes,
                                                  @Nonnull final Quantifier innerQuantifier,
                                                  @Nonnull final Type resultType) {
+        return of(recordTypes, innerQuantifier, resultType, SchemaIdentifier.current());
+    }
+
+    @Nonnull
+    public static LogicalTypeFilterExpression of(@Nonnull final Set<String> recordTypes,
+                                                 @Nonnull final Quantifier innerQuantifier,
+                                                 @Nonnull final Type resultType,
+                                                 @Nonnull final SchemaIdentifier schemaId) {
         final var value = new RecordTypeValue(QuantifiedObjectValue.of(innerQuantifier));
         final var rangeConstraints = recordTypeNamesToRangeConstraints(recordTypes);
 
         final var recordTypePredicate = PredicateWithValueAndRanges.ofRanges(value, rangeConstraints);
-        return new LogicalTypeFilterExpression(recordTypePredicate, recordTypes, innerQuantifier, resultType);
+        return new LogicalTypeFilterExpression(recordTypePredicate, recordTypes, innerQuantifier, resultType, schemaId);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/PredicateWithValueAndRanges.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/PredicateWithValueAndRanges.java
@@ -44,6 +44,7 @@ import com.apple.foundationdb.record.query.plan.explain.ExplainTokens;
 import com.apple.foundationdb.record.query.plan.explain.ExplainTokensWithPrecedence;
 import com.apple.foundationdb.record.query.plan.explain.ExplainTokensWithPrecedence.Precedence;
 import com.google.auto.service.AutoService;
+import com.apple.foundationdb.record.query.plan.cascades.ComparisonRange;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -345,7 +346,28 @@ public class PredicateWithValueAndRanges extends AbstractQueryPredicate implemen
                             PredicateMapping.regularMappingBuilder(originalQueryPredicate, this, candidatePredicate)
                                     .setPredicateCompensation((ignore, boundParameterPrefixMap, pullUp) -> {
                                         if (boundParameterPrefixMap.containsKey(alias)) {
-                                            return PredicateCompensationFunction.noCompensationNeeded();
+                                            // The scan key used one comparison from this range; any remaining
+                                            // comparisons (residuals dropped by asComparisonRange()) must still
+                                            // be applied as a filter.
+                                            final var singleRange = Iterables.getOnlyElement(compensatedQueryPredicate.getRanges());
+                                            var sargRange = ComparisonRange.EMPTY;
+                                            final ImmutableList.Builder<Comparisons.Comparison> residualBuilder = ImmutableList.builder();
+                                            for (final var comparison : singleRange.getComparisons()) {
+                                                final var mergeResult = sargRange.merge(comparison);
+                                                sargRange = mergeResult.getComparisonRange();
+                                                residualBuilder.addAll(mergeResult.getResidualComparisons());
+                                            }
+                                            final var residuals = residualBuilder.build();
+                                            if (residuals.isEmpty()) {
+                                                return PredicateCompensationFunction.noCompensationNeeded();
+                                            }
+                                            final var rangeBuilder = RangeConstraints.newBuilder();
+                                            residuals.forEach(rangeBuilder::addComparisonMaybe);
+                                            return rangeBuilder.build()
+                                                    .map(residualRange -> PredicateWithValueAndRanges.sargable(
+                                                                    compensatedQueryPredicate.getValue(), residualRange)
+                                                            .computeCompensationFunctionForLeaf(pullUp))
+                                                    .orElseGet(() -> computeCompensationFunctionForLeaf(pullUp));
                                         }
                                         return computeCompensationFunctionForLeaf(pullUp);
                                     })

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/CardinalitiesProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/CardinalitiesProperty.java
@@ -87,6 +87,7 @@ import com.apple.foundationdb.record.query.plan.plans.RecordQueryRecursiveDfsJoi
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryRecursiveLevelUnionPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryScanPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryScoreForRankPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryStoreBindingPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQuerySelectorPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryStreamingAggregationPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryTableFunctionPlan;
@@ -408,6 +409,12 @@ public class CardinalitiesProperty implements ExpressionProperty<CardinalitiesPr
         @Override
         public Cardinalities visitRecordQueryTypeFilterPlan(@Nonnull final RecordQueryTypeFilterPlan typeFilterPlan) {
             return fromChild(typeFilterPlan);
+        }
+
+        @Nonnull
+        @Override
+        public Cardinalities visitRecordQueryStoreBindingPlan(@Nonnull final RecordQueryStoreBindingPlan storeBindingPlan) {
+            return fromChild(storeBindingPlan);
         }
 
         @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/DerivationsProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/DerivationsProperty.java
@@ -84,6 +84,7 @@ import com.apple.foundationdb.record.query.plan.plans.RecordQueryScoreForRankPla
 import com.apple.foundationdb.record.query.plan.plans.RecordQuerySelectorPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQuerySetPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryStreamingAggregationPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryStoreBindingPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryTableFunctionPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryTextIndexPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryTypeFilterPlan;
@@ -571,6 +572,12 @@ public class DerivationsProperty implements ExpressionProperty<DerivationsProper
                 resultValuesBuilder.add(replacedChildResultValueOptional.get());
             }
             return new Derivations(resultValuesBuilder.build(), childDerivations.getLocalValues());
+        }
+
+        @Nonnull
+        @Override
+        public Derivations visitStoreBindingPlan(@Nonnull final RecordQueryStoreBindingPlan storeBindingPlan) {
+            return visit(storeBindingPlan.getChild());
         }
 
         @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/DistinctRecordsProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/DistinctRecordsProperty.java
@@ -62,6 +62,7 @@ import com.apple.foundationdb.record.query.plan.plans.RecordQueryPredicatesFilte
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryRangePlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryScanPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryScoreForRankPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryStoreBindingPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQuerySelectorPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryStreamingAggregationPlan;
 import com.apple.foundationdb.record.query.plan.plans.TempTableScanPlan;
@@ -329,6 +330,12 @@ public class DistinctRecordsProperty implements ExpressionProperty<Boolean> {
         @Override
         public Boolean visitTypeFilterPlan(@Nonnull final RecordQueryTypeFilterPlan typeFilterPlan) {
             return distinctRecordsFromSingleChild(typeFilterPlan);
+        }
+
+        @Nonnull
+        @Override
+        public Boolean visitStoreBindingPlan(@Nonnull final RecordQueryStoreBindingPlan storeBindingPlan) {
+            return visit(storeBindingPlan.getChild());
         }
 
         @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/OrderingProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/OrderingProperty.java
@@ -79,6 +79,7 @@ import com.apple.foundationdb.record.query.plan.plans.RecordQueryPredicatesFilte
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryRangePlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryScanPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryScoreForRankPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryStoreBindingPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQuerySelectorPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryStreamingAggregationPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryTextIndexPlan;
@@ -548,6 +549,12 @@ public class OrderingProperty implements ExpressionProperty<Ordering> {
                     Ordering.normalizeOrderingSet(resultBindingMap,
                             PartiallyOrderedSet.of(resultOrderingSetDomain, childOrderingSet.getDependencyMap()));
             return Ordering.ofOrderingSet(resultBindingMap, orderingSet, childOrdering.isDistinct());
+        }
+
+        @Nonnull
+        @Override
+        public Ordering visitStoreBindingPlan(@Nonnull final RecordQueryStoreBindingPlan storeBindingPlan) {
+            return orderingFromSingleChild(storeBindingPlan);
         }
 
         @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/PrimaryKeyProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/PrimaryKeyProperty.java
@@ -64,6 +64,7 @@ import com.apple.foundationdb.record.query.plan.plans.RecordQueryPredicatesFilte
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryRangePlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryScanPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryScoreForRankPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryStoreBindingPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQuerySelectorPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryStreamingAggregationPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryTextIndexPlan;
@@ -351,6 +352,12 @@ public class PrimaryKeyProperty implements ExpressionProperty<Optional<List<Valu
         @Override
         public Optional<List<Value>> visitTypeFilterPlan(@Nonnull final RecordQueryTypeFilterPlan typeFilterPlan) {
             return primaryKeyFromSingleChild(typeFilterPlan);
+        }
+
+        @Nonnull
+        @Override
+        public Optional<List<Value>> visitStoreBindingPlan(@Nonnull final RecordQueryStoreBindingPlan storeBindingPlan) {
+            return visit(storeBindingPlan.getChild());
         }
 
         @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/StoredRecordProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/StoredRecordProperty.java
@@ -60,6 +60,7 @@ import com.apple.foundationdb.record.query.plan.plans.RecordQueryPredicatesFilte
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryRangePlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryScanPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryScoreForRankPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryStoreBindingPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQuerySelectorPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryStreamingAggregationPlan;
 import com.apple.foundationdb.record.query.plan.plans.TempTableScanPlan;
@@ -311,6 +312,12 @@ public class StoredRecordProperty implements ExpressionProperty<Boolean> {
         @Override
         public Boolean visitTypeFilterPlan(@Nonnull final RecordQueryTypeFilterPlan typeFilterPlan) {
             return storedRecordsFromSingleChild(typeFilterPlan);
+        }
+
+        @Nonnull
+        @Override
+        public Boolean visitStoreBindingPlan(@Nonnull final RecordQueryStoreBindingPlan storeBindingPlan) {
+            return visit(storeBindingPlan.getChild());
         }
 
         @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/AbstractDataAccessRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/AbstractDataAccessRule.java
@@ -49,9 +49,12 @@ import com.apple.foundationdb.record.query.plan.cascades.RequestedOrdering;
 import com.apple.foundationdb.record.query.plan.cascades.RequestedOrderingConstraint;
 import com.apple.foundationdb.record.query.plan.cascades.ValueIndexScanMatchCandidate;
 import com.apple.foundationdb.record.query.plan.cascades.events.PlannerEvent.Location;
+import com.apple.foundationdb.record.query.plan.cascades.SchemaIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.LogicalDistinctExpression;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.LogicalIntersectionExpression;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.LogicalTypeFilterExpression;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpression;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryStoreBindingPlan;
 import com.apple.foundationdb.record.query.plan.cascades.matching.structure.BindingMatcher;
 import com.apple.foundationdb.record.query.plan.cascades.properties.CardinalitiesProperty.Cardinality;
 
@@ -144,6 +147,40 @@ public abstract class AbstractDataAccessRule extends CascadesRule<MatchPartition
 
         final var expression = bindings.get(getExpressionMatcher());
 
+        final SchemaIdentifier secondarySchemaId;
+        if (expression instanceof LogicalTypeFilterExpression) {
+            final SchemaIdentifier sid = ((LogicalTypeFilterExpression) expression).getSchemaId();
+            secondarySchemaId = sid.isCurrentSchema() ? null : sid;
+        } else {
+            // The expression is not an LTFE. Determine the schema via three fallback sources:
+            // (a) sibling exploratory expressions in the current group (non-correlated SelectExpression
+            //     added to the same group as the LTFE by exploration rules),
+            // (b) exploratory expressions in each quantifier's directly-referenced child group
+            //     (correlated SelectExpression placed in a new child group by predicate-pushdown whose
+            //     quantifier still ranges over the LTFE's group), and
+            // (c) the PlanContext's match candidate schema map (correlated SelectExpression in a deeper
+            //     child group, where the quantifier ranges over the scan group rather than the LTFE group).
+            SchemaIdentifier sid = secondarySchemaIdFromGroup(call.getRoot());
+            if (sid == null) {
+                sid = expression.getQuantifiers().stream()
+                        .map(Quantifier::getRangesOver)
+                        .map(AbstractDataAccessRule::secondarySchemaIdFromGroup)
+                        .filter(Objects::nonNull)
+                        .findFirst()
+                        .orElse(null);
+            }
+            if (sid == null) {
+                final var planContext = call.getContext();
+                sid = completeMatches.stream()
+                        .map(PartialMatch::getMatchCandidate)
+                        .map(planContext::getSchemaIdForMatchCandidate)
+                        .filter(s -> !s.isCurrentSchema())
+                        .findFirst()
+                        .orElse(null);
+            }
+            secondarySchemaId = sid;
+        }
+
         //
         // return if there is no pre-determined interesting ordering
         //
@@ -220,7 +257,20 @@ public abstract class AbstractDataAccessRule extends CascadesRule<MatchPartition
                         dataAccessForMatchPartition(call,
                                 requestedOrderings,
                                 matchPartition);
-                call.yieldMixedUnknownExpressions(dataAccessExpressions);
+                if (secondarySchemaId != null) {
+                    final LinkedIdentitySet<RelationalExpression> wrapped = new LinkedIdentitySet<>();
+                    for (final RelationalExpression expr : dataAccessExpressions) {
+                        if (expr instanceof RecordQueryPlan) {
+                            final Reference innerRef = call.memoizePlan((RecordQueryPlan) expr);
+                            wrapped.add(new RecordQueryStoreBindingPlan(Quantifier.physical(innerRef), secondarySchemaId));
+                        } else {
+                            wrapped.add(expr);
+                        }
+                    }
+                    call.yieldMixedUnknownExpressions(wrapped);
+                } else {
+                    call.yieldMixedUnknownExpressions(dataAccessExpressions);
+                }
             }
         }
     }
@@ -1346,6 +1396,19 @@ public abstract class AbstractDataAccessRule extends CascadesRule<MatchPartition
         public static <T> Vectored<T> of(@Nonnull final T element, final int position) {
             return new Vectored<>(element, position);
         }
+    }
+
+    @Nullable
+    private static SchemaIdentifier secondarySchemaIdFromGroup(@Nonnull final Reference ref) {
+        for (final RelationalExpression expr : ref.getExploratoryExpressions()) {
+            if (expr instanceof LogicalTypeFilterExpression) {
+                final SchemaIdentifier sid = ((LogicalTypeFilterExpression) expr).getSchemaId();
+                if (!sid.isCurrentSchema()) {
+                    return sid;
+                }
+            }
+        }
+        return null;
     }
 
     protected static class IntersectionResult {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/AbstractDataAccessRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/AbstractDataAccessRule.java
@@ -181,6 +181,23 @@ public abstract class AbstractDataAccessRule extends CascadesRule<MatchPartition
             secondarySchemaId = sid;
         }
 
+        // Filter match candidates to only those belonging to the expected schema, preventing
+        // same-named tables from different schemas from generating mixed plans in the same group.
+        final var planContext = call.getContext();
+        final var schemaFilteredMatches = completeMatches.stream()
+                .filter(match -> {
+                    final SchemaIdentifier candidateSchema = planContext.getSchemaIdForMatchCandidate(match.getMatchCandidate());
+                    if (secondarySchemaId != null) {
+                        return secondarySchemaId.equals(candidateSchema);
+                    } else {
+                        return candidateSchema.isCurrentSchema();
+                    }
+                })
+                .collect(ImmutableList.toImmutableList());
+        if (schemaFilteredMatches.isEmpty()) {
+            return;
+        }
+
         //
         // return if there is no pre-determined interesting ordering
         //
@@ -196,7 +213,7 @@ public abstract class AbstractDataAccessRule extends CascadesRule<MatchPartition
 
         // group all successful matches by their sets of compensated aliases
         final var matchPartitionByMatchAliasMap =
-                completeMatches
+                schemaFilteredMatches
                         .stream()
                         .flatMap(match -> {
                             final var compensatedAliases = match.getCompensatedAliases();
@@ -257,20 +274,7 @@ public abstract class AbstractDataAccessRule extends CascadesRule<MatchPartition
                         dataAccessForMatchPartition(call,
                                 requestedOrderings,
                                 matchPartition);
-                if (secondarySchemaId != null) {
-                    final LinkedIdentitySet<RelationalExpression> wrapped = new LinkedIdentitySet<>();
-                    for (final RelationalExpression expr : dataAccessExpressions) {
-                        if (expr instanceof RecordQueryPlan) {
-                            final Reference innerRef = call.memoizePlan((RecordQueryPlan) expr);
-                            wrapped.add(new RecordQueryStoreBindingPlan(Quantifier.physical(innerRef), secondarySchemaId));
-                        } else {
-                            wrapped.add(expr);
-                        }
-                    }
-                    call.yieldMixedUnknownExpressions(wrapped);
-                } else {
-                    call.yieldMixedUnknownExpressions(dataAccessExpressions);
-                }
+                call.yieldMixedUnknownExpressions(dataAccessExpressions);
             }
         }
     }
@@ -914,9 +918,16 @@ public abstract class AbstractDataAccessRule extends CascadesRule<MatchPartition
                         singleMatchedAccessVectored ->  {
                             final var singleMatchedAccess = singleMatchedAccessVectored.getElement();
                             final var partialMatch = singleMatchedAccess.getPartialMatch();
-                            return partialMatch.getMatchCandidate()
+                            final RecordQueryPlan plan = partialMatch.getMatchCandidate()
                                     .toEquivalentPlan(partialMatch, planContext, memoizer,
                                             singleMatchedAccess.isReverseScanOrder());
+                            final SchemaIdentifier schemaId =
+                                    planContext.getSchemaIdForMatchCandidate(partialMatch.getMatchCandidate());
+                            if (!schemaId.isCurrentSchema()) {
+                                return new RecordQueryStoreBindingPlan(
+                                        Quantifier.physical(memoizer.memoizePlan(plan)), schemaId);
+                            }
+                            return plan;
                         }));
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementNestedLoopJoinRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementNestedLoopJoinRule.java
@@ -35,7 +35,10 @@ import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
 import com.apple.foundationdb.record.query.plan.cascades.Reference;
 import com.apple.foundationdb.record.query.plan.cascades.RequestedOrdering;
 import com.apple.foundationdb.record.query.plan.cascades.RequestedOrderingConstraint;
+import com.apple.foundationdb.record.query.plan.cascades.SchemaIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.debug.Debugger;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.LogicalTypeFilterExpression;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpression;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.SelectExpression;
 import com.apple.foundationdb.record.query.plan.cascades.matching.structure.BindingMatcher;
 import com.apple.foundationdb.record.query.plan.cascades.predicates.QueryPredicate;
@@ -46,6 +49,7 @@ import com.apple.foundationdb.record.query.plan.plans.RecordQueryDefaultOnEmptyP
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryFirstOrDefaultPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryFlatMapPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPredicatesFilterPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryStoreBindingPlan;
 import com.apple.foundationdb.record.util.pair.NonnullPair;
 import com.google.common.base.Function;
 import com.google.common.base.Verify;
@@ -184,7 +188,7 @@ public class ImplementNestedLoopJoinRule extends ImplementationCascadesRule<Sele
                 for (final PlanPartition innerPlanPartition : rollUpIfSatisfyOrdering(requestedOrdering, innerQuantifier, bindings.getAll(innerPlanPartitionsMatcher), Ordering.empty(),
                         o -> pullUpOrderingFromSelectChild(o, selectExpression, innerAlias))) {
                     final Quantifier.Physical newInnerQuantifier = planPartitionToPhysical(call, innerQuantifier, innerReference, outerInnerPredicates, innerPlanPartition);
-                    call.yieldPlan(new RecordQueryFlatMapPlan(newOuterQuantifier, newInnerQuantifier, selectExpression.getResultValue(), innerQuantifier instanceof Quantifier.Existential));
+                    call.yieldPlan(new RecordQueryFlatMapPlan(newOuterQuantifier, wrapCrossSchema(call, newInnerQuantifier, innerQuantifier, innerReference), selectExpression.getResultValue(), innerQuantifier instanceof Quantifier.Existential));
                 }
             }
 
@@ -198,7 +202,7 @@ public class ImplementNestedLoopJoinRule extends ImplementationCascadesRule<Sele
                 final Quantifier.Physical newOuterQuantifier = planPartitionToPhysical(call, outerQuantifier, outerReference, outerPredicates, outerPlanPartition);
                 for (final PlanPartition innerPlanPartition : PlanPartitions.rollUpTo(bindings.getAll(innerPlanPartitionsMatcher), ImmutableSet.of())) {
                     final Quantifier.Physical newInnerQuantifier = planPartitionToPhysical(call, innerQuantifier, innerReference, outerInnerPredicates, innerPlanPartition);
-                    call.yieldPlan(new RecordQueryFlatMapPlan(newOuterQuantifier, newInnerQuantifier, selectExpression.getResultValue(), innerQuantifier instanceof Quantifier.Existential));
+                    call.yieldPlan(new RecordQueryFlatMapPlan(newOuterQuantifier, wrapCrossSchema(call, newInnerQuantifier, innerQuantifier, innerReference), selectExpression.getResultValue(), innerQuantifier instanceof Quantifier.Existential));
                 }
             }
 
@@ -211,7 +215,7 @@ public class ImplementNestedLoopJoinRule extends ImplementationCascadesRule<Sele
                 for (final PlanPartition innerPlanPartition : rollUpIfSatisfyOrdering(requestedOrdering, innerQuantifier, bindings.getAll(innerPlanPartitionsMatcher), outerOrdering,
                         o -> pullUpOrderingFromSelectChild(o, selectExpression, innerAlias))) {
                     final Quantifier.Physical newInnerQuantifier = planPartitionToPhysical(call, innerQuantifier, innerReference, outerInnerPredicates, innerPlanPartition);
-                    call.yieldPlan(new RecordQueryFlatMapPlan(newOuterQuantifier, newInnerQuantifier, selectExpression.getResultValue(), innerQuantifier instanceof Quantifier.Existential));
+                    call.yieldPlan(new RecordQueryFlatMapPlan(newOuterQuantifier, wrapCrossSchema(call, newInnerQuantifier, innerQuantifier, innerReference), selectExpression.getResultValue(), innerQuantifier instanceof Quantifier.Existential));
                 }
             }
         }
@@ -327,5 +331,42 @@ public class ImplementNestedLoopJoinRule extends ImplementationCascadesRule<Sele
         }
 
         return Quantifier.physicalBuilder().withAlias(quantifier.getAlias()).build(ref);
+    }
+
+    /**
+     * If the inner reference belongs to a non-current schema, wraps all plans in the inner quantifier's
+     * reference with a {@link RecordQueryStoreBindingPlan} so that execution redirects to the correct store.
+     * Same-schema joins are returned unchanged.
+     */
+    @Nonnull
+    private Quantifier.Physical wrapCrossSchema(@Nonnull final ImplementationCascadesRuleCall call,
+                                                 @Nonnull final Quantifier.Physical newInnerQuantifier,
+                                                 @Nonnull final Quantifier originalInnerQuantifier,
+                                                 @Nonnull final Reference innerLogicalReference) {
+        final SchemaIdentifier schemaId = schemaIdFromReference(innerLogicalReference);
+        if (schemaId.isCurrentSchema()) {
+            return newInnerQuantifier;
+        }
+        final var innerRef = newInnerQuantifier.getRangesOver();
+        final var wrappedPlans = innerRef.getFinalExpressions().stream()
+                .map(e -> (com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan) e)
+                .map(p -> (com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan) RecordQueryStoreBindingPlan.of(p, schemaId))
+                .collect(ImmutableList.toImmutableList());
+        final var wrappedRef = call.memoizePlansBuilder(wrappedPlans).reference();
+        return Quantifier.physicalBuilder().withAlias(originalInnerQuantifier.getAlias()).build(wrappedRef);
+    }
+
+    /**
+     * Returns the {@link SchemaIdentifier} of the first {@link LogicalTypeFilterExpression} found in the
+     * exploratory expressions of {@code ref}, or {@link SchemaIdentifier#current()} if none is found.
+     */
+    @Nonnull
+    private static SchemaIdentifier schemaIdFromReference(@Nonnull final Reference ref) {
+        for (final RelationalExpression expr : ref.getExploratoryExpressions()) {
+            if (expr instanceof LogicalTypeFilterExpression) {
+                return ((LogicalTypeFilterExpression) expr).getSchemaId();
+            }
+        }
+        return SchemaIdentifier.current();
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementNestedLoopJoinRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementNestedLoopJoinRule.java
@@ -358,13 +358,20 @@ public class ImplementNestedLoopJoinRule extends ImplementationCascadesRule<Sele
 
     /**
      * Returns the {@link SchemaIdentifier} of the first {@link LogicalTypeFilterExpression} found in the
-     * exploratory expressions of {@code ref}, or {@link SchemaIdentifier#current()} if none is found.
+     * exploratory expressions of {@code ref} (or recursively in their quantifiers' referenced groups),
+     * or {@link SchemaIdentifier#current()} if none is found.
      */
     @Nonnull
     private static SchemaIdentifier schemaIdFromReference(@Nonnull final Reference ref) {
         for (final RelationalExpression expr : ref.getExploratoryExpressions()) {
             if (expr instanceof LogicalTypeFilterExpression) {
                 return ((LogicalTypeFilterExpression) expr).getSchemaId();
+            }
+            for (final Quantifier q : expr.getQuantifiers()) {
+                final SchemaIdentifier sid = schemaIdFromReference(q.getRangesOver());
+                if (!sid.isCurrentSchema()) {
+                    return sid;
+                }
             }
         }
         return SchemaIdentifier.current();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementTypeFilterRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementTypeFilterRule.java
@@ -27,12 +27,14 @@ import com.apple.foundationdb.record.query.plan.cascades.LinkedIdentitySet;
 import com.apple.foundationdb.record.query.plan.cascades.PlanPartition;
 import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
 import com.apple.foundationdb.record.query.plan.cascades.Reference;
+import com.apple.foundationdb.record.query.plan.cascades.SchemaIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.LogicalTypeFilterExpression;
 import com.apple.foundationdb.record.query.plan.cascades.matching.structure.BindingMatcher;
 import com.apple.foundationdb.record.query.plan.cascades.properties.RecordTypesProperty.RecordTypesVisitor;
 import com.apple.foundationdb.record.query.plan.cascades.properties.StoredRecordProperty;
 import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryStoreBindingPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryTypeFilterPlan;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Sets;
@@ -93,17 +95,29 @@ public class ImplementTypeFilterRule extends ImplementationCascadesRule<LogicalT
         }
 
         final var unsatisfiedMap = unsatisfiedMapBuilder.build();
+        final SchemaIdentifier schemaId = logicalTypeFilterExpression.getSchemaId();
 
         if (!noTypeFilterNeeded.isEmpty()) {
-            call.yieldPlans(noTypeFilterNeeded);
+            if (schemaId.isCurrentSchema()) {
+                call.yieldPlans(noTypeFilterNeeded);
+            } else {
+                for (final var plan : noTypeFilterNeeded) {
+                    call.yieldPlan(RecordQueryStoreBindingPlan.of(plan, schemaId));
+                }
+            }
         }
 
         for (Map.Entry<Set<String>, Collection<RecordQueryPlan>> unsatisfiedEntry : unsatisfiedMap.asMap().entrySet()) {
-            call.yieldPlan(
+            final RecordQueryTypeFilterPlan typeFilterPlan =
                     new RecordQueryTypeFilterPlan(
                             Quantifier.physical(call.memoizeMemberPlansFromOther(innerReference, unsatisfiedEntry.getValue())),
                             unsatisfiedEntry.getKey(),
-                            Type.Relation.scalarOf(logicalTypeFilterExpression.getResultType())));
+                            Type.Relation.scalarOf(logicalTypeFilterExpression.getResultType()));
+            if (schemaId.isCurrentSchema()) {
+                call.yieldPlan(typeFilterPlan);
+            } else {
+                call.yieldPlan(RecordQueryStoreBindingPlan.of(typeFilterPlan, schemaId));
+            }
         }
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryStoreBindingPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryStoreBindingPlan.java
@@ -25,10 +25,12 @@ import com.apple.foundationdb.record.EvaluationContext;
 import com.apple.foundationdb.record.ExecuteProperties;
 import com.apple.foundationdb.record.ObjectPlanHash;
 import com.apple.foundationdb.record.PlanHashable;
+import com.apple.foundationdb.record.PlanDeserializer;
 import com.apple.foundationdb.record.PlanSerializationContext;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.planprotos.PRecordQueryPlan;
+import com.apple.foundationdb.record.planprotos.PRecordQueryStoreBindingPlan;
 import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
@@ -47,6 +49,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import com.google.auto.service.AutoService;
 import com.google.protobuf.Message;
 
 import javax.annotation.Nonnull;
@@ -223,13 +226,51 @@ public class RecordQueryStoreBindingPlan extends AbstractRelationalExpressionWit
     @Nonnull
     @Override
     public Message toProto(@Nonnull final PlanSerializationContext serializationContext) {
-        throw new RecordCoreException("RecordQueryStoreBindingPlan proto serialization not yet implemented");
+        return toStoreBindingPlanProto(serializationContext);
     }
 
     @Nonnull
     @Override
     public PRecordQueryPlan toRecordQueryPlanProto(@Nonnull final PlanSerializationContext serializationContext) {
-        throw new RecordCoreException("RecordQueryStoreBindingPlan proto serialization not yet implemented");
+        return PRecordQueryPlan.newBuilder().setStoreBindingPlan(toStoreBindingPlanProto(serializationContext)).build();
+    }
+
+    @Nonnull
+    public PRecordQueryStoreBindingPlan toStoreBindingPlanProto(@Nonnull final PlanSerializationContext serializationContext) {
+        final String schemaName = Objects.requireNonNull(schemaId.getSchemaName(),
+                "RecordQueryStoreBindingPlan requires a named schema for serialization");
+        return PRecordQueryStoreBindingPlan.newBuilder()
+                .setInner(inner.toProto(serializationContext))
+                .setSchemaName(schemaName)
+                .build();
+    }
+
+    @Nonnull
+    public static RecordQueryStoreBindingPlan fromProto(@Nonnull final PlanSerializationContext serializationContext,
+                                                        @Nonnull final PRecordQueryStoreBindingPlan proto) {
+        final Quantifier.Physical q =
+                Quantifier.Physical.fromProto(serializationContext, Objects.requireNonNull(proto.getInner()));
+        final String schemaName = Objects.requireNonNull(proto.getSchemaName());
+        return new RecordQueryStoreBindingPlan(q, SchemaIdentifier.of(schemaName));
+    }
+
+    /**
+     * Deserializer.
+     */
+    @AutoService(PlanDeserializer.class)
+    public static class Deserializer implements PlanDeserializer<PRecordQueryStoreBindingPlan, RecordQueryStoreBindingPlan> {
+        @Nonnull
+        @Override
+        public Class<PRecordQueryStoreBindingPlan> getProtoMessageClass() {
+            return PRecordQueryStoreBindingPlan.class;
+        }
+
+        @Nonnull
+        @Override
+        public RecordQueryStoreBindingPlan fromProto(@Nonnull final PlanSerializationContext serializationContext,
+                                                     @Nonnull final PRecordQueryStoreBindingPlan proto) {
+            return RecordQueryStoreBindingPlan.fromProto(serializationContext, proto);
+        }
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryStoreBindingPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryStoreBindingPlan.java
@@ -1,0 +1,240 @@
+/*
+ * RecordQueryStoreBindingPlan.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.plans;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.EvaluationContext;
+import com.apple.foundationdb.record.ExecuteProperties;
+import com.apple.foundationdb.record.ObjectPlanHash;
+import com.apple.foundationdb.record.PlanHashable;
+import com.apple.foundationdb.record.PlanSerializationContext;
+import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.RecordCursor;
+import com.apple.foundationdb.record.planprotos.PRecordQueryPlan;
+import com.apple.foundationdb.record.provider.common.StoreTimer;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
+import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
+import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
+import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
+import com.apple.foundationdb.record.query.plan.cascades.Reference;
+import com.apple.foundationdb.record.query.plan.cascades.SchemaIdentifier;
+import com.apple.foundationdb.record.query.plan.cascades.explain.Attribute;
+import com.apple.foundationdb.record.query.plan.cascades.explain.NodeInfo;
+import com.apple.foundationdb.record.query.plan.cascades.explain.PlannerGraph;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.AbstractRelationalExpressionWithChildren;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpression;
+import com.apple.foundationdb.record.query.plan.cascades.values.Value;
+import com.apple.foundationdb.record.query.plan.cascades.values.translation.TranslationMap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.protobuf.Message;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * A plan node that intercepts {@link #executePlan} and substitutes a secondary
+ * {@link FDBRecordStoreBase} (looked up by schema name from
+ * {@link EvaluationContext#getAuxiliaryStore}) for its inner subtree.
+ *
+ * <p>This node is emitted by {@code ImplementNestedLoopJoinRule} when the inner side of a
+ * {@code RecordQueryFlatMapPlan} belongs to a different schema than the outer side. It is
+ * transparent for all planning purposes — it does not reorder, filter, or transform records.</p>
+ */
+@API(API.Status.EXPERIMENTAL)
+public class RecordQueryStoreBindingPlan extends AbstractRelationalExpressionWithChildren implements RecordQueryPlanWithChild {
+    private static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("Record-Query-Store-Binding-Plan");
+
+    @Nonnull
+    private final Quantifier.Physical inner;
+    @Nonnull
+    private final SchemaIdentifier schemaId;
+
+    public RecordQueryStoreBindingPlan(@Nonnull final Quantifier.Physical inner,
+                                       @Nonnull final SchemaIdentifier schemaId) {
+        this.inner = inner;
+        this.schemaId = schemaId;
+    }
+
+    @Nonnull
+    public SchemaIdentifier getSchemaId() {
+        return schemaId;
+    }
+
+    @Nonnull
+    public RecordQueryPlan getInnerPlan() {
+        return inner.getRangesOverPlan();
+    }
+
+    @Nonnull
+    @Override
+    public RecordQueryPlan getChild() {
+        return getInnerPlan();
+    }
+
+    @Nonnull
+    @Override
+    public RecordQueryPlanWithChild withChild(@Nonnull final Reference childRef) {
+        return new RecordQueryStoreBindingPlan(
+                Quantifier.physical(childRef, inner.getAlias()),
+                schemaId);
+    }
+
+    @Nonnull
+    @Override
+    @SuppressWarnings("unchecked")
+    public <M extends Message> RecordCursor<QueryResult> executePlan(@Nonnull final FDBRecordStoreBase<M> store,
+                                                                     @Nonnull final EvaluationContext context,
+                                                                     @Nullable final byte[] continuation,
+                                                                     @Nonnull final ExecuteProperties executeProperties) {
+        final String schemaName = Objects.requireNonNull(schemaId.getSchemaName(),
+                "RecordQueryStoreBindingPlan requires a named schema, not current()");
+        final FDBRecordStoreBase<?> secondaryStore = context.getAuxiliaryStore(schemaName);
+        if (secondaryStore == null) {
+            throw new RecordCoreException("No auxiliary store bound for schema: " + schemaName);
+        }
+        return getInnerPlan().executePlan((FDBRecordStoreBase<M>) secondaryStore, context, continuation, executeProperties);
+    }
+
+    @Override
+    public boolean isReverse() {
+        return getInnerPlan().isReverse();
+    }
+
+    @Nonnull
+    @Override
+    public List<? extends Quantifier> getQuantifiers() {
+        return ImmutableList.of(inner);
+    }
+
+    @Nonnull
+    @Override
+    public Value getResultValue() {
+        return inner.getFlowedObjectValue();
+    }
+
+    @Nonnull
+    @Override
+    public Set<CorrelationIdentifier> computeCorrelatedToWithoutChildren() {
+        return ImmutableSet.of();
+    }
+
+    @Nonnull
+    @Override
+    public RecordQueryStoreBindingPlan translateCorrelations(@Nonnull final TranslationMap translationMap,
+                                                             final boolean shouldSimplifyValues,
+                                                             @Nonnull final List<? extends Quantifier> translatedQuantifiers) {
+        return new RecordQueryStoreBindingPlan(
+                Iterables.getOnlyElement(translatedQuantifiers).narrow(Quantifier.Physical.class),
+                schemaId);
+    }
+
+    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
+    @Override
+    public boolean equals(final Object other) {
+        return structuralEquals(other);
+    }
+
+    @Override
+    public int hashCode() {
+        return structuralHashCode();
+    }
+
+    @Override
+    public int computeHashCodeWithoutChildren() {
+        return Objects.hash(schemaId);
+    }
+
+    @Override
+    public boolean equalsWithoutChildren(@Nonnull final RelationalExpression otherExpression,
+                                         @Nonnull final AliasMap equivalencesMap) {
+        if (this == otherExpression) {
+            return true;
+        }
+        if (getClass() != otherExpression.getClass()) {
+            return false;
+        }
+        return schemaId.equals(((RecordQueryStoreBindingPlan) otherExpression).schemaId);
+    }
+
+    @Override
+    public int planHash(@Nonnull final PlanHashMode mode) {
+        switch (mode.getKind()) {
+            case LEGACY:
+                return getInnerPlan().planHash(mode);
+            case FOR_CONTINUATION:
+                return PlanHashable.objectsPlanHash(mode, BASE_HASH, getInnerPlan(),
+                        schemaId.getSchemaName());
+            default:
+                throw new RecordCoreException("Unknown PlanHashMode: " + mode.getKind());
+        }
+    }
+
+    @Override
+    public void logPlanStructure(@Nonnull final StoreTimer timer) {
+        getInnerPlan().logPlanStructure(timer);
+    }
+
+    @Override
+    public int getComplexity() {
+        return 1 + getInnerPlan().getComplexity();
+    }
+
+    @Nonnull
+    @Override
+    public String toString() {
+        return "STORE_BIND(" + schemaId + ") | " + getInnerPlan();
+    }
+
+    @Nonnull
+    @Override
+    public PlannerGraph rewritePlannerGraph(@Nonnull final List<? extends PlannerGraph> childGraphs) {
+        return PlannerGraph.fromNodeAndChildGraphs(
+                new PlannerGraph.LogicalOperatorNodeWithInfo(this,
+                        NodeInfo.PREDICATE_FILTER_OPERATOR,
+                        ImmutableList.of("STORE_BIND {{schema}}"),
+                        ImmutableMap.of("schema", Attribute.gml(schemaId.toString()))),
+                childGraphs);
+    }
+
+    @Nonnull
+    @Override
+    public Message toProto(@Nonnull final PlanSerializationContext serializationContext) {
+        throw new RecordCoreException("RecordQueryStoreBindingPlan proto serialization not yet implemented");
+    }
+
+    @Nonnull
+    @Override
+    public PRecordQueryPlan toRecordQueryPlanProto(@Nonnull final PlanSerializationContext serializationContext) {
+        throw new RecordCoreException("RecordQueryStoreBindingPlan proto serialization not yet implemented");
+    }
+
+    @Nonnull
+    public static RecordQueryStoreBindingPlan of(@Nonnull final RecordQueryPlan innerPlan,
+                                                 @Nonnull final SchemaIdentifier schemaId) {
+        return new RecordQueryStoreBindingPlan(Quantifier.physical(Reference.plannedOf(innerPlan)), schemaId);
+    }
+}

--- a/fdb-record-layer-core/src/main/proto/record_query_plan.proto
+++ b/fdb-record-layer-core/src/main/proto/record_query_plan.proto
@@ -1739,6 +1739,7 @@ message PRecordQueryPlan {
     PRecordQueryStreamingAggregationPlan2 streaming_aggregation_plan2 = 38;
     PRecordQueryMultiIntersectionOnValuesPlan multi_intersection_on_values_plan = 39;
     PRecordQueryRecursiveDfsJoinPlan recursive_dfs_join_plan = 40;
+    PRecordQueryStoreBindingPlan store_binding_plan = 41;
   }
 }
 
@@ -2385,4 +2386,12 @@ message PRecordQueryRecursiveDfsJoinPlan {
   optional PPhysicalQuantifier child_quantifier = 2;
   optional string prior_value_correlation = 3;
   optional PDfsTraversalStrategy dfs_traversal_strategy = 4;
+}
+
+//
+// PRecordQueryStoreBindingPlan
+//
+message PRecordQueryStoreBindingPlan {
+  optional PPhysicalQuantifier inner = 1;
+  optional string schema_name = 2;
 }

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/EmbeddedRelationalPreparedStatement.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/EmbeddedRelationalPreparedStatement.java
@@ -224,6 +224,14 @@ public class EmbeddedRelationalPreparedStatement extends AbstractEmbeddedStateme
                 .withMetricsCollector(Assert.notNullUnchecked(conn.getMetricCollector()))
                 .withPreparedParameters(PreparedParams.of(parameters, namedParameters))
                 .withSchemaTemplate(conn.getTransaction().getBoundSchemaTemplateMaybe().orElse(conn.getSchemaTemplate()))
+                .withSecondarySchemaLookup(schemaName -> {
+                    try {
+                        return java.util.Optional.of(
+                                conn.getBackingCatalog().loadSchema(conn.getTransaction(), conn.getPath(), schemaName).getSchemaTemplate());
+                    } catch (RelationalException e) {
+                        return java.util.Optional.empty();
+                    }
+                })
                 .build();
     }
 

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/EmbeddedRelationalStatement.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/EmbeddedRelationalStatement.java
@@ -64,6 +64,14 @@ public class EmbeddedRelationalStatement extends AbstractEmbeddedStatement imple
                 .fromDatabase(conn.getRecordLayerDatabase())
                 .withMetricsCollector(Assert.notNullUnchecked(conn.getMetricCollector()))
                 .withSchemaTemplate(conn.getTransaction().getBoundSchemaTemplateMaybe().orElse(conn.getSchemaTemplate()))
+                .withSecondarySchemaLookup(schemaName -> {
+                    try {
+                        return java.util.Optional.of(
+                                conn.getBackingCatalog().loadSchema(conn.getTransaction(), conn.getPath(), schemaName).getSchemaTemplate());
+                    } catch (RelationalException e) {
+                        return java.util.Optional.empty();
+                    }
+                })
                 .build();
     }
 

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/LogicalOperator.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/LogicalOperator.java
@@ -30,6 +30,7 @@ import com.apple.foundationdb.record.query.plan.cascades.GraphExpansion;
 import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
 import com.apple.foundationdb.record.query.plan.cascades.Reference;
 import com.apple.foundationdb.record.query.plan.cascades.RequestedOrdering;
+import com.apple.foundationdb.record.query.plan.cascades.SchemaIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.ExplodeExpression;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.FullUnorderedScanExpression;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.GroupByExpression;
@@ -53,6 +54,7 @@ import com.apple.foundationdb.record.query.plan.cascades.values.VariadicFunction
 import com.apple.foundationdb.relational.api.exceptions.ErrorCode;
 import com.apple.foundationdb.relational.api.metadata.DataType;
 import com.apple.foundationdb.relational.api.metadata.Table;
+import com.apple.foundationdb.relational.api.metadata.SchemaTemplate;
 import com.apple.foundationdb.relational.recordlayer.metadata.DataTypeUtils;
 import com.apple.foundationdb.relational.recordlayer.metadata.RecordLayerTable;
 import com.apple.foundationdb.relational.util.Assert;
@@ -263,7 +265,17 @@ public class LogicalOperator {
     public static LogicalOperator generateTableAccess(@Nonnull Identifier tableId,
                                                       @Nonnull Set<AccessHint> indexAccessHints,
                                                       @Nonnull SemanticAnalyzer semanticAnalyzer) {
-        final Set<String> tableNames = semanticAnalyzer.getAllTableStorageNames();
+        final SchemaIdentifier schemaId = semanticAnalyzer.getSchemaIdFor(tableId);
+        final SchemaTemplate effectiveTemplate;
+        final Set<String> tableNames;
+        if (schemaId.isCurrentSchema()) {
+            effectiveTemplate = semanticAnalyzer.getMetadataCatalog();
+            tableNames = semanticAnalyzer.getAllTableStorageNames();
+        } else {
+            final var secondaryTemplate = semanticAnalyzer.getLoadedSecondarySchemas().get(schemaId.getSchemaName());
+            effectiveTemplate = secondaryTemplate;
+            tableNames = semanticAnalyzer.getAllTableStorageNamesForTemplate(secondaryTemplate);
+        }
         semanticAnalyzer.validateIndexes(tableId, indexAccessHints);
         final var scanExpression = Quantifier.forEach(Reference.initialOf(
                 new FullUnorderedScanExpression(tableNames,
@@ -271,7 +283,7 @@ public class LogicalOperator {
                         new AccessHints(indexAccessHints.toArray(new AccessHint[0])))));
         final var table = semanticAnalyzer.getTable(tableId);
         Type.Record type = Assert.castUnchecked(table, RecordLayerTable.class).getType();
-        if (semanticAnalyzer.getMetadataCatalog().isStoreRowVersions()) {
+        if (effectiveTemplate.isStoreRowVersions()) {
             // Ideally, the RecordLayerTable would have the full type with all the pseudo-fields,
             // but we need star expansion to skip over these fields. That would be made easier
             // if we fully supported invisible columns (see: https://github.com/FoundationDB/fdb-record-layer/pull/3787)
@@ -279,7 +291,7 @@ public class LogicalOperator {
         }
         final String storageName = type.getStorageName();
         Assert.thatUnchecked(storageName != null, "storage name for table access must not be null");
-        final var typeFilterExpression = LogicalTypeFilterExpression.of(ImmutableSet.of(storageName), scanExpression, type);
+        final var typeFilterExpression = LogicalTypeFilterExpression.of(ImmutableSet.of(storageName), scanExpression, type, schemaId);
         final var resultingQuantifier = Quantifier.forEach(Reference.initialOf(typeFilterExpression));
         final ImmutableList.Builder<Expression> attributesBuilder = ImmutableList.builder();
         int colCount = 0;
@@ -292,7 +304,7 @@ public class LogicalOperator {
             attributesBuilder.add(new Expression(Optional.of(attributeName), attributeType, attributeExpression));
             colCount++;
         }
-        if (semanticAnalyzer.getMetadataCatalog().isStoreRowVersions()
+        if (effectiveTemplate.isStoreRowVersions()
                 && table.getColumns().stream().noneMatch(column -> column.getName().equals(PseudoField.ROW_VERSION.getFieldName()))) {
             final var pseudoFieldValue = FieldValue.ofFieldName(resultingQuantifier.getFlowedObjectValue(), PseudoField.ROW_VERSION.getFieldName());
             final Expression pseudoExpression = new Expression(Optional.of(Identifier.of(PseudoField.ROW_VERSION.getFieldName())), DataType.VersionType.nullable(), pseudoFieldValue);

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/PlanContext.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/PlanContext.java
@@ -25,6 +25,7 @@ import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.RecordStoreState;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.query.plan.RecordQueryPlannerConfiguration;
+import com.apple.foundationdb.record.query.plan.cascades.SchemaIdentifier;
 import com.apple.foundationdb.relational.api.Options;
 import com.apple.foundationdb.relational.api.ddl.DdlQueryFactory;
 import com.apple.foundationdb.relational.api.ddl.MetadataOperationsFactory;
@@ -33,12 +34,16 @@ import com.apple.foundationdb.relational.api.metadata.SchemaTemplate;
 import com.apple.foundationdb.relational.api.metrics.MetricCollector;
 import com.apple.foundationdb.relational.recordlayer.AbstractDatabase;
 import com.apple.foundationdb.relational.util.Assert;
+import com.apple.foundationdb.record.util.pair.NonnullPair;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
 
 import javax.annotation.Nonnull;
 import java.net.URI;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @API(API.Status.EXPERIMENTAL)
@@ -66,6 +71,12 @@ public final class PlanContext {
 
     private final boolean isCaseSensitive;
 
+    @Nonnull
+    private final Function<String, Optional<SchemaTemplate>> secondarySchemaLookup;
+
+    @Nonnull
+    private final ImmutableMap<SchemaIdentifier, NonnullPair<RecordMetaData, RecordStoreState>> additionalSchemas;
+
     /**
      * Creates a new instance of {@link PlanContext} needed for generating plans.
      *
@@ -90,7 +101,9 @@ public final class PlanContext {
                         @Nonnull URI dbUri,
                         @Nonnull PreparedParams preparedStatementParameters,
                         final int userVersion,
-                        boolean isCaseSensitive) {
+                        boolean isCaseSensitive,
+                        @Nonnull Function<String, Optional<SchemaTemplate>> secondarySchemaLookup,
+                        @Nonnull ImmutableMap<SchemaIdentifier, NonnullPair<RecordMetaData, RecordStoreState>> additionalSchemas) {
         this.metaData = metaData;
         this.metricCollector = metricCollector;
         this.schemaTemplate = schemaTemplate;
@@ -101,6 +114,8 @@ public final class PlanContext {
         this.preparedStatementParameters = preparedStatementParameters;
         this.userVersion = userVersion;
         this.isCaseSensitive = isCaseSensitive;
+        this.secondarySchemaLookup = secondarySchemaLookup;
+        this.additionalSchemas = additionalSchemas;
     }
 
     @Nonnull
@@ -158,6 +173,24 @@ public final class PlanContext {
     }
 
     @Nonnull
+    public Function<String, Optional<SchemaTemplate>> getSecondarySchemaLookup() {
+        return secondarySchemaLookup;
+    }
+
+    @Nonnull
+    public ImmutableMap<SchemaIdentifier, NonnullPair<RecordMetaData, RecordStoreState>> getAdditionalSchemas() {
+        return additionalSchemas;
+    }
+
+    @Nonnull
+    public PlanContext withAdditionalSchemas(
+            @Nonnull final ImmutableMap<SchemaIdentifier, NonnullPair<RecordMetaData, RecordStoreState>> newAdditionalSchemas) {
+        return new PlanContext(metaData, metricCollector, schemaTemplate, plannerConfiguration,
+                metadataOperationsFactory, ddlQueryFactory, dbUri, preparedStatementParameters,
+                userVersion, isCaseSensitive, secondarySchemaLookup, newAdditionalSchemas);
+    }
+
+    @Nonnull
     public static Builder builder() {
         return new Builder();
     }
@@ -183,6 +216,9 @@ public final class PlanContext {
         private PreparedParams preparedStatementParameters;
 
         private boolean isCaseSensitive;
+
+        @Nonnull
+        private Function<String, Optional<SchemaTemplate>> secondarySchemaLookup = s -> Optional.empty();
 
         private Builder() {
         }
@@ -265,6 +301,12 @@ public final class PlanContext {
         }
 
         @Nonnull
+        public Builder withSecondarySchemaLookup(@Nonnull final Function<String, Optional<SchemaTemplate>> lookup) {
+            this.secondarySchemaLookup = lookup;
+            return this;
+        }
+
+        @Nonnull
         public Builder fromRecordStore(@Nonnull FDBRecordStoreBase<?> recordStore, @Nonnull final Options options) {
             final var plannerConfig = recordStore.getRecordStoreState().allIndexesReadable() ?
                     PlannerConfiguration.ofAllAvailableIndexes(options) :
@@ -298,7 +340,8 @@ public final class PlanContext {
         public PlanContext build() throws RelationalException {
             verify();
             return new PlanContext(metaData, metricCollector, schemaTemplate, plannerConfiguration, metadataOperationsFactory,
-                    ddlQueryFactory, dbUri, preparedStatementParameters, userVersion, isCaseSensitive);
+                    ddlQueryFactory, dbUri, preparedStatementParameters, userVersion, isCaseSensitive,
+                    secondarySchemaLookup, ImmutableMap.of());
         }
 
         @Nonnull
@@ -318,7 +361,8 @@ public final class PlanContext {
                     .withPlannerConfiguration(planContext.plannerConfiguration)
                     .withUserVersion(planContext.userVersion)
                     .withPreparedParameters(planContext.preparedStatementParameters)
-                    .isCaseSensitive(planContext.isCaseSensitive);
+                    .isCaseSensitive(planContext.isCaseSensitive)
+                    .withSecondarySchemaLookup(planContext.secondarySchemaLookup);
         }
     }
 }

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/PlanGenerator.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/PlanGenerator.java
@@ -30,6 +30,7 @@ import com.apple.foundationdb.record.metadata.MetaDataException;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMatchCandidateRegistry;
 import com.apple.foundationdb.record.query.plan.QueryPlanConstraint;
+import com.apple.foundationdb.record.query.plan.cascades.SchemaIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.CascadesPlanner;
 import com.apple.foundationdb.record.query.plan.cascades.SemanticException;
 import com.apple.foundationdb.record.query.plan.cascades.StableSelectorCostModel;
@@ -49,6 +50,7 @@ import com.apple.foundationdb.relational.api.metrics.RelationalMetric;
 import com.apple.foundationdb.relational.continuation.CompiledStatement;
 import com.apple.foundationdb.relational.continuation.TypedQueryArgument;
 import com.apple.foundationdb.relational.recordlayer.ContinuationImpl;
+import com.apple.foundationdb.relational.api.metadata.SchemaTemplate;
 import com.apple.foundationdb.relational.recordlayer.metadata.DataTypeUtils;
 import com.apple.foundationdb.relational.recordlayer.metadata.RecordLayerSchemaTemplate;
 import com.apple.foundationdb.relational.recordlayer.query.cache.PhysicalPlanEquivalence;
@@ -59,6 +61,7 @@ import com.apple.foundationdb.relational.util.Assert;
 import com.apple.foundationdb.relational.util.RelationalLoggingUtil;
 import com.google.common.base.VerifyException;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.protobuf.InvalidProtocolBufferException;
 import org.apache.logging.log4j.LogManager;
@@ -247,11 +250,13 @@ public final class PlanGenerator {
         planGenerationContext.setForExplain(ast.getQueryExecutionContext().isForExplain());
         final var metadata = Assert.castUnchecked(planContext.getSchemaTemplate(), RecordLayerSchemaTemplate.class);
         try (var ignored = new PlannerEventStatsCollector.DefaultStatsCollectorController()) {
+            final var visitor = new BaseVisitor(planGenerationContext, metadata, planContext.getDdlQueryFactory(),
+                    planContext.getConstantActionFactory(), planContext.getDbUri(), caseSensitive);
+            visitor.getSemanticAnalyzer().setSecondarySchemaLookup(planContext.getSecondarySchemaLookup());
             final var maybePlan = planContext.getMetricsCollector().clock(RelationalMetric.RelationalEvent.GENERATE_LOGICAL_PLAN, () ->
-                    new BaseVisitor(planGenerationContext, metadata, planContext.getDdlQueryFactory(),
-                            planContext.getConstantActionFactory(), planContext.getDbUri(), caseSensitive)
-                            .generateLogicalPlan(ast.getParseTree()));
-            return maybePlan.optimize(planner, planContext, currentPlanHashMode);
+                    visitor.generateLogicalPlan(ast.getParseTree()));
+            final var enrichedPlanContext = enrichWithSecondarySchemas(planContext, visitor.getSemanticAnalyzer().getLoadedSecondarySchemas());
+            return maybePlan.optimize(planner, enrichedPlanContext, currentPlanHashMode);
         } catch (ProtoUtils.InvalidNameException ine) {
             throw new RelationalException(ine.getMessage(), ErrorCode.INVALID_NAME, ine).toUncheckedWrappedException();
         } catch (MetaDataException mde) {
@@ -262,6 +267,22 @@ public final class PlanGenerator {
         } catch (RelationalException e) {
             throw e.toUncheckedWrappedException();
         }
+    }
+
+    @Nonnull
+    private static PlanContext enrichWithSecondarySchemas(@Nonnull final PlanContext planContext,
+                                                          @Nonnull final java.util.Map<String, SchemaTemplate> loadedSecondarySchemas) {
+        if (loadedSecondarySchemas.isEmpty()) {
+            return planContext;
+        }
+        final ImmutableMap.Builder<SchemaIdentifier, NonnullPair<RecordMetaData, RecordStoreState>> builder = ImmutableMap.builder();
+        for (final var entry : loadedSecondarySchemas.entrySet()) {
+            final var schemaId = SchemaIdentifier.of(entry.getKey());
+            final var rlTemplate = Assert.castUnchecked(entry.getValue(), RecordLayerSchemaTemplate.class);
+            final var recMeta = rlTemplate.toRecordMetadata();
+            builder.put(schemaId, NonnullPair.of(recMeta, new RecordStoreState(null, null)));
+        }
+        return planContext.withAdditionalSchemas(builder.build());
     }
 
     @Nonnull

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/QueryPlan.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/QueryPlan.java
@@ -35,6 +35,8 @@ import com.apple.foundationdb.record.query.plan.QueryPlanResult;
 import com.apple.foundationdb.record.query.plan.cascades.CascadesPlanner;
 import com.apple.foundationdb.record.query.plan.cascades.PlannerPhase;
 import com.apple.foundationdb.record.query.plan.cascades.Reference;
+import com.apple.foundationdb.record.query.plan.cascades.SchemaIdentifier;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryStoreBindingPlan;
 import com.apple.foundationdb.record.query.plan.cascades.events.ExecutingTaskPlannerEvent;
 import com.apple.foundationdb.record.query.plan.cascades.events.InsertIntoMemoPlannerEvent;
 import com.apple.foundationdb.record.query.plan.cascades.events.PlannerEvent.Location;
@@ -83,6 +85,8 @@ import com.apple.foundationdb.relational.util.Assert;
 import com.google.common.base.Suppliers;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
 
@@ -257,7 +261,8 @@ public abstract class QueryPlan extends Plan<RelationalResultSet> implements Typ
                 final String schemaName = conn.getSchema();
                 try (RecordLayerSchema recordLayerSchema = conn.getRecordLayerDatabase().loadSchema(schemaName)) {
                     final var evaluationContext = queryExecutionContext.getEvaluationContext();
-                    final var typedEvaluationContext = EvaluationContext.forBindingsAndTypeRepository(evaluationContext.getBindings(), typeRepository);
+                    var typedEvaluationContext = EvaluationContext.forBindingsAndTypeRepository(evaluationContext.getBindings(), typeRepository);
+                    typedEvaluationContext = injectSecondaryStores(typedEvaluationContext, recordQueryPlan, conn);
                     final ContinuationImpl parsedContinuation;
                     try {
                         parsedContinuation = ContinuationImpl.parseContinuation(queryExecutionContext.getContinuation());
@@ -273,6 +278,43 @@ public abstract class QueryPlan extends Plan<RelationalResultSet> implements Typ
                 }
             } catch (SQLException sqle) {
                 throw new RelationalException(sqle);
+            }
+        }
+
+        @Nonnull
+        private static EvaluationContext injectSecondaryStores(@Nonnull final EvaluationContext base,
+                                                               @Nonnull final RecordQueryPlan plan,
+                                                               @Nonnull final EmbeddedRelationalConnection conn) throws RelationalException {
+            final var schemaNames = collectSecondarySchemaNames(plan);
+            if (schemaNames.isEmpty()) {
+                return base;
+            }
+            final ImmutableMap.Builder<String, FDBRecordStoreBase<?>> storeMapBuilder = ImmutableMap.builder();
+            for (final var secondarySchemaName : schemaNames) {
+                try (RecordLayerSchema secondarySchema = conn.getRecordLayerDatabase().loadSchema(secondarySchemaName)) {
+                    storeMapBuilder.put(secondarySchemaName, secondarySchema.loadStore().unwrap(FDBRecordStoreBase.class));
+                }
+            }
+            return base.withAuxiliaryStores(storeMapBuilder.build());
+        }
+
+        @Nonnull
+        private static Set<String> collectSecondarySchemaNames(@Nonnull final RecordQueryPlan plan) {
+            final ImmutableSet.Builder<String> builder = ImmutableSet.builder();
+            collectSecondarySchemaNames(plan, builder);
+            return builder.build();
+        }
+
+        private static void collectSecondarySchemaNames(@Nonnull final RecordQueryPlan plan,
+                                                        @Nonnull final ImmutableSet.Builder<String> builder) {
+            if (plan instanceof RecordQueryStoreBindingPlan) {
+                final var schemaId = ((RecordQueryStoreBindingPlan) plan).getSchemaId();
+                if (!schemaId.isCurrentSchema() && schemaId.getSchemaName() != null) {
+                    builder.add(schemaId.getSchemaName());
+                }
+            }
+            for (final RecordQueryPlan child : plan.getChildren()) {
+                collectSecondarySchemaNames(child, builder);
             }
         }
 
@@ -643,11 +685,21 @@ public abstract class QueryPlan extends Plan<RelationalResultSet> implements Typ
                 final var typedEvaluationContext = EvaluationContext.forBindingsAndTypeRepository(evaluationContext.getBindings(), builder.build());
                 final QueryPlanResult planResult;
                 try {
-                    planResult = planner.planGraph(() ->
-                                    Reference.initialOf(relationalExpression),
-                            planContext.getReadableIndexes().map(s -> s),
-                            IndexQueryabilityFilter.TRUE,
-                            typedEvaluationContext);
+                    final var additionalSchemas = planContext.getAdditionalSchemas();
+                    if (additionalSchemas.isEmpty()) {
+                        planResult = planner.planGraph(() ->
+                                        Reference.initialOf(relationalExpression),
+                                planContext.getReadableIndexes().map(s -> s),
+                                IndexQueryabilityFilter.TRUE,
+                                typedEvaluationContext);
+                    } else {
+                        planResult = planner.planGraph(() ->
+                                        Reference.initialOf(relationalExpression),
+                                planContext.getReadableIndexes().map(s -> s),
+                                IndexQueryabilityFilter.TRUE,
+                                typedEvaluationContext,
+                                additionalSchemas);
+                    }
                 } catch (RecordCoreException ex) {
                     throw ExceptionUtil.toRelationalException(ex);
                 }

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/SemanticAnalyzer.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/SemanticAnalyzer.java
@@ -24,6 +24,7 @@ import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.EvaluationContext;
 import com.apple.foundationdb.record.query.plan.cascades.AccessHint;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
+import com.apple.foundationdb.record.query.plan.cascades.SchemaIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.BuiltInFunction;
 import com.apple.foundationdb.record.query.plan.cascades.BuiltInTableFunction;
 import com.apple.foundationdb.record.query.plan.cascades.CatalogedFunction;
@@ -81,6 +82,8 @@ import org.antlr.v4.runtime.tree.ParseTree;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.net.URI;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -122,6 +125,12 @@ public class SemanticAnalyzer {
 
     private final boolean isCaseSensitive;
 
+    @Nonnull
+    private java.util.function.Function<String, Optional<SchemaTemplate>> secondarySchemaLookup;
+
+    @Nonnull
+    private final LinkedHashMap<String, SchemaTemplate> loadedSecondarySchemas;
+
     public SemanticAnalyzer(@Nonnull SchemaTemplate metadataCatalog,
                             @Nonnull SqlFunctionCatalog functionCatalog,
                             @Nonnull MutablePlanGenerationContext mutablePlanGenerationContext,
@@ -130,6 +139,13 @@ public class SemanticAnalyzer {
         this.functionCatalog = functionCatalog;
         this.mutablePlanGenerationContext = mutablePlanGenerationContext;
         this.isCaseSensitive = isCaseSensitive;
+        this.secondarySchemaLookup = s -> Optional.empty();
+        this.loadedSecondarySchemas = new LinkedHashMap<>();
+    }
+
+    public void setSecondarySchemaLookup(
+            @Nonnull final java.util.function.Function<String, Optional<SchemaTemplate>> lookup) {
+        this.secondarySchemaLookup = lookup;
     }
 
     /**
@@ -195,7 +211,15 @@ public class SemanticAnalyzer {
         if (tableIdentifier.isQualified()) {
             final var qualifier = tableIdentifier.getQualifier().get(0);
             if (!metadataCatalog.getName().equals(qualifier)) {
-                return false;
+                return tryLoadSecondarySchema(qualifier)
+                        .map(template -> {
+                            try {
+                                return template.findTableByName(tableIdentifier.getName()).isPresent();
+                            } catch (RelationalException e) {
+                                throw e.toUncheckedWrappedException();
+                            }
+                        })
+                        .orElse(false);
             }
         }
 
@@ -205,6 +229,17 @@ public class SemanticAnalyzer {
         } catch (RelationalException e) {
             throw e.toUncheckedWrappedException();
         }
+    }
+
+    @Nonnull
+    private Optional<SchemaTemplate> tryLoadSecondarySchema(@Nonnull final String schemaName) {
+        final var cached = loadedSecondarySchemas.get(schemaName);
+        if (cached != null) {
+            return Optional.of(cached);
+        }
+        final var result = secondarySchemaLookup.apply(schemaName);
+        result.ifPresent(template -> loadedSecondarySchemas.put(schemaName, template));
+        return result;
     }
 
     public boolean viewExists(@Nonnull final Identifier viewIdentifier) {
@@ -239,13 +274,22 @@ public class SemanticAnalyzer {
     @Nonnull
     public Table getTable(@Nonnull Identifier tableIdentifier) {
         Assert.thatUnchecked(tableIdentifier.getQualifier().size() <= 1, ErrorCode.INTERNAL_ERROR, () -> String.format(Locale.ROOT, "Unknown table %s", tableIdentifier));
+        final SchemaTemplate targetCatalog;
         if (tableIdentifier.isQualified()) {
             final var qualifier = tableIdentifier.getQualifier().get(0);
-            Assert.thatUnchecked(metadataCatalog.getName().equals(qualifier), ErrorCode.UNDEFINED_DATABASE, () -> String.format(Locale.ROOT, "Unknown schema template %s", qualifier));
+            if (metadataCatalog.getName().equals(qualifier)) {
+                targetCatalog = metadataCatalog;
+            } else {
+                final var secondaryTemplate = tryLoadSecondarySchema(qualifier);
+                Assert.thatUnchecked(secondaryTemplate.isPresent(), ErrorCode.UNDEFINED_DATABASE, () -> String.format(Locale.ROOT, "Unknown schema template %s", qualifier));
+                targetCatalog = secondaryTemplate.get();
+            }
+        } else {
+            targetCatalog = metadataCatalog;
         }
         final var tableName = tableIdentifier.getName();
         try {
-            final var tableMaybe = metadataCatalog.findTableByName(tableName);
+            final var tableMaybe = targetCatalog.findTableByName(tableName);
             Assert.thatUnchecked(tableMaybe.isPresent(), ErrorCode.UNDEFINED_TABLE, () -> String.format(Locale.ROOT, "Unknown table %s", tableName));
             return tableMaybe.get();
         } catch (RelationalException e) {
@@ -295,6 +339,35 @@ public class SemanticAnalyzer {
         } catch (RelationalException e) {
             throw e.toUncheckedWrappedException();
         }
+    }
+
+    @Nonnull
+    public Set<String> getAllTableStorageNamesForTemplate(@Nonnull final SchemaTemplate template) {
+        try {
+            return template.getTables().stream()
+                    .map(table -> Assert.castUnchecked(table, RecordLayerTable.class))
+                    .map(table -> Assert.notNullUnchecked(table.getType().getStorageName()))
+                    .collect(ImmutableSet.toImmutableSet());
+        } catch (RelationalException e) {
+            throw e.toUncheckedWrappedException();
+        }
+    }
+
+    @Nonnull
+    public SchemaIdentifier getSchemaIdFor(@Nonnull final Identifier tableId) {
+        if (!tableId.isQualified()) {
+            return SchemaIdentifier.current();
+        }
+        final var qualifier = tableId.getQualifier().get(0);
+        if (metadataCatalog.getName().equals(qualifier)) {
+            return SchemaIdentifier.current();
+        }
+        return SchemaIdentifier.of(qualifier);
+    }
+
+    @Nonnull
+    public Map<String, SchemaTemplate> getLoadedSecondarySchemas() {
+        return Collections.unmodifiableMap(loadedSecondarySchemas);
     }
 
     @Nonnull

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/CrossSchemaJoinTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/CrossSchemaJoinTest.java
@@ -1,0 +1,128 @@
+/*
+ * CrossSchemaJoinTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.relational.recordlayer.query;
+
+import com.apple.foundationdb.relational.api.Options;
+import com.apple.foundationdb.relational.recordlayer.EmbeddedRelationalExtension;
+import com.apple.foundationdb.relational.recordlayer.RelationalConnectionRule;
+import com.apple.foundationdb.relational.recordlayer.RelationalStatementRule;
+import com.apple.foundationdb.relational.recordlayer.Utils;
+import com.apple.foundationdb.relational.utils.ResultSetAssert;
+import com.apple.foundationdb.relational.utils.SchemaRule;
+import com.apple.foundationdb.relational.utils.SchemaTemplateRule;
+import com.apple.foundationdb.relational.utils.SimpleDatabaseRule;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.net.URI;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Map;
+
+public class CrossSchemaJoinTest {
+
+    private static final String PRIMARY_TEMPLATE_DEF =
+            "CREATE TABLE ITEMS (id BIGINT, name STRING, PRIMARY KEY(id))";
+
+    private static final String SECONDARY_TEMPLATE_NAME = "CrossSchemaJoinTest_SECONDARY_TEMPLATE";
+    private static final String SECONDARY_TEMPLATE_DEF =
+            "CREATE TABLE TAGS (item_id BIGINT, tag STRING, PRIMARY KEY(item_id))";
+    private static final String SECONDARY_SCHEMA_NAME = "SECONDARY_SCHEMA";
+
+    @RegisterExtension
+    @Order(0)
+    public final EmbeddedRelationalExtension relationalExtension = new EmbeddedRelationalExtension();
+
+    @RegisterExtension
+    @Order(1)
+    public final SimpleDatabaseRule db = new SimpleDatabaseRule(CrossSchemaJoinTest.class, PRIMARY_TEMPLATE_DEF);
+
+    @RegisterExtension
+    @Order(2)
+    public final SchemaTemplateRule secondaryTemplateRule = new SchemaTemplateRule(
+            SECONDARY_TEMPLATE_NAME, Options.none(), null, SECONDARY_TEMPLATE_DEF);
+
+    @RegisterExtension
+    @Order(3)
+    public final SchemaRule secondarySchemaRule = new SchemaRule(
+            SECONDARY_SCHEMA_NAME, URI.create("/TEST/CrossSchemaJoinTest"), SECONDARY_TEMPLATE_NAME, Options.none());
+
+    @RegisterExtension
+    @Order(4)
+    public final RelationalConnectionRule connection = new RelationalConnectionRule(db::getConnectionUri)
+            .withSchema(db.getSchemaName());
+
+    @RegisterExtension
+    @Order(5)
+    public final RelationalStatementRule statement = new RelationalStatementRule(connection);
+
+    public CrossSchemaJoinTest() throws SQLException {
+    }
+
+    @BeforeEach
+    void setup() throws Exception {
+        Utils.enableCascadesDebugger();
+        statement.execute("INSERT INTO ITEMS VALUES (1, 'Apple'), (2, 'Banana'), (3, 'Cherry')");
+        try (var secondaryConn = DriverManager.getConnection(db.getConnectionUri().toString())) {
+            secondaryConn.setSchema(SECONDARY_SCHEMA_NAME);
+            try (var stmt = secondaryConn.createStatement()) {
+                stmt.execute("INSERT INTO TAGS VALUES (1, 'fruit'), (2, 'yellow'), (3, 'red')");
+            }
+        }
+    }
+
+    @Test
+    void innerJoinAcrossSchemas() throws Exception {
+        try (var rs = statement.executeQuery(
+                "SELECT a.id, a.name, b.tag FROM ITEMS AS a JOIN " + SECONDARY_SCHEMA_NAME + ".TAGS AS b ON a.id = b.item_id ORDER BY a.id")) {
+            ResultSetAssert.assertThat(rs)
+                    .hasNextRow().hasColumns(Map.of("id", 1L, "name", "Apple",  "tag", "fruit"))
+                    .hasNextRow().hasColumns(Map.of("id", 2L, "name", "Banana", "tag", "yellow"))
+                    .hasNextRow().hasColumns(Map.of("id", 3L, "name", "Cherry", "tag", "red"))
+                    .hasNoNextRow();
+        }
+    }
+
+    @Test
+    void innerJoinAcrossSchemasWithFilter() throws Exception {
+        try (var rs = statement.executeQuery(
+                "SELECT a.id, a.name, b.tag FROM ITEMS AS a JOIN " + SECONDARY_SCHEMA_NAME + ".TAGS AS b ON a.id = b.item_id WHERE a.id = 2")) {
+            ResultSetAssert.assertThat(rs)
+                    .hasNextRow().hasColumns(Map.of("id", 2L, "name", "Banana", "tag", "yellow"))
+                    .hasNoNextRow();
+        }
+    }
+
+    @Test
+    void queryFromSecondarySchemaTableAlone() throws Exception {
+        try (var rs = statement.executeQuery(
+                "SELECT tag FROM " + SECONDARY_SCHEMA_NAME + ".TAGS ORDER BY item_id")) {
+            ResultSetAssert.assertThat(rs)
+                    .hasNextRow().hasColumns(Map.of("tag", "fruit"))
+                    .hasNextRow().hasColumns(Map.of("tag", "yellow"))
+                    .hasNextRow().hasColumns(Map.of("tag", "red"))
+                    .hasNoNextRow();
+        }
+    }
+}

--- a/yaml-tests/src/test/resources/check-explain/addExplain/add-explain.yamsql
+++ b/yaml-tests/src/test/resources/check-explain/addExplain/add-explain.yamsql
@@ -32,6 +32,5 @@ test_block:
   tests:
     -
       - query: SELECT id FROM t1
-      - explain: "SCAN([IS T1])"
       - result: [{!l 1}]
 ...

--- a/yaml-tests/src/test/resources/check-result-metadata/addResultMetadata/add-result-metadata.yamsql
+++ b/yaml-tests/src/test/resources/check-result-metadata/addResultMetadata/add-result-metadata.yamsql
@@ -32,6 +32,5 @@ test_block:
   tests:
     -
       - query: SELECT id FROM t1
-      - resultMetadata: [{ID: BIGINT}]
       - result: [{!l 1}]
 ...


### PR DESCRIPTION
## Summary

- Adds `SchemaIdentifier` to `LogicalTypeFilterExpression` and propagates it through the planner so every scan knows which schema it belongs to
- Introduces `RecordQueryStoreBindingPlan` — a thin wrapper plan node that swaps in a secondary `FDBRecordStoreBase` from `EvaluationContext.getAuxiliaryStore` before executing its inner subtree
- Adds auxiliary-store support to `EvaluationContext` (`withAuxiliaryStore` / `getAuxiliaryStore`)
- Wires `ImplementNestedLoopJoinRule` (and `AbstractDataAccessRule`) to emit `RecordQueryStoreBindingPlan` when the inner side of a join belongs to a secondary schema
- Fixes a WHERE-predicate drop bug in the cross-schema correlated scan path
- Full proto serialization for `RecordQueryStoreBindingPlan` (field 41 in `PRecordQueryPlan`) enabling continuation support

## Stacking

This is PR 3 of 7 in the cross-schema join series.  Base: `cross-schema/pr2` (#4210).

| # | PR | Topic |
|---|--------|-------|
| 1 | #4209 | SemanticAnalyzer cross-schema resolution helper |
| 2 | #4210 | Plan-cache key for multi-schema queries |
| **3** | this | Record Layer store-binding infrastructure |
| 4 | | Secondary-store wiring into execution context |
| 5 | | Type-namespace collision avoidance + catalog metadata |
| 6 | | Java integration tests |
| 7 | | YAML integration tests + documentation |

## Test plan

- [ ] `RecordQueryStoreBindingPlanTest` passes (serialization round-trip)
- [ ] Cross-schema join queries produce `STORE_BIND` nodes in EXPLAIN output
- [ ] Continuation round-trip works for cross-schema scans