### PR TITLE
Enable efficient rule-index-based matching for `AbsorptionRule`

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/simplification/AbsorptionRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/simplification/AbsorptionRule.java
@@ -34,7 +34,6 @@ import com.google.common.collect.Sets;
 
 import javax.annotation.Nonnull;
 import java.util.Collection;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.MultiMatcher.all;
@@ -52,24 +51,18 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  */
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("PMD.TooManyStaticImports")
-public class AbsorptionRule<P extends AndOrPredicate> extends QueryPredicateSimplificationRule<P> {
+public final class AbsorptionRule<P extends AndOrPredicate> extends QueryPredicateSimplificationRule<P> {
     @Nonnull
     private final Class<P> majorClass;
     @Nonnull
     private final BindingMatcher<QueryPredicate> termMatcher;
 
-    public AbsorptionRule(@Nonnull final Class<P> majorClass,
-                          @Nonnull final BindingMatcher<QueryPredicate> termMatcher,
-                          @Nonnull final BindingMatcher<P> rootMatcher) {
+    private AbsorptionRule(@Nonnull final Class<P> majorClass,
+                           @Nonnull final BindingMatcher<QueryPredicate> termMatcher,
+                           @Nonnull final BindingMatcher<P> rootMatcher) {
         super(rootMatcher);
         this.majorClass = majorClass;
         this.termMatcher = termMatcher;
-    }
-
-    @Nonnull
-    @Override
-    public Optional<Class<?>> getRootOperator() {
-        return Optional.empty();
     }
 
     @Override


### PR DESCRIPTION
Remove the unnecessary `getRootOperator()` override in `AbsorptionRule` that returned `Optional.empty()`.

This rule has exactly two instances: `withMajor(AndPredicate.class)` and `withMajor(OrPredicate.class)`, in the `DefaultQueryPredicateRuleSet` rule set. Because of the `getRootOperator()` override, they were unnecessarily added to the `alwaysRules` list, meaning they would get consulted on _every_ `QueryPredicate` visited during simplification.

The inherited default `AbstractRule.getRootOperator()` now returns `Optional.of(matcher.getRootClass())`, which for `AbsorptionRule` resolves to either `AndPredicate.class` or `OrPredicate.class`, as appropriate. This way the rules will benefit from indexing in the rule set.

This issue was found via JFR profiling by looking at allocation traces underneath `executeRuleSetIteratively()`.