### PR TITLE
Extend deserialize retry to cover decryption failures

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/TransformedRecordSerializer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/TransformedRecordSerializer.java
@@ -329,8 +329,29 @@ public class TransformedRecordSerializer<M extends Message> implements RecordSer
         if (!TransformedRecordSerializerPrefix.decodePrefix(state, primaryKey)) {
             return inner.deserialize(metaData, primaryKey, serialized, timer);
         }
-        decryptAndDecompress(metaData, primaryKey, serialized, state, timer, 0);
+        decryptAndDecompress(metaData, primaryKey, serialized, state, timer, 0, null);
         return inner.deserialize(metaData, primaryKey, state.getDataArray(), timer);
+    }
+
+    private void something() {
+
+        // run decryptAndDecompress in try/catch block
+
+        // if deserializeReattemptCount == 0
+        //     throw if error
+
+        Throwable exceptionOnLastAttempt = null;
+        try {
+            decryptAndDecompress();
+            return;
+        } catch (Exception e) {
+            if (deserializeReattemptCount == 0) {
+                throw e;
+            } else {
+                exceptionOnLastAttempt = e;
+            }
+        }
+
     }
 
     private void decryptAndDecompress(@Nonnull RecordMetaData metaData,
@@ -338,7 +359,8 @@ public class TransformedRecordSerializer<M extends Message> implements RecordSer
                                       @Nonnull byte[] serialized,
                                       @Nonnull TransformedRecordSerializerState state,
                                       @Nullable StoreTimer timer,
-                                      int retryAttempt) {
+                                      int retryAttempt,
+                                      @Nullable RecordCoreException lastAttemptFailure) {
         RecordCoreException failure = null;
         if (state.isEncrypted()) {
             try {
@@ -361,11 +383,12 @@ public class TransformedRecordSerializer<M extends Message> implements RecordSer
             }
             TransformedRecordSerializerState retryState = new TransformedRecordSerializerState(serialized);
             Verify.verify(TransformedRecordSerializerPrefix.decodePrefix(retryState, primaryKey));
-            decryptAndDecompress(metaData, primaryKey, serialized, retryState, timer, retryAttempt + 1);
+            decryptAndDecompress(metaData, primaryKey, serialized, retryState, timer, retryAttempt + 1, failure);
             state.setDataArray(retryState.getDataArray());
         } else if (retryAttempt > 0 && failOnDeserializeReattempt) {
+            Verify.verify(lastAttemptFailure != null);
             // deserialization succeeded on retry; however since failOnDeserializeReattempt is set, we throw an error
-            throw new RecordSerializationException("deserialization error")
+            throw new RecordSerializationException("deserialization error", lastAttemptFailure)
                     .addLogInfo(LogMessageKeys.META_DATA_VERSION, metaData.getVersion())
                     .addLogInfo(LogMessageKeys.PRIMARY_KEY, primaryKey)
                     .addLogInfo(LogMessageKeys.RETRY_COUNT, retryAttempt)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/TransformedRecordSerializer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/TransformedRecordSerializer.java
@@ -339,21 +339,24 @@ public class TransformedRecordSerializer<M extends Message> implements RecordSer
                                       @Nonnull TransformedRecordSerializerState state,
                                       @Nullable StoreTimer timer,
                                       int retryAttempt) {
+        RecordCoreException failure = null;
         if (state.isEncrypted()) {
-            decryptOrThrow(metaData, primaryKey, state, timer);
+            try {
+                decryptOrThrow(metaData, primaryKey, state, timer);
+            } catch (RecordCoreException ex) {
+                failure = ex;
+            }
         }
-        if (!state.isCompressed()) {
-            return;
+        if (failure == null && state.isCompressed()) {
+            try {
+                decompressOrThrow(metaData, primaryKey, state, timer);
+            } catch (RecordCoreException ex) {
+                failure = ex;
+            }
         }
-        RecordCoreException decompressException = null;
-        try {
-            decompressOrThrow(metaData, primaryKey, state, timer);
-        } catch (RecordCoreException ex) {
-            decompressException = ex;
-        }
-        if (decompressException != null) {
+        if (failure != null) {
             if (retryAttempt >= deserializeReattemptCount) {
-                throw decompressException.addLogInfo(LogMessageKeys.RETRY_COUNT, retryAttempt)
+                throw failure.addLogInfo(LogMessageKeys.RETRY_COUNT, retryAttempt)
                         .addLogInfo(LogMessageKeys.RESULT, "failure");
             }
             TransformedRecordSerializerState retryState = new TransformedRecordSerializerState(serialized);
@@ -361,8 +364,8 @@ public class TransformedRecordSerializer<M extends Message> implements RecordSer
             decryptAndDecompress(metaData, primaryKey, serialized, retryState, timer, retryAttempt + 1);
             state.setDataArray(retryState.getDataArray());
         } else if (retryAttempt > 0 && failOnDeserializeReattempt) {
-            // decompression succeeded on retry; however since failOnDeserializeReattempt is set, we throw an error
-            throw new RecordSerializationException("decompression error")
+            // deserialization succeeded on retry; however since failOnDeserializeReattempt is set, we throw an error
+            throw new RecordSerializationException("deserialization error")
                     .addLogInfo(LogMessageKeys.META_DATA_VERSION, metaData.getVersion())
                     .addLogInfo(LogMessageKeys.PRIMARY_KEY, primaryKey)
                     .addLogInfo(LogMessageKeys.RETRY_COUNT, retryAttempt)
@@ -534,7 +537,7 @@ public class TransformedRecordSerializer<M extends Message> implements RecordSer
         }
 
         /**
-         * The number of times to reattempt deserialization when decompression fails.
+         * The number of times to reattempt deserialization when decryption or decompression fails.
          * Defaults to {@code 0} (no retries). Setting this to a positive value enables retries.
          * @param deserializeReattemptCount the maximum number of retry attempts
          * @return this <code>Builder</code>

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/TransformedRecordSerializer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/TransformedRecordSerializer.java
@@ -329,70 +329,56 @@ public class TransformedRecordSerializer<M extends Message> implements RecordSer
         if (!TransformedRecordSerializerPrefix.decodePrefix(state, primaryKey)) {
             return inner.deserialize(metaData, primaryKey, serialized, timer);
         }
-        decryptAndDecompress(metaData, primaryKey, serialized, state, timer, 0, null);
+        decryptAndDecompressWithRetries(metaData, primaryKey, serialized, state, timer);
         return inner.deserialize(metaData, primaryKey, state.getDataArray(), timer);
     }
 
-    private void something() {
-
-        // run decryptAndDecompress in try/catch block
-
-        // if deserializeReattemptCount == 0
-        //     throw if error
-
-        Throwable exceptionOnLastAttempt = null;
-        try {
-            decryptAndDecompress();
-            return;
-        } catch (Exception e) {
-            if (deserializeReattemptCount == 0) {
-                throw e;
-            } else {
-                exceptionOnLastAttempt = e;
+    private void decryptAndDecompressWithRetries(@Nonnull RecordMetaData metaData,
+                                                 @Nonnull Tuple primaryKey,
+                                                 @Nonnull byte[] serialized,
+                                                 @Nonnull TransformedRecordSerializerState state,
+                                                 @Nullable StoreTimer timer) {
+        TransformedRecordSerializerState attemptState = state;
+        RecordCoreException lastAttemptFailure = null;
+        for (int attempt = 0; attempt <= deserializeReattemptCount; attempt++) {
+            if (attempt != 0) {
+                // Rebuild a fresh state from the raw serialized bytes so a previous attempt's partial
+                // mutations don't leak into the retry.
+                attemptState = new TransformedRecordSerializerState(serialized);
+                Verify.verify(TransformedRecordSerializerPrefix.decodePrefix(attemptState, primaryKey));
             }
+            try {
+                decryptAndDecompress(metaData, primaryKey, attemptState, timer);
+            } catch (RecordCoreException failure) {
+                lastAttemptFailure = failure;
+                continue;
+            }
+            if (attempt > 0 && failOnDeserializeReattempt) {
+                throw new RecordSerializationException("deserialization error", lastAttemptFailure)
+                        .addLogInfo(LogMessageKeys.META_DATA_VERSION, metaData.getVersion())
+                        .addLogInfo(LogMessageKeys.PRIMARY_KEY, primaryKey)
+                        .addLogInfo(LogMessageKeys.RETRY_COUNT, attempt)
+                        .addLogInfo(LogMessageKeys.RESULT, "success");
+            }
+            if (attemptState != state) {
+                state.setDataArray(attemptState.getDataArray());
+            }
+            return;
         }
-
+        throw Verify.verifyNotNull(lastAttemptFailure)
+                .addLogInfo(LogMessageKeys.RETRY_COUNT, deserializeReattemptCount)
+                .addLogInfo(LogMessageKeys.RESULT, "failure");
     }
 
     private void decryptAndDecompress(@Nonnull RecordMetaData metaData,
                                       @Nonnull Tuple primaryKey,
-                                      @Nonnull byte[] serialized,
                                       @Nonnull TransformedRecordSerializerState state,
-                                      @Nullable StoreTimer timer,
-                                      int retryAttempt,
-                                      @Nullable RecordCoreException lastAttemptFailure) {
-        RecordCoreException failure = null;
+                                      @Nullable StoreTimer timer) {
         if (state.isEncrypted()) {
-            try {
-                decryptOrThrow(metaData, primaryKey, state, timer);
-            } catch (RecordCoreException ex) {
-                failure = ex;
-            }
+            decryptOrThrow(metaData, primaryKey, state, timer);
         }
-        if (failure == null && state.isCompressed()) {
-            try {
-                decompressOrThrow(metaData, primaryKey, state, timer);
-            } catch (RecordCoreException ex) {
-                failure = ex;
-            }
-        }
-        if (failure != null) {
-            if (retryAttempt >= deserializeReattemptCount) {
-                throw failure.addLogInfo(LogMessageKeys.RETRY_COUNT, retryAttempt)
-                        .addLogInfo(LogMessageKeys.RESULT, "failure");
-            }
-            TransformedRecordSerializerState retryState = new TransformedRecordSerializerState(serialized);
-            Verify.verify(TransformedRecordSerializerPrefix.decodePrefix(retryState, primaryKey));
-            decryptAndDecompress(metaData, primaryKey, serialized, retryState, timer, retryAttempt + 1, failure);
-            state.setDataArray(retryState.getDataArray());
-        } else if (retryAttempt > 0 && failOnDeserializeReattempt) {
-            Verify.verify(lastAttemptFailure != null);
-            // deserialization succeeded on retry; however since failOnDeserializeReattempt is set, we throw an error
-            throw new RecordSerializationException("deserialization error", lastAttemptFailure)
-                    .addLogInfo(LogMessageKeys.META_DATA_VERSION, metaData.getVersion())
-                    .addLogInfo(LogMessageKeys.PRIMARY_KEY, primaryKey)
-                    .addLogInfo(LogMessageKeys.RETRY_COUNT, retryAttempt)
-                    .addLogInfo(LogMessageKeys.RESULT, "success");
+        if (state.isCompressed()) {
+            decompressOrThrow(metaData, primaryKey, state, timer);
         }
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/TransformedRecordSerializer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/common/TransformedRecordSerializer.java
@@ -340,34 +340,34 @@ public class TransformedRecordSerializer<M extends Message> implements RecordSer
                                                  @Nullable StoreTimer timer) {
         TransformedRecordSerializerState attemptState = state;
         RecordCoreException lastAttemptFailure = null;
+        int succeededAt = -1;
         for (int attempt = 0; attempt <= deserializeReattemptCount; attempt++) {
             if (attempt != 0) {
-                // Rebuild a fresh state from the raw serialized bytes so a previous attempt's partial
-                // mutations don't leak into the retry.
                 attemptState = new TransformedRecordSerializerState(serialized);
                 Verify.verify(TransformedRecordSerializerPrefix.decodePrefix(attemptState, primaryKey));
             }
             try {
                 decryptAndDecompress(metaData, primaryKey, attemptState, timer);
+                succeededAt = attempt;
+                break;
             } catch (RecordCoreException failure) {
                 lastAttemptFailure = failure;
-                continue;
             }
-            if (attempt > 0 && failOnDeserializeReattempt) {
-                throw new RecordSerializationException("deserialization error", lastAttemptFailure)
-                        .addLogInfo(LogMessageKeys.META_DATA_VERSION, metaData.getVersion())
-                        .addLogInfo(LogMessageKeys.PRIMARY_KEY, primaryKey)
-                        .addLogInfo(LogMessageKeys.RETRY_COUNT, attempt)
-                        .addLogInfo(LogMessageKeys.RESULT, "success");
-            }
-            if (attemptState != state) {
-                state.setDataArray(attemptState.getDataArray());
-            }
-            return;
         }
-        throw Verify.verifyNotNull(lastAttemptFailure)
-                .addLogInfo(LogMessageKeys.RETRY_COUNT, deserializeReattemptCount)
-                .addLogInfo(LogMessageKeys.RESULT, "failure");
+        if (succeededAt < 0) {
+            throw Verify.verifyNotNull(lastAttemptFailure)
+                    .addLogInfo(LogMessageKeys.RETRY_COUNT, deserializeReattemptCount)
+                    .addLogInfo(LogMessageKeys.RESULT, "failure");
+        } else if (succeededAt > 0 && failOnDeserializeReattempt) {
+            // deserialization succeeded on retry; however since failOnDeserializeReattempt is set, we throw an error
+            throw new RecordSerializationException("deserialization error", lastAttemptFailure)
+                    .addLogInfo(LogMessageKeys.META_DATA_VERSION, metaData.getVersion())
+                    .addLogInfo(LogMessageKeys.PRIMARY_KEY, primaryKey)
+                    .addLogInfo(LogMessageKeys.RETRY_COUNT, succeededAt)
+                    .addLogInfo(LogMessageKeys.RESULT, "success");
+        } else if (succeededAt != 0) {
+            state.setDataArray(attemptState.getDataArray());
+        }
     }
 
     private void decryptAndDecompress(@Nonnull RecordMetaData metaData,

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/common/TransformedRecordSerializerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/common/TransformedRecordSerializerTest.java
@@ -60,6 +60,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 import java.util.stream.Stream;
+import java.util.zip.DataFormatException;
 import java.util.zip.Deflater;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -1003,6 +1004,13 @@ public class TransformedRecordSerializerTest {
                         () -> deserialize(deserializer, PRIMARY_KEY, serialized));
                 assertThat(e.getLogInfo(), hasEntry(LogMessageKeys.RETRY_COUNT.toString(), initialKFailures));
                 assertThat(e.getLogInfo(), hasEntry(LogMessageKeys.RESULT.toString(), "success"));
+                // The originating failure from the last failed attempt is threaded through as the cause.
+                // For this test, decrypt corrupts the post-header payload, so decompress fails inside
+                // Inflater with DataFormatException, which decompressOrThrow wraps into a
+                // RecordSerializationException.
+                assertNotNull(e.getCause());
+                assertThat(e.getCause(), instanceOf(RecordSerializationException.class));
+                assertThat(e.getCause().getCause(), instanceOf(DataFormatException.class));
             } else {
                 // No retry needed, or failOnDeserializeReattempt=false: success.
                 Message deserialized = deserialize(deserializer, PRIMARY_KEY, serialized);
@@ -1073,6 +1081,12 @@ public class TransformedRecordSerializerTest {
                         () -> deserialize(deserializer, PRIMARY_KEY, serialized));
                 assertThat(e.getLogInfo(), hasEntry(LogMessageKeys.RETRY_COUNT.toString(), initialKFailures));
                 assertThat(e.getLogInfo(), hasEntry(LogMessageKeys.RESULT.toString(), "success"));
+                // The originating failure from the last failed attempt is threaded through as the cause.
+                // For this test, decrypt threw GeneralSecurityException directly, which gets wrapped in
+                // RecordSerializationException by decryptOrThrow.
+                assertNotNull(e.getCause());
+                assertThat(e.getCause(), instanceOf(RecordSerializationException.class));
+                assertThat(e.getCause().getCause(), instanceOf(GeneralSecurityException.class));
             } else {
                 Message deserialized = deserialize(deserializer, PRIMARY_KEY, serialized);
                 assertEquals(mySimpleRecord, deserialized);
@@ -1087,7 +1101,7 @@ public class TransformedRecordSerializerTest {
     }
 
     /**
-     * Without compression the prior implementation had no retry path, so a transient decrypt
+     * Without compression a prior implementation had no retry path, so a transient decrypt
      * failure was always fatal. This verifies that with the change extending retries to cover
      * decryption, an encryption-only serializer recovers from a single transient decrypt
      * failure when {@code deserializeReattemptCount >= 1}.
@@ -1157,8 +1171,17 @@ public class TransformedRecordSerializerTest {
         protected void decrypt(@Nonnull TransformedRecordSerializerState state, @Nullable StoreTimer timer) throws GeneralSecurityException {
             super.decrypt(state, timer);
             if (decryptCallCount < initialFailCount) {
+                // Preserve the 5-byte compression header (version + uncompressed length) so that
+                // decompress reaches Inflater and fails with DataFormatException — which gets wrapped
+                // by decompressOrThrow into a RecordSerializationException with the DataFormatException
+                // as its cause. Wiping the header instead would short-circuit with "unknown compression
+                // version" and no cause, losing the failure-chain information.
                 byte[] data = state.getDataArray();
-                Arrays.fill(data, (byte) 0);
+                final int payloadStart = state.getOffset() + 5;
+                final int payloadEnd = state.getOffset() + state.getLength();
+                for (int i = payloadStart; i < payloadEnd; i++) {
+                    data[i] = (byte) 0xFF;
+                }
                 state.setDataArray(data);
             }
             decryptCallCount++;

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/common/TransformedRecordSerializerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/common/TransformedRecordSerializerTest.java
@@ -1017,6 +1017,131 @@ public class TransformedRecordSerializerTest {
         }
     }
 
+    static Stream<Arguments> transientDecryptionThrowingFailureTestArgs() {
+        return ParameterizedTestUtils.cartesianProduct(
+                RandomizedTestUtils.randomSeeds(),
+                Stream.of(NonnullPair.of(0, 0), NonnullPair.of(0, 1), NonnullPair.of(1, 1), NonnullPair.of(1, 2), NonnullPair.of(4, 3), NonnullPair.of(4, 5)),
+                ParameterizedTestUtils.booleans("failOnDeserializeReattempt"));
+    }
+
+    /**
+     * Validates deserialization behavior when {@code decrypt} itself throws on the first
+     * {@code initialKFailures} calls. Mirrors {@link #transientDecryptionHardwareFailureTest},
+     * but exercises the retry path where decryption raises a {@link GeneralSecurityException}
+     * directly rather than producing corrupt plaintext that decompression catches.
+     *
+     * <ul>
+     *   <li>If {@code initialKFailures <= reattemptCount}: deserialization succeeds.
+     *       If {@code failOnDeserializeReattempt=true} and at least one retry was needed, a
+     *       {@link RecordSerializationException} with {@code RESULT="success"} is still thrown
+     *       for observability.</li>
+     *   <li>If {@code initialKFailures > reattemptCount}: deserialization fails with a
+     *       {@link RecordSerializationException}. When retries were configured,
+     *       {@code RETRY_COUNT} and {@code RESULT="failure"} are included in the log info.</li>
+     * </ul>
+     */
+    @ParameterizedTest
+    @MethodSource("transientDecryptionThrowingFailureTestArgs")
+    void transientDecryptionThrowingFailureTest(long seed, @Nonnull final NonnullPair<Integer, Integer> reattemptCountAndInitialKFailures, boolean failOnDeserializeReattempt) {
+        final SecretKey key = RandomSecretUtil.randomSecretKey(seed);
+        final int reattemptCount = reattemptCountAndInitialKFailures.getLeft();
+        final int initialKFailures = reattemptCountAndInitialKFailures.getRight();
+
+        final TransformedRecordSerializerJCE<Message> serializer = TransformedRecordSerializerJCE.newDefaultBuilder()
+                .setEncryptWhenSerializing(true)
+                .setEncryptionKey(key)
+                .setCompressWhenSerializing(true)
+                .build();
+
+        final MySimpleRecord mySimpleRecord = MySimpleRecord.newBuilder().setRecNo(PRIMARY_KEY_REC_NO).setStrValueIndexed(SONNET_108).build();
+        final byte[] serialized = serialize(serializer, mySimpleRecord);
+        assertTrue(isCompressed(serialized));
+
+        final ThrowingFirstKDecryptSerializer deserializer = new ThrowingFirstKDecryptSerializer(
+                (TransformedRecordSerializerJCE<Message>) TransformedRecordSerializerJCE.newDefaultBuilder()
+                        .setEncryptionKey(key)
+                        .setDeserializeReattemptCount(reattemptCount)
+                        .setFailOnDeserializeReattempt(failOnDeserializeReattempt)
+                        .setEncryptWhenSerializing(true)
+                        .setCompressWhenSerializing(true)
+                        .build(), initialKFailures);
+
+        final boolean deserializeWillSucceedUltimately = initialKFailures <= reattemptCount;
+        if (deserializeWillSucceedUltimately) {
+            if (failOnDeserializeReattempt && initialKFailures > 0) {
+                RecordSerializationException e = assertThrows(RecordSerializationException.class,
+                        () -> deserialize(deserializer, PRIMARY_KEY, serialized));
+                assertThat(e.getLogInfo(), hasEntry(LogMessageKeys.RETRY_COUNT.toString(), initialKFailures));
+                assertThat(e.getLogInfo(), hasEntry(LogMessageKeys.RESULT.toString(), "success"));
+            } else {
+                Message deserialized = deserialize(deserializer, PRIMARY_KEY, serialized);
+                assertEquals(mySimpleRecord, deserialized);
+            }
+        } else {
+            RecordSerializationException e = assertThrows(RecordSerializationException.class,
+                    () -> deserialize(deserializer, PRIMARY_KEY, serialized));
+            assertThat(e.getLogInfo(), hasEntry(LogMessageKeys.PRIMARY_KEY.toString(), PRIMARY_KEY));
+            assertThat(e.getLogInfo(), hasEntry(LogMessageKeys.RETRY_COUNT.toString(), reattemptCount));
+            assertThat(e.getLogInfo(), hasEntry(LogMessageKeys.RESULT.toString(), "failure"));
+        }
+    }
+
+    /**
+     * Without compression the prior implementation had no retry path, so a transient decrypt
+     * failure was always fatal. This verifies that with the change extending retries to cover
+     * decryption, an encryption-only serializer recovers from a single transient decrypt
+     * failure when {@code deserializeReattemptCount >= 1}.
+     */
+    @Test
+    void transientDecryptThrowsRetryWithoutCompression() {
+        final SecretKey key = RandomSecretUtil.randomSecretKey(0xC0FFEEL);
+
+        final TransformedRecordSerializerJCE<Message> serializer = TransformedRecordSerializerJCE.newDefaultBuilder()
+                .setEncryptWhenSerializing(true)
+                .setEncryptionKey(key)
+                .build();
+
+        final MySimpleRecord mySimpleRecord = MySimpleRecord.newBuilder().setRecNo(PRIMARY_KEY_REC_NO).setStrValueIndexed("Hello").build();
+        final byte[] serialized = serialize(serializer, mySimpleRecord);
+        assertFalse(isCompressed(serialized));
+
+        final ThrowingFirstKDecryptSerializer deserializer = new ThrowingFirstKDecryptSerializer(
+                (TransformedRecordSerializerJCE<Message>) TransformedRecordSerializerJCE.newDefaultBuilder()
+                        .setEncryptionKey(key)
+                        .setDeserializeReattemptCount(1)
+                        .setEncryptWhenSerializing(true)
+                        .build(), 1);
+
+        Message deserialized = deserialize(deserializer, PRIMARY_KEY, serialized);
+        assertEquals(mySimpleRecord, deserialized);
+    }
+
+    private static class ThrowingFirstKDecryptSerializer extends TransformedRecordSerializerJCE<Message> {
+        private int decryptCallCount = 0;
+        private final int initialFailCount;
+
+        ThrowingFirstKDecryptSerializer(@Nonnull TransformedRecordSerializerJCE<Message> base, int initialFailCount) {
+            super(base.inner, base.compressWhenSerializing, base.compressionLevel, base.encryptWhenSerializing,
+                    base.writeValidationRatio, base.writeEncryptionValidationRatio, base.failOnDeserializeReattempt,
+                    base.deserializeReattemptCount, base.keyManager);
+            this.initialFailCount = initialFailCount;
+        }
+
+        @Override
+        protected void decrypt(@Nonnull TransformedRecordSerializerState state, @Nullable StoreTimer timer) throws GeneralSecurityException {
+            if (decryptCallCount++ < initialFailCount) {
+                throw new GeneralSecurityException("simulated transient decrypt failure");
+            }
+            super.decrypt(state, timer);
+        }
+
+        @Nonnull
+        @Override
+        public RecordSerializer<Message> widen() {
+            return this;
+        }
+    }
+
     private static class CorruptFirstKDecryptSerializer extends TransformedRecordSerializerJCE<Message> {
         private int decryptCallCount = 0;
         private final int initialFailCount;


### PR DESCRIPTION
  ## Summary

Extends the deserialization retry path in `TransformedRecordSerializer` to cover failures raised by `decrypt`, building on the retry mechanism added in #4009.

### Background — what #4009 added
  
#4009 introduced retry-on-deserialization for `TransformedRecordSerializer`:

- When `decompress` throws after a successful `decrypt`, the serializer rebuilds a fresh `TransformedRecordSerializerState` from the original raw bytes and re-runs the entire decrypt + decompress pipeline, up to `deserializeReattemptCount` times.
- A `failOnDeserializeReattempt` builder flag, when set, throws a `RecordSerializationException` with `RESULT="success"` and `RETRY_COUNT` even when retries succeed — useful for surfacing transient faults instead of silently swallowing them.

In that PR retries were scoped to `decompress` only — a `decrypt` that threw propagated immediately, and there was no retry path at all when compression was disabled.
  
### What this PR adds

- `decryptOrThrow` failures are now caught into the same `failure` slot as `decompressOrThrow`, so they trigger the existing retry-from-raw-bytes loop. The first failing step short-circuits the second.
- `failOnDeserializeReattempt` now also fires when decryption succeeded only on retry, matching the diagnostic intent for the decompression case.
- The success-on-retry exception message changed from `"decompression error"` to the more accurate `"deserialization error"`. The original failure exception (when retries are exhausted) still carries the specific decrypt-vs-decompress identity in its log info.
- This also enables retries on encryption-only serializers (compression disabled). Previously such a configuration had no retry path at all.