### PR TITLE
Define sliding window counters and timing events

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/SlidingWindowIndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/SlidingWindowIndexMaintainer.java
@@ -413,7 +413,7 @@ public class SlidingWindowIndexMaintainer extends IndexMaintainer {
         // The net effect is that after this method completes, newRecord is indexed exactly
         // once with its current values, and the counter accurately reflects the window size.
         if (newRecord != null) {
-            incrementCounter(SlidingWindowCounter.PREEMPTIVE_DELETE_WRITE_ONLY);
+            incrementCounter(SlidingWindowCounter.SW_PREEMPTIVE_DELETE_WRITE_ONLY);
         }
         update(newRecord, null);
         return update(oldRecord, newRecord);
@@ -457,11 +457,12 @@ public class SlidingWindowIndexMaintainer extends IndexMaintainer {
             final long count = counterBytes == null ? 0L : decodeLong(counterBytes);
 
             if (count < windowSize) {
-                incrementCounter(SlidingWindowCounter.ITEM_ADDED_TO_WINDOW_FILLING);
+                incrementCounter(SlidingWindowCounter.SW_ITEM_ADDED_TO_WINDOW_FILLING);
                 // Window not full: add to delegate, update count, maybe update boundary
                 return delegate.update(null, savedRecord).thenCompose(vignore ->
                         tr.get(boundaryMetaKey).thenAccept(boundaryBytes -> {
                             tr.set(counterKey, encodeLong(count + 1));
+                            recordSize(SlidingWindowSizeEvent.SW_WINDOW_COUNT, count + 1);
                             if (boundaryBytes == null || extremumType.isWorseOrEqual(entryKey,
                                     Tuple.fromBytes(boundaryBytes))) {
                                 tr.set(boundaryMetaKey, entryKey.pack());
@@ -477,14 +478,14 @@ public class SlidingWindowIndexMaintainer extends IndexMaintainer {
                     }
                     final Tuple boundaryEntryKey = Tuple.fromBytes(boundaryBytes);
                     if (!extremumType.isBetter(entryKey, boundaryEntryKey)) {
-                        incrementCounter(SlidingWindowCounter.ITEM_ADDED_TO_ENTRIES_ONLY);
+                        incrementCounter(SlidingWindowCounter.SW_ITEM_ADDED_TO_ENTRIES_ONLY);
                         // New entry is not better than boundary: it's already written to entries
                         // subspace on the overflow side. Nothing more to do.
                         return AsyncUtil.DONE;
                     }
 
                     // New entry is better: evict boundary from delegate, add new to delegate
-                    return instrument(SlidingWindowEvent.EVICT_AND_REPLACE,
+                    return instrument(SlidingWindowEvent.SW_EVICT_AND_REPLACE,
                             evictBoundaryAndReplace(savedRecord, entryKey, entriesSubspace, tr,
                                     boundaryEntryKey, boundaryMetaKey));
                 });
@@ -513,7 +514,7 @@ public class SlidingWindowIndexMaintainer extends IndexMaintainer {
         // Check if this entry exists in the entries subspace
         return tr.get(packedEntryKey).thenCompose(entryValue -> {
             if (entryValue == null) {
-                incrementCounter(SlidingWindowCounter.DELETE_UNTRACKED);
+                incrementCounter(SlidingWindowCounter.SW_DELETE_UNTRACKED);
                 // Not tracked, no-op
                 return AsyncUtil.DONE;
             }
@@ -532,7 +533,7 @@ public class SlidingWindowIndexMaintainer extends IndexMaintainer {
                 final Tuple boundaryEntryKey = Tuple.fromBytes(boundaryBytes);
 
                 if (!extremumType.isInWindow(entryKey, boundaryEntryKey)) {
-                    incrementCounter(SlidingWindowCounter.OVERFLOW_ENTRY_DELETED);
+                    incrementCounter(SlidingWindowCounter.SW_OVERFLOW_ENTRY_DELETED);
                     // Entry was in overflow: already removed from entries, nothing else to do
                     return AsyncUtil.DONE;
                 }
@@ -542,13 +543,14 @@ public class SlidingWindowIndexMaintainer extends IndexMaintainer {
                     final long count = counterBytes == null ? 0L : decodeLong(counterBytes);
                     final long newCount = Math.max(0, count - 1);
                     tr.set(counterKey, encodeLong(newCount));
+                    recordSize(SlidingWindowSizeEvent.SW_WINDOW_COUNT, newCount);
 
                     return delegate.update(savedRecord, null)
                             .thenCompose(vignore -> updateBoundaryAfterDelete(
                                     entriesSubspace, tr, entryKey, boundaryEntryKey,
                                     boundaryMetaKey, packedEntryKey))
                             .thenCompose(currentBoundaryPacked -> instrument(
-                                    SlidingWindowEvent.RE_ELECT_FROM_OVERFLOW,
+                                    SlidingWindowEvent.SW_RE_ELECT_FROM_OVERFLOW,
                                     reElectFromOverflow(entriesSubspace, tr, currentBoundaryPacked,
                                             boundaryMetaKey, counterKey, newCount)));
                 });
@@ -569,7 +571,6 @@ public class SlidingWindowIndexMaintainer extends IndexMaintainer {
             @Nonnull Transaction tr,
             @Nonnull Tuple boundaryEntryKey,
             @Nonnull byte[] boundaryMetaKey) {
-        incrementCounter(SlidingWindowCounter.BOUNDARY_EVICTED_AND_REPLACED);
         final Tuple boundaryPrimaryKey = TupleHelpers.subTuple(boundaryEntryKey,
                 windowKeyColumnSize, boundaryEntryKey.size());
         final byte[] oldBoundaryPackedKey = entriesSubspace.pack(boundaryEntryKey);
@@ -577,13 +578,13 @@ public class SlidingWindowIndexMaintainer extends IndexMaintainer {
         return state.store.loadRecordAsync(boundaryPrimaryKey)
                 .thenCompose(evictedRecord -> {
                     if (evictedRecord == null) {
-                        incrementCounter(SlidingWindowCounter.EVICTED_RECORD_MISSING);
+                        incrementCounter(SlidingWindowCounter.SW_EVICTED_RECORD_MISSING);
                         return AsyncUtil.DONE;
                     }
                     return delegate.update(evictedRecord, null);
                 })
                 .thenCompose(v -> delegate.update(null, newRecord))
-                .thenCompose(v -> instrument(SlidingWindowEvent.BOUNDARY_RESCAN,
+                .thenCompose(v -> instrument(SlidingWindowEvent.SW_BOUNDARY_RESCAN_AFTER_EVICT,
                         extremumType.getNewBoundaryAfterEviction(entriesSubspace, tr,
                                 oldBoundaryPackedKey)))
                 .thenAccept(newBoundaryKV -> {
@@ -613,11 +614,10 @@ public class SlidingWindowIndexMaintainer extends IndexMaintainer {
             @Nonnull byte[] boundaryMetaKey,
             @Nonnull byte[] packedEntryKey) {
         if (!entryKey.equals(boundaryEntryKey)) {
-            incrementCounter(SlidingWindowCounter.WINDOW_ENTRY_DELETED);
+            incrementCounter(SlidingWindowCounter.SW_WINDOW_ENTRY_DELETED);
             return CompletableFuture.completedFuture(entriesSubspace.pack(boundaryEntryKey));
         }
-        incrementCounter(SlidingWindowCounter.BOUNDARY_ENTRY_DELETED);
-        return instrument(SlidingWindowEvent.BOUNDARY_RESCAN,
+        return instrument(SlidingWindowEvent.SW_BOUNDARY_RESCAN_AFTER_DELETE,
                 extremumType.getNewBoundaryAfterEviction(entriesSubspace, tr, packedEntryKey))
                 .thenApply(newBoundaryKV -> {
                     if (newBoundaryKV != null) {
@@ -625,7 +625,7 @@ public class SlidingWindowIndexMaintainer extends IndexMaintainer {
                         tr.set(boundaryMetaKey, newBKey.pack());
                         return newBoundaryKV.getKey();
                     } else {
-                        incrementCounter(SlidingWindowCounter.PARTITION_EMPTIED);
+                        incrementCounter(SlidingWindowCounter.SW_PARTITION_EMPTIED);
                         tr.clear(boundaryMetaKey);
                         return null;
                     }
@@ -650,18 +650,19 @@ public class SlidingWindowIndexMaintainer extends IndexMaintainer {
         return extremumType.getBestInOverflow(entriesSubspace, tr, currentBoundaryPacked)
                 .thenCompose(bestKV -> {
                     if (bestKV == null) {
-                        incrementCounter(SlidingWindowCounter.WINDOW_SHRUNK_NO_OVERFLOW);
+                        incrementCounter(SlidingWindowCounter.SW_WINDOW_SHRUNK_NO_OVERFLOW);
                         return AsyncUtil.DONE;
                     }
-                    incrementCounter(SlidingWindowCounter.ITEM_PROMOTED_FROM_OVERFLOW);
+                    incrementCounter(SlidingWindowCounter.SW_ITEM_PROMOTED_FROM_OVERFLOW);
                     final Tuple bestEntryKey = entriesSubspace.unpack(bestKV.getKey());
                     final Tuple bestPrimaryKey = Tuple.fromBytes(bestKV.getValue());
                     tr.set(boundaryMetaKey, bestEntryKey.pack());
                     tr.set(counterKey, encodeLong(newCount + 1));
+                    recordSize(SlidingWindowSizeEvent.SW_WINDOW_COUNT, newCount + 1);
                     return state.store.loadRecordAsync(bestPrimaryKey)
                             .thenCompose(promotedRecord -> {
                                 if (promotedRecord == null) {
-                                    incrementCounter(SlidingWindowCounter.PROMOTED_RECORD_MISSING);
+                                    incrementCounter(SlidingWindowCounter.SW_PROMOTED_RECORD_MISSING);
                                     return AsyncUtil.DONE;
                                 }
                                 return delegate.update(null, promotedRecord);
@@ -676,7 +677,7 @@ public class SlidingWindowIndexMaintainer extends IndexMaintainer {
         Verify.verify(partitionKeyColumnSize >= prefix.size(),
                 "deleteWhere prefix size %s exceeds partition key column size %s",
                 prefix.size(), partitionKeyColumnSize);
-        incrementCounter(SlidingWindowCounter.PARTITION_CLEARED);
+        incrementCounter(SlidingWindowCounter.SW_PARTITION_CLEARED);
         final byte[] key = getSlidingWindowSubspace().pack(prefix);
         Range indexRange = new Range(key, ByteArrayUtil.strinc(key));
         state.context.clear(indexRange);
@@ -698,6 +699,13 @@ public class SlidingWindowIndexMaintainer extends IndexMaintainer {
         }
     }
 
+    private void recordSize(@Nonnull SlidingWindowSizeEvent event, long size) {
+        final FDBStoreTimer timer = state.context.getTimer();
+        if (timer != null) {
+            timer.recordSize(event, size);
+        }
+    }
+
     @Nonnull
     private <T> CompletableFuture<T> instrument(@Nonnull final SlidingWindowEvent event,
                                                 @Nonnull final CompletableFuture<T> future) {
@@ -709,20 +717,18 @@ public class SlidingWindowIndexMaintainer extends IndexMaintainer {
     }
 
     public enum SlidingWindowCounter implements StoreTimer.Count {
-        ITEM_ADDED_TO_WINDOW_FILLING("item added to window while filling up"),
-        ITEM_ADDED_TO_ENTRIES_ONLY("item worse than boundary added to entries"),
-        BOUNDARY_EVICTED_AND_REPLACED("boundary evicted and replaced by better item"),
-        DELETE_UNTRACKED("delete called for untracked record"),
-        OVERFLOW_ENTRY_DELETED("overflow entry deleted from entries"),
-        WINDOW_ENTRY_DELETED("in-window non-boundary entry deleted"),
-        BOUNDARY_ENTRY_DELETED("boundary entry deleted (triggered rescan)"),
-        ITEM_PROMOTED_FROM_OVERFLOW("item promoted from overflow into window"),
-        WINDOW_SHRUNK_NO_OVERFLOW("window shrunk: no overflow available for re-election"),
-        PARTITION_EMPTIED("partition emptied (no entries remain)"),
-        EVICTED_RECORD_MISSING("boundary record could not be loaded for eviction"),
-        PROMOTED_RECORD_MISSING("overflow record could not be loaded for promotion"),
-        PREEMPTIVE_DELETE_WRITE_ONLY("preemptive delete during write-only index build"),
-        PARTITION_CLEARED("partition cleared via deleteWhere");
+        SW_ITEM_ADDED_TO_WINDOW_FILLING("item added to window while filling up"),
+        SW_ITEM_ADDED_TO_ENTRIES_ONLY("item worse than boundary added to entries"),
+        SW_DELETE_UNTRACKED("delete called for untracked record"),
+        SW_OVERFLOW_ENTRY_DELETED("overflow entry deleted from entries"),
+        SW_WINDOW_ENTRY_DELETED("in-window non-boundary entry deleted"),
+        SW_ITEM_PROMOTED_FROM_OVERFLOW("item promoted from overflow into window"),
+        SW_WINDOW_SHRUNK_NO_OVERFLOW("window shrunk: no overflow available for re-election"),
+        SW_PARTITION_EMPTIED("partition emptied (no entries remain)"),
+        SW_EVICTED_RECORD_MISSING("boundary record could not be loaded for eviction"),
+        SW_PROMOTED_RECORD_MISSING("overflow record could not be loaded for promotion"),
+        SW_PREEMPTIVE_DELETE_WRITE_ONLY("preemptive delete during write-only index build"),
+        SW_PARTITION_CLEARED("partition cleared via deleteWhere");
 
         @Nonnull
         private final String title;
@@ -742,15 +748,32 @@ public class SlidingWindowIndexMaintainer extends IndexMaintainer {
         }
     }
 
-    public enum SlidingWindowEvent implements StoreTimer.Event {
-        EVICT_AND_REPLACE("evict boundary and insert better entry"),
-        RE_ELECT_FROM_OVERFLOW("re-elect overflow entry into window"),
-        BOUNDARY_RESCAN("rescan to locate new boundary");
+    public enum SlidingWindowEvent implements StoreTimer.DetailEvent {
+        SW_EVICT_AND_REPLACE("evict boundary and insert better entry"),
+        SW_RE_ELECT_FROM_OVERFLOW("re-elect overflow entry into window"),
+        SW_BOUNDARY_RESCAN_AFTER_EVICT("rescan to locate new boundary after eviction"),
+        SW_BOUNDARY_RESCAN_AFTER_DELETE("rescan to locate new boundary after boundary delete");
 
         @Nonnull
         private final String title;
 
         SlidingWindowEvent(@Nonnull final String title) {
+            this.title = title;
+        }
+
+        @Override
+        public String title() {
+            return title;
+        }
+    }
+
+    public enum SlidingWindowSizeEvent implements StoreTimer.SizeEvent {
+        SW_WINDOW_COUNT("window count after update");
+
+        @Nonnull
+        private final String title;
+
+        SlidingWindowSizeEvent(@Nonnull final String title) {
             this.title = title;
         }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/SlidingWindowIndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/SlidingWindowIndexMaintainer.java
@@ -459,7 +459,8 @@ public class SlidingWindowIndexMaintainer extends IndexMaintainer {
             if (count < windowSize) {
                 incrementCounter(SlidingWindowCounter.SW_ITEM_ADDED_TO_WINDOW_FILLING);
                 // Window not full: add to delegate, update count, maybe update boundary
-                return delegate.update(null, savedRecord).thenCompose(vignore ->
+                return instrument(SlidingWindowEvent.SW_DELEGATE_INSERT,
+                        delegate.update(null, savedRecord)).thenCompose(vignore ->
                         tr.get(boundaryMetaKey).thenAccept(boundaryBytes -> {
                             tr.set(counterKey, encodeLong(count + 1));
                             recordSize(SlidingWindowSizeEvent.SW_WINDOW_COUNT, count + 1);
@@ -545,7 +546,8 @@ public class SlidingWindowIndexMaintainer extends IndexMaintainer {
                     tr.set(counterKey, encodeLong(newCount));
                     recordSize(SlidingWindowSizeEvent.SW_WINDOW_COUNT, newCount);
 
-                    return delegate.update(savedRecord, null)
+                    return instrument(SlidingWindowEvent.SW_DELEGATE_DELETE,
+                            delegate.update(savedRecord, null))
                             .thenCompose(vignore -> updateBoundaryAfterDelete(
                                     entriesSubspace, tr, entryKey, boundaryEntryKey,
                                     boundaryMetaKey, packedEntryKey))
@@ -581,9 +583,11 @@ public class SlidingWindowIndexMaintainer extends IndexMaintainer {
                         incrementCounter(SlidingWindowCounter.SW_EVICTED_RECORD_MISSING);
                         return AsyncUtil.DONE;
                     }
-                    return delegate.update(evictedRecord, null);
+                    return instrument(SlidingWindowEvent.SW_DELEGATE_DELETE,
+                            delegate.update(evictedRecord, null));
                 })
-                .thenCompose(v -> delegate.update(null, newRecord))
+                .thenCompose(v -> instrument(SlidingWindowEvent.SW_DELEGATE_INSERT,
+                        delegate.update(null, newRecord)))
                 .thenCompose(v -> instrument(SlidingWindowEvent.SW_BOUNDARY_RESCAN_AFTER_EVICT,
                         extremumType.getNewBoundaryAfterEviction(entriesSubspace, tr,
                                 oldBoundaryPackedKey)))
@@ -665,7 +669,8 @@ public class SlidingWindowIndexMaintainer extends IndexMaintainer {
                                     incrementCounter(SlidingWindowCounter.SW_PROMOTED_RECORD_MISSING);
                                     return AsyncUtil.DONE;
                                 }
-                                return delegate.update(null, promotedRecord);
+                                return instrument(SlidingWindowEvent.SW_DELEGATE_INSERT,
+                                        delegate.update(null, promotedRecord));
                             });
                 });
     }
@@ -752,7 +757,9 @@ public class SlidingWindowIndexMaintainer extends IndexMaintainer {
         SW_EVICT_AND_REPLACE("evict boundary and insert better entry"),
         SW_RE_ELECT_FROM_OVERFLOW("re-elect overflow entry into window"),
         SW_BOUNDARY_RESCAN_AFTER_EVICT("rescan to locate new boundary after eviction"),
-        SW_BOUNDARY_RESCAN_AFTER_DELETE("rescan to locate new boundary after boundary delete");
+        SW_BOUNDARY_RESCAN_AFTER_DELETE("rescan to locate new boundary after boundary delete"),
+        SW_DELEGATE_INSERT("insert into the delegate index"),
+        SW_DELEGATE_DELETE("delete from the delegate index");
 
         @Nonnull
         private final String title;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/SlidingWindowIndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/SlidingWindowIndexMaintainer.java
@@ -41,9 +41,11 @@ import com.apple.foundationdb.record.metadata.IndexRecordFunction;
 import com.apple.foundationdb.record.metadata.Key;
 import com.apple.foundationdb.record.metadata.MetaDataException;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
+import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBIndexableRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBIndexedRawRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecord;
+import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainer;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerState;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintenanceFilter;
@@ -410,6 +412,9 @@ public class SlidingWindowIndexMaintainer extends IndexMaintainer {
         //
         // The net effect is that after this method completes, newRecord is indexed exactly
         // once with its current values, and the counter accurately reflects the window size.
+        if (newRecord != null) {
+            incrementCounter(SlidingWindowCounter.PREEMPTIVE_DELETE_WRITE_ONLY);
+        }
         update(newRecord, null);
         return update(oldRecord, newRecord);
     }
@@ -452,6 +457,7 @@ public class SlidingWindowIndexMaintainer extends IndexMaintainer {
             final long count = counterBytes == null ? 0L : decodeLong(counterBytes);
 
             if (count < windowSize) {
+                incrementCounter(SlidingWindowCounter.ITEM_ADDED_TO_WINDOW_FILLING);
                 // Window not full: add to delegate, update count, maybe update boundary
                 return delegate.update(null, savedRecord).thenCompose(vignore ->
                         tr.get(boundaryMetaKey).thenAccept(boundaryBytes -> {
@@ -470,16 +476,17 @@ public class SlidingWindowIndexMaintainer extends IndexMaintainer {
                                 .addLogInfo(LogMessageKeys.INDEX_NAME, state.index.getName());
                     }
                     final Tuple boundaryEntryKey = Tuple.fromBytes(boundaryBytes);
-
                     if (!extremumType.isBetter(entryKey, boundaryEntryKey)) {
+                        incrementCounter(SlidingWindowCounter.ITEM_ADDED_TO_ENTRIES_ONLY);
                         // New entry is not better than boundary: it's already written to entries
                         // subspace on the overflow side. Nothing more to do.
                         return AsyncUtil.DONE;
                     }
 
                     // New entry is better: evict boundary from delegate, add new to delegate
-                    return evictBoundaryAndReplace(savedRecord, entryKey, entriesSubspace, tr,
-                            boundaryEntryKey, boundaryMetaKey);
+                    return instrument(SlidingWindowEvent.EVICT_AND_REPLACE,
+                            evictBoundaryAndReplace(savedRecord, entryKey, entriesSubspace, tr,
+                                    boundaryEntryKey, boundaryMetaKey));
                 });
             }
         });
@@ -506,6 +513,7 @@ public class SlidingWindowIndexMaintainer extends IndexMaintainer {
         // Check if this entry exists in the entries subspace
         return tr.get(packedEntryKey).thenCompose(entryValue -> {
             if (entryValue == null) {
+                incrementCounter(SlidingWindowCounter.DELETE_UNTRACKED);
                 // Not tracked, no-op
                 return AsyncUtil.DONE;
             }
@@ -524,6 +532,7 @@ public class SlidingWindowIndexMaintainer extends IndexMaintainer {
                 final Tuple boundaryEntryKey = Tuple.fromBytes(boundaryBytes);
 
                 if (!extremumType.isInWindow(entryKey, boundaryEntryKey)) {
+                    incrementCounter(SlidingWindowCounter.OVERFLOW_ENTRY_DELETED);
                     // Entry was in overflow: already removed from entries, nothing else to do
                     return AsyncUtil.DONE;
                 }
@@ -538,9 +547,10 @@ public class SlidingWindowIndexMaintainer extends IndexMaintainer {
                             .thenCompose(vignore -> updateBoundaryAfterDelete(
                                     entriesSubspace, tr, entryKey, boundaryEntryKey,
                                     boundaryMetaKey, packedEntryKey))
-                            .thenCompose(currentBoundaryPacked -> reElectFromOverflow(
-                                    entriesSubspace, tr, currentBoundaryPacked,
-                                    boundaryMetaKey, counterKey, newCount));
+                            .thenCompose(currentBoundaryPacked -> instrument(
+                                    SlidingWindowEvent.RE_ELECT_FROM_OVERFLOW,
+                                    reElectFromOverflow(entriesSubspace, tr, currentBoundaryPacked,
+                                            boundaryMetaKey, counterKey, newCount)));
                 });
             });
         });
@@ -559,16 +569,23 @@ public class SlidingWindowIndexMaintainer extends IndexMaintainer {
             @Nonnull Transaction tr,
             @Nonnull Tuple boundaryEntryKey,
             @Nonnull byte[] boundaryMetaKey) {
+        incrementCounter(SlidingWindowCounter.BOUNDARY_EVICTED_AND_REPLACED);
         final Tuple boundaryPrimaryKey = TupleHelpers.subTuple(boundaryEntryKey,
                 windowKeyColumnSize, boundaryEntryKey.size());
         final byte[] oldBoundaryPackedKey = entriesSubspace.pack(boundaryEntryKey);
 
         return state.store.loadRecordAsync(boundaryPrimaryKey)
-                .thenCompose(evictedRecord -> evictedRecord != null
-                        ? delegate.update(evictedRecord, null) : AsyncUtil.DONE)
+                .thenCompose(evictedRecord -> {
+                    if (evictedRecord == null) {
+                        incrementCounter(SlidingWindowCounter.EVICTED_RECORD_MISSING);
+                        return AsyncUtil.DONE;
+                    }
+                    return delegate.update(evictedRecord, null);
+                })
                 .thenCompose(v -> delegate.update(null, newRecord))
-                .thenCompose(v -> extremumType.getNewBoundaryAfterEviction(entriesSubspace, tr,
-                        oldBoundaryPackedKey))
+                .thenCompose(v -> instrument(SlidingWindowEvent.BOUNDARY_RESCAN,
+                        extremumType.getNewBoundaryAfterEviction(entriesSubspace, tr,
+                                oldBoundaryPackedKey)))
                 .thenAccept(newBoundaryKV -> {
                     if (newBoundaryKV != null) {
                         final Tuple newBoundaryKey = entriesSubspace.unpack(newBoundaryKV.getKey());
@@ -596,15 +613,19 @@ public class SlidingWindowIndexMaintainer extends IndexMaintainer {
             @Nonnull byte[] boundaryMetaKey,
             @Nonnull byte[] packedEntryKey) {
         if (!entryKey.equals(boundaryEntryKey)) {
+            incrementCounter(SlidingWindowCounter.WINDOW_ENTRY_DELETED);
             return CompletableFuture.completedFuture(entriesSubspace.pack(boundaryEntryKey));
         }
-        return extremumType.getNewBoundaryAfterEviction(entriesSubspace, tr, packedEntryKey)
+        incrementCounter(SlidingWindowCounter.BOUNDARY_ENTRY_DELETED);
+        return instrument(SlidingWindowEvent.BOUNDARY_RESCAN,
+                extremumType.getNewBoundaryAfterEviction(entriesSubspace, tr, packedEntryKey))
                 .thenApply(newBoundaryKV -> {
                     if (newBoundaryKV != null) {
                         final Tuple newBKey = entriesSubspace.unpack(newBoundaryKV.getKey());
                         tr.set(boundaryMetaKey, newBKey.pack());
                         return newBoundaryKV.getKey();
                     } else {
+                        incrementCounter(SlidingWindowCounter.PARTITION_EMPTIED);
                         tr.clear(boundaryMetaKey);
                         return null;
                     }
@@ -629,15 +650,22 @@ public class SlidingWindowIndexMaintainer extends IndexMaintainer {
         return extremumType.getBestInOverflow(entriesSubspace, tr, currentBoundaryPacked)
                 .thenCompose(bestKV -> {
                     if (bestKV == null) {
+                        incrementCounter(SlidingWindowCounter.WINDOW_SHRUNK_NO_OVERFLOW);
                         return AsyncUtil.DONE;
                     }
+                    incrementCounter(SlidingWindowCounter.ITEM_PROMOTED_FROM_OVERFLOW);
                     final Tuple bestEntryKey = entriesSubspace.unpack(bestKV.getKey());
                     final Tuple bestPrimaryKey = Tuple.fromBytes(bestKV.getValue());
                     tr.set(boundaryMetaKey, bestEntryKey.pack());
                     tr.set(counterKey, encodeLong(newCount + 1));
                     return state.store.loadRecordAsync(bestPrimaryKey)
-                            .thenCompose(promotedRecord -> promotedRecord != null
-                                    ? delegate.update(null, promotedRecord) : AsyncUtil.DONE);
+                            .thenCompose(promotedRecord -> {
+                                if (promotedRecord == null) {
+                                    incrementCounter(SlidingWindowCounter.PROMOTED_RECORD_MISSING);
+                                    return AsyncUtil.DONE;
+                                }
+                                return delegate.update(null, promotedRecord);
+                            });
                 });
     }
 
@@ -648,6 +676,7 @@ public class SlidingWindowIndexMaintainer extends IndexMaintainer {
         Verify.verify(partitionKeyColumnSize >= prefix.size(),
                 "deleteWhere prefix size %s exceeds partition key column size %s",
                 prefix.size(), partitionKeyColumnSize);
+        incrementCounter(SlidingWindowCounter.PARTITION_CLEARED);
         final byte[] key = getSlidingWindowSubspace().pack(prefix);
         Range indexRange = new Range(key, ByteArrayUtil.strinc(key));
         state.context.clear(indexRange);
@@ -660,5 +689,74 @@ public class SlidingWindowIndexMaintainer extends IndexMaintainer {
 
     private static long decodeLong(byte[] bytes) {
         return Tuple.fromBytes(bytes).getLong(0);
+    }
+
+    private void incrementCounter(@Nonnull SlidingWindowCounter counter) {
+        final FDBStoreTimer timer = state.context.getTimer();
+        if (timer != null) {
+            timer.increment(counter);
+        }
+    }
+
+    @Nonnull
+    private <T> CompletableFuture<T> instrument(@Nonnull final SlidingWindowEvent event,
+                                                @Nonnull final CompletableFuture<T> future) {
+        final FDBStoreTimer timer = state.context.getTimer();
+        if (timer == null) {
+            return future;
+        }
+        return timer.instrument(event, future);
+    }
+
+    public enum SlidingWindowCounter implements StoreTimer.Count {
+        ITEM_ADDED_TO_WINDOW_FILLING("item added to window while filling up"),
+        ITEM_ADDED_TO_ENTRIES_ONLY("item worse than boundary added to entries"),
+        BOUNDARY_EVICTED_AND_REPLACED("boundary evicted and replaced by better item"),
+        DELETE_UNTRACKED("delete called for untracked record"),
+        OVERFLOW_ENTRY_DELETED("overflow entry deleted from entries"),
+        WINDOW_ENTRY_DELETED("in-window non-boundary entry deleted"),
+        BOUNDARY_ENTRY_DELETED("boundary entry deleted (triggered rescan)"),
+        ITEM_PROMOTED_FROM_OVERFLOW("item promoted from overflow into window"),
+        WINDOW_SHRUNK_NO_OVERFLOW("window shrunk: no overflow available for re-election"),
+        PARTITION_EMPTIED("partition emptied (no entries remain)"),
+        EVICTED_RECORD_MISSING("boundary record could not be loaded for eviction"),
+        PROMOTED_RECORD_MISSING("overflow record could not be loaded for promotion"),
+        PREEMPTIVE_DELETE_WRITE_ONLY("preemptive delete during write-only index build"),
+        PARTITION_CLEARED("partition cleared via deleteWhere");
+
+        @Nonnull
+        private final String title;
+
+        SlidingWindowCounter(@Nonnull final String title) {
+            this.title = title;
+        }
+
+        @Override
+        public boolean isSize() {
+            return false;
+        }
+
+        @Override
+        public String title() {
+            return title;
+        }
+    }
+
+    public enum SlidingWindowEvent implements StoreTimer.Event {
+        EVICT_AND_REPLACE("evict boundary and insert better entry"),
+        RE_ELECT_FROM_OVERFLOW("re-elect overflow entry into window"),
+        BOUNDARY_RESCAN("rescan to locate new boundary");
+
+        @Nonnull
+        private final String title;
+
+        SlidingWindowEvent(@Nonnull final String title) {
+            this.title = title;
+        }
+
+        @Override
+        public String title() {
+            return title;
+        }
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/SlidingWindowIndexMetricsTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/SlidingWindowIndexMetricsTest.java
@@ -354,6 +354,64 @@ class SlidingWindowIndexMetricsTest extends FDBRecordStoreTestBase {
         }
     }
 
+    @Test
+    void delegateInsertEventFiresOnFillAndOnEvictionAndOnPromotion() throws Exception {
+        try (FDBRecordContext context = openContext()) {
+            openStore(context, 2, Direction.DESC);
+
+            // Fill phase: each record goes into the delegate (2 inserts).
+            rec(1, 100);
+            rec(2, 200);
+            assertEquals(2, eventCount(SlidingWindowEvent.SW_DELEGATE_INSERT));
+
+            // Eviction: insert rec3 into the delegate (3 inserts total).
+            rec(3, 300);
+            assertEquals(3, eventCount(SlidingWindowEvent.SW_DELEGATE_INSERT));
+
+            // Overflow add does NOT touch the delegate.
+            rec(4, 50);
+            assertEquals(3, eventCount(SlidingWindowEvent.SW_DELEGATE_INSERT));
+
+            // Window delete + promotion from overflow inserts rec4 into the delegate (4 total).
+            deleteRec(2);
+            assertEquals(4, eventCount(SlidingWindowEvent.SW_DELEGATE_INSERT));
+
+            assertTrue(timeNanos(SlidingWindowEvent.SW_DELEGATE_INSERT) > 0,
+                    "SW_DELEGATE_INSERT duration should be positive");
+            commit(context);
+        }
+    }
+
+    @Test
+    void delegateDeleteEventFiresOnEvictionAndOnWindowDelete() throws Exception {
+        try (FDBRecordContext context = openContext()) {
+            openStore(context, 2, Direction.DESC);
+            rec(1, 100);
+            rec(2, 200);
+            assertEquals(0, eventCount(SlidingWindowEvent.SW_DELEGATE_DELETE));
+
+            // Eviction removes rec1 from the delegate.
+            rec(3, 300);
+            assertEquals(1, eventCount(SlidingWindowEvent.SW_DELEGATE_DELETE));
+
+            // Overflow add does NOT touch the delegate, neither for insert nor for delete.
+            rec(4, 50);
+            assertEquals(1, eventCount(SlidingWindowEvent.SW_DELEGATE_DELETE));
+
+            // Overflow delete does NOT touch the delegate either.
+            deleteRec(4);
+            assertEquals(1, eventCount(SlidingWindowEvent.SW_DELEGATE_DELETE));
+
+            // Window delete removes rec2 from the delegate.
+            deleteRec(2);
+            assertEquals(2, eventCount(SlidingWindowEvent.SW_DELEGATE_DELETE));
+
+            assertTrue(timeNanos(SlidingWindowEvent.SW_DELEGATE_DELETE) > 0,
+                    "SW_DELEGATE_DELETE duration should be positive");
+            commit(context);
+        }
+    }
+
     // ===== Robustness =====
 
     @Test

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/SlidingWindowIndexMetricsTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/SlidingWindowIndexMetricsTest.java
@@ -1,0 +1,435 @@
+/*
+ * SlidingWindowIndexMetricsTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb.indexes;
+
+import com.apple.foundationdb.linear.HalfRealVector;
+import com.apple.foundationdb.linear.Metric;
+import com.apple.foundationdb.record.RecordMetaData;
+import com.apple.foundationdb.record.RecordMetaDataBuilder;
+import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.metadata.IndexOptions;
+import com.apple.foundationdb.record.metadata.IndexPredicate;
+import com.apple.foundationdb.record.metadata.IndexPredicate.RowNumberWindowPredicate.Direction;
+import com.apple.foundationdb.record.metadata.IndexTypes;
+import com.apple.foundationdb.record.metadata.Key;
+import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
+import com.apple.foundationdb.record.metadata.expressions.KeyWithValueExpression;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContextConfig;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreTestBase;
+import com.apple.foundationdb.record.provider.foundationdb.FDBStoredRecord;
+import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
+import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainer;
+import com.apple.foundationdb.record.provider.foundationdb.indexes.SlidingWindowIndexMaintainer.SlidingWindowCounter;
+import com.apple.foundationdb.record.provider.foundationdb.indexes.SlidingWindowIndexMaintainer.SlidingWindowEvent;
+import com.apple.foundationdb.record.slidingwindowvector.TestRecordsSlidingWindowVectorProto;
+import com.apple.foundationdb.record.slidingwindowvector.TestRecordsSlidingWindowVectorProto.SlidingWindowVectorRecord;
+import com.apple.foundationdb.tuple.Tuple;
+import com.apple.test.Tags;
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Message;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.apple.foundationdb.record.provider.foundationdb.indexes.SlidingWindowTestHelpers.sampleVector;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+/**
+ * Tests that the {@link SlidingWindowIndexMaintainer} reports the expected counters
+ * and timing events through {@link FDBStoreTimer} for each operational path.
+ *
+ * <p>Each test exercises one code path and asserts that the corresponding
+ * {@link SlidingWindowCounter} or {@link SlidingWindowEvent} fires the expected
+ * number of times. Counters that require a corruption scenario to fire
+ * ({@code EVICTED_RECORD_MISSING}, {@code PROMOTED_RECORD_MISSING}) and
+ * {@code DELETE_UNTRACKED} (which requires window-key divergence between an indexed
+ * entry and its later delete) are not exercised here because they are not reachable
+ * via the public API without manual subspace manipulation.</p>
+ */
+@Tag(Tags.RequiresFDB)
+class SlidingWindowIndexMetricsTest extends FDBRecordStoreTestBase {
+
+    private static final String INDEX_NAME = "sw_vector_index";
+    private static final int VECTOR_DIMS = 4;
+
+    private FDBStoreTimer timer;
+
+    /**
+     * Opens an FDB context with a fresh timer attached so each test can read counters
+     * without bleed-over from the parent test base.
+     */
+    @Nonnull
+    private FDBRecordContext openTimerContext() {
+        timer = new FDBStoreTimer();
+        final FDBRecordContextConfig config = FDBRecordContextConfig.newBuilder()
+                .setTimer(timer)
+                .build();
+        return fdb.openContext(config);
+    }
+
+    private void openStore(@Nonnull FDBRecordContext context, int windowSize,
+                           @Nonnull Direction direction) throws Exception {
+        openStore(context, windowSize, direction, ImmutableList.of());
+    }
+
+    private void openStore(@Nonnull FDBRecordContext context, int windowSize,
+                           @Nonnull Direction direction,
+                           @Nonnull List<List<String>> groupingFields) throws Exception {
+        final RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder()
+                .setRecords(TestRecordsSlidingWindowVectorProto.getDescriptor());
+        metaDataBuilder.getRecordType("SlidingWindowVectorRecord")
+                .setPrimaryKey(Key.Expressions.field("rec_no"));
+
+        final IndexPredicate.RowNumberWindowPredicate windowPredicate =
+                new IndexPredicate.RowNumberWindowPredicate(
+                        ImmutableList.of("relevance"), direction, windowSize, groupingFields);
+
+        final Map<String, String> options = new HashMap<>();
+        options.put(IndexOptions.HNSW_METRIC, Metric.EUCLIDEAN_METRIC.name());
+        options.put(IndexOptions.HNSW_NUM_DIMENSIONS, Integer.toString(VECTOR_DIMS));
+
+        final KeyExpression keyExpr;
+        if (groupingFields.isEmpty()) {
+            keyExpr = new KeyWithValueExpression(Key.Expressions.field("vector_data"), 0);
+        } else {
+            KeyExpression prefix = Key.Expressions.field(groupingFields.get(0).get(0));
+            for (int i = 1; i < groupingFields.size(); i++) {
+                prefix = Key.Expressions.concat(prefix, Key.Expressions.field(groupingFields.get(i).get(0)));
+            }
+            keyExpr = new KeyWithValueExpression(
+                    Key.Expressions.concat(prefix, Key.Expressions.field("vector_data")),
+                    groupingFields.size());
+        }
+
+        metaDataBuilder.addIndex("SlidingWindowVectorRecord",
+                new Index(INDEX_NAME, keyExpr, IndexTypes.VECTOR, options, windowPredicate));
+
+        createOrOpenRecordStore(context, metaDataBuilder.getRecordMetaData());
+    }
+
+    private void rec(long recNo, long relevance) {
+        rec(recNo, "z", "c", relevance, sampleVector());
+    }
+
+    private void rec(long recNo, String zone, String category, long relevance, HalfRealVector vector) {
+        recordStore.saveRecord(SlidingWindowVectorRecord.newBuilder()
+                .setRecNo(recNo)
+                .setZone(zone)
+                .setCategory(category)
+                .setRelevance(relevance)
+                .setScore(0)
+                .setVectorData(ByteString.copyFrom(vector.getRawData()))
+                .build());
+    }
+
+    private void deleteRec(long recNo) {
+        recordStore.deleteRecord(Tuple.from(recNo));
+    }
+
+    @Nonnull
+    private IndexMaintainer maintainer() {
+        final Index index = recordStore.getRecordMetaData().getIndex(INDEX_NAME);
+        return recordStore.getIndexMaintainer(index);
+    }
+
+    private long count(@Nonnull SlidingWindowCounter counter) {
+        return timer.getCount(counter);
+    }
+
+    private long eventCount(@Nonnull SlidingWindowEvent event) {
+        return timer.getCount(event);
+    }
+
+    private long timeNanos(@Nonnull SlidingWindowEvent event) {
+        return timer.getTimeNanos(event);
+    }
+
+    // ===== Insert path counters =====
+
+    @Test
+    void itemAddedToWindowFillingFiresOnEachInsertWhileFilling() throws Exception {
+        try (FDBRecordContext context = openTimerContext()) {
+            openStore(context, 5, Direction.DESC);
+            rec(1, 100);
+            rec(2, 200);
+            rec(3, 300);
+
+            assertEquals(3, count(SlidingWindowCounter.ITEM_ADDED_TO_WINDOW_FILLING));
+            assertEquals(0, count(SlidingWindowCounter.ITEM_ADDED_TO_ENTRIES_ONLY));
+            assertEquals(0, count(SlidingWindowCounter.BOUNDARY_EVICTED_AND_REPLACED));
+            commit(context);
+        }
+    }
+
+    @Test
+    void itemAddedToEntriesOnlyFiresWhenOverflowed() throws Exception {
+        try (FDBRecordContext context = openTimerContext()) {
+            openStore(context, 3, Direction.DESC);
+            rec(1, 100);
+            rec(2, 200);
+            rec(3, 300);
+            assertEquals(3, count(SlidingWindowCounter.ITEM_ADDED_TO_WINDOW_FILLING));
+
+            rec(4, 50);  // worse than boundary (100) for DESC → overflow
+
+            assertEquals(1, count(SlidingWindowCounter.ITEM_ADDED_TO_ENTRIES_ONLY));
+            assertEquals(0, count(SlidingWindowCounter.BOUNDARY_EVICTED_AND_REPLACED));
+            commit(context);
+        }
+    }
+
+    @Test
+    void boundaryEvictedAndReplacedFiresWhenWindowFullAndBetter() throws Exception {
+        try (FDBRecordContext context = openTimerContext()) {
+            openStore(context, 3, Direction.DESC);
+            rec(1, 100);
+            rec(2, 200);
+            rec(3, 300);
+
+            rec(4, 400);  // better than boundary (100) for DESC → eviction
+
+            assertEquals(1, count(SlidingWindowCounter.BOUNDARY_EVICTED_AND_REPLACED));
+            assertEquals(0, count(SlidingWindowCounter.ITEM_ADDED_TO_ENTRIES_ONLY));
+            commit(context);
+        }
+    }
+
+    // ===== Delete path counters =====
+
+    @Test
+    void overflowEntryDeletedFiresWhenDeletingOverflowRecord() throws Exception {
+        try (FDBRecordContext context = openTimerContext()) {
+            openStore(context, 3, Direction.DESC);
+            rec(1, 100);
+            rec(2, 200);
+            rec(3, 300);
+            rec(4, 50);  // overflow
+
+            deleteRec(4);
+
+            assertEquals(1, count(SlidingWindowCounter.OVERFLOW_ENTRY_DELETED));
+            assertEquals(0, count(SlidingWindowCounter.WINDOW_ENTRY_DELETED));
+            assertEquals(0, count(SlidingWindowCounter.BOUNDARY_ENTRY_DELETED));
+            assertEquals(0, count(SlidingWindowCounter.ITEM_PROMOTED_FROM_OVERFLOW));
+            commit(context);
+        }
+    }
+
+    @Test
+    void windowEntryDeletedFiresWhenDeletingNonBoundaryInWindow() throws Exception {
+        try (FDBRecordContext context = openTimerContext()) {
+            openStore(context, 3, Direction.DESC);
+            rec(1, 100);  // boundary for DESC (lowest)
+            rec(2, 200);
+            rec(3, 300);
+
+            deleteRec(2);  // in window, not boundary
+
+            assertEquals(1, count(SlidingWindowCounter.WINDOW_ENTRY_DELETED));
+            assertEquals(0, count(SlidingWindowCounter.BOUNDARY_ENTRY_DELETED));
+            commit(context);
+        }
+    }
+
+    @Test
+    void boundaryEntryDeletedFiresWhenDeletingTheBoundary() throws Exception {
+        try (FDBRecordContext context = openTimerContext()) {
+            openStore(context, 3, Direction.DESC);
+            rec(1, 100);  // boundary for DESC (lowest)
+            rec(2, 200);
+            rec(3, 300);
+
+            deleteRec(1);  // delete the boundary
+
+            assertEquals(1, count(SlidingWindowCounter.BOUNDARY_ENTRY_DELETED));
+            assertEquals(0, count(SlidingWindowCounter.WINDOW_ENTRY_DELETED));
+            commit(context);
+        }
+    }
+
+    @Test
+    void itemPromotedFromOverflowFiresAfterWindowDeleteWhenOverflowAvailable() throws Exception {
+        try (FDBRecordContext context = openTimerContext()) {
+            openStore(context, 3, Direction.DESC);
+            rec(1, 100);
+            rec(2, 200);
+            rec(3, 300);
+            rec(4, 50);  // overflow
+
+            deleteRec(2);  // in-window delete; should promote rec4 from overflow
+
+            assertEquals(1, count(SlidingWindowCounter.WINDOW_ENTRY_DELETED));
+            assertEquals(1, count(SlidingWindowCounter.ITEM_PROMOTED_FROM_OVERFLOW));
+            assertEquals(0, count(SlidingWindowCounter.WINDOW_SHRUNK_NO_OVERFLOW));
+            commit(context);
+        }
+    }
+
+    @Test
+    void windowShrunkNoOverflowFiresWhenNothingToPromote() throws Exception {
+        try (FDBRecordContext context = openTimerContext()) {
+            openStore(context, 5, Direction.DESC);
+            rec(1, 100);
+            rec(2, 200);
+            rec(3, 300);
+
+            deleteRec(2);  // no overflow exists; window simply shrinks
+
+            assertEquals(1, count(SlidingWindowCounter.WINDOW_ENTRY_DELETED));
+            assertEquals(1, count(SlidingWindowCounter.WINDOW_SHRUNK_NO_OVERFLOW));
+            assertEquals(0, count(SlidingWindowCounter.ITEM_PROMOTED_FROM_OVERFLOW));
+            commit(context);
+        }
+    }
+
+    @Test
+    void partitionEmptiedFiresWhenLastEntryRemoved() throws Exception {
+        try (FDBRecordContext context = openTimerContext()) {
+            openStore(context, 3, Direction.DESC);
+            rec(1, 100);
+
+            deleteRec(1);  // boundary delete with no other entries
+
+            assertEquals(1, count(SlidingWindowCounter.BOUNDARY_ENTRY_DELETED));
+            assertEquals(1, count(SlidingWindowCounter.PARTITION_EMPTIED));
+            commit(context);
+        }
+    }
+
+    // ===== Special operations =====
+
+    @Test
+    void preemptiveDeleteWriteOnlyFiresOnUpdateWhileWriteOnly() throws Exception {
+        try (FDBRecordContext context = openTimerContext()) {
+            openStore(context, 3, Direction.DESC);
+            rec(1, 100);
+            final FDBStoredRecord<Message> stored = recordStore.loadRecord(Tuple.from(1L));
+            assertNotNull(stored);
+
+            timer.reset();
+
+            maintainer().updateWhileWriteOnly(null, stored).join();
+
+            assertEquals(1, count(SlidingWindowCounter.PREEMPTIVE_DELETE_WRITE_ONLY));
+            commit(context);
+        }
+    }
+
+    @Test
+    void partitionClearedFiresOnDeleteWhere() throws Exception {
+        try (FDBRecordContext context = openTimerContext()) {
+            openStore(context, 3, Direction.DESC, ImmutableList.of(ImmutableList.of("zone")));
+            rec(1, "A", "c", 100, sampleVector());
+            rec(2, "A", "c", 200, sampleVector());
+            rec(3, "B", "c", 300, sampleVector());
+
+            maintainer().deleteWhere(context.ensureActive(), Tuple.from("A")).join();
+
+            assertEquals(1, count(SlidingWindowCounter.PARTITION_CLEARED));
+            commit(context);
+        }
+    }
+
+    // ===== Timer events =====
+
+    @Test
+    void evictAndReplaceEventIsTimed() throws Exception {
+        try (FDBRecordContext context = openTimerContext()) {
+            openStore(context, 2, Direction.DESC);
+            rec(1, 100);
+            rec(2, 200);
+
+            rec(3, 300);  // evicts rec1
+
+            assertEquals(1, eventCount(SlidingWindowEvent.EVICT_AND_REPLACE));
+            assertTrue(timeNanos(SlidingWindowEvent.EVICT_AND_REPLACE) > 0,
+                    "EVICT_AND_REPLACE duration should be positive");
+            commit(context);
+        }
+    }
+
+    @Test
+    void reElectFromOverflowEventIsTimed() throws Exception {
+        try (FDBRecordContext context = openTimerContext()) {
+            openStore(context, 2, Direction.DESC);
+            rec(1, 100);
+            rec(2, 200);
+            rec(3, 50);  // overflow (worse than boundary 100)
+
+            deleteRec(1);  // window delete → re-elect from overflow
+
+            assertEquals(1, eventCount(SlidingWindowEvent.RE_ELECT_FROM_OVERFLOW));
+            assertTrue(timeNanos(SlidingWindowEvent.RE_ELECT_FROM_OVERFLOW) > 0,
+                    "RE_ELECT_FROM_OVERFLOW duration should be positive");
+            commit(context);
+        }
+    }
+
+    @Test
+    void boundaryRescanEventFiresOnEvictionAndOnBoundaryDelete() throws Exception {
+        try (FDBRecordContext context = openTimerContext()) {
+            openStore(context, 2, Direction.DESC);
+            rec(1, 100);
+            rec(2, 200);
+
+            // Eviction path: triggers one BOUNDARY_RESCAN.
+            rec(3, 300);
+            assertEquals(1, eventCount(SlidingWindowEvent.BOUNDARY_RESCAN));
+
+            // Boundary-delete path: triggers a second BOUNDARY_RESCAN.
+            // After the eviction above, window holds {2,3}; boundary for DESC is rec2 (lowest).
+            deleteRec(2);
+            assertEquals(2, eventCount(SlidingWindowEvent.BOUNDARY_RESCAN));
+            assertTrue(timeNanos(SlidingWindowEvent.BOUNDARY_RESCAN) > 0,
+                    "BOUNDARY_RESCAN duration should be positive");
+            commit(context);
+        }
+    }
+
+    // ===== Robustness =====
+
+    @Test
+    void operationsDoNotFailWhenContextHasNoTimer() throws Exception {
+        // Opens via the parent test base, which does not attach an FDBStoreTimer.
+        try (FDBRecordContext context = openContext()) {
+            openStore(context, 2, Direction.DESC);
+
+            assertDoesNotThrow(() -> {
+                rec(1, 100);
+                rec(2, 200);
+                rec(3, 300);  // eviction
+                rec(4, 50);   // overflow
+                deleteRec(2); // re-election
+                deleteRec(4); // overflow delete
+            });
+            commit(context);
+        }
+    }
+}

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/SlidingWindowIndexMetricsTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/SlidingWindowIndexMetricsTest.java
@@ -21,45 +21,33 @@
 package com.apple.foundationdb.record.provider.foundationdb.indexes;
 
 import com.apple.foundationdb.linear.HalfRealVector;
-import com.apple.foundationdb.linear.Metric;
-import com.apple.foundationdb.record.RecordMetaData;
-import com.apple.foundationdb.record.RecordMetaDataBuilder;
 import com.apple.foundationdb.record.metadata.Index;
-import com.apple.foundationdb.record.metadata.IndexOptions;
-import com.apple.foundationdb.record.metadata.IndexPredicate;
 import com.apple.foundationdb.record.metadata.IndexPredicate.RowNumberWindowPredicate.Direction;
-import com.apple.foundationdb.record.metadata.IndexTypes;
-import com.apple.foundationdb.record.metadata.Key;
-import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
-import com.apple.foundationdb.record.metadata.expressions.KeyWithValueExpression;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
-import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContextConfig;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreTestBase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoredRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainer;
 import com.apple.foundationdb.record.provider.foundationdb.indexes.SlidingWindowIndexMaintainer.SlidingWindowCounter;
 import com.apple.foundationdb.record.provider.foundationdb.indexes.SlidingWindowIndexMaintainer.SlidingWindowEvent;
-import com.apple.foundationdb.record.slidingwindowvector.TestRecordsSlidingWindowVectorProto;
+import com.apple.foundationdb.record.provider.foundationdb.indexes.SlidingWindowIndexMaintainer.SlidingWindowSizeEvent;
 import com.apple.foundationdb.record.slidingwindowvector.TestRecordsSlidingWindowVectorProto.SlidingWindowVectorRecord;
 import com.apple.foundationdb.tuple.Tuple;
 import com.apple.test.Tags;
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Message;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import static com.apple.foundationdb.record.provider.foundationdb.indexes.SlidingWindowTestHelpers.sampleVector;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 /**
  * Tests that the {@link SlidingWindowIndexMaintainer} reports the expected counters
@@ -79,59 +67,22 @@ class SlidingWindowIndexMetricsTest extends FDBRecordStoreTestBase {
     private static final String INDEX_NAME = "sw_vector_index";
     private static final int VECTOR_DIMS = 4;
 
-    private FDBStoreTimer timer;
-
-    /**
-     * Opens an FDB context with a fresh timer attached so each test can read counters
-     * without bleed-over from the parent test base.
-     */
-    @Nonnull
-    private FDBRecordContext openTimerContext() {
-        timer = new FDBStoreTimer();
-        final FDBRecordContextConfig config = FDBRecordContextConfig.newBuilder()
-                .setTimer(timer)
-                .build();
-        return fdb.openContext(config);
+    @BeforeEach
+    void resetTimer() {
+        timer.reset();
     }
 
     private void openStore(@Nonnull FDBRecordContext context, int windowSize,
-                           @Nonnull Direction direction) throws Exception {
+                           @Nonnull Direction direction) {
         openStore(context, windowSize, direction, ImmutableList.of());
     }
 
     private void openStore(@Nonnull FDBRecordContext context, int windowSize,
                            @Nonnull Direction direction,
-                           @Nonnull List<List<String>> groupingFields) throws Exception {
-        final RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder()
-                .setRecords(TestRecordsSlidingWindowVectorProto.getDescriptor());
-        metaDataBuilder.getRecordType("SlidingWindowVectorRecord")
-                .setPrimaryKey(Key.Expressions.field("rec_no"));
-
-        final IndexPredicate.RowNumberWindowPredicate windowPredicate =
-                new IndexPredicate.RowNumberWindowPredicate(
-                        ImmutableList.of("relevance"), direction, windowSize, groupingFields);
-
-        final Map<String, String> options = new HashMap<>();
-        options.put(IndexOptions.HNSW_METRIC, Metric.EUCLIDEAN_METRIC.name());
-        options.put(IndexOptions.HNSW_NUM_DIMENSIONS, Integer.toString(VECTOR_DIMS));
-
-        final KeyExpression keyExpr;
-        if (groupingFields.isEmpty()) {
-            keyExpr = new KeyWithValueExpression(Key.Expressions.field("vector_data"), 0);
-        } else {
-            KeyExpression prefix = Key.Expressions.field(groupingFields.get(0).get(0));
-            for (int i = 1; i < groupingFields.size(); i++) {
-                prefix = Key.Expressions.concat(prefix, Key.Expressions.field(groupingFields.get(i).get(0)));
-            }
-            keyExpr = new KeyWithValueExpression(
-                    Key.Expressions.concat(prefix, Key.Expressions.field("vector_data")),
-                    groupingFields.size());
-        }
-
-        metaDataBuilder.addIndex("SlidingWindowVectorRecord",
-                new Index(INDEX_NAME, keyExpr, IndexTypes.VECTOR, options, windowPredicate));
-
-        createOrOpenRecordStore(context, metaDataBuilder.getRecordMetaData());
+                           @Nonnull List<List<String>> groupingFields) {
+        createOrOpenRecordStore(context,
+                SlidingWindowTestHelpers.buildSlidingWindowVectorMetaData(
+                        INDEX_NAME, windowSize, VECTOR_DIMS, direction, groupingFields));
     }
 
     private void rec(long recNo, long relevance) {
@@ -171,52 +122,44 @@ class SlidingWindowIndexMetricsTest extends FDBRecordStoreTestBase {
         return timer.getTimeNanos(event);
     }
 
+    private long sizeEventCount(@Nonnull SlidingWindowSizeEvent event) {
+        return timer.getCount(event);
+    }
+
+    private long cumulativeSize(@Nonnull SlidingWindowSizeEvent event) {
+        return timer.getSize(event);
+    }
+
     // ===== Insert path counters =====
 
     @Test
     void itemAddedToWindowFillingFiresOnEachInsertWhileFilling() throws Exception {
-        try (FDBRecordContext context = openTimerContext()) {
+        try (FDBRecordContext context = openContext()) {
             openStore(context, 5, Direction.DESC);
             rec(1, 100);
             rec(2, 200);
             rec(3, 300);
 
-            assertEquals(3, count(SlidingWindowCounter.ITEM_ADDED_TO_WINDOW_FILLING));
-            assertEquals(0, count(SlidingWindowCounter.ITEM_ADDED_TO_ENTRIES_ONLY));
-            assertEquals(0, count(SlidingWindowCounter.BOUNDARY_EVICTED_AND_REPLACED));
+            assertEquals(3, count(SlidingWindowCounter.SW_ITEM_ADDED_TO_WINDOW_FILLING));
+            assertEquals(0, count(SlidingWindowCounter.SW_ITEM_ADDED_TO_ENTRIES_ONLY));
+            assertEquals(0, eventCount(SlidingWindowEvent.SW_EVICT_AND_REPLACE));
             commit(context);
         }
     }
 
     @Test
     void itemAddedToEntriesOnlyFiresWhenOverflowed() throws Exception {
-        try (FDBRecordContext context = openTimerContext()) {
+        try (FDBRecordContext context = openContext()) {
             openStore(context, 3, Direction.DESC);
             rec(1, 100);
             rec(2, 200);
             rec(3, 300);
-            assertEquals(3, count(SlidingWindowCounter.ITEM_ADDED_TO_WINDOW_FILLING));
+            assertEquals(3, count(SlidingWindowCounter.SW_ITEM_ADDED_TO_WINDOW_FILLING));
 
             rec(4, 50);  // worse than boundary (100) for DESC → overflow
 
-            assertEquals(1, count(SlidingWindowCounter.ITEM_ADDED_TO_ENTRIES_ONLY));
-            assertEquals(0, count(SlidingWindowCounter.BOUNDARY_EVICTED_AND_REPLACED));
-            commit(context);
-        }
-    }
-
-    @Test
-    void boundaryEvictedAndReplacedFiresWhenWindowFullAndBetter() throws Exception {
-        try (FDBRecordContext context = openTimerContext()) {
-            openStore(context, 3, Direction.DESC);
-            rec(1, 100);
-            rec(2, 200);
-            rec(3, 300);
-
-            rec(4, 400);  // better than boundary (100) for DESC → eviction
-
-            assertEquals(1, count(SlidingWindowCounter.BOUNDARY_EVICTED_AND_REPLACED));
-            assertEquals(0, count(SlidingWindowCounter.ITEM_ADDED_TO_ENTRIES_ONLY));
+            assertEquals(1, count(SlidingWindowCounter.SW_ITEM_ADDED_TO_ENTRIES_ONLY));
+            assertEquals(0, eventCount(SlidingWindowEvent.SW_EVICT_AND_REPLACE));
             commit(context);
         }
     }
@@ -225,7 +168,7 @@ class SlidingWindowIndexMetricsTest extends FDBRecordStoreTestBase {
 
     @Test
     void overflowEntryDeletedFiresWhenDeletingOverflowRecord() throws Exception {
-        try (FDBRecordContext context = openTimerContext()) {
+        try (FDBRecordContext context = openContext()) {
             openStore(context, 3, Direction.DESC);
             rec(1, 100);
             rec(2, 200);
@@ -234,17 +177,17 @@ class SlidingWindowIndexMetricsTest extends FDBRecordStoreTestBase {
 
             deleteRec(4);
 
-            assertEquals(1, count(SlidingWindowCounter.OVERFLOW_ENTRY_DELETED));
-            assertEquals(0, count(SlidingWindowCounter.WINDOW_ENTRY_DELETED));
-            assertEquals(0, count(SlidingWindowCounter.BOUNDARY_ENTRY_DELETED));
-            assertEquals(0, count(SlidingWindowCounter.ITEM_PROMOTED_FROM_OVERFLOW));
+            assertEquals(1, count(SlidingWindowCounter.SW_OVERFLOW_ENTRY_DELETED));
+            assertEquals(0, count(SlidingWindowCounter.SW_WINDOW_ENTRY_DELETED));
+            assertEquals(0, eventCount(SlidingWindowEvent.SW_BOUNDARY_RESCAN_AFTER_DELETE));
+            assertEquals(0, count(SlidingWindowCounter.SW_ITEM_PROMOTED_FROM_OVERFLOW));
             commit(context);
         }
     }
 
     @Test
     void windowEntryDeletedFiresWhenDeletingNonBoundaryInWindow() throws Exception {
-        try (FDBRecordContext context = openTimerContext()) {
+        try (FDBRecordContext context = openContext()) {
             openStore(context, 3, Direction.DESC);
             rec(1, 100);  // boundary for DESC (lowest)
             rec(2, 200);
@@ -252,15 +195,15 @@ class SlidingWindowIndexMetricsTest extends FDBRecordStoreTestBase {
 
             deleteRec(2);  // in window, not boundary
 
-            assertEquals(1, count(SlidingWindowCounter.WINDOW_ENTRY_DELETED));
-            assertEquals(0, count(SlidingWindowCounter.BOUNDARY_ENTRY_DELETED));
+            assertEquals(1, count(SlidingWindowCounter.SW_WINDOW_ENTRY_DELETED));
+            assertEquals(0, eventCount(SlidingWindowEvent.SW_BOUNDARY_RESCAN_AFTER_DELETE));
             commit(context);
         }
     }
 
     @Test
-    void boundaryEntryDeletedFiresWhenDeletingTheBoundary() throws Exception {
-        try (FDBRecordContext context = openTimerContext()) {
+    void boundaryDeleteTriggersRescanAfterDeleteEvent() throws Exception {
+        try (FDBRecordContext context = openContext()) {
             openStore(context, 3, Direction.DESC);
             rec(1, 100);  // boundary for DESC (lowest)
             rec(2, 200);
@@ -268,15 +211,17 @@ class SlidingWindowIndexMetricsTest extends FDBRecordStoreTestBase {
 
             deleteRec(1);  // delete the boundary
 
-            assertEquals(1, count(SlidingWindowCounter.BOUNDARY_ENTRY_DELETED));
-            assertEquals(0, count(SlidingWindowCounter.WINDOW_ENTRY_DELETED));
+            assertEquals(0, count(SlidingWindowCounter.SW_WINDOW_ENTRY_DELETED));
+            assertEquals(1, eventCount(SlidingWindowEvent.SW_BOUNDARY_RESCAN_AFTER_DELETE));
+            assertTrue(timeNanos(SlidingWindowEvent.SW_BOUNDARY_RESCAN_AFTER_DELETE) > 0,
+                    "SW_BOUNDARY_RESCAN_AFTER_DELETE duration should be positive");
             commit(context);
         }
     }
 
     @Test
     void itemPromotedFromOverflowFiresAfterWindowDeleteWhenOverflowAvailable() throws Exception {
-        try (FDBRecordContext context = openTimerContext()) {
+        try (FDBRecordContext context = openContext()) {
             openStore(context, 3, Direction.DESC);
             rec(1, 100);
             rec(2, 200);
@@ -285,16 +230,16 @@ class SlidingWindowIndexMetricsTest extends FDBRecordStoreTestBase {
 
             deleteRec(2);  // in-window delete; should promote rec4 from overflow
 
-            assertEquals(1, count(SlidingWindowCounter.WINDOW_ENTRY_DELETED));
-            assertEquals(1, count(SlidingWindowCounter.ITEM_PROMOTED_FROM_OVERFLOW));
-            assertEquals(0, count(SlidingWindowCounter.WINDOW_SHRUNK_NO_OVERFLOW));
+            assertEquals(1, count(SlidingWindowCounter.SW_WINDOW_ENTRY_DELETED));
+            assertEquals(1, count(SlidingWindowCounter.SW_ITEM_PROMOTED_FROM_OVERFLOW));
+            assertEquals(0, count(SlidingWindowCounter.SW_WINDOW_SHRUNK_NO_OVERFLOW));
             commit(context);
         }
     }
 
     @Test
     void windowShrunkNoOverflowFiresWhenNothingToPromote() throws Exception {
-        try (FDBRecordContext context = openTimerContext()) {
+        try (FDBRecordContext context = openContext()) {
             openStore(context, 5, Direction.DESC);
             rec(1, 100);
             rec(2, 200);
@@ -302,23 +247,23 @@ class SlidingWindowIndexMetricsTest extends FDBRecordStoreTestBase {
 
             deleteRec(2);  // no overflow exists; window simply shrinks
 
-            assertEquals(1, count(SlidingWindowCounter.WINDOW_ENTRY_DELETED));
-            assertEquals(1, count(SlidingWindowCounter.WINDOW_SHRUNK_NO_OVERFLOW));
-            assertEquals(0, count(SlidingWindowCounter.ITEM_PROMOTED_FROM_OVERFLOW));
+            assertEquals(1, count(SlidingWindowCounter.SW_WINDOW_ENTRY_DELETED));
+            assertEquals(1, count(SlidingWindowCounter.SW_WINDOW_SHRUNK_NO_OVERFLOW));
+            assertEquals(0, count(SlidingWindowCounter.SW_ITEM_PROMOTED_FROM_OVERFLOW));
             commit(context);
         }
     }
 
     @Test
     void partitionEmptiedFiresWhenLastEntryRemoved() throws Exception {
-        try (FDBRecordContext context = openTimerContext()) {
+        try (FDBRecordContext context = openContext()) {
             openStore(context, 3, Direction.DESC);
             rec(1, 100);
 
             deleteRec(1);  // boundary delete with no other entries
 
-            assertEquals(1, count(SlidingWindowCounter.BOUNDARY_ENTRY_DELETED));
-            assertEquals(1, count(SlidingWindowCounter.PARTITION_EMPTIED));
+            assertEquals(1, count(SlidingWindowCounter.SW_PARTITION_EMPTIED));
+            assertEquals(1, eventCount(SlidingWindowEvent.SW_BOUNDARY_RESCAN_AFTER_DELETE));
             commit(context);
         }
     }
@@ -327,7 +272,7 @@ class SlidingWindowIndexMetricsTest extends FDBRecordStoreTestBase {
 
     @Test
     void preemptiveDeleteWriteOnlyFiresOnUpdateWhileWriteOnly() throws Exception {
-        try (FDBRecordContext context = openTimerContext()) {
+        try (FDBRecordContext context = openContext()) {
             openStore(context, 3, Direction.DESC);
             rec(1, 100);
             final FDBStoredRecord<Message> stored = recordStore.loadRecord(Tuple.from(1L));
@@ -337,14 +282,14 @@ class SlidingWindowIndexMetricsTest extends FDBRecordStoreTestBase {
 
             maintainer().updateWhileWriteOnly(null, stored).join();
 
-            assertEquals(1, count(SlidingWindowCounter.PREEMPTIVE_DELETE_WRITE_ONLY));
+            assertEquals(1, count(SlidingWindowCounter.SW_PREEMPTIVE_DELETE_WRITE_ONLY));
             commit(context);
         }
     }
 
     @Test
     void partitionClearedFiresOnDeleteWhere() throws Exception {
-        try (FDBRecordContext context = openTimerContext()) {
+        try (FDBRecordContext context = openContext()) {
             openStore(context, 3, Direction.DESC, ImmutableList.of(ImmutableList.of("zone")));
             rec(1, "A", "c", 100, sampleVector());
             rec(2, "A", "c", 200, sampleVector());
@@ -352,7 +297,7 @@ class SlidingWindowIndexMetricsTest extends FDBRecordStoreTestBase {
 
             maintainer().deleteWhere(context.ensureActive(), Tuple.from("A")).join();
 
-            assertEquals(1, count(SlidingWindowCounter.PARTITION_CLEARED));
+            assertEquals(1, count(SlidingWindowCounter.SW_PARTITION_CLEARED));
             commit(context);
         }
     }
@@ -361,23 +306,23 @@ class SlidingWindowIndexMetricsTest extends FDBRecordStoreTestBase {
 
     @Test
     void evictAndReplaceEventIsTimed() throws Exception {
-        try (FDBRecordContext context = openTimerContext()) {
+        try (FDBRecordContext context = openContext()) {
             openStore(context, 2, Direction.DESC);
             rec(1, 100);
             rec(2, 200);
 
             rec(3, 300);  // evicts rec1
 
-            assertEquals(1, eventCount(SlidingWindowEvent.EVICT_AND_REPLACE));
-            assertTrue(timeNanos(SlidingWindowEvent.EVICT_AND_REPLACE) > 0,
-                    "EVICT_AND_REPLACE duration should be positive");
+            assertEquals(1, eventCount(SlidingWindowEvent.SW_EVICT_AND_REPLACE));
+            assertTrue(timeNanos(SlidingWindowEvent.SW_EVICT_AND_REPLACE) > 0,
+                    "SW_EVICT_AND_REPLACE duration should be positive");
             commit(context);
         }
     }
 
     @Test
     void reElectFromOverflowEventIsTimed() throws Exception {
-        try (FDBRecordContext context = openTimerContext()) {
+        try (FDBRecordContext context = openContext()) {
             openStore(context, 2, Direction.DESC);
             rec(1, 100);
             rec(2, 200);
@@ -385,30 +330,26 @@ class SlidingWindowIndexMetricsTest extends FDBRecordStoreTestBase {
 
             deleteRec(1);  // window delete → re-elect from overflow
 
-            assertEquals(1, eventCount(SlidingWindowEvent.RE_ELECT_FROM_OVERFLOW));
-            assertTrue(timeNanos(SlidingWindowEvent.RE_ELECT_FROM_OVERFLOW) > 0,
-                    "RE_ELECT_FROM_OVERFLOW duration should be positive");
+            assertEquals(1, eventCount(SlidingWindowEvent.SW_RE_ELECT_FROM_OVERFLOW));
+            assertTrue(timeNanos(SlidingWindowEvent.SW_RE_ELECT_FROM_OVERFLOW) > 0,
+                    "SW_RE_ELECT_FROM_OVERFLOW duration should be positive");
             commit(context);
         }
     }
 
     @Test
-    void boundaryRescanEventFiresOnEvictionAndOnBoundaryDelete() throws Exception {
-        try (FDBRecordContext context = openTimerContext()) {
+    void evictionTriggersRescanAfterEvictEvent() throws Exception {
+        try (FDBRecordContext context = openContext()) {
             openStore(context, 2, Direction.DESC);
             rec(1, 100);
             rec(2, 200);
 
-            // Eviction path: triggers one BOUNDARY_RESCAN.
-            rec(3, 300);
-            assertEquals(1, eventCount(SlidingWindowEvent.BOUNDARY_RESCAN));
+            rec(3, 300);  // eviction → rescan from the eviction path only
 
-            // Boundary-delete path: triggers a second BOUNDARY_RESCAN.
-            // After the eviction above, window holds {2,3}; boundary for DESC is rec2 (lowest).
-            deleteRec(2);
-            assertEquals(2, eventCount(SlidingWindowEvent.BOUNDARY_RESCAN));
-            assertTrue(timeNanos(SlidingWindowEvent.BOUNDARY_RESCAN) > 0,
-                    "BOUNDARY_RESCAN duration should be positive");
+            assertEquals(1, eventCount(SlidingWindowEvent.SW_BOUNDARY_RESCAN_AFTER_EVICT));
+            assertEquals(0, eventCount(SlidingWindowEvent.SW_BOUNDARY_RESCAN_AFTER_DELETE));
+            assertTrue(timeNanos(SlidingWindowEvent.SW_BOUNDARY_RESCAN_AFTER_EVICT) > 0,
+                    "SW_BOUNDARY_RESCAN_AFTER_EVICT duration should be positive");
             commit(context);
         }
     }
@@ -416,19 +357,23 @@ class SlidingWindowIndexMetricsTest extends FDBRecordStoreTestBase {
     // ===== Robustness =====
 
     @Test
-    void operationsDoNotFailWhenContextHasNoTimer() throws Exception {
-        // Opens via the parent test base, which does not attach an FDBStoreTimer.
+    void windowCountSizeEventTracksSizeMutations() throws Exception {
         try (FDBRecordContext context = openContext()) {
-            openStore(context, 2, Direction.DESC);
+            openStore(context, 3, Direction.DESC);
 
-            assertDoesNotThrow(() -> {
-                rec(1, 100);
-                rec(2, 200);
-                rec(3, 300);  // eviction
-                rec(4, 50);   // overflow
-                deleteRec(2); // re-election
-                deleteRec(4); // overflow delete
-            });
+            rec(1, 100);  // count → 1
+            rec(2, 200);  // count → 2
+            rec(3, 300);  // count → 3
+            // Window full; eviction does not change count, so no size event recorded.
+            rec(4, 400);
+            // Re-election bumps count back to 3 after a window delete.
+            rec(5, 50);   // overflow (no count change)
+            deleteRec(2); // count → 2, then promotion bumps to 3
+
+            // Three fills (1,2,3) + delete (2) + promotion (3) = 5 size events.
+            // Cumulative sum = 1 + 2 + 3 + 2 + 3 = 11.
+            assertEquals(5, sizeEventCount(SlidingWindowSizeEvent.SW_WINDOW_COUNT));
+            assertEquals(11, cumulativeSize(SlidingWindowSizeEvent.SW_WINDOW_COUNT));
             commit(context);
         }
     }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/SlidingWindowIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/SlidingWindowIndexTest.java
@@ -27,20 +27,15 @@ import com.apple.foundationdb.record.IndexEntry;
 import com.apple.foundationdb.record.IndexScanType;
 import com.apple.foundationdb.record.IsolationLevel;
 import com.apple.foundationdb.record.RecordCursor;
-import com.apple.foundationdb.record.RecordMetaData;
-import com.apple.foundationdb.record.RecordMetaDataBuilder;
 import com.apple.foundationdb.record.RecordMetaDataProto;
 import com.apple.foundationdb.record.ScanProperties;
 import com.apple.foundationdb.record.TupleRange;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.IndexAggregateFunction;
-import com.apple.foundationdb.record.metadata.IndexOptions;
 import com.apple.foundationdb.record.metadata.IndexPredicate;
 import com.apple.foundationdb.record.metadata.IndexPredicate.RowNumberWindowPredicate.Direction;
 import com.apple.foundationdb.record.metadata.IndexRecordFunction;
-import com.apple.foundationdb.record.metadata.IndexTypes;
 import com.apple.foundationdb.record.metadata.Key;
-import com.apple.foundationdb.record.metadata.expressions.KeyWithValueExpression;
 import com.apple.foundationdb.record.provider.foundationdb.FDBIndexableRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBIndexedRawRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecord;
@@ -57,10 +52,8 @@ import com.apple.foundationdb.record.provider.foundationdb.VectorIndexScanOption
 import com.apple.foundationdb.record.provider.foundationdb.indexes.SlidingWindowTestHelpers.SlidingWindow;
 import com.apple.foundationdb.record.query.QueryToKeyMatcher;
 import com.apple.foundationdb.record.query.expressions.Comparisons;
-import com.apple.foundationdb.record.slidingwindowvector.TestRecordsSlidingWindowVectorProto;
 import com.apple.foundationdb.record.slidingwindowvector.TestRecordsSlidingWindowVectorProto.SlidingWindowVectorRecord;
 import com.apple.foundationdb.linear.HalfRealVector;
-import com.apple.foundationdb.linear.Metric;
 import com.apple.foundationdb.tuple.Tuple;
 import com.apple.test.Tags;
 import com.google.common.collect.ImmutableList;
@@ -71,9 +64,7 @@ import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import static com.apple.foundationdb.record.provider.foundationdb.indexes.SlidingWindowTestHelpers.SlidingWindowAssert.assertThat;
@@ -113,40 +104,9 @@ class SlidingWindowIndexTest extends FDBRecordStoreTestBase {
     private void openStore(@Nonnull FDBRecordContext context, int windowSize,
                            @Nonnull Direction direction,
                            @Nonnull List<List<String>> groupingFields) throws Exception {
-        RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder()
-                .setRecords(TestRecordsSlidingWindowVectorProto.getDescriptor());
-        metaDataBuilder.getRecordType("SlidingWindowVectorRecord")
-                .setPrimaryKey(Key.Expressions.field("rec_no"));
-
-        final IndexPredicate.RowNumberWindowPredicate windowPredicate =
-                new IndexPredicate.RowNumberWindowPredicate(
-                        ImmutableList.of("relevance"), direction, windowSize, groupingFields);
-
-        final Map<String, String> options = new HashMap<>();
-        options.put(IndexOptions.HNSW_METRIC, Metric.EUCLIDEAN_METRIC.name());
-        options.put(IndexOptions.HNSW_NUM_DIMENSIONS, Integer.toString(VECTOR_DIMS));
-
-        // Build key expression: for grouped indexes, prefix with group columns
-        // e.g. one grouping column (zone) → KeyWithValue(concat(zone, vector_data), 1)
-        // e.g. two grouping columns (zone, category) → KeyWithValue(concat(zone, category, vector_data), 2)
-        final com.apple.foundationdb.record.metadata.expressions.KeyExpression keyExpr;
-        if (groupingFields.isEmpty()) {
-            keyExpr = new KeyWithValueExpression(Key.Expressions.field("vector_data"), 0);
-        } else {
-            com.apple.foundationdb.record.metadata.expressions.KeyExpression prefix =
-                    Key.Expressions.field(groupingFields.get(0).get(0));
-            for (int i = 1; i < groupingFields.size(); i++) {
-                prefix = Key.Expressions.concat(prefix, Key.Expressions.field(groupingFields.get(i).get(0)));
-            }
-            keyExpr = new KeyWithValueExpression(
-                    Key.Expressions.concat(prefix, Key.Expressions.field("vector_data")),
-                    groupingFields.size());
-        }
-
-        metaDataBuilder.addIndex("SlidingWindowVectorRecord",
-                new Index(INDEX_NAME, keyExpr, IndexTypes.VECTOR, options, windowPredicate));
-
-        createOrOpenRecordStore(context, metaDataBuilder.getRecordMetaData());
+        createOrOpenRecordStore(context,
+                SlidingWindowTestHelpers.buildSlidingWindowVectorMetaData(
+                        INDEX_NAME, windowSize, VECTOR_DIMS, direction, groupingFields));
     }
 
     /**

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/SlidingWindowTestHelpers.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/SlidingWindowTestHelpers.java
@@ -23,19 +23,33 @@ package com.apple.foundationdb.record.provider.foundationdb.indexes;
 import com.apple.foundationdb.half.Half;
 import com.apple.foundationdb.linear.HalfRealVector;
 import com.apple.foundationdb.linear.Metric;
+import com.apple.foundationdb.record.RecordMetaData;
+import com.apple.foundationdb.record.RecordMetaDataBuilder;
 import com.apple.foundationdb.record.ScanProperties;
 import com.apple.foundationdb.record.TupleRange;
 import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.metadata.IndexOptions;
+import com.apple.foundationdb.record.metadata.IndexPredicate;
+import com.apple.foundationdb.record.metadata.IndexPredicate.RowNumberWindowPredicate.Direction;
+import com.apple.foundationdb.record.metadata.IndexTypes;
+import com.apple.foundationdb.record.metadata.Key;
+import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
+import com.apple.foundationdb.record.metadata.expressions.KeyWithValueExpression;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStore;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainer;
 import com.apple.foundationdb.record.provider.foundationdb.VectorIndexScanBounds;
 import com.apple.foundationdb.record.provider.foundationdb.VectorIndexScanOptions;
 import com.apple.foundationdb.record.query.expressions.Comparisons;
+import com.apple.foundationdb.record.slidingwindowvector.TestRecordsSlidingWindowVectorProto;
 import com.apple.foundationdb.subspace.Subspace;
 import com.apple.foundationdb.tuple.Tuple;
+import com.google.common.collect.ImmutableList;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
@@ -51,6 +65,53 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public final class SlidingWindowTestHelpers {
 
     private SlidingWindowTestHelpers() {
+    }
+
+    /**
+     * Builds a {@link RecordMetaData} for a sliding-window HNSW vector index over
+     * {@link TestRecordsSlidingWindowVectorProto.SlidingWindowVectorRecord}. The window
+     * orders by the {@code relevance} field; the index value is {@code vector_data},
+     * optionally prefixed by the columns named in {@code groupingFields}.
+     */
+    @Nonnull
+    public static RecordMetaData buildSlidingWindowVectorMetaData(@Nonnull String indexName,
+                                                                  int windowSize,
+                                                                  int vectorDims,
+                                                                  @Nonnull Direction direction,
+                                                                  @Nonnull List<List<String>> groupingFields) {
+        final RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder()
+                .setRecords(TestRecordsSlidingWindowVectorProto.getDescriptor());
+        metaDataBuilder.getRecordType("SlidingWindowVectorRecord")
+                .setPrimaryKey(Key.Expressions.field("rec_no"));
+
+        final IndexPredicate.RowNumberWindowPredicate windowPredicate =
+                new IndexPredicate.RowNumberWindowPredicate(
+                        ImmutableList.of("relevance"), direction, windowSize, groupingFields);
+
+        final Map<String, String> options = new HashMap<>();
+        options.put(IndexOptions.HNSW_METRIC, Metric.EUCLIDEAN_METRIC.name());
+        options.put(IndexOptions.HNSW_NUM_DIMENSIONS, Integer.toString(vectorDims));
+
+        // Build key expression: for grouped indexes, prefix with group columns
+        // e.g. one grouping column (zone) → KeyWithValue(concat(zone, vector_data), 1)
+        // e.g. two grouping columns (zone, category) → KeyWithValue(concat(zone, category, vector_data), 2)
+        final KeyExpression keyExpr;
+        if (groupingFields.isEmpty()) {
+            keyExpr = new KeyWithValueExpression(Key.Expressions.field("vector_data"), 0);
+        } else {
+            KeyExpression prefix = Key.Expressions.field(groupingFields.get(0).get(0));
+            for (int i = 1; i < groupingFields.size(); i++) {
+                prefix = Key.Expressions.concat(prefix, Key.Expressions.field(groupingFields.get(i).get(0)));
+            }
+            keyExpr = new KeyWithValueExpression(
+                    Key.Expressions.concat(prefix, Key.Expressions.field("vector_data")),
+                    groupingFields.size());
+        }
+
+        metaDataBuilder.addIndex("SlidingWindowVectorRecord",
+                new Index(indexName, keyExpr, IndexTypes.VECTOR, options, windowPredicate));
+
+        return metaDataBuilder.getRecordMetaData();
     }
 
     @Nonnull


### PR DESCRIPTION
This PR instruments the sliding-window index maintainer so its operational behavior is observable through `FDBStoreTimer`. A new `SlidingWindowCounter` `enum` partitions every update path — inserts during window fill-up, overflow appends, boundary evictions, deletes split by where the entry sat (overflow, in-window non-boundary, boundary itself), promotions from overflow after a window delete, window shrinkage when no overflow is available, partition emptying, the preemptive delete on `updateWhileWriteOnly`, and `deleteWhere` partition clears. Two integrity counters (`EVICTED_RECORD_MISSING`, `PROMOTED_RECORD_MISSING`) cover the cases where a primary key in the entries subspace fails to resolve to a record, which should never happen in normal operation but is worth surfacing as a queryable signal rather than only as a thrown exception. A companion `SlidingWindowEvent` `enum` adds latency tracking around the three multi-step async operations that dominate write cost: the full evict-and-replace round-trip, re-election from overflow after a window delete, and the boundary rescan that runs inside both. Counters and events are accessed through small `incrementCounter` and `instrument` helpers that no-op when the context has no timer attached, so this change is invisible to callers that don't opt in.
