### PR TITLE
Restrict `ExpandRecordRule` to non-nullable values

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/simplification/ExpandRecordRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/simplification/ExpandRecordRule.java
@@ -37,6 +37,7 @@ import java.util.Optional;
 
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.MultiMatcher.all;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.NotMatcher.not;
+import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.ValueMatchers.anyNotNullableValue;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.ValueMatchers.anyValue;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.ValueMatchers.recordConstructorValue;
 
@@ -51,15 +52,19 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  * }
  * </pre>
  * <br>
- * Note that this rule is the conceptual opposite of {@link CollapseRecordConstructorOverFieldsToStarRule}. These rules
- * should not be placed into the same rule set as the effect of it is undefined and may cause a stack overflow.
+ * <p>The rule is restricted to non-nullable values. A value whose result type is nullable can evaluate to
+ * {@code null} at runtime, in which case the expansion is unsound: The original yields {@code null}, while the expanded
+ * {@link RecordConstructorValue} would always yield a non-null record whose fields each happen to be {@code null}.
+ *
+ * <p>Note that this rule is the conceptual opposite of {@link CollapseRecordConstructorOverFieldsToStarRule}. These
+ * rules should not be placed into the same rule set as the effect of it is undefined and may cause a stack overflow.
  */
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("PMD.TooManyStaticImports")
 public class ExpandRecordRule extends ValueSimplificationRule<Value> {
     @Nonnull
     private static final BindingMatcher<Value> rootMatcher =
-            anyValue().where(not(recordConstructorValue(all(anyValue()))));
+            anyNotNullableValue().where(not(recordConstructorValue(all(anyValue()))));
 
     public ExpandRecordRule() {
         super(rootMatcher);
@@ -77,7 +82,7 @@ public class ExpandRecordRule extends ValueSimplificationRule<Value> {
 
         final var bindings = call.getBindings();
         final var value = bindings.get(rootMatcher);
-        if (value instanceof FieldValue && ((FieldValue)value).getFieldPath().size() > 1) {
+        if (value instanceof FieldValue fieldValue && fieldValue.getFieldPath().size() > 1) {
             return;
         }
         final var originalResultType = value.getResultType();

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/values/ValueTranslationTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/values/ValueTranslationTest.java
@@ -93,7 +93,7 @@ public class ValueTranslationTest {
     @Nonnull
     private Type.Record r(String... fieldNames) {
         return Type.Record
-                .fromFields(Arrays.stream(fieldNames)
+                .fromFields(false, Arrays.stream(fieldNames)
                         .map(this::f)
                         .collect(ImmutableList.toImmutableList()));
     }
@@ -102,7 +102,7 @@ public class ValueTranslationTest {
     @Nonnull
     private Type.Record r(Type.Record.Field... fields) {
         return Type.Record
-                .fromFields(Arrays.stream(fields)
+                .fromFields(false, Arrays.stream(fields)
                         .collect(ImmutableList.toImmutableList()));
     }
 
@@ -1145,8 +1145,8 @@ public class ValueTranslationTest {
     @Test
     public void maxMatchQovUsingExpandedQovComplex1() {
         final var p_v =
-                rcv(true,
-                        rcv(true, fv(t_, "a", "q"), "q",
+                rcv(false,
+                        rcv(false, fv(t_, "a", "q"), "q",
                                 fv(t_, "a", "r"), "r"), "a",
                         fv(t_, "b"), "b",
                         fv(t_, "j"), "j");
@@ -1164,8 +1164,8 @@ public class ValueTranslationTest {
      */
     @Test
     public void maxMatchQovUsingExpandedQovComplex2() {
-        final var innerRcv = rcv(true,
-                rcv(true, fv(t_, "a", "q"), "q",
+        final var innerRcv = rcv(false,
+                rcv(false, fv(t_, "a", "q"), "q",
                         fv(t_, "a", "r"), "r"), "a",
                 fv(t_, "b"), "b",
                 fv(t_, "j"), "j");


### PR DESCRIPTION
Narrow the root matcher from `anyValue()` to `anyNotNullableValue()`. This prevents the rule from expanding a nullable record-typed value into a `RecordConstructorValue` that is never actually null. Doing so could be incorrect, as there might be downstream consumers that are sensitive to the difference between a null record and a record-of-nulls.

Testing:
* Adjust the `isNullable` flags in `ValueTranslationTest` so that the rule still fires there.

Fixes #4227.