### PR TITLE
Change FDBDatabaseExtension to have a ConcurrentHashMap

### DIFF
--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/test/FDBDatabaseExtension.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/test/FDBDatabaseExtension.java
@@ -38,10 +38,10 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
 
@@ -75,7 +75,7 @@ public class FDBDatabaseExtension implements AfterEachCallback {
     @Nullable
     private FDBDatabaseFactory databaseFactory;
     @Nonnull
-    private final Map<String, FDBDatabase> databases = new HashMap<>();
+    private final Map<String, FDBDatabase> databases = new ConcurrentHashMap<>();
     private String defaultClusterFile = FDBTestEnvironment.randomClusterFile();
 
 


### PR DESCRIPTION
We noticed a "Database not closed" log when running tests. That appeared 6419 times in a recent PRB. The hope is that this causes that to go away, and properly closes the databases
This is an attempt to resolve: https://github.com/FoundationDB/fdb-record-layer/issues/4287