### PR TITLE
Add observability for the set of indexes updated in a transaction

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/ContextSessionKey.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/ContextSessionKey.java
@@ -1,0 +1,83 @@
+/*
+ * ContextSessionKey.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb;
+
+import com.apple.foundationdb.annotation.API;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Set;
+
+/**
+ * A typed key for well-known values stored in the {@link FDBRecordContext} session data map.
+ * Keys are defined as {@code public static final} constants in this class.
+ * The constructor is package protected so no external code can introduce new keys.
+ *
+ * <p>Use {@link FDBRecordContext#getInSession(ContextSessionKey)} to retrieve values.</p>
+ *
+ * @param <T> the value type for this key
+ */
+@API(API.Status.EXPERIMENTAL)
+public final class ContextSessionKey<T> {
+    /**
+     * Session key for the set of write-only index names updated in this transaction.
+     * Value type: {@code Set<String>}. Returns {@code null} if no write-only index was updated.
+     * Useful for diagnosing conflicts that may happen when an index is updated by the indexer.
+     */
+    public static final ContextSessionKey<Set<String>> WRITE_ONLY_INDEXES_UPDATED = new ContextSessionKey<>("writeOnlyIndexesUpdated");
+    /**
+     * Session key for the set of readable index names updated in this transaction.
+     * Note that this captures both {@link com.apple.foundationdb.record.IndexState#READABLE} and
+     * {@link com.apple.foundationdb.record.IndexState#READABLE_UNIQUE_PENDING}.
+     * Value type: {@code Set<String>}. Returns {@code null} if no readable index was updated.
+     */
+    public static final ContextSessionKey<Set<String>> READABLE_INDEXES_UPDATED = new ContextSessionKey<>("readableIndexesUpdated");
+
+    @Nonnull
+    private final String name;
+
+    ContextSessionKey(@Nonnull String name) {
+        this.name = name;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Nullable
+    T cast(@Nullable Object value) {
+        return (T)value;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ContextSessionKey)) {
+            return false;
+        }
+        final ContextSessionKey<?> that = (ContextSessionKey<?>)o;
+        return name.equals(that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return name.hashCode();
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
@@ -61,9 +61,11 @@ import java.nio.charset.Charset;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
@@ -136,6 +138,15 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
      * @see com.apple.foundationdb.TransactionOptions#setDebugTransactionIdentifier(String)
      */
     public static final int MAX_TR_ID_SIZE = 100;
+
+    /**
+     * Session key for the set of write-only index names updated in this transaction.
+     * Value type: {@code Set<String>}. Returns {@code null} if no write-only index was updated.
+     * Useful for diagnosing conflicts that may happen when an index is updated by the indexer.
+     *
+     * @see #getInSession(SessionKey)
+     */
+    public static final SessionKey<Set<String>> WRITE_ONLY_INDEXES_UPDATED = new SessionKey<>("writeOnlyIndexesUpdated");
 
     @Nullable
     private CompletableFuture<Long> readVersionFuture;
@@ -1551,6 +1562,19 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
     }
 
     /**
+     * Retrieve a typed value from the session data using a {@link SessionKey}.
+     *
+     * @param key the session key
+     * @param <T> the value type, as declared by the key constant
+     * @return the stored value for the transaction, or {@code null} if absent
+     */
+    @Nullable
+    @API(API.Status.EXPERIMENTAL)
+    public synchronized <T> T getInSession(@Nonnull SessionKey<T> key) {
+        return key.cast(session.get(key));
+    }
+
+    /**
      * Put an object into the session of the FDBRecordContext.
      *
      * @param key key
@@ -1559,6 +1583,18 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
      */
     @API(API.Status.EXPERIMENTAL)
     public synchronized <T extends Object> void putInSessionIfAbsent(@Nonnull Object key, @Nonnull T value) {
+        session.put(key, value);
+    }
+
+    /**
+     * Store a typed value in the session under the given {@link SessionKey}, replacing any existing value.
+     *
+     * @param key the session key
+     * @param value the value to store
+     * @param <T> the value type, as declared by the key constant
+     */
+    @API(API.Status.EXPERIMENTAL)
+    public synchronized <T> void putInSession(@Nonnull SessionKey<T> key, @Nonnull T value) {
         session.put(key, value);
     }
 
@@ -1574,6 +1610,20 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
     @API(API.Status.EXPERIMENTAL)
     public synchronized <T> T removeFromSession(@Nonnull String key, @Nonnull Class<T> clazz) {
         return (T) session.remove(key);
+    }
+
+    /**
+     * Remove and return the value stored under the given {@link SessionKey}.
+     * Returns {@code null} if no value was stored under this key.
+     *
+     * @param key the session key
+     * @param <T> the value type, as declared by the key constant
+     * @return the previously stored value, or {@code null} if absent
+     */
+    @Nullable
+    @API(API.Status.EXPERIMENTAL)
+    public synchronized <T> T removeFromSession(@Nonnull SessionKey<T> key) {
+        return key.cast(session.remove(key));
     }
 
     /**
@@ -1640,5 +1690,58 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
     @Nonnull
     public TempTable.Factory getTempTableFactory() {
         return tempTableFactory;
+    }
+
+    /**
+     * Record that a write-only index was written to in this transaction.
+     *
+     * @param indexName the name of the write-only index
+     */
+    @SuppressWarnings("unchecked")
+    synchronized void addTouchedWriteOnlyIndex(@Nonnull String indexName) {
+        Set<String> indexes = (Set<String>) session.computeIfAbsent(WRITE_ONLY_INDEXES_UPDATED, k -> new HashSet<>());
+        indexes.add(indexName);
+    }
+
+    /**
+     * A typed key for well-known values stored in the {@link FDBRecordContext} session data map.
+     * Keys are defined as {@code public static final} constants in this class.
+     * The constructor is private so no external code can introduce new keys.
+     *
+     * <p>Use {@link FDBRecordContext#getInSession(SessionKey)} to retrieve values.</p>
+     *
+     * @param <T> the value type for this key
+     */
+    @API(API.Status.EXPERIMENTAL)
+    public static final class SessionKey<T> {
+        @Nonnull
+        private final String name;
+
+        SessionKey(@Nonnull String name) {
+            this.name = name;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Nullable
+        private T cast(@Nullable Object value) {
+            return (T) value;
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof SessionKey)) {
+                return false;
+            }
+            final SessionKey<?> that = (SessionKey<?>) o;
+            return name.equals(that.name);
+        }
+
+        @Override
+        public int hashCode() {
+            return name.hashCode();
+        }
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
@@ -139,15 +139,6 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
      */
     public static final int MAX_TR_ID_SIZE = 100;
 
-    /**
-     * Session key for the set of write-only index names updated in this transaction.
-     * Value type: {@code Set<String>}. Returns {@code null} if no write-only index was updated.
-     * Useful for diagnosing conflicts that may happen when an index is updated by the indexer.
-     *
-     * @see #getInSession(SessionKey)
-     */
-    public static final SessionKey<Set<String>> WRITE_ONLY_INDEXES_UPDATED = new SessionKey<>("writeOnlyIndexesUpdated");
-
     @Nullable
     private CompletableFuture<Long> readVersionFuture;
     private long readVersion = UNSET_VERSION;
@@ -1562,7 +1553,7 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
     }
 
     /**
-     * Retrieve a typed value from the session data using a {@link SessionKey}.
+     * Retrieve a typed value from the session data using a {@link ContextSessionKey}.
      *
      * @param key the session key
      * @param <T> the value type, as declared by the key constant
@@ -1570,7 +1561,7 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
      */
     @Nullable
     @API(API.Status.EXPERIMENTAL)
-    public synchronized <T> T getInSession(@Nonnull SessionKey<T> key) {
+    public synchronized <T> T getInSession(@Nonnull ContextSessionKey<T> key) {
         return key.cast(session.get(key));
     }
 
@@ -1587,15 +1578,31 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
     }
 
     /**
-     * Store a typed value in the session under the given {@link SessionKey}, replacing any existing value.
+     * Store a typed value in the session under the given {@link ContextSessionKey}, replacing any existing value.
      *
      * @param key the session key
      * @param value the value to store
      * @param <T> the value type, as declared by the key constant
      */
     @API(API.Status.EXPERIMENTAL)
-    public synchronized <T> void putInSession(@Nonnull SessionKey<T> key, @Nonnull T value) {
+    public synchronized <T> void putInSession(@Nonnull ContextSessionKey<T> key, @Nonnull T value) {
         session.put(key, value);
+    }
+
+    /**
+     * Add an element to a set of values for the given key.
+     * Convenience method to add elements to a set in the session info. This would create a HashSet for the elements
+     * if none yet exists, then add the element to the set.
+     *
+     * @param key the key for the session info set of values
+     * @param value the value to add to the set
+     * @param <T> the type of value being added
+     */
+    @API(API.Status.EXPERIMENTAL)
+    @SuppressWarnings("unchecked")
+    public synchronized <T> void addToSessionSet(@Nonnull ContextSessionKey<Set<T>> key, @Nonnull T value) {
+        Set<T> valueSet = (Set<T>) session.computeIfAbsent(key, k -> new HashSet<>());
+        valueSet.add(value);
     }
 
     /**
@@ -1613,7 +1620,7 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
     }
 
     /**
-     * Remove and return the value stored under the given {@link SessionKey}.
+     * Remove and return the value stored under the given {@link ContextSessionKey}.
      * Returns {@code null} if no value was stored under this key.
      *
      * @param key the session key
@@ -1622,7 +1629,7 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
      */
     @Nullable
     @API(API.Status.EXPERIMENTAL)
-    public synchronized <T> T removeFromSession(@Nonnull SessionKey<T> key) {
+    public synchronized <T> T removeFromSession(@Nonnull ContextSessionKey<T> key) {
         return key.cast(session.remove(key));
     }
 
@@ -1690,58 +1697,5 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
     @Nonnull
     public TempTable.Factory getTempTableFactory() {
         return tempTableFactory;
-    }
-
-    /**
-     * Record that a write-only index was written to in this transaction.
-     *
-     * @param indexName the name of the write-only index
-     */
-    @SuppressWarnings("unchecked")
-    synchronized void addTouchedWriteOnlyIndex(@Nonnull String indexName) {
-        Set<String> indexes = (Set<String>) session.computeIfAbsent(WRITE_ONLY_INDEXES_UPDATED, k -> new HashSet<>());
-        indexes.add(indexName);
-    }
-
-    /**
-     * A typed key for well-known values stored in the {@link FDBRecordContext} session data map.
-     * Keys are defined as {@code public static final} constants in this class.
-     * The constructor is private so no external code can introduce new keys.
-     *
-     * <p>Use {@link FDBRecordContext#getInSession(SessionKey)} to retrieve values.</p>
-     *
-     * @param <T> the value type for this key
-     */
-    @API(API.Status.EXPERIMENTAL)
-    public static final class SessionKey<T> {
-        @Nonnull
-        private final String name;
-
-        SessionKey(@Nonnull String name) {
-            this.name = name;
-        }
-
-        @SuppressWarnings("unchecked")
-        @Nullable
-        private T cast(@Nullable Object value) {
-            return (T) value;
-        }
-
-        @Override
-        public boolean equals(final Object o) {
-            if (this == o) {
-                return true;
-            }
-            if (!(o instanceof SessionKey)) {
-                return false;
-            }
-            final SessionKey<?> that = (SessionKey<?>) o;
-            return name.equals(that.name);
-        }
-
-        @Override
-        public int hashCode() {
-            return name.hashCode();
-        }
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -780,6 +780,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
                 // process has already built the relevant ranges, and it
                 // may adjust the way the index is built in response.
                 future = maintainer.updateWhileWriteOnly(oldRecord, newRecord);
+                context.addTouchedWriteOnlyIndex(index.getName());
             } else {
                 future = maintainer.update(oldRecord, newRecord);
             }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -780,9 +780,11 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
                 // process has already built the relevant ranges, and it
                 // may adjust the way the index is built in response.
                 future = maintainer.updateWhileWriteOnly(oldRecord, newRecord);
-                context.addTouchedWriteOnlyIndex(index.getName());
+                context.addToSessionSet(ContextSessionKey.WRITE_ONLY_INDEXES_UPDATED, index.getName());
             } else {
                 future = maintainer.update(oldRecord, newRecord);
+                // Both READABLE and READABLE_UNIQUE_PENDING will cause the index to be updated and so are captured here
+                context.addToSessionSet(ContextSessionKey.READABLE_INDEXES_UPDATED, index.getName());
             }
             if (!MoreAsyncUtil.isCompletedNormally(future)) {
                 futures.add(future);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContextTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContextTest.java
@@ -54,6 +54,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
@@ -71,6 +72,7 @@ import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -461,6 +463,79 @@ public class FDBRecordContextTest {
             assertEquals("YOLO", context.getInSession("Yo", String.class));
             assertEquals("YOLO", context.removeFromSession("Yo", String.class));
             assertNull(context.getInSession("Yo", String.class));
+        }
+    }
+
+    @Test
+    void sessionKeyEqualityBasedOnName() {
+        final FDBRecordContext.SessionKey<String> key1 = new FDBRecordContext.SessionKey<>("myKey");
+        final FDBRecordContext.SessionKey<String> key2 = new FDBRecordContext.SessionKey<>("myKey");
+        final FDBRecordContext.SessionKey<String> keyOther = new FDBRecordContext.SessionKey<>("otherKey");
+
+        assertEquals(key1, key2, "keys with the same name must be equal");
+        assertEquals(key1.hashCode(), key2.hashCode(), "equal keys must have the same hash code");
+        assertNotEquals(key1, keyOther, "keys with different names must not be equal");
+        assertNotEquals(key1, null, "a key must not equal null");
+    }
+
+    @Test
+    void sessionKeyTypedGetReturnsNullWhenAbsent() {
+        final FDBRecordContext.SessionKey<String> key = new FDBRecordContext.SessionKey<>("absent");
+        try (FDBRecordContext context = fdb.openContext()) {
+            assertNull(context.getInSession(key));
+        }
+    }
+
+    @Test
+    void sessionKeyTypedGetAndSet() {
+        final FDBRecordContext.SessionKey<String> key = new FDBRecordContext.SessionKey<>("myString");
+        try (FDBRecordContext context = fdb.openContext()) {
+            context.putInSession(key, "hello");
+            // No cast needed at the call site — type safety provided by SessionKey<String>
+            final String value = context.getInSession(key);
+            assertEquals("hello", value);
+        }
+    }
+
+    @Test
+    void sessionKeyMultipleKeysOfDifferentTypes() {
+        final FDBRecordContext.SessionKey<String> stringKey = new FDBRecordContext.SessionKey<>("myString");
+        final FDBRecordContext.SessionKey<Integer> intKey = new FDBRecordContext.SessionKey<>("myInt");
+        try (FDBRecordContext context = fdb.openContext()) {
+            context.putInSession(stringKey, "hello");
+            context.putInSession(intKey, 42);
+
+            // Each key returns its own typed value — no cross-contamination
+            final String strVal = context.getInSession(stringKey);
+            final Integer intVal = context.getInSession(intKey);
+            assertEquals("hello", strVal);
+            assertEquals(42, intVal);
+        }
+    }
+
+    @Test
+    void sessionKeyTwoKeysWithSameType() {
+        final FDBRecordContext.SessionKey<String> key1 = new FDBRecordContext.SessionKey<>("keyOne");
+        final FDBRecordContext.SessionKey<String> key2 = new FDBRecordContext.SessionKey<>("keyTwo");
+        try (FDBRecordContext context = fdb.openContext()) {
+            context.putInSessionIfAbsent(key1, "value1");
+            context.putInSessionIfAbsent(key2, "value2");
+
+            assertEquals("value1", context.getInSession(key1));
+            assertEquals("value2", context.getInSession(key2));
+        }
+    }
+
+    @Test
+    void sessionKeyTypeMismatchCausesClassCastException() {
+        // putInSessionIfAbsent accepts Object so a caller can store the wrong type.
+        // getInSession will trigger a ClassCastException when the value is used.
+        final FDBRecordContext.SessionKey<String> key = new FDBRecordContext.SessionKey<>("typedKey");
+        try (FDBRecordContext context = fdb.openContext()) {
+            context.putInSessionIfAbsent(key, 42); // Integer stored under a String key
+            assertThrows(ClassCastException.class, () -> {
+                final String value = context.getInSession(key); // cast fails here
+            });
         }
     }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContextTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContextTest.java
@@ -54,7 +54,6 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContextTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContextTest.java
@@ -493,6 +493,11 @@ public class FDBRecordContextTest {
             // No cast needed at the call site — type safety provided by SessionKey<String>
             final String value = context.getInSession(key);
             assertEquals("hello", value);
+            // remove
+            final String removed = context.removeFromSession(key);
+            assertEquals("hello", removed);
+            assertNull(context.removeFromSession(key));
+            assertNull(context.getInSession(key));
         }
     }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContextTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContextTest.java
@@ -467,9 +467,9 @@ public class FDBRecordContextTest {
 
     @Test
     void sessionKeyEqualityBasedOnName() {
-        final FDBRecordContext.SessionKey<String> key1 = new FDBRecordContext.SessionKey<>("myKey");
-        final FDBRecordContext.SessionKey<String> key2 = new FDBRecordContext.SessionKey<>("myKey");
-        final FDBRecordContext.SessionKey<String> keyOther = new FDBRecordContext.SessionKey<>("otherKey");
+        final ContextSessionKey<String> key1 = new ContextSessionKey<>("myKey");
+        final ContextSessionKey<String> key2 = new ContextSessionKey<>("myKey");
+        final ContextSessionKey<String> keyOther = new ContextSessionKey<>("otherKey");
 
         assertEquals(key1, key2, "keys with the same name must be equal");
         assertEquals(key1.hashCode(), key2.hashCode(), "equal keys must have the same hash code");
@@ -479,7 +479,7 @@ public class FDBRecordContextTest {
 
     @Test
     void sessionKeyTypedGetReturnsNullWhenAbsent() {
-        final FDBRecordContext.SessionKey<String> key = new FDBRecordContext.SessionKey<>("absent");
+        final ContextSessionKey<String> key = new ContextSessionKey<>("absent");
         try (FDBRecordContext context = fdb.openContext()) {
             assertNull(context.getInSession(key));
         }
@@ -487,7 +487,7 @@ public class FDBRecordContextTest {
 
     @Test
     void sessionKeyTypedGetAndSet() {
-        final FDBRecordContext.SessionKey<String> key = new FDBRecordContext.SessionKey<>("myString");
+        final ContextSessionKey<String> key = new ContextSessionKey<>("myString");
         try (FDBRecordContext context = fdb.openContext()) {
             context.putInSession(key, "hello");
             // No cast needed at the call site — type safety provided by SessionKey<String>
@@ -503,8 +503,8 @@ public class FDBRecordContextTest {
 
     @Test
     void sessionKeyMultipleKeysOfDifferentTypes() {
-        final FDBRecordContext.SessionKey<String> stringKey = new FDBRecordContext.SessionKey<>("myString");
-        final FDBRecordContext.SessionKey<Integer> intKey = new FDBRecordContext.SessionKey<>("myInt");
+        final ContextSessionKey<String> stringKey = new ContextSessionKey<>("myString");
+        final ContextSessionKey<Integer> intKey = new ContextSessionKey<>("myInt");
         try (FDBRecordContext context = fdb.openContext()) {
             context.putInSession(stringKey, "hello");
             context.putInSession(intKey, 42);
@@ -519,8 +519,8 @@ public class FDBRecordContextTest {
 
     @Test
     void sessionKeyTwoKeysWithSameType() {
-        final FDBRecordContext.SessionKey<String> key1 = new FDBRecordContext.SessionKey<>("keyOne");
-        final FDBRecordContext.SessionKey<String> key2 = new FDBRecordContext.SessionKey<>("keyTwo");
+        final ContextSessionKey<String> key1 = new ContextSessionKey<>("keyOne");
+        final ContextSessionKey<String> key2 = new ContextSessionKey<>("keyTwo");
         try (FDBRecordContext context = fdb.openContext()) {
             context.putInSessionIfAbsent(key1, "value1");
             context.putInSessionIfAbsent(key2, "value2");
@@ -534,7 +534,7 @@ public class FDBRecordContextTest {
     void sessionKeyTypeMismatchCausesClassCastException() {
         // putInSessionIfAbsent accepts Object so a caller can store the wrong type.
         // getInSession will trigger a ClassCastException when the value is used.
-        final FDBRecordContext.SessionKey<String> key = new FDBRecordContext.SessionKey<>("typedKey");
+        final ContextSessionKey<String> key = new ContextSessionKey<>("typedKey");
         try (FDBRecordContext context = fdb.openContext()) {
             context.putInSessionIfAbsent(key, 42); // Integer stored under a String key
             assertThrows(ClassCastException.class, () -> {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreIndexTest.java
@@ -3118,6 +3118,48 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
         database.close();
     }
 
+    @Test
+    void testWriteOnlyIndexUpdatesTrackedInSession() throws Exception {
+        final String indexName = "MySimpleRecord$num_value_3_indexed";
+
+        // Mark the index write-only in a committed transaction first
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context);
+            recordStore.markIndexWriteOnly(indexName).get();
+            commit(context);
+        }
+
+        // Save a record; the write-only index update should be registered in the session
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context);
+            recordStore.saveRecord(TestRecords1Proto.MySimpleRecord.newBuilder()
+                    .setRecNo(1066L)
+                    .setNumValue3Indexed(42)
+                    .build());
+
+            final Set<String> tracked = context.getInSession(FDBRecordContext.WRITE_ONLY_INDEXES_UPDATED);
+            assertNotNull(tracked, "session should record write-only index updates");
+            assertEquals(1, tracked.size());
+            assertTrue(tracked.contains(indexName),
+                    "tracked set should contain the write-only index name");
+        }
+    }
+
+    @Test
+    void testReadableIndexUpdatesNotTrackedInSession() throws Exception {
+        // All indexes are readable by default — nothing should be recorded in the session
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context);
+            recordStore.saveRecord(TestRecords1Proto.MySimpleRecord.newBuilder()
+                    .setRecNo(1066L)
+                    .setNumValue3Indexed(42)
+                    .build());
+
+            assertNull(context.getInSession(FDBRecordContext.WRITE_ONLY_INDEXES_UPDATED),
+                    "session should be empty when no write-only indexes were touched");
+        }
+    }
+
     private void testRangeCount(@Nonnull FDBRecordContext context, @Nonnull ArrayList<byte[]> keys, byte[] upperBound, int rangeCount) {
         MockedLocalityUtil.init(keys, rangeCount);
         CloseableAsyncIterator<byte[]> cursor = MockedLocalityUtil.instance().getBoundaryKeys(context.ensureActive(), keys.get(0), upperBound);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreIndexTest.java
@@ -3137,17 +3137,22 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
                     .setNumValue3Indexed(42)
                     .build());
 
-            final Set<String> tracked = context.getInSession(FDBRecordContext.WRITE_ONLY_INDEXES_UPDATED);
+            Set<String> tracked = context.getInSession(ContextSessionKey.WRITE_ONLY_INDEXES_UPDATED);
             assertNotNull(tracked, "session should record write-only index updates");
             assertEquals(1, tracked.size());
             assertTrue(tracked.contains(indexName),
                     "tracked set should contain the write-only index name");
+
+            tracked = context.getInSession(ContextSessionKey.READABLE_INDEXES_UPDATED);
+            assertFalse(tracked.contains(indexName), "index is not readable, should not be tracked");
         }
     }
 
     @Test
-    void testReadableIndexUpdatesNotTrackedInSession() throws Exception {
-        // All indexes are readable by default — nothing should be recorded in the session
+    void testReadableIndexUpdatesTrackedInSession() throws Exception {
+        final String indexName = "MySimpleRecord$num_value_3_indexed";
+
+        // All indexes are readable by default
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
             recordStore.saveRecord(TestRecords1Proto.MySimpleRecord.newBuilder()
@@ -3155,8 +3160,14 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
                     .setNumValue3Indexed(42)
                     .build());
 
-            assertNull(context.getInSession(FDBRecordContext.WRITE_ONLY_INDEXES_UPDATED),
+            assertNull(context.getInSession(ContextSessionKey.WRITE_ONLY_INDEXES_UPDATED),
                     "session should be empty when no write-only indexes were touched");
+
+            Set<String> tracked = context.getInSession(ContextSessionKey.READABLE_INDEXES_UPDATED);
+            assertNotNull(tracked, "session should record readable index updates");
+            assertFalse(tracked.isEmpty());
+            assertTrue(tracked.contains(indexName),
+                    "tracked set should contain the readable index name");
         }
     }
 


### PR DESCRIPTION
When a transaction fails with `NOT_COMMITTED` (conflict), it can be difficult to know whether the conflict was caused by a background index build via OnlineIndexer. Indexes in WRITE_ONLY state are actively being written to by both the OnlineIndexer and normal record save operations — making them a potential source of contention.

This change tracks which write-only indexes were touched during a transaction and, if that transaction conflicts, these values can be inspected.

In support of this, a mechanism to store and retrieve values in a `FdbRecordContext` was added in a generic fashion using the `session` field. It is meant for external consumption, with a protected typed API that prevents access to other pre-existing values.

Resolves #4288 