### PR TITLE
Removed a check from `checkVersion` that would clear the `omit_unsplit_record_suffix` on empty stores

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -310,8 +310,6 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     @Nonnull
     private final FDBPreloadRecordCache preloadCache;
 
-    private boolean recordsReadConflict;
-
     private boolean storeStateReadConflict;
     private IndexDeferredMaintenanceControl indexDeferredMaintenanceControl;
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -4771,34 +4771,6 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
             AtomicLong recordsSizeRef = new AtomicLong(-1);
             final Supplier<CompletableFuture<Long>> lazyRecordsSize = getAndRememberFutureLong(recordsSizeRef,
                     () -> getRecordSizeForRebuildIndexes(singleRecordTypeWithPrefixKey));
-            if (singleRecordTypeWithPrefixKey == null
-                    && formatVersion.isAtLeast(FormatVersion.SAVE_UNSPLIT_WITH_SUFFIX)
-                    && omitUnsplitRecordSuffix) {
-                // Check to see if the unsplit format can be upgraded on an empty store.
-                // Only works if singleRecordTypeWithPrefixKey is null as otherwise, the recordCount will not contain
-                // all records
-                work.add(lazyRecordCount.get().thenAccept(recordCount -> {
-                    if (recordCount == 0) {
-                        if (newStore ? LOGGER.isDebugEnabled() : LOGGER.isInfoEnabled()) {
-                            KeyValueLogMessage msg = KeyValueLogMessage.build("upgrading unsplit format on empty store",
-                                    LogMessageKeys.NEW_FORMAT_VERSION, formatVersion,
-                                    subspaceProvider.logKey(), subspaceProvider.toString(context));
-                            if (newStore) {
-                                if (LOGGER.isDebugEnabled()) {
-                                    LOGGER.debug(msg.toString());
-                                }
-                            } else {
-                                if (LOGGER.isInfoEnabled()) {
-                                    LOGGER.info(msg.toString());
-                                }
-                            }
-                        }
-                        omitUnsplitRecordSuffix = !formatVersion.isAtLeast(FormatVersion.SAVE_UNSPLIT_WITH_SUFFIX);
-                        info.clearOmitUnsplitRecordSuffix();
-                        addRecordsReadConflict(); // We used snapshot to determine emptiness, and are now acting on it.
-                    }
-                }));
-            }
 
             Map<Index, CompletableFuture<IndexState>> newStates = getStatesForRebuildIndexes(userVersionChecker, indexes, lazyRecordCount, lazyRecordsSize, newStore, oldMetaDataVersion, oldFormatVersion);
             return rebuildIndexes(indexes, newStates, work, newStore ? RebuildIndexReason.NEW_STORE : RebuildIndexReason.FEW_RECORDS, oldMetaDataVersion).thenRun(() -> {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -4040,20 +4040,6 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     }
 
     /**
-     * Add a read conflict key for all records.
-     */
-    @SuppressWarnings("PMD.CloseResource")
-    private void addRecordsReadConflict() {
-        if (recordsReadConflict) {
-            return;
-        }
-        recordsReadConflict = true;
-        Transaction tr = ensureContextActive();
-        byte[] recordKey = getSubspace().pack(Tuple.from(RECORD_KEY));
-        tr.addReadConflictRange(recordKey, ByteArrayUtil.strinc(recordKey));
-    }
-
-    /**
      * Add a read conflict key so that the transaction will fail if the index state has changed.
      * @param indexName the index to conflict on, if it's state changes
      */
@@ -4753,10 +4739,10 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
             removeFormerIndex(formerIndex);
         }
 
-        return checkRebuildIndexes(userVersionChecker, info, oldFormatVersion, metaData, oldMetaDataVersion, rebuildRecordCounts, work);
+        return checkRebuildIndexes(userVersionChecker, oldFormatVersion, metaData, oldMetaDataVersion, rebuildRecordCounts, work);
     }
 
-    private CompletableFuture<Void> checkRebuildIndexes(@Nullable UserVersionChecker userVersionChecker, @Nonnull RecordMetaDataProto.DataStoreInfo.Builder info,
+    private CompletableFuture<Void> checkRebuildIndexes(@Nullable UserVersionChecker userVersionChecker,
                                                         int oldFormatVersion, @Nonnull RecordMetaData metaData, int oldMetaDataVersion,
                                                         boolean rebuildRecordCounts, List<CompletableFuture<Void>> work) {
         final boolean newStore = oldFormatVersion == 0;

--- a/fdb-record-layer-core/src/main/proto/record_metadata.proto
+++ b/fdb-record-layer-core/src/main/proto/record_metadata.proto
@@ -66,16 +66,18 @@ message DataStoreInfo {
   optional uint64 lastUpdateTime = 5;
   // This was introduced with FormatVersion.SAVE_UNSPLIT_WITH_SUFFIX to maintain backwards compatibility on stores
   // that have a metadata with splitLongRecords disabled.
-  // If the format version is at least 5, and the metadata has splitLongRecords disabled, and this is true, we will
-  // not insert or expect a split suffix. If splitLongRecords is enabled, or this is false records will always have
-  // a split suffix on the key, regardless of the record size.
-  // Without the suffix, you cannot start splitting long records, so by enabling the suffix you sacrifice a byte
-  // per-record, in exchange for be able to allow larger records in the future.
-  // Additionally, if the suffix is not used, and isStoreRecordVersions is enabled on the metaData, then they are placed
-  // in a disjoint space. This is less efficient, because it requires an additional read anytime you load a record.
-  // The existing of this means that upgrading the format version can happen transactionally, but the stores will not
-  // get the advantages of having the split-record-suffix.
-  // Ideally we would have a way to migrate stores: https://github.com/FoundationDB/fdb-record-layer/issues/3303
+  // Prior to format version 5, we would save split records with an additional suffix that was left off of unsplit
+  // records. This was more space efficient, but it meant that upgrading from unsplit to split records was impossible
+  // without a much more involved data migration. However, if we open a store with unsplit records that was written
+  // with an older format version, this flag needs to be set in order to correctly read previous data. Note that as
+  // we never try to migrate the old data from the old format to the new (instead reverting to the old behavior for
+  // reads and new writes), this is a one-way flag. Once set on a store, it will not be unset.
+  // Additionally, if the suffix is not used, and isStoreRecordVersions is enabled on the metaData, then record
+  // versions are not stored next to a record but instead in their own space. This is less efficient, because it
+  // requires an additional read any time a record is loaded.
+  // This backwards compatibility flag is employed instead of a migration as it allows us to update the format version
+  // without performing an unbounded amount of work in checkVersion. However, ideally, we would have a way to migrate
+  // stores to the new format. See: https://github.com/FoundationDB/fdb-record-layer/issues/3303
   optional bool omit_unsplit_record_suffix = 6;
   // Whether this store's store header should be cached using MetaDataVersionStampStoreStateCache
   // This is most important for very active stores that rarely change their metadata to avoid creating a hot shard on

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreSplitRecordsTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreSplitRecordsTest.java
@@ -212,8 +212,9 @@ public class FDBRecordStoreSplitRecordsTest extends FDBRecordStoreTestBase {
             );
             recordStore = recordStore.asBuilder().setFormatVersion(FormatVersion.SAVE_UNSPLIT_WITH_SUFFIX).open();
             assertEquals(FormatVersion.SAVE_UNSPLIT_WITH_SUFFIX, recordStore.getFormatVersionEnum());
+            assertTrue(recordStore.getRecordStoreState().getStoreHeader().getOmitUnsplitRecordSuffix(), "store header should still be in compatibility mode");
 
-            final byte[] rec1Key = recordStore.getSubspace().pack(Tuple.from(FDBRecordStore.RECORD_KEY, 1415L, SplitHelper.UNSPLIT_RECORD));
+            final byte[] rec1Key = recordStore.getSubspace().pack(Tuple.from(FDBRecordStore.RECORD_KEY, 1415L));
             FDBStoredRecord<Message> writtenRec1 = recordStore.saveRecord(rec1);
             assertNotNull(writtenRec1);
             assertFalse(writtenRec1.isSplit());
@@ -237,8 +238,9 @@ public class FDBRecordStoreSplitRecordsTest extends FDBRecordStoreTestBase {
             );
             recordStore = recordStore.asBuilder().setFormatVersion(FormatVersionTestUtils.previous(FormatVersion.SAVE_UNSPLIT_WITH_SUFFIX)).open();
             assertEquals(FormatVersion.SAVE_UNSPLIT_WITH_SUFFIX, recordStore.getFormatVersionEnum());
+            assertTrue(recordStore.getRecordStoreState().getStoreHeader().getOmitUnsplitRecordSuffix(), "store header should still be in compatibility mode");
 
-            final byte[] rawKey1 = recordStore.getSubspace().pack(Tuple.from(FDBRecordStore.RECORD_KEY, 1415L, SplitHelper.UNSPLIT_RECORD));
+            final byte[] rawKey1 = recordStore.getSubspace().pack(Tuple.from(FDBRecordStore.RECORD_KEY, 1415L));
             FDBStoredRecord<Message> writtenRec1 = recordStore.loadRecord(Tuple.from(1415L));
             assertNotNull(writtenRec1);
             assertEquals(rec1, writtenRec1.getRecord());
@@ -246,7 +248,7 @@ public class FDBRecordStoreSplitRecordsTest extends FDBRecordStoreTestBase {
             assertEquals(rawKey1.length, writtenRec1.getKeySize());
 
             final TestRecords1Proto.MySimpleRecord rec2 = rec1.toBuilder().setRecNo(1623L).build();
-            final byte[] rawKey2 = recordStore.getSubspace().pack(Tuple.from(FDBRecordStore.RECORD_KEY, 1623L, SplitHelper.UNSPLIT_RECORD));
+            final byte[] rawKey2 = recordStore.getSubspace().pack(Tuple.from(FDBRecordStore.RECORD_KEY, 1623L));
             FDBStoredRecord<Message> writtenRec2 = recordStore.saveRecord(rec1.toBuilder().setRecNo(1623L).build());
             assertEquals(rec2, writtenRec2.getRecord());
             assertEquals(1, writtenRec2.getKeyCount());
@@ -262,15 +264,17 @@ public class FDBRecordStoreSplitRecordsTest extends FDBRecordStoreTestBase {
     }
 
     /**
-     * Test mode for {@link #clearOmitUnsplitRecordSuffix(ClearOmitUnsplitRecordSuffixMode)}.
+     * Test mode for {@link #doNotClearOmitUnsplitRecordSuffix(SplitFormatVersionUpdateMode)}.
      */
-    public enum ClearOmitUnsplitRecordSuffixMode {
-        EMPTY, SAVE, DELETE
+    public enum SplitFormatVersionUpdateMode {
+        EMPTY,  // The store should never have been written into
+        SAVE,   // The store has at least one record
+        DELETE, // The store used to have records, but they were deleted
     }
 
-    @EnumSource(ClearOmitUnsplitRecordSuffixMode.class)
-    @ParameterizedTest(name = "clearOmitUnsplitRecordSuffix [mode = {0}]")
-    public void clearOmitUnsplitRecordSuffix(ClearOmitUnsplitRecordSuffixMode mode) {
+    @EnumSource(SplitFormatVersionUpdateMode.class)
+    @ParameterizedTest(name = "doNotClearOmitUnsplitRecordSuffix [mode = {0}]")
+    public void doNotClearOmitUnsplitRecordSuffix(SplitFormatVersionUpdateMode mode) {
         final RecordMetaDataBuilder metaData = RecordMetaData.newBuilder().setRecords(TestRecords1Proto.getDescriptor());
 
         FDBRecordStore.Builder builder = FDBRecordStore.newBuilder()
@@ -280,7 +284,7 @@ public class FDBRecordStoreSplitRecordsTest extends FDBRecordStoreTestBase {
 
         try (FDBRecordContext context = openContext()) {
             recordStore = builder.setContext(context).create();
-            if (mode != ClearOmitUnsplitRecordSuffixMode.EMPTY) {
+            if (mode != SplitFormatVersionUpdateMode.EMPTY) {
                 TestRecords1Proto.MySimpleRecord record = TestRecords1Proto.MySimpleRecord.newBuilder()
                         .setRecNo(1L)
                         .setStrValueIndexed("abc")
@@ -290,7 +294,7 @@ public class FDBRecordStoreSplitRecordsTest extends FDBRecordStoreTestBase {
             commit(context);
         }
 
-        if (mode == ClearOmitUnsplitRecordSuffixMode.DELETE) {
+        if (mode == SplitFormatVersionUpdateMode.DELETE) {
             try (FDBRecordContext context = openContext()) {
                 recordStore = builder.setContext(context).open();
                 recordStore.deleteRecord(Tuple.from(1L));
@@ -302,14 +306,18 @@ public class FDBRecordStoreSplitRecordsTest extends FDBRecordStoreTestBase {
         builder.setFormatVersion(FormatVersion.getMaximumSupportedVersion());
 
         try (FDBRecordContext context = openContext()) {
+            // The omit_unsplit_records_suffix flag is set as the store was initially opened
+            // in the legacy mode, and we need to remember that. In theory, if the store is empty,
+            // we could clear it out, but that's hard to get right without accidentally reading
+            // too much data. (See: https://github.com/FoundationDB/fdb-record-layer/issues/4275)
+            // For that reason, we always expect it to still be here, even if the store was empty
             recordStore = builder.setContext(context).open();
-            assertEquals(mode == ClearOmitUnsplitRecordSuffixMode.SAVE,
-                    recordStore.getRecordStoreState().getStoreHeader().getOmitUnsplitRecordSuffix());
+            assertTrue(recordStore.getRecordStoreState().getStoreHeader().getOmitUnsplitRecordSuffix());
         }
     }
 
     @Test
-    public void clearOmitUnsplitRecordSuffixTyped() {
+    public void doNotClearOmitUnsplitRecordSuffixWithRecordsPrefixedByRecordType() {
         final RecordMetaDataBuilder metaData = RecordMetaData.newBuilder().setRecords(TestRecords1Proto.getDescriptor());
         final KeyExpression pkey = concat(Key.Expressions.recordType(), field("rec_no"));
         metaData.getRecordType("MySimpleRecord").setPrimaryKey(pkey);
@@ -343,7 +351,7 @@ public class FDBRecordStoreSplitRecordsTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    public void clearOmitUnsplitRecordSuffixOverlapping() {
+    public void updateFormatVersionToOmitUnsplitOverlappingWithWrite() {
         final RecordMetaDataBuilder metaData = RecordMetaData.newBuilder().setRecords(TestRecords1Proto.getDescriptor());
 
         FDBRecordStore.Builder builder = FDBRecordStore.newBuilder()
@@ -356,6 +364,7 @@ public class FDBRecordStoreSplitRecordsTest extends FDBRecordStoreTestBase {
             commit(context);
         }
 
+        // Save a record on an old meta-data and format version
         FDBRecordContext context1 = openContext();
         FDBRecordStore recordStore = builder.setContext(context1).open();
         TestRecords1Proto.MySimpleRecord record = TestRecords1Proto.MySimpleRecord.newBuilder()
@@ -364,11 +373,11 @@ public class FDBRecordStoreSplitRecordsTest extends FDBRecordStoreTestBase {
                 .build();
         FDBStoredRecord<Message> saved = recordStore.saveRecord(record);
 
+        // Update the meta-data and format version
         metaData.addIndex("MySimpleRecord", "num_value_2");
         builder.setFormatVersion(FormatVersion.getMaximumSupportedVersion());
 
-        // If we did build, we'd create a read confict on the new index.
-        // We want to test that a conflict comes from the clearing itself.
+        // If we did build, we'd create a read conflict on the new index. Without building, we don't care about the concurrent record write
         final FDBRecordStoreBase.UserVersionChecker dontBuild = new FDBRecordStoreBase.UserVersionChecker() {
             @Override
             public CompletableFuture<Integer> checkUserVersion(@Nonnull final RecordMetaDataProto.DataStoreInfo storeHeader, final RecordMetaDataProvider metaData) {
@@ -390,13 +399,16 @@ public class FDBRecordStoreSplitRecordsTest extends FDBRecordStoreTestBase {
 
         FDBRecordContext context2 = openContext();
         FDBRecordStore recordStore2 = builder.setContext(context2).open();
-        assertFalse(recordStore2.getRecordStoreState().getStoreHeader().getOmitUnsplitRecordSuffix());
+        assertTrue(recordStore2.getRecordStoreState().getStoreHeader().getOmitUnsplitRecordSuffix());
 
         commit(context1);
-        assertThrows(FDBExceptions.FDBStoreTransactionConflictException.class, () -> commit(context2));
+        commit(context2);
 
+        // Downgrade the format version in the builder so that when we open the store, we know it came from the original store
+        builder.setFormatVersion(FormatVersionTestUtils.previous(FormatVersion.SAVE_UNSPLIT_WITH_SUFFIX));
         try (FDBRecordContext context = openContext()) {
             recordStore = builder.setContext(context).open();
+            assertEquals(FormatVersion.getMaximumSupportedVersion(), recordStore.getFormatVersionEnum());
             FDBStoredRecord<Message> loaded = recordStore.loadRecord(saved.getPrimaryKey());
             assertNotNull(loaded);
             assertEquals(saved.getRecord(), loaded.getRecord());


### PR DESCRIPTION
This removes a check from `checkVersion` that would attempt to remove the `omit_unsplit_record_suffix` flag if the store is empty. The idea there is that while we never actually migrate record data from one format to the other, it would have been nice if we could remove the compatibility setting if the store was provably empty, with the secondary goal of getting this empty-check "for free" by only asking for it if we already needed to get the record count for other reasons.

As it happens, we were not always getting this value for free, as the `UserVersionChecker` can be configured to ignore the record count. Most obviously, if all of the indexes are on new record types, then we wouldn't need the record count, but we'd still read it for this check here. For that reason, this is marked as a `performance` improvement--it allows users to avoid extra reads during store opening.

In theory, we could resolve this by making the check a range-one limited scan of the records subspace. This has some appeal, but I went with this approach instead because it makes `checkVersion` easier to reason about as there are fewer corner cases to discover. In practice, this shouldn't change too much, as the case it was handling (an empty store that was originally written with an old format version but no split records) should be relatively niche.

While I was here, I clarified some of the documentation around this flag.

This resolves #4275.