### PR TITLE
Indexer: Remove indexing metadata after successfully marking the index as readable

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -5051,7 +5051,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
         context.clear(indexUniquenessViolationsSubspace(index).range());
         // Under the index build subspace, there are multiple lower level subspaces - the lock subspace and few others. We are
         // not supposed to clear the lock subspace, which might have been used to an online index job that had invoked this method.
-        IndexingSubspaces.eraseAllIndexingDataButTheLock(context, this, index);
+        IndexingSubspaces.eraseAllIndexingDataButTheLockAndRangeSet(context, this, index);
     }
 
     @SuppressWarnings("PMD.CloseResource")

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
@@ -318,9 +318,15 @@ public abstract class IndexingBase {
                 common.getRecordStoreBuilder().copyBuilder().setContext(context).openAsync()
                         .thenCompose(store -> {
                             clearHeartbeatForIndex(store, index);
-                            return policy.shouldAllowUniquePendingState(store) ?
-                                   store.markIndexReadableOrUniquePending(index) :
-                                   store.markIndexReadable(index);
+                            CompletableFuture<Boolean> markFuture =
+                                    policy.shouldAllowUniquePendingState(store) ?
+                                    store.markIndexReadableOrUniquePending(index) :
+                                    store.markIndexReadable(index);
+                            return markFuture.thenApply(changed -> {
+                                // Once the index is readable there is no need for this data
+                                IndexingSubspaces.eraseAllIndexingDataButTheLockAndRangeSet(store.getContext(), store, index);
+                                return changed;
+                            });
                         })
         ).handle((changed, ex) -> {
             if (ex == null) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingSubspaces.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingSubspaces.java
@@ -205,7 +205,7 @@ public final class IndexingSubspaces {
      * @param store store
      * @param index index
      */
-    public static void eraseAllIndexingDataButTheLock(@Nonnull FDBRecordContext context, @Nonnull FDBRecordStore store, @Nonnull Index index) {
+    public static void eraseAllIndexingDataButTheLockAndRangeSet(@Nonnull FDBRecordContext context, @Nonnull FDBRecordStore store, @Nonnull Index index) {
         eraseAllIndexingScrubbingData(context, store, index);
         context.clear(Range.startsWith(indexBuildScannedRecordsSubspace(store, index).pack()));
         context.clear(Range.startsWith(indexBuildTypeSubspace(store, index).pack()));

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerSimpleTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerSimpleTest.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.provider.foundationdb;
 
 import com.apple.foundationdb.FDBException;
+import com.apple.foundationdb.KeyValue;
 import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.async.RangeSet;
 import com.apple.foundationdb.record.RecordCoreException;
@@ -139,6 +140,10 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
         try (FDBRecordContext context = openContext()) {
             assertEquals(0L, IndexBuildState.loadRecordsScannedAsync(recordStore, index).join().longValue());
             assertNull(recordStore.loadIndexingTypeStampAsync(index).join());
+            // Make sure there is nothing left under the indexBuildSubspace
+            final List<KeyValue> remaining = context.ensureActive()
+                    .getRange(recordStore.indexBuildSubspace(index).range()).asList().join();
+            assertThat(remaining, Matchers.empty());
         }
     }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerSimpleTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerSimpleTest.java
@@ -119,6 +119,29 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
         }
     }
 
+    @SuppressWarnings("try")
+    @Test
+    void buildMetadataClearedWhenMarkedReadable() {
+        // Verify that after a successful build is marked readable, the build metadata is cleared.
+        final Index index = new Index("simple$value_2", field("num_value_2"), IndexTypes.VALUE);
+        openSimpleMetaData(metaDataBuilder -> metaDataBuilder.addIndex("MySimpleRecord", index));
+
+        try (FDBRecordContext context = openContext()) {
+            LongStream.range(0, 5).forEach(val -> recordStore.saveRecord(TestRecords1Proto.MySimpleRecord.newBuilder()
+                    .setRecNo(val).setNumValue2((int)val).build()));
+            context.commit();
+        }
+
+        try (OnlineIndexer indexBuilder = newIndexerBuilder().setIndex(index).build()) {
+            indexBuilder.buildIndex();
+        }
+
+        try (FDBRecordContext context = openContext()) {
+            assertEquals(0L, IndexBuildState.loadRecordsScannedAsync(recordStore, index).join().longValue());
+            assertNull(recordStore.loadIndexingTypeStampAsync(index).join());
+        }
+    }
+
     @Test
     public void logsEnd() {
         List<TestRecords1Proto.MySimpleRecord> records = LongStream.range(0, 50).mapToObj(val ->


### PR DESCRIPTION
Making sure that the online indexer, when making the index readable, clears all the temporary metadata that was used during the indexing process. 