### PR TITLE
Stabilize hash codes used by the planner

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/Comparisons.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/expressions/Comparisons.java
@@ -1390,7 +1390,8 @@ public class Comparisons {
         }
 
         public int computeHashCode() {
-            return Objects.hash(type, relatedByEquality());
+            // Note: This hash must be stable across JVMs, as it is used in `Comparison.semanticHashCode()`.
+            return Objects.hash(type.name(), relatedByEquality());
         }
 
         private Set<String> relatedByEquality() {
@@ -2195,7 +2196,9 @@ public class Comparisons {
 
         @Override
         public int hashCode() {
-            return Objects.hash(type, getComparandWithRealEquals(), javaType);
+            // Note: This hash must be stable across JVMs, as it is used in `Comparison.semanticHashCode()`.
+            final Object javaTypeName = javaType == null ? null : javaType.name();
+            return Objects.hash(type.name(), getComparandWithRealEquals(), javaTypeName);
         }
 
         @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/Correlated.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/Correlated.java
@@ -183,22 +183,30 @@ public interface Correlated<S extends Correlated<S>> {
     }
 
     /**
-     * Return a semantic hash code for this object. The hash code must obey the convention that for any two objects
-     * {@code o1} and {@code o2} and for every {@link AliasMap} {@code aliasMap}:
+     * Returns a semantic hash code for this object.
      *
-     * <pre>
-     * {@code o1.semanticEquals(o1, aliasMap)} follows {@code o1.semanticHash() == o2.semanticHash()}
-     * </pre>
+     * <p>The hash code must be consistent with <strong>semantic equality</strong>:
+     * <blockquote>
+     * For any two objects {@code o1} and {@code o2} and for every {@link AliasMap} {@code aliasMap},
+     * {@code o1.semanticEquals(o2, aliasMap)} implies {@code o1.semanticHashCode() == o2.semanticHashCode()}.
+     * </blockquote>
      *
-     * If the semantic hash code of two implementing objects is equal and {@link #semanticEquals} returns {@code true}
-     * for these two objects the plan fragments are considered to produce the same result under the given
-     * correlations bindings.
+     * <p>When {@code o1.semanticEquals(o2, aliasMap)} returns {@code true}, {@code o1} and {@code o2} are considered to
+     * produce the same result under the given correlation bindings. The contract above ensures that hash-based
+     * collections respect the equivalence.
      *
-     * The left side {@code o1.semanticEquals(o1, aliasMap)} depends on an {@link AliasMap} while
-     * {@code o1.semanticHash() == o2.semanticHash()} does not. Hence, the hash that is computed is identical regardless
-     * of possible bindings.
+     * <p>Note that the computed hash code is independent of bindings. Only {@code o1.semanticEquals(o2, aliasMap)}
+     * depends on an alias map.
      *
-     * @return the semantic hash code
+     * <p><strong>Hash stability across JVMs.</strong> Implementations must ensure that the hash code for semantically
+     * equal inputs is the same across separate JVM runs, not just within one process. Note that this is stronger than
+     * the standard {@link Object#hashCode()} contract. Implementations must not rely on identity-based hashing. In
+     * particular, do not use {@code hashCode()} for {@link Enum} constants and {@code byte[]}; instead, use
+     * {@link Enum#name()}, {@link java.util.Arrays#hashCode(byte[])}, or {@code PlanHashable#objectPlanHash}.
+     * Stability across JVMs matters because semantic hash codes feed into planner decisions. A hash that varies between
+     * runs can result in different (but cost-equivalent) plans getting chosen for the same query.
+     *
+     * @see #semanticEquals
      */
     int semanticHashCode();
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/Ordering.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/Ordering.java
@@ -1279,7 +1279,8 @@ public class Ordering {
 
         @Override
         public int hashCode() {
-            return Objects.hash(sortOrder, comparison);
+            // Note: This hash must be stable across JVMs, as `Binding` is stored in hash-based sets during planning.
+            return Objects.hash(sortOrder.name(), comparison);
         }
 
         @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PredicateMultiMap.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PredicateMultiMap.java
@@ -606,7 +606,8 @@ public class PredicateMultiMap {
 
             @Override
             public int hashCode() {
-                return Objects.hash(originalQueryPredicate, candidatePredicate, mappingKind);
+                // Note: This hash must be stable across JVMs, as `MappingKey` is stored in hash-based sets during planning.
+                return Objects.hash(originalQueryPredicate, candidatePredicate, mappingKind.name());
             }
         }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/LiteralValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/LiteralValue.java
@@ -47,7 +47,6 @@ import com.google.protobuf.Message;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
-import java.util.Objects;
 import java.util.function.Supplier;
 
 /**
@@ -127,7 +126,7 @@ public class LiteralValue<T> extends AbstractValue implements LeafValue, Value.R
 
     @Override
     public int hashCodeWithoutChildren() {
-        return Objects.hash(value);
+        return PlanHashable.objectPlanHash(PlanHashable.CURRENT_FOR_CONTINUATION, value);
     }
 
     @Override


### PR DESCRIPTION
This change fixes some unstable hash codes that can affect the planner; in particular, uses of `Enum.hashCode()` and `byte[].hashCode()`. Those inherit the identity-based `hashCode()` method from `Object` and can therefore return different values on every JVM run for the same logical content. To stabilize them, we compute the hashes from `enum.name()` or `PlanHashable.objectPlanHash()` instead.

* The hashes of `ListComparison`, `ParameterComparisonBase`, and `LitervalValue.hashCodeWithoutChildren()` flow into `AbstractValue.semanticHashCode()`, which is used as the tie-breaker in `RewritingCostModel`.

* The hashes of `Ordering.Binding` and `PredicateMultiMap.MappingKey` can affect the bucket layout for maps keyed on `Binding` or `MappingKey`, and thus the planning iteration order.