### PR TITLE
Index scrubbing iteration may leave behind a rangeSet key

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexScrubbing.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexScrubbing.java
@@ -187,9 +187,15 @@ public class IndexScrubbing extends IndexingBase {
                 });
     }
 
-    private static CompletableFuture<Boolean> updateRangeAndCheckIfExhausted(final IndexingRangeSet rangeSet, final Tuple rangeStart, final Tuple rangeEnd, final Tuple continuation) {
+    private CompletableFuture<Boolean> updateRangeAndCheckIfExhausted(final IndexingRangeSet rangeSet, final Tuple rangeStart, final Tuple rangeEnd, final Tuple continuation) {
+        if (allRangesAreExhausted(continuation, rangeEnd)) {
+            // Last missing range just got covered. Clear so the next scrubbing session starts fresh.
+            logScrubberRangeReset("range exhausted at iteration end");
+            rangeSet.clear();
+            return AsyncUtil.READY_FALSE;
+        }
         return rangeSet.insertRangeAsync(packOrNull(rangeStart), packOrNull(continuation), true)
-                .thenApply(ignore -> notAllRangesExhausted(continuation, rangeEnd));
+                .thenApply(ignore -> true);
     }
 
     private Boolean checkScanLimit(final Boolean ret, final @Nonnull AtomicLong recordsScanned, final long scanLimit) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexScrubbing.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexScrubbing.java
@@ -187,6 +187,22 @@ public class IndexScrubbing extends IndexingBase {
                 });
     }
 
+    /**
+     * Record the progress of a single scrubbing iteration in the range set and report whether more work remains.
+     * <p>
+     * After a chunk of records has been scanned, this marks the sub-range {@code [rangeStart, continuation)} as
+     * covered by inserting it into {@code rangeSet}. If the cursor reached the end of the overall scrubbed range
+     * (see {@link #allRangesAreExhausted(Tuple, Tuple)}), the entire range set is cleared so that the next
+     * scrubbing session starts fresh rather than resuming from a stale checkpoint.
+     * </p>
+     *
+     * @param rangeSet the persistent range set tracking which sub-ranges have already been scrubbed
+     * @param rangeStart the inclusive start of the sub-range that was just scanned, or {@code null} for the first key
+     * @param rangeEnd the exclusive end of the overall range being scrubbed, or {@code null} if it extends to the final key
+     * @param continuation the key at which this iteration stopped; equal to {@code rangeEnd} (or {@code null}) when the cursor was exhausted
+     * @return a future yielding {@code true} when more ranges remain to be scrubbed, or {@code false} when the
+     *         entire range has been covered and the range set has been cleared
+     */
     private CompletableFuture<Boolean> updateRangeAndCheckIfExhausted(final IndexingRangeSet rangeSet, final Tuple rangeStart, final Tuple rangeEnd, final Tuple continuation) {
         if (allRangesAreExhausted(continuation, rangeEnd)) {
             // Last missing range just got covered. Clear so the next scrubbing session starts fresh.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
@@ -956,10 +956,10 @@ public abstract class IndexingBase {
         store.getIndexDeferredMaintenanceControl().setAutoMergeDuringCommit(false);
     }
 
-    protected static boolean notAllRangesExhausted(Tuple cont, Tuple end) {
+    protected static boolean allRangesAreExhausted(Tuple cont, Tuple end) {
         // if cont isn't null, it means that the cursor was not exhausted
         // if end isn't null, it means that the range is a segment (i.e. closed or half-open interval) - the rangeSet may contain more unbuilt ranges
-        return end != null || cont != null;
+        return end == null && cont == null;
     }
 
     protected ScanProperties scanPropertiesWithLimits(boolean isIdempotent) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMutuallyByRecords.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMutuallyByRecords.java
@@ -390,7 +390,7 @@ public class IndexingMutuallyByRecords extends IndexingBase {
                                           lastResult.get().get().getPrimaryKey() :
                                           rangeEnd)
                     .thenCompose(cont -> insertRanges(targetRangeSets, packOrNull(rangeStart), packOrNull(cont))
-                            .thenApply(ignore -> notAllRangesExhausted(cont, rangeEnd)));
+                            .thenApply(ignore -> !allRangesAreExhausted(cont, rangeEnd)));
         });
     }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexScrubberTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexScrubberTest.java
@@ -42,6 +42,7 @@ import com.google.protobuf.Message;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -139,22 +140,31 @@ class OnlineIndexScrubberTest extends OnlineIndexerTest {
         assertFullIterationNoFix(tgtIndex, 0, numRecords, false, false);
     }
 
-    @Test
-    void testScrubberClearsRangeSetSubspaceWhenComplete() {
+    @ParameterizedTest
+    @CsvSource({"0", "1", "10000"})
+    void testScrubberClearsRangeSetSubspaceWhenComplete(int rangeId) {
         final long numRecords = 50;
         Index tgtIndex = createValueIndexAndPopulateData(numRecords, true);
 
         try (OnlineIndexScrubber indexScrubber = newScrubberBuilder(tgtIndex)
-                .setScrubbingPolicy(OnlineIndexScrubber.ScrubbingPolicy.newBuilder().build())
+                .setScrubbingPolicy(OnlineIndexScrubber.ScrubbingPolicy.newBuilder()
+                        .setScrubbingRangeId(rangeId)
+                        .build())
                 .build()) {
             indexScrubber.scrubMissingIndexEntries();
             indexScrubber.scrubDanglingIndexEntries();
         }
 
-        // After a full scrub, both rangeSet subspaces (rangeId 0) should be physically cleared.
+        // After a full scrub, both rangeSet subspaces should be physically cleared.
         try (FDBRecordContext context = openContext()) {
-            assertTrue(IndexingRangeSet.forScrubbingRecords(recordStore, tgtIndex, 0).isEmptyAsync().join());
-            assertTrue(IndexingRangeSet.forScrubbingIndex(recordStore, tgtIndex, 0).isEmptyAsync().join());
+            assertTrue(IndexingRangeSet.forScrubbingRecords(recordStore, tgtIndex, rangeId).isEmptyAsync().join());
+            assertTrue(IndexingRangeSet.forScrubbingIndex(recordStore, tgtIndex, rangeId).isEmptyAsync().join());
+            // assert that the subspaces are empty
+            Subspace recordsSub = IndexingSubspaces.indexScrubRecordsRangeSubspace(recordStore, tgtIndex, rangeId);
+            assertTrue(context.ensureActive().getRange(recordsSub.range(), 1).asList().join().isEmpty());
+            Subspace indexSub   = IndexingSubspaces.indexScrubIndexRangeSubspace(recordStore, tgtIndex, rangeId);
+            assertTrue(context.ensureActive().getRange(indexSub.range(), 1).asList().join().isEmpty());
+
             context.commit();
         }
     }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexScrubberTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexScrubberTest.java
@@ -140,6 +140,27 @@ class OnlineIndexScrubberTest extends OnlineIndexerTest {
     }
 
     @Test
+    void testScrubberClearsRangeSetSubspaceWhenComplete() {
+        final long numRecords = 50;
+        Index tgtIndex = createValueIndexAndPopulateData(numRecords, true);
+
+        try (OnlineIndexScrubber indexScrubber = newScrubberBuilder(tgtIndex)
+                .setScrubbingPolicy(OnlineIndexScrubber.ScrubbingPolicy.newBuilder().build())
+                .build()) {
+            indexScrubber.scrubMissingIndexEntries();
+            indexScrubber.scrubDanglingIndexEntries();
+        }
+
+        // After a full scrub, both rangeSet subspaces (rangeId 0) should be physically cleared.
+        try (FDBRecordContext context = openContext()) {
+   // TODO:         IndexingSubspaces.eraseAllIndexingScrubbingData(context, recordStore, tgtIndex);
+            assertTrue(IndexingRangeSet.forScrubbingRecords(recordStore, tgtIndex, 0).isEmptyAsync().join());
+            assertTrue(IndexingRangeSet.forScrubbingIndex(recordStore, tgtIndex, 0).isEmptyAsync().join());
+            context.commit();
+        }
+    }
+
+    @Test
     void testScrubberLimits() {
         final int numRecords = 52;
         final int chunkSize = 7;

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexScrubberTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexScrubberTest.java
@@ -153,7 +153,6 @@ class OnlineIndexScrubberTest extends OnlineIndexerTest {
 
         // After a full scrub, both rangeSet subspaces (rangeId 0) should be physically cleared.
         try (FDBRecordContext context = openContext()) {
-   // TODO:         IndexingSubspaces.eraseAllIndexingScrubbingData(context, recordStore, tgtIndex);
             assertTrue(IndexingRangeSet.forScrubbingRecords(recordStore, tgtIndex, 0).isEmptyAsync().join());
             assertTrue(IndexingRangeSet.forScrubbingIndex(recordStore, tgtIndex, 0).isEmptyAsync().join());
             context.commit();


### PR DESCRIPTION
Make sure the clear the rangeSet when index scrubbing finishes an iteration. 
