### PR TITLE
Add AI assistant tooling: AGENTS.md, CLAUDE.md, skills

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,0 +1,69 @@
+# Setting up Claude Code with fdb-record-layer
+
+## Java
+
+Claude Code (and Gradle) require Java 21. Make sure `JAVA_HOME` points to JDK 21 in your
+shell's non-interactive startup file. For zsh, add to `~/.zshenv`:
+
+```
+export JAVA_HOME=$(/usr/libexec/java_home -v 21)
+```
+
+You can verify the setup is correct by running:
+
+```
+claude
+Can you run `./gradlew :fdb-relational-core:compileJava` and show me the output?
+```
+
+If `JAVA_HOME` is not set correctly, Claude will try to fix it but will likely fail due to
+its security settings.
+
+## FDB
+
+Some tests require a running FoundationDB instance. Before running those tests, check whether
+`fdb-environment.yaml` exists in the repo root. If it does not, ask the user whether FDB is
+installed and whether they need help with setup.
+
+## Tooling overview
+
+The `.claude/` directory contains Claude Code-specific enhancements on top of `AGENTS.md`:
+
+- `skills/` — Reusable skills invocable via `/skill-name`
+- `commands/` — Session-level commands (e.g., `/refine` for session retrospectives)
+
+Other AI tools (Copilot, Gemini) use `AGENTS.md` at the repo root as their context file.
+
+## Example prompts
+
+### Review my branch
+```
+Code review the PR on the current branch
+```
+
+### Write a yaml test for a new SQL feature
+```
+Write a yaml test for the new feature in yaml-tests/src/test/resources/my-feature-tests.yamsql
+```
+
+### Explain why a query plan looks wrong
+```
+/relational-query-processor
+Explain why this query is doing a full table scan: SELECT * FROM t WHERE id = 1
+```
+
+### Run tests for a specific class
+```
+/test-runner
+Run the tests for EmbeddedRelationalStatement
+```
+
+### Resume work after a session break
+```
+/context-resumption
+```
+
+### Session retrospective (capture learnings, improve tooling)
+```
+/refine
+```

--- a/.claude/commands/refine.md
+++ b/.claude/commands/refine.md
@@ -1,0 +1,164 @@
+# Refine
+
+Your session retrospective specialist. Captures what worked and what didn't, then generates
+actionable improvements to skills, agents, commands, and AGENTS.md.
+
+## When to use
+
+At the end of a session (or mid-session after significant work):
+- Capture what worked well and what didn't.
+- Generate improvement suggestions for the tooling you used.
+- Identify gaps — missing skills, missing context in AGENTS.md, broken commands.
+- Turn corrections you gave the assistant into durable improvements.
+
+## Usage
+
+```
+/refine [focus-area]
+```
+
+### Examples
+
+```
+/refine
+/refine "the yaml-test workflow was clunky"
+/refine skills
+/refine agents
+```
+
+## What this command does
+
+1. **Analyzes the session** — identifies which skills, agents, and docs were used; finds
+   friction points (corrections, retries, confusion, missing context) and successes.
+2. **Reads the relevant source files** — loads the definitions of what was used.
+3. **Generates specific suggestions** in one of four categories:
+   - **Bug fixes** — something is broken or produces wrong output.
+   - **Enhancements** — something works but could work better.
+   - **New components** — a skill, agent, or AGENTS.md entry that should exist but doesn't.
+   - **Documentation** — knowledge discovered during the session that should be captured.
+4. **Asks for approval** — presents suggestions and asks which to apply.
+5. **Applies approved changes on a new branch and opens a PR**.
+
+## Instructions
+
+### Step 1 — Analyze the session
+
+Review the full conversation and identify:
+
+**a. Components used**: skills invoked, agents launched, AGENTS.md sections referenced.
+
+**b. Friction points** — look for:
+- User corrections: "No, I meant...", "That's not right", "Don't do that"
+- Retries: the assistant had to redo something after an error
+- Missing context: the assistant lacked information that could be in a skill or AGENTS.md
+- Failed tool calls or wrong Gradle tasks
+- Manual steps the user had to take that could be automated
+
+**c. Successes** — look for:
+- Smooth workflows completed without correction
+- Patterns the user praised or expressed satisfaction with
+
+**d. Focus area**: if provided, prioritize it while still scanning the full session.
+
+### Step 2 — Read relevant source files
+
+- Skills: `.claude/skills/*/SKILL.md`
+- Agents: `.claude/agents/*.md`
+- Commands: `.claude/commands/*.md`
+- Universal context: `AGENTS.md`
+- Architecture docs: `docs/sphinx/source/architecture/` — consult these for design context that
+  can reveal how to correctly improve a skill or AGENTS.md entry
+
+### Step 3 — Generate suggestions
+
+Format each suggestion as:
+
+```
+[category] component-name — title
+File: <path>
+Issue: <what happened in this session>
+Suggestion: <specific improvement>
+```
+
+Categories: Bug Fix / Enhancement / New Component / Documentation
+
+For Documentation suggestions, use the `docs-writer` skill to draft the actual doc changes.
+
+### Step 4 — Present the retrospective report
+
+```
+## Refine — Session Retrospective
+
+### Session Analysis
+Skills used: ...
+Agents used: ...
+Friction points: N
+Suggestions: N
+
+---
+
+### Bug Fixes
+...
+
+### Enhancements
+...
+
+### New Components
+...
+
+### Documentation Updates
+...
+```
+
+### Step 5 — Get approval
+
+Ask: "Which improvements should I apply?"
+Options:
+1. Apply all (recommended)
+2. Let me pick — present each one individually
+3. Save the report only — write to `.claude/retrospectives/YYYY-MM-DD-HHMMSS.md`
+4. None for now
+
+### Step 6 — Apply on a new branch and open a PR
+
+If applying changes:
+
+```bash
+git fetch origin main
+BRANCH="refine/retrospective-$(date +%Y%m%d-%H%M%S)"
+git checkout -b "$BRANCH" origin/main
+```
+
+Apply edits, then:
+
+```bash
+git add -u
+git commit -m "..."
+git push -u origin "$BRANCH"
+gh pr create --draft --title "Refine: session retrospective improvements" --body "..."
+git checkout -
+```
+
+PR should only reference files tracked in the repo — not local gitignored files.
+
+### Step 7 — Summary
+
+```
+## Refine — Changes Applied
+
+Applied (in PR <url>):
+  - [component] change description
+
+Deferred:
+  - [component] reason
+
+Your tooling just got better.
+```
+
+## Guidelines
+
+- Be specific: every suggestion must reference a concrete moment from the session.
+- Don't over-suggest: quality over quantity.
+- Preserve existing functionality: enhancements add to behavior, not replace it.
+- New components should follow the established file structure and naming.
+- PR descriptions must only reference files tracked in the repository.

--- a/.claude/skills/code-reviewer/SKILL.md
+++ b/.claude/skills/code-reviewer/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: code-reviewer
+description: Code review the current branch for adherence to project standards, correctness, and best practices.
+  Some example usages:
+  "Review my branch"
+  "Check my changes before I open a PR"
+  "Review this implementation for correctness"
+---
+
+You are an expert Java code reviewer for the FoundationDB Record Layer. You have deep knowledge
+of the codebase's async patterns, index/query planner architecture, and the coding standards
+documented in the project.
+
+**SCOPE BOUNDARIES:** This skill handles code review only. For writing production or test code,
+use the appropriate coding standard skill.
+
+## Review process
+
+1. **Determine scope**: Run `git diff main...HEAD` to get all changes since branch divergence.
+2. **Apply coding standards**: Check against `frl-coding-standard` and, for test code,
+   `frl-test-coding-standard`.
+3. **Check async correctness**: Look for `join()`/`get()` in production code, blocking inside
+   futures, misuse of `*Async()` variants. Also flag any call that returns `CompletableFuture`
+   where the result is not assigned, chained, or explicitly noted as a background task — these
+   are fire-and-forget bugs (e.g. `store.markIndexDisabled()` without `await`).
+4. **Check exception structure**: Static messages with structured context — see `frl-coding-standard` for the correct API per layer (`addLogInfo()` for record layer, `addContext()` + `ErrorCode` for relational layer).
+5. **Check logging**: `KeyValueLogMessage.of()` with static text — no string concatenation.
+6. **Verify test coverage**: Are new code paths covered? Is the right test type used (yamsql
+   vs JUnit)?
+7. **Check PR hygiene**: Will the PR title make sense
+   in release notes? Is a label needed?
+8. **DRY check**: Is there repeated logic that should be extracted?
+
+## Output format
+
+```
+### Code Review Summary
+[Brief overall assessment]
+
+### Critical Issues
+[Violations of coding standards, async safety problems, or correctness bugs that must be fixed]
+
+### Suggestions for Improvement
+[Code quality, performance, maintainability — not blocking but worth addressing]
+
+### Positive Observations
+[What the code does well]
+
+### Testing Recommendations
+[Specific test suggestions if coverage is missing or could be improved]
+```
+
+Be specific and reference file paths and line numbers where possible.

--- a/.claude/skills/code-simplifier/SKILL.md
+++ b/.claude/skills/code-simplifier/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: code-simplifier
+description: Simplifies and refines recently modified code for clarity, consistency, and maintainability while preserving all functionality.
+  Some example usages:
+  "Simplify the code I just wrote"
+  "Clean up the changes in EmbeddedRelationalStatement"
+---
+
+Your goal is to improve clarity, consistency, and maintainability of recently modified code
+without altering its behavior.
+
+Your refinements should:
+
+1. **Preserve functionality**: Never change what the code does — only how it does it.
+
+2. **Apply project standards**: Follow `frl-coding-standard`. In particular:
+   - Exception messages must be static strings with structured context — see the skill for
+     the correct API per layer (`addLogInfo()` vs `addContext()`).
+   - `KeyValueLogMessage.of()` for log statements.
+   - No `join()`/`get()` in production code.
+   - Files end with a newline.
+
+3. **Enhance clarity**:
+   - Reduce unnecessary nesting and complexity.
+   - Eliminate redundant code and dead abstractions.
+   - Improve variable and method names where they are unclear.
+   - Consolidate related logic.
+   - Remove comments that describe what the code obviously does — keep only comments
+     that explain *why*.
+   - Avoid nested ternary operators; prefer if/else or switch.
+
+4. **Maintain balance**: Do not over-simplify. Avoid:
+   - Combining too many concerns into a single method.
+   - Removing abstractions that genuinely improve organization.
+   - Prioritizing fewer lines over readability.
+   - Making code harder to debug or extend.
+
+5. **Scope**: Only refine code that has been recently modified or touched in the current
+   session, unless explicitly asked to review a broader scope.
+
+## Process
+
+1. Identify recently modified code sections.
+2. Analyze for clarity, consistency, and standards compliance.
+3. Apply improvements.
+4. Verify all functionality is unchanged.
+5. Confirm the result is simpler and more maintainable.

--- a/.claude/skills/context-resumption/SKILL.md
+++ b/.claude/skills/context-resumption/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: context-resumption
+description: Rebuild working context after a session restart. Reads branch state, recent commits, open PRs, and changed files to produce a "what was I doing" summary.
+  Some example usages:
+  "/context-resumption"
+  "What was I working on?"
+  "Resume work on PR #1234"
+---
+
+This is a read-only skill. It does not modify any files.
+
+## Process
+
+1. **Determine the work area**
+   ```
+   git status
+   git branch --show-current
+   ```
+
+2. **Read recent branch commits**
+   ```
+   git log main...HEAD --oneline
+   git log -10 --oneline   # if on main or branch unclear
+   ```
+
+3. **Check for an open PR**
+   ```
+   gh pr view --json title,url,state,body,reviews,comments 2>/dev/null
+   ```
+
+4. **Look for a saved context file** in `.claude/context/` or the repo root matching
+   `context-*.md` or `*-notes.md`.
+
+5. **Read key changed files**
+   ```
+   git diff main...HEAD --name-only
+   ```
+   Read the most recently modified files to understand the current state.
+
+6. **Produce the context summary** (see format below).
+
+## Output format
+
+```
+## Context Summary
+
+**Branch**: <branch-name>
+**PR**: <#number — title> | <open/draft/none>
+
+### What's been done
+- <chronological bullet from oldest to newest commit/change>
+- ...
+
+### Current state
+<1-3 sentences: what is the code in right now? does it compile? are tests passing?>
+
+### Open review feedback
+<any unresolved PR comments or review requests, if a PR exists>
+
+### Key files
+- `path/to/file.java` — <why it matters>
+- ...
+
+### Likely next steps
+- <inferred from commit messages, PR description, open comments>
+```
+
+Keep the summary tight — it should fit in one screen. If you have the PR or issue number,
+link to it.
+
+## Arguments: `$ARGUMENTS`
+
+- PR number or URL → focus on that PR's context.
+- Branch name → check out context for that branch.
+- No argument → use current branch.

--- a/.claude/skills/docs-writer/SKILL.md
+++ b/.claude/skills/docs-writer/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: docs-writer
+description: Write or update documentation in docs/sphinx/source/. Applies the appropriate style for user-facing vs. architecture docs.
+  Some example usages:
+  "Document how schema templates work"
+  "Write an architecture doc for the Cascades planner"
+  "Update the SQL reference for the new GROUP BY syntax"
+---
+
+You write and update documentation in `docs/sphinx/source/`. Your output is a draft for human
+review — a domain expert decides what ships.
+
+## Two doc types, two styles
+
+### User-facing docs (`docs/sphinx/source/*.md`)
+Audience: developers building applications with the Record Layer or Relational Layer.
+
+- Code blocks are **welcome** — working examples help users get started.
+- Include concrete SQL, Java, or Gradle snippets.
+- Focus on practical usage: how to do X, what happens when Y.
+- Tone: clear and direct. Not a tutorial blog post, not a reference dump — somewhere between.
+- SQL Code snippets should be replicated in yaml-tests/src/test/resources/documentation-queries + yaml-tests/src/test/java/DocumentationQueriesTests.java to make sure that the doc is correct
+- Java Code snippets should be sourced from examples/src/... See direct_access.rst for a direct example
+
+### Architecture docs (`docs/sphinx/source/architecture/`)
+Audience: contributors and maintainers understanding the internals.
+
+- Minimize code blocks. The code is in the source — don't duplicate it here.
+- Explain the *why* and the trade-offs: why was this design chosen, what are the constraints,
+  what are the known limitations.
+- Prose over snippets. ASCII diagrams (in plain code blocks) are fine for structure.
+- Tables for comparing options or listing parameters with their semantics.
+- Tone: precise and technical. Formal is fine; wordy is not.
+
+## Process
+
+1. **Read the code first.** Grep/Glob to find relevant classes, then read them.
+2. **Identify the non-obvious.** Surprises, trade-offs, cross-module dependencies, gotchas.
+3. **Draft the doc** in the appropriate style for the doc type.
+4. **Add a Source References section** (architecture docs only — see below).
+
+## Formatting
+
+- One topic per file.
+- Start with a 2-3 sentence overview paragraph.
+- Use `##` for top-level sections, `###` for subsections.
+- Bold (`**term**`) for key terms on first use.
+- GitHub link base: `https://github.com/FoundationDB/fdb-record-layer/blob/main/`
+  Append path from repo root. Use `#L51` suffix for line links. Link the class name on
+  first mention in each section. **Before writing any line-number link**, verify the current
+  line with `grep -n` or Read — hardcoded line numbers drift as the code evolves.
+
+## Source References (architecture docs only)
+
+Every architecture doc must end with a `## Source References` section listing Java files
+consulted when writing but not already linked inline in the doc body. This enables freshness
+checking when the code evolves.
+
+```markdown
+## Source References
+
+- [EmbeddedRelationalStatement.java](https://github.com/FoundationDB/fdb-record-layer/blob/main/fdb-relational-core/src/main/java/.../EmbeddedRelationalStatement.java) — SQL execution entry point
+```
+
+If all source files are already linked inline, write: "All source files are linked inline above."
+
+## Input
+
+Arguments: `$ARGUMENTS`
+
+- File path → update that doc.
+- Topic → create a new doc in the appropriate directory.
+- No argument → ask what to document.

--- a/.claude/skills/frl-coding-standard/SKILL.md
+++ b/.claude/skills/frl-coding-standard/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: frl-coding-standard
+description: Coding standards for all Java code in fdb-record-layer. Apply when writing or reviewing any Java code.
+  Some example usages:
+  "Review this class for coding standards"
+  "Write a new implementation of RecordCursor"
+---
+
+All Java, Gradle, and property files MUST end with a newline character.
+
+Target Java 17 language level, compiled with JDK 21.
+
+## Exceptions
+
+The two layers use different exception systems. **Know which layer you are in.**
+
+### fdb-record-layer-* (record layer)
+
+Exceptions extend `RecordCoreException`, which extends `LoggableException` (unchecked).
+
+- The exception message MUST be a **static string** — no string interpolation or variables.
+- Use `.addLogInfo(LogMessageKeys.KEY, value)` to attach context. Include as much as needed
+  to diagnose the error: subspace, primary key, record type, index name, etc.
+
+```java
+// Wrong
+throw new RecordCoreException("Found corrupt record: " + record.getPrimaryKey());
+
+// Correct
+throw new RecordCoreException("Found corrupt record")
+    .addLogInfo(LogMessageKeys.PRIMARY_KEY, record.getPrimaryKey())
+    .addLogInfo(LogMessageKeys.RECORD_TYPE, record.getRecordType());
+```
+
+### fdb-relational-* (relational / SQL layer)
+
+Exceptions are `RelationalException` (checked, extends `Exception`). Always pair with an
+`ErrorCode`, which maps to a SQLSTATE-standard 5-digit code.
+
+- Message must still be a **static string**.
+- Attach context with `.addContext("key", value)` — this travels with the exception for
+  logging and is preserved when converting to `SQLException`.
+
+```java
+// Minimal form
+throw new RelationalException("Transaction rolled back", ErrorCode.SERIALIZATION_FAILURE);
+
+// With context
+throw new RelationalException("Unsupported type in column", ErrorCode.CANNOT_CONVERT_TYPE)
+    .addContext("columnName", colName)
+    .addContext("typeName", typeName);
+```
+
+At JDBC interface boundaries (where the signature throws `SQLException`), convert via
+`.toSqlException()`, which produces a `ContextualSQLException` carrying the `ErrorCode`
+as the SQLState and the context map for logging:
+
+```java
+throw new RelationalException("Element is not of STRUCT type", ErrorCode.CANNOT_CONVERT_TYPE)
+    .toSqlException();
+```
+
+Specialized subclasses (`InvalidColumnReferenceException`, `InvalidTypeException`) exist for
+common error cases — prefer them when they fit. `InternalErrorException` is deprecated; use
+`new RelationalException("...", ErrorCode.INTERNAL_ERROR)` directly.
+
+`UncheckedRelationalException` wraps a `RelationalException` as a `RuntimeException` for
+contexts where checked exceptions cannot be thrown (e.g., inside lambdas). Unwrap with
+`.unwrap()` to recover the original `RelationalException`.
+
+## Logging
+
+Same principle as exceptions — structured, static messages:
+
+- Always use `KeyValueLogMessage.of("static message", key, value, ...)`.
+- The message text must be a static string. Variables go in key/value pairs.
+
+```java
+// Wrong
+LOGGER.info("Unable to open file: " + filename);
+
+// Correct
+LOGGER.info(KeyValueLogMessage.of("Unable to open file", LogMessageKeys.FILENAME, filename));
+```
+
+## Futures (async code)
+
+The `fdb-record-layer-*` and lower-level parts of `fdb-relational-core` are fully asynchronous
+via `CompletableFuture`. The JDBC-facing relational API presents a synchronous surface, but
+async code is common in the implementation beneath it.
+
+- **Never** call `join()` or `get()` in production code. Use `context.asyncToSync()` or
+  `database.asyncToSync()` instead — they enforce timeouts, record wait timers, and handle
+  error wrapping.
+- **Never** call any blocking method from inside a `CompletableFuture` completion lambda. The
+  thread pool is finite; blocking inside a future can deadlock the entire system.
+- **Avoid** `thenApplyAsync()` / `thenComposeAsync()` unless the lambda does significant CPU
+  work. These enqueue a new task on the executor for no benefit in the common case. When you
+  do need them, always pass an explicit `Executor`.
+- **Always pass an `Executor`** to any `AsyncUtil` or `MoreAsyncUtil` method that accepts one
+  (e.g. `AsyncUtil.whileTrue()`). Never use the overload without an executor.
+
+## Checkstyle-banned imports
+
+The authoritative list is in `gradle/check.gradle` (`BANNED_IMPORTS`).
+
+## Inline comments
+
+Describe **intent**, not mechanics. Explain the *why* — a hidden constraint, a non-obvious
+invariant, a workaround for a specific FDB behavior. If removing the comment would not confuse
+a future reader, don't write it.
+
+## Javadoc
+
+Add Javadoc for public APIs. It is not necessary for private methods unless the logic is
+genuinely non-obvious.

--- a/.claude/skills/frl-test-coding-standard/SKILL.md
+++ b/.claude/skills/frl-test-coding-standard/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: frl-test-coding-standard
+description: Standards for writing tests in fdb-record-layer. Apply when writing or reviewing test code.
+  Some example usages:
+  "Write a test for the new index type"
+  "Help me write a yaml test for this SQL query"
+---
+
+**Always apply the `frl-coding-standard` skill in addition to the standards below.**
+
+## Choosing the right test type
+
+| What you're testing | Preferred approach |
+|---|---|
+| SQL query behavior, query plans, result sets | yaml-tests (`.yamsql` file) |
+| JDBC-level interactions | JUnit test in `fdb-relational-jdbc` or `fdb-relational-core` |
+| Record layer API (below SQL) | JUnit test |
+| Async / CompletableFuture edge cases | JUnit test |
+| Index maintenance, key expression logic | JUnit test |
+
+When in doubt, prefer yaml-tests for anything reachable through SQL.
+
+## yaml-tests
+
+### Creating a new yamsql test file
+
+1. Create `yaml-tests/src/test/resources/<feature>-tests.yamsql`.
+2. Register it in `yaml-tests/src/test/java/YamlIntegrationTests.java` with a `@YamlTest`
+   annotated method:
+   ```java
+   @YamlTest(schemaTemplateFiles = {}, queryFiles = "my-feature-tests.yamsql")
+   void myFeatureTests(YamlTest.Runner runner) throws Exception {
+       runner.runYamsql();
+   }
+   ```
+3. Decorate with `@MaintainYamlTestConfig(YamlTestConfigFilters.CORRECT_EXPECTATIONS)` to
+   have the framework auto-populate expected query plans, metrics, and metadata on first run.
+   Remove the annotation once the expected values are stable and reviewed.
+
+### yamsql file structure
+
+See `yaml-tests/src/test/resources/showcasing-tests.yamsql` for a full reference.
+Key building blocks:
+
+```yaml
+options:
+  supported_version: 1.0.0     # minimum FRL version required
+
+schema_template:               # declarative schema — reused across test blocks
+  create table t (id bigint, name string, primary key(id))
+
+setup:                         # DML run once before the test block
+  - query: insert into t values (1, 'Alice'), (2, 'Bob')
+
+test_block:
+  preset: single_repetition_ordered
+  tests:
+    - query: select * from t where id = 1
+      result:
+        - [1, Alice]
+    - query: explain select * from t where id = 1
+      explain: "COVERING(...)"   # auto-filled by CORRECT_EXPECTATIONS on first run
+```
+
+Common result matchers: `!ignore`, `!l` (Long literal), `!null`, `!not_null`,
+`!sc <substring>` (string contains), `!pos <value>` (positional).
+
+### Debugging a yaml test
+
+Add `@DebugPlanner` to the test method to launch `PlannerRepl` and inspect the plan
+interactively.
+
+## JUnit tests
+
+- Use **JUnit 5** exclusively. No `junit.framework` or `org.junit.Assert` (checkstyle-banned).
+- Use **AssertJ** for assertions (`org.assertj.core.api.Assertions`).
+- Test method naming: `<methodUnderTest><Condition><ExpectedResult>`.
+- Extract shared setup into `@BeforeEach` or helper methods; DRY up after writing.
+
+## What not to do
+
+- Do not use `Thread.sleep()` to wait for async operations — use `asyncToSync()` or
+  `CompletableFuture` composition.
+- Do not call `join()` or `get()` directly in test code if `asyncToSync()` is available on
+  the context — it gives better error messages and timeout behavior.

--- a/.claude/skills/relational-query-processor/SKILL.md
+++ b/.claude/skills/relational-query-processor/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: relational-query-processor
+description: Specialized skill for working in the fdb-relational-core SQL processing layer — parser, plan generator, and Cascades planner. Use when debugging query plans, writing planner rules, or understanding the SQL execution path.
+  Some example usages:
+  "Why is this query doing a full table scan?"
+  "Explain this EXPLAIN output"
+  "How do I write a new Cascades rule?"
+  "Why is my query not using the index?"
+---
+
+This skill provides context for working in `fdb-relational-core`, the SQL processing layer
+of the Record Layer — covering the parser, plan generator, and Cascades planner.
+
+## Key entry points
+
+| Class | Role |
+|---|---|
+| `EmbeddedRelationalStatement` | Main SQL statement implementation. `executeGet` → point read via `source.get()`; `executeScan` → range scan via `source.openScan()`. |
+| `RelationalDirectAccessStatement` | Bypasses the SQL planner entirely — goes directly to FDB. |
+| `RecordLayerEngine` | Engine setup; manages the connection between JDBC and the record layer. |
+| `RelationalPlanCache` | Caches compiled query plans. **Must be initialized** for SQL performance — `RelationalPlanCache.buildWithDefaults()`. Without it, every query runs the full Cascades planner. |
+
+## SQL execution path (normal case)
+
+```
+JDBC call
+  → EmbeddedRelationalStatement
+    → SQL parse + Cascades planner (on cache miss)
+      → LogicalQueryPlan.optimize()
+        → Simplification.executeRuleSetIteratively()   ← only on cold miss
+    → RelationalPlanCache (warm hit: wraps existing plan)
+      → PhysicalQueryPlan.withExecutionContext()
+        → executePhysicalPlan()
+          → FDB read
+```
+
+On a **warm cache hit**, simplification is skipped entirely. The planner overhead is
+~0.3–0.5 ms per call.
+
+## Reading EXPLAIN output
+
+Run `EXPLAIN <query>` via JDBC or in a yaml test:
+
+```sql
+EXPLAIN SELECT * FROM t WHERE id = 1
+```
+
+Common plan shapes:
+- `COVERING(idx_name [EQUALS ?] → [...])` — index-only scan, no fetch needed.
+- `FETCH(COVERING(...))` — index scan followed by a record fetch.
+- `SCAN(<,>) | FILTER ...` — full table scan with a post-scan filter. This usually means the
+  planner could not match a primary key or index scan candidate.
+- `MAP (_.col AS col)` — projection step.
+
+## Writing a yaml test that checks the plan
+
+```yaml
+- query: explain select * from t where id = 1
+  explain: "COVERING(idx_id [EQUALS ?] → [id: KEY[0], name: VALUE[0]])"
+```
+
+Use `@MaintainYamlTestConfig(YamlTestConfigFilters.CORRECT_EXPECTATIONS)` on the test method
+to have the framework fill in the `explain:` value automatically on first run.
+
+## Debugging a plan interactively
+
+Add `@DebugPlanner` to the `@YamlTest` method to launch `PlannerRepl`, which lets you step
+through the Cascades optimization phases.
+
+## Cascades planner overview
+
+The planner is a Cascades-style rule-based optimizer:
+
+1. **Logical rules** transform the logical plan (e.g., push predicates into index scans).
+2. **Physical rules** convert logical operators to physical plans (e.g., select index vs. scan).
+3. **Match candidates** (e.g., `PrimaryScanMatchCandidate`, `ValueIndexScanMatchCandidate`)
+   determine which access paths are available for a given predicate.
+4. **Simplification** runs `Derivations.simplifyLocalValues()` — only on cold cache misses.
+
+If a query is doing a full table scan when you expect an index scan, common causes:
+- The predicate is on a non-indexed column.
+- The index exists but the match candidate is not recognizing the predicate shape (check
+  that the column names and types match exactly).
+- The `RelationalPlanCache` is not initialized (every call looks like a cold miss).
+
+## Transaction lifecycle in tests
+
+With `autoCommit=true`, `ensureTransactionActive()` rolls back and restarts the transaction
+on every statement, clearing per-transaction caches. Both SQL and direct-access paths share
+this overhead in benchmarks.
+
+## Schema templates
+
+Schema templates persist in FDB across JVM runs. If you see unexpected state in tests, the
+template may be stale. Creation code should be idempotent (drop-then-create pattern).

--- a/.claude/skills/test-runner/SKILL.md
+++ b/.claude/skills/test-runner/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: test-runner
+description: Run tests in the fdb-record-layer codebase, interpret results, and diagnose failures.
+  Some example usages:
+  "Run EmbeddedRelationalStatementTest"
+  "Run the yaml integration tests"
+  "Why is this test failing?"
+  "Run the tests for the class I just modified"
+---
+
+Always apply the `using-gradle` skill for Gradle task syntax and build commands.
+
+## How to run tests
+
+- For yaml-tests: `./gradlew :yaml-tests:test` (or `--tests 'YamlIntegrationTests.<name>'`).
+- For embedded-only yaml-tests (faster): `./gradlew :yaml-tests:quickTest`.
+- For mixed-mode yaml-tests locally: `./gradlew :yaml-tests:mixedModeTest`.
+- For JUnit tests in a module: `./gradlew :<module>:test --tests '<fully.qualified.ClassName>'`.
+
+## Diagnosing failures
+
+1. Read the full test output — look for the stack trace and the assertion message.
+2. Check if the failure is in a yaml test:
+   - `plan mismatch` → the actual query plan changed; edit `YamlIntegrationTests.java` to add
+     `@MaintainYamlTestConfig(YamlTestConfigFilters.CORRECT_EXPECTATIONS)` to the test entry,
+     then re-run — the framework will auto-correct the expected plan.
+   - `result mismatch` → data or query logic changed; inspect the yamsql file.
+3. Check if the failure is an async issue:
+   - `BlockingInAsyncContextException` → something called `join()`/`get()` inside a future.
+   - Timeout → possible deadlock; check for blocking calls in completion lambdas.
+4. Check if FDB connectivity is the issue:
+   - `FDBException` or connection refused → FDB is not running or cluster file is wrong.

--- a/.claude/skills/using-gradle/SKILL.md
+++ b/.claude/skills/using-gradle/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: using-gradle
+description: Use this skill when you need to build the project, compile code, or run tests.
+  Some example usages:
+  "Check this code compiles"
+  "Run the tests for EmbeddedRelationalStatement"
+  "Run the yaml-tests suite"
+---
+
+# Building
+
+```
+./gradlew build                        # full build
+./gradlew package                      # build + generate protobuf sources (required before first compile)
+./gradlew clean                        # clean build artifacts
+./gradlew -PspotbugsEnableHtmlReport check   # all checks including SpotBugs and Checkstyle
+```
+
+Compile a single module without running tests:
+```
+./gradlew :fdb-relational-core:compileJava
+./gradlew :fdb-record-layer-core:compileJava
+```
+
+# Running tests
+
+## Standard test tasks
+
+| Task | What it runs |
+|---|---|
+| `test` | Unit + integration tests, excluding `WipesFDB` and `AutomatedTest` tags |
+| `quickTest` | Like `test` but faster (excludes `WipesFDB`) |
+| `destructiveTest` | Tests tagged `WipesFDB` — wipes FDB data, single fork |
+| `performanceTest` | Tests tagged `Performance`, assertions disabled |
+| `rpcTest` | Tests via embedded RPC server rather than embedded connection |
+| `mixedModeTest` | Tests tagged `MixedMode` (requires external server JARs) |
+| `singleVersionTest` | Tests against a single external server version |
+
+Run a specific test class or method in a module:
+```
+./gradlew :fdb-relational-core:test --tests 'com.apple.foundationdb.relational.recordlayer.EmbeddedRelationalStatementTest'
+./gradlew :fdb-relational-core:test --tests 'com.apple.foundationdb.relational.recordlayer.EmbeddedRelationalStatementTest.testGet'
+```
+
+## yaml-tests
+
+```
+./gradlew :yaml-tests:test             # run all yaml integration tests
+./gradlew :yaml-tests:test --tests 'YamlIntegrationTests.myTestName'
+```
+
+Custom seed and iteration count (for reproducing flaky yaml tests):
+```
+./gradlew :yaml-tests:test -Ptests.yaml.seed=12345 -Ptests.yaml.iterations=10
+```
+
+## FDB prerequisite
+
+Tests that hit FDB require a running FoundationDB cluster and `fdb-environment.yaml` in the
+repo root.
+
+Example `fdb-environment.yaml`:
+```yaml
+libraryPath: /usr/local/lib/libfdb_c.dylib
+clusterFiles:
+  - /usr/local/etc/foundationdb/fdb.cluster
+```
+
+## Publishing locally (to use in another project)
+
+```
+./gradlew publishToMavenLocal -PpublishBuild=true
+```
+
+Jars land in `~/.m2/repository/org/foundationdb/`.
+
+## JMH benchmarks (fdb-relational-core)
+
+```
+./gradlew :fdb-relational-core:jmh
+```
+
+Benchmark sources live in `fdb-relational-core/src/jmh/java/`. The active benchmarks are
+controlled by the `includes` list in the `jmh {}` block of `fdb-relational-core.gradle`.
+Useful JMH options (pass as Gradle properties or edit the block):
+
+```
+./gradlew :fdb-relational-core:jmh -Pjmh.include=DirectAccessVsQueryBenchmark
+```

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../AGENTS.md

--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,9 @@ fdb-relational-core/src/main/antlr/*.tokens
 
 # output during release build process
 /mixed-mode-results.md
+
+# AI assistant local analysis artifacts
+/claude-analysis/
+
+# Claude Code local settings (personal permissions and hooks)
+.claude/settings.local.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,88 @@
+<!-- NOTE: CLAUDE.md, GEMINI.md, and .github/copilot-instructions.md are symlinks to this file. Only edit AGENTS.md. -->
+
+## Project Overview
+
+FoundationDB Record Layer is a layered database library built on top of FoundationDB. The
+repository contains two main layers:
+
+- **Record Layer** (`fdb-record-layer-core`, `fdb-extensions`, etc.): A structured key-value
+  store with rich indexing, querying, and schema evolution capabilities. The core API is
+  asynchronous, built around `CompletableFuture`.
+- **Relational Layer** (`fdb-relational-*`): A SQL database layer on top of the record layer,
+  providing JDBC connectivity, a Cascades-based query planner, and schema templates for
+  multi-tenant architectures. Also exposes a direct-access API
+  (`RelationalDirectAccessStatement`) that bypasses the SQL planner for lower-overhead reads;
+  this API is expected to be deprecated in the future as the SQL layer matures.
+
+## General Guidelines
+
+All Java, Gradle, and property files MUST end with a newline character.
+
+JDK 21 is required to build. The code targets Java 17 language compatibility.
+
+## PR Workflow
+
+- The default PR target branch is `main`.
+- PRs can reference the issue they address (e.g., `Fixes #492`).
+- PR titles are used to generate release notes — make them clear and descriptive.
+- PRs must carry one of these labels: `breaking change`, `enhancement`, `bug fix`,
+  `performance`, `dependencies`, `build improvement`, `testing improvement`, `documentation`.
+- Always create PRs as **drafts** (`gh pr create --draft`). Let the human decide when it's
+  ready for review.
+- Never merge branches or PRs without explicit user consent.
+
+## Test Strategy
+
+### SQL-layer tests (yaml-tests)
+
+The primary way to test SQL-layer behavior is via `.yamsql` files in
+`yaml-tests/src/test/resources/`. To add a test:
+
+1. Create or extend a `.yamsql` file.
+2. Register it in `yaml-tests/src/test/java/YamlIntegrationTests.java`.
+3. Decorate the entry with `@MaintainYamlTestConfig(YamlTestConfigFilters.CORRECT_EXPECTATIONS)`
+   to have the framework auto-correct expected query plans, metadata, and metrics on first run.
+
+See `yaml-tests/src/test/resources/showcasing-tests.yamsql` for a comprehensive reference of
+the yamsql format (schema templates, setup blocks, result matchers, parameterization, etc.).
+
+### JUnit tests
+
+Use JUnit 5 for things that operate below the SQL layer, or that cannot be easily expressed in
+the yamsql framework (e.g., specific JDBC interactions, record layer API behavior, async edge
+cases). Some JUnit tests require a running FDB instance — configure `fdb-environment.yaml` in
+the repo root before running them.
+
+## Agent Routing Rules
+
+Use the appropriate specialized skill for each task type.
+
+### Building
+→ Apply the `using-gradle` skill.
+
+### Running and diagnosing tests
+→ Apply the `test-runner` skill.
+
+### Writing or reviewing Java code
+→ Apply the `frl-coding-standard` skill. For test code, also apply `frl-test-coding-standard`.
+
+### Code review
+→ Use the `code-reviewer` skill.
+
+### Writing or updating documentation
+→ Use the `docs-writer` skill.
+
+### Working in the SQL processing layer (`fdb-relational-core`)
+→ Use the `relational-query-processor` skill.
+
+## Tooling for AI Assistants
+
+Each AI assistant reads its own context file, all of which point here:
+
+- **Claude Code**: `CLAUDE.md` → `AGENTS.md`. Additional tooling (agents, skills, commands)
+  is available under `.claude/`. See `.claude/README.md`.
+- **GitHub Copilot**: `.github/copilot-instructions.md` → `AGENTS.md`.
+- **Gemini**: `GEMINI.md` → `AGENTS.md`.
+
+The `.claude/` directory is Claude Code-specific — no equivalent directory exists yet for
+other tools. Contributions adding similar tooling for Copilot, Gemini, or Cursor are welcome.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary

- Adds `AGENTS.md` (shared context file for all AI assistants) with project overview, test strategy, and agent routing rules; `CLAUDE.md`, `GEMINI.md`, and `.github/copilot-instructions.md` are symlinks to it
- Adds Claude Code-specific tooling under `.claude/`: skills for code review, coding standards, docs writing, query processing, test running, and session management
- Skills are invocable via `/skill-name` in Claude Code and provide reusable, focused instruction sets for common tasks

## Test plan

- [x] Verify `/code-reviewer`, `/using-gradle`, `/test-runner`, and other skills load correctly in Claude Code
- [x] Confirm `CLAUDE.md` and `GEMINI.md` resolve correctly as symlinks to `AGENTS.md`
- [x] Check that the routing rules in `AGENTS.md` match the available skills