### PR TITLE
Expose shutdown hook disablement through `FDBDatabaseFactory`

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactory.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.provider.foundationdb;
 
 import com.apple.foundationdb.Database;
+import com.apple.foundationdb.FDB;
 import com.apple.foundationdb.NetworkOptions;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
@@ -665,6 +666,39 @@ public abstract class FDBDatabaseFactory {
      * @see FDBTraceFormat
      */
     public abstract void setTraceFormat(@Nonnull FDBTraceFormat traceFormat);
+
+    /**
+     * Disable the FDB shutdown hook. By default, the FDB client will register a shutdown hook that stops
+     * the FDB client and cleans up native resources upon application shutdown. However, as the order of
+     * shutdown hooks is not defined, the shutdown hook can conflict with other shutdown tasks. If the
+     * user wants to have more control, they should consider disabling the shutdown hook via this method, and
+     * then invoking {@link #shutdown()} in a hook that they control.
+     *
+     * <p>
+     * This method can be called before or after {@link FDB} initialization. If it is called before the
+     * FDB client is initialized, then the shutdown hook will never be registered. If it is called after
+     * the client is initialized, then the previously registered shutdown hook will be removed. That does
+     * mean that if an instance is shut down between FDB client initialization and the invocation of
+     * this method, the shutdown hook <em>will</em> run. To avoid that case, it is generally suggested that
+     * the user invoke this before client initialization. If this method is invoked multiple times, it has
+     * no effect.
+     * </p>
+     *
+     * @see #shutdown()
+     * @see FDB#disableShutdownHook()
+     */
+    public abstract void disableShutdownHook();
+
+    /**
+     * Whether the FDB shutdown hook has been disabled. By default, the FDB shutdown hook will run, but
+     * the user can invoke {@link #disableShutdownHook()} to assert more control over shutdown hook order.
+     * Once disabled, there is no way to re-enable the default hook, so this method will return {@code true}
+     * if {@link #disableShutdownHook()} has ever been invoked.
+     *
+     * @return whether the FDB shutdown hook has been disabled
+     * @see #disableShutdownHook()
+     */
+    public abstract boolean isShutdownHookDisabled();
 
     /**
      * Set whether additional run-loop profiling of the FDB client is enabled. This can be useful for debugging

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactoryImpl.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactoryImpl.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Objects;
 import java.util.function.Supplier;
 
 /**
@@ -84,6 +85,7 @@ public class FDBDatabaseFactoryImpl extends FDBDatabaseFactory {
     private FDBTraceFormat traceFormat = FDBTraceFormat.DEFAULT;
     @Nonnull
     private APIVersion apiVersion = APIVersion.getDefault();
+    private volatile boolean shutdownHookDisabled;
 
     private boolean runLoopProfilingEnabled = false;
 
@@ -138,6 +140,9 @@ public class FDBDatabaseFactoryImpl extends FDBDatabaseFactory {
             }
             if (runLoopProfilingEnabled) {
                 options.setEnableRunLoopProfiling();
+            }
+            if (shutdownHookDisabled) {
+                fdb.disableShutdownHook();
             }
             if (networkExecutor == null) {
                 fdb.startNetwork();
@@ -222,6 +227,19 @@ public class FDBDatabaseFactoryImpl extends FDBDatabaseFactory {
     @Override
     public boolean isRunLoopProfilingEnabled() {
         return runLoopProfilingEnabled;
+    }
+
+    @Override
+    public synchronized void disableShutdownHook() {
+        if (!shutdownHookDisabled && inited) {
+            Objects.requireNonNull(fdb).disableShutdownHook();
+        }
+        shutdownHookDisabled = true;
+    }
+
+    @Override
+    public boolean isShutdownHookDisabled() {
+        return shutdownHookDisabled;
     }
 
     // TODO: Demote these to UNSTABLE and deprecate at some point.

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/test/FDBDatabaseExtension.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/test/FDBDatabaseExtension.java
@@ -36,16 +36,18 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Extension that allows the user to specify the database. It ensures that FDB has been properly initialized
@@ -104,6 +106,9 @@ public class FDBDatabaseExtension implements AfterEachCallback {
                         baseFactory.setTrace(".", "fdb_record_layer_test");
                     }
                     baseFactory.setAPIVersion(getAPIVersion());
+                    assertFalse(baseFactory.isShutdownHookDisabled());
+                    baseFactory.disableShutdownHook();
+                    assertTrue(baseFactory.isShutdownHookDisabled());
                     baseFactory.setUnclosedWarning(true);
                     for (final String clusterFile : FDBTestEnvironment.allClusterFiles()) {
                         FDBDatabase unused = baseFactory.getDatabase(clusterFile);


### PR DESCRIPTION
This exposes the ability to disable the FDB shutdown hook through the `FDBDatabaseFactory`. Prior to this, a user wanting to disable the shutdown hook would need to first let FDB be initialized, then invoke `disableShutdownHook` on the `FDB` singleton directly. This allows a library consumer to avoid making a direct call to the FDB API, and it allows them to invoke the method before FDB has been initialized, which plugs one potential gap (if the shutdown signal comes between FDB being initialized and `disableShutdownHook` being called.)

This isn't particuarly easy to test. The data in question is a global variable that is stored on a singleton, and there's not a test fixture. The new methods are invoked now in the `FDBDatabaseExtension`, but it's slim in actual testing.

This resolves #899.