### PR TITLE
Clear INDEX_SLIDING_WINDOW_SPACE in clearIndexData and related lifecycle paths

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -5046,6 +5046,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     void clearIndexData(@Nonnull Index index) {
         context.clear(Range.startsWith(indexSubspace(index).pack())); // startsWith to handle ungrouped aggregate indexes
         context.clear(indexSecondarySubspace(index).range());
+        context.clear(indexSlidingWindowSubspace(index).range());
         IndexingRangeSet.forIndexBuild(this, index).clear();
         // clear even if non-unique in case the index was previously unique
         context.clear(indexUniquenessViolationsSubspace(index).range());

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpaceTreeResolver.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpaceTreeResolver.java
@@ -583,6 +583,7 @@ public class KeySpaceTreeResolver {
                 case INDEX_RANGE_SPACE:
                 case INDEX_UNIQUENESS_VIOLATIONS_SPACE:
                 case INDEX_BUILD_SPACE:
+                case INDEX_SLIDING_WINDOW_SPACE:
                     // TODO: As of now, INDEX_STATE_SPACE has the index _name_, which doesn't really need resolving.
                     // Once https://github.com/FoundationDB/fdb-record-layer/issues/514 is addressed, that will need this, too.
                     if (distance == 0 && object != null) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreClearIndexDataTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreClearIndexDataTest.java
@@ -82,7 +82,7 @@ class FDBRecordStoreClearIndexDataTest extends FDBRecordStoreTestBase {
     );
 
     /**
-     * For each per-index keyspace, the {@link Tuple} suffix to write a sentinel under within
+     * For each per-index keyspace, the {@link Tuple} suffix to write a sentinel within
      * {@code (keyspace.key(), index.getSubspaceTupleKey(), suffix...)} for the
      * {@code clearAndMarkIndexWriteOnly} test.
      *
@@ -282,8 +282,7 @@ class FDBRecordStoreClearIndexDataTest extends FDBRecordStoreTestBase {
 
     private byte[] lockSentinelKey(Index index) {
         // Lock subspace lives at sub-key 0L under INDEX_BUILD_SPACE — see IndexingSubspaces.
-        return recordStore.getSubspace()
-                .subspace(Tuple.from(FDBRecordStoreKeyspace.INDEX_BUILD_SPACE.key(), index.getSubspaceTupleKey()))
-                .pack(Tuple.from(0L, "lock-sentinel"));
+        return IndexingSubspaces.indexBuildLockSubspace(recordStore, index)
+                .pack(Tuple.from("lock-sentinel"));
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreClearIndexDataTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreClearIndexDataTest.java
@@ -1,0 +1,289 @@
+/*
+ * FDBRecordStoreClearIndexDataTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb;
+
+import com.apple.foundationdb.record.metadata.FormerIndex;
+import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.tuple.Tuple;
+import com.apple.test.Tags;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Forward-looking tests verifying that the methods that clear per-index data cover every
+ * per-index value of {@link FDBRecordStoreKeyspace}.
+ *
+ * <p>The lifecycle methods under test are
+ * {@link FDBRecordStore#clearAndMarkIndexWriteOnly(Index)} (which routes through
+ * {@code clearIndexData}), {@link FDBRecordStore#removeFormerIndex(FormerIndex)}, and
+ * {@link FDBRecordStore#rebuildAllIndexes()}.</p>
+ *
+ * <p>Each test is parameterized over the relevant per-index keyspace and writes a sentinel
+ * key under the per-index path before invoking the lifecycle method, then asserts that the
+ * sentinel is gone. {@link #keyspaceIsCategorized} fails by design if a future enum value
+ * isn't categorized in {@link #NON_PER_INDEX_KEYSPACES} or
+ * {@link #CLEARED_BY_CLEAR_INDEX_DATA}, forcing the author to decide which lifecycle methods
+ * need updating.</p>
+ *
+ * <p>This complements the focused regression test for {@code INDEX_SLIDING_WINDOW_SPACE} in
+ * {@code SlidingWindowIndexTest} by ensuring future per-index keyspaces don't quietly slip
+ * past the same lifecycle gaps.</p>
+ */
+@Tag(Tags.RequiresFDB)
+class FDBRecordStoreClearIndexDataTest extends FDBRecordStoreTestBase {
+
+    private static final String INDEX_NAME = "MySimpleRecord$str_value_indexed";
+
+    /**
+     * Keyspaces that are NOT keyed by {@code index.getSubspaceTupleKey()} and so are
+     * intentionally outside the scope of the per-index lifecycle methods. New entries must be
+     * justified by a comment.
+     */
+    private static final Set<FDBRecordStoreKeyspace> NON_PER_INDEX_KEYSPACES = ImmutableSet.of(
+            FDBRecordStoreKeyspace.STORE_INFO,             // store header
+            FDBRecordStoreKeyspace.RECORD,                 // record data
+            FDBRecordStoreKeyspace.RECORD_COUNT,           // global record counts
+            FDBRecordStoreKeyspace.RECORD_VERSION_SPACE,   // per-record versions
+            FDBRecordStoreKeyspace.INDEX_STATE_SPACE       // keyed by index NAME, not subspace tuple key
+    );
+
+    /**
+     * For each per-index keyspace, the {@link Tuple} suffix to write a sentinel under within
+     * {@code (keyspace.key(), index.getSubspaceTupleKey(), suffix...)} for the
+     * {@code clearAndMarkIndexWriteOnly} test.
+     *
+     * <p>Most keyspaces are full-range cleared, so any suffix works. INDEX_BUILD_SPACE is
+     * special: {@code clearIndexData} only clears specific sub-keys (1L = scanned-records,
+     * 2L = type-version, 3L–6L = scrub ranges, 7L = heartbeats), preserving the lock subspace
+     * at sub-key 0L. The sentinel here is placed under sub-key 1L, which is cleared. The
+     * lock-preservation contract is verified separately by
+     * {@link #clearAndMarkPreservesIndexBuildLock()}.</p>
+     */
+    private static final Map<FDBRecordStoreKeyspace, Tuple> CLEARED_BY_CLEAR_INDEX_DATA = ImmutableMap.<FDBRecordStoreKeyspace, Tuple>builder()
+            .put(FDBRecordStoreKeyspace.INDEX, Tuple.from("test-sentinel"))
+            .put(FDBRecordStoreKeyspace.INDEX_SECONDARY_SPACE, Tuple.from("test-sentinel"))
+            .put(FDBRecordStoreKeyspace.INDEX_SLIDING_WINDOW_SPACE, Tuple.from("test-sentinel"))
+            .put(FDBRecordStoreKeyspace.INDEX_RANGE_SPACE, Tuple.from("test-sentinel"))
+            .put(FDBRecordStoreKeyspace.INDEX_UNIQUENESS_VIOLATIONS_SPACE, Tuple.from("test-sentinel"))
+            .put(FDBRecordStoreKeyspace.INDEX_BUILD_SPACE, Tuple.from(1L, "test-sentinel"))
+            .build();
+
+    /**
+     * Per-index keyspaces cleared by {@link FDBRecordStore#removeFormerIndex(FormerIndex)} for
+     * the former index's subspace tuple key. INDEX_BUILD_SPACE is intentionally absent —
+     * {@code removeFormerIndex} does not currently clear that keyspace for the former index.
+     * If that ever changes, add it here.
+     */
+    private static final Map<FDBRecordStoreKeyspace, Tuple> CLEARED_BY_REMOVE_FORMER_INDEX = ImmutableMap.<FDBRecordStoreKeyspace, Tuple>builder()
+            .put(FDBRecordStoreKeyspace.INDEX, Tuple.from("test-sentinel"))
+            .put(FDBRecordStoreKeyspace.INDEX_SECONDARY_SPACE, Tuple.from("test-sentinel"))
+            .put(FDBRecordStoreKeyspace.INDEX_SLIDING_WINDOW_SPACE, Tuple.from("test-sentinel"))
+            .put(FDBRecordStoreKeyspace.INDEX_RANGE_SPACE, Tuple.from("test-sentinel"))
+            .put(FDBRecordStoreKeyspace.INDEX_UNIQUENESS_VIOLATIONS_SPACE, Tuple.from("test-sentinel"))
+            .build();
+
+    /**
+     * Per-index keyspaces cleared by {@link FDBRecordStore#rebuildAllIndexes()} via a
+     * full-range clear. INDEX_BUILD_SPACE is intentionally absent — rebuild manages its own
+     * build state and does not range-clear that keyspace. If that ever changes, add it here.
+     */
+    private static final Map<FDBRecordStoreKeyspace, Tuple> CLEARED_BY_REBUILD_ALL = ImmutableMap.<FDBRecordStoreKeyspace, Tuple>builder()
+            .put(FDBRecordStoreKeyspace.INDEX, Tuple.from("test-sentinel"))
+            .put(FDBRecordStoreKeyspace.INDEX_SECONDARY_SPACE, Tuple.from("test-sentinel"))
+            .put(FDBRecordStoreKeyspace.INDEX_SLIDING_WINDOW_SPACE, Tuple.from("test-sentinel"))
+            .put(FDBRecordStoreKeyspace.INDEX_RANGE_SPACE, Tuple.from("test-sentinel"))
+            .put(FDBRecordStoreKeyspace.INDEX_UNIQUENESS_VIOLATIONS_SPACE, Tuple.from("test-sentinel"))
+            .build();
+
+    static Stream<Arguments> clearedByClearIndexData() {
+        return CLEARED_BY_CLEAR_INDEX_DATA.entrySet().stream()
+                .map(e -> Arguments.of(e.getKey(), e.getValue()));
+    }
+
+    static Stream<Arguments> clearedByRemoveFormerIndex() {
+        return CLEARED_BY_REMOVE_FORMER_INDEX.entrySet().stream()
+                .map(e -> Arguments.of(e.getKey(), e.getValue()));
+    }
+
+    static Stream<Arguments> clearedByRebuildAll() {
+        return CLEARED_BY_REBUILD_ALL.entrySet().stream()
+                .map(e -> Arguments.of(e.getKey(), e.getValue()));
+    }
+
+    /**
+     * Forward-looking guard: if a new value is added to {@link FDBRecordStoreKeyspace} but is
+     * not categorized in {@link #NON_PER_INDEX_KEYSPACES} or
+     * {@link #CLEARED_BY_CLEAR_INDEX_DATA}, this test fails. The failure message points to
+     * the tables to update.
+     */
+    @ParameterizedTest
+    @EnumSource(FDBRecordStoreKeyspace.class)
+    void keyspaceIsCategorized(FDBRecordStoreKeyspace keyspace) {
+        final boolean nonPerIndex = NON_PER_INDEX_KEYSPACES.contains(keyspace);
+        final boolean inClearIndexData = CLEARED_BY_CLEAR_INDEX_DATA.containsKey(keyspace);
+        if (nonPerIndex) {
+            assertFalse(inClearIndexData,
+                    keyspace + " is in NON_PER_INDEX_KEYSPACES but also in CLEARED_BY_CLEAR_INDEX_DATA");
+            assertFalse(CLEARED_BY_REMOVE_FORMER_INDEX.containsKey(keyspace),
+                    keyspace + " is in NON_PER_INDEX_KEYSPACES but also in CLEARED_BY_REMOVE_FORMER_INDEX");
+            assertFalse(CLEARED_BY_REBUILD_ALL.containsKey(keyspace),
+                    keyspace + " is in NON_PER_INDEX_KEYSPACES but also in CLEARED_BY_REBUILD_ALL");
+        } else {
+            assertTrue(inClearIndexData,
+                    keyspace + " is per-index but not categorized in CLEARED_BY_CLEAR_INDEX_DATA. "
+                            + "Either add it (and verify FDBRecordStore.clearIndexData clears it), or list "
+                            + "it in NON_PER_INDEX_KEYSPACES with a comment justifying why it isn't keyed by "
+                            + "index subspace tuple key. Also consider whether removeFormerIndex and "
+                            + "rebuildAllIndexes need similar updates.");
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("clearedByClearIndexData")
+    void clearAndMarkIndexWriteOnlyClearsKeyspace(FDBRecordStoreKeyspace keyspace, Tuple suffix) throws Exception {
+        runClearLifecycleTest(keyspace, suffix, recordStore -> {
+            final Index index = recordStore.getRecordMetaData().getIndex(INDEX_NAME);
+            recordStore.clearAndMarkIndexWriteOnly(index).join();
+        });
+    }
+
+    /**
+     * Companion to {@link #clearAndMarkIndexWriteOnlyClearsKeyspace} that pins down the
+     * lock-preservation contract for INDEX_BUILD_SPACE: a sentinel under the lock sub-key
+     * (0L) must survive a clear, while sentinels under any other sub-key are removed (the
+     * latter is verified by the parameterized test above).
+     */
+    @Test
+    void clearAndMarkPreservesIndexBuildLock() throws Exception {
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context);
+            commit(context);
+        }
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context);
+            final Index index = recordStore.getRecordMetaData().getIndex(INDEX_NAME);
+            context.ensureActive().set(lockSentinelKey(index), new byte[]{1});
+            commit(context);
+        }
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context);
+            final Index index = recordStore.getRecordMetaData().getIndex(INDEX_NAME);
+            recordStore.clearAndMarkIndexWriteOnly(index).join();
+            assertNotNull(context.ensureActive().get(lockSentinelKey(index)).join(),
+                    "INDEX_BUILD_SPACE lock subspace must be preserved by clearAndMarkIndexWriteOnly");
+            commit(context);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("clearedByRemoveFormerIndex")
+    void removeFormerIndexClearsKeyspace(FDBRecordStoreKeyspace keyspace, Tuple suffix) throws Exception {
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context);
+            commit(context);
+        }
+        final Object subspaceKey;
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context);
+            final Index index = recordStore.getRecordMetaData().getIndex(INDEX_NAME);
+            subspaceKey = index.getSubspaceKey();
+            context.ensureActive().set(sentinelKey(index, keyspace, suffix), new byte[]{1});
+            commit(context);
+        }
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context);
+            final Index index = recordStore.getRecordMetaData().getIndex(INDEX_NAME);
+            assertNotNull(context.ensureActive().get(sentinelKey(index, keyspace, suffix)).join(),
+                    "Sentinel under " + keyspace + " was not present before removeFormerIndex");
+            // Synthetic FormerIndex pointing at the same subspace key as the live index. We
+            // pick a different former-name to avoid colliding with the live index's
+            // INDEX_STATE_SPACE entry.
+            final FormerIndex formerIndex = new FormerIndex(subspaceKey, 1, 2, INDEX_NAME + "_synthetic_former");
+            recordStore.removeFormerIndex(formerIndex);
+            assertNull(context.ensureActive().get(sentinelKey(index, keyspace, suffix)).join(),
+                    "Sentinel under " + keyspace + " (suffix " + suffix + ") survived removeFormerIndex; "
+                            + "removeFormerIndex probably needs to be updated to clear " + keyspace);
+            commit(context);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("clearedByRebuildAll")
+    void rebuildAllIndexesClearsKeyspace(FDBRecordStoreKeyspace keyspace, Tuple suffix) throws Exception {
+        runClearLifecycleTest(keyspace, suffix, recordStore -> recordStore.rebuildAllIndexes().join());
+    }
+
+    // ===== Helpers =====
+
+    private void runClearLifecycleTest(FDBRecordStoreKeyspace keyspace, Tuple suffix,
+                                       Consumer<FDBRecordStore> action) throws Exception {
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context);
+            commit(context);
+        }
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context);
+            final Index index = recordStore.getRecordMetaData().getIndex(INDEX_NAME);
+            context.ensureActive().set(sentinelKey(index, keyspace, suffix), new byte[]{1});
+            commit(context);
+        }
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context);
+            final Index index = recordStore.getRecordMetaData().getIndex(INDEX_NAME);
+            assertNotNull(context.ensureActive().get(sentinelKey(index, keyspace, suffix)).join(),
+                    "Sentinel under " + keyspace + " was not present before the clear");
+            action.accept(recordStore);
+            assertNull(context.ensureActive().get(sentinelKey(index, keyspace, suffix)).join(),
+                    "Sentinel under " + keyspace + " (suffix " + suffix + ") survived the clear; "
+                            + "lifecycle method probably needs to be updated to clear " + keyspace);
+            commit(context);
+        }
+    }
+
+    private byte[] sentinelKey(Index index, FDBRecordStoreKeyspace keyspace, Tuple suffix) {
+        return recordStore.getSubspace()
+                .subspace(Tuple.from(keyspace.key(), index.getSubspaceTupleKey()))
+                .pack(suffix);
+    }
+
+    private byte[] lockSentinelKey(Index index) {
+        // Lock subspace lives at sub-key 0L under INDEX_BUILD_SPACE — see IndexingSubspaces.
+        return recordStore.getSubspace()
+                .subspace(Tuple.from(FDBRecordStoreKeyspace.INDEX_BUILD_SPACE.key(), index.getSubspaceTupleKey()))
+                .pack(Tuple.from(0L, "lock-sentinel"));
+    }
+}

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
@@ -20,7 +20,6 @@
 
 package com.apple.foundationdb.record.provider.foundationdb;
 
-import com.apple.foundationdb.Range;
 import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.RecordMetaDataBuilder;
 import com.apple.foundationdb.record.TestRecords1Proto;
@@ -100,17 +99,6 @@ public abstract class OnlineIndexerTest {
         fdb = dbExtension.getDatabase();
         fdb.setAsyncToSyncTimeout(5, TimeUnit.MINUTES);
         path = pathManager.createPath(TestKeySpace.RECORD_STORE);
-    }
-
-    void clearIndexData(@Nonnull Index index) {
-        fdb.database().run(tr -> {
-            tr.clear(Range.startsWith(recordStore.indexSubspace(index).pack()));
-            tr.clear(recordStore.indexSecondarySubspace(index).range());
-            tr.clear(recordStore.indexSlidingWindowSubspace(index).range());
-            tr.clear(recordStore.indexRangeSubspace(index).range());
-            tr.clear(recordStore.indexBuildSubspace(index).range());
-            return null;
-        });
     }
 
     void openMetaData(@Nonnull Descriptors.FileDescriptor descriptor, @Nonnull RecordMetaDataHook hook) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
@@ -106,6 +106,7 @@ public abstract class OnlineIndexerTest {
         fdb.database().run(tr -> {
             tr.clear(Range.startsWith(recordStore.indexSubspace(index).pack()));
             tr.clear(recordStore.indexSecondarySubspace(index).range());
+            tr.clear(recordStore.indexSlidingWindowSubspace(index).range());
             tr.clear(recordStore.indexRangeSubspace(index).range());
             tr.clear(recordStore.indexBuildSubspace(index).range());
             return null;

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/SlidingWindowIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/SlidingWindowIndexTest.java
@@ -885,6 +885,40 @@ class SlidingWindowIndexTest extends FDBRecordStoreTestBase {
         }
     }
 
+    // ===== Regression test for clearIndexData =====
+
+    @Test
+    void clearAndMarkWriteOnlyClearsSlidingWindowSubspace() throws Exception {
+        // Regression test: previously FDBRecordStore.clearIndexData did not clear the sliding window
+        // subspace, so calling clearAndMarkIndexWriteOnly (which routes through clearIndexData)
+        // would leave stale window/overflow bookkeeping behind. After a subsequent rebuild that
+        // bookkeeping would be reconciled with the records seen during the build, but any data
+        // that persisted across the clear (e.g. boundary pointer, overflow entries) could be
+        // observed by callers reading the subspace directly and could corrupt re-election logic.
+        try (FDBRecordContext context = openContext()) {
+            openStore(context, 2, Direction.DESC);
+            rec(1, 100);   // window
+            rec(2, 200);   // window
+            rec(3, 50);    // overflow
+            commit(context);
+        }
+        try (FDBRecordContext context = openContext()) {
+            openStore(context, 2, Direction.DESC);
+            final Index index = recordStore.getRecordMetaData().getIndex(INDEX_NAME);
+            // Sanity: sliding window subspace is populated before the clear.
+            final Subspace slidingWindowSubspace = recordStore.indexSlidingWindowSubspace(index);
+            assertFalse(context.ensureActive().getRange(slidingWindowSubspace.range()).asList().join().isEmpty(),
+                    "sliding window subspace should be populated before clearAndMarkIndexWriteOnly");
+
+            recordStore.clearAndMarkIndexWriteOnly(index).join();
+
+            // After the fix to clearIndexData, the sliding window subspace must be empty.
+            assertTrue(context.ensureActive().getRange(slidingWindowSubspace.range()).asList().join().isEmpty(),
+                    "sliding window subspace should be empty after clearAndMarkIndexWriteOnly");
+            commit(context);
+        }
+    }
+
     // ===== Serialization tests =====
 
     @Test

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/SlidingWindowIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/SlidingWindowIndexTest.java
@@ -889,32 +889,44 @@ class SlidingWindowIndexTest extends FDBRecordStoreTestBase {
 
     @Test
     void clearAndMarkWriteOnlyClearsSlidingWindowSubspace() throws Exception {
-        // Regression test: previously FDBRecordStore.clearIndexData did not clear the sliding window
-        // subspace, so calling clearAndMarkIndexWriteOnly (which routes through clearIndexData)
-        // would leave stale window/overflow bookkeeping behind. After a subsequent rebuild that
-        // bookkeeping would be reconciled with the records seen during the build, but any data
-        // that persisted across the clear (e.g. boundary pointer, overflow entries) could be
-        // observed by callers reading the subspace directly and could corrupt re-election logic.
+        // Regression test for the originally reported bug: FDBRecordStore.clearIndexData did
+        // not clear the sliding window subspace, so calling clearAndMarkIndexWriteOnly (which
+        // routes through clearIndexData) left stale window bookkeeping (count, boundary,
+        // entries) behind. Subsequent writes under the WRITE_ONLY state go through
+        // SlidingWindowIndexMaintainer.updateWhileWriteOnly → handleInsert, which reads the
+        // count and boundary from the subspace to decide whether to add to the window or
+        // evict. With stale state, the maintainer would incorrectly believe the window is
+        // already full and trigger a phantom eviction (against a delegate that has already
+        // been cleared), leaving the window's count out of sync with the records actually
+        // indexed since the clear.
+        //
+        // This test exercises that path directly: after a clear + a single new write, the
+        // count must be exactly 1. Without the fix, the count would be 2 (the stale pre-clear
+        // value, preserved through a window-full eviction).
         try (FDBRecordContext context = openContext()) {
             openStore(context, 2, Direction.DESC);
-            rec(1, 100);   // window
-            rec(2, 200);   // window
-            rec(3, 50);    // overflow
+            rec(1, 100);   // window: count becomes 1
+            rec(2, 200);   // window: count becomes 2, boundary becomes (100, 1)
+            assertEquals(2L, readWindowCount());
             commit(context);
         }
         try (FDBRecordContext context = openContext()) {
             openStore(context, 2, Direction.DESC);
             final Index index = recordStore.getRecordMetaData().getIndex(INDEX_NAME);
-            // Sanity: sliding window subspace is populated before the clear.
-            final Subspace slidingWindowSubspace = recordStore.indexSlidingWindowSubspace(index);
-            assertFalse(context.ensureActive().getRange(slidingWindowSubspace.range()).asList().join().isEmpty(),
-                    "sliding window subspace should be populated before clearAndMarkIndexWriteOnly");
-
             recordStore.clearAndMarkIndexWriteOnly(index).join();
 
-            // After the fix to clearIndexData, the sliding window subspace must be empty.
-            assertTrue(context.ensureActive().getRange(slidingWindowSubspace.range()).asList().join().isEmpty(),
-                    "sliding window subspace should be empty after clearAndMarkIndexWriteOnly");
+            // Save a single record under the now-WRITE_ONLY state. With the fix, the sliding
+            // window subspace was emptied by clearAndMarkIndexWriteOnly, so this is the first
+            // entry: count must be 1. Without the fix, the maintainer reads the stale count=2,
+            // takes the "window full" branch, evicts the stale (100, 1) boundary entry, and
+            // leaves count at 2 — a value that no longer reflects the records actually present
+            // in the (rebuilt-from-empty) delegate index.
+            rec(3, 300);
+            assertEquals(1L, readWindowCount(),
+                    "After clearAndMarkIndexWriteOnly + one write, the sliding window count must "
+                            + "reflect only the new record. A count > 1 means clearIndexData left "
+                            + "stale window bookkeeping behind, corrupting the window's internal "
+                            + "accounting.");
             commit(context);
         }
     }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpaceTreeResolverTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/KeySpaceTreeResolverTest.java
@@ -1,0 +1,165 @@
+/*
+ * KeySpaceTreeResolverTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb.keyspace;
+
+import com.apple.foundationdb.record.RecordMetaData;
+import com.apple.foundationdb.record.RecordMetaDataBuilder;
+import com.apple.foundationdb.record.TestRecords1Proto;
+import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreKeyspace;
+import com.google.common.collect.ImmutableSet;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link KeySpaceTreeResolver}.
+ *
+ * <p>If a new per-index value is added to {@link FDBRecordStoreKeyspace} without being added
+ * to the switch in {@link KeySpaceTreeResolver#resolveNonDirectory}, the resolver returns
+ * {@code UNRESOLVED} for paths under that keyspace and tooling that visualizes the keyspace
+ * tree (e.g. {@code KeySpaceCountTree}) loses the ability to label keys by their owning
+ * index. {@link #resolverHandlesPerIndexKeyspace} catches that gap; the
+ * {@link #keyspaceIsCategorized} guard fails the build outright if a future enum value
+ * isn't categorized in the test, forcing the author to consider it.</p>
+ */
+class KeySpaceTreeResolverTest {
+
+    /**
+     * Keyspaces that are NOT keyed by {@code index.getSubspaceTupleKey()} and so are
+     * intentionally not handled by the per-index switch in
+     * {@link KeySpaceTreeResolver#resolveNonDirectory}. New entries must be justified.
+     */
+    private static final Set<FDBRecordStoreKeyspace> NON_PER_INDEX_KEYSPACES = ImmutableSet.of(
+            FDBRecordStoreKeyspace.STORE_INFO,             // store header
+            FDBRecordStoreKeyspace.RECORD,                 // record data — has its own resolution branch
+            FDBRecordStoreKeyspace.RECORD_COUNT,           // global record counts
+            FDBRecordStoreKeyspace.RECORD_VERSION_SPACE,   // per-record versions
+            FDBRecordStoreKeyspace.INDEX_STATE_SPACE       // keyed by index NAME, not subspace key (see TODO in resolveNonDirectory)
+    );
+
+    static Stream<FDBRecordStoreKeyspace> perIndexKeyspaces() {
+        return Arrays.stream(FDBRecordStoreKeyspace.values())
+                .filter(k -> !NON_PER_INDEX_KEYSPACES.contains(k));
+    }
+
+    static Stream<FDBRecordStoreKeyspace> nonPerIndexKeyspaces() {
+        return NON_PER_INDEX_KEYSPACES.stream();
+    }
+
+    @ParameterizedTest
+    @EnumSource(FDBRecordStoreKeyspace.class)
+    void keyspaceIsCategorized(FDBRecordStoreKeyspace keyspace) {
+        // Forward-looking guard: every value must either be in NON_PER_INDEX_KEYSPACES (and
+        // therefore intentionally not resolved as an index keyspace), or be handled by the
+        // per-index switch in KeySpaceTreeResolver.resolveNonDirectory.
+        final boolean nonPerIndex = NON_PER_INDEX_KEYSPACES.contains(keyspace);
+        assertTrue(nonPerIndex || isPerIndex(keyspace),
+                keyspace + " is not categorized. Either add it to NON_PER_INDEX_KEYSPACES (with a "
+                        + "justification) or to the per-index switch in "
+                        + "KeySpaceTreeResolver.resolveNonDirectory and ensure "
+                        + "resolverHandlesPerIndexKeyspace passes.");
+    }
+
+    @ParameterizedTest
+    @MethodSource("perIndexKeyspaces")
+    void resolverHandlesPerIndexKeyspace(FDBRecordStoreKeyspace keyspace) {
+        final RecordMetaData metaData = buildMetaData();
+        final Index index = metaData.getIndex("MySimpleRecord$str_value_indexed");
+        final KeySpaceTreeResolver resolver = new KeySpaceTreeResolver();
+        final KeySpace dummyKeySpace = new KeySpace(
+                new KeySpaceDirectory("root", KeySpaceDirectory.KeyType.STRING, "test"));
+        final KeySpaceTreeResolver.Resolved root = new KeySpaceTreeResolver.ResolvedRoot(dummyKeySpace);
+
+        final KeySpaceTreeResolver.ResolvedRecordStoreKeyspace parent =
+                new KeySpaceTreeResolver.ResolvedRecordStoreKeyspace(root, keyspace, metaData, keyspace.key());
+
+        final KeySpaceTreeResolver.Resolved resolved =
+                resolver.resolve(parent, index.getSubspaceTupleKey()).join();
+
+        assertNotNull(resolved,
+                "KeySpaceTreeResolver returned UNRESOLVED for " + keyspace + " under an index subspace key. "
+                        + "The per-index switch in KeySpaceTreeResolver.resolveNonDirectory probably needs a "
+                        + "case for this keyspace.");
+        assertTrue(resolved instanceof KeySpaceTreeResolver.ResolvedIndexKeyspace,
+                "KeySpaceTreeResolver did not produce a ResolvedIndexKeyspace for " + keyspace
+                        + " — got " + resolved.getClass().getSimpleName() + " instead.");
+        final KeySpaceTreeResolver.ResolvedIndexKeyspace asIndex =
+                (KeySpaceTreeResolver.ResolvedIndexKeyspace) resolved;
+        assertSame(index, asIndex.getIndex(),
+                "Resolved index does not match the index whose subspace key was looked up for " + keyspace);
+    }
+
+    @ParameterizedTest
+    @MethodSource("nonPerIndexKeyspaces")
+    void resolverDoesNotResolveNonPerIndexKeyspaceAsIndex(FDBRecordStoreKeyspace keyspace) {
+        // Pin down current behavior: for keyspaces NOT in the per-index switch, the resolver
+        // must NOT return a ResolvedIndexKeyspace — even if the object happens to match a
+        // valid index subspace key. This keeps NON_PER_INDEX_KEYSPACES honest.
+        final RecordMetaData metaData = buildMetaData();
+        final Index index = metaData.getIndex("MySimpleRecord$str_value_indexed");
+        final KeySpaceTreeResolver resolver = new KeySpaceTreeResolver();
+        final KeySpace dummyKeySpace = new KeySpace(
+                new KeySpaceDirectory("root", KeySpaceDirectory.KeyType.STRING, "test"));
+        final KeySpaceTreeResolver.Resolved root = new KeySpaceTreeResolver.ResolvedRoot(dummyKeySpace);
+
+        final KeySpaceTreeResolver.ResolvedRecordStoreKeyspace parent =
+                new KeySpaceTreeResolver.ResolvedRecordStoreKeyspace(root, keyspace, metaData, keyspace.key());
+
+        final KeySpaceTreeResolver.Resolved resolved =
+                resolver.resolve(parent, index.getSubspaceTupleKey()).join();
+
+        assertFalse(resolved instanceof KeySpaceTreeResolver.ResolvedIndexKeyspace,
+                "KeySpaceTreeResolver should not resolve " + keyspace
+                        + " as a ResolvedIndexKeyspace, but did.");
+    }
+
+    private static boolean isPerIndex(FDBRecordStoreKeyspace keyspace) {
+        // Mirrors the per-index switch in KeySpaceTreeResolver.resolveNonDirectory.
+        switch (keyspace) {
+            case INDEX:
+            case INDEX_SECONDARY_SPACE:
+            case INDEX_RANGE_SPACE:
+            case INDEX_UNIQUENESS_VIOLATIONS_SPACE:
+            case INDEX_BUILD_SPACE:
+            case INDEX_SLIDING_WINDOW_SPACE:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private static RecordMetaData buildMetaData() {
+        // Use the simple test meta-data, which has an index named MySimpleRecord$str_value_indexed.
+        final RecordMetaDataBuilder builder = RecordMetaData.newBuilder()
+                .setRecords(TestRecords1Proto.getDescriptor());
+        return builder.getRecordMetaData();
+    }
+}


### PR DESCRIPTION
`FDBRecordStore.clearIndexData` did not clear the sliding window subspace, so calling `clearAndMarkIndexWriteOnly` (which routes through it) left stale window/overflow bookkeeping behind. After a subsequent online rebuild, the window would be from the previous build, which may reference records that do not exist anymore.

This includes 3 production fixes, one referenced above, plus two others that were missed in the original sliding window implementation:
  - FDBRecordStore.clearIndexData: clear indexSlidingWindowSubspace.
  - KeySpaceTreeResolver.resolveNonDirectory: add INDEX_SLIDING_WINDOW_SPACE to the per-index switch so tooling resolves keys under it back to their owning Index.
  - OnlineIndexerTest.clearIndexData test helper: mirror the production fix.

In addition to basic regression tests, testing has expanded to help protect against missing this in the future.
  - SlidingWindowIndexTest: focused regression for clearIndexData leaving the sliding window subspace populated.
  - FDBRecordStoreClearIndexDataTest: forward-looking, parameterized over FDBRecordStoreKeyspace. Categorizes every enum value as non-per-index or per-method "cleared by" so a future per-index keyspace addition fails by design unless explicitly categorized. Pins the lock-preservation contract for INDEX_BUILD_SPACE.
  - KeySpaceTreeResolverTest: parameterized forward-looking coverage for the per-index switch in resolveNonDirectory.