### PR TITLE
Make `CastValue.hashCodeWithoutChildren()` stable

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/CastValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/CastValue.java
@@ -382,7 +382,7 @@ public class CastValue extends AbstractValue implements ValueWithChild, Value.Ra
 
     @Override
     public int hashCodeWithoutChildren() {
-        return Objects.hash(castToType, physicalOperator);
+        return Objects.hash(castToType, physicalOperator.name());
     }
 
     @Override

--- a/yaml-tests/src/test/resources/join-tests.yamsql
+++ b/yaml-tests/src/test/resources/join-tests.yamsql
@@ -436,37 +436,36 @@ test_block:
       - supported_version: 4.12.4.0
       - explain: "SCAN([IS JA]) | FLATMAP q0 -> { SCAN([IS JB]) | FILTER false AS q1 RETURN (q0.C1 AS C1, q0.C2 AS C2, q1.C3 AS C3) }"
       - result: []
-    # TODO Issue #4237: Investigate spurious explain changes in the query below
-    #-
-    #  # same join as above, but using an explicit WHERE FALSE clause
-    #  - query: select ja.c1, ja.c2, jb.c3 from ja, jb where false;
-    #  - supported_version: 4.12.4.0
-    #  - explain: "SCAN([IS JA]) | FLATMAP q0 -> { SCAN([IS JB]) | FILTER false AS q1 RETURN (q0.C1 AS C1, q0.C2 AS C2, q1.C3 AS C3) }"
-    #  - result: []
-    #-
-    #  # inner join with ON UNKNOWN: has the same effect as ON FALSE
-    #  - query: select ja.c1, ja.c2, jb.c3 from ja inner join jb on cast(null as boolean);
-    #  - supported_version: 4.12.6.0
-    #  - explain: "SCAN([IS JA]) | FLATMAP q0 -> { SCAN([IS JB]) | FILTER null AS q1 RETURN (q0.C1 AS C1, q0.C2 AS C2, q1.C3 AS C3) }"
-    #  - result: []
-    #-
-    #  # same join as above, but using an explicit WHERE NULL clause
-    #  - query: select ja.c1, ja.c2, jb.c3 from ja, jb where cast(null as boolean);
-    #  - supported_version: 4.12.6.0
-    #  - explain: "SCAN([IS JA]) | FLATMAP q0 -> { SCAN([IS JB]) | FILTER null AS q1 RETURN (q0.C1 AS C1, q0.C2 AS C2, q1.C3 AS C3) }"
-    #  - result: []
-    #-
-    #  # inner join with ON NULL: a plain NULL predicate is recognized as a null boolean and yields an empty result
-    #  - query: select ja.c1, ja.c2, jb.c3 from ja inner join jb on null;
-    #  - supported_version: 4.12.4.0
-    #  - explain: "SCAN([IS JA]) | FLATMAP q0 -> { SCAN([IS JB]) | FILTER null AS q1 RETURN (q0.C1 AS C1, q0.C2 AS C2, q1.C3 AS C3) }"
-    #  - result: []
-    #-
-    #  # same join as above, but using an explicit WHERE NULL clause
-    #  - query: select ja.c1, ja.c2, jb.c3 from ja, jb where null;
-    #  - supported_version: 4.12.4.0
-    #  - explain: "SCAN([IS JA]) | FLATMAP q0 -> { SCAN([IS JB]) | FILTER null AS q1 RETURN (q0.C1 AS C1, q0.C2 AS C2, q1.C3 AS C3) }"
-    #  - result: []
+    -
+      # same join as above, but using an explicit WHERE FALSE clause
+      - query: select ja.c1, ja.c2, jb.c3 from ja, jb where false;
+      - supported_version: 4.12.4.0
+      - explain: "SCAN([IS JA]) | FLATMAP q0 -> { SCAN([IS JB]) | FILTER false AS q1 RETURN (q0.C1 AS C1, q0.C2 AS C2, q1.C3 AS C3) }"
+      - result: []
+    -
+      # inner join with ON UNKNOWN: has the same effect as ON FALSE
+      - query: select ja.c1, ja.c2, jb.c3 from ja inner join jb on cast(null as boolean);
+      - supported_version: 4.12.6.0
+      - explain: "SCAN([IS JA]) | FLATMAP q0 -> { SCAN([IS JB]) | FILTER null AS q1 RETURN (q0.C1 AS C1, q0.C2 AS C2, q1.C3 AS C3) }"
+      - result: []
+    -
+      # same join as above, but using an explicit WHERE NULL clause
+      - query: select ja.c1, ja.c2, jb.c3 from ja, jb where cast(null as boolean);
+      - supported_version: 4.12.6.0
+      - explain: "SCAN([IS JA]) | FLATMAP q0 -> { SCAN([IS JB]) | FILTER null AS q1 RETURN (q0.C1 AS C1, q0.C2 AS C2, q1.C3 AS C3) }"
+      - result: []
+    -
+      # inner join with ON NULL: a plain NULL predicate is recognized as a null boolean and yields an empty result
+      - query: select ja.c1, ja.c2, jb.c3 from ja inner join jb on null;
+      - supported_version: 4.12.4.0
+      - explain: "SCAN([IS JA]) | FLATMAP q0 -> { SCAN([IS JB]) | FILTER null AS q1 RETURN (q0.C1 AS C1, q0.C2 AS C2, q1.C3 AS C3) }"
+      - result: []
+    -
+      # same join as above, but using an explicit WHERE NULL clause
+      - query: select ja.c1, ja.c2, jb.c3 from ja, jb where null;
+      - supported_version: 4.12.4.0
+      - explain: "SCAN([IS JA]) | FLATMAP q0 -> { SCAN([IS JB]) | FILTER null AS q1 RETURN (q0.C1 AS C1, q0.C2 AS C2, q1.C3 AS C3) }"
+      - result: []
 ---
 # All 3-way (or more) join queries from above, repeated with PLAN_RIGHT_DEEP enabled.
 test_block:


### PR DESCRIPTION
Hash `physicalOperator.name()` rather than the enum itself. `Enum.hashCode()` is inherited from `Object` and is identity-based, so the previous code produced a different hash on every JVM run. That instability propagated to the `semanticHashCode()` tie-breaker in `RewritingCostModel`. This in turn caused spurious `explain` changes in the test case that we un-disable with this fix.

Fixes https://github.com/FoundationDB/fdb-record-layer/issues/4237.