### PR TITLE
  Refine DistinctRecordsProperty for EXPLODE WITH ORDINALITY

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/DistinctRecordsProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/DistinctRecordsProperty.java
@@ -226,7 +226,7 @@ public class DistinctRecordsProperty implements ExpressionProperty<Boolean> {
         @Nonnull
         @Override
         public Boolean visitExplodePlan(@Nonnull final RecordQueryExplodePlan element) {
-            return false;
+            return element.isWithOrdinality();
         }
 
         @Nonnull

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/plans/ExplodePlanTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/plans/ExplodePlanTest.java
@@ -30,6 +30,7 @@ import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.explain.ExplainPlanVisitor;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.ExplodeExpression;
 import com.apple.foundationdb.record.query.plan.cascades.properties.DerivationsProperty;
+import com.apple.foundationdb.record.query.plan.cascades.properties.DistinctRecordsProperty;
 import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
 import com.apple.foundationdb.record.query.plan.cascades.values.FieldValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.LiteralValue;
@@ -284,6 +285,20 @@ public class ExplodePlanTest {
         Assertions.assertTrue(withoutOrdinality.getResultValues().get(0).getCorrelatedTo().contains(sourceAlias));
         final var withOrdinality = visitor.visitExplodePlan(new RecordQueryExplodePlan(collectionValue, true));
         Assertions.assertTrue(withOrdinality.getResultValues().get(0).getCorrelatedTo().contains(sourceAlias));
+    }
+
+    @Test
+    void distinctRecordsWithoutOrdinalityIsFalse() {
+        final var collectionValue = LiteralValue.ofList(List.of(1, 2, 3));
+        final var plan = new RecordQueryExplodePlan(collectionValue, false);
+        Assertions.assertFalse(DistinctRecordsProperty.distinctRecords().evaluate(plan));
+    }
+
+    @Test
+    void distinctRecordsWithOrdinalityIsTrue() {
+        final var collectionValue = LiteralValue.ofList(List.of(1, 2, 3));
+        final var plan = new RecordQueryExplodePlan(collectionValue, true);
+        Assertions.assertTrue(DistinctRecordsProperty.distinctRecords().evaluate(plan));
     }
 
     /**


### PR DESCRIPTION
### Summary                                                                                                                                                                              

  - The `DistinctRecordsProperty` visitor previously returned `false` unconditionally for `RecordQueryExplodePlan`, treating all explode results as potentially non-distinct.
  - In the `WITH ORDINALITY` variant, each output row includes a unique 1-based ordinal alongside the array element. Even if the source array contains duplicate values, the (element, ordinal) tuples are always distinct because the ordinal is unique.
  - Updated `visitExplodePlan` to return `element.isWithOrdinality()` so the planner can recognize distinctness.
