### PR TITLE
Expand the SQL documentation for ARRAY unnesting

### DIFF
--- a/docs/sphinx/source/SQL_Reference.md
+++ b/docs/sphinx/source/SQL_Reference.md
@@ -1,7 +1,6 @@
 # SQL Reference
 
-The FDB relational subproject provides a SQL API for interacting with Record Layer databases. This SQL API is currently under active development and is expected
-to change frequently. This reference is currently also a work in progress to be updated as the SQL engine develops.
+The FDB relational subproject provides a SQL API for interacting with Record Layer databases. This SQL API is currently under active development and is expected to change frequently. This reference is currently also a work in progress to be updated as the SQL engine develops.
 
 
 ```{toctree}
@@ -13,6 +12,7 @@ reference/sql_commands
 reference/Functions
 reference/Subqueries
 reference/Joins
+reference/Unnesting
 ```
 
 ```{toctree}

--- a/docs/sphinx/source/reference/Indexes.rst
+++ b/docs/sphinx/source/reference/Indexes.rst
@@ -8,7 +8,7 @@ Defining indexes
 ################
 
 It is possible to define indexes in the Relational Layer as materialized views of :doc:`SELECT <sql_commands/DQL/SELECT>`
-statements.To be used in an index, the query must able to be incrementally updated. That is, when a row on an indexed
+statements. To be used in an index, the query must able to be incrementally updated. That is, when a row on an indexed
 table is inserted, updated, or deleted, it must be possible to construct a finite set up modifications to the index
 structure to reflect the new query results.
 
@@ -189,6 +189,42 @@ For INDEX AS SELECT syntax, the same ordering is specified in the ORDER BY claus
         FROM products
         ORDER BY rating ASC NULLS LAST
 
+Indexes on Unnested ``ARRAY`` Fields
+####################################
+
+If the table underlying the index contains an ``ARRAY`` column, it is possible to define an index on the result of unnesting the array. (This is subject to certain constraints, as described under :ref:`index_rules`.)
+
+Let us consider a simple example. Suppose we have a table ``restaurant``:
+
+.. code-block:: sql
+
+    CREATE TYPE AS STRUCT restaurant_review (reviewer STRING, rating INT64);
+
+    CREATE TABLE restaurant (
+        rest_no INT64,
+        name STRING,
+        reviews restaurant_review ARRAY,
+        PRIMARY KEY(rest_no)
+    );
+
+To optimize queries involving restaurant ratings, it may make sense to have an index defined on the unnested ``rating`` array. To do so, use the constructs described under :doc:`Unnesting`:
+
+.. code-block:: sql
+
+    CREATE INDEX mv AS
+        SELECT review.rating FROM restaurant AS RR, RR.reviews AS review;
+
+As a (less terse) alternative, the same index can also be written with an explicit subquery as follows:
+
+.. code-block:: sql
+
+    CREATE INDEX mv AS
+        SELECT SQ.rating FROM restaurant AS RR, (SELECT rating FROM RR.reviews) SQ;
+
+Both forms produce the same underlying key expression, ``field("reviews", FAN_OUT).nest(field("rating"))``. For each row of ``restaurant``, the index emits one entry per element of ``reviews``, keyed on the ``rating`` of the element. The general translation rule is described under :ref:`Implementation details <implementation_details>` below.
+
+Note that the planner currently leverages indexes of this form only in a limited way; broader support is planned for the future.
+
 Partitioning for Vector Indexes
 ################################
 
@@ -210,42 +246,18 @@ categories for better performance.
 **Important:** The ``PARTITION BY`` clause cannot be used with regular (non-vector) indexes created using either
 the INDEX AS SELECT or INDEX ON syntax.
 
-Indexes on nested fields
-########################
-
-The Relational Layer also offers a special version of indexes that can be used to describe how to index nested fields and
-:sql:`ARRAY` fields. They are defined using SQL, and they follow a strict set of rules, but before we get into the details, let
-us introduce them first by the following simple example. Suppose we have a table :sql:`restaurant` that is defined like this:
-
-.. code-block:: sql
-
-    CREATE TYPE AS STRUCT restaurant_review (reviewer STRING, rating INT64);
-    CREATE TABLE restaurant (
-        rest_no INT64, name STRING, reviews restaurant_review ARRAY, PRIMARY KEY(rest_no)
-    );
-
-Let us say we have too many queries involving restaurant ratings, so it makes sense to have an index defined on :sql:`rating`.
-We can define an index to do exactly that:
-
-.. code-block:: sql
-
-    CREATE INDEX mv AS
-        SELECT SQ.rating from restaurant AS RR, (select rating from RR.reviews) SQ;
-
-At first glance, it looks like the query is performing a join between :sql:`restaurant` and a subquery. However, if we
-take a closer look, we see that the table we select from in the subquery is nothing but the nested repeated field in
-:sql:`restaurant`. We use the alias :sql:`RR` to link the nested repeated field and its parent together.
-
+.. _index_rules:
 
 Index rules
 ###########
 
 Defining a index must adhere to these rules:
 
-* It must involve a single table only, correlated joins that navigate from one nested repeated field to another is possible.
+* The index body must involve only a single base table. Unnestings may be chained, however: an unnesting of a
+  nested repeated field may itself contain a further unnesting of another nested repeated field within it.
 * Predicates are not allowed in any (sub)query.
 * Each subquery can have a single _source_ and an arbitrary number of other nested subqueries. A source is effectively a
-  nested-repeated field. In the example above, :sql:`RR.reviews` is the source of the containing subquery.
+  nested-repeated field. In the examples above, :sql:`RR.reviews` is such a source.
 * The parent query must have the table itself as a source.
 * Propagation of selected fields from subqueries must follow the same order and clustering. Interleaving is not supported. For example, this is illegal:
 
@@ -258,6 +270,8 @@ Defining a index must adhere to these rules:
     .. code-block:: sql
 
         SELECT T1.a, T1.a, T2.c FROM T t, (SELECT a, b FROM t.X) T1, (SELECT c FROM t.Y) T2
+
+.. _implementation_details:
 
 Implementation details
 ######################
@@ -279,3 +293,4 @@ See Also
 ########
 
 * :doc:`CREATE INDEX <sql_commands/DDL/CREATE/INDEX>` - Complete CREATE INDEX command reference with detailed syntax and examples
+* :doc:`Unnesting` - PartiQL array unnesting (the construct used in the body of nested-field indexes)

--- a/docs/sphinx/source/reference/Indexes.rst
+++ b/docs/sphinx/source/reference/Indexes.rst
@@ -8,8 +8,8 @@ Defining indexes
 ################
 
 It is possible to define indexes in the Relational Layer as materialized views of :doc:`SELECT <sql_commands/DQL/SELECT>`
-statements. To be used in an index, the query must able to be incrementally updated. That is, when a row on an indexed
-table is inserted, updated, or deleted, it must be possible to construct a finite set up modifications to the index
+statements. To be used in an index, the query must be able to be incrementally updated. That is, when a row on an indexed
+table is inserted, updated, or deleted, it must be possible to construct a finite set of modifications to the index
 structure to reflect the new query results.
 
 In practice, that means that indexes are translated into a Record Layer key expression and index type. Indexes currently
@@ -211,19 +211,17 @@ To optimize queries involving restaurant ratings, it may make sense to have an i
 
 .. code-block:: sql
 
-    CREATE INDEX mv AS
+    CREATE INDEX idx_review_rating AS
         SELECT review.rating FROM restaurant AS RR, RR.reviews AS review;
 
 As a (less terse) alternative, the same index can also be written with an explicit subquery as follows:
 
 .. code-block:: sql
 
-    CREATE INDEX mv AS
+    CREATE INDEX idx_review_rating AS
         SELECT SQ.rating FROM restaurant AS RR, (SELECT rating FROM RR.reviews) SQ;
 
 Both forms produce the same underlying key expression, ``field("reviews", FAN_OUT).nest(field("rating"))``. For each row of ``restaurant``, the index emits one entry per element of ``reviews``, keyed on the ``rating`` of the element. The general translation rule is described under :ref:`Implementation details <implementation_details>` below.
-
-Note that the planner currently leverages indexes of this form only in a limited way; broader support is planned for the future.
 
 Partitioning for Vector Indexes
 ################################
@@ -251,7 +249,7 @@ the INDEX AS SELECT or INDEX ON syntax.
 Index rules
 ###########
 
-Defining a index must adhere to these rules:
+Defining an index must adhere to these rules:
 
 * The index body must involve only a single base table. Unnestings may be chained, however: an unnesting of a
   nested repeated field may itself contain a further unnesting of another nested repeated field within it.
@@ -293,4 +291,4 @@ See Also
 ########
 
 * :doc:`CREATE INDEX <sql_commands/DDL/CREATE/INDEX>` - Complete CREATE INDEX command reference with detailed syntax and examples
-* :doc:`Unnesting` - PartiQL array unnesting (the construct used in the body of nested-field indexes)
+* :doc:`Unnesting` - Array unnesting (used in the body of nested-field indexes)

--- a/docs/sphinx/source/reference/Subqueries.rst
+++ b/docs/sphinx/source/reference/Subqueries.rst
@@ -37,15 +37,6 @@ A subquery that references columns from the outer query:
     SELECT columns FROM table1 AS t1
     WHERE EXISTS (SELECT * FROM table2 WHERE table2.col = t1.col)
 
-Array Unnesting
----------------
-
-FDB supports PartiQL-style array unnesting:
-
-.. code-block:: sql
-
-    SELECT columns FROM table, table.array_column AS alias
-
 Examples
 ========
 
@@ -124,24 +115,10 @@ Use a correlated subquery as a derived table:
 
 The subquery ``(SELECT * FROM r WHERE r.idr = a.x)`` is correlated because it references ``a.x`` from the outer query.
 
-Array Unnesting with PartiQL
------------------------------
+Unnesting Arrays with a Subquery
+--------------------------------
 
-Unnest an array column using PartiQL syntax:
-
-.. code-block:: sql
-
-    SELECT idr FROM r, r.nr AS nest WHERE nest.f = 23
-
-.. list-table::
-    :header-rows: 1
-
-    * - :sql:`idr`
-    * - :json:`2`
-
-This query iterates over the ``nr`` array in each row of ``r`` and returns rows where the nested struct's ``f`` field equals 23.
-
-You can also use a subquery for array unnesting:
+A subquery in the ``FROM`` clause can be used to unnest an array column:
 
 .. code-block:: sql
 
@@ -152,6 +129,10 @@ You can also use a subquery for array unnesting:
 
     * - :sql:`idr`
     * - :json:`2`
+
+Here the subquery iterates over the ``nr`` array in each row of ``r`` and returns rows where the nested struct’s ``f`` field equals 23.
+
+For more information about unnesting arrays, see :doc:`Unnesting`.
 
 Correlated Subquery with GROUP BY
 ----------------------------------
@@ -223,4 +204,5 @@ See Also
 * :doc:`sql_commands/DQL/Operators/Logical/EXISTS` - EXISTS operator documentation
 * :doc:`sql_commands/DQL/WHERE` - WHERE clause filtering
 * :doc:`sql_commands/DQL/SELECT` - SELECT statement syntax
+* :doc:`Unnesting` - Array unnesting
 

--- a/docs/sphinx/source/reference/Unnesting.rst
+++ b/docs/sphinx/source/reference/Unnesting.rst
@@ -58,9 +58,11 @@ The element alias is optional when ``AT`` is used. In the rare case where only t
 
     SELECT table.*, ordinal FROM table, table.array_column AT ordinal
 
-The ``AT`` clause is only valid on an array-typed source. Applying it to a base table, view, or CTE raises SQLSTATE 42809.
+The ``AT`` clause is only valid on an array-typed source. Applying it to a base table, view, or CTE raises a ``WRONG_OBJECT_TYPE`` error (SQLSTATE 42809).
 
-Sorting on the ``AT`` ordinal is not supported.
+.. note::
+
+   Sorting on the ``AT`` ordinal is not supported.
 
 Examples
 ========
@@ -210,6 +212,24 @@ If you only care about the positions, omit the element alias:
 .. code-block:: sql
 
     SELECT order_id, at FROM orders, orders.items AT at
+
+.. list-table::
+    :header-rows: 1
+
+    * - :sql:`order_id`
+      - :sql:`at`
+    * - :json:`1`
+      - :json:`1`
+    * - :json:`1`
+      - :json:`2`
+    * - :json:`2`
+      - :json:`1`
+    * - :json:`3`
+      - :json:`1`
+    * - :json:`3`
+      - :json:`2`
+    * - :json:`3`
+      - :json:`3`
 
 This does not bind any alias to the elements themselves; only the ``at`` ordinal is in scope.
 

--- a/docs/sphinx/source/reference/Unnesting.rst
+++ b/docs/sphinx/source/reference/Unnesting.rst
@@ -1,0 +1,377 @@
+=========
+Unnesting
+=========
+
+.. _unnesting:
+
+Unnesting expands an array-valued field into a stream of rows, one per array element. The unnesting features in FDB Record Layer are aligned with the PartiQL notation, in which an array-typed reference appears as a table source in the ``FROM`` clause.
+
+.. important::
+
+   FDB Record Layer does *not* support the standard SQL ``UNNEST()`` table function.
+
+Basic Syntax
+============
+
+To unnest an array field, reference it as a table source after the row source that contains it:
+
+.. code-block:: sql
+
+    SELECT table.*, element FROM table, table.array_column AS element
+
+For each row of ``table``, the array is expanded and ``element`` is bound, in turn, to each element. The result is one row per input-row/element pair. If the array is ``NULL`` or empty in a row, that row contributes no output rows. In other words, the semantics of unnesting are comparable to an inner join.
+
+.. important::
+
+   FDB Record Layer does *not* support a ``LEFT OUTER JOIN`` variant for unnesting with outer join semantics.
+
+As with other table sources, the ``AS`` keyword is optional:
+
+.. code-block:: sql
+
+    SELECT table.*, element FROM table, table.array_column element
+
+If the array element type is a ``STRUCT``, ``element`` refers to the struct and its fields can be accessed via qualified names (``element.field``) or by star expansion (``element.*``). If the element type is a scalar, ``element`` refers directly to the scalar value and writing ``element.*`` is not allowed.
+
+The query above shows the PartiQL notation for unnesting. An equivalent but more verbose way to express this unnesting operation is with a lateral subquery in the ``FROM`` clause:
+
+.. code-block:: sql
+
+    SELECT table.*, elements.element FROM table, (SELECT element FROM table.array_column) AS elements
+
+The planner produces the same plan as with the PartiQL form.
+
+Generating Ordinals with the ``AT`` Clause
+------------------------------------------
+
+In addition to the array elements themselves, unnesting can generate the 1-based position of each element in its original array. To do so, add an ``AT`` clause after the element alias:
+
+.. code-block:: sql
+
+    SELECT table.*, element, ordinal FROM table, table.array_column AS element AT ordinal
+
+``ordinal`` is an ``INTEGER`` bound to the position of the element. The position is 1-based.
+
+The element alias is optional when ``AT`` is used. In the rare case where only the ordinals are needed, you can leave it out:
+
+.. code-block:: sql
+
+    SELECT table.*, ordinal FROM table, table.array_column AT ordinal
+
+The ``AT`` clause is only valid on an array-typed source. Applying it to a base table, view, or CTE raises SQLSTATE 42809.
+
+Sorting on the ``AT`` ordinal is not supported.
+
+Examples
+========
+
+Setup
+-----
+
+For these examples, assume we have the following type and table:
+
+.. code-block:: sql
+
+    CREATE TYPE AS STRUCT line_item (sku STRING, qty INTEGER)
+
+    CREATE TABLE orders (
+        order_id BIGINT,
+        tags STRING ARRAY,
+        items line_item ARRAY,
+        prices DOUBLE ARRAY,
+        PRIMARY KEY (order_id)
+    )
+
+    INSERT INTO orders VALUES
+        (1, ['priority', 'gift'], [('A1', 2), ('A2', 1)],            [9.99, 19.99]),
+        (2, ['backorder'],        [('B1', 3)],                       [4.50]),
+        (3, NULL,                 [('C1', 1), ('C2', 2), ('C3', 1)], [29.99, 14.50, 5.00]),
+        (4, [],                   [],                                [])
+
+The ``prices`` array is positionally aligned with the ``items`` array: ``prices[i]`` is the unit price of ``items[i]``.
+
+Unnesting a Scalar Array
+------------------------
+
+The following query unnests the ``tags`` array so that each tag becomes its own row:
+
+.. code-block:: sql
+
+    SELECT order_id, tag FROM orders, orders.tags AS tag
+
+.. list-table::
+    :header-rows: 1
+
+    * - :sql:`order_id`
+      - :sql:`tag`
+    * - :json:`1`
+      - :json:`"priority"`
+    * - :json:`1`
+      - :json:`"gift"`
+    * - :json:`2`
+      - :json:`"backorder"`
+
+Orders 3 and 4 contribute no rows because their ``tags`` value is ``NULL`` and ``[]``, respectively.
+
+Unnesting a ``STRUCT`` Array
+----------------------------
+
+The following query unnests ``items`` and accesses the fields of the ``line_item`` struct via qualified names:
+
+.. code-block:: sql
+
+    SELECT order_id, item.sku, item.qty FROM orders, orders.items AS item
+
+.. list-table::
+    :header-rows: 1
+
+    * - :sql:`order_id`
+      - :sql:`sku`
+      - :sql:`qty`
+    * - :json:`1`
+      - :json:`"A1"`
+      - :json:`2`
+    * - :json:`1`
+      - :json:`"A2"`
+      - :json:`1`
+    * - :json:`2`
+      - :json:`"B1"`
+      - :json:`3`
+    * - :json:`3`
+      - :json:`"C1"`
+      - :json:`1`
+    * - :json:`3`
+      - :json:`"C2"`
+      - :json:`2`
+    * - :json:`3`
+      - :json:`"C3"`
+      - :json:`1`
+
+Star Expansion on a ``STRUCT`` Element
+--------------------------------------
+
+Because each ``items`` element is a ``STRUCT``, ``item.*`` expands to one field per struct field:
+
+.. code-block:: sql
+
+    SELECT order_id, item.* FROM orders, orders.items AS item
+
+This produces the same result as the previous example.
+
+.. important::
+
+   The ``alias.*`` notation is rejected when the array element type is a scalar (such as ``STRING`` or ``INTEGER``) or a ``VECTOR``, because there are no fields to expand. For instance, ``SELECT tag.* FROM orders, orders.tags AS tag`` is invalid.
+
+   In the unusual case where you need a one-field record wrapping a scalar element, you can build one explicitly with a subquery:
+
+   .. code-block:: sql
+
+       SELECT order_id, sq.*
+       FROM orders, (SELECT (tag) AS wrapped FROM orders.tags AS tag) AS sq
+
+Unnesting in a Lateral Subquery
+-------------------------------
+
+The struct-array example above can equivalently be written with a lateral subquery:
+
+.. code-block:: sql
+
+    SELECT order_id, item.sku, item.qty FROM orders, (SELECT sku, qty FROM orders.items) AS item
+
+The result is identical and the planner produces the same plan.
+
+Element Ordinals with ``AT``
+----------------------------
+
+Use ``AT`` to query the 1-based ordinal of each element alongside its value:
+
+.. code-block:: sql
+
+    SELECT order_id, tag, at FROM orders, orders.tags AS tag AT at
+
+.. list-table::
+    :header-rows: 1
+
+    * - :sql:`order_id`
+      - :sql:`tag`
+      - :sql:`at`
+    * - :json:`1`
+      - :json:`"priority"`
+      - :json:`1`
+    * - :json:`1`
+      - :json:`"gift"`
+      - :json:`2`
+    * - :json:`2`
+      - :json:`"backorder"`
+      - :json:`1`
+
+If you only care about the positions, omit the element alias:
+
+.. code-block:: sql
+
+    SELECT order_id, at FROM orders, orders.items AT at
+
+This does not bind any alias to the elements themselves; only the ``at`` ordinal is in scope.
+
+Ordinals and Filtering
+----------------------
+
+When you combine ``AT`` with a ``WHERE`` predicate to filter the elements, the elements keep the ordinals they had in the original array.
+
+.. code-block:: sql
+
+    SELECT order_id, item.sku, item.qty, at
+      FROM orders, orders.items AS item AT at
+     WHERE item.qty >= 2
+
+.. list-table::
+    :header-rows: 1
+
+    * - :sql:`order_id`
+      - :sql:`sku`
+      - :sql:`qty`
+      - :sql:`at`
+    * - :json:`1`
+      - :json:`"A1"`
+      - :json:`2`
+      - :json:`1`
+    * - :json:`2`
+      - :json:`"B1"`
+      - :json:`3`
+      - :json:`1`
+    * - :json:`3`
+      - :json:`"C2"`
+      - :json:`2`
+      - :json:`2`
+
+The row of Order 3 ``(C1, 1)`` is filtered out, but ``(C2, 2)`` keeps its original ordinal ``2``, not ``1``.
+
+Unnesting Two Arrays in Parallel using ``AT`` as a Subscript
+------------------------------------------------------------
+
+When two arrays in the same row are positionally aligned, you can use the ``AT`` ordinal as a subscript for the second array to produce one row per element pair.
+
+.. code-block:: sql
+
+    SELECT order_id, item.sku, item.qty, orders.prices[at] AS price
+    FROM orders, orders.items AS item AT at
+
+.. list-table::
+    :header-rows: 1
+
+    * - :sql:`order_id`
+      - :sql:`sku`
+      - :sql:`qty`
+      - :sql:`price`
+    * - :json:`1`
+      - :json:`"A1"`
+      - :json:`2`
+      - :json:`9.99`
+    * - :json:`1`
+      - :json:`"A2"`
+      - :json:`1`
+      - :json:`19.99`
+    * - :json:`2`
+      - :json:`"B1"`
+      - :json:`3`
+      - :json:`4.50`
+    * - :json:`3`
+      - :json:`"C1"`
+      - :json:`1`
+      - :json:`29.99`
+    * - :json:`3`
+      - :json:`"C2"`
+      - :json:`2`
+      - :json:`14.50`
+    * - :json:`3`
+      - :json:`"C3"`
+      - :json:`1`
+      - :json:`5.00`
+
+Computing the Cross Product of Two Unnested Arrays
+--------------------------------------------------
+
+Two array sources in ``FROM`` produce a cross product within each row. The ``AT`` ordinals on each side are independent.
+
+.. code-block:: sql
+
+    SELECT order_id, tag, item.sku, at_t, at_i
+    FROM orders,
+         orders.tags AS tag AT at_t,
+         orders.items AS item AT at_i
+
+For each order/tag pair, ``at_i`` restarts at ``1`` in the result:
+
+.. list-table::
+    :header-rows: 1
+
+    * - :sql:`order_id`
+      - :sql:`tag`
+      - :sql:`sku`
+      - :sql:`at_t`
+      - :sql:`at_i`
+    * - :json:`1`
+      - :json:`"priority"`
+      - :json:`"A1"`
+      - :json:`1`
+      - :json:`1`
+    * - :json:`1`
+      - :json:`"priority"`
+      - :json:`"A2"`
+      - :json:`1`
+      - :json:`2`
+    * - :json:`1`
+      - :json:`"gift"`
+      - :json:`"A1"`
+      - :json:`2`
+      - :json:`1`
+    * - :json:`1`
+      - :json:`"gift"`
+      - :json:`"A2"`
+      - :json:`2`
+      - :json:`2`
+    * - :json:`2`
+      - :json:`"backorder"`
+      - :json:`"B1"`
+      - :json:`1`
+      - :json:`1`
+
+Orders 3 and 4 produce no rows because at least one of their arrays is ``[]`` or ``NULL``.
+
+``AT`` in a Correlated Subquery
+-------------------------------
+
+Both the element alias and the ``AT`` alias can be referenced from a later ``FROM`` item, including a lateral subquery that unnests another array:
+
+.. code-block:: sql
+
+    SELECT order_id, item.sku, sq.matched_price
+      FROM orders,
+           orders.items AS item AT at,
+           (SELECT price AS matched_price
+              FROM orders.prices AS price AT at2
+             WHERE at2 = at AND price >= 15.0
+           ) AS sq
+
+For each item, the subquery looks up the price at the same ordinal and returns a row only if that price is at least ``15.0``:
+
+.. list-table::
+    :header-rows: 1
+
+    * - :sql:`order_id`
+      - :sql:`sku`
+      - :sql:`matched_price`
+    * - :json:`1`
+      - :json:`"A2"`
+      - :json:`19.99`
+    * - :json:`3`
+      - :json:`"C1"`
+      - :json:`29.99`
+
+See Also
+========
+
+* :doc:`Subqueries` - Subqueries and correlated subqueries
+* :doc:`Joins` - Joining multiple tables
+* :doc:`Indexes` - Indexing nested fields and unnested arrays
+* :doc:`sql_commands/DQL/SELECT` - ``SELECT`` statement syntax

--- a/docs/sphinx/source/reference/sql_types.rst
+++ b/docs/sphinx/source/reference/sql_types.rst
@@ -57,7 +57,7 @@ Thus, an array could be of a single primitive type:
 
 .. code-block:: sql
 
-    CREATE TABLE foo (a STRING, b STRING ARRAY);
+    CREATE TABLE T1 (a STRING, b STRING ARRAY);
 
 In this example, `b` is an array with a single :sql:`STRING` column.
 
@@ -66,11 +66,13 @@ Arrays can also be created with struct columns:
 .. code-block:: sql
 
     CREATE TYPE AS STRUCT nested_struct (b STRING, d STRING)
-    CREATE TABLE structArray (a STRING, c nested_struct array);
+    CREATE TABLE T2 (a STRING, c nested_struct ARRAY);
 
 In this example, `c` is an array, and each record within the array is a struct of type :sql:`nested_struct`. You can generally treat an array as a "nested `ResultSet`"--that is to say, you can just pull up a `ResultSet` of an array type, and interrogate it as if it were the output of its own query.
 
 It is possible to nest arrays within structs, and structs within arrays, to an arbitrary depth (limited by the JVM's stack size, currently).
+
+An array column can be expanded into a stream of rows using the SQL constructs described under :doc:`Unnesting`.
 
 .. _vector_types:
 

--- a/yaml-tests/src/test/java/YamlIntegrationTests.java
+++ b/yaml-tests/src/test/java/YamlIntegrationTests.java
@@ -91,7 +91,7 @@ public class YamlIntegrationTests {
     }
 
     @TestTemplate
-    public void arraysUnnestingDocumentationQueries(YamlTest.Runner runner) throws Exception {
+    void arraysUnnestingDocumentationQueries(YamlTest.Runner runner) throws Exception {
         runner.runYamsql("arrays-unnesting-documentation-queries.yamsql");
     }
 

--- a/yaml-tests/src/test/java/YamlIntegrationTests.java
+++ b/yaml-tests/src/test/java/YamlIntegrationTests.java
@@ -91,6 +91,11 @@ public class YamlIntegrationTests {
     }
 
     @TestTemplate
+    public void arraysUnnestingDocumentationQueries(YamlTest.Runner runner) throws Exception {
+        runner.runYamsql("arrays-unnesting-documentation-queries.yamsql");
+    }
+
+    @TestTemplate
     public void betweenTest(YamlTest.Runner runner) throws Exception {
         runner.runYamsql("between.yamsql");
     }

--- a/yaml-tests/src/test/resources/array-join-at.yamsql
+++ b/yaml-tests/src/test/resources/array-join-at.yamsql
@@ -3,7 +3,7 @@
 #
 # This source file is part of the FoundationDB open source project
 #
-# Copyright 2023-2030 Apple Inc. and the FoundationDB project authors
+# Copyright 2023-2026 Apple Inc. and the FoundationDB project authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/yaml-tests/src/test/resources/arrays-unnesting-documentation-queries.yamsql
+++ b/yaml-tests/src/test/resources/arrays-unnesting-documentation-queries.yamsql
@@ -145,4 +145,16 @@ test_block:
       - unorderedResult: [
           {order_id: 1, sku: 'A2', matched_price: 19.99},
           {order_id: 3, sku: 'C1', matched_price: 29.99}]
+    -
+      # Claim: "Applying AT to a base table raises SQLSTATE 42809."
+      - query: SELECT order_id, at FROM orders AT at
+      - error: WRONG_OBJECT_TYPE
+    -
+      # Claim: "Applying AT to a CTE raises SQLSTATE 42809."
+      - query: WITH cte AS (SELECT order_id FROM orders) SELECT order_id FROM cte AT at
+      - error: WRONG_OBJECT_TYPE
+    -
+      # Claim: `SELECT tag.* FROM orders, orders.tags AS tag` is invalid because the element type is a scalar.
+      - query: SELECT tag.* FROM orders, orders.tags AS tag
+      - error: INVALID_COLUMN_REFERENCE
 ...

--- a/yaml-tests/src/test/resources/arrays-unnesting-documentation-queries.yamsql
+++ b/yaml-tests/src/test/resources/arrays-unnesting-documentation-queries.yamsql
@@ -1,0 +1,148 @@
+#
+# arrays-unnesting-documentation-queries.yamsql
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2023-2026 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+options:
+  supported_version: !current_version
+  connection_options:
+    CASE_SENSITIVE_IDENTIFIERS: true
+---
+# Tests for the example queries shown in `Unnesting.rst`. Each test below corresponds to one of the example queries
+# in that document.
+schema_template:
+  CREATE TYPE AS STRUCT line_item (sku STRING, qty INTEGER)
+  CREATE TABLE orders (
+      order_id BIGINT,
+      tags STRING ARRAY,
+      items line_item ARRAY,
+      prices DOUBLE ARRAY,
+      PRIMARY KEY (order_id))
+---
+setup:
+  steps:
+    - query: INSERT INTO orders VALUES
+               (1, ['priority', 'gift'], [('A1', 2), ('A2', 1)],            [9.99, 19.99]),
+               (2, ['backorder'],        [('B1', 3)],                       [4.50]),
+               (3, NULL,                 [('C1', 1), ('C2', 2), ('C3', 1)], [29.99, 14.50, 5.00]),
+               (4, [],                   [],                                [])
+---
+test_block:
+  name: arrays-unnesting-documentation-queries
+  tests:
+    -
+      # "Unnesting a Scalar Array" example.
+      - query: SELECT order_id, tag FROM orders, orders.tags AS tag
+      - unorderedResult: [
+          {order_id: 1, tag: 'priority'},
+          {order_id: 1, tag: 'gift'},
+          {order_id: 2, tag: 'backorder'}]
+    -
+      # "Unnesting a STRUCT Array" example.
+      - query: SELECT order_id, item.sku AS sku, item.qty AS qty
+                 FROM orders, orders.items AS item
+      - unorderedResult: [
+          {order_id: 1, sku: 'A1', qty: 2},
+          {order_id: 1, sku: 'A2', qty: 1},
+          {order_id: 2, sku: 'B1', qty: 3},
+          {order_id: 3, sku: 'C1', qty: 1},
+          {order_id: 3, sku: 'C2', qty: 2},
+          {order_id: 3, sku: 'C3', qty: 1}]
+    -
+      # "Star Expansion on a STRUCT Element" example.
+      - query: SELECT order_id, item.* FROM orders, orders.items AS item
+      - unorderedResult: [
+          {order_id: 1, sku: 'A1', qty: 2},
+          {order_id: 1, sku: 'A2', qty: 1},
+          {order_id: 2, sku: 'B1', qty: 3},
+          {order_id: 3, sku: 'C1', qty: 1},
+          {order_id: 3, sku: 'C2', qty: 2},
+          {order_id: 3, sku: 'C3', qty: 1}]
+    -
+      # "Unnesting in a Lateral Subquery" example.
+      - query: SELECT order_id, item.sku AS sku, item.qty AS qty
+                 FROM orders, (SELECT sku, qty FROM orders.items) AS item
+      - unorderedResult: [
+          {order_id: 1, sku: 'A1', qty: 2},
+          {order_id: 1, sku: 'A2', qty: 1},
+          {order_id: 2, sku: 'B1', qty: 3},
+          {order_id: 3, sku: 'C1', qty: 1},
+          {order_id: 3, sku: 'C2', qty: 2},
+          {order_id: 3, sku: 'C3', qty: 1}]
+    -
+      # "Element Ordinals with AT" example.
+      - query: SELECT order_id, tag, at FROM orders, orders.tags AS tag AT at
+      - unorderedResult: [
+          {order_id: 1, tag: 'priority', at: 1},
+          {order_id: 1, tag: 'gift', at: 2},
+          {order_id: 2, tag: 'backorder', at: 1}]
+    -
+      # "Element Ordinals with AT" example, omitting the element alias.
+      - query: SELECT order_id, at FROM orders, orders.items AT at
+      - unorderedResult: [
+          {order_id: 1, at: 1},
+          {order_id: 1, at: 2},
+          {order_id: 2, at: 1},
+          {order_id: 3, at: 1},
+          {order_id: 3, at: 2},
+          {order_id: 3, at: 3}]
+    -
+      # "Ordinals and Filtering" example.
+      - query: SELECT order_id, item.sku AS sku, item.qty AS qty, at
+                 FROM orders, orders.items AS item AT at
+                WHERE item.qty >= 2
+      - unorderedResult: [
+          {order_id: 1, sku: 'A1', qty: 2, at: 1},
+          {order_id: 2, sku: 'B1', qty: 3, at: 1},
+          {order_id: 3, sku: 'C2', qty: 2, at: 2}]
+    -
+      # "Unnesting Two Arrays in Parallel using AT as a Subscript" example.
+      - query: SELECT order_id, item.sku AS sku, item.qty AS qty,
+                      orders.prices[at] AS price
+                 FROM orders, orders.items AS item AT at
+      - unorderedResult: [
+          {order_id: 1, sku: 'A1', qty: 2, price: 9.99},
+          {order_id: 1, sku: 'A2', qty: 1, price: 19.99},
+          {order_id: 2, sku: 'B1', qty: 3, price: 4.50},
+          {order_id: 3, sku: 'C1', qty: 1, price: 29.99},
+          {order_id: 3, sku: 'C2', qty: 2, price: 14.50},
+          {order_id: 3, sku: 'C3', qty: 1, price: 5.00}]
+    -
+      # "Computing the Cross Product of Two Unnested Arrays" example.
+      - query: SELECT order_id, tag, item.sku AS sku, at_t, at_i
+                 FROM orders,
+                      orders.tags AS tag AT at_t,
+                      orders.items AS item AT at_i
+      - unorderedResult: [
+          {order_id: 1, tag: 'priority',  sku: 'A1', at_t: 1, at_i: 1},
+          {order_id: 1, tag: 'priority',  sku: 'A2', at_t: 1, at_i: 2},
+          {order_id: 1, tag: 'gift',      sku: 'A1', at_t: 2, at_i: 1},
+          {order_id: 1, tag: 'gift',      sku: 'A2', at_t: 2, at_i: 2},
+          {order_id: 2, tag: 'backorder', sku: 'B1', at_t: 1, at_i: 1}]
+    -
+      # "AT in a Correlated Subquery" example.
+      - query: SELECT order_id, item.sku AS sku, sq.matched_price
+                 FROM orders,
+                      orders.items AS item AT at,
+                      (SELECT price AS matched_price
+                         FROM orders.prices AS price AT at2
+                        WHERE at2 = at AND price >= 15.0
+                      ) AS sq
+      - unorderedResult: [
+          {order_id: 1, sku: 'A2', matched_price: 19.99},
+          {order_id: 3, sku: 'C1', matched_price: 29.99}]
+...


### PR DESCRIPTION
* Introduce a dedicated page, `Unnesting.rst`, to describe the unnesting features of Relational FDB.
* Consolidate all existing places that mention unnesting.

Testing:
* `unnesting-documentation-queries.yamsql` covers all added example queries.