### PR TITLE
Indexer: fix typed records optimization

### DIFF
--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/RangeSet.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/RangeSet.java
@@ -96,6 +96,14 @@ public class RangeSet {
         return Arrays.equals(key, FINAL_KEY);
     }
 
+    public static byte[] nullIfFirst(@Nonnull byte[] key) {
+        return isFirstKey(key) ? null : key;
+    }
+
+    public static byte[] nullIfFinal(@Nonnull byte[] key) {
+        return isFinalKey(key) ? null : key;
+    }
+
     // This returns the next possible key after another key (i.e., a key that is greater than current key but
     // every key greater than this key will be greater than or equal to the returned key).
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/KeyRange.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/KeyRange.java
@@ -24,6 +24,7 @@ import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.annotation.API;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * A range within a subspace specified by two byte value endpoints.
@@ -43,19 +44,19 @@ public class KeyRange {
      * Creates a key range.
      *
      * @param lowKey the starting key in the range. Note that a direct reference to this key is retained, so
-     *    care must be taken not to modify its contents
+     *    care must be taken not to modify its contents. If null, assume negative infinity.
      * @param lowEndpoint how the low endpoint is to be treated
      * @param highKey the ending key in the range. Note that a direct reference to this key is retained, so
-     *    care must be taken not to modify its contents
+     *    care must be taken not to modify its contents. If null, assume infinity.
      * @param highEndpoint how the high endpoint is to be treated
      */
     @SpotBugsSuppressWarnings("EI_EXPOSE_REP2")
-    public KeyRange(@Nonnull byte[] lowKey, @Nonnull EndpointType lowEndpoint,
-                    @Nonnull byte[] highKey, @Nonnull EndpointType highEndpoint) {
-        this.lowKey = lowKey;
-        this.lowEndpoint = lowEndpoint;
-        this.highKey = highKey;
-        this.highEndpoint = highEndpoint;
+    public KeyRange(@Nullable byte[] lowKey, @Nonnull EndpointType lowEndpoint,
+                    @Nullable byte[] highKey, @Nonnull EndpointType highEndpoint) {
+        this.lowKey = lowKey == null ? new byte[0] : lowKey;
+        this.lowEndpoint = lowKey == null ? EndpointType.TREE_START : lowEndpoint;
+        this.highKey = highKey == null ? new byte[0] : highKey;
+        this.highEndpoint = highKey == null ? EndpointType.TREE_END : highEndpoint;
     }
 
     /**
@@ -64,7 +65,7 @@ public class KeyRange {
      * @param lowKey the starting key of the range, inclusive
      * @param highKey the ending key of the range, exclusive
      */
-    public KeyRange(@Nonnull byte[] lowKey, @Nonnull byte[] highKey) {
+    public KeyRange(@Nullable byte[] lowKey, @Nullable byte[] highKey) {
         this(lowKey, EndpointType.RANGE_INCLUSIVE, highKey, EndpointType.RANGE_EXCLUSIVE);
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/KeyRange.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/KeyRange.java
@@ -20,8 +20,8 @@
 
 package com.apple.foundationdb.record;
 
-import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -46,6 +46,7 @@ import com.apple.foundationdb.record.IndexEntry;
 import com.apple.foundationdb.record.IndexScanType;
 import com.apple.foundationdb.record.IndexState;
 import com.apple.foundationdb.record.IsolationLevel;
+import com.apple.foundationdb.record.KeyRange;
 import com.apple.foundationdb.record.MutableRecordStoreState;
 import com.apple.foundationdb.record.PipelineOperation;
 import com.apple.foundationdb.record.PlanHashable;
@@ -1282,6 +1283,13 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     }
 
     @Nonnull
+    public RecordCursor<FDBStoredRecord<Message>> scanRecords(@Nonnull final KeyRange range,
+                                                              @Nullable byte[] continuation,
+                                                              @Nonnull ScanProperties scanProperties) {
+        return scanTypedRecords(serializer, range, continuation, scanProperties);
+    }
+
+    @Nonnull
     @Override
     @SuppressWarnings("PMD.CloseResource")
     public RecordCursor<Tuple> scanRecordKeys(@Nullable final byte[] continuation, @Nonnull final ScanProperties scanProperties) {
@@ -1335,6 +1343,33 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
                                                                                  @Nonnull final EndpointType lowEndpoint, @Nonnull final EndpointType highEndpoint,
                                                                                  @Nullable byte[] continuation,
                                                                                  @Nonnull ScanProperties scanProperties) {
+        final Subspace recordsSubspace = recordsSubspace();
+        return scanTypedRecords(typedSerializer,
+                low != null ? recordsSubspace.pack(low) : recordsSubspace.pack(), lowEndpoint,
+                high != null ? recordsSubspace.pack(high) : recordsSubspace.pack(), highEndpoint,
+                continuation, scanProperties);
+    }
+
+    @Nonnull
+    @SuppressWarnings("PMD.CloseResource")
+    public <M extends Message> RecordCursor<FDBStoredRecord<M>> scanTypedRecords(@Nonnull RecordSerializer<M> typedSerializer,
+                                                                                 @Nonnull final KeyRange range,
+                                                                                 @Nullable byte[] continuation,
+                                                                                 @Nonnull ScanProperties scanProperties) {
+        final byte[] subspacePrefix = recordsSubspace().pack();
+        return scanTypedRecords(typedSerializer,
+                ByteArrayUtil.join(subspacePrefix, range.getLowKey()), range.getLowEndpoint(),
+                ByteArrayUtil.join(subspacePrefix, range.getHighKey()), range.getHighEndpoint(),
+                continuation, scanProperties);
+    }
+
+    @Nonnull
+    @SuppressWarnings("PMD.CloseResource")
+    private <M extends Message> RecordCursor<FDBStoredRecord<M>> scanTypedRecords(@Nonnull RecordSerializer<M> typedSerializer,
+                                                                                  @Nonnull byte[] lowBytes, @Nonnull EndpointType lowEndpoint,
+                                                                                  @Nonnull byte[] highBytes, @Nonnull EndpointType highEndpoint,
+                                                                                  @Nullable byte[] continuation,
+                                                                                  @Nonnull ScanProperties scanProperties) {
         final RecordMetaData metaData = metaDataProvider.getRecordMetaData();
         final Subspace recordsSubspace = recordsSubspace();
         final SplitHelper.SizeInfo sizeInfo = new SplitHelper.SizeInfo();
@@ -1342,8 +1377,8 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
         if (metaData.isSplitLongRecords()) {
             RecordCursor<KeyValue> keyValues = KeyValueCursor.Builder.withSubspace(recordsSubspace)
                     .setContext(context).setContinuation(continuation)
-                    .setLow(low, lowEndpoint)
-                    .setHigh(high, highEndpoint)
+                    .setLow(lowBytes, lowEndpoint)
+                    .setHigh(highBytes, highEndpoint)
                     .setScanProperties(scanProperties.with(ExecuteProperties::clearRowAndTimeLimits).with(ExecuteProperties::clearSkipAndLimit).with(ExecuteProperties::clearState))
                     .build();
             rawRecords = new SplitHelper.KeyValueUnsplitter(context, recordsSubspace, keyValues, useOldVersionFormat(), sizeInfo, scanProperties.isReverse(),
@@ -1353,8 +1388,8 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
         } else {
             KeyValueCursor.Builder keyValuesBuilder = KeyValueCursor.Builder.withSubspace(recordsSubspace)
                     .setContext(context).setContinuation(continuation)
-                    .setLow(low, lowEndpoint)
-                    .setHigh(high, highEndpoint);
+                    .setLow(lowBytes, lowEndpoint)
+                    .setHigh(highBytes, highEndpoint);
             if (omitUnsplitRecordSuffix) {
                 rawRecords = keyValuesBuilder.setScanProperties(scanProperties).build().map(kv -> {
                     sizeInfo.set(kv);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -1283,8 +1283,8 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     }
 
     /**
-     * Scan the records in the database in a rang - using {@link KeyRange} raw key bytes boundaries. This can be useful when the
-     * range should be opaque.
+     * Scan the records in the database in a range - using {@link KeyRange} raw key bytes boundaries. This can be useful
+     * when it is not possible to arrange for strict primary key scan boundaries, which is typically during an internal use.
      *
      * @param range the range of records to scan, expressed as raw key bytes within the records subspace
      * @param continuation any continuation from a previous scan invocation

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -1282,7 +1282,18 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
         return scanTypedRecords(serializer, low, high, lowEndpoint, highEndpoint, continuation, scanProperties);
     }
 
+    /**
+     * Scan the records in the database in a rang - using {@link KeyRange} raw key bytes boundaries. This can be useful when the
+     * range should be opaque.
+     *
+     * @param range the range of records to scan, expressed as raw key bytes within the records subspace
+     * @param continuation any continuation from a previous scan invocation
+     * @param scanProperties skip, limit and other properties of the scan
+     *
+     * @return a cursor over the stored records in the given range
+     */
     @Nonnull
+    @API(API.Status.INTERNAL)
     public RecordCursor<FDBStoredRecord<Message>> scanRecords(@Nonnull final KeyRange range,
                                                               @Nullable byte[] continuation,
                                                               @Nonnull ScanProperties scanProperties) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
@@ -22,6 +22,7 @@ package com.apple.foundationdb.record.provider.foundationdb;
 
 import com.apple.foundationdb.FDBException;
 import com.apple.foundationdb.MutationType;
+import com.apple.foundationdb.Range;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.async.MoreAsyncUtil;
@@ -36,6 +37,7 @@ import com.apple.foundationdb.record.RecordCursorResult;
 import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.RecordMetaDataProvider;
 import com.apple.foundationdb.record.ScanProperties;
+import com.apple.foundationdb.record.TupleRange;
 import com.apple.foundationdb.record.logging.KeyValueLogMessage;
 import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.metadata.Index;
@@ -575,6 +577,39 @@ public abstract class IndexingBase {
     public <R> CompletableFuture<R> buildCommitRetryAsync(@Nonnull BiFunction<FDBRecordStore, AtomicLong, CompletableFuture<R>> buildFunction,
                                                           @Nullable List<Object> additionalLogMessageKeyValues, final boolean duringRangesIteration) {
         return throttle.buildCommitRetryAsync(buildFunction, null, additionalLogMessageKeyValues, duringRangesIteration);
+    }
+
+    @Nonnull
+    protected static CompletableFuture<Void> insertRanges(@Nonnull List<IndexingRangeSet> rangeSets,
+                                                          @Nullable byte[] start, @Nullable byte[] end) {
+        return AsyncUtil.whenAll(rangeSets.stream().map(set -> set.insertRangeAsync(start, end, true)).toList());
+    }
+
+    /**
+     * In typed records only - if only a subset of the record types is being indexed, the relevant records are confined to a sub-range of the
+     * records space (as determined by {@link IndexingCommon#computeRecordsRange()}). In that case, preemptively mark
+     * the key ranges outside that records range as already-indexed for every target index, so that they are skipped
+     * during the build. If the whole records space is relevant, there is nothing to preset.
+     * @return a future that completes once the out-of-range key ranges (if any) have been marked as indexed
+     */
+    @Nonnull
+    protected CompletableFuture<Void> maybePresetRangeFuture() {
+        final TupleRange tupleRange = common.computeRecordsRange();
+        if (tupleRange == null) {
+            return AsyncUtil.DONE;
+        }
+        final Range range = tupleRange.toRange();
+        final byte[] rangeStart = range.begin;
+        final byte[] rangeEnd = range.end;
+        return buildCommitRetryAsync((store, recordsScanned) -> {
+            final List<IndexingRangeSet> targetRangeSets = common.getTargetIndexes().stream()
+                    .map(targetIndex -> IndexingRangeSet.forIndexBuild(store, targetIndex))
+                    .toList();
+            // Insert the leading and trailing out-of-range gaps sequentially (rather than in parallel) to keep the
+            // range mutations safely ordered within the transaction.
+            return insertRanges(targetRangeSets, null, rangeStart)
+                    .thenCompose(ignore -> insertRanges(targetRangeSets, rangeEnd, null));
+        }, null);
     }
 
     protected void timerIncrement(StoreTimer.Count event) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
@@ -593,7 +593,7 @@ public abstract class IndexingBase {
      * @return a future that completes once the out-of-range key ranges (if any) have been marked as indexed
      */
     @Nonnull
-    protected CompletableFuture<Void> maybePresetRangeFuture() {
+    protected CompletableFuture<Void> maybePresetRecordsRangeAsync() {
         final TupleRange tupleRange = common.computeRecordsRange();
         if (tupleRange == null) {
             return AsyncUtil.DONE;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
@@ -1003,6 +1003,10 @@ public abstract class IndexingBase {
         return end == null && cont == null;
     }
 
+    protected static boolean rangesAreNotExhausted(boolean hasMore, byte[]rangeBoundary) {
+        return hasMore || rangeBoundary != null;
+    }
+
     protected ScanProperties scanPropertiesWithLimits(boolean isIdempotent) {
         final IsolationLevel isolationLevel =
                 isIdempotent ?

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingCommon.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingCommon.java
@@ -22,11 +22,14 @@ package com.apple.foundationdb.record.provider.foundationdb;
 
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.RecordMetaData;
+import com.apple.foundationdb.record.TupleRange;
 import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.MetaDataException;
 import com.apple.foundationdb.record.metadata.RecordType;
 import com.apple.foundationdb.record.query.plan.synthetic.SyntheticRecordPlanner;
+import com.apple.foundationdb.tuple.Tuple;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -203,6 +206,27 @@ public class IndexingCommon {
     @Nonnull
     public Collection<RecordType> getAllRecordTypes() {
         return allRecordTypes;
+    }
+
+    @Nullable
+    public TupleRange computeRecordsRange() {
+        Tuple low = null;
+        Tuple high = null;
+        for (RecordType recordType : getAllRecordTypes()) {
+            if (!recordType.primaryKeyHasRecordTypePrefix() || recordType.isSynthetic()) {
+                // If any of the types to build for does not have a prefix, give up.
+                return null;
+            }
+            Tuple prefix = recordType.getRecordTypeKeyTuple();
+            if (low == null) {
+                low = high = prefix;
+            } else if (low.compareTo(prefix) > 0) {
+                low = prefix;
+            } else if (high.compareTo(prefix) < 0) {
+                high = prefix;
+            }
+        }
+        return low == null ? null : TupleRange.betweenInclusive(low, high);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMultiTargetByRecords.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMultiTargetByRecords.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.provider.foundationdb;
 
+import com.apple.foundationdb.Range;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.async.RangeSet;
@@ -33,6 +34,7 @@ import com.apple.foundationdb.record.TupleRange;
 import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.provider.foundationdb.indexing.IndexingRangeSet;
+import com.apple.foundationdb.tuple.ByteArrayUtil;
 import com.apple.foundationdb.tuple.Tuple;
 import com.google.protobuf.Message;
 
@@ -115,8 +117,41 @@ public class IndexingMultiTargetByRecords extends IndexingBase {
 
     @Nonnull
     private CompletableFuture<Void> buildMultiTargetIndex() {
-        final List<Object> additionalLogMessageKeyValues = Arrays.asList(LogMessageKeys.CALLING_METHOD, "buildMultiTargetIndex");
-        return iterateAllRanges(additionalLogMessageKeyValues, this::buildRangeOnly);
+        final TupleRange tupleRange = common.computeRecordsRange();
+        final byte[] rangeStart;
+        final byte[] rangeEnd;
+        if (tupleRange == null) {
+            rangeStart = rangeEnd = null;
+        } else {
+            final Range range = tupleRange.toRange();
+            rangeStart = range.begin;
+            // tupleRange has an inclusive high endpoint, so end isn't a valid tuple.
+            // But buildRangeOnly needs to convert missing Ranges back to TupleRanges, so round up.
+            rangeEnd = ByteArrayUtil.strinc(range.end);
+        }
+
+        final CompletableFuture<FDBRecordStore> maybePresetRangeFuture =
+                rangeStart == null ?
+                CompletableFuture.completedFuture(null) :
+                buildCommitRetryAsync((store, recordsScanned) -> {
+                    // Here: only records inside the defined records-range are relevant to the index. Hence, the completing range
+                    // can be preemptively marked as indexed.
+                    final List<Index> targetIndexes = common.getTargetIndexes();
+                    final List<IndexingRangeSet> targetRangeSets = targetIndexes.stream()
+                            .map(targetIndex -> IndexingRangeSet.forIndexBuild(store, targetIndex))
+                            .collect(Collectors.toList());
+                    return CompletableFuture.allOf(
+                            insertRanges(targetRangeSets, null, rangeStart),
+                                    insertRanges(targetRangeSets, rangeEnd, null))
+                            .thenApply(ignore -> null);
+                }, null);
+
+        final List<Object> additionalLogMessageKeyValues = Arrays.asList(LogMessageKeys.CALLING_METHOD, "buildMultiTargetIndex",
+                LogMessageKeys.RANGE_START, rangeStart,
+                LogMessageKeys.RANGE_END, rangeEnd);
+
+        return maybePresetRangeFuture.thenCompose(ignore ->
+                        iterateAllRanges(additionalLogMessageKeyValues, this::buildRangeOnly));
     }
 
     @Nonnull
@@ -188,10 +223,17 @@ public class IndexingMultiTargetByRecords extends IndexingBase {
     @Nonnull
     @Override
     CompletableFuture<Void> rebuildIndexInternalAsync(FDBRecordStore store) {
-        AtomicReference<Tuple> nextResultCont = new AtomicReference<>(null);
+        final TupleRange tupleRange = common.computeRecordsRange();
+        // if non-null, the tupleRange contains the range of all the records need indexing (in practice,
+        // the type keys containing the lexicographically first to last types). Hence, we can skip indexing records
+        // that are outside this range.
+        final Tuple rangeStart = tupleRange == null ? null : tupleRange.getLow();
+        final Tuple rangeEndInclusive = tupleRange == null ? null : tupleRange.getHigh();
+
+        AtomicReference<Tuple> nextResultCont = new AtomicReference<>(rangeStart);
         AtomicLong recordScanned = new AtomicLong();
         return AsyncUtil.whileTrue(() ->
-                rebuildRangeOnly(store, nextResultCont.get(), recordScanned, null).thenApply(cont -> {
+                rebuildRangeOnly(store, nextResultCont.get(), recordScanned, rangeEndInclusive).thenApply(cont -> {
                     if (cont == null) {
                         return false;
                     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMultiTargetByRecords.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMultiTargetByRecords.java
@@ -117,7 +117,7 @@ public class IndexingMultiTargetByRecords extends IndexingBase {
     @Nonnull
     private CompletableFuture<Void> buildMultiTargetIndex() {
         final List<Object> additionalLogMessageKeyValues = Arrays.asList(LogMessageKeys.CALLING_METHOD, "buildMultiTargetIndex");
-        return maybePresetRangeFuture().thenCompose(ignore ->
+        return maybePresetRecordsRangeAsync().thenCompose(ignore ->
                         iterateAllRanges(additionalLogMessageKeyValues, this::buildRangeOnly));
     }
 
@@ -140,8 +140,8 @@ public class IndexingMultiTargetByRecords extends IndexingBase {
                 return AsyncUtil.READY_FALSE; // no more missing ranges - all done
             }
             // Keep the boundaries as (opaque) raw bytes.
-            final byte[] rangeStart = RangeSet.isFirstKey(range.begin) ? null : range.begin;
-            final byte[] rangeEnd = RangeSet.isFinalKey(range.end) ? null : range.end;
+            final byte[] rangeStart = RangeSet.nullIfFirst(range.begin);
+            final byte[] rangeEnd = RangeSet.nullIfFinal(range.end);
 
             RecordCursor<FDBStoredRecord<Message>> cursor =
                     store.scanRecords(new KeyRange(rangeStart, rangeEnd), null, scanProperties);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMultiTargetByRecords.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMultiTargetByRecords.java
@@ -24,9 +24,11 @@ import com.apple.foundationdb.Range;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.async.RangeSet;
+import com.apple.foundationdb.record.EndpointType;
 import com.apple.foundationdb.record.ExecuteProperties;
 import com.apple.foundationdb.record.IndexBuildProto;
 import com.apple.foundationdb.record.IsolationLevel;
+import com.apple.foundationdb.record.KeyRange;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordCursorResult;
 import com.apple.foundationdb.record.ScanProperties;
@@ -34,7 +36,6 @@ import com.apple.foundationdb.record.TupleRange;
 import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.provider.foundationdb.indexing.IndexingRangeSet;
-import com.apple.foundationdb.tuple.ByteArrayUtil;
 import com.apple.foundationdb.tuple.Tuple;
 import com.google.protobuf.Message;
 
@@ -125,9 +126,7 @@ public class IndexingMultiTargetByRecords extends IndexingBase {
         } else {
             final Range range = tupleRange.toRange();
             rangeStart = range.begin;
-            // tupleRange has an inclusive high endpoint, so end isn't a valid tuple.
-            // But buildRangeOnly needs to convert missing Ranges back to TupleRanges, so round up.
-            rangeEnd = ByteArrayUtil.strinc(range.end);
+            rangeEnd = range.end;
         }
 
         final CompletableFuture<FDBRecordStore> maybePresetRangeFuture =
@@ -172,12 +171,18 @@ public class IndexingMultiTargetByRecords extends IndexingBase {
             if (range == null) {
                 return AsyncUtil.READY_FALSE; // no more missing ranges - all done
             }
-            final Tuple rangeStart = RangeSet.isFirstKey(range.begin) ? null : Tuple.fromBytes(range.begin);
-            final Tuple rangeEnd = RangeSet.isFinalKey(range.end) ? null : Tuple.fromBytes(range.end);
-            final TupleRange tupleRange = TupleRange.between(rangeStart, rangeEnd);
+            // Keep the boundaries as (opaque) raw bytes.
+            final byte[] rangeStart = RangeSet.isFirstKey(range.begin) ? null : range.begin;
+            final byte[] rangeEnd = RangeSet.isFinalKey(range.end) ? null : range.end;
 
             RecordCursor<FDBStoredRecord<Message>> cursor =
-                    store.scanRecords(tupleRange, null, scanProperties);
+                    store.scanRecords(
+                            new KeyRange(
+                                    rangeStart != null ? rangeStart : new byte[0],
+                                    rangeStart == null ? EndpointType.TREE_START : EndpointType.RANGE_INCLUSIVE,
+                                    rangeEnd != null ? rangeEnd : new byte[0],
+                                    rangeEnd == null ? EndpointType.TREE_END : EndpointType.RANGE_EXCLUSIVE),
+                            null, scanProperties);
 
             final AtomicReference<RecordCursorResult<FDBStoredRecord<Message>>> lastResult = new AtomicReference<>(RecordCursorResult.exhausted());
             final AtomicBoolean hasMore = new AtomicBoolean(true);
@@ -195,14 +200,14 @@ public class IndexingMultiTargetByRecords extends IndexingBase {
 
     private CompletableFuture<Boolean> postIterateRangeOnly(List<IndexingRangeSet> targetRangeSets, boolean hasMore,
                                                             AtomicReference<RecordCursorResult<FDBStoredRecord<Message>>> lastResult,
-                                                            Tuple rangeStart, Tuple rangeEnd, boolean isReverse) {
+                                                            byte[] rangeStart, byte[] rangeEnd, boolean isReverse) {
         if (isReverse) {
-            Tuple continuation = hasMore ? lastResult.get().get().getPrimaryKey() : rangeStart;
-            return insertRanges(targetRangeSets, packOrNull(continuation), packOrNull(rangeEnd))
+            byte[] continuation = hasMore ? lastResult.get().get().getPrimaryKey().pack() : rangeStart;
+            return insertRanges(targetRangeSets, continuation, rangeEnd)
                     .thenApply(ignore -> hasMore || rangeStart != null);
         } else {
-            Tuple continuation = hasMore ? lastResult.get().get().getPrimaryKey() : rangeEnd;
-            return insertRanges(targetRangeSets, packOrNull(rangeStart), packOrNull(continuation))
+            byte[] continuation = hasMore ? lastResult.get().get().getPrimaryKey().pack() : rangeEnd;
+            return insertRanges(targetRangeSets, rangeStart, continuation)
                     .thenApply(ignore -> hasMore || rangeEnd != null);
         }
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMultiTargetByRecords.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMultiTargetByRecords.java
@@ -20,7 +20,6 @@
 
 package com.apple.foundationdb.record.provider.foundationdb;
 
-import com.apple.foundationdb.Range;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.async.RangeSet;
@@ -118,38 +117,8 @@ public class IndexingMultiTargetByRecords extends IndexingBase {
 
     @Nonnull
     private CompletableFuture<Void> buildMultiTargetIndex() {
-        final TupleRange tupleRange = common.computeRecordsRange();
-        final byte[] rangeStart;
-        final byte[] rangeEnd;
-        if (tupleRange == null) {
-            rangeStart = rangeEnd = null;
-        } else {
-            final Range range = tupleRange.toRange();
-            rangeStart = range.begin;
-            rangeEnd = range.end;
-        }
-
-        final CompletableFuture<FDBRecordStore> maybePresetRangeFuture =
-                rangeStart == null ?
-                CompletableFuture.completedFuture(null) :
-                buildCommitRetryAsync((store, recordsScanned) -> {
-                    // Here: only records inside the defined records-range are relevant to the index. Hence, the completing range
-                    // can be preemptively marked as indexed.
-                    final List<Index> targetIndexes = common.getTargetIndexes();
-                    final List<IndexingRangeSet> targetRangeSets = targetIndexes.stream()
-                            .map(targetIndex -> IndexingRangeSet.forIndexBuild(store, targetIndex))
-                            .collect(Collectors.toList());
-                    return CompletableFuture.allOf(
-                            insertRanges(targetRangeSets, null, rangeStart),
-                                    insertRanges(targetRangeSets, rangeEnd, null))
-                            .thenApply(ignore -> null);
-                }, null);
-
-        final List<Object> additionalLogMessageKeyValues = Arrays.asList(LogMessageKeys.CALLING_METHOD, "buildMultiTargetIndex",
-                LogMessageKeys.RANGE_START, rangeStart,
-                LogMessageKeys.RANGE_END, rangeEnd);
-
-        return maybePresetRangeFuture.thenCompose(ignore ->
+        final List<Object> additionalLogMessageKeyValues = Arrays.asList(LogMessageKeys.CALLING_METHOD, "buildMultiTargetIndex");
+        return maybePresetRangeFuture().thenCompose(ignore ->
                         iterateAllRanges(additionalLogMessageKeyValues, this::buildRangeOnly));
     }
 
@@ -210,11 +179,6 @@ public class IndexingMultiTargetByRecords extends IndexingBase {
             return insertRanges(targetRangeSets, rangeStart, continuation)
                     .thenApply(ignore -> hasMore || rangeEnd != null);
         }
-    }
-
-    private static CompletableFuture<Void> insertRanges(List<IndexingRangeSet> rangeSets,
-                                                        byte[] start, byte[] end) {
-        return AsyncUtil.whenAll(rangeSets.stream().map(set -> set.insertRangeAsync(start, end, true)).collect(Collectors.toList()));
     }
 
     @SuppressWarnings("unused")

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMultiTargetByRecords.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMultiTargetByRecords.java
@@ -23,7 +23,6 @@ package com.apple.foundationdb.record.provider.foundationdb;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.async.RangeSet;
-import com.apple.foundationdb.record.EndpointType;
 import com.apple.foundationdb.record.ExecuteProperties;
 import com.apple.foundationdb.record.IndexBuildProto;
 import com.apple.foundationdb.record.IsolationLevel;
@@ -145,13 +144,7 @@ public class IndexingMultiTargetByRecords extends IndexingBase {
             final byte[] rangeEnd = RangeSet.isFinalKey(range.end) ? null : range.end;
 
             RecordCursor<FDBStoredRecord<Message>> cursor =
-                    store.scanRecords(
-                            new KeyRange(
-                                    rangeStart != null ? rangeStart : new byte[0],
-                                    rangeStart == null ? EndpointType.TREE_START : EndpointType.RANGE_INCLUSIVE,
-                                    rangeEnd != null ? rangeEnd : new byte[0],
-                                    rangeEnd == null ? EndpointType.TREE_END : EndpointType.RANGE_EXCLUSIVE),
-                            null, scanProperties);
+                    store.scanRecords(new KeyRange(rangeStart, rangeEnd), null, scanProperties);
 
             final AtomicReference<RecordCursorResult<FDBStoredRecord<Message>>> lastResult = new AtomicReference<>(RecordCursorResult.exhausted());
             final AtomicBoolean hasMore = new AtomicBoolean(true);
@@ -173,11 +166,11 @@ public class IndexingMultiTargetByRecords extends IndexingBase {
         if (isReverse) {
             byte[] continuation = hasMore ? lastResult.get().get().getPrimaryKey().pack() : rangeStart;
             return insertRanges(targetRangeSets, continuation, rangeEnd)
-                    .thenApply(ignore -> hasMore || rangeStart != null);
+                    .thenApply(ignore -> rangesAreNotExhausted(hasMore, rangeStart));
         } else {
             byte[] continuation = hasMore ? lastResult.get().get().getPrimaryKey().pack() : rangeEnd;
             return insertRanges(targetRangeSets, rangeStart, continuation)
-                    .thenApply(ignore -> hasMore || rangeEnd != null);
+                    .thenApply(ignore -> rangesAreNotExhausted(hasMore, rangeEnd));
         }
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMutuallyByRecords.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMutuallyByRecords.java
@@ -24,7 +24,6 @@ import com.apple.foundationdb.FDBException;
 import com.apple.foundationdb.Range;
 import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.async.RangeSet;
-import com.apple.foundationdb.record.EndpointType;
 import com.apple.foundationdb.record.IndexBuildProto;
 import com.apple.foundationdb.record.KeyRange;
 import com.apple.foundationdb.record.RecordCursor;
@@ -399,13 +398,7 @@ public class IndexingMutuallyByRecords extends IndexingBase {
             final byte[] rangeEnd = RangeSet.isFinalKey(range.end) ? null : range.end;
 
             RecordCursor<FDBStoredRecord<Message>> cursor =
-                    store.scanRecords(
-                            new KeyRange(
-                                    rangeStart != null ? rangeStart : new byte[0],
-                                    rangeStart == null ? EndpointType.TREE_START : EndpointType.RANGE_INCLUSIVE,
-                                    rangeEnd != null ? rangeEnd : new byte[0],
-                                    rangeEnd == null ? EndpointType.TREE_END : EndpointType.RANGE_EXCLUSIVE),
-                            null, scanProperties);
+                    store.scanRecords(new KeyRange(rangeStart, rangeEnd), null, scanProperties);
 
             final AtomicReference<RecordCursorResult<FDBStoredRecord<Message>>> lastResult = new AtomicReference<>(RecordCursorResult.exhausted());
             final AtomicBoolean hasMore = new AtomicBoolean(true);
@@ -417,7 +410,7 @@ public class IndexingMutuallyByRecords extends IndexingBase {
                                           lastResult.get().get().getPrimaryKey().pack() :
                                           rangeEnd)
                     .thenCompose(cont -> insertRanges(targetRangeSets, rangeStart, cont)
-                            .thenApply(ignore -> !(cont == null && rangeEnd == null)));
+                            .thenApply(ignore -> rangesAreNotExhausted(cont != null, rangeEnd)));
         });
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMutuallyByRecords.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMutuallyByRecords.java
@@ -165,25 +165,9 @@ public class IndexingMutuallyByRecords extends IndexingBase {
             boundaries = new ArrayList<>();
         }
 
-        // Add the two endpoints to the range
-        if (tupleRange == null) {
-            // Here: make sure that the boundaries cover everything
-            boundaries.add(0, null);
-            boundaries.add(null);
-        } else {
-            // Add the low endpoint (an inclusive record-type-key prefix) as the bottom boundary, unless an existing
-            // boundary already precedes it.
-            if (boundaries.isEmpty() || tupleRange.getLow() == null || tupleRange.getLow().compareTo(boundaries.get(0)) < 0) {
-                boundaries.add(0, tupleRange.getLow());
-            }
-            // The high endpoint is an inclusive record-type-key prefix; it cannot be used directly as an (exclusive)
-            // fragment boundary, since all of that type's records sort after it - and when low == high (a single
-            // record type) it would otherwise collapse the boundaries into a single empty fragment, leaving no range
-            // to build. Leave the top open instead: maybePresetRangeFuture has already marked every key beyond the
-            // records range as built, so each fragment is clamped back to the records range when its missing
-            // sub-range is computed.
-            boundaries.add(null);
-        }
+        // Add the two endpoints to the range, making sure that the boundaries cover everything
+        boundaries.add(0, null);
+        boundaries.add(null);
 
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug(KeyValueLogMessage.of("got boundaries",
@@ -296,7 +280,7 @@ public class IndexingMutuallyByRecords extends IndexingBase {
     @Nonnull
     private CompletableFuture<Void> buildMultiTargetIndex() {
         final List<Object> additionalLogMessageKeyValues = Arrays.asList(LogMessageKeys.CALLING_METHOD, "mutualMultiTargetIndex-wrapper");
-        return maybePresetRangeFuture().thenCompose(ignore ->
+        return maybePresetRecordsRangeAsync().thenCompose(ignore ->
                 iterateAllRanges(additionalLogMessageKeyValues,
                         (store, recordsScanned) -> buildRangeOnly(store)));
     }
@@ -394,8 +378,8 @@ public class IndexingMutuallyByRecords extends IndexingBase {
                 return AsyncUtil.READY_FALSE; // no more missing ranges - all done
             }
             // Keep the boundaries as (opaque) raw bytes
-            final byte[] rangeStart = RangeSet.isFirstKey(range.begin) ? null : range.begin;
-            final byte[] rangeEnd = RangeSet.isFinalKey(range.end) ? null : range.end;
+            final byte[] rangeStart = RangeSet.nullIfFirst(range.begin);
+            final byte[] rangeEnd = RangeSet.nullIfFinal(range.end);
 
             RecordCursor<FDBStoredRecord<Message>> cursor =
                     store.scanRecords(new KeyRange(rangeStart, rangeEnd), null, scanProperties);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMutuallyByRecords.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMutuallyByRecords.java
@@ -172,13 +172,18 @@ public class IndexingMutuallyByRecords extends IndexingBase {
             boundaries.add(0, null);
             boundaries.add(null);
         } else {
-            // Here: add the endpoints, unless they are already included
+            // Add the low endpoint (an inclusive record-type-key prefix) as the bottom boundary, unless an existing
+            // boundary already precedes it.
             if (boundaries.isEmpty() || tupleRange.getLow() == null || tupleRange.getLow().compareTo(boundaries.get(0)) < 0) {
                 boundaries.add(0, tupleRange.getLow());
             }
-            if (tupleRange.getHigh() == null || tupleRange.getHigh().compareTo(boundaries.get(boundaries.size() - 1)) > 0) {
-                boundaries.add(tupleRange.getHigh());
-            }
+            // The high endpoint is an inclusive record-type-key prefix; it cannot be used directly as an (exclusive)
+            // fragment boundary, since all of that type's records sort after it - and when low == high (a single
+            // record type) it would otherwise collapse the boundaries into a single empty fragment, leaving no range
+            // to build. Leave the top open instead: maybePresetRangeFuture has already marked every key beyond the
+            // records range as built, so each fragment is clamped back to the records range when its missing
+            // sub-range is computed.
+            boundaries.add(null);
         }
 
         if (LOGGER.isDebugEnabled()) {
@@ -291,38 +296,8 @@ public class IndexingMutuallyByRecords extends IndexingBase {
 
     @Nonnull
     private CompletableFuture<Void> buildMultiTargetIndex() {
-        final TupleRange tupleRange = common.computeRecordsRange();
-        final byte[] rangeStart;
-        final byte[] rangeEnd;
-        if (tupleRange == null) {
-            rangeStart = rangeEnd = null;
-        } else {
-            final Range range = tupleRange.toRange();
-            rangeStart = range.begin;
-            rangeEnd = range.end;
-        }
-
-        final CompletableFuture<FDBRecordStore> maybePresetRangeFuture =
-                rangeStart == null ?
-                CompletableFuture.completedFuture(null) :
-                buildCommitRetryAsync((store, recordsScanned) -> {
-                    // Here: only records inside the defined records-range are relevant to the index. Hence, the completing range
-                    // can be preemptively marked as indexed.
-                    final List<Index> targetIndexes = common.getTargetIndexes();
-                    final List<IndexingRangeSet> targetRangeSets = targetIndexes.stream()
-                            .map(targetIndex -> IndexingRangeSet.forIndexBuild(store, targetIndex))
-                            .collect(Collectors.toList());
-                    return CompletableFuture.allOf(
-                                    insertRanges(targetRangeSets, null, rangeStart),
-                                    insertRanges(targetRangeSets, rangeEnd, null))
-                            .thenApply(ignore -> null);
-                }, null);
-
-        final List<Object> additionalLogMessageKeyValues = Arrays.asList(LogMessageKeys.CALLING_METHOD, "mutualMultiTargetIndex-wrapper",
-                LogMessageKeys.RANGE_START, rangeStart,
-                LogMessageKeys.RANGE_END, rangeEnd);
-
-        return maybePresetRangeFuture.thenCompose(ignore ->
+        final List<Object> additionalLogMessageKeyValues = Arrays.asList(LogMessageKeys.CALLING_METHOD, "mutualMultiTargetIndex-wrapper");
+        return maybePresetRangeFuture().thenCompose(ignore ->
                 iterateAllRanges(additionalLogMessageKeyValues,
                         (store, recordsScanned) -> buildRangeOnly(store)));
     }
@@ -516,11 +491,6 @@ public class IndexingMutuallyByRecords extends IndexingBase {
         return squasshed ?
                ranges.stream().filter(Objects::nonNull).collect(Collectors.toList()) :
                ranges;
-    }
-
-    private static CompletableFuture<Void> insertRanges(List<IndexingRangeSet> rangeSets,
-                                                        byte[] start, byte[] end) {
-        return AsyncUtil.whenAll(rangeSets.stream().map(set -> set.insertRangeAsync(start, end, true)).collect(Collectors.toList()));
     }
 
     private void infiniteLoopProtection(final Range range, final List<Range> missingRanges) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMutuallyByRecords.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMutuallyByRecords.java
@@ -24,7 +24,9 @@ import com.apple.foundationdb.FDBException;
 import com.apple.foundationdb.Range;
 import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.async.RangeSet;
+import com.apple.foundationdb.record.EndpointType;
 import com.apple.foundationdb.record.IndexBuildProto;
+import com.apple.foundationdb.record.KeyRange;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordCursorResult;
 import com.apple.foundationdb.record.ScanProperties;
@@ -417,12 +419,18 @@ public class IndexingMutuallyByRecords extends IndexingBase {
             if (range == null) {
                 return AsyncUtil.READY_FALSE; // no more missing ranges - all done
             }
-            final Tuple rangeStart = RangeSet.isFirstKey(range.begin) ? null : Tuple.fromBytes(range.begin);
-            final Tuple rangeEnd = RangeSet.isFinalKey(range.end) ? null : Tuple.fromBytes(range.end);
-            final TupleRange tupleRange = TupleRange.between(rangeStart, rangeEnd);
+            // Keep the boundaries as (opaque) raw bytes
+            final byte[] rangeStart = RangeSet.isFirstKey(range.begin) ? null : range.begin;
+            final byte[] rangeEnd = RangeSet.isFinalKey(range.end) ? null : range.end;
 
             RecordCursor<FDBStoredRecord<Message>> cursor =
-                    store.scanRecords(tupleRange, null, scanProperties);
+                    store.scanRecords(
+                            new KeyRange(
+                                    rangeStart != null ? rangeStart : new byte[0],
+                                    rangeStart == null ? EndpointType.TREE_START : EndpointType.RANGE_INCLUSIVE,
+                                    rangeEnd != null ? rangeEnd : new byte[0],
+                                    rangeEnd == null ? EndpointType.TREE_END : EndpointType.RANGE_EXCLUSIVE),
+                            null, scanProperties);
 
             final AtomicReference<RecordCursorResult<FDBStoredRecord<Message>>> lastResult = new AtomicReference<>(RecordCursorResult.exhausted());
             final AtomicBoolean hasMore = new AtomicBoolean(true);
@@ -431,10 +439,10 @@ public class IndexingMutuallyByRecords extends IndexingBase {
                     this::getRecordIfTypeMatch,
                     lastResult, hasMore, recordsScanned, isIdempotent)
                     .thenApply(vignore -> hasMore.get() ?
-                                          lastResult.get().get().getPrimaryKey() :
+                                          lastResult.get().get().getPrimaryKey().pack() :
                                           rangeEnd)
-                    .thenCompose(cont -> insertRanges(targetRangeSets, packOrNull(rangeStart), packOrNull(cont))
-                            .thenApply(ignore -> !allRangesAreExhausted(cont, rangeEnd)));
+                    .thenCompose(cont -> insertRanges(targetRangeSets, rangeStart, cont)
+                            .thenApply(ignore -> !(cont == null && rangeEnd == null)));
         });
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMutuallyByRecords.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMutuallyByRecords.java
@@ -153,9 +153,10 @@ public class IndexingMutuallyByRecords extends IndexingBase {
     }
 
     private List<Tuple> getPrimaryKeyBoundaries(@Nonnull FDBRecordStore store) {
+        TupleRange tupleRange = common.computeRecordsRange();
         store.getContext().getReadVersion(); // for instrumentation reasons
         List<Tuple> boundaries;
-        try (RecordCursor<Tuple> cursor = store.getPrimaryKeyBoundaries(null)) {
+        try (RecordCursor<Tuple> cursor = store.getPrimaryKeyBoundaries(tupleRange)) {
             boundaries = cursor.asList().join();
         }
 
@@ -163,13 +164,25 @@ public class IndexingMutuallyByRecords extends IndexingBase {
             boundaries = new ArrayList<>();
         }
 
-        // Add the two endpoints to cover everything
-        boundaries.add(0, null);
-        boundaries.add(null);
+        // Add the two endpoints to the range
+        if (tupleRange == null) {
+            // Here: make sure that the boundaries cover everything
+            boundaries.add(0, null);
+            boundaries.add(null);
+        } else {
+            // Here: add the endpoints, unless they are already included
+            if (boundaries.isEmpty() || tupleRange.getLow() == null || tupleRange.getLow().compareTo(boundaries.get(0)) < 0) {
+                boundaries.add(0, tupleRange.getLow());
+            }
+            if (tupleRange.getHigh() == null || tupleRange.getHigh().compareTo(boundaries.get(boundaries.size() - 1)) > 0) {
+                boundaries.add(tupleRange.getHigh());
+            }
+        }
 
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug(KeyValueLogMessage.of("got boundaries",
                     LogMessageKeys.INDEX_NAME, common.getTargetIndexesNames(),
+                    LogMessageKeys.RANGE, tupleRange,
                     LogMessageKeys.KEY_COUNT, boundaries.size()));
         }
 
@@ -276,9 +289,40 @@ public class IndexingMutuallyByRecords extends IndexingBase {
 
     @Nonnull
     private CompletableFuture<Void> buildMultiTargetIndex() {
-        final List<Object> additionalLogMessageKeyValues = Arrays.asList(LogMessageKeys.CALLING_METHOD, "mutualMultiTargetIndex-wrapper");
-        return iterateAllRanges(additionalLogMessageKeyValues,
-                        (store, recordsScanned) -> buildRangeOnly(store));
+        final TupleRange tupleRange = common.computeRecordsRange();
+        final byte[] rangeStart;
+        final byte[] rangeEnd;
+        if (tupleRange == null) {
+            rangeStart = rangeEnd = null;
+        } else {
+            final Range range = tupleRange.toRange();
+            rangeStart = range.begin;
+            rangeEnd = range.end;
+        }
+
+        final CompletableFuture<FDBRecordStore> maybePresetRangeFuture =
+                rangeStart == null ?
+                CompletableFuture.completedFuture(null) :
+                buildCommitRetryAsync((store, recordsScanned) -> {
+                    // Here: only records inside the defined records-range are relevant to the index. Hence, the completing range
+                    // can be preemptively marked as indexed.
+                    final List<Index> targetIndexes = common.getTargetIndexes();
+                    final List<IndexingRangeSet> targetRangeSets = targetIndexes.stream()
+                            .map(targetIndex -> IndexingRangeSet.forIndexBuild(store, targetIndex))
+                            .collect(Collectors.toList());
+                    return CompletableFuture.allOf(
+                                    insertRanges(targetRangeSets, null, rangeStart),
+                                    insertRanges(targetRangeSets, rangeEnd, null))
+                            .thenApply(ignore -> null);
+                }, null);
+
+        final List<Object> additionalLogMessageKeyValues = Arrays.asList(LogMessageKeys.CALLING_METHOD, "mutualMultiTargetIndex-wrapper",
+                LogMessageKeys.RANGE_START, rangeStart,
+                LogMessageKeys.RANGE_END, rangeEnd);
+
+        return maybePresetRangeFuture.thenCompose(ignore ->
+                iterateAllRanges(additionalLogMessageKeyValues,
+                        (store, recordsScanned) -> buildRangeOnly(store)));
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMultiTargetTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMultiTargetTest.java
@@ -28,6 +28,7 @@ import com.apple.foundationdb.record.metadata.IndexOptions;
 import com.apple.foundationdb.record.metadata.IndexTypes;
 import com.apple.foundationdb.record.metadata.expressions.EmptyKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.GroupingKeyExpression;
+import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.synchronizedsession.SynchronizedSessionLockedException;
 import com.apple.test.BooleanSource;
 import com.apple.test.SuperSlow;
@@ -49,7 +50,9 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 
+import static com.apple.foundationdb.record.metadata.Key.Expressions.concat;
 import static com.apple.foundationdb.record.metadata.Key.Expressions.field;
+import static com.apple.foundationdb.record.metadata.Key.Expressions.recordType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -613,6 +616,74 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
         assertEquals(numRecords + numRecordsOther, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED));
         assertEquals(numChunks , timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RANGES_BY_COUNT));
         scrubAndValidate(Arrays.asList(indexMyA, indexMyB, indexOtherA, indexOtherB));
+    }
+
+    @ParameterizedTest
+    @BooleanSource
+    void testMultiTargetByteRangeTypedRecords(boolean splitLongRecords) {
+        // Exercise the byte-range (non-Tuple) typed-records optimization for multi-target indexing.
+
+        final FDBStoreTimer timer = new FDBStoreTimer();
+        final int numRecords = 90;
+        final int numRecordsOther = 30;
+        final int chunkSize = 13;
+        final int numChunks = 1 + (numRecords / chunkSize);
+
+        final Index indexA = new Index("indexA", field("num_value_2"), EmptyKeyExpression.EMPTY, IndexTypes.VALUE, IndexOptions.UNIQUE_OPTIONS);
+        final Index indexB = new Index("indexB", field("num_value_3_indexed"), IndexTypes.VALUE);
+        final Index indexC = new Index("indexC", field("num_value_unique"), EmptyKeyExpression.EMPTY, IndexTypes.VALUE, IndexOptions.UNIQUE_OPTIONS);
+        final List<Index> indexes = Arrays.asList(indexA, indexB, indexC);
+
+        final FDBRecordStoreTestBase.RecordMetaDataHook hook = metaDataBuilder -> {
+            // Prefix both record types' primary keys with the record type, so the indexer can restrict the scan to a
+            // single record-type byte range.
+            final KeyExpression pkey = concat(recordType(), field("rec_no"));
+            metaDataBuilder.getRecordType("MySimpleRecord").setPrimaryKey(pkey);
+            metaDataBuilder.getRecordType("MyOtherRecord").setPrimaryKey(pkey);
+            // Give the indexed type the record type key 0
+            metaDataBuilder.getRecordType("MySimpleRecord").setRecordTypeKey(0L);
+            metaDataBuilder.setSplitLongRecords(splitLongRecords);
+            for (Index index : indexes) {
+                metaDataBuilder.addIndex("MySimpleRecord", index);
+            }
+        };
+
+        // Populate both record types using the prefixed-primary-key meta-data.
+        openSimpleMetaData(hook);
+        try (FDBRecordContext context = openContext()) {
+            for (int i = 0; i < numRecords; i++) {
+                recordStore.saveRecord(TestRecords1Proto.MySimpleRecord.newBuilder()
+                        .setRecNo(i)
+                        .setNumValue2(i * 7)
+                        .setNumValue3Indexed(i * 11)
+                        .setNumValueUnique(i * 13)
+                        .build());
+            }
+            for (int i = 0; i < numRecordsOther; i++) {
+                recordStore.saveRecord(TestRecords1Proto.MyOtherRecord.newBuilder()
+                        .setRecNo(i)
+                        .setNumValue2(i)
+                        .build());
+            }
+            context.commit();
+        }
+
+        disableAll(indexes);
+        try (OnlineIndexer indexBuilder = newIndexerBuilder(indexes, timer)
+                .setLimit(chunkSize)
+                .build()) {
+            indexBuilder.buildIndex(true);
+        }
+
+        // Only the MySimpleRecord records are scanned/indexed - the preset MyOtherRecord byte range is skipped.
+        assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_SCANNED));
+        assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED));
+        assertEquals(numChunks, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RANGES_BY_COUNT));
+
+        // All target indexes are fully built and consistent with the scanned records.
+        openSimpleMetaData(hook);
+        assertReadable(indexes);
+        scrubAndValidate(indexes);
     }
 
     @Test

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMutualTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMutualTest.java
@@ -37,6 +37,7 @@ import com.apple.foundationdb.record.metadata.IndexTypes;
 import com.apple.foundationdb.record.metadata.IndexValidator;
 import com.apple.foundationdb.record.metadata.expressions.EmptyKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.GroupingKeyExpression;
+import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.provider.foundationdb.indexes.AtomicMutationIndexMaintainerFactory;
 import com.apple.foundationdb.record.provider.foundationdb.indexes.RankIndexMaintainerFactory;
 import com.apple.foundationdb.record.provider.foundationdb.indexes.ValueIndexMaintainerFactory;
@@ -69,7 +70,9 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 
+import static com.apple.foundationdb.record.metadata.Key.Expressions.concat;
 import static com.apple.foundationdb.record.metadata.Key.Expressions.field;
+import static com.apple.foundationdb.record.metadata.Key.Expressions.recordType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -126,6 +129,76 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
         }
         assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_SCANNED));
         assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED));
+        assertReadable(indexes);
+        scrubAndValidate(indexes);
+    }
+
+    @ParameterizedTest
+    @BooleanSource
+    void testMutualIndexingTypedRecords(boolean splitLongRecords) {
+        // Exercise the byte-range (non-Tuple) typed-records optimization for mutual indexing, with the indexed record
+        // type using record type key 0.
+
+        final FDBStoreTimer timer = new FDBStoreTimer();
+        final int numRecords = 90;
+        final int numRecordsOther = 30;
+
+        final Index indexA = new Index("indexA", field("num_value_2"), EmptyKeyExpression.EMPTY, IndexTypes.VALUE, IndexOptions.UNIQUE_OPTIONS);
+        final Index indexB = new Index("indexB", field("num_value_3_indexed"), IndexTypes.VALUE);
+        final Index indexC = new Index("indexC", field("num_value_unique"), EmptyKeyExpression.EMPTY, IndexTypes.VALUE, IndexOptions.UNIQUE_OPTIONS);
+        final List<Index> indexes = Arrays.asList(indexA, indexB, indexC);
+
+        final FDBRecordStoreTestBase.RecordMetaDataHook hook = metaDataBuilder -> {
+            // Prefix both record types' primary keys with the record type, so the indexer can restrict the scan to a
+            // single record-type byte range.
+            final KeyExpression pkey = concat(recordType(), field("rec_no"));
+            metaDataBuilder.getRecordType("MySimpleRecord").setPrimaryKey(pkey);
+            metaDataBuilder.getRecordType("MyOtherRecord").setPrimaryKey(pkey);
+            // Give the indexed type the record type key 0 - the byte-range boundary (the Tuple encoding of 0).
+            metaDataBuilder.getRecordType("MySimpleRecord").setRecordTypeKey(0L);
+            metaDataBuilder.setSplitLongRecords(splitLongRecords);
+            for (Index index : indexes) {
+                metaDataBuilder.addIndex("MySimpleRecord", index);
+            }
+        };
+
+        // Populate both record types using the prefixed-primary-key meta-data.
+        openSimpleMetaData(hook);
+        try (FDBRecordContext context = openContext()) {
+            for (int i = 0; i < numRecords; i++) {
+                recordStore.saveRecord(TestRecords1Proto.MySimpleRecord.newBuilder()
+                        .setRecNo(i)
+                        .setNumValue2(i * 7)
+                        .setNumValue3Indexed(i * 11)
+                        .setNumValueUnique(i * 13)
+                        .build());
+            }
+            for (int i = 0; i < numRecordsOther; i++) {
+                recordStore.saveRecord(TestRecords1Proto.MyOtherRecord.newBuilder()
+                        .setRecNo(i)
+                        .setNumValue2(i)
+                        .build());
+            }
+            context.commit();
+        }
+
+        disableAll(indexes);
+        try (OnlineIndexer indexBuilder = newIndexerBuilder(indexes, timer)
+                .setLimit(13)
+                .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
+                        .setMutualIndexing() // no boundaries -> self detection (single shard for this small data set)
+                        .build())
+                .build()) {
+
+            indexBuilder.buildIndex(true);
+        }
+
+        // Only the MySimpleRecord records are scanned/indexed - the preset MyOtherRecord byte range is skipped.
+        assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_SCANNED));
+        assertEquals(numRecords, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED));
+
+        // All target indexes are fully built and consistent with the scanned records.
+        openSimpleMetaData(hook);
         assertReadable(indexes);
         scrubAndValidate(indexes);
     }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RecordTypeKeyTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RecordTypeKeyTest.java
@@ -803,7 +803,6 @@ public class RecordTypeKeyTest extends FDBRecordStoreQueryTestBase {
             context.commit();
         }
 
-        // Add a value index on MySimpleRecord.num_value_2; >200 records keeps it disabled on reopen.
         final RecordMetaDataHook addIndex = metaData -> {
             setupHook.apply(metaData);
             metaData.addIndex("MySimpleRecord", "newIndex", "num_value_2");
@@ -815,12 +814,10 @@ public class RecordTypeKeyTest extends FDBRecordStoreQueryTestBase {
             context.commit();
         }
 
-        // Build the index online.
         try (OnlineIndexer indexBuilder = OnlineIndexer.forRecordStoreAndIndex(recordStore, "newIndex")) {
             indexBuilder.buildIndex();
         }
 
-        // Verify readable and that exactly the 201 MySimpleRecord entries are indexed (with type key 0L).
         try (FDBRecordContext context = openContext()) {
             uncheckedOpenSimpleRecordStore(context, addIndex);
             recordStore.checkVersion(null, FDBRecordStoreBase.StoreExistenceCheck.ERROR_IF_NOT_EXISTS).join();

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RecordTypeKeyTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RecordTypeKeyTest.java
@@ -621,7 +621,7 @@ public class RecordTypeKeyTest extends FDBRecordStoreQueryTestBase {
 
             assertTrue(recordStore.isIndexReadable("newIndex"));
 
-            assertEquals(510, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_SCANNED));
+            assertEquals(10, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_SCANNED));
             assertEquals(10, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED));
 
             assertEquals(IntStream.range(0, 10).mapToObj(i -> Tuple.from(i, 1, i)).collect(Collectors.toList()),
@@ -668,7 +668,7 @@ public class RecordTypeKeyTest extends FDBRecordStoreQueryTestBase {
             }
             recordStore.markIndexReadable("newIndex").join();
 
-            assertEquals(500, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_SCANNED));
+            assertEquals(250, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_SCANNED));
             assertEquals(250, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED));
 
             assertEquals(IntStream.range(0, 250).mapToObj(i -> Tuple.from(i, 1, i)).collect(Collectors.toList()),
@@ -695,7 +695,7 @@ public class RecordTypeKeyTest extends FDBRecordStoreQueryTestBase {
         }
 
         assertThat(timer.getCount(FDBStoreTimer.Events.COMMIT), Matchers.greaterThanOrEqualTo(3));
-        assertEquals(500, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_SCANNED));
+        assertEquals(250, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_SCANNED));
         assertEquals(250, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED));
 
         try (FDBRecordContext context = openContext()) {
@@ -753,7 +753,7 @@ public class RecordTypeKeyTest extends FDBRecordStoreQueryTestBase {
         }
 
         assertThat(timer.getCount(FDBStoreTimer.Events.COMMIT), Matchers.greaterThanOrEqualTo(3));
-        assertEquals(500, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_SCANNED));
+        assertEquals(250, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_SCANNED));
         assertEquals(250, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED));
 
         try (FDBRecordContext context = openContext()) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RecordTypeKeyTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RecordTypeKeyTest.java
@@ -773,6 +773,65 @@ public class RecordTypeKeyTest extends FDBRecordStoreQueryTestBase {
         }
     }
 
+    @Test
+    void testOnlineIndexBuilderRecordTypeKeyZero() throws Exception {
+        final int numRecords = 201; // Exceed MAX_RECORDS_FOR_REBUILD so the new index stays disabled.
+
+        // MySimpleRecord gets explicit record type key 0; MyOtherRecord keeps its default (= 2).
+        final RecordMetaDataHook setupHook = metaData -> {
+            BASIC_HOOK.apply(metaData);
+            metaData.getRecordType("MySimpleRecord").setRecordTypeKey(0L);
+        };
+
+        // Create the store and save records of the type-key-0 type, plus a few of the other type
+        // to verify the OnlineIndexer only indexes records matching the index's record type.
+        try (FDBRecordContext context = openContext()) {
+            uncheckedOpenSimpleRecordStore(context, setupHook);
+            recordStore.checkVersion(null, FDBRecordStoreBase.StoreExistenceCheck.ERROR_IF_EXISTS).join();
+            for (int j = 0; j < numRecords; j++) {
+                recordStore.saveRecord(TestRecords1Proto.MySimpleRecord.newBuilder()
+                        .setRecNo(j)
+                        .setNumValue2(j)
+                        .build());
+            }
+            for (int j = 0; j < 3; j++) {
+                recordStore.saveRecord(TestRecords1Proto.MyOtherRecord.newBuilder()
+                        .setRecNo(j)
+                        .setNumValue2(j)
+                        .build());
+            }
+            context.commit();
+        }
+
+        // Add a value index on MySimpleRecord.num_value_2; >200 records keeps it disabled on reopen.
+        final RecordMetaDataHook addIndex = metaData -> {
+            setupHook.apply(metaData);
+            metaData.addIndex("MySimpleRecord", "newIndex", "num_value_2");
+        };
+        try (FDBRecordContext context = openContext()) {
+            uncheckedOpenSimpleRecordStore(context, addIndex);
+            recordStore.checkVersion(null, FDBRecordStoreBase.StoreExistenceCheck.ERROR_IF_NOT_EXISTS).join();
+            assertTrue(recordStore.isIndexDisabled("newIndex"));
+            context.commit();
+        }
+
+        // Build the index online.
+        try (OnlineIndexer indexBuilder = OnlineIndexer.forRecordStoreAndIndex(recordStore, "newIndex")) {
+            indexBuilder.buildIndex();
+        }
+
+        // Verify readable and that exactly the 201 MySimpleRecord entries are indexed (with type key 0L).
+        try (FDBRecordContext context = openContext()) {
+            uncheckedOpenSimpleRecordStore(context, addIndex);
+            recordStore.checkVersion(null, FDBRecordStoreBase.StoreExistenceCheck.ERROR_IF_NOT_EXISTS).join();
+            assertTrue(recordStore.isIndexReadable("newIndex"));
+            assertEquals(IntStream.range(0, numRecords).mapToObj(j -> Tuple.from(j, 0L, j)).collect(Collectors.toList()),
+                    recordStore.scanIndex(recordStore.getRecordMetaData().getIndex("newIndex"),
+                            IndexScanType.BY_VALUE, TupleRange.ALL, null, ScanProperties.FORWARD_SCAN)
+                            .map(IndexEntry::getKey).asList().join());
+        }
+    }
+
     private List<FDBStoredRecord<Message>> saveSomeRecords(@Nonnull RecordMetaDataHook hook) throws Exception {
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, hook);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RecordTypeKeyTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RecordTypeKeyTest.java
@@ -816,6 +816,9 @@ public class RecordTypeKeyTest extends FDBRecordStoreQueryTestBase {
 
         try (OnlineIndexer indexBuilder = OnlineIndexer.forRecordStoreAndIndex(recordStore, "newIndex")) {
             indexBuilder.buildIndex();
+            // The typed-records optimization restricts the scan to MySimpleRecord's record-type range, so only the
+            // matching records are scanned - the 3 MyOtherRecord records are skipped.
+            assertEquals(numRecords, indexBuilder.getTotalRecordsScanned());
         }
 
         try (FDBRecordContext context = openContext()) {


### PR DESCRIPTION
This bug may happen while indexing a value index of typed records with record type 0. It is caused with an indexing optimization the pre-set the rangeSet to mark everything but the type as indexed. The record type find its way to the rangeSet, and certain values will break parsing.
    
steps: 
Revert the optimization's removal
Create a test to expose the bug
Fix the bug
