### PR TITLE
Add PR information to the teamscale upload task

### DIFF
--- a/.github/workflows/teamscale_upload.yml
+++ b/.github/workflows/teamscale_upload.yml
@@ -17,6 +17,22 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
+      - name: 'Add PR link and commit hash to summary'
+        continue-on-error: true # temporary in case this breaks things
+        env:
+          PR_URL: ${{ github.event.workflow_run.pull_requests[0].html_url }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}
+          COMMIT_URL: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.event.workflow_run.head_sha }}
+        run: |
+          {
+            echo "## Teamscale Coverage Upload"
+            echo ""
+            if [ -n "${PR_NUMBER}" ]; then
+              echo "- Pull Request: [#${PR_NUMBER}](${PR_URL})"
+            fi
+            echo "- Commit: [\`${COMMIT_SHA}\`](${COMMIT_URL})"
+          } >> "${GITHUB_STEP_SUMMARY}"
       # This checks out the latest commit on main, not teh PRs head
       # This is needed to get the teamscale-upload action
       - name: Checkout sources


### PR DESCRIPTION
This should add a summary to the job indicating the PR number (with link) and commit sha (with link). This should make it much easier to determine what happened.
Since it is hard to test this; I added a `continue-on-error: true` so that if this fails we should be able to continue to upload teamscale information. 