### PR TITLE
Upgrade JUnit 5.14.1 → 6.0.3

### DIFF
--- a/fdb-record-layer-lucene/fdb-record-layer-lucene.gradle
+++ b/fdb-record-layer-lucene/fdb-record-layer-lucene.gradle
@@ -37,7 +37,6 @@ dependencies {
     testImplementation project(path: coreProject, configuration: 'tests')
     testImplementation(libs.bundles.test.impl)
     testImplementation(libs.lucene.testFramework)
-    testRuntimeOnly(libs.junit.vintange)
     testRuntimeOnly(libs.bundles.test.runtime)
     testCompileOnly(libs.bundles.test.compileOnly)
     testImplementation(libs.snakeyaml)

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/engine/AutoTestEngine.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/autotest/engine/AutoTestEngine.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.engine.execution.JupiterEngineExecutionContext;
 import org.junit.jupiter.engine.execution.LauncherStoreFacade;
 import org.junit.platform.commons.support.AnnotationSupport;
 import org.junit.platform.commons.support.ReflectionSupport;
+import org.junit.platform.engine.DiscoveryIssue;
 import org.junit.platform.engine.EngineDiscoveryRequest;
 import org.junit.platform.engine.ExecutionRequest;
 import org.junit.platform.engine.TestDescriptor;
@@ -36,10 +37,12 @@ import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.discovery.ClassSelector;
 import org.junit.platform.engine.discovery.ClasspathRootSelector;
 import org.junit.platform.engine.discovery.PackageSelector;
+import org.junit.platform.engine.support.discovery.DiscoveryIssueReporter;
 import org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine;
 
 import javax.annotation.Nonnull;
 import java.net.URI;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 public class AutoTestEngine extends HierarchicalTestEngine<JupiterEngineExecutionContext> {
@@ -53,19 +56,21 @@ public class AutoTestEngine extends HierarchicalTestEngine<JupiterEngineExecutio
 
     @Override
     public TestDescriptor discover(EngineDiscoveryRequest discoveryRequest, UniqueId uniqueId) {
+        DiscoveryIssueReporter issueReporter = DiscoveryIssueReporter.deduplicating(
+                DiscoveryIssueReporter.forwarding(discoveryRequest.getDiscoveryListener(), uniqueId));
         JupiterConfiguration config = new CachingJupiterConfiguration(
                 new DefaultJupiterConfiguration(discoveryRequest.getConfigurationParameters(),
-                        discoveryRequest.getOutputDirectoryCreator()));
+                        discoveryRequest.getOutputDirectoryCreator(), issueReporter));
         TestDescriptor rootDescriptor = new JupiterEngineDescriptor(uniqueId, config);
 
         discoveryRequest.getSelectorsByType(ClasspathRootSelector.class).forEach(selector ->
-                appendTestsInClasspathRoot(selector.getClasspathRoot(), rootDescriptor, config));
+                appendTestsInClasspathRoot(selector.getClasspathRoot(), rootDescriptor, config, issueReporter));
 
         discoveryRequest.getSelectorsByType(PackageSelector.class).forEach(selector ->
-                appendTestsInPackage(selector.getPackageName(), rootDescriptor, config));
+                appendTestsInPackage(selector.getPackageName(), rootDescriptor, config, issueReporter));
 
         discoveryRequest.getSelectorsByType(ClassSelector.class).forEach(selector ->
-                appendTestsInClass(selector.getJavaClass(), rootDescriptor, config));
+                appendTestsInClass(selector.getJavaClass(), rootDescriptor, config, issueReporter));
         return rootDescriptor;
     }
 
@@ -77,30 +82,40 @@ public class AutoTestEngine extends HierarchicalTestEngine<JupiterEngineExecutio
                 new LauncherStoreFacade(request.getStore()));
     }
 
-    private void appendTestsInClass(Class<?> javaClass, TestDescriptor engineDesc, JupiterConfiguration config) {
+    private void appendTestsInClass(Class<?> javaClass, TestDescriptor engineDesc, JupiterConfiguration config,
+                                     DiscoveryIssueReporter issueReporter) {
         if (AnnotationSupport.isAnnotated(javaClass, AutomatedTest.class)) {
-            final TestDescriptor classTestDescriptor = getClassTestDescriptor(engineDesc, config, javaClass);
-            engineDesc.addChild(classTestDescriptor);
+            getClassTestDescriptor(engineDesc, config, javaClass, issueReporter)
+                    .ifPresent(engineDesc::addChild);
         }
     }
 
-    private void appendTestsInPackage(String packageName, TestDescriptor engineDesc, JupiterConfiguration config) {
+    private void appendTestsInPackage(String packageName, TestDescriptor engineDesc, JupiterConfiguration config,
+                                       DiscoveryIssueReporter issueReporter) {
         ReflectionSupport.findAllClassesInPackage(packageName, IS_AUTO_TEST_CONTAINER, name -> true)
                 .stream()
-                .map(clazz -> getClassTestDescriptor(engineDesc, config, clazz))
+                .flatMap(clazz -> getClassTestDescriptor(engineDesc, config, clazz, issueReporter).stream())
                 .forEach(engineDesc::addChild);
     }
 
-    private void appendTestsInClasspathRoot(URI rootUri, TestDescriptor engineDesc, JupiterConfiguration config) {
+    private void appendTestsInClasspathRoot(URI rootUri, TestDescriptor engineDesc, JupiterConfiguration config,
+                                             DiscoveryIssueReporter issueReporter) {
         ReflectionSupport.findAllClassesInClasspathRoot(rootUri, IS_AUTO_TEST_CONTAINER, name -> true)
                 .stream()
-                .map(aClass -> getClassTestDescriptor(engineDesc, config, aClass))
+                .flatMap(aClass -> getClassTestDescriptor(engineDesc, config, aClass, issueReporter).stream())
                 .forEach(engineDesc::addChild);
     }
 
     @Nonnull
-    private TestDescriptor getClassTestDescriptor(TestDescriptor engineDesc, JupiterConfiguration config, Class<?> aClass) {
-        return new AutoTestResolver().resolveTest(engineDesc, config, aClass);
+    private Optional<TestDescriptor> getClassTestDescriptor(TestDescriptor engineDesc, JupiterConfiguration config,
+                                                             Class<?> aClass, DiscoveryIssueReporter issueReporter) {
+        try {
+            return Optional.of(new AutoTestResolver().resolveTest(engineDesc, config, aClass));
+        } catch (Exception e) {
+            issueReporter.reportIssue(DiscoveryIssue.builder(DiscoveryIssue.Severity.ERROR,
+                    "Failed to resolve auto-test class: " + aClass.getName()).cause(e).build());
+            return Optional.empty();
+        }
     }
 
     /*

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -63,8 +63,7 @@ diffutils = "4.12"
 hamcrest = "2.2"
 jcommander = "1.81"
 jline = "3.30.4"
-junit = "5.14.1"
-junit-platform = "1.14.1"
+junit = "6.0.3"
 mockito = "3.7.7"
 snakeyaml = "2.2"
 
@@ -135,8 +134,7 @@ jline = { module = "org.jline:jline", version.ref = "jline" }
 junit-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit" }
 junit-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }
 junit-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit" }
-junit-platform = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit-platform" }
-junit-vintange = { module = "org.junit.vintage:junit-vintage-engine", version.ref = "junit" }
+junit-platform = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit" }
 lucene-testFramework = { module = "org.apache.lucene:lucene-test-framework", version.ref = "lucene" }
 opencsv = { module = "com.opencsv:opencsv", version.ref = "opencsv" }
 hamcrest = { module = "org.hamcrest:hamcrest", version.ref = "hamcrest" }


### PR DESCRIPTION
## Summary

- Bump `junit` and `junit-platform` to `6.0.3` (versions are now unified in JUnit 6; a single version key covers both)
- Remove `junit-vintage-engine` — no JUnit 4 tests exist in the codebase and there is no JUnit 6 vintage engine
- Fix `AutoTestEngine.discover()` for the new `DefaultJupiterConfiguration` constructor (requires a `DiscoveryIssueReporter` in JUnit 6); thread the reporter through the `append*` discovery methods so resolution failures are reported rather than propagating or silently dropped

## Test plan

- [ ] `./gradlew compileTestJava` — all subprojects compile clean
- [ ] `:fdb-record-layer-core:test` — passes (requires FDB)
- [ ] `:fdb-relational-core:test` — passes