### PR TITLE
Temporarily disable some `join-tests.yamsql` tests

### DIFF
--- a/yaml-tests/src/test/resources/join-tests.yamsql
+++ b/yaml-tests/src/test/resources/join-tests.yamsql
@@ -436,36 +436,37 @@ test_block:
       - supported_version: 4.12.4.0
       - explain: "SCAN([IS JA]) | FLATMAP q0 -> { SCAN([IS JB]) | FILTER false AS q1 RETURN (q0.C1 AS C1, q0.C2 AS C2, q1.C3 AS C3) }"
       - result: []
-    -
-      # same join as above, but using an explicit WHERE FALSE clause
-      - query: select ja.c1, ja.c2, jb.c3 from ja, jb where false;
-      - supported_version: 4.12.4.0
-      - explain: "SCAN([IS JA]) | FLATMAP q0 -> { SCAN([IS JB]) | FILTER false AS q1 RETURN (q0.C1 AS C1, q0.C2 AS C2, q1.C3 AS C3) }"
-      - result: []
-    -
-      # inner join with ON UNKNOWN: has the same effect as ON FALSE
-      - query: select ja.c1, ja.c2, jb.c3 from ja inner join jb on cast(null as boolean);
-      - supported_version: !current_version
-      - explain: "SCAN([IS JA]) | FLATMAP q0 -> { SCAN([IS JB]) | FILTER null AS q1 RETURN (q0.C1 AS C1, q0.C2 AS C2, q1.C3 AS C3) }"
-      - result: []
-    -
-      # same join as above, but using an explicit WHERE NULL clause
-      - query: select ja.c1, ja.c2, jb.c3 from ja, jb where cast(null as boolean);
-      - supported_version: !current_version
-      - explain: "SCAN([IS JA]) | FLATMAP q0 -> { SCAN([IS JB]) | FILTER null AS q1 RETURN (q0.C1 AS C1, q0.C2 AS C2, q1.C3 AS C3) }"
-      - result: []
-    -
-      # inner join with ON NULL: a plain NULL predicate is recognized as a null boolean and yields an empty result
-      - query: select ja.c1, ja.c2, jb.c3 from ja inner join jb on null;
-      - supported_version: 4.12.4.0
-      - explain: "SCAN([IS JA]) | FLATMAP q0 -> { SCAN([IS JB]) | FILTER null AS q1 RETURN (q0.C1 AS C1, q0.C2 AS C2, q1.C3 AS C3) }"
-      - result: []
-    -
-      # same join as above, but using an explicit WHERE NULL clause
-      - query: select ja.c1, ja.c2, jb.c3 from ja, jb where null;
-      - supported_version: 4.12.4.0
-      - explain: "SCAN([IS JA]) | FLATMAP q0 -> { SCAN([IS JB]) | FILTER null AS q1 RETURN (q0.C1 AS C1, q0.C2 AS C2, q1.C3 AS C3) }"
-      - result: []
+    # TODO Issue #4237: Investigate spurious explain changes in the query below
+    #-
+    #  # same join as above, but using an explicit WHERE FALSE clause
+    #  - query: select ja.c1, ja.c2, jb.c3 from ja, jb where false;
+    #  - supported_version: 4.12.4.0
+    #  - explain: "SCAN([IS JA]) | FLATMAP q0 -> { SCAN([IS JB]) | FILTER false AS q1 RETURN (q0.C1 AS C1, q0.C2 AS C2, q1.C3 AS C3) }"
+    #  - result: []
+    #-
+    #  # inner join with ON UNKNOWN: has the same effect as ON FALSE
+    #  - query: select ja.c1, ja.c2, jb.c3 from ja inner join jb on cast(null as boolean);
+    #  - supported_version: !current_version
+    #  - explain: "SCAN([IS JA]) | FLATMAP q0 -> { SCAN([IS JB]) | FILTER null AS q1 RETURN (q0.C1 AS C1, q0.C2 AS C2, q1.C3 AS C3) }"
+    #  - result: []
+    #-
+    #  # same join as above, but using an explicit WHERE NULL clause
+    #  - query: select ja.c1, ja.c2, jb.c3 from ja, jb where cast(null as boolean);
+    #  - supported_version: !current_version
+    #  - explain: "SCAN([IS JA]) | FLATMAP q0 -> { SCAN([IS JB]) | FILTER null AS q1 RETURN (q0.C1 AS C1, q0.C2 AS C2, q1.C3 AS C3) }"
+    #  - result: []
+    #-
+    #  # inner join with ON NULL: a plain NULL predicate is recognized as a null boolean and yields an empty result
+    #  - query: select ja.c1, ja.c2, jb.c3 from ja inner join jb on null;
+    #  - supported_version: 4.12.4.0
+    #  - explain: "SCAN([IS JA]) | FLATMAP q0 -> { SCAN([IS JB]) | FILTER null AS q1 RETURN (q0.C1 AS C1, q0.C2 AS C2, q1.C3 AS C3) }"
+    #  - result: []
+    #-
+    #  # same join as above, but using an explicit WHERE NULL clause
+    #  - query: select ja.c1, ja.c2, jb.c3 from ja, jb where null;
+    #  - supported_version: 4.12.4.0
+    #  - explain: "SCAN([IS JA]) | FLATMAP q0 -> { SCAN([IS JB]) | FILTER null AS q1 RETURN (q0.C1 AS C1, q0.C2 AS C2, q1.C3 AS C3) }"
+    #  - result: []
 ---
 # All 3-way (or more) join queries from above, repeated with PLAN_RIGHT_DEEP enabled.
 test_block:


### PR DESCRIPTION
These tests cover certain join corner cases with constant `TRUE`/`FALSE`/`NULL` join conditions. They were added only recently with PR #4162 but, together with the constant folding improvements of PR #4224, now suffer from a (presumably pre-existing) issue that causes the explain output to spuriously change as shown below.

To reduce friction for other PRs this change temporarily comments out these tests while we investigate this under Issue #4237.

```
↪ expected plan :
SCAN([IS JA]) | FLATMAP q0 -> { SCAN([IS JB]) | FILTER null AS q1 RETURN (q0.C1 AS C1, q0.C2 AS C2, q1.C3 AS C3) }

↩ actual plan:
SCAN([IS JA]) | FLATMAP q0 -> { SCAN([IS JB]) | FILTER NULL EQUALS true AS q1 RETURN (q0.C1 AS C1, q0.C2 AS C2, q1.C3 AS C3) }
```