### PR TITLE
Make `NormalizedResidualPredicateProperty` exclude `ConstantPredicate` from the residual-conjunct count

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/NormalizedResidualPredicateProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/NormalizedResidualPredicateProperty.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,35 +27,38 @@ import com.apple.foundationdb.record.query.plan.cascades.SimpleExpressionVisitor
 import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpression;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpressionWithPredicates;
 import com.apple.foundationdb.record.query.plan.cascades.predicates.AndPredicate;
+import com.apple.foundationdb.record.query.plan.cascades.predicates.ConstantPredicate;
 import com.apple.foundationdb.record.query.plan.cascades.predicates.OrPredicate;
 import com.apple.foundationdb.record.query.plan.cascades.predicates.QueryPredicate;
 import com.apple.foundationdb.record.query.plan.planning.BooleanPredicateNormalizer;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnionOnValuesPlan;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 
 import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Objects;
 
 /**
- * This property collects a {@link QueryPredicate} that represents the entirety of all accumulated residual predicates.
- * This predicate cannot be applied in any meaningful way to a stream of data, but it can be reasoned over using boolean
- * algebra. In addition, this approach also allows us to unify set operations such a UNION and INTERSECTION with their
- * boolean counterparts OR and AND.
- * One particular use of the collected residual predicate is to derive the number of effective boolean factors of its
- * CNF which is a direct measure of the number of residual filters that have to be applied and therefore its static
- * filter factor. Note that such a number can always be computed without actually materializing the CNF.
+ * A property that summarizes all <em>residual</em> filtering work in an expression tree as a single synthetic
+ * {@link QueryPredicate}.
+ *
+ * <p>A <em>residual predicate</em> is a predicate that the planner cannot push down into an index range and thus
+ * survives in the plan as a row-by-row filter (for example, a {@code FILTER} node somewhere above a {@code SCAN}). The
+ * <em>accumulated</em> residual predicate is the recursive boolean combination of every such filter in the tree.
+ * Filters at ordinary nodes are combined with {@code AND}; filters at union-like plans are combined with {@code OR}.
+ * Tautologies and constant predicates are excluded, since they incur no meaningful work at runtime.</p>
+ *
+ * <p>The returned predicate is purely analytical; it cannot be evaluated against a stream of data. Its only purpose is
+ * to be reasoned about as a boolean formula. The main consumer is {@link #countNormalizedConjuncts}, which serves
+ * as a cost-model tie-breaker (lower means less residual filtering, hence preferred).</p>
  */
 @API(API.Status.EXPERIMENTAL)
-public class NormalizedResidualPredicateProperty implements ExpressionProperty<QueryPredicate> {
+public final class NormalizedResidualPredicateProperty implements ExpressionProperty<QueryPredicate> {
     @Nonnull
-    private static final NormalizedResidualPredicateProperty NORMALIZED_RESIDUAL_PREDICATE =
-            new NormalizedResidualPredicateProperty();
+    private static final NormalizedResidualPredicateProperty INSTANCE = new NormalizedResidualPredicateProperty();
 
     private NormalizedResidualPredicateProperty() {
-        // prevent outside instantiation
     }
 
     @Nonnull
@@ -76,26 +79,34 @@ public class NormalizedResidualPredicateProperty implements ExpressionProperty<Q
 
     @Nonnull
     public static NormalizedResidualPredicateProperty normalizedResidualPredicate() {
-        return NORMALIZED_RESIDUAL_PREDICATE;
+        return INSTANCE;
     }
 
-    public static long countNormalizedConjuncts(@Nonnull RelationalExpression expression) {
-        final var magicPredicate = normalizedResidualPredicate().evaluate(expression);
-        return magicPredicate.isTautology()
+    /**
+     * Counts the conjuncts in the CNF of the residual predicate accumulated across {@code expression}. A return value
+     * of {@code 0} means the residual is a tautology and the expression has no residual filtering work at runtime.
+     *
+     * @param expression the expression to inspect
+     * @return the CNF conjunct count of the accumulated residual predicate, or {@code 0} if it is a tautology
+     */
+    public static long countNormalizedConjuncts(@Nonnull final RelationalExpression expression) {
+        final QueryPredicate residual = normalizedResidualPredicate().evaluate(expression);
+        return residual.isTautology()
                ? 0
                : BooleanPredicateNormalizer
-                       .getDefaultInstanceForCnf()
-                       .getMetrics(magicPredicate)
-                       .getNormalFormFullSize();
+                 .getDefaultInstanceForCnf()
+                 .getMetrics(residual)
+                 .getNormalFormFullSize();
     }
 
-    public static class NormalizedResidualPredicateVisitor implements SimpleExpressionVisitor<QueryPredicate> {
+    public static final class NormalizedResidualPredicateVisitor implements SimpleExpressionVisitor<QueryPredicate> {
         @Nonnull
         @Override
         public QueryPredicate visitRecordQueryUnionOnValuesPlan(@Nonnull final RecordQueryUnionOnValuesPlan unionPlan) {
+            // For UNION-like plans, the predicates from the quantifiers must be combined using OR.
             final var predicatesFromQuantifiers = visitQuantifiers(unionPlan).stream()
                     .filter(Objects::nonNull)
-                    .filter(predicate -> !predicate.isTautology())
+                    .filter(NormalizedResidualPredicateVisitor::isResidual)
                     .collect(ImmutableList.toImmutableList());
             return OrPredicate.orOrTrue(predicatesFromQuantifiers);
         }
@@ -104,20 +115,29 @@ public class NormalizedResidualPredicateProperty implements ExpressionProperty<Q
         @Override
         public QueryPredicate evaluateAtExpression(@Nonnull final RelationalExpression expression,
                                                    @Nonnull final List<QueryPredicate> childResults) {
-            final var resultPredicatesBuilder = ImmutableList.<QueryPredicate>builder();
+            final var builder = ImmutableList.<QueryPredicate>builder();
 
             childResults.stream()
                     .filter(Objects::nonNull)
-                    .filter(predicate -> !predicate.isTautology())
-                    .forEach(resultPredicatesBuilder::add);
+                    .filter(NormalizedResidualPredicateVisitor::isResidual)
+                    .forEach(builder::add);
 
-            if (expression instanceof RelationalExpressionWithPredicates) {
-                ((RelationalExpressionWithPredicates)expression).getPredicates()
+            if (expression instanceof RelationalExpressionWithPredicates withPredicates) {
+                withPredicates.getPredicates()
                         .stream()
-                        .filter(predicate -> !predicate.isTautology())
-                        .forEach(resultPredicatesBuilder::add);
+                        .filter(NormalizedResidualPredicateVisitor::isResidual)
+                        .forEach(builder::add);
             }
-            return AndPredicate.and(resultPredicatesBuilder.build());
+            return AndPredicate.and(builder.build());
+        }
+
+        /**
+         * A predicate is a runtime residual only if it actually has to be evaluated against rows. Tautologies and
+         * {@link ConstantPredicate} objects (including {@code FALSE} and {@code NULL}) reduce to fixed plan-time values
+         * and therefore do not contribute to the residual conjunct count used by the cost model.
+         */
+        private static boolean isResidual(@Nonnull final QueryPredicate predicate) {
+            return !(predicate instanceof ConstantPredicate) && !predicate.isTautology();
         }
 
         @Nonnull
@@ -125,7 +145,7 @@ public class NormalizedResidualPredicateProperty implements ExpressionProperty<Q
         public QueryPredicate evaluateAtRef(@Nonnull final Reference ref,
                                             @Nonnull final List<QueryPredicate> memberResults) {
             Verify.verify(memberResults.size() == 1);
-            return Iterables.getOnlyElement(memberResults);
+            return memberResults.get(0);
         }
     }
 }

--- a/yaml-tests/src/test/resources/arrays-cardinality.metrics.binpb
+++ b/yaml-tests/src/test/resources/arrays-cardinality.metrics.binpb
@@ -293,32 +293,34 @@ h
   3 -> 2 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   4 -> 3 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q23> label="q23" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}Ç
+}‡
 m
-arrays-cardinality-index-testsKEXPLAIN SELECT "id" FROM "tab1_indexed" WHERE CARDINALITY("int_arr") = NULLê
-ãüÖºh µÙC(!0á®	8*@NCOVERING(tab1_indexed_index [EQUALS NULL] -> [id: KEY:[2]]) | MAP (_.id AS id)£
-digraph G {
+arrays-cardinality-index-testsKEXPLAIN SELECT "id" FROM "tab1_indexed" WHERE CARDINALITY("int_arr") = NULLÓ
+“Ñ°≠u Ω†·(#0ˇº?85@RCOVERING(tab1_indexed_index <,> -> [id: KEY:[2]]) | FILTER null | MAP (_.id AS id)¸digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
-  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q53.id AS id)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id)" ];
-  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Covering Index Scan</td></tr><tr><td align="left">comparisons: [EQUALS NULL]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id, ARRAY(INT) AS int_arr)" ];
-  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">tab1_indexed_index</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id, ARRAY(INT) AS int_arr)" ];
-  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  2 -> 1 [ label=<&nbsp;q53> label="q53" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}ã
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q46.id AS id)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE null</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id, ARRAY(INT) AS int_arr)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Covering Index Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id, ARRAY(INT) AS int_arr)" ];
+  4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">tab1_indexed_index</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id, ARRAY(INT) AS int_arr)" ];
+  3 -> 2 [ label=<&nbsp;q42> label="q42" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  4 -> 3 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q46> label="q46" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}È
 p
-arrays-cardinality-index-testsNEXPLAIN SELECT "id" FROM "tab1_indexed_nn" WHERE CARDINALITY("int_arr") = NULLñ
-ã±ï¨h ÛÍ>(!0Ÿü8*@QCOVERING(tab1_indexed_nn_index [EQUALS NULL] -> [id: KEY:[2]]) | MAP (_.id AS id)¶
-digraph G {
+arrays-cardinality-index-testsNEXPLAIN SELECT "id" FROM "tab1_indexed_nn" WHERE CARDINALITY("int_arr") = NULLÙ
+“„”·u Úìà(#0€∑)85@UCOVERING(tab1_indexed_nn_index <,> -> [id: KEY:[2]]) | FILTER null | MAP (_.id AS id)ˇdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
-  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q53.id AS id)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id)" ];
-  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Covering Index Scan</td></tr><tr><td align="left">comparisons: [EQUALS NULL]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id, ARRAY(INT) AS int_arr)" ];
-  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">tab1_indexed_nn_index</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id, ARRAY(INT) AS int_arr)" ];
-  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  2 -> 1 [ label=<&nbsp;q53> label="q53" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q46.id AS id)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE null</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id, ARRAY(INT) AS int_arr)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Covering Index Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id, ARRAY(INT) AS int_arr)" ];
+  4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">tab1_indexed_nn_index</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS id, ARRAY(INT) AS int_arr)" ];
+  3 -> 2 [ label=<&nbsp;q42> label="q42" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  4 -> 3 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q46> label="q46" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
 }õ
 ∞
 arrays-cardinality-index-testsçEXPLAIN SELECT CARDINALITY("int_arr") AS "card", "id" FROM "tab1_indexed_nn" WHERE CARDINALITY("int_arr") = 1 ORDER BY CARDINALITY("int_arr")Â

--- a/yaml-tests/src/test/resources/arrays-cardinality.metrics.yaml
+++ b/yaml-tests/src/test/resources/arrays-cardinality.metrics.yaml
@@ -278,33 +278,33 @@ arrays-cardinality-index-tests:
     insert_reused_count: 2
 -   query: EXPLAIN SELECT "id" FROM "tab1_indexed" WHERE CARDINALITY("int_arr") =
         NULL
-    ref: arrays-cardinality.yamsql:188
-    explain: 'COVERING(tab1_indexed_index [EQUALS NULL] -> [id: KEY:[2]]) | MAP (_.id
-        AS id)'
-    task_count: 395
-    task_total_time_ms: 3
-    transform_count: 104
-    transform_time_ms: 1
-    transform_yield_count: 33
-    insert_time_ms: 0
-    insert_new_count: 42
-    insert_reused_count: 3
+    ref: arrays-cardinality.yamsql:187
+    explain: 'COVERING(tab1_indexed_index <,> -> [id: KEY:[2]]) | FILTER null | MAP
+        (_.id AS id)'
+    task_count: 466
+    task_total_time_ms: 13
+    transform_count: 117
+    transform_time_ms: 5
+    transform_yield_count: 35
+    insert_time_ms: 1
+    insert_new_count: 53
+    insert_reused_count: 5
 -   query: EXPLAIN SELECT "id" FROM "tab1_indexed_nn" WHERE CARDINALITY("int_arr")
         = NULL
-    ref: arrays-cardinality.yamsql:191
-    explain: 'COVERING(tab1_indexed_nn_index [EQUALS NULL] -> [id: KEY:[2]]) | MAP
-        (_.id AS id)'
-    task_count: 395
-    task_total_time_ms: 2
-    transform_count: 104
-    transform_time_ms: 1
-    transform_yield_count: 33
+    ref: arrays-cardinality.yamsql:190
+    explain: 'COVERING(tab1_indexed_nn_index <,> -> [id: KEY:[2]]) | FILTER null |
+        MAP (_.id AS id)'
+    task_count: 466
+    task_total_time_ms: 9
+    transform_count: 117
+    transform_time_ms: 4
+    transform_yield_count: 35
     insert_time_ms: 0
-    insert_new_count: 42
-    insert_reused_count: 3
+    insert_new_count: 53
+    insert_reused_count: 5
 -   query: EXPLAIN SELECT CARDINALITY("int_arr") AS "card", "id" FROM "tab1_indexed_nn"
         WHERE CARDINALITY("int_arr") = 1 ORDER BY CARDINALITY("int_arr")
-    ref: arrays-cardinality.yamsql:195
+    ref: arrays-cardinality.yamsql:194
     explain: ISCAN(tab1_indexed_nn_index [EQUALS promote(@c18 AS INT)]) | MAP (cardinality(_.int_arr)
         AS card, _.id AS id)
     task_count: 276
@@ -317,7 +317,7 @@ arrays-cardinality-index-tests:
     insert_reused_count: 1
 -   query: EXPLAIN SELECT CARDINALITY("struct"."int_arr") AS "card", "id" FROM "tab2"
         WHERE CARDINALITY("struct"."int_arr") = 1 ORDER BY CARDINALITY("struct"."int_arr")
-    ref: arrays-cardinality.yamsql:200
+    ref: arrays-cardinality.yamsql:199
     explain: ISCAN(tab2_index [EQUALS promote(@c22 AS INT)]) | MAP (cardinality(_.struct.int_arr)
         AS card, _.id AS id)
     task_count: 276

--- a/yaml-tests/src/test/resources/arrays-cardinality.yamsql
+++ b/yaml-tests/src/test/resources/arrays-cardinality.yamsql
@@ -173,22 +173,21 @@ test_block:
     - - query: SELECT "id" FROM "tab1_indexed_nn" WHERE CARDINALITY("int_arr") IS NOT NULL
       - explain: "COVERING(tab1_indexed_nn_index ([null],> -> [id: KEY:[2]]) | MAP (_.id AS id)"
       - unorderedResult: [{id: 1}, {id: 2}, {id: 3}]
-    - # WHERE CARDINALITY() = NULL. By SQL semantics this should always return 0 rows (the predicate evaluates to
-      # UNKNOWN). The non-indexed cases get this right (the planner constant-folds the predicate to `null`), but the
-      # indexed nullable case currently exhibits a general planner bug where `«indexed_field» = NULL` is incorrectly
-      # mapped to an IS NULL index range scan. The tests below document the current behavior. See also Issue #4170.
+    - # WHERE CARDINALITY() = NULL. By SQL semantics this should always return 0 rows (the predicate evaluates to UNKNOWN).
       - query: SELECT "id" FROM "tab1" WHERE CARDINALITY("int_arr") = NULL
       - explain: "SCAN([IS tab1]) | FILTER null | MAP (_.id AS id)"
       - unorderedResult: []
     - - query: SELECT "id" FROM "tab1_nn" WHERE CARDINALITY("int_arr") = NULL
       - explain: "SCAN([IS tab1_nn]) | FILTER null | MAP (_.id AS id)"
       - unorderedResult: []
-    - # TODO Issue #4170: This should return [].
-      - query: SELECT "id" FROM "tab1_indexed" WHERE CARDINALITY("int_arr") = NULL
-      - explain: "COVERING(tab1_indexed_index [EQUALS NULL] -> [id: KEY:[2]]) | MAP (_.id AS id)"
+    - - query: SELECT "id" FROM "tab1_indexed" WHERE CARDINALITY("int_arr") = NULL
+      - explain: "COVERING(tab1_indexed_index <,> -> [id: KEY:[2]]) | FILTER null | MAP (_.id AS id)"
+      - initialVersionLessThan: !current_version
       - unorderedResult: [{id: 0}]
+      - initialVersionAtLeast: !current_version
+      - unorderedResult: []
     - - query: SELECT "id" FROM "tab1_indexed_nn" WHERE CARDINALITY("int_arr") = NULL
-      - explain: "COVERING(tab1_indexed_nn_index [EQUALS NULL] -> [id: KEY:[2]]) | MAP (_.id AS id)"
+      - explain: "COVERING(tab1_indexed_nn_index <,> -> [id: KEY:[2]]) | FILTER null | MAP (_.id AS id)"
       - unorderedResult: []
     - # SELECT + WHERE + ORDER BY.
       - query: SELECT CARDINALITY("int_arr") AS "card", "id" FROM "tab1_indexed_nn" WHERE CARDINALITY("int_arr") = 1 ORDER BY CARDINALITY("int_arr")

--- a/yaml-tests/src/test/resources/vector.yamsql
+++ b/yaml-tests/src/test/resources/vector.yamsql
@@ -257,7 +257,7 @@ test_block:
     -
       - query: select a from tFloatVector where b != null
       - supported_version: 4.9.6.0
-      - explain: "SCAN([IS TFLOATVECTOR]) | FILTER _.B NOT_EQUALS NULL | MAP (_.A AS A)"
+      - explain: "SCAN([IS TFLOATVECTOR]) | FILTER null | MAP (_.A AS A)"
       - result: []
     -
       - query: select a from tHalfVector where null = b
@@ -267,7 +267,7 @@ test_block:
     -
       - query: select a from tFloatVector where null != b
       - supported_version: 4.9.6.0
-      - explain: "SCAN([IS TFLOATVECTOR]) | FILTER _.B NOT_EQUALS NULL | MAP (_.A AS A)"
+      - explain: "SCAN([IS TFLOATVECTOR]) | FILTER null | MAP (_.A AS A)"
       - result: []
     -
       - query: select a from tDoubleVector where b is distinct from null


### PR DESCRIPTION
Constant predicates, in particular `FALSE`, and `NULL`, should not count towards the residual conjuncts. This is a natural generalization to how `TRUE` tautologies are already skipped by this property. Such predicates incur no runtime filtering work, so counting them overstates their cost.

The counts from this analysis go into the `countNormalizedConjuncts()`-based tie-breaker in `PlanningCostModel` and `RewritingCostModel`. With this change, the tie-breaking is now slightly more effective, as shown in the changed yamsql tests.