### PR TITLE
Clean up the structure of the Sphinx documentation

### DIFF
--- a/docs/sphinx/source/Coding_Best_Practices.md
+++ b/docs/sphinx/source/Coding_Best_Practices.md
@@ -1,7 +1,6 @@
-# FoundationDB Record Layer Coding Best Practices
+# Coding guidelines
 
-This is a living document aimed towards documenting and clarifying our
-coding best practives.
+This living document collects and clarifies our coding best practices.
 
 ## Exceptions 
 

--- a/docs/sphinx/source/Extending.md
+++ b/docs/sphinx/source/Extending.md
@@ -1,4 +1,4 @@
-# Extending the Record Layer
+# Extension points
 
 As the name suggests, the Record Layer is meant to sit above the FoundationDB key-value store and possibly below higher level layers such as query language parsers. Within the layer itself, there are a number of extension points. Generally, concepts that have several variants or involve significant implementation tradeoffs are defined and accessed through such an extension point.
 

--- a/docs/sphinx/source/FAQ.md
+++ b/docs/sphinx/source/FAQ.md
@@ -1,4 +1,4 @@
-# FoundationDB Record Layer FAQ
+# FAQ
 
 Welcome to FoundationDB Record Layer Frequently Asked Questions (FAQ)! 
 

--- a/docs/sphinx/source/GettingStarted.md
+++ b/docs/sphinx/source/GettingStarted.md
@@ -1,4 +1,4 @@
-# Getting Started Guide
+# Getting started
 
 This is intended as a quick guide to getting started developing applications with the FDB Record Layer. We will cover:
 

--- a/docs/sphinx/source/Overview.md
+++ b/docs/sphinx/source/Overview.md
@@ -1,4 +1,4 @@
-# FoundationDB Record Layer Overview
+# Overview
 
 Records are instances of Protobuf messages. The core layer conventionalizes serialization
 and maintains secondary indexes. It supports simple predicate queries that use those indexes.

--- a/docs/sphinx/source/ReleaseNotes.md
+++ b/docs/sphinx/source/ReleaseNotes.md
@@ -1,5 +1,4 @@
-
-# Release Notes
+# Release notes
 
 This document contains a log of changes to the FoundationDB Record Layer. It aims to include mostly user-visible changes or improvements. Within each minor release, larger or more involved changes are highlighted first before detailing the changes that were included in each build or patch version. Users should especially take note of any breaking changes or special upgrade instructions which should always be included as a preface to the minor version as a whole before looking at changes at a version-by-version level.
 

--- a/docs/sphinx/source/SQL_Reference.md
+++ b/docs/sphinx/source/SQL_Reference.md
@@ -1,4 +1,4 @@
-# SQL Reference
+# SQL reference
 
 The FDB relational subproject provides a SQL API for interacting with Record Layer databases. This SQL API is currently under active development and is expected to change frequently. This reference is currently also a work in progress to be updated as the SQL engine develops.
 

--- a/docs/sphinx/source/SchemaEvolution.md
+++ b/docs/sphinx/source/SchemaEvolution.md
@@ -1,4 +1,6 @@
-# Schema Evolution and Meta-data Maintenance
+# Schema evolution
+
+This guide explains how to evolve your schema and maintain the metadata of the record stores in your application.
 
 ## General Principles
 

--- a/docs/sphinx/source/Versioning.md
+++ b/docs/sphinx/source/Versioning.md
@@ -1,4 +1,4 @@
-# Record Layer Versions
+# Setup
 
 ## Variants
 

--- a/docs/sphinx/source/_templates/page.html
+++ b/docs/sphinx/source/_templates/page.html
@@ -1,0 +1,81 @@
+{% extends "!page.html" %}
+
+{# Reproduce Furo's footer block, inserting a License link right after the copyright line. #}
+{% block footer %}
+<footer>
+  <div class="related-pages">
+    {% if next -%}
+      <a class="next-page" href="{{ next.link }}">
+        <div class="page-info">
+          <div class="context">
+            <span>{{ _("Next") }}</span>
+          </div>
+          <div class="title">{{ next.title }}</div>
+        </div>
+        <svg class="furo-related-icon"><use href="#svg-arrow-right"></use></svg>
+      </a>
+    {%- endif %}
+    {% if prev -%}
+      <a class="prev-page" href="{{ prev.link }}">
+        <svg class="furo-related-icon"><use href="#svg-arrow-right"></use></svg>
+        <div class="page-info">
+          <div class="context">
+            <span>{{ _("Previous") }}</span>
+          </div>
+          {% if prev.link == pathto(master_doc) %}
+          <div class="title">{{ _("Home") }}</div>
+          {% else %}
+          <div class="title">{{ prev.title }}</div>
+          {% endif %}
+        </div>
+      </a>
+    {%- endif %}
+  </div>
+  <div class="bottom-of-page">
+    <div class="left-details">
+      {%- if show_copyright %}
+      <div class="copyright">
+        {%- if hasdoc('copyright') %}
+          {% trans path=pathto('copyright'), copyright=copyright|e -%}
+            <a href="{{ path }}">Copyright</a> &#169; {{ copyright }}
+          {%- endtrans %}
+        {%- else %}
+          {% trans copyright=copyright|e -%}
+            Copyright &#169; {{ copyright }}
+          {%- endtrans %}
+        {%- endif %}
+        &#183; <a class="muted-link" href="https://github.com/FoundationDB/fdb-record-layer/blob/main/LICENSE">License</a>
+      </div>
+      {%- endif %}
+      {% trans %}Made with {% endtrans -%}
+      {%- if show_sphinx -%}
+      {% trans %}<a href="https://www.sphinx-doc.org/">Sphinx</a> and {% endtrans -%}
+      <a class="muted-link" href="https://pradyunsg.me">@pradyunsg</a>'s
+      {% endif -%}
+      {% trans %}
+      <a href="https://github.com/pradyunsg/furo">Furo</a>
+      {% endtrans %}
+      {%- if last_updated -%}
+      <div class="last-updated">
+        {% trans last_updated=last_updated|e -%}
+          Last updated on {{ last_updated }}
+        {%- endtrans -%}
+      </div>
+      {%- endif %}
+    </div>
+    <div class="right-details">
+      {% if theme_footer_icons or READTHEDOCS -%}
+      <div class="icons">
+        {% if theme_footer_icons -%}
+        {% for icon_dict in theme_footer_icons -%}
+        <a class="muted-link {{ icon_dict.class }}" href="{{ icon_dict.url }}" aria-label="{{ icon_dict.name }}">
+          {{- icon_dict.html -}}
+        </a>
+        {% endfor %}
+        {%- endif %}
+      </div>
+      {%- endif %}
+    </div>
+  </div>
+</footer>
+{% endblock %}

--- a/docs/sphinx/source/api/index.md.template
+++ b/docs/sphinx/source/api/index.md.template
@@ -1,4 +1,4 @@
-# API Documentation
+# Java API
 
 Below find the current Javadoc documentation for the various Record Layer
 subprojects.

--- a/docs/sphinx/source/architecture/index.md
+++ b/docs/sphinx/source/architecture/index.md
@@ -1,6 +1,4 @@
-# Architecture
-
-## Documentation
+# Design notes
 
 ```{toctree}
 :maxdepth: 1

--- a/docs/sphinx/source/conf.py
+++ b/docs/sphinx/source/conf.py
@@ -40,6 +40,10 @@ html_theme = 'furo'
 html_theme_options = {
 }
 
+# Override Sphinx's default of "<project> documentation" so the sidebar/title
+# reads just the project name.
+html_title = project
+
 html_static_path = ['_static']
 html_show_sphinx = False
 

--- a/docs/sphinx/source/index.md
+++ b/docs/sphinx/source/index.md
@@ -24,20 +24,30 @@ reliability, and performance in a distributed setting.
 
 ```{toctree}
 :maxdepth: 1
-Overview and Examples <Overview>
+:caption: User Guide
+Overview
+Versioning
 GettingStarted
-JDBC Guide <jdbc/index>
-Building <Building>
 SchemaEvolution
 Extending
-Versioning Guide <Versioning>
-Coding Best Practices <Coding_Best_Practices>
+FAQ
 ReleaseNotes
-Frequently Asked Questions <FAQ>
-SQL Reference <SQL_Reference>
-API <api/index>
-Architecture <architecture/index>
+```
+
+```{toctree}
+:maxdepth: 1
+:caption: Reference
+SQL_Reference
+jdbc/index
+api/index
+```
+
+```{toctree}
+:maxdepth: 1
+:caption: Development
+Building <Building>
+Coding_Best_Practices
+architecture/index
 Contributing <https://github.com/FoundationDB/fdb-record-layer/blob/main/CONTRIBUTING.md>
-Code of Conduct <https://github.com/FoundationDB/fdb-record-layer/blob/main/CODE_OF_CONDUCT.md>
-License <https://github.com/FoundationDB/fdb-record-layer/blob/main/LICENSE>
+Code of conduct <https://github.com/FoundationDB/fdb-record-layer/blob/main/CODE_OF_CONDUCT.md>
 ```

--- a/docs/sphinx/source/jdbc/index.rst
+++ b/docs/sphinx/source/jdbc/index.rst
@@ -1,6 +1,6 @@
-===========
-JDBC Guide
-===========
+==============
+JDBC interface
+==============
 
 .. important::
    The JDBC interface is experimental and not production-ready at this stage. APIs and behaviors are subject to change.


### PR DESCRIPTION
* Group the table-of-contents pages under section headers: User Guide, Reference, and Development.
* Normalize page titles to sentence case and drop the redundant “FoundationDB Record Layer” prefix; rename a few for clarity.
* Reword and fix typos in some page intros.
* Drop “documentation” from the sidebar title to save space.
* Move the License entry from the table of contents into the footer of every page.