### PR TITLE
Investigate teamscale_upload PR summary

### DIFF
--- a/.github/workflows/teamscale_upload.yml
+++ b/.github/workflows/teamscale_upload.yml
@@ -20,6 +20,7 @@ jobs:
       - name: 'Add PR link and commit hash to summary'
         continue-on-error: true # temporary in case this breaks things
         env:
+          PR: ${{ github.event.workflow_run.pull_requests }}
           PR_URL: ${{ github.event.workflow_run.pull_requests[0].html_url }}
           PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
           COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}


### PR DESCRIPTION
Looking at recent actions there is no pull request number or link. I suspect I am getting that incorrectly, so echo the entire pull_requests field to see more, and hopefully fix. Unfortunately this has to merge to be testable.