### PR TITLE
Fix an unreachable `if` branch in `QueryPredicateSimplificationRule`

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/AndPredicate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/AndPredicate.java
@@ -62,7 +62,7 @@ import java.util.function.Supplier;
  * <li>Else {@code null}.</li>
  * </ul>
  */
-public class AndPredicate extends AndOrPredicate {
+public final class AndPredicate extends AndOrPredicate {
     private static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("And-Predicate");
 
     private AndPredicate(@Nonnull final PlanSerializationContext serializationContext,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/OrPredicate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/OrPredicate.java
@@ -71,7 +71,7 @@ import java.util.stream.Stream;
  * </ul>
  */
 @API(API.Status.EXPERIMENTAL)
-public class OrPredicate extends AndOrPredicate {
+public final class OrPredicate extends AndOrPredicate {
     private static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("Or-Predicate");
 
     private OrPredicate(@Nonnull final PlanSerializationContext serializationContext,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/QueryPredicateSimplificationRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/QueryPredicateSimplificationRule.java
@@ -21,7 +21,6 @@
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
-import com.apple.foundationdb.record.query.plan.cascades.Constrained;
 import com.apple.foundationdb.record.query.plan.cascades.ExplorationCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ExplorationCascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.Quantifiers;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/QueryPredicateSimplificationRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/QueryPredicateSimplificationRule.java
@@ -30,7 +30,6 @@ import com.apple.foundationdb.record.query.plan.cascades.matching.structure.Coll
 import com.apple.foundationdb.record.query.plan.cascades.predicates.AndPredicate;
 import com.apple.foundationdb.record.query.plan.cascades.predicates.QueryPredicate;
 import com.apple.foundationdb.record.query.plan.cascades.predicates.simplification.ConstantFoldingRuleSet;
-import com.apple.foundationdb.record.query.plan.cascades.values.Value;
 import com.apple.foundationdb.record.query.plan.cascades.values.simplification.Simplification;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/QueryPredicateSimplificationRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/QueryPredicateSimplificationRule.java
@@ -116,7 +116,7 @@ public class QueryPredicateSimplificationRule extends ExplorationCascadesRule<Se
             return;
         }
 
-        final Value resultValue = selectExpression.getResultValue();
+        final var resultValue = selectExpression.getResultValue();
         final var quantifier = selectExpression.getQuantifiers();
         final SelectExpression simplifiedSelectExpression;
         final List<? extends QueryPredicate> newPredicates;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/QueryPredicateSimplificationRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/QueryPredicateSimplificationRule.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
+import com.apple.foundationdb.record.query.plan.cascades.Constrained;
 import com.apple.foundationdb.record.query.plan.cascades.ExplorationCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ExplorationCascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.Quantifiers;
@@ -30,11 +31,14 @@ import com.apple.foundationdb.record.query.plan.cascades.matching.structure.Coll
 import com.apple.foundationdb.record.query.plan.cascades.predicates.AndPredicate;
 import com.apple.foundationdb.record.query.plan.cascades.predicates.QueryPredicate;
 import com.apple.foundationdb.record.query.plan.cascades.predicates.simplification.ConstantFoldingRuleSet;
+import com.apple.foundationdb.record.query.plan.cascades.values.Value;
 import com.apple.foundationdb.record.query.plan.cascades.values.simplification.Simplification;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 
 import javax.annotation.Nonnull;
+
+import java.util.List;
 
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.MultiMatcher.all;
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.MultiMatcher.atLeastOne;
@@ -107,21 +111,22 @@ public class QueryPredicateSimplificationRule extends ExplorationCascadesRule<Se
         final var constantAliases = Sets.difference(conjunction.getCorrelatedTo(),
                 Quantifiers.aliases(selectExpression.getQuantifiers()));
 
-        final var simplifiedConjunction = Simplification.optimize(conjunction, call.getEvaluationContext(), aliasMap,
-                constantAliases, ConstantFoldingRuleSet.ofSimplificationRules());
-
-        if (simplifiedConjunction.get().semanticEquals(conjunction, aliasMap)) {
+        final QueryPredicate simplifiedConjunction = Simplification.optimize(conjunction, call.getEvaluationContext(),
+                aliasMap, constantAliases, ConstantFoldingRuleSet.ofSimplificationRules()).get();
+        if (simplifiedConjunction.semanticEquals(conjunction, aliasMap)) {
             return;
         }
 
-        final var resultValue = selectExpression.getResultValue();
+        final Value resultValue = selectExpression.getResultValue();
         final var quantifier = selectExpression.getQuantifiers();
         final SelectExpression simplifiedSelectExpression;
-        if (simplifiedConjunction instanceof AndPredicate) {
-            simplifiedSelectExpression = new SelectExpression(resultValue, quantifier, ((AndPredicate)simplifiedConjunction).getChildren());
+        final List<? extends QueryPredicate> newPredicates;
+        if (simplifiedConjunction instanceof AndPredicate andPredicate) {
+            newPredicates = andPredicate.getChildren();
         } else {
-            simplifiedSelectExpression = new SelectExpression(resultValue, quantifier, ImmutableList.of(simplifiedConjunction.get()));
+            newPredicates = ImmutableList.of(simplifiedConjunction);
         }
+        simplifiedSelectExpression = new SelectExpression(resultValue, quantifier, newPredicates);
 
         call.yieldExploratoryExpression(simplifiedSelectExpression);
     }


### PR DESCRIPTION
`onMatch()` had an `if (simplifiedConjunction instanceof AndPredicate)` that was effectively never true because the `simplifiedConjunction` returned by `Simplification.optimize()` is of type `Constrained<QueryPredicate>`, which is unrelated to `AndPredicate`. The check should have used `simplifiedConjunction.get()`.

This was uncovered by marking `AndPredicate` and `OrPredicate` as `final`. Without this, the compiler cannot prove that the two types are indeed unrelated.