### PR TITLE
Disallow `LEFT` and `RIGHT` as simple identifiers in the SQL grammar

### DIFF
--- a/fdb-relational-core/src/main/antlr/RelationalParser.g4
+++ b/fdb-relational-core/src/main/antlr/RelationalParser.g4
@@ -1195,6 +1195,7 @@ partitionClause
 
 scalarFunctionName
     : functionNameBase
+    | functionNameKeyword
     | ASCII | CURDATE | CURRENT_DATE | CURRENT_TIME
     | CURRENT_TIMESTAMP | CURTIME | DATE_ADD | DATE_SUB
     | IF | INSERT | LOCALTIME | LOCALTIMESTAMP | MID | NOW
@@ -1398,7 +1399,7 @@ functionNameBase
     | ISCLOSED | ISEMPTY | ISNULL
     | ISSIMPLE | IS_FREE_LOCK | IS_IPV4 | IS_IPV4_COMPAT
     | IS_IPV4_MAPPED | IS_IPV6 | IS_USED_LOCK | LAG | LAST_INSERT_ID | LAST_VALUE
-    | LCASE | LEAD | LEAST | LEFT | LENGTH | LINEFROMTEXT | LINEFROMWKB
+    | LCASE | LEAD | LEAST | LENGTH | LINEFROMTEXT | LINEFROMWKB
     | LINESTRING | LINESTRINGFROMTEXT | LINESTRINGFROMWKB | LN
     | LOAD_FILE | LOCATE | LOG | LOG10 | LOG2 | LOWER | LPAD
     | LTRIM | MAKEDATE | MAKETIME | MAKE_SET | MASTER_POS_WAIT
@@ -1415,7 +1416,7 @@ functionNameBase
     | POINTFROMTEXT | POINTFROMWKB | POINTN | POLYFROMTEXT
     | POLYFROMWKB | POLYGON | POLYGONFROMTEXT | POLYGONFROMWKB
     | POSITION | POW | POWER | QUARTER | QUOTE | RADIANS | RAND | RANK
-    | RANDOM_BYTES | RELEASE_LOCK | REVERSE | RIGHT | ROUND
+    | RANDOM_BYTES | RELEASE_LOCK | REVERSE | ROUND
     | ROW_COUNT | ROW_NUMBER | RPAD | RTRIM | SECOND | SEC_TO_TIME
     | SCHEMA | SESSION_USER | SESSION_VARIABLES_ADMIN
     | SHA | SHA1 | SHA2 | SIGN | SIN | SLEEP
@@ -1457,4 +1458,15 @@ functionNameBase
     | JSON_VALID | JSON_TABLE | JSON_SCHEMA_VALID | JSON_SCHEMA_VALIDATION_REPORT
     | JSON_PRETTY | JSON_STORAGE_FREE | JSON_STORAGE_SIZE | JSON_ARRAYAGG
     | JSON_OBJECTAGG
+    ;
+
+// Tokens that may serve as function names but are also keywords. These are _not_ accepted as identifiers (`simpleId`)
+// because they also introduce other grammar constructs.
+//
+// For example, LEFT and RIGHT are included here because they introduce {LEFT|RIGHT} [OUTER] JOIN clauses, and allowing
+// them as table aliases would create a grammar ambiguity in `tableSourceItem`. They are, however, available as
+// function names via `scalarFunctionName`. To use them as identifiers, they must be double-quoted (e.g., "left").
+functionNameKeyword
+    : LEFT
+    | RIGHT
     ;

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/BaseVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/BaseVisitor.java
@@ -1752,6 +1752,12 @@ public class BaseVisitor extends RelationalParserBaseVisitor<Object> implements 
 
     @Nonnull
     @Override
+    public Object visitFunctionNameKeyword(@Nonnull RelationalParser.FunctionNameKeywordContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    @Nonnull
+    @Override
     public Object visitExecuteContinuationStatement(@Nonnull RelationalParser.ExecuteContinuationStatementContext ctx) {
         return visitChildren(ctx);
     }

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DelegatingVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DelegatingVisitor.java
@@ -1680,6 +1680,12 @@ public class DelegatingVisitor<D extends TypedVisitor> implements TypedVisitor {
         return getDelegate().visitFunctionNameBase(ctx);
     }
 
+    @Nonnull
+    @Override
+    public Object visitFunctionNameKeyword(@Nonnull RelationalParser.FunctionNameKeywordContext ctx) {
+        return getDelegate().visitFunctionNameKeyword(ctx);
+    }
+
     @Override
     public Object visit(ParseTree tree) {
         return getDelegate().visit(tree);

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/TypedVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/TypedVisitor.java
@@ -1004,5 +1004,9 @@ public interface TypedVisitor extends RelationalParserVisitor<Object> {
 
     @Nonnull
     @Override
+    Object visitFunctionNameKeyword(@Nonnull RelationalParser.FunctionNameKeywordContext ctx);
+
+    @Nonnull
+    @Override
     Object visitExecuteContinuationStatement(@Nonnull RelationalParser.ExecuteContinuationStatementContext ctx);
 }

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/DelegatingVisitorTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/DelegatingVisitorTest.java
@@ -556,6 +556,35 @@ public class DelegatingVisitorTest {
                 });
     }
 
+    /**
+     * Covers {@link DelegatingVisitor#visitFunctionNameKeyword}.
+     */
+    @Test
+    void visitFunctionNameKeywordTest() {
+        testSimple("LEFT",
+                RelationalParser::functionNameKeyword,
+                DelegatingVisitor::visitFunctionNameKeyword,
+                called -> new BaseVisitor(new MutablePlanGenerationContext(PreparedParams.empty(), PlanHashable.PlanHashMode.VC0, "", "", 42),
+                        generateMetadata(), NoOpQueryFactory.INSTANCE, NoOpMetadataOperationsFactory.INSTANCE, URI.create("/FDB/FRL1"), false) {
+                    @Nonnull
+                    @Override
+                    public Object visitFunctionNameKeyword(@Nonnull RelationalParser.FunctionNameKeywordContext ctx) {
+                        called.setTrue();
+                        return null;
+                    }
+                });
+    }
+
+    /**
+     * Covers {@link BaseVisitor#visitFunctionNameKeyword}.
+     */
+    @Test
+    void baseVisitorVisitFunctionNameKeywordTest() {
+        final var visitor = createBaseVisitor("LEFT", new MutableBoolean(false));
+        final var context = parseQuery("LEFT", RelationalParser::functionNameKeyword);
+        Assertions.assertThat(visitor.visitFunctionNameKeyword(context)).isNull();
+    }
+
     @Test
     void visitCopyImport() {
         final TypedVisitor baseVisitor = Mockito.mock(TypedVisitor.class);

--- a/yaml-tests/src/test/resources/join-tests-outer.yamsql
+++ b/yaml-tests/src/test/resources/join-tests-outer.yamsql
@@ -156,6 +156,40 @@ test_block:
         {!pos 1: !l 3, !pos 2: 'Carol', !pos 3: 'Lee', !pos 4: !l 2, !pos 5: !l 2, !pos 6: 'Sales'},
         {!pos 1: !l 4, !pos 2: 'Dave', !pos 3: 'Kim', !pos 4: !l 99, !pos 5: !null _, !pos 6: !null _}]
     -
+      # LEFT JOIN with no table aliases. Note that the LEFT token unambiguously introduces the LEFT [OUTER] JOIN clause.
+      # LEFT and RIGHT are classified as `functionNameKeyword`, not `functionNameBase`, in the grammar. This prevents
+      # the use of bare `left` as a valid alias (which would constitute an ANTLR parser ambiguity).
+      - query: SELECT * FROM "emp" left JOIN "dept" ON "emp"."dept_id" = "dept"."id";
+      - supported_version: !current_version
+      - unorderedResult: [
+          {!pos 1: !l 1, !pos 2: 'Alice', !pos 3: 'Smith', !pos 4: !l 1, !pos 5: !l 1, !pos 6: 'Engineering'},
+          {!pos 1: !l 2, !pos 2: 'Bob', !pos 3: 'Jones', !pos 4: !l 1, !pos 5: !l 1, !pos 6: 'Engineering'},
+          {!pos 1: !l 3, !pos 2: 'Carol', !pos 3: 'Lee', !pos 4: !l 2, !pos 5: !l 2, !pos 6: 'Sales'},
+          {!pos 1: !l 4, !pos 2: 'Dave', !pos 3: 'Kim', !pos 4: !l 99, !pos 5: !null _, !pos 6: !null _}]
+    -
+      # “left” and “right” can be used as table aliases (and identifiers in general), but they must be double-quoted.
+      - query: SELECT "left"."fname", "right"."name" FROM "emp" "left" LEFT JOIN "dept" "right" ON "left"."dept_id" = "right"."id";
+      - supported_version: !current_version
+      - unorderedResult: [
+          {'Alice', 'Engineering'},
+          {'Bob', 'Engineering'},
+          {'Carol', 'Sales'},
+          {'Dave', !null _}]
+    -
+      # Same as the previous test but with the explicit AS form.
+      - query: SELECT "left"."fname", "right"."name" FROM "emp" AS "left" LEFT JOIN "dept" AS "right" ON "left"."dept_id" = "right"."id";
+      - supported_version: !current_version
+      - unorderedResult: [
+          {'Alice', 'Engineering'},
+          {'Bob', 'Engineering'},
+          {'Carol', 'Sales'},
+          {'Dave', !null _}]
+    -
+      # A bare `left` cannot be used as a table alias even with the AS form.
+      - query: SELECT * FROM "emp" AS left JOIN "dept" ON "emp"."dept_id" = "dept"."id";
+      - supported_version: !current_version
+      - error: SYNTAX_ERROR
+    -
       # LEFT JOIN with compound ON condition (two predicates in the ON clause, combined with AND).
       - query: SELECT "e"."fname", "d"."name" FROM "emp" "e" LEFT JOIN "dept" "d" ON "e"."dept_id" = "d"."id" AND "d"."name" <> 'Sales';
       - explain: "ISCAN(emp$fname <,>) | FLATMAP q0 -> { COVERING(dept$name <,> -> [id: KEY:[2], name: KEY:[0]]) | FILTER q0.dept_id EQUALS _.id AND _.name NOT_EQUALS promote(@c29 AS STRING) | FETCH | ON EMPTY NULL AS q1 RETURN (q0.fname AS fname, q1.name AS name) }"
@@ -220,7 +254,7 @@ test_block:
       # ORDER BY on a column from the null-producing side: In general, the null-padded rows have no defined ordering
       # relative to matching rows, and the planner cannot satisfy the ordering from a scan on the preserved side.
       - query: SELECT "e"."fname", "d"."name" FROM "emp" "e" LEFT JOIN "dept" "d" ON "e"."dept_id" = "d"."id" ORDER BY "d"."name";
-      - error: '0AF00'
+      - error: UNSUPPORTED_QUERY
     -
       # ORDER BY on the null-producing side when the preserved side has a cardinality of 1 (scalar subquery).
       # The result cardinality is bounded by the null-producing side, so the planner can satisfy the ordering by
@@ -355,6 +389,29 @@ test_block:
           {'Carol', 'Sales'},
           {!null _, 'Marketing'}]
     -
+      # RIGHT JOIN with no table aliases; see the corresponding LEFT JOIN case above.
+      - query: SELECT * FROM "emp" RIGHT JOIN "dept" ON "emp"."dept_id" = "dept"."id";
+      - supported_version: !current_version
+      - unorderedResult: [
+          {!pos 1: !l 1, !pos 2: 'Alice', !pos 3: 'Smith', !pos 4: !l 1, !pos 5: !l 1, !pos 6: 'Engineering'},
+          {!pos 1: !l 2, !pos 2: 'Bob', !pos 3: 'Jones', !pos 4: !l 1, !pos 5: !l 1, !pos 6: 'Engineering'},
+          {!pos 1: !l 3, !pos 2: 'Carol', !pos 3: 'Lee', !pos 4: !l 2, !pos 5: !l 2, !pos 6: 'Sales'},
+          {!pos 1: !null _, !pos 2: !null _, !pos 3: !null _, !pos 4: !null _, !pos 5: !l 3, !pos 6: 'Marketing'}]
+    -
+      # “right” and “left” can be used as table aliases (and identifiers in general), but they must be double-quoted.
+      - query: SELECT "right"."fname", "left"."name" FROM "emp" "right" RIGHT JOIN "dept" "left" ON "right"."dept_id" = "left"."id";
+      - supported_version: !current_version
+      - unorderedResult: [
+          {'Alice', 'Engineering'},
+          {'Bob', 'Engineering'},
+          {'Carol', 'Sales'},
+          {!null _, 'Marketing'}]
+    -
+      # A bare `right` cannot be used as a table alias even with the AS form.
+      - query: SELECT * FROM "emp" AS right JOIN "dept" ON "emp"."dept_id" = "dept"."id";
+      - supported_version: !current_version
+      - error: SYNTAX_ERROR
+    -
       # RIGHT JOIN equivalent to a LEFT JOIN with the operand order flipped: `dept RIGHT JOIN emp` should produce the
       # same set of rows as `emp LEFT JOIN dept`, with `emp` preserved on both sides.
       - query: SELECT "e"."fname", "d"."name" FROM "dept" "d" RIGHT JOIN "emp" "e" ON "e"."dept_id" = "d"."id";
@@ -421,4 +478,4 @@ test_block:
     -
       # FULL OUTER JOIN is not recognized by the parser currently.
       - query: SELECT "e"."fname", "d"."name" FROM "emp" "e" FULL OUTER JOIN "dept" "d" ON "e"."dept_id" = "d"."id";
-      - error: '42601'  # SYNTAX_ERROR
+      - error: SYNTAX_ERROR


### PR DESCRIPTION
In `RelationalParser.g4`, move the `LEFT` and `RIGHT` tokens out of `functionNameBase` into a new `functionNameKeyword` rule that is reachable from `scalarFunctionName` only.

This way, “left” and “right” remain valid function names (for hypothetical `LEFT(s, n)` and `RIGHT(s, n)` string functions) but are no longer accepted as a `simpleId`. To use them as identifiers, uses have to double-quote them (`"left"`, `"right"`).

With this grammar change we eliminate parser ambiguities around `LEFT JOIN` and `RIGHT JOIN` clauses. Previously, in something like `FROM T1 LEFT JOIN …`, the `LEFT` could be parsed in two ways: either as the first token in a `LEFT [OUTER] JOIN` clause, or as an alias of `T1` followed by an `[INNER] JOIN` clause. ANTLR’s adaptive LL(*) parsing algorithm would flag this as ambiguous and raise a parser error under `debugBuild=true`.

Notes:
* The `INNER` token of `INNER JOIN` is unproblematic because, unlike `LEFT`/`RIGHT`, the `INNER` keyword is fully reserved. It was never accepted as a `simpleId` via either `keywordsCanBeId` or `functionNameBase`.
* The “function name or keyword” classification introduced here is aligned with how other SQL grammars such as PostgreSQL handle this potential ambiguity.
* The SQL:2003+ grammar is stricter than this. It treats `LEFT` and `RIGHT` as a «reserved word», just like `INNER`.

Testing:
* Extends tests in `join-tests-outer.yamsql`.