### PR TITLE
Enable opt-in concurrency for tests

### DIFF
--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/OperationsTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/OperationsTest.java
@@ -324,97 +324,92 @@ class OperationsTest implements BaseTest {
     @ParameterizedTest
     @MethodSource("differentConfigsAndMetrics")
     void testBasicInsert(final long seed, final Config config) throws Exception {
-        try (TestHelpers.TestLogFile logFile = TestHelpers.TestLogFile.create("OperationsTest.testBasicInsert", seed, config)) {
-            try {
-                final Random random = new Random(seed);
-                final int size = 1000;
-                final TestOnWriteListener onWriteListener = new TestOnWriteListener();
-                final TestOnReadListener onReadListener = new TestOnReadListener();
+        TestLogFile.run("OperationsTest.testBasicInsert", List.of(seed, config), logFile -> {
+            final Random random = new Random(seed);
+            final int size = 1000;
+            final TestOnWriteListener onWriteListener = new TestOnWriteListener();
+            final TestOnReadListener onReadListener = new TestOnReadListener();
 
-                final HNSW hnsw = new HNSW(subspaceExtension.getSubspace(), TestExecutors.defaultThreadPool(), config,
-                        onWriteListener, onReadListener);
-                logFile.log("HNSW constructed; size=%d", size);
+            final HNSW hnsw = new HNSW(subspaceExtension.getSubspace(), TestExecutors.defaultThreadPool(), config,
+                    onWriteListener, onReadListener);
+            logFile.log("HNSW constructed; size=%d", size);
 
-                final int k = 50;
-                final List<PrimaryKeyAndVector> insertedData = randomVectors(random, config.getNumDimensions(), size);
-                logFile.log("Generated %d random vectors", insertedData.size());
+            final int k = 50;
+            final List<PrimaryKeyAndVector> insertedData = randomVectors(random, config.getNumDimensions(), size);
+            logFile.log("Generated %d random vectors", insertedData.size());
 
-                TestHelpers.basicInsert(getDb(), hnsw, insertedData, logFile);
-                logFile.log("primary insert loop complete");
+            TestHelpers.basicInsert(getDb(), hnsw, insertedData, logFile);
+            logFile.log("primary insert loop complete");
 
-                final HalfRealVector queryVector = createRandomHalfVector(random, config.getNumDimensions());
+            final HalfRealVector queryVector = createRandomHalfVector(random, config.getNumDimensions());
 
-                //
-                // Attempt to mutate some records by updating them using the same primary keys but different random vectors.
-                // This should not fail but should be silently ignored. If this succeeds, the following searches will all
-                // return records that are not aligned with recordsOrderedByDistance.
-                //
-                for (int i = 0; i < 100; ) {
-                    logFile.log("mutation insert loop iter=%d", i);
-                    i += TestHelpers.basicInsertBatch(getDb(), hnsw, 100, 0,
-                            (tr, ignored) -> {
-                                final var primaryKey = TestHelpers.createPrimaryKey(random.nextInt(1000));
-                                final HalfRealVector dataVector = createRandomHalfVector(random, config.getNumDimensions());
-                                return new PrimaryKeyAndVector(primaryKey, dataVector);
-                            }, logFile).size();
-                }
-                logFile.log("mutation insert loop complete");
-
-                onReadListener.reset();
-                final long beginTs = System.nanoTime();
-                final List<? extends ResultEntry> results =
-                        db.run(tr ->
-                                hnsw.kNearestNeighborsSearch(tr, k, 100, true, queryVector).join());
-                final long endTs = System.nanoTime();
-                logFile.log("kNN search completed in %d ms; resultCount=%d",
-                        TimeUnit.NANOSECONDS.toMillis(endTs - beginTs), results.size());
-
-                final ImmutableSet<Tuple> trueNN =
-                        orderedByDistances(config.getMetric(), insertedData, queryVector).stream()
-                                .limit(k)
-                                .map(PrimaryKeyVectorAndDistance::getPrimaryKey)
-                                .collect(ImmutableSet.toImmutableSet());
-
-                int recallCount = 0;
-                for (ResultEntry resultEntry : results) {
-                    logger.info("nodeId ={} at distance={}", resultEntry.getPrimaryKey().getLong(0),
-                            resultEntry.getDistance());
-                    if (trueNN.contains(resultEntry.getPrimaryKey())) {
-                        recallCount++;
-                    }
-                }
-                final double recall = (double)recallCount / (double)k;
-                logger.info("search transaction took elapsedTime={}ms; read nodes={}, read bytes={}, recall={}",
-                        TimeUnit.NANOSECONDS.toMillis(endTs - beginTs),
-                        onReadListener.getNodeCountByLayer(), onReadListener.getBytesReadByLayer(),
-                        String.format(Locale.ROOT, "%.2f", recall * 100.0d));
-                logFile.log("recall=%.4f recallCount=%d/%d readCounts=%s readBytes=%s",
-                        recall, recallCount, k,
-                        onReadListener.getNodeCountByLayer(), onReadListener.getBytesReadByLayer());
-                assertThat(recall).isGreaterThan(0.9);
-
-                final Set<Long> insertedIds =
-                        LongStream.range(0, 1000)
-                                .boxed()
-                                .collect(Collectors.toSet());
-
-                final Set<Long> readIds = Sets.newHashSet();
-                TestHelpers.scanLayer(getDb(), getSubspace(), config, 0, 100,
-                        node ->
-                                assertThat(readIds.add(node.getPrimaryKey().getLong(0))).isTrue());
-                assertThat(readIds).isEqualTo(insertedIds);
-                logFile.log("scanLayer(0) ok readIds=%d", readIds.size());
-
-                readIds.clear();
-                TestHelpers.scanLayer(getDb(), getSubspace(), config, 1, 100,
-                        node -> assertThat(readIds.add(node.getPrimaryKey().getLong(0))).isTrue());
-                assertThat(readIds.size()).isBetween(10, 100);
-                logFile.log("scanLayer(1) ok readIds=%d", readIds.size());
-            } catch (Throwable t) {
-                logFile.logFailure("testBasicInsert seed=" + seed + " config=" + config, t);
-                throw t;
+            //
+            // Attempt to mutate some records by updating them using the same primary keys but different random vectors.
+            // This should not fail but should be silently ignored. If this succeeds, the following searches will all
+            // return records that are not aligned with recordsOrderedByDistance.
+            //
+            for (int i = 0; i < 100; ) {
+                logFile.log("mutation insert loop iter=%d", i);
+                i += TestHelpers.basicInsertBatch(getDb(), hnsw, 100, 0,
+                        (tr, ignored) -> {
+                            final var primaryKey = TestHelpers.createPrimaryKey(random.nextInt(1000));
+                            final HalfRealVector dataVector = createRandomHalfVector(random, config.getNumDimensions());
+                            return new PrimaryKeyAndVector(primaryKey, dataVector);
+                        }, logFile).size();
             }
-        }
+            logFile.log("mutation insert loop complete");
+
+            onReadListener.reset();
+            final long beginTs = System.nanoTime();
+            final List<? extends ResultEntry> results =
+                    db.run(tr ->
+                            hnsw.kNearestNeighborsSearch(tr, k, 100, true, queryVector).join());
+            final long endTs = System.nanoTime();
+            logFile.log("kNN search completed in %d ms; resultCount=%d",
+                    TimeUnit.NANOSECONDS.toMillis(endTs - beginTs), results.size());
+
+            final ImmutableSet<Tuple> trueNN =
+                    orderedByDistances(config.getMetric(), insertedData, queryVector).stream()
+                            .limit(k)
+                            .map(PrimaryKeyVectorAndDistance::getPrimaryKey)
+                            .collect(ImmutableSet.toImmutableSet());
+
+            int recallCount = 0;
+            for (ResultEntry resultEntry : results) {
+                logger.info("nodeId ={} at distance={}", resultEntry.getPrimaryKey().getLong(0),
+                        resultEntry.getDistance());
+                if (trueNN.contains(resultEntry.getPrimaryKey())) {
+                    recallCount++;
+                }
+            }
+            final double recall = (double)recallCount / (double)k;
+            logger.info("search transaction took elapsedTime={}ms; read nodes={}, read bytes={}, recall={}",
+                    TimeUnit.NANOSECONDS.toMillis(endTs - beginTs),
+                    onReadListener.getNodeCountByLayer(), onReadListener.getBytesReadByLayer(),
+                    String.format(Locale.ROOT, "%.2f", recall * 100.0d));
+            logFile.log("recall=%.4f recallCount=%d/%d readCounts=%s readBytes=%s",
+                    recall, recallCount, k,
+                    onReadListener.getNodeCountByLayer(), onReadListener.getBytesReadByLayer());
+            assertThat(recall).isGreaterThan(0.9);
+
+            final Set<Long> insertedIds =
+                    LongStream.range(0, 1000)
+                            .boxed()
+                            .collect(Collectors.toSet());
+
+            final Set<Long> readIds = Sets.newHashSet();
+            TestHelpers.scanLayer(getDb(), getSubspace(), config, 0, 100,
+                    node ->
+                            assertThat(readIds.add(node.getPrimaryKey().getLong(0))).isTrue());
+            assertThat(readIds).isEqualTo(insertedIds);
+            logFile.log("scanLayer(0) ok readIds=%d", readIds.size());
+
+            readIds.clear();
+            TestHelpers.scanLayer(getDb(), getSubspace(), config, 1, 100,
+                    node -> assertThat(readIds.add(node.getPrimaryKey().getLong(0))).isTrue());
+            assertThat(readIds.size()).isBetween(10, 100);
+            logFile.log("scanLayer(1) ok readIds=%d", readIds.size());
+        });
     }
 
     @ExtendWith(TestHelpers.DumpLayersIfFailure.class)
@@ -467,91 +462,93 @@ class OperationsTest implements BaseTest {
 
     @ParameterizedTest
     @MethodSource("differentConfigsAndMetrics")
-    void testBasicInsertDelete(final long seed, final Config config) throws ExecutionException, InterruptedException, TimeoutException {
-        final Random random = new Random(seed);
-        final int size = 1000;
-        final TestOnWriteListener onWriteListener = new TestOnWriteListener();
-        final TestOnReadListener onReadListener = new TestOnReadListener();
+    void testBasicInsertDelete(final long seed, final Config config) throws Exception {
+        TestLogFile.run("OperationsTest.testBasicInsert", List.of(seed, config), logFile -> {
+            final Random random = new Random(seed);
+            final int size = 1000;
+            final TestOnWriteListener onWriteListener = new TestOnWriteListener();
+            final TestOnReadListener onReadListener = new TestOnReadListener();
 
-        final HNSW hnsw = new HNSW(subspaceExtension.getSubspace(), TestExecutors.defaultThreadPool(), config,
-                onWriteListener, onReadListener);
+            final HNSW hnsw = new HNSW(subspaceExtension.getSubspace(), TestExecutors.defaultThreadPool(), config,
+                    onWriteListener, onReadListener);
 
-        final int k = 50;
-        final List<PrimaryKeyAndVector> insertedData = randomVectors(random, config.getNumDimensions(), size);
+            final int k = 50;
+            final List<PrimaryKeyAndVector> insertedData = randomVectors(random, config.getNumDimensions(), size);
 
-        TestHelpers.basicInsert(getDb(), hnsw, insertedData, null);
+            TestHelpers.basicInsert(getDb(), hnsw, insertedData, null);
 
-        final int numVectorsPerDeleteBatch = 50;
-        List<PrimaryKeyAndVector> remainingData = insertedData;
-        do {
-            final List<PrimaryKeyAndVector> toBeDeleted =
-                    TestHelpers.pickRandomVectors(random, remainingData, numVectorsPerDeleteBatch);
+            final int numVectorsPerDeleteBatch = 50;
+            List<PrimaryKeyAndVector> remainingData = insertedData;
+            do {
+                final List<PrimaryKeyAndVector> toBeDeleted =
+                        TestHelpers.pickRandomVectors(random, remainingData, numVectorsPerDeleteBatch);
 
-            final long beginTs = System.nanoTime();
-            db.run(tr -> {
-                onWriteListener.reset();
-                onReadListener.reset();
+                final long beginTs = System.nanoTime();
+                db.run(tr -> {
+                    onWriteListener.reset();
+                    onReadListener.reset();
 
-                for (final PrimaryKeyAndVector primaryKeyAndVector : toBeDeleted) {
-                    hnsw.delete(tr, primaryKeyAndVector.getPrimaryKey()).join();
-                }
-                return null;
-            });
-            long endTs = System.nanoTime();
-
-            assertThat(onWriteListener.getDeleteCountByLayer().get(0)).isEqualTo(toBeDeleted.size());
-
-            logger.info("delete transaction of {} records after {} records took elapsedTime={}ms; read nodes={}, read bytes={}",
-                    numVectorsPerDeleteBatch,
-                    size - remainingData.size(),
-                    TimeUnit.NANOSECONDS.toMillis(endTs - beginTs),
-                    onReadListener.getNodeCountByLayer(), onReadListener.getBytesReadByLayer());
-
-            final Set<PrimaryKeyAndVector> deletedSet = toBeDeleted.stream().collect(ImmutableSet.toImmutableSet());
-            remainingData = remainingData.stream()
-                    .filter(vector -> !deletedSet.contains(vector))
-                    .collect(ImmutableList.toImmutableList());
-
-            if (!remainingData.isEmpty()) {
-                final HalfRealVector queryVector = createRandomHalfVector(random, config.getNumDimensions());
-                final ImmutableSet<Tuple> trueNN =
-                        orderedByDistances(config.getMetric(), remainingData, queryVector).stream()
-                                .limit(k)
-                                .map(PrimaryKeyVectorAndDistance::getPrimaryKey)
-                                .collect(ImmutableSet.toImmutableSet());
-                onReadListener.reset();
-
-                final long beginTsQuery = System.nanoTime();
-                final List<? extends ResultEntry> results =
-                        db.run(tr ->
-                                hnsw.kNearestNeighborsSearch(tr, k, 100, true, queryVector).join());
-                final long endTsQuery = System.nanoTime();
-
-                int recallCount = 0;
-                for (ResultEntry resultEntry : results) {
-                    if (trueNN.contains(resultEntry.getPrimaryKey())) {
-                        recallCount++;
+                    for (final PrimaryKeyAndVector primaryKeyAndVector : toBeDeleted) {
+                        hnsw.delete(tr, primaryKeyAndVector.getPrimaryKey()).join();
                     }
-                }
-                final double recall = (double)recallCount / (double)trueNN.size();
+                    return null;
+                });
+                long endTs = System.nanoTime();
 
-                logger.info("search transaction after delete of {} records took elapsedTime={}ms; read nodes={}, read bytes={}, recall={}",
+                assertThat(onWriteListener.getDeleteCountByLayer().get(0)).isEqualTo(toBeDeleted.size());
+
+                logger.info("delete transaction of {} records after {} records took elapsedTime={}ms; read nodes={}, read bytes={}",
+                        numVectorsPerDeleteBatch,
                         size - remainingData.size(),
-                        TimeUnit.NANOSECONDS.toMillis(endTsQuery - beginTsQuery),
-                        onReadListener.getNodeCountByLayer(), onReadListener.getBytesReadByLayer(),
-                        String.format(Locale.ROOT, "%.2f", recall * 100.0d));
+                        TimeUnit.NANOSECONDS.toMillis(endTs - beginTs),
+                        onReadListener.getNodeCountByLayer(), onReadListener.getBytesReadByLayer());
 
-                assertThat(recall).isGreaterThan(0.9);
+                final Set<PrimaryKeyAndVector> deletedSet = toBeDeleted.stream().collect(ImmutableSet.toImmutableSet());
+                remainingData = remainingData.stream()
+                        .filter(vector -> !deletedSet.contains(vector))
+                        .collect(ImmutableList.toImmutableList());
 
-                final long remainingNumNodes = TestHelpers.countNodesOnLayer(getDb(), getSubspace(), config, 0);
-                assertThat(remainingNumNodes).isEqualTo(remainingData.size());
-            }
-        } while (!remainingData.isEmpty());
+                if (!remainingData.isEmpty()) {
+                    final HalfRealVector queryVector = createRandomHalfVector(random, config.getNumDimensions());
+                    final ImmutableSet<Tuple> trueNN =
+                            orderedByDistances(config.getMetric(), remainingData, queryVector).stream()
+                                    .limit(k)
+                                    .map(PrimaryKeyVectorAndDistance::getPrimaryKey)
+                                    .collect(ImmutableSet.toImmutableSet());
+                    onReadListener.reset();
 
-        final var accessInfo =
-                db.run(transaction -> StorageAdapter.fetchAccessInfo(hnsw.getConfig(),
-                        transaction, hnsw.getSubspace(), OnReadListener.NOOP).join());
-        assertThat(accessInfo).isNull();
+                    final long beginTsQuery = System.nanoTime();
+                    final List<? extends ResultEntry> results =
+                            db.run(tr ->
+                                    hnsw.kNearestNeighborsSearch(tr, k, 100, true, queryVector).join());
+                    final long endTsQuery = System.nanoTime();
+
+                    int recallCount = 0;
+                    for (ResultEntry resultEntry : results) {
+                        if (trueNN.contains(resultEntry.getPrimaryKey())) {
+                            recallCount++;
+                        }
+                    }
+                    final double recall = (double)recallCount / (double)trueNN.size();
+
+                    logger.info("search transaction after delete of {} records took elapsedTime={}ms; read nodes={}, read bytes={}, recall={}",
+                            size - remainingData.size(),
+                            TimeUnit.NANOSECONDS.toMillis(endTsQuery - beginTsQuery),
+                            onReadListener.getNodeCountByLayer(), onReadListener.getBytesReadByLayer(),
+                            String.format(Locale.ROOT, "%.2f", recall * 100.0d));
+
+                    assertThat(recall).isGreaterThan(0.9);
+
+                    final long remainingNumNodes = TestHelpers.countNodesOnLayer(getDb(), getSubspace(), config, 0);
+                    assertThat(remainingNumNodes).isEqualTo(remainingData.size());
+                }
+            } while (!remainingData.isEmpty());
+
+            final var accessInfo =
+                    db.run(transaction -> StorageAdapter.fetchAccessInfo(hnsw.getConfig(),
+                            transaction, hnsw.getSubspace(), OnReadListener.NOOP).join());
+            assertThat(accessInfo).isNull();
+        });
     }
 
     @ParameterizedTest()

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/OperationsTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/OperationsTest.java
@@ -342,7 +342,7 @@ class OperationsTest implements BaseTest {
                 for (int i = 0; i < size;) {
                     logger.info("basicInsertBatch " + i);
                     logFile.log("primary insert loop iter=%d size=%d", i, size);
-                    i += TestHelpers.basicInsertBatch(getDb(), hnsw, 100, i,
+                    i += TestHelpers.basicInsertBatch(getDb(), hnsw, i < 800 ? 100 : 50, i,
                             (tr, nextId) -> insertedData.get(Math.toIntExact(nextId)), logFile).size();
                 }
                 logFile.log("primary insert loop complete");

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/OperationsTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/OperationsTest.java
@@ -324,78 +324,97 @@ class OperationsTest implements BaseTest {
     @ParameterizedTest
     @MethodSource("differentConfigsAndMetrics")
     void testBasicInsert(final long seed, final Config config) throws Exception {
-        final Random random = new Random(seed);
-        final int size = 1000;
-        final TestOnWriteListener onWriteListener = new TestOnWriteListener();
-        final TestOnReadListener onReadListener = new TestOnReadListener();
+        try (TestHelpers.TestLogFile logFile = TestHelpers.TestLogFile.create("OperationsTest.testBasicInsert", seed, config)) {
+            try {
+                final Random random = new Random(seed);
+                final int size = 1000;
+                final TestOnWriteListener onWriteListener = new TestOnWriteListener();
+                final TestOnReadListener onReadListener = new TestOnReadListener();
 
-        final HNSW hnsw = new HNSW(subspaceExtension.getSubspace(), TestExecutors.defaultThreadPool(), config,
-                onWriteListener, onReadListener);
+                final HNSW hnsw = new HNSW(subspaceExtension.getSubspace(), TestExecutors.defaultThreadPool(), config,
+                        onWriteListener, onReadListener);
+                logFile.log("HNSW constructed; size=%d", size);
 
-        final int k = 50;
-        final List<PrimaryKeyAndVector> insertedData = randomVectors(random, config.getNumDimensions(), size);
+                final int k = 50;
+                final List<PrimaryKeyAndVector> insertedData = randomVectors(random, config.getNumDimensions(), size);
+                logFile.log("Generated %d random vectors", insertedData.size());
 
-        TestHelpers.basicInsert(getDb(), hnsw, insertedData);
+                TestHelpers.basicInsert(getDb(), hnsw, insertedData, logFile);
+                logFile.log("primary insert loop complete");
 
-        final HalfRealVector queryVector = createRandomHalfVector(random, config.getNumDimensions());
+                final HalfRealVector queryVector = createRandomHalfVector(random, config.getNumDimensions());
 
-        //
-        // Attempt to mutate some records by updating them using the same primary keys but different random vectors.
-        // This should not fail but should be silently ignored. If this succeeds, the following searches will all
-        // return records that are not aligned with recordsOrderedByDistance.
-        //
-        for (int i = 0; i < 100; ) {
-            i += TestHelpers.basicInsertBatch(getDb(), hnsw, 100, 0,
-                    (tr, ignored) -> {
-                        final var primaryKey = TestHelpers.createPrimaryKey(random.nextInt(1000));
-                        final HalfRealVector dataVector = createRandomHalfVector(random, config.getNumDimensions());
-                        return new PrimaryKeyAndVector(primaryKey, dataVector);
-                    }).size();
-        }
+                //
+                // Attempt to mutate some records by updating them using the same primary keys but different random vectors.
+                // This should not fail but should be silently ignored. If this succeeds, the following searches will all
+                // return records that are not aligned with recordsOrderedByDistance.
+                //
+                for (int i = 0; i < 100; ) {
+                    logFile.log("mutation insert loop iter=%d", i);
+                    i += TestHelpers.basicInsertBatch(getDb(), hnsw, 100, 0,
+                            (tr, ignored) -> {
+                                final var primaryKey = TestHelpers.createPrimaryKey(random.nextInt(1000));
+                                final HalfRealVector dataVector = createRandomHalfVector(random, config.getNumDimensions());
+                                return new PrimaryKeyAndVector(primaryKey, dataVector);
+                            }, logFile).size();
+                }
+                logFile.log("mutation insert loop complete");
 
-        onReadListener.reset();
-        final long beginTs = System.nanoTime();
-        final List<? extends ResultEntry> results =
-                db.run(tr ->
-                        hnsw.kNearestNeighborsSearch(tr, k, 100, true, queryVector).join());
-        final long endTs = System.nanoTime();
+                onReadListener.reset();
+                final long beginTs = System.nanoTime();
+                final List<? extends ResultEntry> results =
+                        db.run(tr ->
+                                hnsw.kNearestNeighborsSearch(tr, k, 100, true, queryVector).join());
+                final long endTs = System.nanoTime();
+                logFile.log("kNN search completed in %d ms; resultCount=%d",
+                        TimeUnit.NANOSECONDS.toMillis(endTs - beginTs), results.size());
 
-        final ImmutableSet<Tuple> trueNN =
-                orderedByDistances(config.getMetric(), insertedData, queryVector).stream()
-                        .limit(k)
-                        .map(PrimaryKeyVectorAndDistance::getPrimaryKey)
-                        .collect(ImmutableSet.toImmutableSet());
+                final ImmutableSet<Tuple> trueNN =
+                        orderedByDistances(config.getMetric(), insertedData, queryVector).stream()
+                                .limit(k)
+                                .map(PrimaryKeyVectorAndDistance::getPrimaryKey)
+                                .collect(ImmutableSet.toImmutableSet());
 
-        int recallCount = 0;
-        for (ResultEntry resultEntry : results) {
-            logger.info("nodeId ={} at distance={}", resultEntry.getPrimaryKey().getLong(0),
-                    resultEntry.getDistance());
-            if (trueNN.contains(resultEntry.getPrimaryKey())) {
-                recallCount++;
+                int recallCount = 0;
+                for (ResultEntry resultEntry : results) {
+                    logger.info("nodeId ={} at distance={}", resultEntry.getPrimaryKey().getLong(0),
+                            resultEntry.getDistance());
+                    if (trueNN.contains(resultEntry.getPrimaryKey())) {
+                        recallCount++;
+                    }
+                }
+                final double recall = (double)recallCount / (double)k;
+                logger.info("search transaction took elapsedTime={}ms; read nodes={}, read bytes={}, recall={}",
+                        TimeUnit.NANOSECONDS.toMillis(endTs - beginTs),
+                        onReadListener.getNodeCountByLayer(), onReadListener.getBytesReadByLayer(),
+                        String.format(Locale.ROOT, "%.2f", recall * 100.0d));
+                logFile.log("recall=%.4f recallCount=%d/%d readCounts=%s readBytes=%s",
+                        recall, recallCount, k,
+                        onReadListener.getNodeCountByLayer(), onReadListener.getBytesReadByLayer());
+                assertThat(recall).isGreaterThan(0.9);
+
+                final Set<Long> insertedIds =
+                        LongStream.range(0, 1000)
+                                .boxed()
+                                .collect(Collectors.toSet());
+
+                final Set<Long> readIds = Sets.newHashSet();
+                TestHelpers.scanLayer(getDb(), getSubspace(), config, 0, 100,
+                        node ->
+                                assertThat(readIds.add(node.getPrimaryKey().getLong(0))).isTrue());
+                assertThat(readIds).isEqualTo(insertedIds);
+                logFile.log("scanLayer(0) ok readIds=%d", readIds.size());
+
+                readIds.clear();
+                TestHelpers.scanLayer(getDb(), getSubspace(), config, 1, 100,
+                        node -> assertThat(readIds.add(node.getPrimaryKey().getLong(0))).isTrue());
+                assertThat(readIds.size()).isBetween(10, 100);
+                logFile.log("scanLayer(1) ok readIds=%d", readIds.size());
+            } catch (Throwable t) {
+                logFile.logFailure("testBasicInsert seed=" + seed + " config=" + config, t);
+                throw t;
             }
         }
-        final double recall = (double)recallCount / (double)k;
-        logger.info("search transaction took elapsedTime={}ms; read nodes={}, read bytes={}, recall={}",
-                TimeUnit.NANOSECONDS.toMillis(endTs - beginTs),
-                onReadListener.getNodeCountByLayer(), onReadListener.getBytesReadByLayer(),
-                String.format(Locale.ROOT, "%.2f", recall * 100.0d));
-        assertThat(recall).isGreaterThan(0.9);
-
-        final Set<Long> insertedIds =
-                LongStream.range(0, 1000)
-                        .boxed()
-                        .collect(Collectors.toSet());
-
-        final Set<Long> readIds = Sets.newHashSet();
-        TestHelpers.scanLayer(getDb(), getSubspace(), config, 0, 100,
-                node ->
-                        assertThat(readIds.add(node.getPrimaryKey().getLong(0))).isTrue());
-        assertThat(readIds).isEqualTo(insertedIds);
-
-        readIds.clear();
-        TestHelpers.scanLayer(getDb(), getSubspace(), config, 1, 100,
-                node -> assertThat(readIds.add(node.getPrimaryKey().getLong(0))).isTrue());
-        assertThat(readIds.size()).isBetween(10, 100);
     }
 
     @ExtendWith(TestHelpers.DumpLayersIfFailure.class)
@@ -414,7 +433,7 @@ class OperationsTest implements BaseTest {
         final int k = 30;
         final List<PrimaryKeyAndVector> insertedData = randomVectors(random, config.getNumDimensions(), size);
 
-        TestHelpers.basicInsert(getDb(), hnsw, insertedData);
+        TestHelpers.basicInsert(getDb(), hnsw, insertedData, null);
 
         final double radius = 1d;
         final HalfRealVector queryVector = createRandomHalfVector(random, config.getNumDimensions());
@@ -460,7 +479,7 @@ class OperationsTest implements BaseTest {
         final int k = 50;
         final List<PrimaryKeyAndVector> insertedData = randomVectors(random, config.getNumDimensions(), size);
 
-        TestHelpers.basicInsert(getDb(), hnsw, insertedData);
+        TestHelpers.basicInsert(getDb(), hnsw, insertedData, null);
 
         final int numVectorsPerDeleteBatch = 50;
         List<PrimaryKeyAndVector> remainingData = insertedData;
@@ -559,7 +578,7 @@ class OperationsTest implements BaseTest {
         final int numRecords = 1000;
         final int k = 499;
         final List<PrimaryKeyAndVector> insertedData = randomVectors(random, numDimensions, numRecords);
-        TestHelpers.basicInsert(getDb(), hnsw, insertedData);
+        TestHelpers.basicInsert(getDb(), hnsw, insertedData, null);
 
         final DoubleRealVector queryVector = createRandomDoubleVector(random, numDimensions);
 
@@ -633,7 +652,7 @@ class OperationsTest implements BaseTest {
 
         final List<PrimaryKeyAndVector> insertedData = randomVectors(random, config.getNumDimensions(), size);
 
-        TestHelpers.basicInsert(getDb(), hnsw, insertedData);
+        TestHelpers.basicInsert(getDb(), hnsw, insertedData, null);
 
         final int skip = 100;
         final HalfRealVector queryVector = createRandomHalfVector(random, config.getNumDimensions());

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/OperationsTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/OperationsTest.java
@@ -340,7 +340,6 @@ class OperationsTest implements BaseTest {
                 logFile.log("Generated %d random vectors", insertedData.size());
 
                 for (int i = 0; i < size;) {
-                    logger.info("basicInsertBatch " + i);
                     logFile.log("primary insert loop iter=%d size=%d", i, size);
                     i += TestHelpers.basicInsertBatch(getDb(), hnsw, i < 800 ? 100 : 50, i,
                             (tr, nextId) -> insertedData.get(Math.toIntExact(nextId)), logFile).size();

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/OperationsTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/OperationsTest.java
@@ -323,82 +323,103 @@ class OperationsTest implements BaseTest {
     @ExtendWith(TestHelpers.DumpLayersIfFailure.class)
     @ParameterizedTest
     @MethodSource("differentConfigsAndMetrics")
-    void testBasicInsert(final long seed, final Config config) throws ExecutionException, InterruptedException, TimeoutException {
-        final Random random = new Random(seed);
-        final int size = 1000;
-        final TestOnWriteListener onWriteListener = new TestOnWriteListener();
-        final TestOnReadListener onReadListener = new TestOnReadListener();
+    void testBasicInsert(final long seed, final Config config) throws Exception {
+        try (TestHelpers.TestLogFile logFile = TestHelpers.TestLogFile.create("OperationsTest.testBasicInsert", seed, config)) {
+            try {
+                final Random random = new Random(seed);
+                final int size = 1000;
+                final TestOnWriteListener onWriteListener = new TestOnWriteListener();
+                final TestOnReadListener onReadListener = new TestOnReadListener();
 
-        final HNSW hnsw = new HNSW(subspaceExtension.getSubspace(), TestExecutors.defaultThreadPool(), config,
-                onWriteListener, onReadListener);
+                final HNSW hnsw = new HNSW(subspaceExtension.getSubspace(), TestExecutors.defaultThreadPool(), config,
+                        onWriteListener, onReadListener);
+                logFile.log("HNSW constructed; size=%d", size);
 
-        final int k = 50;
-        final List<PrimaryKeyAndVector> insertedData = randomVectors(random, config.getNumDimensions(), size);
+                final int k = 50;
+                final List<PrimaryKeyAndVector> insertedData = randomVectors(random, config.getNumDimensions(), size);
+                logFile.log("Generated %d random vectors", insertedData.size());
 
-        for (int i = 0; i < size;) {
-            i += TestHelpers.basicInsertBatch(getDb(), hnsw, 100, i,
-                    (tr, nextId) -> insertedData.get(Math.toIntExact(nextId))).size();
-        }
+                for (int i = 0; i < size;) {
+                    logger.info("basicInsertBatch " + i);
+                    logFile.log("primary insert loop iter=%d size=%d", i, size);
+                    i += TestHelpers.basicInsertBatch(getDb(), hnsw, 100, i,
+                            (tr, nextId) -> insertedData.get(Math.toIntExact(nextId)), logFile).size();
+                }
+                logFile.log("primary insert loop complete");
 
-        final HalfRealVector queryVector = createRandomHalfVector(random, config.getNumDimensions());
+                final HalfRealVector queryVector = createRandomHalfVector(random, config.getNumDimensions());
 
-        //
-        // Attempt to mutate some records by updating them using the same primary keys but different random vectors.
-        // This should not fail but should be silently ignored. If this succeeds, the following searches will all
-        // return records that are not aligned with recordsOrderedByDistance.
-        //
-        for (int i = 0; i < 100; ) {
-            i += TestHelpers.basicInsertBatch(getDb(), hnsw, 100, 0,
-                    (tr, ignored) -> {
-                        final var primaryKey = TestHelpers.createPrimaryKey(random.nextInt(1000));
-                        final HalfRealVector dataVector = createRandomHalfVector(random, config.getNumDimensions());
-                        return new PrimaryKeyAndVector(primaryKey, dataVector);
-                    }).size();
-        }
+                //
+                // Attempt to mutate some records by updating them using the same primary keys but different random vectors.
+                // This should not fail but should be silently ignored. If this succeeds, the following searches will all
+                // return records that are not aligned with recordsOrderedByDistance.
+                //
+                for (int i = 0; i < 100; ) {
+                    logFile.log("mutation insert loop iter=%d", i);
+                    i += TestHelpers.basicInsertBatch(getDb(), hnsw, 100, 0,
+                            (tr, ignored) -> {
+                                final var primaryKey = TestHelpers.createPrimaryKey(random.nextInt(1000));
+                                final HalfRealVector dataVector = createRandomHalfVector(random, config.getNumDimensions());
+                                return new PrimaryKeyAndVector(primaryKey, dataVector);
+                            }, logFile).size();
+                }
+                logFile.log("mutation insert loop complete");
 
-        onReadListener.reset();
-        final long beginTs = System.nanoTime();
-        final List<? extends ResultEntry> results =
-                db.run(tr ->
-                        hnsw.kNearestNeighborsSearch(tr, k, 100, true, queryVector).join());
-        final long endTs = System.nanoTime();
+                onReadListener.reset();
+                final long beginTs = System.nanoTime();
+                final List<? extends ResultEntry> results =
+                        db.run(tr ->
+                                hnsw.kNearestNeighborsSearch(tr, k, 100, true, queryVector).join());
+                final long endTs = System.nanoTime();
+                logFile.log("kNN search completed in %d ms; resultCount=%d",
+                        TimeUnit.NANOSECONDS.toMillis(endTs - beginTs), results.size());
 
-        final ImmutableSet<Tuple> trueNN =
-                orderedByDistances(config.getMetric(), insertedData, queryVector).stream()
-                        .limit(k)
-                        .map(PrimaryKeyVectorAndDistance::getPrimaryKey)
-                        .collect(ImmutableSet.toImmutableSet());
+                final ImmutableSet<Tuple> trueNN =
+                        orderedByDistances(config.getMetric(), insertedData, queryVector).stream()
+                                .limit(k)
+                                .map(PrimaryKeyVectorAndDistance::getPrimaryKey)
+                                .collect(ImmutableSet.toImmutableSet());
 
-        int recallCount = 0;
-        for (ResultEntry resultEntry : results) {
-            logger.info("nodeId ={} at distance={}", resultEntry.getPrimaryKey().getLong(0),
-                    resultEntry.getDistance());
-            if (trueNN.contains(resultEntry.getPrimaryKey())) {
-                recallCount++;
+                int recallCount = 0;
+                for (ResultEntry resultEntry : results) {
+                    logger.info("nodeId ={} at distance={}", resultEntry.getPrimaryKey().getLong(0),
+                            resultEntry.getDistance());
+                    if (trueNN.contains(resultEntry.getPrimaryKey())) {
+                        recallCount++;
+                    }
+                }
+                final double recall = (double)recallCount / (double)k;
+                logger.info("search transaction took elapsedTime={}ms; read nodes={}, read bytes={}, recall={}",
+                        TimeUnit.NANOSECONDS.toMillis(endTs - beginTs),
+                        onReadListener.getNodeCountByLayer(), onReadListener.getBytesReadByLayer(),
+                        String.format(Locale.ROOT, "%.2f", recall * 100.0d));
+                logFile.log("recall=%.4f recallCount=%d/%d readCounts=%s readBytes=%s",
+                        recall, recallCount, k,
+                        onReadListener.getNodeCountByLayer(), onReadListener.getBytesReadByLayer());
+                assertThat(recall).isGreaterThan(0.9);
+
+                final Set<Long> insertedIds =
+                        LongStream.range(0, 1000)
+                                .boxed()
+                                .collect(Collectors.toSet());
+
+                final Set<Long> readIds = Sets.newHashSet();
+                TestHelpers.scanLayer(getDb(), getSubspace(), config, 0, 100,
+                        node ->
+                                assertThat(readIds.add(node.getPrimaryKey().getLong(0))).isTrue());
+                assertThat(readIds).isEqualTo(insertedIds);
+                logFile.log("scanLayer(0) ok readIds=%d", readIds.size());
+
+                readIds.clear();
+                TestHelpers.scanLayer(getDb(), getSubspace(), config, 1, 100,
+                        node -> assertThat(readIds.add(node.getPrimaryKey().getLong(0))).isTrue());
+                assertThat(readIds.size()).isBetween(10, 100);
+                logFile.log("scanLayer(1) ok readIds=%d", readIds.size());
+            } catch (Throwable t) {
+                logFile.logFailure("testBasicInsert seed=" + seed + " config=" + config, t);
+                throw t;
             }
         }
-        final double recall = (double)recallCount / (double)k;
-        logger.info("search transaction took elapsedTime={}ms; read nodes={}, read bytes={}, recall={}",
-                TimeUnit.NANOSECONDS.toMillis(endTs - beginTs),
-                onReadListener.getNodeCountByLayer(), onReadListener.getBytesReadByLayer(),
-                String.format(Locale.ROOT, "%.2f", recall * 100.0d));
-        assertThat(recall).isGreaterThan(0.9);
-
-        final Set<Long> insertedIds =
-                LongStream.range(0, 1000)
-                        .boxed()
-                        .collect(Collectors.toSet());
-
-        final Set<Long> readIds = Sets.newHashSet();
-        TestHelpers.scanLayer(getDb(), getSubspace(), config, 0, 100,
-                node ->
-                        assertThat(readIds.add(node.getPrimaryKey().getLong(0))).isTrue());
-        assertThat(readIds).isEqualTo(insertedIds);
-
-        readIds.clear();
-        TestHelpers.scanLayer(getDb(), getSubspace(), config, 1, 100,
-                node -> assertThat(readIds.add(node.getPrimaryKey().getLong(0))).isTrue());
-        assertThat(readIds.size()).isBetween(10, 100);
     }
 
     @ExtendWith(TestHelpers.DumpLayersIfFailure.class)

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/OperationsTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/OperationsTest.java
@@ -341,7 +341,7 @@ class OperationsTest implements BaseTest {
 
                 for (int i = 0; i < size;) {
                     logFile.log("primary insert loop iter=%d size=%d", i, size);
-                    i += TestHelpers.basicInsertBatch(getDb(), hnsw, i < 800 ? 100 : 50, i,
+                    i += TestHelpers.basicInsertBatch(getDb(), hnsw, 100, i,
                             (tr, nextId) -> insertedData.get(Math.toIntExact(nextId)), logFile).size();
                 }
                 logFile.log("primary insert loop complete");

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/OperationsTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/OperationsTest.java
@@ -324,97 +324,78 @@ class OperationsTest implements BaseTest {
     @ParameterizedTest
     @MethodSource("differentConfigsAndMetrics")
     void testBasicInsert(final long seed, final Config config) throws Exception {
-        try (TestHelpers.TestLogFile logFile = TestHelpers.TestLogFile.create("OperationsTest.testBasicInsert", seed, config)) {
-            try {
-                final Random random = new Random(seed);
-                final int size = 1000;
-                final TestOnWriteListener onWriteListener = new TestOnWriteListener();
-                final TestOnReadListener onReadListener = new TestOnReadListener();
+        final Random random = new Random(seed);
+        final int size = 1000;
+        final TestOnWriteListener onWriteListener = new TestOnWriteListener();
+        final TestOnReadListener onReadListener = new TestOnReadListener();
 
-                final HNSW hnsw = new HNSW(subspaceExtension.getSubspace(), TestExecutors.defaultThreadPool(), config,
-                        onWriteListener, onReadListener);
-                logFile.log("HNSW constructed; size=%d", size);
+        final HNSW hnsw = new HNSW(subspaceExtension.getSubspace(), TestExecutors.defaultThreadPool(), config,
+                onWriteListener, onReadListener);
 
-                final int k = 50;
-                final List<PrimaryKeyAndVector> insertedData = randomVectors(random, config.getNumDimensions(), size);
-                logFile.log("Generated %d random vectors", insertedData.size());
+        final int k = 50;
+        final List<PrimaryKeyAndVector> insertedData = randomVectors(random, config.getNumDimensions(), size);
 
-                TestHelpers.basicInsert(getDb(), hnsw, insertedData, logFile);
-                logFile.log("primary insert loop complete");
+        TestHelpers.basicInsert(getDb(), hnsw, insertedData);
 
-                final HalfRealVector queryVector = createRandomHalfVector(random, config.getNumDimensions());
+        final HalfRealVector queryVector = createRandomHalfVector(random, config.getNumDimensions());
 
-                //
-                // Attempt to mutate some records by updating them using the same primary keys but different random vectors.
-                // This should not fail but should be silently ignored. If this succeeds, the following searches will all
-                // return records that are not aligned with recordsOrderedByDistance.
-                //
-                for (int i = 0; i < 100; ) {
-                    logFile.log("mutation insert loop iter=%d", i);
-                    i += TestHelpers.basicInsertBatch(getDb(), hnsw, 100, 0,
-                            (tr, ignored) -> {
-                                final var primaryKey = TestHelpers.createPrimaryKey(random.nextInt(1000));
-                                final HalfRealVector dataVector = createRandomHalfVector(random, config.getNumDimensions());
-                                return new PrimaryKeyAndVector(primaryKey, dataVector);
-                            }, logFile).size();
-                }
-                logFile.log("mutation insert loop complete");
+        //
+        // Attempt to mutate some records by updating them using the same primary keys but different random vectors.
+        // This should not fail but should be silently ignored. If this succeeds, the following searches will all
+        // return records that are not aligned with recordsOrderedByDistance.
+        //
+        for (int i = 0; i < 100; ) {
+            i += TestHelpers.basicInsertBatch(getDb(), hnsw, 100, 0,
+                    (tr, ignored) -> {
+                        final var primaryKey = TestHelpers.createPrimaryKey(random.nextInt(1000));
+                        final HalfRealVector dataVector = createRandomHalfVector(random, config.getNumDimensions());
+                        return new PrimaryKeyAndVector(primaryKey, dataVector);
+                    }).size();
+        }
 
-                onReadListener.reset();
-                final long beginTs = System.nanoTime();
-                final List<? extends ResultEntry> results =
-                        db.run(tr ->
-                                hnsw.kNearestNeighborsSearch(tr, k, 100, true, queryVector).join());
-                final long endTs = System.nanoTime();
-                logFile.log("kNN search completed in %d ms; resultCount=%d",
-                        TimeUnit.NANOSECONDS.toMillis(endTs - beginTs), results.size());
+        onReadListener.reset();
+        final long beginTs = System.nanoTime();
+        final List<? extends ResultEntry> results =
+                db.run(tr ->
+                        hnsw.kNearestNeighborsSearch(tr, k, 100, true, queryVector).join());
+        final long endTs = System.nanoTime();
 
-                final ImmutableSet<Tuple> trueNN =
-                        orderedByDistances(config.getMetric(), insertedData, queryVector).stream()
-                                .limit(k)
-                                .map(PrimaryKeyVectorAndDistance::getPrimaryKey)
-                                .collect(ImmutableSet.toImmutableSet());
+        final ImmutableSet<Tuple> trueNN =
+                orderedByDistances(config.getMetric(), insertedData, queryVector).stream()
+                        .limit(k)
+                        .map(PrimaryKeyVectorAndDistance::getPrimaryKey)
+                        .collect(ImmutableSet.toImmutableSet());
 
-                int recallCount = 0;
-                for (ResultEntry resultEntry : results) {
-                    logger.info("nodeId ={} at distance={}", resultEntry.getPrimaryKey().getLong(0),
-                            resultEntry.getDistance());
-                    if (trueNN.contains(resultEntry.getPrimaryKey())) {
-                        recallCount++;
-                    }
-                }
-                final double recall = (double)recallCount / (double)k;
-                logger.info("search transaction took elapsedTime={}ms; read nodes={}, read bytes={}, recall={}",
-                        TimeUnit.NANOSECONDS.toMillis(endTs - beginTs),
-                        onReadListener.getNodeCountByLayer(), onReadListener.getBytesReadByLayer(),
-                        String.format(Locale.ROOT, "%.2f", recall * 100.0d));
-                logFile.log("recall=%.4f recallCount=%d/%d readCounts=%s readBytes=%s",
-                        recall, recallCount, k,
-                        onReadListener.getNodeCountByLayer(), onReadListener.getBytesReadByLayer());
-                assertThat(recall).isGreaterThan(0.9);
-
-                final Set<Long> insertedIds =
-                        LongStream.range(0, 1000)
-                                .boxed()
-                                .collect(Collectors.toSet());
-
-                final Set<Long> readIds = Sets.newHashSet();
-                TestHelpers.scanLayer(getDb(), getSubspace(), config, 0, 100,
-                        node ->
-                                assertThat(readIds.add(node.getPrimaryKey().getLong(0))).isTrue());
-                assertThat(readIds).isEqualTo(insertedIds);
-                logFile.log("scanLayer(0) ok readIds=%d", readIds.size());
-
-                readIds.clear();
-                TestHelpers.scanLayer(getDb(), getSubspace(), config, 1, 100,
-                        node -> assertThat(readIds.add(node.getPrimaryKey().getLong(0))).isTrue());
-                assertThat(readIds.size()).isBetween(10, 100);
-                logFile.log("scanLayer(1) ok readIds=%d", readIds.size());
-            } catch (Throwable t) {
-                logFile.logFailure("testBasicInsert seed=" + seed + " config=" + config, t);
-                throw t;
+        int recallCount = 0;
+        for (ResultEntry resultEntry : results) {
+            logger.info("nodeId ={} at distance={}", resultEntry.getPrimaryKey().getLong(0),
+                    resultEntry.getDistance());
+            if (trueNN.contains(resultEntry.getPrimaryKey())) {
+                recallCount++;
             }
         }
+        final double recall = (double)recallCount / (double)k;
+        logger.info("search transaction took elapsedTime={}ms; read nodes={}, read bytes={}, recall={}",
+                TimeUnit.NANOSECONDS.toMillis(endTs - beginTs),
+                onReadListener.getNodeCountByLayer(), onReadListener.getBytesReadByLayer(),
+                String.format(Locale.ROOT, "%.2f", recall * 100.0d));
+        assertThat(recall).isGreaterThan(0.9);
+
+        final Set<Long> insertedIds =
+                LongStream.range(0, 1000)
+                        .boxed()
+                        .collect(Collectors.toSet());
+
+        final Set<Long> readIds = Sets.newHashSet();
+        TestHelpers.scanLayer(getDb(), getSubspace(), config, 0, 100,
+                node ->
+                        assertThat(readIds.add(node.getPrimaryKey().getLong(0))).isTrue());
+        assertThat(readIds).isEqualTo(insertedIds);
+
+        readIds.clear();
+        TestHelpers.scanLayer(getDb(), getSubspace(), config, 1, 100,
+                node -> assertThat(readIds.add(node.getPrimaryKey().getLong(0))).isTrue());
+        assertThat(readIds.size()).isBetween(10, 100);
     }
 
     @ExtendWith(TestHelpers.DumpLayersIfFailure.class)
@@ -433,7 +414,7 @@ class OperationsTest implements BaseTest {
         final int k = 30;
         final List<PrimaryKeyAndVector> insertedData = randomVectors(random, config.getNumDimensions(), size);
 
-        TestHelpers.basicInsert(getDb(), hnsw, insertedData, null);
+        TestHelpers.basicInsert(getDb(), hnsw, insertedData);
 
         final double radius = 1d;
         final HalfRealVector queryVector = createRandomHalfVector(random, config.getNumDimensions());
@@ -479,7 +460,7 @@ class OperationsTest implements BaseTest {
         final int k = 50;
         final List<PrimaryKeyAndVector> insertedData = randomVectors(random, config.getNumDimensions(), size);
 
-        TestHelpers.basicInsert(getDb(), hnsw, insertedData, null);
+        TestHelpers.basicInsert(getDb(), hnsw, insertedData);
 
         final int numVectorsPerDeleteBatch = 50;
         List<PrimaryKeyAndVector> remainingData = insertedData;
@@ -578,7 +559,7 @@ class OperationsTest implements BaseTest {
         final int numRecords = 1000;
         final int k = 499;
         final List<PrimaryKeyAndVector> insertedData = randomVectors(random, numDimensions, numRecords);
-        TestHelpers.basicInsert(getDb(), hnsw, insertedData, null);
+        TestHelpers.basicInsert(getDb(), hnsw, insertedData);
 
         final DoubleRealVector queryVector = createRandomDoubleVector(random, numDimensions);
 
@@ -652,7 +633,7 @@ class OperationsTest implements BaseTest {
 
         final List<PrimaryKeyAndVector> insertedData = randomVectors(random, config.getNumDimensions(), size);
 
-        TestHelpers.basicInsert(getDb(), hnsw, insertedData, null);
+        TestHelpers.basicInsert(getDb(), hnsw, insertedData);
 
         final int skip = 100;
         final HalfRealVector queryVector = createRandomHalfVector(random, config.getNumDimensions());

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/OperationsTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/OperationsTest.java
@@ -339,11 +339,7 @@ class OperationsTest implements BaseTest {
                 final List<PrimaryKeyAndVector> insertedData = randomVectors(random, config.getNumDimensions(), size);
                 logFile.log("Generated %d random vectors", insertedData.size());
 
-                for (int i = 0; i < size;) {
-                    logFile.log("primary insert loop iter=%d size=%d", i, size);
-                    i += TestHelpers.basicInsertBatch(getDb(), hnsw, 100, i,
-                            (tr, nextId) -> insertedData.get(Math.toIntExact(nextId)), logFile).size();
-                }
+                TestHelpers.basicInsert(getDb(), hnsw, insertedData, logFile);
                 logFile.log("primary insert loop complete");
 
                 final HalfRealVector queryVector = createRandomHalfVector(random, config.getNumDimensions());
@@ -437,10 +433,7 @@ class OperationsTest implements BaseTest {
         final int k = 30;
         final List<PrimaryKeyAndVector> insertedData = randomVectors(random, config.getNumDimensions(), size);
 
-        for (int i = 0; i < size;) {
-            i += TestHelpers.basicInsertBatch(getDb(), hnsw, 100, i,
-                    (tr, nextId) -> insertedData.get(Math.toIntExact(nextId))).size();
-        }
+        TestHelpers.basicInsert(getDb(), hnsw, insertedData, null);
 
         final double radius = 1d;
         final HalfRealVector queryVector = createRandomHalfVector(random, config.getNumDimensions());
@@ -486,10 +479,7 @@ class OperationsTest implements BaseTest {
         final int k = 50;
         final List<PrimaryKeyAndVector> insertedData = randomVectors(random, config.getNumDimensions(), size);
 
-        for (int i = 0; i < size;) {
-            i += TestHelpers.basicInsertBatch(getDb(), hnsw, 100, i,
-                    (tr, nextId) -> insertedData.get(Math.toIntExact(nextId))).size();
-        }
+        TestHelpers.basicInsert(getDb(), hnsw, insertedData, null);
 
         final int numVectorsPerDeleteBatch = 50;
         List<PrimaryKeyAndVector> remainingData = insertedData;
@@ -588,10 +578,7 @@ class OperationsTest implements BaseTest {
         final int numRecords = 1000;
         final int k = 499;
         final List<PrimaryKeyAndVector> insertedData = randomVectors(random, numDimensions, numRecords);
-        for (int i = 0; i < numRecords;) {
-            i += TestHelpers.basicInsertBatch(getDb(), hnsw, 100, i,
-                    (tr, nextId) -> insertedData.get(Math.toIntExact(nextId))).size();
-        }
+        TestHelpers.basicInsert(getDb(), hnsw, insertedData, null);
 
         final DoubleRealVector queryVector = createRandomDoubleVector(random, numDimensions);
 
@@ -665,10 +652,7 @@ class OperationsTest implements BaseTest {
 
         final List<PrimaryKeyAndVector> insertedData = randomVectors(random, config.getNumDimensions(), size);
 
-        for (int i = 0; i < size;) {
-            i += TestHelpers.basicInsertBatch(getDb(), hnsw, 100, i,
-                    (tr, nextId) -> insertedData.get(Math.toIntExact(nextId))).size();
-        }
+        TestHelpers.basicInsert(getDb(), hnsw, insertedData, null);
 
         final int skip = 100;
         final HalfRealVector queryVector = createRandomHalfVector(random, config.getNumDimensions());

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/TestHelpers.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/TestHelpers.java
@@ -69,6 +69,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -168,11 +169,8 @@ class TestHelpers {
                 }
                 data.add(record);
 
-                if (logFile != null) {
-                    logFile.log("Inserting to batch %d", i);
-                }
                 return hnsw.insert(tr, record.getPrimaryKey(), record.getVector()).thenApply(vignore -> true);
-            });
+            }, ForkJoinPool.commonPool());
             return future.thenApply(vignore -> data.build())
                     .whenComplete((result, error) -> {
                         if (error != null) {

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/TestHelpers.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/TestHelpers.java
@@ -123,7 +123,7 @@ class TestHelpers {
             logFile.log("basicInsertBatch begin batchSize=%d firstId=%d", batchSize, firstId);
         }
         AtomicInteger attempt = new AtomicInteger(0);
-        try (Transaction tr = db.createTransaction()) {
+        return db.runAsync(tr -> {
             attempt.incrementAndGet();
             final TestOnWriteListener onWriteListener = (TestOnWriteListener)hnsw.getOnWriteListener();
             onWriteListener.reset();
@@ -151,9 +151,7 @@ class TestHelpers {
                     return hnsw.insert(tr, record.getPrimaryKey(), record.getVector());
                 });
             }
-            return future
-                    .thenCompose(vignore -> tr.commit())
-                    .thenApply(vignore -> data.build())
+            return future.thenApply(vignore -> data.build())
                     .whenComplete((result, error) -> {
                         if (error != null) {
                             logger.info("Failed to insert batchSize={}", error);
@@ -173,8 +171,8 @@ class TestHelpers {
                                         onReadListener.getNodeCountByLayer(), onReadListener.getBytesReadByLayer());
                             }
                         }
-                    }).get(2, TimeUnit.MINUTES);
-        }
+                    });
+        }).get(2, TimeUnit.MINUTES); // set a timeout for inserting a single batch including retries so setup won't run forever
     }
 
     static List<PrimaryKeyAndVector> insertSIFTSmall(@Nonnull final Database db,

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/TestHelpers.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/TestHelpers.java
@@ -141,7 +141,6 @@ class TestHelpers {
                 data.add(record);
                 final int finalI = i;
                 future = future.thenCompose((vignore) -> {
-                    logger.info("Inserting to batch {}", finalI);
                     if (logFile != null) {
                         logFile.log("Inserting to batch %d", finalI);
                     }

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/TestHelpers.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/TestHelpers.java
@@ -22,6 +22,7 @@ package com.apple.foundationdb.async.hnsw;
 
 import com.apple.foundationdb.Database;
 import com.apple.foundationdb.Transaction;
+import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.linear.AffineOperator;
 import com.apple.foundationdb.linear.DoubleRealVector;
 import com.apple.foundationdb.linear.HalfRealVector;
@@ -150,19 +151,25 @@ class TestHelpers {
 
             // In theory this could put all the futures in a List and run the inserts concurrently, but for a `basicInsertBatch`
             // it's probably better to not test the concurrent handling of hnsw, even if it makes the tests slower.
-            CompletableFuture<Void> future = CompletableFuture.completedFuture(null);
             final long beginTs = System.nanoTime();
             // This is a simplistic version of ThrottledRetryingIterator, but that cannot be used here because it depends
             // on many classes from fdb-record-layer-core
+            AtomicInteger index = new AtomicInteger(0);
             final int attemptBatchSize = Math.max(1, batchSize / attempt.get());
-            for (int i = 0; i < attemptBatchSize; i ++) {
+            CompletableFuture<Void> future = AsyncUtil.whileTrue(() -> {
+                int i = index.getAndIncrement();
+                if (i >= attemptBatchSize) {
+                    return AsyncUtil.READY_FALSE;
+                }
+
                 final PrimaryKeyAndVector record = insertFunction.apply(tr, firstId + i);
                 if (record == null) {
-                    break;
+                    return AsyncUtil.READY_FALSE;
                 }
                 data.add(record);
-                future = future.thenCompose((vignore) -> hnsw.insert(tr, record.getPrimaryKey(), record.getVector()));
-            }
+
+                return hnsw.insert(tr, record.getPrimaryKey(), record.getVector()).thenApply(vignore -> true);
+            });
             return future.thenApply(vignore -> data.build())
                     .whenComplete((result, error) -> {
                         if (error != null) {

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/TestHelpers.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/TestHelpers.java
@@ -49,14 +49,11 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.BufferedWriter;
 import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
-import java.time.Instant;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -101,31 +98,20 @@ class TestHelpers {
         }
     }
 
-    @Nonnull
-    static List<PrimaryKeyAndVector> basicInsertBatch(@Nonnull final Database db,
-                                                      @Nonnull final HNSW hnsw,
-                                                      final int batchSize,
-                                                      final long firstId,
-                                                      @Nonnull final BiFunction<Transaction, Long, PrimaryKeyAndVector> insertFunction)
-            throws ExecutionException, InterruptedException, TimeoutException {
-        return basicInsertBatch(db, hnsw, batchSize, firstId, insertFunction, null);
-    }
-
     static void basicInsert(@Nonnull Database db, @Nonnull final HNSW hnsw,
-                            final List<PrimaryKeyAndVector> insertedData,
-                            TestLogFile logFile)
+                            final List<PrimaryKeyAndVector> insertedData)
             throws ExecutionException, InterruptedException, TimeoutException {
-        basicInsert(db, hnsw, insertedData.size(), (tr, nextId) -> insertedData.get(Math.toIntExact(nextId)), logFile);
+        basicInsert(db, hnsw, insertedData.size(), (tr, nextId) -> insertedData.get(Math.toIntExact(nextId)));
     }
 
     static void basicInsert(@Nonnull final Database db,
                             @Nonnull final HNSW hnsw,
                             final int count,
-                            @Nonnull final BiFunction<Transaction, Long, PrimaryKeyAndVector> insertFunction, final TestLogFile logFile)
+                            @Nonnull final BiFunction<Transaction, Long, PrimaryKeyAndVector> insertFunction)
             throws ExecutionException, InterruptedException, TimeoutException {
         int inserted = 0;
         while (inserted < count) {
-            inserted += basicInsertBatch(db, hnsw, Math.min(100, count - inserted), inserted, insertFunction, logFile)
+            inserted += basicInsertBatch(db, hnsw, Math.min(100, count - inserted), inserted, insertFunction)
                     .size();
         }
     }
@@ -135,12 +121,8 @@ class TestHelpers {
                                                       @Nonnull final HNSW hnsw,
                                                       final int batchSize,
                                                       final long firstId,
-                                                      @Nonnull final BiFunction<Transaction, Long, PrimaryKeyAndVector> insertFunction,
-                                                      @Nullable final TestLogFile logFile)
+                                                      @Nonnull final BiFunction<Transaction, Long, PrimaryKeyAndVector> insertFunction)
             throws ExecutionException, InterruptedException, TimeoutException {
-        if (logFile != null) {
-            logFile.log("basicInsertBatch begin batchSize=%d firstId=%d", batchSize, firstId);
-        }
         AtomicInteger attempt = new AtomicInteger(0);
         return db.runAsync(tr -> {
             attempt.incrementAndGet();
@@ -166,9 +148,6 @@ class TestHelpers {
                 data.add(record);
                 final int finalI = i;
                 future = future.thenCompose((vignore) -> {
-                    if (logFile != null) {
-                        logFile.log("Inserting to batch %d", finalI);
-                    }
                     return hnsw.insert(tr, record.getPrimaryKey(), record.getVector());
                 });
             }
@@ -176,21 +155,11 @@ class TestHelpers {
                     .whenComplete((result, error) -> {
                         if (error != null) {
                             logger.info("Failed to insert batchSize={}", error);
-                            if (logFile != null) {
-                                logFile.logFailure(
-                                        String.format(Locale.ROOT, "basicInsertBatch error batchSize=%d firstId=%d", batchSize, firstId),
-                                        error);
-                            }
                         } else {
                             final long endTs = System.nanoTime();
                             logger.info("inserted batchSize={} records={} starting at nodeId={} took elapsedTime={}ms, readCounts={}, readBytes={}",
                                     batchSize, result.size(), firstId, TimeUnit.NANOSECONDS.toMillis(endTs - beginTs),
                                     onReadListener.getNodeCountByLayer(), onReadListener.getBytesReadByLayer());
-                            if (logFile != null) {
-                                logFile.log("basicInsertBatch end batchSize=%d records=%d firstId=%d elapsedMs=%d readCounts=%s readBytes=%s",
-                                        batchSize, result.size(), firstId, TimeUnit.NANOSECONDS.toMillis(endTs - beginTs),
-                                        onReadListener.getNodeCountByLayer(), onReadListener.getBytesReadByLayer());
-                            }
                         }
                     });
         }).get(2, TimeUnit.MINUTES); // set a timeout for inserting a single batch including retries so setup won't run forever
@@ -658,120 +627,6 @@ class TestHelpers {
         @Override
         public int hashCode() {
             return Objects.hash(super.hashCode(), getDistance());
-        }
-    }
-
-    /**
-     * Per-invocation log file written to {@code fdb-extensions/.out/reports/}. Lets a parameterised test
-     * dump a structured trace of itself (and any helpers it calls) to a dedicated file separate from the
-     * shared logger output, so CI failures can be inspected without untangling interleaved parallel-test
-     * log streams.
-     *
-     * <p>Typical usage from a parameterised test:</p>
-     * <pre>
-     * try (TestHelpers.TestLogFile logFile = TestHelpers.TestLogFile.create("OperationsTest.testBasicInsert", seed, config)) {
-     *     try {
-     *         // ... test body, with logFile.log(...) calls ...
-     *         basicInsertBatch(db, hnsw, batchSize, firstId, insertFn, logFile);
-     *     } catch (Throwable t) {
-     *         logFile.logFailure("testBasicInsert", t);
-     *         throw t;
-     *     }
-     * }
-     * </pre>
-     */
-    public static final class TestLogFile implements AutoCloseable {
-        @Nonnull
-        private static final Path REPORTS_DIR = Paths.get(".out", "reports");
-        @Nonnull
-        private static final AtomicLong COUNTER = new AtomicLong();
-
-        @Nonnull
-        private final Path path;
-        @Nonnull
-        private final PrintWriter writer;
-
-        private TestLogFile(@Nonnull final Path path, @Nonnull final PrintWriter writer) {
-            this.path = path;
-            this.writer = writer;
-        }
-
-        /**
-         * Create a new log file for a single test invocation. The file is created under
-         * {@code fdb-extensions/.out/reports/} with a name derived from {@code testName} and a
-         * monotonically increasing counter. The file is opened immediately, and a header recording
-         * the test name and arguments is written before the method returns.
-         */
-        @Nonnull
-        public static TestLogFile create(@Nonnull final String testName, @Nonnull final Object... args) throws IOException {
-            Files.createDirectories(REPORTS_DIR);
-            final long index = COUNTER.incrementAndGet();
-            final String sanitized = testName.replaceAll("[^A-Za-z0-9._-]", "_");
-            final Path file = REPORTS_DIR.resolve(String.format(Locale.ROOT, "%s-%d.log", sanitized, index));
-            // Synchronized PrintWriter; writes from FDB callback threads and the test thread are safe.
-            final BufferedWriter buffered = Files.newBufferedWriter(file,
-                    StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE);
-            final PrintWriter writer = new PrintWriter(buffered, true);
-            final TestLogFile logFile = new TestLogFile(file, writer);
-            // Header: test name, arguments, start timestamp.
-            logFile.writer.println("# test=" + testName);
-            for (int i = 0; i < args.length; i++) {
-                logFile.writer.println("# arg[" + i + "]=" + Objects.toString(args[i]));
-            }
-            logFile.writer.println("# startedAt=" + Instant.now());
-            logFile.writer.println("# file=" + file.toAbsolutePath());
-            logFile.writer.println();
-            logFile.writer.flush();
-            return logFile;
-        }
-
-        /**
-         * Append a single timestamped log line. Format string follows {@link String#format(Locale, String, Object...)}
-         * semantics. Safe to call from any thread.
-         */
-        public void log(@Nonnull final String fmt, @Nonnull final Object... args) {
-            final String formatted = String.format(Locale.ROOT, fmt, args);
-            synchronized (writer) {
-                writer.print(Instant.now());
-                writer.print(' ');
-                writer.print('[');
-                writer.print(Thread.currentThread().getName());
-                writer.print("] ");
-                writer.println(formatted);
-            }
-        }
-
-        /**
-         * Append a failure record including the stack trace. Use this before rethrowing in a test's
-         * catch block.
-         */
-        public void logFailure(@Nonnull final String context, @Nonnull final Throwable t) {
-            final StringWriter stack = new StringWriter();
-            try (PrintWriter pw = new PrintWriter(stack)) {
-                t.printStackTrace(pw);
-            }
-            synchronized (writer) {
-                writer.print(Instant.now());
-                writer.print(" [");
-                writer.print(Thread.currentThread().getName());
-                writer.print("] FAILURE ");
-                writer.println(context);
-                writer.println(stack.toString());
-            }
-        }
-
-        @Nonnull
-        public Path getPath() {
-            return path;
-        }
-
-        @Override
-        public void close() {
-            synchronized (writer) {
-                writer.println();
-                writer.println("# closedAt=" + Instant.now());
-                writer.close();
-            }
         }
     }
 }

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/TestHelpers.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/TestHelpers.java
@@ -49,11 +49,14 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.BufferedWriter;
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -98,20 +101,31 @@ class TestHelpers {
         }
     }
 
-    static void basicInsert(@Nonnull Database db, @Nonnull final HNSW hnsw,
-                            final List<PrimaryKeyAndVector> insertedData)
+    @Nonnull
+    static List<PrimaryKeyAndVector> basicInsertBatch(@Nonnull final Database db,
+                                                      @Nonnull final HNSW hnsw,
+                                                      final int batchSize,
+                                                      final long firstId,
+                                                      @Nonnull final BiFunction<Transaction, Long, PrimaryKeyAndVector> insertFunction)
             throws ExecutionException, InterruptedException, TimeoutException {
-        basicInsert(db, hnsw, insertedData.size(), (tr, nextId) -> insertedData.get(Math.toIntExact(nextId)));
+        return basicInsertBatch(db, hnsw, batchSize, firstId, insertFunction, null);
+    }
+
+    static void basicInsert(@Nonnull Database db, @Nonnull final HNSW hnsw,
+                            final List<PrimaryKeyAndVector> insertedData,
+                            TestLogFile logFile)
+            throws ExecutionException, InterruptedException, TimeoutException {
+        basicInsert(db, hnsw, insertedData.size(), (tr, nextId) -> insertedData.get(Math.toIntExact(nextId)), logFile);
     }
 
     static void basicInsert(@Nonnull final Database db,
                             @Nonnull final HNSW hnsw,
                             final int count,
-                            @Nonnull final BiFunction<Transaction, Long, PrimaryKeyAndVector> insertFunction)
+                            @Nonnull final BiFunction<Transaction, Long, PrimaryKeyAndVector> insertFunction, final TestLogFile logFile)
             throws ExecutionException, InterruptedException, TimeoutException {
         int inserted = 0;
         while (inserted < count) {
-            inserted += basicInsertBatch(db, hnsw, Math.min(100, count - inserted), inserted, insertFunction)
+            inserted += basicInsertBatch(db, hnsw, Math.min(100, count - inserted), inserted, insertFunction, logFile)
                     .size();
         }
     }
@@ -121,8 +135,12 @@ class TestHelpers {
                                                       @Nonnull final HNSW hnsw,
                                                       final int batchSize,
                                                       final long firstId,
-                                                      @Nonnull final BiFunction<Transaction, Long, PrimaryKeyAndVector> insertFunction)
+                                                      @Nonnull final BiFunction<Transaction, Long, PrimaryKeyAndVector> insertFunction,
+                                                      @Nullable final TestLogFile logFile)
             throws ExecutionException, InterruptedException, TimeoutException {
+        if (logFile != null) {
+            logFile.log("basicInsertBatch begin batchSize=%d firstId=%d", batchSize, firstId);
+        }
         AtomicInteger attempt = new AtomicInteger(0);
         return db.runAsync(tr -> {
             attempt.incrementAndGet();
@@ -148,6 +166,9 @@ class TestHelpers {
                 data.add(record);
                 final int finalI = i;
                 future = future.thenCompose((vignore) -> {
+                    if (logFile != null) {
+                        logFile.log("Inserting to batch %d", finalI);
+                    }
                     return hnsw.insert(tr, record.getPrimaryKey(), record.getVector());
                 });
             }
@@ -155,11 +176,21 @@ class TestHelpers {
                     .whenComplete((result, error) -> {
                         if (error != null) {
                             logger.info("Failed to insert batchSize={}", error);
+                            if (logFile != null) {
+                                logFile.logFailure(
+                                        String.format(Locale.ROOT, "basicInsertBatch error batchSize=%d firstId=%d", batchSize, firstId),
+                                        error);
+                            }
                         } else {
                             final long endTs = System.nanoTime();
                             logger.info("inserted batchSize={} records={} starting at nodeId={} took elapsedTime={}ms, readCounts={}, readBytes={}",
                                     batchSize, result.size(), firstId, TimeUnit.NANOSECONDS.toMillis(endTs - beginTs),
                                     onReadListener.getNodeCountByLayer(), onReadListener.getBytesReadByLayer());
+                            if (logFile != null) {
+                                logFile.log("basicInsertBatch end batchSize=%d records=%d firstId=%d elapsedMs=%d readCounts=%s readBytes=%s",
+                                        batchSize, result.size(), firstId, TimeUnit.NANOSECONDS.toMillis(endTs - beginTs),
+                                        onReadListener.getNodeCountByLayer(), onReadListener.getBytesReadByLayer());
+                            }
                         }
                     });
         }).get(2, TimeUnit.MINUTES); // set a timeout for inserting a single batch including retries so setup won't run forever
@@ -627,6 +658,120 @@ class TestHelpers {
         @Override
         public int hashCode() {
             return Objects.hash(super.hashCode(), getDistance());
+        }
+    }
+
+    /**
+     * Per-invocation log file written to {@code fdb-extensions/.out/reports/}. Lets a parameterised test
+     * dump a structured trace of itself (and any helpers it calls) to a dedicated file separate from the
+     * shared logger output, so CI failures can be inspected without untangling interleaved parallel-test
+     * log streams.
+     *
+     * <p>Typical usage from a parameterised test:</p>
+     * <pre>
+     * try (TestHelpers.TestLogFile logFile = TestHelpers.TestLogFile.create("OperationsTest.testBasicInsert", seed, config)) {
+     *     try {
+     *         // ... test body, with logFile.log(...) calls ...
+     *         basicInsertBatch(db, hnsw, batchSize, firstId, insertFn, logFile);
+     *     } catch (Throwable t) {
+     *         logFile.logFailure("testBasicInsert", t);
+     *         throw t;
+     *     }
+     * }
+     * </pre>
+     */
+    public static final class TestLogFile implements AutoCloseable {
+        @Nonnull
+        private static final Path REPORTS_DIR = Paths.get(".out", "reports");
+        @Nonnull
+        private static final AtomicLong COUNTER = new AtomicLong();
+
+        @Nonnull
+        private final Path path;
+        @Nonnull
+        private final PrintWriter writer;
+
+        private TestLogFile(@Nonnull final Path path, @Nonnull final PrintWriter writer) {
+            this.path = path;
+            this.writer = writer;
+        }
+
+        /**
+         * Create a new log file for a single test invocation. The file is created under
+         * {@code fdb-extensions/.out/reports/} with a name derived from {@code testName} and a
+         * monotonically increasing counter. The file is opened immediately, and a header recording
+         * the test name and arguments is written before the method returns.
+         */
+        @Nonnull
+        public static TestLogFile create(@Nonnull final String testName, @Nonnull final Object... args) throws IOException {
+            Files.createDirectories(REPORTS_DIR);
+            final long index = COUNTER.incrementAndGet();
+            final String sanitized = testName.replaceAll("[^A-Za-z0-9._-]", "_");
+            final Path file = REPORTS_DIR.resolve(String.format(Locale.ROOT, "%s-%d.log", sanitized, index));
+            // Synchronized PrintWriter; writes from FDB callback threads and the test thread are safe.
+            final BufferedWriter buffered = Files.newBufferedWriter(file,
+                    StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE);
+            final PrintWriter writer = new PrintWriter(buffered, true);
+            final TestLogFile logFile = new TestLogFile(file, writer);
+            // Header: test name, arguments, start timestamp.
+            logFile.writer.println("# test=" + testName);
+            for (int i = 0; i < args.length; i++) {
+                logFile.writer.println("# arg[" + i + "]=" + Objects.toString(args[i]));
+            }
+            logFile.writer.println("# startedAt=" + Instant.now());
+            logFile.writer.println("# file=" + file.toAbsolutePath());
+            logFile.writer.println();
+            logFile.writer.flush();
+            return logFile;
+        }
+
+        /**
+         * Append a single timestamped log line. Format string follows {@link String#format(Locale, String, Object...)}
+         * semantics. Safe to call from any thread.
+         */
+        public void log(@Nonnull final String fmt, @Nonnull final Object... args) {
+            final String formatted = String.format(Locale.ROOT, fmt, args);
+            synchronized (writer) {
+                writer.print(Instant.now());
+                writer.print(' ');
+                writer.print('[');
+                writer.print(Thread.currentThread().getName());
+                writer.print("] ");
+                writer.println(formatted);
+            }
+        }
+
+        /**
+         * Append a failure record including the stack trace. Use this before rethrowing in a test's
+         * catch block.
+         */
+        public void logFailure(@Nonnull final String context, @Nonnull final Throwable t) {
+            final StringWriter stack = new StringWriter();
+            try (PrintWriter pw = new PrintWriter(stack)) {
+                t.printStackTrace(pw);
+            }
+            synchronized (writer) {
+                writer.print(Instant.now());
+                writer.print(" [");
+                writer.print(Thread.currentThread().getName());
+                writer.print("] FAILURE ");
+                writer.println(context);
+                writer.println(stack.toString());
+            }
+        }
+
+        @Nonnull
+        public Path getPath() {
+            return path;
+        }
+
+        @Override
+        public void close() {
+            synchronized (writer) {
+                writer.println();
+                writer.println("# closedAt=" + Instant.now());
+                writer.close();
+            }
         }
     }
 }

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/TestHelpers.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/TestHelpers.java
@@ -121,7 +121,7 @@ class TestHelpers {
         if (logFile != null) {
             logFile.log("basicInsertBatch begin batchSize=%d firstId=%d", batchSize, firstId);
         }
-        return db.runAsync(tr -> {
+        try (Transaction tr = db.createTransaction()) {
             final TestOnWriteListener onWriteListener = (TestOnWriteListener)hnsw.getOnWriteListener();
             onWriteListener.reset();
             final TestOnReadListener onReadListener = (TestOnReadListener)hnsw.getOnReadListener();
@@ -148,7 +148,9 @@ class TestHelpers {
                     return hnsw.insert(tr, record.getPrimaryKey(), record.getVector());
                 });
             }
-            return future.thenApply(vignore -> data.build())
+            return future
+                    .thenCompose(vignore -> tr.commit())
+                    .thenApply(vignore -> data.build())
                     .whenComplete((result, error) -> {
                         if (error != null) {
                             logger.info("Failed to insert batchSize={}", error);
@@ -168,8 +170,8 @@ class TestHelpers {
                                         onReadListener.getNodeCountByLayer(), onReadListener.getBytesReadByLayer());
                             }
                         }
-                    });
-        }).get(2, TimeUnit.MINUTES); // set a timeout for inserting a single batch including retries so setup won't run forever
+                    }).get(2, TimeUnit.MINUTES);
+        }
     }
 
     static List<PrimaryKeyAndVector> insertSIFTSmall(@Nonnull final Database db,

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/TestHelpers.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/TestHelpers.java
@@ -73,6 +73,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -121,7 +122,9 @@ class TestHelpers {
         if (logFile != null) {
             logFile.log("basicInsertBatch begin batchSize=%d firstId=%d", batchSize, firstId);
         }
+        AtomicInteger attempt = new AtomicInteger(0);
         try (Transaction tr = db.createTransaction()) {
+            attempt.incrementAndGet();
             final TestOnWriteListener onWriteListener = (TestOnWriteListener)hnsw.getOnWriteListener();
             onWriteListener.reset();
             final TestOnReadListener onReadListener = (TestOnReadListener)hnsw.getOnReadListener();
@@ -133,7 +136,8 @@ class TestHelpers {
             // it's probably better to not test the concurrent handling of hnsw, even if it makes the tests slower.
             CompletableFuture<Void> future = CompletableFuture.completedFuture(null);
             final long beginTs = System.nanoTime();
-            for (int i = 0; i < batchSize; i ++) {
+            final int attemptBatchSize = batchSize / attempt.get();
+            for (int i = 0; i < attemptBatchSize; i ++) {
                 final PrimaryKeyAndVector record = insertFunction.apply(tr, firstId + i);
                 if (record == null) {
                     break;

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/TestHelpers.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/TestHelpers.java
@@ -161,13 +161,7 @@ class TestHelpers {
                     break;
                 }
                 data.add(record);
-                final int finalI = i;
-                future = future.thenCompose((vignore) -> {
-                    if (logFile != null) {
-                        logFile.log("Inserting to batch %d", finalI);
-                    }
-                    return hnsw.insert(tr, record.getPrimaryKey(), record.getVector());
-                });
+                future = future.thenCompose((vignore) -> hnsw.insert(tr, record.getPrimaryKey(), record.getVector()));
             }
             return future.thenApply(vignore -> data.build())
                     .whenComplete((result, error) -> {

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/TestHelpers.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/TestHelpers.java
@@ -49,11 +49,14 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.BufferedWriter;
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -104,6 +107,20 @@ class TestHelpers {
                                                       final long firstId,
                                                       @Nonnull final BiFunction<Transaction, Long, PrimaryKeyAndVector> insertFunction)
             throws ExecutionException, InterruptedException, TimeoutException {
+        return basicInsertBatch(db, hnsw, batchSize, firstId, insertFunction, null);
+    }
+
+    @Nonnull
+    static List<PrimaryKeyAndVector> basicInsertBatch(@Nonnull final Database db,
+                                                      @Nonnull final HNSW hnsw,
+                                                      final int batchSize,
+                                                      final long firstId,
+                                                      @Nonnull final BiFunction<Transaction, Long, PrimaryKeyAndVector> insertFunction,
+                                                      @Nullable final TestLogFile logFile)
+            throws ExecutionException, InterruptedException, TimeoutException {
+        if (logFile != null) {
+            logFile.log("basicInsertBatch begin batchSize=%d firstId=%d", batchSize, firstId);
+        }
         return db.runAsync(tr -> {
             final TestOnWriteListener onWriteListener = (TestOnWriteListener)hnsw.getOnWriteListener();
             onWriteListener.reset();
@@ -122,17 +139,34 @@ class TestHelpers {
                     break;
                 }
                 data.add(record);
-                future = future.thenCompose((vignore) -> hnsw.insert(tr, record.getPrimaryKey(), record.getVector()));
+                final int finalI = i;
+                future = future.thenCompose((vignore) -> {
+                    logger.info("Inserting to batch {}", finalI);
+                    if (logFile != null) {
+                        logFile.log("Inserting to batch %d", finalI);
+                    }
+                    return hnsw.insert(tr, record.getPrimaryKey(), record.getVector());
+                });
             }
             return future.thenApply(vignore -> data.build())
                     .whenComplete((result, error) -> {
                         if (error != null) {
                             logger.info("Failed to insert batchSize={}", error);
+                            if (logFile != null) {
+                                logFile.logFailure(
+                                        String.format(Locale.ROOT, "basicInsertBatch error batchSize=%d firstId=%d", batchSize, firstId),
+                                        error);
+                            }
                         } else {
                             final long endTs = System.nanoTime();
                             logger.info("inserted batchSize={} records={} starting at nodeId={} took elapsedTime={}ms, readCounts={}, readBytes={}",
                                     batchSize, result.size(), firstId, TimeUnit.NANOSECONDS.toMillis(endTs - beginTs),
                                     onReadListener.getNodeCountByLayer(), onReadListener.getBytesReadByLayer());
+                            if (logFile != null) {
+                                logFile.log("basicInsertBatch end batchSize=%d records=%d firstId=%d elapsedMs=%d readCounts=%s readBytes=%s",
+                                        batchSize, result.size(), firstId, TimeUnit.NANOSECONDS.toMillis(endTs - beginTs),
+                                        onReadListener.getNodeCountByLayer(), onReadListener.getBytesReadByLayer());
+                            }
                         }
                     });
         }).get(2, TimeUnit.MINUTES); // set a timeout for inserting a single batch including retries so setup won't run forever
@@ -600,6 +634,120 @@ class TestHelpers {
         @Override
         public int hashCode() {
             return Objects.hash(super.hashCode(), getDistance());
+        }
+    }
+
+    /**
+     * Per-invocation log file written to {@code fdb-extensions/.out/reports/}. Lets a parameterised test
+     * dump a structured trace of itself (and any helpers it calls) to a dedicated file separate from the
+     * shared logger output, so CI failures can be inspected without untangling interleaved parallel-test
+     * log streams.
+     *
+     * <p>Typical usage from a parameterised test:</p>
+     * <pre>
+     * try (TestHelpers.TestLogFile logFile = TestHelpers.TestLogFile.create("OperationsTest.testBasicInsert", seed, config)) {
+     *     try {
+     *         // ... test body, with logFile.log(...) calls ...
+     *         basicInsertBatch(db, hnsw, batchSize, firstId, insertFn, logFile);
+     *     } catch (Throwable t) {
+     *         logFile.logFailure("testBasicInsert", t);
+     *         throw t;
+     *     }
+     * }
+     * </pre>
+     */
+    public static final class TestLogFile implements AutoCloseable {
+        @Nonnull
+        private static final Path REPORTS_DIR = Paths.get(".out", "reports");
+        @Nonnull
+        private static final AtomicLong COUNTER = new AtomicLong();
+
+        @Nonnull
+        private final Path path;
+        @Nonnull
+        private final PrintWriter writer;
+
+        private TestLogFile(@Nonnull final Path path, @Nonnull final PrintWriter writer) {
+            this.path = path;
+            this.writer = writer;
+        }
+
+        /**
+         * Create a new log file for a single test invocation. The file is created under
+         * {@code fdb-extensions/.out/reports/} with a name derived from {@code testName} and a
+         * monotonically increasing counter. The file is opened immediately, and a header recording
+         * the test name and arguments is written before the method returns.
+         */
+        @Nonnull
+        public static TestLogFile create(@Nonnull final String testName, @Nonnull final Object... args) throws IOException {
+            Files.createDirectories(REPORTS_DIR);
+            final long index = COUNTER.incrementAndGet();
+            final String sanitized = testName.replaceAll("[^A-Za-z0-9._-]", "_");
+            final Path file = REPORTS_DIR.resolve(String.format(Locale.ROOT, "%s-%d.log", sanitized, index));
+            // Synchronized PrintWriter; writes from FDB callback threads and the test thread are safe.
+            final BufferedWriter buffered = Files.newBufferedWriter(file,
+                    StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE);
+            final PrintWriter writer = new PrintWriter(buffered, true);
+            final TestLogFile logFile = new TestLogFile(file, writer);
+            // Header: test name, arguments, start timestamp.
+            logFile.writer.println("# test=" + testName);
+            for (int i = 0; i < args.length; i++) {
+                logFile.writer.println("# arg[" + i + "]=" + Objects.toString(args[i]));
+            }
+            logFile.writer.println("# startedAt=" + Instant.now());
+            logFile.writer.println("# file=" + file.toAbsolutePath());
+            logFile.writer.println();
+            logFile.writer.flush();
+            return logFile;
+        }
+
+        /**
+         * Append a single timestamped log line. Format string follows {@link String#format(Locale, String, Object...)}
+         * semantics. Safe to call from any thread.
+         */
+        public void log(@Nonnull final String fmt, @Nonnull final Object... args) {
+            final String formatted = String.format(Locale.ROOT, fmt, args);
+            synchronized (writer) {
+                writer.print(Instant.now());
+                writer.print(' ');
+                writer.print('[');
+                writer.print(Thread.currentThread().getName());
+                writer.print("] ");
+                writer.println(formatted);
+            }
+        }
+
+        /**
+         * Append a failure record including the stack trace. Use this before rethrowing in a test's
+         * catch block.
+         */
+        public void logFailure(@Nonnull final String context, @Nonnull final Throwable t) {
+            final StringWriter stack = new StringWriter();
+            try (PrintWriter pw = new PrintWriter(stack)) {
+                t.printStackTrace(pw);
+            }
+            synchronized (writer) {
+                writer.print(Instant.now());
+                writer.print(" [");
+                writer.print(Thread.currentThread().getName());
+                writer.print("] FAILURE ");
+                writer.println(context);
+                writer.println(stack.toString());
+            }
+        }
+
+        @Nonnull
+        public Path getPath() {
+            return path;
+        }
+
+        @Override
+        public void close() {
+            synchronized (writer) {
+                writer.println();
+                writer.println("# closedAt=" + Instant.now());
+                writer.close();
+            }
         }
     }
 }

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/TestHelpers.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/TestHelpers.java
@@ -168,6 +168,9 @@ class TestHelpers {
                 }
                 data.add(record);
 
+                if (logFile != null) {
+                    logFile.log("Inserting to batch %d", i);
+                }
                 return hnsw.insert(tr, record.getPrimaryKey(), record.getVector()).thenApply(vignore -> true);
             });
             return future.thenApply(vignore -> data.build())

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/TestHelpers.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/TestHelpers.java
@@ -49,14 +49,11 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.BufferedWriter;
 import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
-import java.time.Instant;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -661,117 +658,4 @@ class TestHelpers {
         }
     }
 
-    /**
-     * Per-invocation log file written to {@code fdb-extensions/.out/reports/}. Lets a parameterised test
-     * dump a structured trace of itself (and any helpers it calls) to a dedicated file separate from the
-     * shared logger output, so CI failures can be inspected without untangling interleaved parallel-test
-     * log streams.
-     *
-     * <p>Typical usage from a parameterised test:</p>
-     * <pre>
-     * try (TestHelpers.TestLogFile logFile = TestHelpers.TestLogFile.create("OperationsTest.testBasicInsert", seed, config)) {
-     *     try {
-     *         // ... test body, with logFile.log(...) calls ...
-     *         basicInsertBatch(db, hnsw, batchSize, firstId, insertFn, logFile);
-     *     } catch (Throwable t) {
-     *         logFile.logFailure("testBasicInsert", t);
-     *         throw t;
-     *     }
-     * }
-     * </pre>
-     */
-    public static final class TestLogFile implements AutoCloseable {
-        @Nonnull
-        private static final Path REPORTS_DIR = Paths.get(".out", "reports");
-        @Nonnull
-        private static final AtomicLong COUNTER = new AtomicLong();
-
-        @Nonnull
-        private final Path path;
-        @Nonnull
-        private final PrintWriter writer;
-
-        private TestLogFile(@Nonnull final Path path, @Nonnull final PrintWriter writer) {
-            this.path = path;
-            this.writer = writer;
-        }
-
-        /**
-         * Create a new log file for a single test invocation. The file is created under
-         * {@code fdb-extensions/.out/reports/} with a name derived from {@code testName} and a
-         * monotonically increasing counter. The file is opened immediately, and a header recording
-         * the test name and arguments is written before the method returns.
-         */
-        @Nonnull
-        public static TestLogFile create(@Nonnull final String testName, @Nonnull final Object... args) throws IOException {
-            Files.createDirectories(REPORTS_DIR);
-            final long index = COUNTER.incrementAndGet();
-            final String sanitized = testName.replaceAll("[^A-Za-z0-9._-]", "_");
-            final Path file = REPORTS_DIR.resolve(String.format(Locale.ROOT, "%s-%d.log", sanitized, index));
-            // Synchronized PrintWriter; writes from FDB callback threads and the test thread are safe.
-            final BufferedWriter buffered = Files.newBufferedWriter(file,
-                    StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE);
-            final PrintWriter writer = new PrintWriter(buffered, true);
-            final TestLogFile logFile = new TestLogFile(file, writer);
-            // Header: test name, arguments, start timestamp.
-            logFile.writer.println("# test=" + testName);
-            for (int i = 0; i < args.length; i++) {
-                logFile.writer.println("# arg[" + i + "]=" + Objects.toString(args[i]));
-            }
-            logFile.writer.println("# startedAt=" + Instant.now());
-            logFile.writer.println("# file=" + file.toAbsolutePath());
-            logFile.writer.println();
-            logFile.writer.flush();
-            return logFile;
-        }
-
-        /**
-         * Append a single timestamped log line. Format string follows {@link String#format(Locale, String, Object...)}
-         * semantics. Safe to call from any thread.
-         */
-        public void log(@Nonnull final String fmt, @Nonnull final Object... args) {
-            final String formatted = String.format(Locale.ROOT, fmt, args);
-            synchronized (writer) {
-                writer.print(Instant.now());
-                writer.print(' ');
-                writer.print('[');
-                writer.print(Thread.currentThread().getName());
-                writer.print("] ");
-                writer.println(formatted);
-            }
-        }
-
-        /**
-         * Append a failure record including the stack trace. Use this before rethrowing in a test's
-         * catch block.
-         */
-        public void logFailure(@Nonnull final String context, @Nonnull final Throwable t) {
-            final StringWriter stack = new StringWriter();
-            try (PrintWriter pw = new PrintWriter(stack)) {
-                t.printStackTrace(pw);
-            }
-            synchronized (writer) {
-                writer.print(Instant.now());
-                writer.print(" [");
-                writer.print(Thread.currentThread().getName());
-                writer.print("] FAILURE ");
-                writer.println(context);
-                writer.println(stack.toString());
-            }
-        }
-
-        @Nonnull
-        public Path getPath() {
-            return path;
-        }
-
-        @Override
-        public void close() {
-            synchronized (writer) {
-                writer.println();
-                writer.println("# closedAt=" + Instant.now());
-                writer.close();
-            }
-        }
-    }
 }

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/TestHelpers.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/TestHelpers.java
@@ -169,6 +169,9 @@ class TestHelpers {
                 }
                 data.add(record);
 
+                if (logFile != null) {
+                    logFile.log("Inserting to batch %d", i);
+                }
                 return hnsw.insert(tr, record.getPrimaryKey(), record.getVector()).thenApply(vignore -> true);
             }, ForkJoinPool.commonPool());
             return future.thenApply(vignore -> data.build())

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/TestHelpers.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/TestHelpers.java
@@ -111,6 +111,25 @@ class TestHelpers {
         return basicInsertBatch(db, hnsw, batchSize, firstId, insertFunction, null);
     }
 
+    static void basicInsert(@Nonnull Database db, @Nonnull final HNSW hnsw,
+                            final List<PrimaryKeyAndVector> insertedData,
+                            TestLogFile logFile)
+            throws ExecutionException, InterruptedException, TimeoutException {
+        basicInsert(db, hnsw, insertedData.size(), (tr, nextId) -> insertedData.get(Math.toIntExact(nextId)), logFile);
+    }
+
+    static void basicInsert(@Nonnull final Database db,
+                            @Nonnull final HNSW hnsw,
+                            final int count,
+                            @Nonnull final BiFunction<Transaction, Long, PrimaryKeyAndVector> insertFunction, final TestLogFile logFile)
+            throws ExecutionException, InterruptedException, TimeoutException {
+        int inserted = 0;
+        while (inserted < count) {
+            inserted += basicInsertBatch(db, hnsw, Math.min(100, count - inserted), inserted, insertFunction, logFile)
+                    .size();
+        }
+    }
+
     @Nonnull
     static List<PrimaryKeyAndVector> basicInsertBatch(@Nonnull final Database db,
                                                       @Nonnull final HNSW hnsw,
@@ -136,7 +155,9 @@ class TestHelpers {
             // it's probably better to not test the concurrent handling of hnsw, even if it makes the tests slower.
             CompletableFuture<Void> future = CompletableFuture.completedFuture(null);
             final long beginTs = System.nanoTime();
-            final int attemptBatchSize = batchSize / attempt.get();
+            // This is a simplistic version of ThrottledRetryingIterator, but that cannot be used here because it depends
+            // on many classes from fdb-record-layer-core
+            final int attemptBatchSize = Math.max(1, batchSize / attempt.get());
             for (int i = 0; i < attemptBatchSize; i ++) {
                 final PrimaryKeyAndVector record = insertFunction.apply(tr, firstId + i);
                 if (record == null) {

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/TestLogFile.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/TestLogFile.java
@@ -115,14 +115,12 @@ public final class TestLogFile implements AutoCloseable {
      */
     public void log(@Nonnull final String fmt, @Nonnull final Object... args) {
         final String formatted = String.format(Locale.ROOT, fmt, args);
-        synchronized (writer) {
-            writer.print(Instant.now());
-            writer.print(' ');
-            writer.print('[');
-            writer.print(Thread.currentThread().getName());
-            writer.print("] ");
-            writer.println(formatted);
-        }
+        writer.print(Instant.now());
+        writer.print(' ');
+        writer.print('[');
+        writer.print(Thread.currentThread().getName());
+        writer.print("] ");
+        writer.println(formatted);
     }
 
     /**
@@ -130,14 +128,12 @@ public final class TestLogFile implements AutoCloseable {
      * catch block.
      */
     public void logFailure(@Nonnull final String context, @Nonnull final Throwable t) {
-        synchronized (writer) {
-            writer.print(Instant.now());
-            writer.print(" [");
-            writer.print(Thread.currentThread().getName());
-            writer.print("] FAILURE ");
-            writer.println(context);
-            t.printStackTrace(writer);
-        }
+        writer.print(Instant.now());
+        writer.print(" [");
+        writer.print(Thread.currentThread().getName());
+        writer.print("] FAILURE ");
+        writer.println(context);
+        t.printStackTrace(writer);
     }
 
     @Nonnull
@@ -147,11 +143,9 @@ public final class TestLogFile implements AutoCloseable {
 
     @Override
     public void close() {
-        synchronized (writer) {
-            writer.println();
-            writer.println("# closedAt=" + Instant.now());
-            writer.close();
-        }
+        writer.println();
+        writer.println("# closedAt=" + Instant.now());
+        writer.close();
     }
 
     @FunctionalInterface

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/TestLogFile.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/TestLogFile.java
@@ -114,15 +114,6 @@ public final class TestLogFile implements AutoCloseable {
      * semantics. Safe to call from any thread.
      */
     public void log(@Nonnull final String fmt, @Nonnull final Object... args) {
-        final String formatted = String.format(Locale.ROOT, fmt, args);
-        synchronized (writer) {
-            writer.print(Instant.now());
-            writer.print(' ');
-            writer.print('[');
-            writer.print(Thread.currentThread().getName());
-            writer.print("] ");
-            writer.println(formatted);
-        }
     }
 
     /**
@@ -130,14 +121,6 @@ public final class TestLogFile implements AutoCloseable {
      * catch block.
      */
     public void logFailure(@Nonnull final String context, @Nonnull final Throwable t) {
-        synchronized (writer) {
-            writer.print(Instant.now());
-            writer.print(" [");
-            writer.print(Thread.currentThread().getName());
-            writer.print("] FAILURE ");
-            writer.println(context);
-            t.printStackTrace(writer);
-        }
     }
 
     @Nonnull

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/TestLogFile.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/TestLogFile.java
@@ -1,0 +1,161 @@
+/*
+ * TestLogFile.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.async.hnsw;
+
+import javax.annotation.Nonnull;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.time.Instant;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Per-invocation log file written to {@code fdb-extensions/.out/reports/}. Lets a parameterised test
+ * dump a structured trace of itself (and any helpers it calls) to a dedicated file separate from the
+ * shared logger output, so CI failures can be inspected without untangling interleaved parallel-test
+ * log streams.
+ *
+ * <p>Typical usage from a parameterised test:</p>
+ * <pre>
+ * try (TestHelpers.TestLogFile logFile = TestHelpers.TestLogFile.create("OperationsTest.testBasicInsert", seed, config)) {
+ *     try {
+ *         // ... test body, with logFile.log(...) calls ...
+ *         basicInsertBatch(db, hnsw, batchSize, firstId, insertFn, logFile);
+ *     } catch (Throwable t) {
+ *         logFile.logFailure("testBasicInsert", t);
+ *         throw t;
+ *     }
+ * }
+ * </pre>
+ */
+public final class TestLogFile implements AutoCloseable {
+    @Nonnull
+    private static final Path REPORTS_DIR = Paths.get(".out", "reports");
+    @Nonnull
+    private static final AtomicLong COUNTER = new AtomicLong();
+
+    @Nonnull
+    private final Path path;
+    @Nonnull
+    private final PrintWriter writer;
+
+    private TestLogFile(@Nonnull final Path path, @Nonnull final PrintWriter writer) {
+        this.path = path;
+        this.writer = writer;
+    }
+
+    /**
+     * Create a new log file for a single test invocation. The file is created under
+     * {@code fdb-extensions/.out/reports/} with a name derived from {@code testName} and a
+     * monotonically increasing counter. The file is opened immediately, and a header recording
+     * the test name and arguments is written before the method returns.
+     */
+    @Nonnull
+    public static TestLogFile create(@Nonnull final String testName, @Nonnull final List<Object> args) throws IOException {
+        Files.createDirectories(REPORTS_DIR);
+        final long index = COUNTER.incrementAndGet();
+        final String sanitized = testName.replaceAll("[^A-Za-z0-9._-]", "_");
+        final Path file = REPORTS_DIR.resolve(String.format(Locale.ROOT, "%s-%d.log", sanitized, index));
+        // Synchronized PrintWriter; writes from FDB callback threads and the test thread are safe.
+        final BufferedWriter buffered = Files.newBufferedWriter(file,
+                StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE);
+        final PrintWriter writer = new PrintWriter(buffered, true);
+        final TestLogFile logFile = new TestLogFile(file, writer);
+        // Header: test name, arguments, start timestamp.
+        logFile.writer.println("# test=" + testName);
+        for (int i = 0; i < args.size(); i++) {
+            logFile.writer.println("# arg[" + i + "]=" + Objects.toString(args.get(i)));
+        }
+        logFile.writer.println("# startedAt=" + Instant.now());
+        logFile.writer.println("# file=" + file.toAbsolutePath());
+        logFile.writer.println();
+        logFile.writer.flush();
+        return logFile;
+    }
+
+    public static void run(final String testName, List<Object> args, TestCode testCode) throws Exception {
+        try (TestLogFile logFile = create(testName, args)) {
+            try {
+                testCode.runTest(logFile);
+            } catch (Exception e) {
+                logFile.logFailure("Test Failed", e);
+                throw e;
+            }
+        }
+    }
+
+    /**
+     * Append a single timestamped log line. Format string follows {@link String#format(Locale, String, Object...)}
+     * semantics. Safe to call from any thread.
+     */
+    public void log(@Nonnull final String fmt, @Nonnull final Object... args) {
+        final String formatted = String.format(Locale.ROOT, fmt, args);
+        synchronized (writer) {
+            writer.print(Instant.now());
+            writer.print(' ');
+            writer.print('[');
+            writer.print(Thread.currentThread().getName());
+            writer.print("] ");
+            writer.println(formatted);
+        }
+    }
+
+    /**
+     * Append a failure record including the stack trace. Use this before rethrowing in a test's
+     * catch block.
+     */
+    public void logFailure(@Nonnull final String context, @Nonnull final Throwable t) {
+        synchronized (writer) {
+            writer.print(Instant.now());
+            writer.print(" [");
+            writer.print(Thread.currentThread().getName());
+            writer.print("] FAILURE ");
+            writer.println(context);
+            t.printStackTrace(writer);
+        }
+    }
+
+    @Nonnull
+    public Path getPath() {
+        return path;
+    }
+
+    @Override
+    public void close() {
+        synchronized (writer) {
+            writer.println();
+            writer.println("# closedAt=" + Instant.now());
+            writer.close();
+        }
+    }
+
+    @FunctionalInterface
+    public interface TestCode {
+        void runTest(TestLogFile logFile) throws Exception;
+    }
+}

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/TestLogFile.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/TestLogFile.java
@@ -114,6 +114,15 @@ public final class TestLogFile implements AutoCloseable {
      * semantics. Safe to call from any thread.
      */
     public void log(@Nonnull final String fmt, @Nonnull final Object... args) {
+        final String formatted = String.format(Locale.ROOT, fmt, args);
+        synchronized (writer) {
+            writer.print(Instant.now());
+            writer.print(' ');
+            writer.print('[');
+            writer.print(Thread.currentThread().getName());
+            writer.print("] ");
+            writer.println(formatted);
+        }
     }
 
     /**
@@ -121,6 +130,14 @@ public final class TestLogFile implements AutoCloseable {
      * catch block.
      */
     public void logFailure(@Nonnull final String context, @Nonnull final Throwable t) {
+        synchronized (writer) {
+            writer.print(Instant.now());
+            writer.print(" [");
+            writer.print(Thread.currentThread().getName());
+            writer.print("] FAILURE ");
+            writer.println(context);
+            t.printStackTrace(writer);
+        }
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseTest.java
@@ -45,8 +45,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.function.Executable;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.slf4j.Logger;
@@ -83,7 +81,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Tests for {@link FDBDatabase}.
  */
 @Tag(Tags.RequiresFDB)
-@Execution(ExecutionMode.CONCURRENT)
 class FDBDatabaseTest {
     @Nonnull
     private static final Logger LOGGER = LoggerFactory.getLogger(FDBDatabaseTest.class);

--- a/fdb-record-layer-debugger/src/test/java/com/apple/foundationdb/record/query/plan/cascades/debug/CommandsTest.java
+++ b/fdb-record-layer-debugger/src/test/java/com/apple/foundationdb/record/query/plan/cascades/debug/CommandsTest.java
@@ -61,6 +61,8 @@ import org.jline.terminal.impl.DumbTerminal;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import javax.annotation.Nonnull;
 import java.io.ByteArrayOutputStream;
@@ -77,7 +79,11 @@ import java.util.Set;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-
+// Tests set up shared state (the debugger) on a ThreadLocal via Debugger.setDebugger in @BeforeEach.
+// When JUnit's parallel execution is enabled, lifecycle methods and the test body can run on
+// different worker threads, leaving the test body without a debugger installed. Pin everything in
+// this class to a single thread so the thread-local survives between @BeforeEach and @Test.
+@Execution(ExecutionMode.SAME_THREAD)
 class CommandsTest {
     private String query;
     private PipedOutputStream outIn;
@@ -307,7 +313,7 @@ class CommandsTest {
 
         terminal.writer().close();
         assertThat(outputStream.toString()).contains(
-                ReplTestUtil.coloredKeyValue("paused in", "Test worker at") + " " + ReplTestUtil.coloredKeyValue("tick", "2"),
+                ReplTestUtil.coloredKeyValue("paused in", Thread.currentThread().getName() + " at") + " " + ReplTestUtil.coloredKeyValue("tick", "2"),
                 String.join(
                         "; ",
                         ReplTestUtil.coloredKeyValue("shorthand", "insert_into_memo"),
@@ -344,7 +350,7 @@ class CommandsTest {
                         ReplTestUtil.coloredKeyValue("location", "end")
                 ),
 
-                ReplTestUtil.coloredKeyValue("paused in", "Test worker at") + " " + ReplTestUtil.coloredKeyValue("tick", "3"),
+                ReplTestUtil.coloredKeyValue("paused in", Thread.currentThread().getName() + " at") + " " + ReplTestUtil.coloredKeyValue("tick", "3"),
                 String.join(
                         "; ",
                         ReplTestUtil.coloredKeyValue("shorthand", "initphase"),
@@ -367,7 +373,7 @@ class CommandsTest {
 
         terminal.writer().close();
         assertThat(outputStream.toString()).contains(
-                ReplTestUtil.coloredKeyValue("paused in", "Test worker at") + " " + ReplTestUtil.coloredKeyValue("tick", "2"),
+                ReplTestUtil.coloredKeyValue("paused in", Thread.currentThread().getName() + " at") + " " + ReplTestUtil.coloredKeyValue("tick", "2"),
                 String.join(
                         "; ",
                         ReplTestUtil.coloredKeyValue("shorthand", "initphase"),
@@ -407,7 +413,7 @@ class CommandsTest {
                         ReplTestUtil.coloredKeyValue("count down", "-1"),
                         ReplTestUtil.coloredKeyValue("ruleNamePrefix", "ImplementSimpleSelectRule")
                 ),
-                ReplTestUtil.coloredKeyValue("paused in", "Test worker at") + " " + ReplTestUtil.coloredKeyValue("tick", "3"),
+                ReplTestUtil.coloredKeyValue("paused in", Thread.currentThread().getName() + " at") + " " + ReplTestUtil.coloredKeyValue("tick", "3"),
                 String.join(
                         "; ",
                         ReplTestUtil.coloredKeyValue("shorthand", "transform"),
@@ -465,7 +471,7 @@ class CommandsTest {
                         ReplTestUtil.coloredKeyValue("count down", "-1"),
                         ReplTestUtil.coloredKeyValue("ruleNamePrefix", "ImplementSimpleSelectRule")
                 ),
-                ReplTestUtil.coloredKeyValue("paused in", "Test worker at") + " " + ReplTestUtil.coloredKeyValue("tick", "3"),
+                ReplTestUtil.coloredKeyValue("paused in", Thread.currentThread().getName() + " at") + " " + ReplTestUtil.coloredKeyValue("tick", "3"),
                 String.join(
                         "; ",
                         ReplTestUtil.coloredKeyValue("shorthand", "rulecall"),
@@ -518,7 +524,7 @@ class CommandsTest {
                         ReplTestUtil.coloredKeyValue("location", "end"),
                         ReplTestUtil.coloredKeyValue("expression", "exp1")
                 ),
-                ReplTestUtil.coloredKeyValue("paused in", "Test worker at") + " " + ReplTestUtil.coloredKeyValue("tick", "4"),
+                ReplTestUtil.coloredKeyValue("paused in", Thread.currentThread().getName() + " at") + " " + ReplTestUtil.coloredKeyValue("tick", "4"),
                 String.join(
                         "; ",
                         ReplTestUtil.coloredKeyValue("shorthand", "rulecall"),
@@ -586,7 +592,7 @@ class CommandsTest {
                         ReplTestUtil.coloredKeyValue("location", "end"),
                         ReplTestUtil.coloredKeyValue("candidate", "idx1")
                 ),
-                ReplTestUtil.coloredKeyValue("paused in", "Test worker at") + " " + ReplTestUtil.coloredKeyValue("tick", "1"),
+                ReplTestUtil.coloredKeyValue("paused in", Thread.currentThread().getName() + " at") + " " + ReplTestUtil.coloredKeyValue("tick", "1"),
                 String.join(
                         "; ",
                         ReplTestUtil.coloredKeyValue("shorthand", "rulecall"),

--- a/fdb-test-utils/src/main/java/com/apple/foundationdb/test/TestDatabaseExtension.java
+++ b/fdb-test-utils/src/main/java/com/apple/foundationdb/test/TestDatabaseExtension.java
@@ -31,6 +31,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Objects;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ForkJoinPool;
 
 /**
  * Test extension to use to get a connection to an FDB {@link Database}. This handles setting up the FDB
@@ -107,7 +108,7 @@ public class TestDatabaseExtension implements BeforeAllCallback, AfterAllCallbac
     @Nonnull
     public Database getDatabase() {
         if (db == null) {
-            db = FDB.instance().open(FDBTestEnvironment.randomClusterFile(), threadPoolExecutor);
+            db = FDB.instance().open(FDBTestEnvironment.randomClusterFile(), ForkJoinPool.commonPool());
         }
         return db;
     }

--- a/fdb-test-utils/src/main/java/com/apple/foundationdb/test/TestDatabaseExtension.java
+++ b/fdb-test-utils/src/main/java/com/apple/foundationdb/test/TestDatabaseExtension.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Objects;
+import java.util.concurrent.ForkJoinPool;
 
 /**
  * Test extension to use to get a connection to an FDB {@link Database}. This handles setting up the FDB
@@ -95,7 +96,7 @@ public class TestDatabaseExtension implements BeforeAllCallback, AfterAllCallbac
     @Nonnull
     public Database getDatabase() {
         if (db == null) {
-            db = FDB.instance().open(FDBTestEnvironment.randomClusterFile());
+            db = FDB.instance().open(FDBTestEnvironment.randomClusterFile(), ForkJoinPool.commonPool());
         }
         return db;
     }

--- a/fdb-test-utils/src/main/java/com/apple/foundationdb/test/TestDatabaseExtension.java
+++ b/fdb-test-utils/src/main/java/com/apple/foundationdb/test/TestDatabaseExtension.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Objects;
+import java.util.concurrent.Executor;
 
 /**
  * Test extension to use to get a connection to an FDB {@link Database}. This handles setting up the FDB
@@ -54,6 +55,17 @@ public class TestDatabaseExtension implements BeforeAllCallback, AfterAllCallbac
 
     @Nullable
     private static volatile FDB fdb;
+
+    /**
+     * Multi-thread executor used as the default callback executor for every {@link Database} that this
+     * extension opens. Without it, {@link FDB#open(String)} falls back to {@link FDB#DEFAULT_EXECUTOR},
+     * a JVM-wide executor that can become a bottleneck for parallel tests (e.g. classes annotated
+     * {@code @Execution(ExecutionMode.CONCURRENT)} like {@code OperationsTest}) and lead to CI-only
+     * timeouts. Using a dedicated cached pool here mirrors what {@code FDBDatabaseExtension} does for
+     * {@code FDBDatabaseFactory.setExecutor}.
+     */
+    @Nonnull
+    private static final Executor threadPoolExecutor = TestExecutors.newThreadPool("fdb-extensions-test");
 
     private Database db;
 
@@ -95,7 +107,7 @@ public class TestDatabaseExtension implements BeforeAllCallback, AfterAllCallbac
     @Nonnull
     public Database getDatabase() {
         if (db == null) {
-            db = FDB.instance().open(FDBTestEnvironment.randomClusterFile());
+            db = FDB.instance().open(FDBTestEnvironment.randomClusterFile(), threadPoolExecutor);
         }
         return db;
     }

--- a/fdb-test-utils/src/main/java/com/apple/foundationdb/test/TestDatabaseExtension.java
+++ b/fdb-test-utils/src/main/java/com/apple/foundationdb/test/TestDatabaseExtension.java
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Objects;
-import java.util.concurrent.ForkJoinPool;
 
 /**
  * Test extension to use to get a connection to an FDB {@link Database}. This handles setting up the FDB
@@ -96,7 +95,7 @@ public class TestDatabaseExtension implements BeforeAllCallback, AfterAllCallbac
     @Nonnull
     public Database getDatabase() {
         if (db == null) {
-            db = FDB.instance().open(FDBTestEnvironment.randomClusterFile(), ForkJoinPool.commonPool());
+            db = FDB.instance().open(FDBTestEnvironment.randomClusterFile());
         }
         return db;
     }

--- a/fdb-test-utils/src/main/java/com/apple/foundationdb/test/TestDatabaseExtension.java
+++ b/fdb-test-utils/src/main/java/com/apple/foundationdb/test/TestDatabaseExtension.java
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Objects;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ForkJoinPool;
 
 /**
@@ -56,17 +55,6 @@ public class TestDatabaseExtension implements BeforeAllCallback, AfterAllCallbac
 
     @Nullable
     private static volatile FDB fdb;
-
-    /**
-     * Multi-thread executor used as the default callback executor for every {@link Database} that this
-     * extension opens. Without it, {@link FDB#open(String)} falls back to {@link FDB#DEFAULT_EXECUTOR},
-     * a JVM-wide executor that can become a bottleneck for parallel tests (e.g. classes annotated
-     * {@code @Execution(ExecutionMode.CONCURRENT)} like {@code OperationsTest}) and lead to CI-only
-     * timeouts. Using a dedicated cached pool here mirrors what {@code FDBDatabaseExtension} does for
-     * {@code FDBDatabaseFactory.setExecutor}.
-     */
-    @Nonnull
-    private static final Executor threadPoolExecutor = TestExecutors.newThreadPool("fdb-extensions-test");
 
     private Database db;
 

--- a/fdb-test-utils/src/main/java/com/apple/foundationdb/test/TestExecutors.java
+++ b/fdb-test-utils/src/main/java/com/apple/foundationdb/test/TestExecutors.java
@@ -22,7 +22,7 @@ package com.apple.foundationdb.test;
 
 import javax.annotation.Nonnull;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
+import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -58,7 +58,7 @@ public final class TestExecutors {
     }
 
     public static Executor newThreadPool(@Nonnull String namePrefix) {
-        return Executors.newCachedThreadPool(new TestThreadFactory(namePrefix));
+        return ForkJoinPool.commonPool();
     }
 
     @Nonnull

--- a/gradle/testing.gradle
+++ b/gradle/testing.gradle
@@ -357,9 +357,14 @@ tasks.withType(Test).configureEach { task ->
         task.testFramework.options.excludeTags.add('Performance')
 
         if (task.name == 'test') {
-            task.systemProperty('junit.jupiter.execution.parallel.enabled', 'false')
+            task.systemProperty('junit.jupiter.execution.parallel.enabled', 'true')
             task.systemProperty('junit.jupiter.execution.parallel.mode.default', 'same_thread')
-            task.systemProperty('junit.jupiter.execution.parallel.mode.classes.default', 'concurrent')
+            task.systemProperty('junit.jupiter.execution.parallel.mode.classes.default', 'same_thread')
+
+            // We use worker_thread_pool rather than fork_join_pool because we heavily depend on ForkJoinPool for
+            // FDB operations, which causes junit to incorrectly increase the number of concurrent tests to well
+            // beyond what we want.
+            task.systemProperty('junit.jupiter.execution.parallel.config.executor-service', 'worker_thread_pool')
         }
     }
 


### PR DESCRIPTION
This updates our configuration so that test classes annotated with `@Execution(ExecutionMode.CONCURRENT)` will run the tests in parallel, which, right now is 15 classes.
I hope to change the default to run concurrently, but there are a variety of tests failing under that configuration, for a variety of reasons that would need to be addressed.