### PR TITLE
Update some Gradle plugins and remove the `com.github.ben-manes.versions` plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,6 @@ buildscript {
 
 plugins {
     alias(libs.plugins.protobuf)
-    alias(libs.plugins.versions)
     alias(libs.plugins.spotbugs)
     alias(libs.plugins.nexus)
     alias(libs.plugins.download)
@@ -71,7 +70,6 @@ allprojects {
     apply plugin: 'maven-publish'
     apply plugin: 'signing'
     apply plugin: 'project-reports'
-    apply plugin: 'com.github.ben-manes.versions'
     apply plugin: 'de.undercouch.download'
 
     // Configure all source files to be read using UTF-8

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -158,5 +158,5 @@ jmh = { id = "me.champeau.jmh", version = "0.7.3" }
 nexus = { id = "io.github.gradle-nexus.publish-plugin", version = "2.0.0" }
 protobuf = { id = "com.google.protobuf", version = "0.9.6" }
 shadow = { id = "com.gradleup.shadow", version = "8.3.10" }
-spotbugs = { id = "com.github.spotbugs", version = "6.5.4" }
+spotbugs = { id = "com.github.spotbugs", version = "6.5.5" }
 versions = { id = "com.github.ben-manes.versions", version = "0.54.0" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -157,6 +157,6 @@ gitversion = { id = "com.palantir.git-version", version = "5.0.0" }
 jmh = { id = "me.champeau.jmh", version = "0.7.3" }
 nexus = { id = "io.github.gradle-nexus.publish-plugin", version = "2.0.0" }
 protobuf = { id = "com.google.protobuf", version = "0.9.6" }
-shadow = { id = "com.gradleup.shadow", version = "9.4.1" }
+shadow = { id = "com.gradleup.shadow", version = "8.3.10" }
 spotbugs = { id = "com.github.spotbugs", version = "6.5.4" }
 versions = { id = "com.github.ben-manes.versions", version = "0.54.0" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -156,7 +156,7 @@ download = { id = "de.undercouch.download", version = "5.7.0" }
 gitversion = { id = "com.palantir.git-version", version = "5.0.0" }
 jmh = { id = "me.champeau.jmh", version = "0.7.3" }
 nexus = { id = "io.github.gradle-nexus.publish-plugin", version = "2.0.0" }
-protobuf = { id = "com.google.protobuf", version = "0.10.0" }
+protobuf = { id = "com.google.protobuf", version = "0.9.6" }
 shadow = { id = "com.gradleup.shadow", version = "9.4.1" }
 spotbugs = { id = "com.github.spotbugs", version = "6.5.4" }
 versions = { id = "com.github.ben-manes.versions", version = "0.54.0" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -152,11 +152,11 @@ test-compileOnly = [ "autoService", "jsr305" ]
 
 [plugins]
 
-download = { id = "de.undercouch.download", version = "5.6.0" }
-gitversion = { id = "com.palantir.git-version", version = "3.1.0" }
+download = { id = "de.undercouch.download", version = "5.7.0" }
+gitversion = { id = "com.palantir.git-version", version = "5.0.0" }
 jmh = { id = "me.champeau.jmh", version = "0.7.3" }
 nexus = { id = "io.github.gradle-nexus.publish-plugin", version = "2.0.0" }
-protobuf = { id = "com.google.protobuf", version = "0.9.6" }
-shadow = { id = "com.gradleup.shadow", version = "8.3.10" }
-spotbugs = { id = "com.github.spotbugs", version = "6.1.3" }
-versions = { id = "com.github.ben-manes.versions", version = "0.52.0" }
+protobuf = { id = "com.google.protobuf", version = "0.10.0" }
+shadow = { id = "com.gradleup.shadow", version = "9.4.1" }
+spotbugs = { id = "com.github.spotbugs", version = "6.5.4" }
+versions = { id = "com.github.ben-manes.versions", version = "0.54.0" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -159,4 +159,3 @@ nexus = { id = "io.github.gradle-nexus.publish-plugin", version = "2.0.0" }
 protobuf = { id = "com.google.protobuf", version = "0.9.6" }
 shadow = { id = "com.gradleup.shadow", version = "8.3.10" }
 spotbugs = { id = "com.github.spotbugs", version = "6.5.5" }
-versions = { id = "com.github.ben-manes.versions", version = "0.54.0" }

--- a/gradle/proto.gradle
+++ b/gradle/proto.gradle
@@ -29,10 +29,6 @@ configurations {
 }
 
 protobuf {
-    generatedFilesBaseDir = "${projectDir}/protogen"
-    clean {
-        delete generatedFilesBaseDir
-    }
     protoc {
         artifact = "com.google.protobuf:protoc:${libs.versions.protobuf.get()}"
     }

--- a/gradle/proto.gradle
+++ b/gradle/proto.gradle
@@ -29,6 +29,10 @@ configurations {
 }
 
 protobuf {
+    generatedFilesBaseDir = "${projectDir}/protogen"
+    clean {
+        delete generatedFilesBaseDir
+    }
     protoc {
         artifact = "com.google.protobuf:protoc:${libs.versions.protobuf.get()}"
     }


### PR DESCRIPTION
Remove `com.github.ben-manes.versions`, as it is essentially unused, and update the following plugins to the latest available versions:

* `de.undercouch.download` 5.6.0 → 5.7.0.
* `com.palantir.git-version` 3.1.0 → 5.0.0.
* `com.github.spotbugs` 6.1.3 → 6.5.5

Notes:

* The **git-version** update in particular is important for compatibility with the Gradle 9 configuration cache.
* The `com.google.protobuf` and `com.gradleup.shadow` updates are somewhat non-trivial and therefore left for later.