### PR TITLE
Make the null-supplying side of `OUTER JOIN` nullable in the result value

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/Quantifier.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/Quantifier.java
@@ -749,20 +749,22 @@ public abstract class Quantifier implements Correlated<Quantifier> {
     @Nonnull
     protected abstract List<Column<? extends FieldValue>> computeFlowedColumns();
 
+    /**
+     * Builds the canonical “pull-up” columns for a record-typed flow. Returns one {@link Column} per field of
+     * {@code type}, each carrying a {@link FieldValue} that reads its ordinal off a fresh {@link QuantifiedObjectValue}
+     * bound to {@code alias}. Throws if {@code type} is not a record type, since only record-flowing quantifiers
+     * have addressable columns.
+     */
     @Nonnull
-    protected static List<Column<? extends FieldValue>> pullUpResultColumns(@Nonnull final Type type, @Nonnull CorrelationIdentifier alias) {
-        final List<Field> fields;
-        if (type instanceof Type.Record) {
-            fields = Objects.requireNonNull(((Type.Record)type).getFields());
-        } else {
+    protected static List<Column<? extends FieldValue>> pullUpResultColumns(@Nonnull final Type type, @Nonnull final CorrelationIdentifier alias) {
+        if (!(type instanceof Type.Record recordType)) {
             throw new IllegalStateException("quantifier does not flow records");
         }
-
-        final var recordType = (Type.Record)type;
-        final var resultBuilder = ImmutableList.<Column<? extends FieldValue>>builder();
-        for (var i = 0; i < fields.size(); i++) {
-            final var field = fields.get(i);
-            resultBuilder.add(Column.of(field, FieldValue.ofOrdinalNumber(QuantifiedObjectValue.of(alias, recordType), Math.toIntExact(i))));
+        final List<Field> fields = Objects.requireNonNull(recordType.getFields());
+        final QuantifiedObjectValue qov = QuantifiedObjectValue.of(alias, recordType);
+        final ImmutableList.Builder<Column<? extends FieldValue>> resultBuilder = ImmutableList.builder();
+        for (int i = 0; i < fields.size(); i++) {
+            resultBuilder.add(Column.of(fields.get(i), FieldValue.ofOrdinalNumber(qov, i)));
         }
         return resultBuilder.build();
     }
@@ -776,6 +778,22 @@ public abstract class Quantifier implements Correlated<Quantifier> {
     private List<? extends FieldValue> computeFlowedValues() {
         return getFlowedColumns()
                 .stream()
+                .map(Column::getValue)
+                .collect(ImmutableList.toImmutableList());
+    }
+
+    /**
+     * Returns the flowed values as if the flowed object type had the given {@code nullability}. If the flowed object
+     * type already has the requested nullability, this method returns the memoized {@link #getFlowedValues()} directly.
+     */
+    @Nonnull
+    public List<? extends FieldValue> pullUpResultColumnsWithNullability(boolean nullability) {
+        final Type type = getFlowedObjectType();
+        if (type.isNullable() == nullability) {
+            return getFlowedValues();
+        }
+        final Type typeWithNullability = type.withNullability(nullability);
+        return pullUpResultColumns(typeWithNullability, getAlias()).stream()
                 .map(Column::getValue)
                 .collect(ImmutableList.toImmutableList());
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/OuterJoinExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/OuterJoinExpression.java
@@ -30,6 +30,7 @@ import com.apple.foundationdb.record.query.plan.cascades.explain.InternalPlanner
 import com.apple.foundationdb.record.query.plan.cascades.explain.PlannerGraph;
 import com.apple.foundationdb.record.query.plan.cascades.predicates.AndPredicate;
 import com.apple.foundationdb.record.query.plan.cascades.predicates.QueryPredicate;
+import com.apple.foundationdb.record.query.plan.cascades.values.QuantifiedObjectValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.Value;
 import com.apple.foundationdb.record.query.plan.cascades.values.translation.TranslationMap;
 import com.apple.foundationdb.record.query.plan.explain.WithIndentationsExplainFormatter;
@@ -113,6 +114,15 @@ public class OuterJoinExpression extends AbstractRelationalExpressionWithChildre
                                @Nonnull final Value resultValue) {
         Verify.verify(!preservedQuantifier.isNullOnEmpty());
         Verify.verify(!nullSupplyingQuantifier.isNullOnEmpty());
+        // Every reference to the null-supplying alias inside the result value must carry a nullable type.
+        final CorrelationIdentifier nullSupplyingAlias = nullSupplyingQuantifier.getAlias();
+        Verify.verify(
+                resultValue.preOrderStream()
+                        .filter(QuantifiedObjectValue.class::isInstance)
+                        .map(QuantifiedObjectValue.class::cast)
+                        .filter(qov -> qov.getAlias().equals(nullSupplyingAlias))
+                        .allMatch(qov -> qov.getResultType().isNullable()),
+                "The result value must reference the null-supplying side with a nullable type.");
         this.preservedQuantifier = preservedQuantifier;
         this.nullSupplyingQuantifier = nullSupplyingQuantifier;
         this.joinPredicates = ImmutableList.copyOf(joinPredicates);

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/QueryVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/QueryVisitor.java
@@ -623,26 +623,29 @@ public final class QueryVisitor extends DelegatingVisitor<BaseVisitor> {
                 aliases,
                 getDelegate().isForDdl());
 
-        // Build the result value: a flat record combining all flowed values from both sides (left then right). The
-        // result column ordering is independent of the join type: LEFT JOIN and RIGHT JOIN both produce the SQL outputs
-        // in the source order.
-        final ImmutableList<Value> values = ImmutableList.<Value>builder()
-                .addAll(leftQun.getFlowedValues())
-                .addAll(rightQun.getFlowedValues())
-                .build();
-        final RecordConstructorValue resultValue = ofUnnamed(values);
-
-        // Set up the preserved/null-supplying quantifiers for `OuterJoinExpression`. A LEFT OUTER JOIN preserves the
-        // left side; a RIGHT OUTER JOIN preserves the right side.
+        // Build the result value, a flat record combining the flowed values from both sides.
+        // 1. Determine the preserved/null-supplying quantifiers for `OuterJoinExpression` as per the LEFT/RIGHT type.
+        // 2. Ensure that the flowed values of the null-supplying side are nullable.
+        // 3. Assemble the result values in source order (left then right).
         final Quantifier.ForEach preservedQun;
         final Quantifier.ForEach nullSupplyingQun;
+        final ImmutableList<Value> values;
         if (joinType == JoinType.LEFT) {
             preservedQun = leftQun;
             nullSupplyingQun = rightQun;
+            values = ImmutableList.<Value>builder()
+                    .addAll(leftQun.getFlowedValues())
+                    .addAll(rightQun.pullUpResultColumnsWithNullability(true))
+                    .build();
         } else {
             preservedQun = rightQun;
             nullSupplyingQun = leftQun;
+            values = ImmutableList.<Value>builder()
+                    .addAll(leftQun.pullUpResultColumnsWithNullability(true))
+                    .addAll(rightQun.getFlowedValues())
+                    .build();
         }
+        final RecordConstructorValue resultValue = ofUnnamed(values);
 
         final OuterJoinExpression outerJoinExpression = new OuterJoinExpression(
                 preservedQun, nullSupplyingQun,

--- a/yaml-tests/src/test/resources/join-tests-outer.metrics.binpb
+++ b/yaml-tests/src/test/resources/join-tests-outer.metrics.binpb
@@ -922,6 +922,66 @@ k
     rankDir=LR;
     2 -> 4 [ color="red" style="invis" ];
   }
+}Ì!
+Ü
+left-outer-joinsEXPLAIN SELECT "e"."fname", ("d"."id", "d"."name") FROM "emp" "e" LEFT JOIN "dept" "d" ON "e"."dept_id" = "d"."id";· 
+Èª¬äÇ ÕÉ©(20ËÕ 8=@ﬂISCAN(emp$fname <,>) | FLATMAP q0 -> { COVERING(dept$name <,> -> [id: KEY:[2], name: KEY:[0]]) | FILTER q0.dept_id EQUALS _.id | FETCH | ON EMPTY NULL AS q1 RETURN (q0.fname AS fname, (q1.id AS id, q1.name AS name) AS _1) }‡digraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=line;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Nested Loop Join</td></tr><tr><td align="left">FLATMAP (q2.fname AS fname, (q6.id AS id, q6.name AS name) AS _1)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(STRING AS fname, LONG AS id, STRING AS name AS _1)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS id, STRING AS fname, STRING AS lname, LONG AS dept_id)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">emp$fname</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS id, STRING AS fname, STRING AS lname, LONG AS dept_id)" ];
+  4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">$q6 OR NULL</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS id, STRING AS name)" ];
+  5 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Fetch Records</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="12" tooltip="RELATION(LONG AS id, STRING AS name)" ];
+  6 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE q2.dept_id EQUALS q62.id</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS id, STRING AS name)" ];
+  7 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Covering Index Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS id, STRING AS name)" ];
+  8 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">dept$name</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS id, STRING AS name)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q2> label="q2" color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  5 -> 4 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  6 -> 5 [ label=<&nbsp;q64> label="q64" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  7 -> 6 [ label=<&nbsp;q62> label="q62" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  8 -> 7 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  4 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  {
+    6 -> 1 [ color="blue" style="dotted" arrowhead="none" tailport="nw" headport="s" constraint="false" ];
+  }
+  {
+    rank=same;
+    rankDir=LR;
+    2 -> 4 [ color="red" style="invis" ];
+  }
+}’"
+±
+left-outer-joinùEXPLAIN SELECT "e"."fname", "sq"."info" FROM "emp" "e" LEFT JOIN (SELECT "id" AS "k", ("id", "name") AS "info" FROM "dept") "sq" ON "e"."dept_id" = "sq"."k";û!
+åÊŸë© ◊çˆ(80˙˛8N@∑ISCAN(emp$fname <,>) | FLATMAP q0 -> { SCAN([IS dept]) | FILTER q0.dept_id EQUALS _.id | MAP (_.id AS k, _ AS info) | ON EMPTY NULL AS q1 RETURN (q0.fname AS fname, q1.info AS info) }≈digraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=line;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Nested Loop Join</td></tr><tr><td align="left">FLATMAP (q2.fname AS fname, q8.info AS info)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(STRING AS fname, LONG AS id, STRING AS name AS info)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS id, STRING AS fname, STRING AS lname, LONG AS dept_id)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">emp$fname</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS id, STRING AS fname, STRING AS lname, LONG AS dept_id)" ];
+  4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">$q8 OR NULL</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS k, LONG AS id, STRING AS name AS info)" ];
+  5 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q6.id AS k, q6 AS info)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS k, LONG AS id, STRING AS name AS info)" ];
+  6 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE q2.dept_id EQUALS q6.id</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS id, STRING AS name)" ];
+  7 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Scan</td></tr><tr><td align="left">comparisons: [IS dept]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS id, STRING AS name)" ];
+  8 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Primary Storage</td></tr><tr><td align="left">record types: [project, emp, award, dept]</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS id, STRING AS name)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q2> label="q2" color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  5 -> 4 [ label=<&nbsp;q8> label="q8" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  6 -> 5 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  7 -> 6 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  8 -> 7 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  4 -> 1 [ label=<&nbsp;q8> label="q8" color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  {
+    6 -> 1 [ color="blue" style="dotted" arrowhead="none" tailport="nw" headport="s" constraint="false" ];
+  }
+  {
+    rank=same;
+    rankDir=LR;
+    2 -> 4 [ color="red" style="invis" ];
+  }
 }ä
 |
 right-outer-joinhEXPLAIN SELECT "e"."fname", "d"."name" FROM "emp" "e" RIGHT JOIN "dept" "d" ON "e"."dept_id" = "d"."id";â
@@ -1159,6 +1219,34 @@ m
   rankdir=BT;
   splines=line;
   1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Nested Loop Join</td></tr><tr><td align="left">FLATMAP (coalesce_string(q2.fname, promote(@c7 AS STRING)) AS _0, q6.name AS name)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(STRING AS _0, STRING AS name)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS id, STRING AS name)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">dept$name</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS id, STRING AS name)" ];
+  4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">$q2 OR NULL</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS id, STRING AS fname, STRING AS lname, LONG AS dept_id)" ];
+  5 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE q2.dept_id EQUALS q6.id</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS id, STRING AS fname, STRING AS lname, LONG AS dept_id)" ];
+  6 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS id, STRING AS fname, STRING AS lname, LONG AS dept_id)" ];
+  7 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">emp$fname</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS id, STRING AS fname, STRING AS lname, LONG AS dept_id)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  5 -> 4 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  6 -> 5 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  7 -> 6 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  4 -> 1 [ label=<&nbsp;q2> label="q2" color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  {
+    5 -> 1 [ color="blue" style="dotted" arrowhead="none" tailport="nw" headport="s" constraint="false" ];
+  }
+  {
+    rank=same;
+    rankDir=LR;
+    2 -> 4 [ color="red" style="invis" ];
+  }
+}”
+à
+right-outer-jointEXPLAIN SELECT ("e"."id", "e"."fname"), "d"."name" FROM "emp" "e" RIGHT JOIN "dept" "d" ON "e"."dept_id" = "d"."id";≈
+Ã˙õã~ ¸À“(10›ê87@¥ISCAN(dept$name <,>) | FLATMAP q0 -> { ISCAN(emp$fname <,>) | FILTER _.dept_id EQUALS q0.id | ON EMPTY NULL AS q1 RETURN ((q1.id AS id, q1.fname AS fname) AS _0, q0.name AS name) }digraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=line;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Nested Loop Join</td></tr><tr><td align="left">FLATMAP ((q2.id AS id, q2.fname AS fname) AS _0, q6.name AS name)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS id, STRING AS fname AS _0, STRING AS name)" ];
   2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS id, STRING AS name)" ];
   3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">dept$name</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS id, STRING AS name)" ];
   4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">$q2 OR NULL</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS id, STRING AS fname, STRING AS lname, LONG AS dept_id)" ];

--- a/yaml-tests/src/test/resources/join-tests-outer.metrics.yaml
+++ b/yaml-tests/src/test/resources/join-tests-outer.metrics.yaml
@@ -413,10 +413,40 @@ left-outer-join:
     insert_time_ms: 2
     insert_new_count: 130
     insert_reused_count: 13
+-   query: EXPLAIN SELECT "e"."fname", ("d"."id", "d"."name") FROM "emp" "e" LEFT
+        JOIN "dept" "d" ON "e"."dept_id" = "d"."id";
+    ref: join-tests-outer.yamsql:338
+    explain: 'ISCAN(emp$fname <,>) | FLATMAP q0 -> { COVERING(dept$name <,> -> [id:
+        KEY:[2], name: KEY:[0]]) | FILTER q0.dept_id EQUALS _.id | FETCH | ON EMPTY
+        NULL AS q1 RETURN (q0.fname AS fname, (q1.id AS id, q1.name AS name) AS _1)
+        }'
+    task_count: 489
+    task_total_time_ms: 8
+    transform_count: 130
+    transform_time_ms: 4
+    transform_yield_count: 50
+    insert_time_ms: 0
+    insert_new_count: 61
+    insert_reused_count: 4
+-   query: EXPLAIN SELECT "e"."fname", "sq"."info" FROM "emp" "e" LEFT JOIN (SELECT
+        "id" AS "k", ("id", "name") AS "info" FROM "dept") "sq" ON "e"."dept_id" =
+        "sq"."k";
+    ref: join-tests-outer.yamsql:351
+    explain: ISCAN(emp$fname <,>) | FLATMAP q0 -> { SCAN([IS dept]) | FILTER q0.dept_id
+        EQUALS _.id | MAP (_.id AS k, _ AS info) | ON EMPTY NULL AS q1 RETURN (q0.fname
+        AS fname, q1.info AS info) }
+    task_count: 652
+    task_total_time_ms: 8
+    transform_count: 169
+    transform_time_ms: 4
+    transform_yield_count: 56
+    insert_time_ms: 0
+    insert_new_count: 78
+    insert_reused_count: 2
 right-outer-join:
 -   query: EXPLAIN SELECT "e"."fname", "d"."name" FROM "emp" "e" RIGHT JOIN "dept"
         "d" ON "e"."dept_id" = "d"."id";
-    ref: join-tests-outer.yamsql:342
+    ref: join-tests-outer.yamsql:366
     explain: ISCAN(dept$name <,>) | FLATMAP q0 -> { ISCAN(emp$fname <,>) | FILTER
         _.dept_id EQUALS q0.id | ON EMPTY NULL AS q1 RETURN (q1.fname AS fname, q0.name
         AS name) }
@@ -430,7 +460,7 @@ right-outer-join:
     insert_reused_count: 3
 -   query: EXPLAIN SELECT "e"."fname", "d"."name" FROM "emp" "e" RIGHT OUTER JOIN
         "dept" "d" ON "e"."dept_id" = "d"."id";
-    ref: join-tests-outer.yamsql:351
+    ref: join-tests-outer.yamsql:375
     explain: ISCAN(dept$name <,>) | FLATMAP q0 -> { ISCAN(emp$fname <,>) | FILTER
         _.dept_id EQUALS q0.id | ON EMPTY NULL AS q1 RETURN (q1.fname AS fname, q0.name
         AS name) }
@@ -444,7 +474,7 @@ right-outer-join:
     insert_reused_count: 3
 -   query: EXPLAIN SELECT "e"."fname", "d"."name" FROM "dept" "d" RIGHT JOIN "emp"
         "e" ON "e"."dept_id" = "d"."id";
-    ref: join-tests-outer.yamsql:361
+    ref: join-tests-outer.yamsql:385
     explain: 'ISCAN(emp$fname <,>) | FLATMAP q0 -> { COVERING(dept$name <,> -> [id:
         KEY:[2], name: KEY:[0]]) | FILTER q0.dept_id EQUALS _.id | FETCH | ON EMPTY
         NULL AS q1 RETURN (q0.fname AS fname, q1.name AS name) }'
@@ -458,7 +488,7 @@ right-outer-join:
     insert_reused_count: 4
 -   query: EXPLAIN SELECT "e"."fname", "d"."name" FROM "emp" "e" RIGHT JOIN "dept"
         "d" ON "e"."dept_id" = "d"."id" WHERE "d"."id" < 3;
-    ref: join-tests-outer.yamsql:370
+    ref: join-tests-outer.yamsql:394
     explain: SCAN([IS dept, [LESS_THAN promote(@c28 AS LONG)]]) | FLATMAP q0 -> {
         ISCAN(emp$fname <,>) | FILTER _.dept_id EQUALS q0.id | ON EMPTY NULL AS q1
         RETURN (q1.fname AS fname, q0.name AS name) }
@@ -472,7 +502,7 @@ right-outer-join:
     insert_reused_count: 7
 -   query: EXPLAIN SELECT "d"."name" FROM "emp" "e" RIGHT JOIN "dept" "d" ON "e"."dept_id"
         = "d"."id" WHERE "e"."id" IS NULL;
-    ref: join-tests-outer.yamsql:379
+    ref: join-tests-outer.yamsql:403
     explain: ISCAN(dept$name <,>) | FLATMAP q0 -> { ISCAN(emp$fname <,>) | FILTER
         _.dept_id EQUALS q0.id | ON EMPTY NULL | FILTER _.id IS_NULL AS q1 RETURN
         (q0.name AS name) }
@@ -486,7 +516,7 @@ right-outer-join:
     insert_reused_count: 8
 -   query: EXPLAIN SELECT "d"."name", "p"."name" FROM "project" "p" RIGHT JOIN "dept"
         "d" ON "d"."id" = "p"."emp_id";
-    ref: join-tests-outer.yamsql:384
+    ref: join-tests-outer.yamsql:408
     explain: ISCAN(dept$name <,>) | FLATMAP q0 -> { SCAN([IS project]) | FILTER q0.id
         EQUALS _.emp_id | ON EMPTY NULL AS q1 RETURN (q0.name AS _0, q1.name AS _1)
         }
@@ -500,7 +530,7 @@ right-outer-join:
     insert_reused_count: 2
 -   query: EXPLAIN SELECT "a"."name", "d"."name" FROM "award" "a" RIGHT JOIN "dept"
         "d" ON "a"."emp_id" = "d"."id";
-    ref: join-tests-outer.yamsql:393
+    ref: join-tests-outer.yamsql:417
     explain: ISCAN(dept$name <,>) | FLATMAP q0 -> { SCAN([IS award]) | FILTER _.emp_id
         EQUALS q0.id | ON EMPTY NULL AS q1 RETURN (q1.name AS _0, q0.name AS _1) }
     task_count: 356
@@ -513,7 +543,7 @@ right-outer-join:
     insert_reused_count: 2
 -   query: EXPLAIN SELECT "e"."fname", "d"."name" FROM "emp" "e" RIGHT JOIN "dept"
         "d" USING ("id");
-    ref: join-tests-outer.yamsql:402
+    ref: join-tests-outer.yamsql:426
     explain: ISCAN(dept$name <,>) | FLATMAP q0 -> { SCAN([IS emp, EQUALS q0.id]) |
         ON EMPTY NULL AS q1 RETURN (q1.fname AS fname, q0.name AS name) }
     task_count: 479
@@ -526,7 +556,7 @@ right-outer-join:
     insert_reused_count: 3
 -   query: EXPLAIN SELECT COALESCE("e"."fname", 'None'), "d"."name" FROM "emp" "e"
         RIGHT JOIN "dept" "d" ON "e"."dept_id" = "d"."id";
-    ref: join-tests-outer.yamsql:410
+    ref: join-tests-outer.yamsql:434
     explain: ISCAN(dept$name <,>) | FLATMAP q0 -> { ISCAN(emp$fname <,>) | FILTER
         _.dept_id EQUALS q0.id | ON EMPTY NULL AS q1 RETURN (coalesce_string(q1.fname,
         promote(@c7 AS STRING)) AS _0, q0.name AS name) }
@@ -534,6 +564,20 @@ right-outer-join:
     task_total_time_ms: 12
     transform_count: 126
     transform_time_ms: 6
+    transform_yield_count: 49
+    insert_time_ms: 0
+    insert_new_count: 55
+    insert_reused_count: 3
+-   query: EXPLAIN SELECT ("e"."id", "e"."fname"), "d"."name" FROM "emp" "e" RIGHT
+        JOIN "dept" "d" ON "e"."dept_id" = "d"."id";
+    ref: join-tests-outer.yamsql:445
+    explain: ISCAN(dept$name <,>) | FLATMAP q0 -> { ISCAN(emp$fname <,>) | FILTER
+        _.dept_id EQUALS q0.id | ON EMPTY NULL AS q1 RETURN ((q1.id AS id, q1.fname
+        AS fname) AS _0, q0.name AS name) }
+    task_count: 460
+    task_total_time_ms: 6
+    transform_count: 126
+    transform_time_ms: 3
     transform_yield_count: 49
     insert_time_ms: 0
     insert_new_count: 55

--- a/yaml-tests/src/test/resources/join-tests-outer.yamsql
+++ b/yaml-tests/src/test/resources/join-tests-outer.yamsql
@@ -330,6 +330,30 @@ test_block:
       - explain: "ISCAN(emp$fname <,>) | FLATMAP q0 -> { COVERING(dept$name <,> -> [id: KEY:[2], name: KEY:[0]]) | FILTER q0.dept_id EQUALS _.id | FILTER _.name GREATER_THAN promote(@c28 AS STRING) | FETCH AS q1 RETURN (q0.fname AS fname, q1.name AS name) }"
       - unorderedResult: [
           {'Carol', 'Sales'}]
+    -
+      # Row constructor in the SELECT list, projecting fields from the null-producing side of a LEFT JOIN.
+      # This exercises the propagation of nullability through a freshly-constructed record over an outer-join field.
+      - query: SELECT "e"."fname", ("d"."id", "d"."name") FROM "emp" "e" LEFT JOIN "dept" "d" ON "e"."dept_id" = "d"."id";
+      - supported_version: !current_version
+      - explain: "ISCAN(emp$fname <,>) | FLATMAP q0 -> { COVERING(dept$name <,> -> [id: KEY:[2], name: KEY:[0]]) | FILTER q0.dept_id EQUALS _.id | FETCH | ON EMPTY NULL AS q1 RETURN (q0.fname AS fname, (q1.id AS id, q1.name AS name) AS _1) }"
+      - unorderedResult: [
+          {'Alice', {!l 1, 'Engineering'}},
+          {'Bob', {!l 1, 'Engineering'}},
+          {'Carol', {!l 2, 'Sales'}},
+          {'Dave', {!pos 1: !null _, !pos 2: !null _}}]
+    -
+      # Similar shape, but the row constructor sits in a derived table on the null-producing side of the LEFT JOIN.
+      # Here the entire `sq.info` field is NULL for unmatched rows (because the outer join null-pads the whole derived
+      # row), rather than a record with NULL fields as in the previous case where the row constructor is built freshly
+      # in the outer SELECT.
+      - query: SELECT "e"."fname", "sq"."info" FROM "emp" "e" LEFT JOIN (SELECT "id" AS "k", ("id", "name") AS "info" FROM "dept") "sq" ON "e"."dept_id" = "sq"."k";
+      - supported_version: !current_version
+      - explain: "ISCAN(emp$fname <,>) | FLATMAP q0 -> { SCAN([IS dept]) | FILTER q0.dept_id EQUALS _.id | MAP (_.id AS k, _ AS info) | ON EMPTY NULL AS q1 RETURN (q0.fname AS fname, q1.info AS info) }"
+      - unorderedResult: [
+          {'Alice', {!l 1, 'Engineering'}},
+          {'Bob', {!l 1, 'Engineering'}},
+          {'Carol', {!l 2, 'Sales'}},
+          {'Dave', !null _}]
 ---
 test_block:
   name: right-outer-join
@@ -413,6 +437,17 @@ test_block:
           {'Bob', 'Engineering'},
           {'Carol', 'Sales'},
           {'None', 'Marketing'}]
+    -
+      # Row constructor in the SELECT list, projecting fields from the null-producing (SQL-left) side of a RIGHT JOIN.
+      # Symmetric to the corresponding LEFT JOIN test above.
+      - query: SELECT ("e"."id", "e"."fname"), "d"."name" FROM "emp" "e" RIGHT JOIN "dept" "d" ON "e"."dept_id" = "d"."id";
+      - supported_version: !current_version
+      - explain: "ISCAN(dept$name <,>) | FLATMAP q0 -> { ISCAN(emp$fname <,>) | FILTER _.dept_id EQUALS q0.id | ON EMPTY NULL AS q1 RETURN ((q1.id AS id, q1.fname AS fname) AS _0, q0.name AS name) }"
+      - unorderedResult: [
+          {{!l 1, 'Alice'}, 'Engineering'},
+          {{!l 2, 'Bob'}, 'Engineering'},
+          {{!l 3, 'Carol'}, 'Sales'},
+          {{!pos 1: !null _, !pos 2: !null _}, 'Marketing'}]
 ---
 test_block:
   name: full-outer-join


### PR DESCRIPTION
In `QueryVisitor.wrapOperandsForOuterJoin()`, build the flowed values of the null-supplying side as nullable, so that the embedded `QuantifiedObjectValue` carries a nullable outer record type. The nullability then propagates correctly down through `FieldValue` into each constructed column.

Previously the code reused the flowed values of the regular `ForEach` quantifier directly, so the embedded `QuantifiedObjectValue` carried a non-nullable record type. Because `RewriteOuterJoinRule` reuses the alias when it introduces the null-on-empty quantifier, downstream rewrites would work with the incorrect nullability. This could then surface as a “Cannot set a non-nullable field to the NULL value” error in `RecordConstructorValue.eval()` when evaluating the surrounding row constructor for an unmatched row.

Testing:
* Add tests to `join-tests-outer.yamsql`.