### PR TITLE
teamscale_upload workflow: Convert array of pull requests to json

### DIFF
--- a/.github/workflows/teamscale_upload.yml
+++ b/.github/workflows/teamscale_upload.yml
@@ -20,7 +20,7 @@ jobs:
       - name: 'Add PR link and commit hash to summary'
         continue-on-error: true # temporary in case this breaks things
         env:
-          PR: ${{ github.event.workflow_run.pull_requests }}
+          PR: ${{ toJSON(github.event.workflow_run.pull_requests) }}
           PR_URL: ${{ github.event.workflow_run.pull_requests[0].html_url }}
           PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
           COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}


### PR DESCRIPTION
I want to log the actual pull_requests because the PR_URL and PR_NUMBER appear to be blank for builds where they shouldn't. But pull_requests is an array, and thus this becomes invalid. toJSON should fix this.