### PR TITLE
Raise the `maxHeapSize` from 512 MB to 4 GB on Gradle `Test` tasks

### DIFF
--- a/gradle/testing.gradle
+++ b/gradle/testing.gradle
@@ -238,6 +238,9 @@ tasks.withType(Test) { theTask ->
     testClassesDirs = sourceSets.test.output.classesDirs
     classpath = sourceSets.test.runtimeClasspath
 
+    // Raise the default heap size for the forked worker JVMs that run the tests. (Gradle’s default is only 512 MB.)
+    maxHeapSize = '4g'
+
     configureTestTask('allTest', theTask)
     configureTestTask(theTask.name, theTask)
     testLogging {


### PR DESCRIPTION
Set `maxHeapSize = '4g'` in the `tasks.withType(Test)` block in `gradle/testing.gradle`. This affects the worker JVMs that Gradle forks to run tests.

Raising this should mitigate “Java heap space” failures such as the following:

```
Execution failed for task ':fdb-record-layer-core:test' (registered by plugin 'org.gradle.jvm-test-suite').
> Test process encountered an unexpected problem.
   > Could not complete execution for Gradle Test Executor 2.
      > Java heap space
```

Note that the existing `org.gradle.jvmargs=-Xmx4096m` line in `gradle.properties` only configures the Gradle daemon JVM, not the worker JVMs. Since no `Test` task in the project sets `maxHeapSize` itself, the worker JVMs were falling back to the 512 MB default. The 4 GB now matches what the Gradle daemon is getting and gives all `Test`-typed tasks (`test`, `quickTest`, `performanceTest`, et cetera) comfortable headroom.

Reference:
* https://docs.gradle.org/current/userguide/config_gradle.html

Resolves #4266.