### PR TITLE
Introduce minimal parallelism in tests

### DIFF
--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseTest.java
@@ -45,8 +45,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.function.Executable;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.slf4j.Logger;
@@ -83,7 +81,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Tests for {@link FDBDatabase}.
  */
 @Tag(Tags.RequiresFDB)
-@Execution(ExecutionMode.CONCURRENT)
 class FDBDatabaseTest {
     @Nonnull
     private static final Logger LOGGER = LoggerFactory.getLogger(FDBDatabaseTest.class);

--- a/fdb-record-layer-debugger/src/test/java/com/apple/foundationdb/record/query/plan/cascades/debug/CommandsTest.java
+++ b/fdb-record-layer-debugger/src/test/java/com/apple/foundationdb/record/query/plan/cascades/debug/CommandsTest.java
@@ -61,6 +61,8 @@ import org.jline.terminal.impl.DumbTerminal;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import javax.annotation.Nonnull;
 import java.io.ByteArrayOutputStream;
@@ -77,7 +79,11 @@ import java.util.Set;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-
+// Tests set up shared state (the debugger) on a ThreadLocal via Debugger.setDebugger in @BeforeEach.
+// When JUnit's parallel execution is enabled, lifecycle methods and the test body can run on
+// different worker threads, leaving the test body without a debugger installed. Pin everything in
+// this class to a single thread so the thread-local survives between @BeforeEach and @Test.
+@Execution(ExecutionMode.SAME_THREAD)
 class CommandsTest {
     private String query;
     private PipedOutputStream outIn;
@@ -307,7 +313,7 @@ class CommandsTest {
 
         terminal.writer().close();
         assertThat(outputStream.toString()).contains(
-                ReplTestUtil.coloredKeyValue("paused in", "Test worker at") + " " + ReplTestUtil.coloredKeyValue("tick", "2"),
+                ReplTestUtil.coloredKeyValue("paused in", Thread.currentThread().getName() + " at") + " " + ReplTestUtil.coloredKeyValue("tick", "2"),
                 String.join(
                         "; ",
                         ReplTestUtil.coloredKeyValue("shorthand", "insert_into_memo"),
@@ -344,7 +350,7 @@ class CommandsTest {
                         ReplTestUtil.coloredKeyValue("location", "end")
                 ),
 
-                ReplTestUtil.coloredKeyValue("paused in", "Test worker at") + " " + ReplTestUtil.coloredKeyValue("tick", "3"),
+                ReplTestUtil.coloredKeyValue("paused in", Thread.currentThread().getName() + " at") + " " + ReplTestUtil.coloredKeyValue("tick", "3"),
                 String.join(
                         "; ",
                         ReplTestUtil.coloredKeyValue("shorthand", "initphase"),
@@ -367,7 +373,7 @@ class CommandsTest {
 
         terminal.writer().close();
         assertThat(outputStream.toString()).contains(
-                ReplTestUtil.coloredKeyValue("paused in", "Test worker at") + " " + ReplTestUtil.coloredKeyValue("tick", "2"),
+                ReplTestUtil.coloredKeyValue("paused in", Thread.currentThread().getName() + " at") + " " + ReplTestUtil.coloredKeyValue("tick", "2"),
                 String.join(
                         "; ",
                         ReplTestUtil.coloredKeyValue("shorthand", "initphase"),
@@ -407,7 +413,7 @@ class CommandsTest {
                         ReplTestUtil.coloredKeyValue("count down", "-1"),
                         ReplTestUtil.coloredKeyValue("ruleNamePrefix", "ImplementSimpleSelectRule")
                 ),
-                ReplTestUtil.coloredKeyValue("paused in", "Test worker at") + " " + ReplTestUtil.coloredKeyValue("tick", "3"),
+                ReplTestUtil.coloredKeyValue("paused in", Thread.currentThread().getName() + " at") + " " + ReplTestUtil.coloredKeyValue("tick", "3"),
                 String.join(
                         "; ",
                         ReplTestUtil.coloredKeyValue("shorthand", "transform"),
@@ -465,7 +471,7 @@ class CommandsTest {
                         ReplTestUtil.coloredKeyValue("count down", "-1"),
                         ReplTestUtil.coloredKeyValue("ruleNamePrefix", "ImplementSimpleSelectRule")
                 ),
-                ReplTestUtil.coloredKeyValue("paused in", "Test worker at") + " " + ReplTestUtil.coloredKeyValue("tick", "3"),
+                ReplTestUtil.coloredKeyValue("paused in", Thread.currentThread().getName() + " at") + " " + ReplTestUtil.coloredKeyValue("tick", "3"),
                 String.join(
                         "; ",
                         ReplTestUtil.coloredKeyValue("shorthand", "rulecall"),
@@ -518,7 +524,7 @@ class CommandsTest {
                         ReplTestUtil.coloredKeyValue("location", "end"),
                         ReplTestUtil.coloredKeyValue("expression", "exp1")
                 ),
-                ReplTestUtil.coloredKeyValue("paused in", "Test worker at") + " " + ReplTestUtil.coloredKeyValue("tick", "4"),
+                ReplTestUtil.coloredKeyValue("paused in", Thread.currentThread().getName() + " at") + " " + ReplTestUtil.coloredKeyValue("tick", "4"),
                 String.join(
                         "; ",
                         ReplTestUtil.coloredKeyValue("shorthand", "rulecall"),
@@ -586,7 +592,7 @@ class CommandsTest {
                         ReplTestUtil.coloredKeyValue("location", "end"),
                         ReplTestUtil.coloredKeyValue("candidate", "idx1")
                 ),
-                ReplTestUtil.coloredKeyValue("paused in", "Test worker at") + " " + ReplTestUtil.coloredKeyValue("tick", "1"),
+                ReplTestUtil.coloredKeyValue("paused in", Thread.currentThread().getName() + " at") + " " + ReplTestUtil.coloredKeyValue("tick", "1"),
                 String.join(
                         "; ",
                         ReplTestUtil.coloredKeyValue("shorthand", "rulecall"),

--- a/fdb-test-utils/src/main/java/com/apple/foundationdb/test/TestDatabaseExtension.java
+++ b/fdb-test-utils/src/main/java/com/apple/foundationdb/test/TestDatabaseExtension.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Objects;
+import java.util.concurrent.Executor;
 
 /**
  * Test extension to use to get a connection to an FDB {@link Database}. This handles setting up the FDB
@@ -54,6 +55,17 @@ public class TestDatabaseExtension implements BeforeAllCallback, AfterAllCallbac
 
     @Nullable
     private static volatile FDB fdb;
+
+    /**
+     * Multi-thread executor used as the default callback executor for every {@link Database} that this
+     * extension opens. Without it, {@link FDB#open(String)} falls back to {@link FDB#DEFAULT_EXECUTOR},
+     * a JVM-wide executor that can become a bottleneck for parallel tests (e.g. classes annotated
+     * {@code @Execution(ExecutionMode.CONCURRENT)} like {@code OperationsTest}) and lead to CI-only
+     * timeouts. Using a dedicated cached pool here mirrors what {@code FDBDatabaseExtension} does for
+     * {@code FDBDatabaseFactory.setExecutor}.
+     */
+    @Nonnull
+    private static final Executor threadPoolExecutor = TestExecutors.newThreadPool("fdb-extensions-test");
 
     private Database db;
 
@@ -95,7 +107,7 @@ public class TestDatabaseExtension implements BeforeAllCallback, AfterAllCallbac
     @Nonnull
     public Database getDatabase() {
         if (db == null) {
-            db = FDB.instance().open(FDBTestEnvironment.randomClusterFile());
+            db = FDB.instance().open(FDBTestEnvironment.randomClusterFile(), threadPoolExecutor);
         }
         return db;
     }

--- a/gradle/testing.gradle
+++ b/gradle/testing.gradle
@@ -360,7 +360,11 @@ tasks.withType(Test).configureEach { task ->
             task.systemProperty('junit.jupiter.execution.parallel.enabled', 'true')
             task.systemProperty('junit.jupiter.execution.parallel.mode.default', 'same_thread')
             task.systemProperty('junit.jupiter.execution.parallel.mode.classes.default', 'same_thread')
-
+            // So far, using the dynamic strategy results in tests that should be fairly fast timing out
+            // at 5 minutes. The current theory is some thread pool is saturated and unable to unblock
+            // itself. In the meantime, try a fixed 2 threads.
+            task.systemProperty('junit.jupiter.execution.parallel.config.strategy', 'fixed')
+            task.systemProperty('junit.jupiter.execution.parallel.config.fixed.parallelism', '2')
             // We use worker_thread_pool rather than fork_join_pool because we heavily depend on ForkJoinPool for
             // FDB operations, which causes junit to incorrectly increase the number of concurrent tests to well
             // beyond what we want.

--- a/gradle/testing.gradle
+++ b/gradle/testing.gradle
@@ -357,9 +357,14 @@ tasks.withType(Test).configureEach { task ->
         task.testFramework.options.excludeTags.add('Performance')
 
         if (task.name == 'test') {
-            task.systemProperty('junit.jupiter.execution.parallel.enabled', 'false')
+            task.systemProperty('junit.jupiter.execution.parallel.enabled', 'true')
             task.systemProperty('junit.jupiter.execution.parallel.mode.default', 'same_thread')
-            task.systemProperty('junit.jupiter.execution.parallel.mode.classes.default', 'concurrent')
+            task.systemProperty('junit.jupiter.execution.parallel.mode.classes.default', 'same_thread')
+
+            // We use worker_thread_pool rather than fork_join_pool because we heavily depend on ForkJoinPool for
+            // FDB operations, which causes junit to incorrectly increase the number of concurrent tests to well
+            // beyond what we want.
+            task.systemProperty('junit.jupiter.execution.parallel.config.executor-service', 'worker_thread_pool')
         }
     }
 


### PR DESCRIPTION
This enables JUnit's parallelism when running tests.
It is only enabled for tests that are annotated `@Execution(ExecutionMode.CONCURRENT)` (currently 15 classes). 

I tried using the default dynamic parallelism (number of processors) (see: #4301) but I could not get the tests to not have timeouts. In an effort to get the benefits seen here, this enables a fixed parallelism of 2, which seems to work and reduces the runtime of `fdb-extensions` from 28 to 20 minutes. I believe all other modules were within standard deviation. This means that the overall test suite is now limited by `yaml-tests`, which is ~25 minutes, so not a big win, but means that `fdb-extensions` can add more tests without becoming the bottleneck again.

This is the first step of #4320 