### PR TITLE
Introduce `AbstractCascadesRule` and split rule kinds into interfaces

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlannerConfiguration.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/RecordQueryPlannerConfiguration.java
@@ -24,6 +24,7 @@ import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.IndexFetchMethod;
 import com.apple.foundationdb.record.RecordPlannerConfigurationProto;
 import com.apple.foundationdb.record.query.RecordQuery;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.CascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.PlannerRule;
 import com.apple.foundationdb.record.query.plan.cascades.PlanningRuleSet;
@@ -637,9 +638,9 @@ public class RecordQueryPlannerConfiguration {
          */
         @CanIgnoreReturnValue
         @Nonnull
-        public Builder setDisabledTransformationRules(@Nonnull final Set<Class<? extends CascadesRule<?>>> disabledTransformationRules) {
+        public Builder setDisabledTransformationRules(@Nonnull final Set<Class<? extends AbstractCascadesRule<?>>> disabledTransformationRules) {
             protoBuilder.clearDisabledTransformationRules();
-            for (Class<? extends CascadesRule<?>> rule : disabledTransformationRules) {
+            for (Class<? extends AbstractCascadesRule<?>> rule : disabledTransformationRules) {
                 protoBuilder.addDisabledTransformationRules(rule.getSimpleName());
             }
             return this;
@@ -679,7 +680,7 @@ public class RecordQueryPlannerConfiguration {
         @Nonnull
         public Builder disableRewritingRules() {
             for (CascadesRule<?> rule : RewritingRuleSet.OPTIONAL_RULES) {
-                disableTransformationRule((Class<? extends CascadesRule<?>>) rule.getClass());
+                disableTransformationRule((Class<? extends AbstractCascadesRule<?>>) rule.getClass());
             }
             return this;
         }
@@ -691,7 +692,7 @@ public class RecordQueryPlannerConfiguration {
          */
         @CanIgnoreReturnValue
         @Nonnull
-        public Builder disableTransformationRule(@Nonnull Class<? extends CascadesRule<?>> ruleClass) {
+        public Builder disableTransformationRule(@Nonnull Class<? extends AbstractCascadesRule<?>> ruleClass) {
             protoBuilder.addDisabledTransformationRules(ruleClass.getSimpleName());
             return this;
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/AbstractCascadesRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/AbstractCascadesRule.java
@@ -1,0 +1,108 @@
+/*
+ * AbstractCascadesRule.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.cascades;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpression;
+import com.apple.foundationdb.record.query.plan.cascades.matching.structure.BindingMatcher;
+import com.google.common.collect.ImmutableSet;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Classes that inherit from {@code AbstractCascadesRule} form the base of the Cascades planning system. During the
+ * planning process, rules are matched to a current {@link RelationalExpression} and then provide zero or more logically
+ * equivalent expressions.
+ *
+ * <p>The rule matching occurs in two stages: first, the planner examines the {@link #matcher} of the rule, which is
+ * a {@link BindingMatcher} expression that expresses the operators that the rule applies to and the hierarchical
+ * structure that they take on in the expression tree. If the rule matches the binding, its {@link #onMatch(PlannerRuleCall)}
+ * method is called, with a parameter that provides the planner's {@link PlanContext} and access to the map of bindings,
+ * among other things. This method can inspect the operators bound during the structural matching and implement other
+ * logic.
+ *
+ * <p>The {@code onMatch()} method returns logically equivalent expressions to the planner by calling the
+ * yield methods on its rule call, with a new {@link RelationalExpression}s. These methods can be called more than once,
+ * or zero times if no alternative expressions are found.
+ *
+ * <p>A rule should not attempt to modify any of the bound objects that the rule call provides. Nearly all such objects
+ * are immutable, and the mutable ones are hidden behind interfaces that do not expose mutation methods. In particular,
+ * a rule should never cast an {@link Reference} in an attempt to access it.
+ *
+ * <p>A {@code AbstractCascadesRule} should not store state between successive calls to {@link #onMatch(PlannerRuleCall)},
+ * since it may be reused an arbitrary number of times and may be reinstantiated at any time. To simplify cleanup,
+ * any state that needs to be shared within a rule call should be encapsulated in a helper object (such as a static
+ * inner class) or documented carefully.
+ *
+ * @param <T> a parent planner expression type of all possible root planner expressions that this rule could match
+ * @see com.apple.foundationdb.record.query.plan.cascades
+ * @see PlannerRuleCall
+ */
+@API(API.Status.EXPERIMENTAL)
+public abstract class AbstractCascadesRule<T> implements CascadesRule<T> {
+    @Nonnull
+    private final BindingMatcher<T> matcher;
+
+    @Nonnull
+    private final Set<PlannerConstraint<?>> requirementDependencies;
+
+    public AbstractCascadesRule(@Nonnull BindingMatcher<T> matcher) {
+        this.matcher = matcher;
+        this.requirementDependencies = ImmutableSet.of();
+    }
+
+    public AbstractCascadesRule(@Nonnull BindingMatcher<T> matcher, Collection<PlannerConstraint<?>> requirementDependencies) {
+        this.matcher = matcher;
+        this.requirementDependencies = ImmutableSet.copyOf(requirementDependencies);
+    }
+
+    /**
+     * Returns the class of the operator at the root of the binding expression, if this rule uses a non-trivial binding.
+     * Used primarily for indexing rules for more efficient rule search.
+     * @return the class of the root of this rule's binding, or <code>Optional.empty()</code> if the rule matches anything
+     * @see PlanningRuleSet
+     */
+    @Nonnull
+    @Override
+    public Optional<Class<?>> getRootOperator() {
+        return Optional.of(matcher.getRootClass());
+    }
+
+    @Override
+    @Nonnull
+    public Set<PlannerConstraint<?>> getConstraintDependencies() {
+        return requirementDependencies;
+    }
+
+    @Nonnull
+    @Override
+    public BindingMatcher<T> getMatcher() {
+        return matcher;
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName();
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CascadesPlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CascadesPlanner.java
@@ -92,7 +92,7 @@ import java.util.function.Supplier;
  * </p>
  *
  * <p>
- * Like many optimization frameworks, Cascades is driven by sets of {@link CascadesRule}s that can be defined for
+ * Like many optimization frameworks, Cascades is driven by sets of {@link AbstractCascadesRule}s that can be defined for
  * {@link RelationalExpression}s, {@link PartialMatch}es and {@link MatchPartition}s, each of which describes a
  * particular transformation and encapsulates the logic for determining its applicability and applying it. The planner
  * searches through its {@link PlanningRuleSet} to find a matching rule and then executes that rule, creating zero or
@@ -105,7 +105,7 @@ import java.util.function.Supplier;
  *         of the current planner expression, the current partial match, or the current match partition.
  *     </li>
  *     <li>
- *         A {@link CascadesRule#onMatch(CascadesRuleCall)} method that is run for each successful match, producing zero
+ *         A {@link AbstractCascadesRule#onMatch(PlannerRuleCall)} method that is run for each successful match, producing zero
  *         or more new expressions and/or zero or more new partial matches.
  *     </li>
  * </ul>
@@ -210,7 +210,7 @@ import java.util.function.Supplier;
  *
  * @see Reference
  * @see RelationalExpression
- * @see CascadesRule
+ * @see AbstractCascadesRule
  * @see CascadesCostModel
  */
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
@@ -857,7 +857,7 @@ public class CascadesPlanner implements QueryPlanner {
             taskStack.push(new TransformExpression(getPlannerPhase(), getGroup(), getExpression(), rule));
         }
 
-        private void pushTransformMatchPartition(CascadesRule<? extends MatchPartition> rule) {
+        private void pushTransformMatchPartition(AbstractCascadesRule<? extends MatchPartition> rule) {
             taskStack.push(new TransformMatchPartition(getPlannerPhase(), getGroup(), getExpression(), rule));
         }
 
@@ -1147,7 +1147,7 @@ public class CascadesPlanner implements QueryPlanner {
         public TransformMatchPartition(@Nonnull final PlannerPhase plannerPhase,
                                        @Nonnull final Reference group,
                                        @Nonnull final RelationalExpression expression,
-                                       @Nonnull final CascadesRule<? extends MatchPartition> rule) {
+                                       @Nonnull final AbstractCascadesRule<? extends MatchPartition> rule) {
             super(plannerPhase, group, expression, rule);
             this.matchPartitionSupplier = Suppliers.memoize(() -> MatchPartition.of(group, expression));
         }
@@ -1170,7 +1170,7 @@ public class CascadesPlanner implements QueryPlanner {
                                      @Nonnull final Reference group,
                                      @Nonnull final RelationalExpression expression,
                                      @Nonnull final PartialMatch partialMatch,
-                                     @Nonnull final CascadesRule<? extends PartialMatch> rule) {
+                                     @Nonnull final AbstractCascadesRule<? extends PartialMatch> rule) {
             super(plannerPhase, group, expression, rule);
             this.partialMatch = partialMatch;
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CascadesRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CascadesRule.java
@@ -1,5 +1,5 @@
 /*
- * CascadesRule.java
+ * AbstractCascadesRule.java
  *
  * This source file is part of the FoundationDB open source project
  *
@@ -21,89 +21,20 @@
 package com.apple.foundationdb.record.query.plan.cascades;
 
 import com.apple.foundationdb.annotation.API;
-import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpression;
-import com.apple.foundationdb.record.query.plan.cascades.matching.structure.BindingMatcher;
-import com.google.common.collect.ImmutableSet;
 
 import javax.annotation.Nonnull;
-import java.util.Collection;
-import java.util.Optional;
 import java.util.Set;
 
 /**
- * Classes that inherit from <code>CascadesRule</code> form the base of the Cascades planning system. During the planning
- * process, rules are matched to a current {@link RelationalExpression} and then provide zero or more logically equivalent
- * expressions.
- * <br>
- * The rule matching occurs in two stages: first, the planner examines the {@link #matcher} of the rule,
- * which is a {@link BindingMatcher} expression that expresses the operators that the rule applies to and the hierarchical
- * structure that they take on in the expression tree. If the rule matches the binding, its {@link #onMatch(CascadesRuleCall)}
- * method is called, with a parameter that provides the planner's {@link PlanContext} and access to the map of bindings,
- * among other things. This method can inspect the operators bound during the structural matching and implement other
- * logic.
- * <br>
- * The <code>onMatch()</code> method returns logically equivalent expressions to the planner by calling the
- * yield methods on its rule call, with a new {@link RelationalExpression}s. These methods can be called more than once,
- * or zero times if no alternative expressions are found.
- * <br>
- * A rule should not attempt to modify any of the bound objects that the rule call provides. Nearly all such objects are
- * immutable, and the mutable ones are hidden behind interfaces that do not expose mutation methods. In particular,
- * a rule should never cast an {@link Reference} in an attempt to access it.
- * <br>
- * A <code>CascadesRule</code> should not store state between successive calls to {@link #onMatch(CascadesRuleCall)},
- * since it may be reused an arbitrary number of times and may be reinstantiated at any time. To simplify cleanup,
- * any state that needs to be shared within a rule call should be encapsulated in a helper object (such as a static
- * inner class) or documented carefully.
- * @param <T> a parent planner expression type of all possible root planner expressions that this rule could match
- * @see com.apple.foundationdb.record.query.plan.cascades
- * @see PlannerRuleCall
+ * Root interface implemented by all Cascades planner rules.
+ *
+ * <p>Besides the basic {@link PlannerRule} contract, a {@code CascadesRule} declares the {@link PlannerConstraint} set
+ * it depends on via {@link #getConstraintDependencies()}.
+ *
+ * @param <T> A parent planner expression type of all possible root planner expressions that this rule could match.
  */
 @API(API.Status.EXPERIMENTAL)
-public abstract class CascadesRule<T> implements PlannerRule<CascadesRuleCall, T> {
+public interface CascadesRule<T> extends PlannerRule<CascadesRuleCall, T> {
     @Nonnull
-    private final BindingMatcher<T> matcher;
-
-    @Nonnull
-    private final Set<PlannerConstraint<?>> requirementDependencies;
-
-    public CascadesRule(@Nonnull BindingMatcher<T> matcher) {
-        this.matcher = matcher;
-        this.requirementDependencies = ImmutableSet.of();
-    }
-
-    public CascadesRule(@Nonnull BindingMatcher<T> matcher, Collection<PlannerConstraint<?>> requirementDependencies) {
-        this.matcher = matcher;
-        this.requirementDependencies = ImmutableSet.copyOf(requirementDependencies);
-    }
-
-    /**
-     * Returns the class of the operator at the root of the binding expression, if this rule uses a non-trivial binding.
-     * Used primarily for indexing rules for more efficient rule search.
-     * @return the class of the root of this rule's binding, or <code>Optional.empty()</code> if the rule matches anything
-     * @see PlanningRuleSet
-     */
-    @Nonnull
-    @Override
-    public Optional<Class<?>> getRootOperator() {
-        return Optional.of(matcher.getRootClass());
-    }
-
-    @Nonnull
-    public Set<PlannerConstraint<?>> getConstraintDependencies() {
-        return requirementDependencies;
-    }
-
-    @Override
-    public abstract void onMatch(@Nonnull CascadesRuleCall call);
-
-    @Nonnull
-    @Override
-    public BindingMatcher<T> getMatcher() {
-        return matcher;
-    }
-
-    @Override
-    public String toString() {
-        return getClass().getSimpleName();
-    }
+    Set<PlannerConstraint<?>> getConstraintDependencies();
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CascadesRuleCall.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CascadesRuleCall.java
@@ -52,7 +52,7 @@ import java.util.function.Function;
 /**
  * A rule call implementation for the {@link CascadesPlanner}. The life cycle of a rule call object starts with the
  * planner's decision to call a rule and ends after yielded objects have been processed. The planner instantiates a new
- * instance of this class and passes it to {@link CascadesRule#onMatch(CascadesRuleCall)} when the rule is executed.
+ * instance of this class and passes it to {@link AbstractCascadesRule#onMatch(PlannerRuleCall)} when the rule is executed.
  * During the execution of a rule, the rule implementation can invoke various yielding methods (most prominently
  * {@link #yieldExploratoryExpression(RelationalExpression)}, {@link #yieldFinalExpression(RelationalExpression)},
  * and {@link #yieldPartialMatch}) which modify the query graph if needed, and (if necessary) queue up those newly

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CascadesRuleSet.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CascadesRuleSet.java
@@ -59,23 +59,23 @@ public class CascadesRuleSet extends AbstractRuleSet<CascadesRuleCall, Relationa
     }
 
     @Nonnull
-    public Stream<CascadesRule<? extends PartialMatch>> getPartialMatchRules() {
+    public Stream<AbstractCascadesRule<? extends PartialMatch>> getPartialMatchRules() {
         return getPartialMatchRules(ignored -> true);
     }
 
     @Nonnull
-    public Stream<CascadesRule<? extends PartialMatch>> getPartialMatchRules(@Nonnull final Predicate<CascadesRule<? extends PartialMatch>> rulePredicate) {
+    public Stream<AbstractCascadesRule<? extends PartialMatch>> getPartialMatchRules(@Nonnull final Predicate<AbstractCascadesRule<? extends PartialMatch>> rulePredicate) {
         return Stream.empty();
     }
 
 
     @Nonnull
-    public Stream<CascadesRule<? extends MatchPartition>> getMatchPartitionRules() {
+    public Stream<AbstractCascadesRule<? extends MatchPartition>> getMatchPartitionRules() {
         return getMatchPartitionRules(ignored -> true);
     }
 
     @Nonnull
-    public Stream<CascadesRule<? extends MatchPartition>> getMatchPartitionRules(@Nonnull final Predicate<CascadesRule<? extends MatchPartition>> rulePredicate) {
+    public Stream<AbstractCascadesRule<? extends MatchPartition>> getMatchPartitionRules(@Nonnull final Predicate<AbstractCascadesRule<? extends MatchPartition>> rulePredicate) {
         return Stream.empty();
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ExplorationCascadesRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ExplorationCascadesRule.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2015-2018 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,22 +22,21 @@ package com.apple.foundationdb.record.query.plan.cascades;
 
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpression;
-import com.apple.foundationdb.record.query.plan.cascades.matching.structure.BindingMatcher;
-import com.google.common.collect.ImmutableSet;
 
 import javax.annotation.Nonnull;
-import java.util.Collection;
 
 /**
- * Abstract class to be extended for all exploration rules. The main purpose of this class is to constrain the
- * parameter of the {@link #onMatch(CascadesRuleCall)} method to {@link #onMatch(ExplorationCascadesRuleCall)} which
- * provides a restricted API for the specific rule implementation.
- * <br>
- * The main difference of an exploration rule as compared to an implementation rule (apart from how the planner
+ * Marker interface for exploration rules.
+ *
+ * <p>The main purpose of this interface is to constrain the parameter of the {@link #onMatch(CascadesRuleCall)} method
+ * to {@link #onMatch(ExplorationCascadesRuleCall)} which provides a restricted API for the specific rule
+ * implementation.
+ *
+ * <p>The main difference of an exploration rule as compared to an implementation rule (apart from how the planner
  * distinguishes between exploratory and final expressions) lies in the mechanics of how the expression DAG is modified
  * by the rule as a consequence of how the rule reasons about its subject and the subjects' inputs.
- * <br>
- * An exploration rule always matches some expression called the subject together with some sub DAG that is reachable
+ *
+ * <p>An exploration rule always matches some expression called the subject together with some sub DAG that is reachable
  * from the subject that always terminates at a set of references. Those references can be leaf references of the DAG
  * itself or just intermediate references of the DAG that just happened to be the furthest we matched with the
  * precondition matchers starting at the subject. Let's call those references base references. When the exploration
@@ -46,33 +45,26 @@ import java.util.Collection;
  * shared between different variations. That sharing is important for performance reasons (memory and computation) but
  * it requires extra care as those shared references must not be destructively modified which can be statically
  * guaranteed only during the exploration of the DAG.
+ *
  * @param <T> a parent planner expression type of all possible root planner expressions that this rule could match
  */
 @API(API.Status.EXPERIMENTAL)
-public abstract class ExplorationCascadesRule<T extends RelationalExpression> extends CascadesRule<T> {
-    public ExplorationCascadesRule(@Nonnull BindingMatcher<T> matcher) {
-        this(matcher, ImmutableSet.of());
-    }
-
-    public ExplorationCascadesRule(@Nonnull final BindingMatcher<T> matcher,
-                                   @Nonnull final Collection<PlannerConstraint<?>> requirementDependencies) {
-        super(matcher, requirementDependencies);
-    }
-
+public interface ExplorationCascadesRule<T extends RelationalExpression> extends CascadesRule<T> {
     /**
-     * Note that this method is intentionally {@code final} to prevent reimplementation by subclasses. Subclassed should
-     * instead override the more constrained {@link #onMatch(ExplorationCascadesRuleCall)}.
-     * @param call the regular {@link CascadesRuleCall}
+     * {@inheritDoc}
+     *
+     * <p>Note that this method is not intended to be reimplemented by implementing classes. Implementing classes
+     * should instead override the more constrained {@link #onMatch(ExplorationCascadesRuleCall)}.
      */
     @Override
-    public final void onMatch(@Nonnull final CascadesRuleCall call) {
-        // needs to be cast up to select the right overloaded method
-        onMatch((ExplorationCascadesRuleCall)call);
+    default void onMatch(@Nonnull final CascadesRuleCall call) {
+        onMatch((ExplorationCascadesRuleCall) call);
     }
 
     /**
-     * Abstract method to be implemented by the specific rule.
+     * The specific rule’s implementation of {@link #onMatch(CascadesRuleCall)}.
+     *
      * @param call the constrained rule call
      */
-    public abstract void onMatch(@Nonnull ExplorationCascadesRuleCall call);
+    void onMatch(@Nonnull ExplorationCascadesRuleCall call);
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ImplementationCascadesRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ImplementationCascadesRule.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,22 +22,22 @@ package com.apple.foundationdb.record.query.plan.cascades;
 
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpression;
-import com.apple.foundationdb.record.query.plan.cascades.matching.structure.BindingMatcher;
-import com.google.common.collect.ImmutableSet;
 
 import javax.annotation.Nonnull;
 import java.util.Collection;
 
 /**
- * Abstract class to be extended for all implementation rules. The main purpose of this class is to constrain the
- * parameter of the {@link #onMatch(CascadesRuleCall)} method to {@link #onMatch(ImplementationCascadesRuleCall)} which
- * provides a restricted API for the specific rule implementation.
- * <br>
- * The main difference of an implementation rule as compared to an explorations rule (apart from how the planner
+ * Interface to be implemented (in addition to extending {@link AbstractCascadesRule}) by all implementation rules.
+ *
+ * <p>The main purpose of this interface is to constrain the parameter of the {@link #onMatch(CascadesRuleCall)} method
+ * to {@link #onMatch(ImplementationCascadesRuleCall)} which provides a restricted API for the specific rule
+ * implementation.
+ *
+ * <p>The main difference of an implementation rule as compared to an exploration rule (apart from how the planner
  * distinguishes between exploratory and final expressions) lies in the mechanics of how the expression DAG is modified
  * by the rule as a consequence of how the rule reasons about its subject and the subjects' inputs.
- * <br>
- * An implementation rule always matches some expression called the subject together with some sub DAG that is reachable
+ *
+ * <p>An implementation rule always matches some expression called the subject together with some sub DAG that is reachable
  * from the subject which always terminates at a collection of expression partitions. An expression partition consists
  * of a subset of a reference's final expression members. When the implementation rule is executed, it creates new
  * variants by a combination of memoizing and yielding final expressions that are solely based on those expression
@@ -46,8 +46,8 @@ import java.util.Collection;
  * {@link FinalMemoizer#memoizeFinalExpressionsFromOther(Reference, Collection)} or
  * {@link FinalMemoizer#memoizeMemberPlansFromOther(Reference, Collection)} to create a new reference (the memoizer
  * guarantees to create a new reference) of a reference only containing the plans of the expression partition.
- * <br>
- * An expression partition can only contain final expressions and a final expression's children references can only
+ *
+ * <p>An expression partition can only contain final expressions and a final expression's children references can only
  * contain exactly one final expression each (which is the pruned expression). Those pruned expressions themselves where
  * yielded (before pruning) by some other execution of some implementation rule prior to the execution of this
  * implementation rule. Thus, it can inductively be shown that implementation rules construct a DAG bottom up that never
@@ -55,33 +55,26 @@ import java.util.Collection;
  * the current group from the rest of the expression DAG. That property of the subgraph of being disentangled is
  * extremely important as the planner prunes the children of the yielded expression immediately after the rule is called
  * which constitutes as a destructive modification of the pruned reference.
+ *
  * @param <T> a parent planner expression type of all possible root planner expressions that this rule could match
  */
 @API(API.Status.EXPERIMENTAL)
-public abstract class ImplementationCascadesRule<T extends RelationalExpression> extends CascadesRule<T> {
-    public ImplementationCascadesRule(@Nonnull BindingMatcher<T> matcher) {
-        this(matcher, ImmutableSet.of());
-    }
-
-    public ImplementationCascadesRule(@Nonnull final BindingMatcher<T> matcher,
-                                      @Nonnull final Collection<PlannerConstraint<?>> requirementDependencies) {
-        super(matcher, requirementDependencies);
-    }
-
+public interface ImplementationCascadesRule<T extends RelationalExpression> extends CascadesRule<T> {
     /**
-     * Note that this method is intentionally final to prevent reimplementation by subclasses. Subclassed should instead
-     * override the more constrained {@link #onMatch(ImplementationCascadesRuleCall)}.
-     * @param call the regular {@link CascadesRuleCall}
+     * {@inheritDoc}
+     *
+     * <p>Note that this method is not intended to be reimplemented by implementing classes. Implementing classes
+     * should instead override the more constrained {@link #onMatch(ImplementationCascadesRuleCall)}.
      */
     @Override
-    public final void onMatch(@Nonnull final CascadesRuleCall call) {
-        // needs to be cast up to select the right overloaded method
-        onMatch((ImplementationCascadesRuleCall)call);
+    default void onMatch(@Nonnull final CascadesRuleCall call) {
+        onMatch((ImplementationCascadesRuleCall) call);
     }
 
     /**
-     * Abstract method to be implemented by the specific rule.
+     * The specific rule’s implementation of {@link #onMatch(CascadesRuleCall)}.
+     *
      * @param call the constrained rule call
      */
-    public abstract void onMatch(@Nonnull ImplementationCascadesRuleCall call);
+    void onMatch(@Nonnull ImplementationCascadesRuleCall call);
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PlanContext.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PlanContext.java
@@ -27,9 +27,9 @@ import javax.annotation.Nonnull;
 import java.util.Set;
 
 /**
- * A basic context object that stores all of the metadata about a record store, such as the available indexes.
+ * A basic context object that stores all metadata about a record store, such as the available indexes.
  * It provides access to this information to the planner and the
- * {@link CascadesRule#onMatch(CascadesRuleCall)} method.
+ * {@link AbstractCascadesRule#onMatch(PlannerRuleCall)} method.
  */
 @API(API.Status.EXPERIMENTAL)
 public interface PlanContext {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PlannerRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PlannerRule.java
@@ -45,6 +45,11 @@ public interface PlannerRule<C extends PlannerRuleCall, T> {
     @Nonnull
     Optional<Class<?>> getRootOperator();
 
+    /**
+     * Called by the planner when the matcher of this rule matches part of the expression being planned.
+     *
+     * @param call the rule call, providing access to the planner context and the matched bindings
+     */
     void onMatch(@Nonnull C call);
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PlannerRuleCall.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PlannerRuleCall.java
@@ -31,7 +31,7 @@ import javax.annotation.Nonnull;
  * A <code>PlannerRuleCall</code> is a context object that supports a single application of a rule to a particular
  * expression. It stores and provides convenient access to various context related to the transformation, such as any
  * bindings, access to the {@link PlanContext}, etc. A <code>PlannerRuleCall</code> is passed to every rule's
- * {@link CascadesRule#onMatch(CascadesRuleCall)} method.
+ * {@link AbstractCascadesRule#onMatch(PlannerRuleCall)} method.
  */
 @API(API.Status.EXPERIMENTAL)
 public interface PlannerRuleCall {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PlanningRuleSet.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PlanningRuleSet.java
@@ -112,7 +112,7 @@ public class PlanningRuleSet extends CascadesRuleSet {
             new PartitionSelectRule(),
             new PartitionBinarySelectRule()
             );
-    private static final Set<CascadesRule<? extends RelationalExpression>> MATCHING_RULES = ImmutableSet.of(
+    private static final Set<AbstractCascadesRule<? extends RelationalExpression>> MATCHING_RULES = ImmutableSet.of(
             new MatchLeafRule(),
             new MatchIntermediateRule()
     );
@@ -180,10 +180,10 @@ public class PlanningRuleSet extends CascadesRuleSet {
                     .addAll(MATCHING_RULES)
                     .addAll(EXPLORATION_RULES)
                     .build();
-    private static final Set<CascadesRule<? extends PartialMatch>> PARTIAL_MATCH_RULES = ImmutableSet.of(
+    private static final Set<AbstractCascadesRule<? extends PartialMatch>> PARTIAL_MATCH_RULES = ImmutableSet.of(
             new AdjustMatchRule()
     );
-    private static final Set<CascadesRule<? extends MatchPartition>> MATCH_PARTITION_RULES = ImmutableSet.of(
+    private static final Set<AbstractCascadesRule<? extends MatchPartition>> MATCH_PARTITION_RULES = ImmutableSet.of(
             new WithPrimaryKeyDataAccessRule(),
             new AggregateDataAccessRule(),
             new PredicateToLogicalUnionRule()
@@ -209,14 +209,14 @@ public class PlanningRuleSet extends CascadesRuleSet {
 
     @Nonnull
     @Override
-    public Stream<CascadesRule<? extends PartialMatch>> getPartialMatchRules(@Nonnull final Predicate<CascadesRule<? extends PartialMatch>> rulePredicate) {
+    public Stream<AbstractCascadesRule<? extends PartialMatch>> getPartialMatchRules(@Nonnull final Predicate<AbstractCascadesRule<? extends PartialMatch>> rulePredicate) {
         return PARTIAL_MATCH_RULES.stream()
                 .filter(rulePredicate);
     }
 
     @Nonnull
     @Override
-    public Stream<CascadesRule<? extends MatchPartition>> getMatchPartitionRules(@Nonnull final Predicate<CascadesRule<? extends MatchPartition>> rulePredicate) {
+    public Stream<AbstractCascadesRule<? extends MatchPartition>> getMatchPartitionRules(@Nonnull final Predicate<AbstractCascadesRule<? extends MatchPartition>> rulePredicate) {
         return MATCH_PARTITION_RULES.stream()
                 .filter(rulePredicate);
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/RewritingRuleSet.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/RewritingRuleSet.java
@@ -47,7 +47,7 @@ public class RewritingRuleSet extends CascadesRuleSet {
             new DecorrelateValuesRule(),
             new RewriteOuterJoinRule()
     );
-    private static final Set<CascadesRule<? extends RelationalExpression>> PREORDER_RULES = ImmutableSet.of();
+    private static final Set<AbstractCascadesRule<? extends RelationalExpression>> PREORDER_RULES = ImmutableSet.of();
 
     private static final Set<ImplementationCascadesRule<? extends RelationalExpression>> IMPLEMENTATION_RULES = ImmutableSet.of(
             new SelectMergeRule(),

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/events/PlannerEventStatsCollectorState.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/events/PlannerEventStatsCollectorState.java
@@ -85,7 +85,7 @@ class PlannerEventStatsCollectorState {
                 forEventClass.increaseOwnTimeInNs(ownTime);
                 if (plannerEvent instanceof TransformRuleCallPlannerEvent) {
                     final CascadesRule<?> rule = ((TransformRuleCallPlannerEvent)plannerEvent).getRule();
-                    final Class<? extends CascadesRule<?>> ruleClass = (Class<? extends CascadesRule<?>>)rule.getClass();
+                    final var ruleClass = (Class<? extends CascadesRule<?>>) rule.getClass();
                     final MutableStats forPlannerRuleClass = getEventStatsForPlannerRuleClass(ruleClass);
                     forPlannerRuleClass.increaseTotalTimeInNs(totalTime);
                     forPlannerRuleClass.increaseOwnTimeInNs(ownTime);
@@ -111,7 +111,7 @@ class PlannerEventStatsCollectorState {
 
         if (plannerEvent instanceof PlannerEventWithRule) {
             final CascadesRule<?> rule = ((PlannerEventWithRule)plannerEvent).getRule();
-            final Class<? extends CascadesRule<?>> ruleClass = (Class<? extends CascadesRule<?>>)rule.getClass();
+            final var ruleClass = (Class<? extends CascadesRule<?>>) rule.getClass();
             final MutableStats forPlannerRuleClass = getEventStatsForPlannerRuleClass(ruleClass);
             forPlannerRuleClass.increaseCount(plannerEvent.getLocation(), 1L);
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/AbstractDataAccessRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/AbstractDataAccessRule.java
@@ -23,8 +23,8 @@ package com.apple.foundationdb.record.query.plan.cascades.rules;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.query.combinatorics.ChooseK;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.CascadesPlanner;
-import com.apple.foundationdb.record.query.plan.cascades.CascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.CascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.ComparisonRange;
 import com.apple.foundationdb.record.query.plan.cascades.Compensation;
@@ -110,7 +110,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.properties.Cardi
  */
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings({"java:S3776", "java:S4738", "OptionalUsedAsFieldOrParameterType"})
-public abstract class AbstractDataAccessRule extends CascadesRule<MatchPartition> {
+public abstract class AbstractDataAccessRule extends AbstractCascadesRule<MatchPartition> {
     private static final Logger logger = LoggerFactory.getLogger(AbstractDataAccessRule.class);
 
     private final BindingMatcher<PartialMatch> completeMatchMatcher;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/AdjustMatchRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/AdjustMatchRule.java
@@ -21,7 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
-import com.apple.foundationdb.record.query.plan.cascades.CascadesRule;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.CascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
 import com.apple.foundationdb.record.query.plan.cascades.Reference;
@@ -59,7 +59,7 @@ import java.util.Optional;
  * provided properties guaranteed by the candidate side.
  */
 @API(API.Status.EXPERIMENTAL)
-public class AdjustMatchRule extends CascadesRule<PartialMatch> {
+public class AdjustMatchRule extends AbstractCascadesRule<PartialMatch> {
     private static final BindingMatcher<PartialMatch> rootMatcher = PartialMatchMatchers.incompleteMatch();
 
     public AdjustMatchRule() {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/DecorrelateValuesRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/DecorrelateValuesRule.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.ExplorationCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ExplorationCascadesRuleCall;
@@ -134,7 +135,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  * }</pre>
  */
 @SuppressWarnings("PMD.TooManyStaticImports")
-public class DecorrelateValuesRule extends ExplorationCascadesRule<SelectExpression> {
+public class DecorrelateValuesRule extends AbstractCascadesRule<SelectExpression> implements ExplorationCascadesRule<SelectExpression> {
     // TODO: This could use filtered expression partitions, but we have to make modifications to the test infrastructure to ensure there are final children
     // We currently use a predicate over the expressions in the reference rather than a matcher here because we don't
     // want to create multiple matches if there happens to be a reference containing multiple range(1) values. Doing

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/EliminateNullOnEmptyRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/EliminateNullOnEmptyRule.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.record.EvaluationContext;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.ExplorationCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ExplorationCascadesRuleCall;
@@ -51,7 +52,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  * tuple at that quantifier's alias. The rule fires once per matching {@code SelectExpression} and rewrites all
  * eligible null-on-empty quantifiers in a single yielded expression.
  */
-public class EliminateNullOnEmptyRule extends ExplorationCascadesRule<SelectExpression> {
+public class EliminateNullOnEmptyRule extends AbstractCascadesRule<SelectExpression> implements ExplorationCascadesRule<SelectExpression> {
 
     @Nonnull
     private static final CollectionMatcher<Quantifier.ForEach> nullOnEmptyQuantifiers =

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/FinalizeExpressionsRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/FinalizeExpressionsRule.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ExpressionPartition;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRuleCall;
@@ -52,7 +53,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  */
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("PMD.TooManyStaticImports")
-public class FinalizeExpressionsRule extends ImplementationCascadesRule<RelationalExpression> {
+public class FinalizeExpressionsRule extends AbstractCascadesRule<RelationalExpression> implements ImplementationCascadesRule<RelationalExpression> {
     @Nonnull
     private static final BindingMatcher<ExpressionPartition<RelationalExpression>> childPartitionsMatcher =
             anyExpressionPartition();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementDeleteRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementDeleteRule.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.PlanPartition;
@@ -47,7 +48,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  */
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("PMD.TooManyStaticImports")
-public class ImplementDeleteRule extends ImplementationCascadesRule<DeleteExpression> {
+public class ImplementDeleteRule extends AbstractCascadesRule<DeleteExpression> implements ImplementationCascadesRule<DeleteExpression> {
     @Nonnull
     private static final BindingMatcher<PlanPartition> innerPlanPartitionMatcher = anyPlanPartition();
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementDistinctRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementDistinctRule.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.PlanPartition;
@@ -59,7 +60,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  */
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("PMD.TooManyStaticImports")
-public class ImplementDistinctRule extends ImplementationCascadesRule<LogicalDistinctExpression> {
+public class ImplementDistinctRule extends AbstractCascadesRule<LogicalDistinctExpression> implements ImplementationCascadesRule<LogicalDistinctExpression> {
     @Nonnull
     private static final BindingMatcher<PlanPartition> innerPlanPartitionMatcher = anyPlanPartition();
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementDistinctUnionRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementDistinctUnionRule.java
@@ -22,6 +22,7 @@ package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.query.combinatorics.CrossProduct;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.Ordering;
@@ -73,7 +74,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  */
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("PMD.TooManyStaticImports")
-public class ImplementDistinctUnionRule extends ImplementationCascadesRule<LogicalDistinctExpression> {
+public class ImplementDistinctUnionRule extends AbstractCascadesRule<LogicalDistinctExpression> implements ImplementationCascadesRule<LogicalDistinctExpression> {
 
     @Nonnull
     private static final CollectionMatcher<PlanPartition> unionLegPlanPartitionsMatcher = all(anyPlanPartition());

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementExplodeRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementExplodeRule.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.ExplodeExpression;
@@ -36,7 +37,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  * A rule that implements an {@link ExplodeExpression} as a {@link RecordQueryExplodePlan}.
  */
 @API(API.Status.EXPERIMENTAL)
-public class ImplementExplodeRule extends ImplementationCascadesRule<ExplodeExpression> {
+public class ImplementExplodeRule extends AbstractCascadesRule<ExplodeExpression> implements ImplementationCascadesRule<ExplodeExpression> {
     private static final BindingMatcher<ExplodeExpression> root = explodeExpression();
 
     public ImplementExplodeRule() {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementFilterRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementFilterRule.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.PlanPartition;
@@ -50,7 +51,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  */
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("PMD.TooManyStaticImports")
-public class ImplementFilterRule extends ImplementationCascadesRule<LogicalFilterExpression> {
+public class ImplementFilterRule extends AbstractCascadesRule<LogicalFilterExpression> implements ImplementationCascadesRule<LogicalFilterExpression> {
     @Nonnull
     private static final BindingMatcher<PlanPartition> innerPlanPartitionMatcher = anyPlanPartition();
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementInJoinRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementInJoinRule.java
@@ -24,6 +24,7 @@ import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.query.combinatorics.CrossProduct;
 import com.apple.foundationdb.record.query.combinatorics.TopologicalSort;
 import com.apple.foundationdb.record.query.expressions.Comparisons;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRuleCall;
@@ -87,7 +88,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.rules.PushReques
  */
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings({"PMD.TooManyStaticImports", "java:S4738", "java:S3776"})
-public class ImplementInJoinRule extends ImplementationCascadesRule<SelectExpression> {
+public class ImplementInJoinRule extends AbstractCascadesRule<SelectExpression> implements ImplementationCascadesRule<SelectExpression> {
     private static final BindingMatcher<ExplodeExpression> explodeExpressionMatcher = explodeExpression();
     private static final CollectionMatcher<Quantifier.ForEach> explodeQuantifiersMatcher = some(forEachQuantifier(explodeExpressionMatcher));
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementInUnionRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementInUnionRule.java
@@ -22,6 +22,7 @@ package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.query.expressions.Comparisons;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRuleCall;
@@ -72,7 +73,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.rules.PushReques
  */
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("PMD.TooManyStaticImports")
-public class ImplementInUnionRule extends ImplementationCascadesRule<SelectExpression> {
+public class ImplementInUnionRule extends AbstractCascadesRule<SelectExpression> implements ImplementationCascadesRule<SelectExpression> {
     private static final BindingMatcher<ExplodeExpression> explodeExpressionMatcher = explodeExpression();
     private static final CollectionMatcher<Quantifier.ForEach> explodeQuantifiersMatcher = some(forEachQuantifier(explodeExpressionMatcher));
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementInsertRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementInsertRule.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.PlanPartition;
@@ -43,7 +44,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  */
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("PMD.TooManyStaticImports")
-public class ImplementInsertRule extends ImplementationCascadesRule<InsertExpression> {
+public class ImplementInsertRule extends AbstractCascadesRule<InsertExpression> implements ImplementationCascadesRule<InsertExpression> {
     @Nonnull
     private static final BindingMatcher<PlanPartition> innerPlanPartitionMatcher = anyPlanPartition();
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementIntersectionRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementIntersectionRule.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.PlanPartition;
@@ -57,7 +58,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  */
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("PMD.TooManyStaticImports")
-public class ImplementIntersectionRule extends ImplementationCascadesRule<LogicalIntersectionExpression> {
+public class ImplementIntersectionRule extends AbstractCascadesRule<LogicalIntersectionExpression> implements ImplementationCascadesRule<LogicalIntersectionExpression> {
     @Nonnull
     private static final BindingMatcher<PlanPartition> intersectionLegPlanPartitionMatcher = anyPlanPartition();
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementNestedLoopJoinRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementNestedLoopJoinRule.java
@@ -23,6 +23,7 @@ package com.apple.foundationdb.record.query.plan.cascades.rules;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.EvaluationContext;
 import com.apple.foundationdb.record.logging.KeyValueLogMessage;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRule;
@@ -73,7 +74,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  */
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("PMD.TooManyStaticImports")
-public class ImplementNestedLoopJoinRule extends ImplementationCascadesRule<SelectExpression> {
+public class ImplementNestedLoopJoinRule extends AbstractCascadesRule<SelectExpression> implements ImplementationCascadesRule<SelectExpression> {
     @Nonnull
     private static final Logger logger = LoggerFactory.getLogger(ImplementNestedLoopJoinRule.class);
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementRecursiveDfsJoinRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementRecursiveDfsJoinRule.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.PlanPartition;
@@ -63,7 +64,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.SetMatcher.exactlyInAnyOrder;
 
 @SuppressWarnings("PMD.TooManyStaticImports")
-public class ImplementRecursiveDfsJoinRule extends ImplementationCascadesRule<RecursiveUnionExpression> {
+public class ImplementRecursiveDfsJoinRule extends AbstractCascadesRule<RecursiveUnionExpression> implements ImplementationCascadesRule<RecursiveUnionExpression> {
 
     @Nonnull
     private static final BindingMatcher<RecordQueryPlan> initialInnerPlanMatcher = anyPlan();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementRecursiveLevelUnionRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementRecursiveLevelUnionRule.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.PlanPartition;
@@ -47,7 +48,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  */
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("PMD.TooManyStaticImports")
-public class ImplementRecursiveLevelUnionRule extends ImplementationCascadesRule<RecursiveUnionExpression> {
+public class ImplementRecursiveLevelUnionRule extends AbstractCascadesRule<RecursiveUnionExpression> implements ImplementationCascadesRule<RecursiveUnionExpression> {
 
     @Nonnull
     private static final BindingMatcher<PlanPartition> initialPlanPartitionsMatcher = anyPlanPartition();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementSimpleSelectRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementSimpleSelectRule.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRule;
@@ -75,7 +76,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  */
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("PMD.TooManyStaticImports")
-public class ImplementSimpleSelectRule extends ImplementationCascadesRule<SelectExpression> {
+public class ImplementSimpleSelectRule extends AbstractCascadesRule<SelectExpression> implements ImplementationCascadesRule<SelectExpression> {
     @Nonnull
     private static final BindingMatcher<PlanPartition> innerPlanPartitionMatcher = anyPlanPartition();
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementStreamingAggregationRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementStreamingAggregationRule.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRuleCall;
@@ -60,7 +61,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  */
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("PMD.TooManyStaticImports")
-public class ImplementStreamingAggregationRule extends ImplementationCascadesRule<GroupByExpression> {
+public class ImplementStreamingAggregationRule extends AbstractCascadesRule<GroupByExpression> implements ImplementationCascadesRule<GroupByExpression> {
     @Nonnull
     private static final BindingMatcher<PlanPartition> innerPlanPartitions = anyPlanPartition();
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementTableFunctionRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementTableFunctionRule.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.TableFunctionExpression;
@@ -35,7 +36,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  * A rule that implements a table function expression into a {@link RecordQueryTableFunctionPlan}.
  */
 @API(API.Status.EXPERIMENTAL)
-public class ImplementTableFunctionRule extends ImplementationCascadesRule<TableFunctionExpression> {
+public class ImplementTableFunctionRule extends AbstractCascadesRule<TableFunctionExpression> implements ImplementationCascadesRule<TableFunctionExpression> {
     private static final BindingMatcher<TableFunctionExpression> root =
             tableFunctionExpression();
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementTempTableInsertRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementTempTableInsertRule.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.PlanPartition;
@@ -43,7 +44,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  */
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("PMD.TooManyStaticImports")
-public class ImplementTempTableInsertRule extends ImplementationCascadesRule<TempTableInsertExpression> {
+public class ImplementTempTableInsertRule extends AbstractCascadesRule<TempTableInsertExpression> implements ImplementationCascadesRule<TempTableInsertExpression> {
     @Nonnull
     private static final BindingMatcher<PlanPartition> innerPlanPartitionMatcher = anyPlanPartition();
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementTempTableScanRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementTempTableScanRule.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.TempTableScanExpression;
@@ -33,7 +34,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
 /**
  * A rule that implements a {@link TempTableScanExpression} producing a {@link TempTableScanPlan} operator.
  */
-public class ImplementTempTableScanRule extends ImplementationCascadesRule<TempTableScanExpression> {
+public class ImplementTempTableScanRule extends AbstractCascadesRule<TempTableScanExpression> implements ImplementationCascadesRule<TempTableScanExpression> {
 
     @Nonnull
     private static final BindingMatcher<TempTableScanExpression> root = tempTableScanExpression();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementTypeFilterRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementTypeFilterRule.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.LinkedIdentitySet;
@@ -56,7 +57,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  */
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("PMD.TooManyStaticImports")
-public class ImplementTypeFilterRule extends ImplementationCascadesRule<LogicalTypeFilterExpression> {
+public class ImplementTypeFilterRule extends AbstractCascadesRule<LogicalTypeFilterExpression> implements ImplementationCascadesRule<LogicalTypeFilterExpression> {
     @Nonnull
     private static final BindingMatcher<PlanPartition> innerPlanPartitionMatcher = anyPlanPartition();
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementUniqueRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementUniqueRule.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.PlanPartition;
@@ -47,7 +48,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  * This rule implements {@link LogicalUniqueExpression} by absorbing it if the inner reference is already distinct.
  */
 @SuppressWarnings("PMD.TooManyStaticImports")
-public class ImplementUniqueRule extends ImplementationCascadesRule<LogicalUniqueExpression> {
+public class ImplementUniqueRule extends AbstractCascadesRule<LogicalUniqueExpression> implements ImplementationCascadesRule<LogicalUniqueExpression> {
 
     @Nonnull
     private static final CollectionMatcher<PlanPartition> anyPlanPartitionMatcher = all(anyPlanPartition());

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementUnorderedUnionRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementUnorderedUnionRule.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.PlanPartition;
@@ -51,7 +52,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  */
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("PMD.TooManyStaticImports")
-public class ImplementUnorderedUnionRule extends ImplementationCascadesRule<LogicalUnionExpression> {
+public class ImplementUnorderedUnionRule extends AbstractCascadesRule<LogicalUnionExpression> implements ImplementationCascadesRule<LogicalUnionExpression> {
     @Nonnull
     private static final BindingMatcher<PlanPartition> unionLegPlanPartitionsMatcher = anyPlanPartition();
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementUpdateRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/ImplementUpdateRule.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.PlanPartition;
@@ -46,7 +47,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  */
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("PMD.TooManyStaticImports")
-public class ImplementUpdateRule extends ImplementationCascadesRule<UpdateExpression> {
+public class ImplementUpdateRule extends AbstractCascadesRule<UpdateExpression> implements ImplementationCascadesRule<UpdateExpression> {
     @Nonnull
     private static final BindingMatcher<PlanPartition> innerPlanPartitionMatcher = anyPlanPartition();
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/InComparisonToExplodeRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/InComparisonToExplodeRule.java
@@ -23,6 +23,7 @@ package com.apple.foundationdb.record.query.plan.cascades.rules;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.query.expressions.Comparisons;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.Column;
 import com.apple.foundationdb.record.query.plan.cascades.ExplorationCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ExplorationCascadesRuleCall;
@@ -120,7 +121,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  */
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("PMD.TooManyStaticImports")
-public class InComparisonToExplodeRule extends ExplorationCascadesRule<SelectExpression> {
+public class InComparisonToExplodeRule extends AbstractCascadesRule<SelectExpression> implements ExplorationCascadesRule<SelectExpression> {
     private static final BindingMatcher<ValuePredicate> inPredicateMatcher =
             valuePredicate(ValueMatchers.anyValue(), anyComparisonOfType(Comparisons.Type.IN));
     private static final BindingMatcher<Quantifier.ForEach> innerQuantifierMatcher = forEachQuantifier();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/MatchIntermediateRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/MatchIntermediateRule.java
@@ -25,7 +25,7 @@ import com.apple.foundationdb.record.EvaluationContext;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.query.combinatorics.EnumeratingIterable;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
-import com.apple.foundationdb.record.query.plan.cascades.CascadesRule;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.CascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.Reference;
 import com.apple.foundationdb.record.query.plan.cascades.IdentityBiMap;
@@ -149,7 +149,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  * </p>
  */
 @API(API.Status.EXPERIMENTAL)
-public class MatchIntermediateRule extends CascadesRule<RelationalExpression> {
+public class MatchIntermediateRule extends AbstractCascadesRule<RelationalExpression> {
     private static final BindingMatcher<Quantifier> quantifierMatcher = QuantifierMatchers.anyQuantifier();
     private static final BindingMatcher<RelationalExpression> root =
             RelationalExpressionMatchers.ofTypeOwning(RelationalExpression.class, all(quantifierMatcher));

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/MatchLeafRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/MatchLeafRule.java
@@ -22,8 +22,8 @@ package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.EvaluationContext;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
-import com.apple.foundationdb.record.query.plan.cascades.CascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.CascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.Reference;
 import com.apple.foundationdb.record.query.plan.cascades.Traversal;
@@ -50,7 +50,7 @@ import java.util.Set;
  * further rules such as {@link MatchIntermediateRule} and {@link AdjustMatchRule}.
  */
 @API(API.Status.EXPERIMENTAL)
-public class MatchLeafRule extends CascadesRule<RelationalExpression> {
+public class MatchLeafRule extends AbstractCascadesRule<RelationalExpression> {
     // match any relational expression that is a leaf, that is, any expression that does not have any children
     private static final BindingMatcher<RelationalExpression> root =
             RelationalExpressionMatchers.ofTypeOwning(RelationalExpression.class, CollectionMatcher.empty());

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/MergeFetchIntoCoveringIndexRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/MergeFetchIntoCoveringIndexRule.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.matching.structure.BindingMatcher;
@@ -38,7 +39,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  * A rule that merges a fetch into a covering index scan.
  */
 @API(API.Status.EXPERIMENTAL)
-public class MergeFetchIntoCoveringIndexRule extends ImplementationCascadesRule<RecordQueryFetchFromPartialRecordPlan> {
+public class MergeFetchIntoCoveringIndexRule extends AbstractCascadesRule<RecordQueryFetchFromPartialRecordPlan> implements ImplementationCascadesRule<RecordQueryFetchFromPartialRecordPlan> {
     @Nonnull
     private static final BindingMatcher<RecordQueryIndexPlan> innerPlanMatcher = indexPlan();
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/MergeProjectionAndFetchRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/MergeProjectionAndFetchRule.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRuleCall;
@@ -46,7 +47,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  */
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("PMD.TooManyStaticImports")
-public class MergeProjectionAndFetchRule extends ImplementationCascadesRule<LogicalProjectionExpression> {
+public class MergeProjectionAndFetchRule extends AbstractCascadesRule<LogicalProjectionExpression> implements ImplementationCascadesRule<LogicalProjectionExpression> {
     @Nonnull
     private static final BindingMatcher<RecordQueryFetchFromPartialRecordPlan> innerPlanMatcher = fetchFromPartialRecordPlan(anyPlan());
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/NormalizePredicatesRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/NormalizePredicatesRule.java
@@ -22,6 +22,7 @@ package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.query.plan.RecordQueryPlannerConfiguration;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ExplorationCascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.ExplorationCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
@@ -51,7 +52,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  * {@link PredicateToLogicalUnionRule}.
  */
 @API(API.Status.EXPERIMENTAL)
-public class NormalizePredicatesRule extends ExplorationCascadesRule<SelectExpression> {
+public class NormalizePredicatesRule extends AbstractCascadesRule<SelectExpression> implements ExplorationCascadesRule<SelectExpression> {
     private static final CollectionMatcher<QueryPredicate> predicatesMatcher = all(anyPredicate());
     private static final CollectionMatcher<Quantifier> innerQuantifiersMatcher = all(anyQuantifier());
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PartitionBinarySelectRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PartitionBinarySelectRule.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ExplorationCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ExplorationCascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.GraphExpansion;
@@ -87,7 +88,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  */
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("PMD.TooManyStaticImports")
-public class PartitionBinarySelectRule extends ExplorationCascadesRule<SelectExpression> {
+public class PartitionBinarySelectRule extends AbstractCascadesRule<SelectExpression> implements ExplorationCascadesRule<SelectExpression> {
     private static final BindingMatcher<Quantifier> leftQuantifierMatcher = anyQuantifier();
 
     private static final BindingMatcher<Quantifier> rightQuantifierMatcher = anyQuantifier();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PartitionSelectRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PartitionSelectRule.java
@@ -23,6 +23,7 @@ package com.apple.foundationdb.record.query.plan.cascades.rules;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.query.plan.RecordQueryPlannerConfiguration;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.Column;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.ExplorationCascadesRule;
@@ -59,7 +60,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  */
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("PMD.TooManyStaticImports")
-public class PartitionSelectRule extends ExplorationCascadesRule<SelectExpression> {
+public class PartitionSelectRule extends AbstractCascadesRule<SelectExpression> implements ExplorationCascadesRule<SelectExpression> {
     private static final CollectionMatcher<Quantifier> combinationQuantifierMatcher = all(anyQuantifier());
 
     private static final BindingMatcher<SelectExpression> root =

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PredicatePushDownRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PredicatePushDownRule.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.ExplorationCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ExplorationCascadesRuleCall;
@@ -174,7 +175,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  */
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("PMD.TooManyStaticImports")
-public class PredicatePushDownRule extends ExplorationCascadesRule<SelectExpression> {
+public class PredicatePushDownRule extends AbstractCascadesRule<SelectExpression> implements ExplorationCascadesRule<SelectExpression> {
     @Nonnull
     private static final CollectionMatcher<RelationalExpression> belowExpressionsMatcher = all(anyExpression());
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PredicateToLogicalUnionRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PredicateToLogicalUnionRule.java
@@ -24,7 +24,7 @@ import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.EvaluationContext;
 import com.apple.foundationdb.record.query.plan.RecordQueryPlannerConfiguration;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
-import com.apple.foundationdb.record.query.plan.cascades.CascadesRule;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.CascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.Reference;
@@ -121,7 +121,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  */
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("PMD.TooManyStaticImports")
-public class PredicateToLogicalUnionRule extends CascadesRule<MatchPartition> {
+public class PredicateToLogicalUnionRule extends AbstractCascadesRule<MatchPartition> {
     public static final int DEFAULT_MAX_NUM_CONJUNCTS = 9; // 510 combinations
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushDistinctBelowFilterRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushDistinctBelowFilterRule.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
@@ -75,7 +76,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  *
  * where pred' is rebased along the translation from qun to newQun.
  */
-public class PushDistinctBelowFilterRule extends ImplementationCascadesRule<RecordQueryUnorderedPrimaryKeyDistinctPlan> {
+public class PushDistinctBelowFilterRule extends AbstractCascadesRule<RecordQueryUnorderedPrimaryKeyDistinctPlan> implements ImplementationCascadesRule<RecordQueryUnorderedPrimaryKeyDistinctPlan> {
     @Nonnull
     private static final BindingMatcher<? extends Reference> innerRefMatcher = anyRefOverOnlyPlans();
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushDistinctThroughFetchRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushDistinctThroughFetchRule.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRuleCall;
@@ -71,7 +72,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  *
  */
 @API(API.Status.EXPERIMENTAL)
-public class PushDistinctThroughFetchRule extends ImplementationCascadesRule<RecordQueryUnorderedPrimaryKeyDistinctPlan> {
+public class PushDistinctThroughFetchRule extends AbstractCascadesRule<RecordQueryUnorderedPrimaryKeyDistinctPlan> implements ImplementationCascadesRule<RecordQueryUnorderedPrimaryKeyDistinctPlan> {
     @Nonnull
     private static final BindingMatcher<RecordQueryPlan> innerPlanMatcher = anyPlan();
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushFilterThroughFetchRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushFilterThroughFetchRule.java
@@ -22,6 +22,7 @@ package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRuleCall;
@@ -138,7 +139,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  * </pre>
  */
 @API(API.Status.EXPERIMENTAL)
-public class PushFilterThroughFetchRule extends ImplementationCascadesRule<RecordQueryPredicatesFilterPlan> {
+public class PushFilterThroughFetchRule extends AbstractCascadesRule<RecordQueryPredicatesFilterPlan> implements ImplementationCascadesRule<RecordQueryPredicatesFilterPlan> {
     @Nonnull
     private static final BindingMatcher<RecordQueryPlan> innerPlanMatcher = anyPlan();
     @Nonnull
@@ -240,9 +241,9 @@ public class PushFilterThroughFetchRule extends ImplementationCascadesRule<Recor
         final var pushedLeafPredicateOptional =
                 predicateWithValue.translateValueAndComparisonsMaybe(
                         value -> fetchPlan.pushValue(value, oldInnerAlias, newInnerAlias),
-                        comparison -> comparison.replaceValuesMaybe(value -> {
-                            return fetchPlan.pushValue(value, oldInnerAlias, newInnerAlias);
-                        }));
+                        comparison ->
+                                comparison.replaceValuesMaybe(value -> fetchPlan.pushValue(value, oldInnerAlias,
+                                        newInnerAlias)));
         // Something went wrong when attempting to push this value through the fetch.
         // We must return null to prevent pushing of this conjunct.
         return pushedLeafPredicateOptional.orElse(null);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushInJoinThroughFetchRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushInJoinThroughFetchRule.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
@@ -80,7 +81,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  *        {@link RecordQueryInValuesJoinPlan} and {@link RecordQueryInParameterJoinPlan}.
  */
 @API(API.Status.EXPERIMENTAL)
-public class PushInJoinThroughFetchRule<P extends RecordQueryInJoinPlan> extends ImplementationCascadesRule<P> {
+public class PushInJoinThroughFetchRule<P extends RecordQueryInJoinPlan> extends AbstractCascadesRule<P> implements ImplementationCascadesRule<P> {
     @Nonnull
     private static final BindingMatcher<RecordQueryPlan> innerPlanMatcher = anyPlan();
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushMapThroughFetchRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushMapThroughFetchRule.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRuleCall;
@@ -113,7 +114,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  *
  */
 @API(API.Status.EXPERIMENTAL)
-public class PushMapThroughFetchRule extends ImplementationCascadesRule<RecordQueryMapPlan> {
+public class PushMapThroughFetchRule extends AbstractCascadesRule<RecordQueryMapPlan> implements ImplementationCascadesRule<RecordQueryMapPlan> {
     @Nonnull
     private static final BindingMatcher<RecordQueryPlan> innerPlanMatcher = anyPlan();
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushReferencedFieldsThroughDistinctRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushReferencedFieldsThroughDistinctRule.java
@@ -21,7 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
-import com.apple.foundationdb.record.query.plan.cascades.CascadesRule;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.CascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.Reference;
 import com.apple.foundationdb.record.query.plan.cascades.PlannerRule.PreOrderRule;
@@ -46,7 +46,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  */
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("PMD.TooManyStaticImports")
-public class PushReferencedFieldsThroughDistinctRule extends CascadesRule<LogicalDistinctExpression> implements PreOrderRule {
+public class PushReferencedFieldsThroughDistinctRule extends AbstractCascadesRule<LogicalDistinctExpression> implements PreOrderRule {
     private static final BindingMatcher<Reference> lowerRefMatcher = ReferenceMatchers.anyRef();
     private static final BindingMatcher<Quantifier.ForEach> innerQuantifierMatcher = forEachQuantifierOverRef(lowerRefMatcher);
     private static final BindingMatcher<LogicalDistinctExpression> root =

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushReferencedFieldsThroughFilterRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushReferencedFieldsThroughFilterRule.java
@@ -21,7 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
-import com.apple.foundationdb.record.query.plan.cascades.CascadesRule;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.CascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.Reference;
 import com.apple.foundationdb.record.query.plan.cascades.PlannerRule.PreOrderRule;
@@ -52,7 +52,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  */
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("PMD.TooManyStaticImports")
-public class PushReferencedFieldsThroughFilterRule extends CascadesRule<LogicalFilterExpression> implements PreOrderRule {
+public class PushReferencedFieldsThroughFilterRule extends AbstractCascadesRule<LogicalFilterExpression> implements PreOrderRule {
     private static final BindingMatcher<Reference> lowerRefMatcher = ReferenceMatchers.anyRef();
     private static final BindingMatcher<Quantifier.ForEach> innerQuantifierMatcher = forEachQuantifierOverRef(lowerRefMatcher);
     private static final BindingMatcher<QueryPredicate> predicateMatcher = anyPredicate();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushReferencedFieldsThroughSelectRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushReferencedFieldsThroughSelectRule.java
@@ -21,7 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
-import com.apple.foundationdb.record.query.plan.cascades.CascadesRule;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.CascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.Reference;
 import com.apple.foundationdb.record.query.plan.cascades.PlannerRule.PreOrderRule;
@@ -52,7 +52,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  */
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("PMD.TooManyStaticImports")
-public class PushReferencedFieldsThroughSelectRule extends CascadesRule<SelectExpression> implements PreOrderRule {
+public class PushReferencedFieldsThroughSelectRule extends AbstractCascadesRule<SelectExpression> implements PreOrderRule {
     private static final BindingMatcher<Reference> lowerRefMatcher = ReferenceMatchers.anyRef();
     private static final BindingMatcher<Quantifier.ForEach> innerQuantifierMatcher = forEachQuantifierOverRef(lowerRefMatcher);
     private static final BindingMatcher<QueryPredicate> predicateMatcher = anyPredicate();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushReferencedFieldsThroughUniqueRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushReferencedFieldsThroughUniqueRule.java
@@ -21,7 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
-import com.apple.foundationdb.record.query.plan.cascades.CascadesRule;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.CascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.Reference;
 import com.apple.foundationdb.record.query.plan.cascades.PlannerRule.PreOrderRule;
@@ -46,7 +46,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  */
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("PMD.TooManyStaticImports")
-public class PushReferencedFieldsThroughUniqueRule extends CascadesRule<LogicalUniqueExpression> implements PreOrderRule {
+public class PushReferencedFieldsThroughUniqueRule extends AbstractCascadesRule<LogicalUniqueExpression> implements PreOrderRule {
     private static final BindingMatcher<Reference> lowerRefMatcher = ReferenceMatchers.anyRef();
     private static final BindingMatcher<Quantifier.ForEach> innerQuantifierMatcher = forEachQuantifierOverRef(lowerRefMatcher);
     private static final BindingMatcher<LogicalUniqueExpression> root =

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushRequestedOrderingThroughDeleteRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushRequestedOrderingThroughDeleteRule.java
@@ -21,7 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
-import com.apple.foundationdb.record.query.plan.cascades.CascadesRule;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.CascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.Reference;
 import com.apple.foundationdb.record.query.plan.cascades.PlannerRule.PreOrderRule;
@@ -42,7 +42,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  */
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("PMD.TooManyStaticImports")
-public class PushRequestedOrderingThroughDeleteRule extends CascadesRule<DeleteExpression> implements PreOrderRule {
+public class PushRequestedOrderingThroughDeleteRule extends AbstractCascadesRule<DeleteExpression> implements PreOrderRule {
     private static final BindingMatcher<Reference> lowerRefMatcher = ReferenceMatchers.anyRef();
     private static final BindingMatcher<Quantifier.ForEach> innerQuantifierMatcher = forEachQuantifierOverRef(lowerRefMatcher);
     private static final BindingMatcher<DeleteExpression> root =

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushRequestedOrderingThroughDistinctRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushRequestedOrderingThroughDistinctRule.java
@@ -21,7 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
-import com.apple.foundationdb.record.query.plan.cascades.CascadesRule;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.CascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.Reference;
 import com.apple.foundationdb.record.query.plan.cascades.PlannerRule.PreOrderRule;
@@ -43,7 +43,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  */
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("PMD.TooManyStaticImports")
-public class PushRequestedOrderingThroughDistinctRule extends CascadesRule<LogicalDistinctExpression> implements PreOrderRule {
+public class PushRequestedOrderingThroughDistinctRule extends AbstractCascadesRule<LogicalDistinctExpression> implements PreOrderRule {
     private static final BindingMatcher<Reference> lowerRefMatcher = ReferenceMatchers.anyRef();
     private static final BindingMatcher<Quantifier.ForEach> innerQuantifierMatcher = forEachQuantifierOverRef(lowerRefMatcher);
     private static final BindingMatcher<LogicalDistinctExpression> root =

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushRequestedOrderingThroughGroupByRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushRequestedOrderingThroughGroupByRule.java
@@ -22,7 +22,7 @@ package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.record.EvaluationContext;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
-import com.apple.foundationdb.record.query.plan.cascades.CascadesRule;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.CascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.OrderingPart.RequestedOrderingPart;
 import com.apple.foundationdb.record.query.plan.cascades.OrderingPart.RequestedSortOrder;
@@ -49,7 +49,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  * Rule that passes sorting requirements from {@code GROUP BY} expression downstream. This limits the search space of available
  * access paths to the ones having a compatible sort order allowing physical grouping operator later on to generate the correct results.
  */
-public class PushRequestedOrderingThroughGroupByRule extends CascadesRule<GroupByExpression> implements CascadesRule.PreOrderRule  {
+public class PushRequestedOrderingThroughGroupByRule extends AbstractCascadesRule<GroupByExpression> implements AbstractCascadesRule.PreOrderRule  {
 
     private static final BindingMatcher<Reference> lowerRefMatcher = ReferenceMatchers.anyRef();
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushRequestedOrderingThroughInLikeSelectRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushRequestedOrderingThroughInLikeSelectRule.java
@@ -21,7 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
-import com.apple.foundationdb.record.query.plan.cascades.CascadesRule;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.PlannerRule.PreOrderRule;
 import com.apple.foundationdb.record.query.plan.cascades.CascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
@@ -51,7 +51,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  */
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("PMD.TooManyStaticImports")
-public class PushRequestedOrderingThroughInLikeSelectRule extends CascadesRule<SelectExpression> implements PreOrderRule {
+public class PushRequestedOrderingThroughInLikeSelectRule extends AbstractCascadesRule<SelectExpression> implements PreOrderRule {
     private static final BindingMatcher<ExplodeExpression> explodeExpressionMatcher = explodeExpression();
     private static final CollectionMatcher<Quantifier.ForEach> explodeQuantifiersMatcher = some(forEachQuantifier(explodeExpressionMatcher));
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushRequestedOrderingThroughInsertRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushRequestedOrderingThroughInsertRule.java
@@ -22,7 +22,7 @@ package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
-import com.apple.foundationdb.record.query.plan.cascades.CascadesRule;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.CascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.Reference;
 import com.apple.foundationdb.record.query.plan.cascades.PlannerRule.PreOrderRule;
@@ -45,7 +45,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  */
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("PMD.TooManyStaticImports")
-public class PushRequestedOrderingThroughInsertRule extends CascadesRule<InsertExpression> implements PreOrderRule {
+public class PushRequestedOrderingThroughInsertRule extends AbstractCascadesRule<InsertExpression> implements PreOrderRule {
     private static final BindingMatcher<Reference> lowerRefMatcher = ReferenceMatchers.anyRef();
     private static final BindingMatcher<Quantifier.ForEach> innerQuantifierMatcher = forEachQuantifierOverRef(lowerRefMatcher);
     private static final BindingMatcher<InsertExpression> root =

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushRequestedOrderingThroughInsertTempTableRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushRequestedOrderingThroughInsertTempTableRule.java
@@ -22,7 +22,7 @@ package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
-import com.apple.foundationdb.record.query.plan.cascades.CascadesRule;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.CascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.PlannerRule.PreOrderRule;
 import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
@@ -45,7 +45,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  */
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("PMD.TooManyStaticImports")
-public class PushRequestedOrderingThroughInsertTempTableRule extends CascadesRule<TempTableInsertExpression> implements PreOrderRule {
+public class PushRequestedOrderingThroughInsertTempTableRule extends AbstractCascadesRule<TempTableInsertExpression> implements PreOrderRule {
     private static final BindingMatcher<Reference> lowerRefMatcher = ReferenceMatchers.anyRef();
     private static final BindingMatcher<Quantifier.ForEach> innerQuantifierMatcher = forEachQuantifierOverRef(lowerRefMatcher);
     private static final BindingMatcher<TempTableInsertExpression> root =

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushRequestedOrderingThroughRecursiveUnionRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushRequestedOrderingThroughRecursiveUnionRule.java
@@ -21,7 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
-import com.apple.foundationdb.record.query.plan.cascades.CascadesRule;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.CascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.PlannerRule.PreOrderRule;
 import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
@@ -45,7 +45,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  */
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("PMD.TooManyStaticImports")
-public class PushRequestedOrderingThroughRecursiveUnionRule extends CascadesRule<RecursiveUnionExpression> implements PreOrderRule {
+public class PushRequestedOrderingThroughRecursiveUnionRule extends AbstractCascadesRule<RecursiveUnionExpression> implements PreOrderRule {
 
     @Nonnull
     private static final BindingMatcher<Reference> initialRefMatcher = anyRef();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushRequestedOrderingThroughSelectExistentialRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushRequestedOrderingThroughSelectExistentialRule.java
@@ -21,7 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
-import com.apple.foundationdb.record.query.plan.cascades.CascadesRule;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.CascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.Reference;
 import com.apple.foundationdb.record.query.plan.cascades.PlannerRule.PreOrderRule;
@@ -45,7 +45,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  */
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("PMD.TooManyStaticImports")
-public class PushRequestedOrderingThroughSelectExistentialRule extends CascadesRule<SelectExpression> implements PreOrderRule {
+public class PushRequestedOrderingThroughSelectExistentialRule extends AbstractCascadesRule<SelectExpression> implements PreOrderRule {
     @Nonnull
     private static final BindingMatcher<Reference> lowerRefMatcher = ReferenceMatchers.anyRef();
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushRequestedOrderingThroughSelectRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushRequestedOrderingThroughSelectRule.java
@@ -21,8 +21,8 @@
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
-import com.apple.foundationdb.record.query.plan.cascades.CascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.CascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.Reference;
 import com.apple.foundationdb.record.query.plan.cascades.PlannerRule.PreOrderRule;
@@ -46,7 +46,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  */
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("PMD.TooManyStaticImports")
-public class PushRequestedOrderingThroughSelectRule extends CascadesRule<SelectExpression> implements PreOrderRule {
+public class PushRequestedOrderingThroughSelectRule extends AbstractCascadesRule<SelectExpression> implements PreOrderRule {
     @Nonnull
     private static final BindingMatcher<Reference> lowerRefMatcher = ReferenceMatchers.anyRef();
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushRequestedOrderingThroughSortRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushRequestedOrderingThroughSortRule.java
@@ -22,7 +22,7 @@ package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
-import com.apple.foundationdb.record.query.plan.cascades.CascadesRule;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.CascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.OrderingPart.RequestedOrderingPart;
 import com.apple.foundationdb.record.query.plan.cascades.PlannerRule.PreOrderRule;
@@ -49,7 +49,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  */
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("PMD.TooManyStaticImports")
-public class PushRequestedOrderingThroughSortRule extends CascadesRule<LogicalSortExpression> implements PreOrderRule {
+public class PushRequestedOrderingThroughSortRule extends AbstractCascadesRule<LogicalSortExpression> implements PreOrderRule {
     private static final BindingMatcher<Reference> lowerRefMatcher = ReferenceMatchers.anyRef();
     private static final BindingMatcher<Quantifier.ForEach> innerQuantifierMatcher = forEachQuantifierOverRef(lowerRefMatcher);
     private static final BindingMatcher<LogicalSortExpression> root =

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushRequestedOrderingThroughUnionRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushRequestedOrderingThroughUnionRule.java
@@ -21,7 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
-import com.apple.foundationdb.record.query.plan.cascades.CascadesRule;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.CascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.Reference;
 import com.apple.foundationdb.record.query.plan.cascades.PlannerRule.PreOrderRule;
@@ -50,7 +50,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  */
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("PMD.TooManyStaticImports")
-public class PushRequestedOrderingThroughUnionRule extends CascadesRule<LogicalUnionExpression> implements PreOrderRule {
+public class PushRequestedOrderingThroughUnionRule extends AbstractCascadesRule<LogicalUnionExpression> implements PreOrderRule {
     private static final BindingMatcher<Reference> lowerRefMatcher = ReferenceMatchers.anyRef();
     private static final BindingMatcher<Quantifier.ForEach> innerQuantifierMatcher = forEachQuantifierOverRef(lowerRefMatcher);
     private static final BindingMatcher<LogicalUnionExpression> root =

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushRequestedOrderingThroughUniqueRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushRequestedOrderingThroughUniqueRule.java
@@ -21,7 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
-import com.apple.foundationdb.record.query.plan.cascades.CascadesRule;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.CascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.Reference;
 import com.apple.foundationdb.record.query.plan.cascades.PlannerRule.PreOrderRule;
@@ -43,7 +43,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  */
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("PMD.TooManyStaticImports")
-public class PushRequestedOrderingThroughUniqueRule extends CascadesRule<LogicalUniqueExpression> implements PreOrderRule {
+public class PushRequestedOrderingThroughUniqueRule extends AbstractCascadesRule<LogicalUniqueExpression> implements PreOrderRule {
     private static final BindingMatcher<Reference> lowerRefMatcher = ReferenceMatchers.anyRef();
     private static final BindingMatcher<Quantifier.ForEach> innerQuantifierMatcher = forEachQuantifierOverRef(lowerRefMatcher);
     private static final BindingMatcher<LogicalUniqueExpression> root =

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushRequestedOrderingThroughUpdateRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushRequestedOrderingThroughUpdateRule.java
@@ -21,8 +21,8 @@
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
-import com.apple.foundationdb.record.query.plan.cascades.CascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.CascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.Reference;
 import com.apple.foundationdb.record.query.plan.cascades.PlannerRule.PreOrderRule;
@@ -44,7 +44,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  */
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("PMD.TooManyStaticImports")
-public class PushRequestedOrderingThroughUpdateRule extends CascadesRule<UpdateExpression> implements PreOrderRule {
+public class PushRequestedOrderingThroughUpdateRule extends AbstractCascadesRule<UpdateExpression> implements PreOrderRule {
     private static final BindingMatcher<Reference> lowerRefMatcher = ReferenceMatchers.anyRef();
     private static final BindingMatcher<Quantifier.ForEach> innerQuantifierMatcher = forEachQuantifierOverRef(lowerRefMatcher);
     private static final BindingMatcher<UpdateExpression> root =

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushSetOperationThroughFetchRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushSetOperationThroughFetchRule.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRuleCall;
@@ -126,7 +127,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  */
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("PMD.TooManyStaticImports")
-public class PushSetOperationThroughFetchRule<P extends RecordQuerySetPlan> extends ImplementationCascadesRule<P> {
+public class PushSetOperationThroughFetchRule<P extends RecordQuerySetPlan> extends AbstractCascadesRule<P> implements ImplementationCascadesRule<P> {
     @Nonnull
     private static final BindingMatcher<RecordQueryFetchFromPartialRecordPlan> fetchPlanMatcher =
             fetchFromPartialRecordPlan(anyPlan());

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushTypeFilterBelowFilterRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/PushTypeFilterBelowFilterRule.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
@@ -84,7 +85,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  */
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("PMD.TooManyStaticImports")
-public class PushTypeFilterBelowFilterRule extends ImplementationCascadesRule<RecordQueryTypeFilterPlan> {
+public class PushTypeFilterBelowFilterRule extends AbstractCascadesRule<RecordQueryTypeFilterPlan> implements ImplementationCascadesRule<RecordQueryTypeFilterPlan> {
     private static final BindingMatcher<? extends Reference> innerMatcher = anyRefOverOnlyPlans();
     private static final BindingMatcher<Quantifier.Physical> qunMatcher = physicalQuantifierOverRef(innerMatcher);
     private static final BindingMatcher<QueryPredicate> predMatcher = anyPredicate();

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/QueryPredicateSimplificationRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/QueryPredicateSimplificationRule.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ExplorationCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ExplorationCascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.Quantifiers;
@@ -90,7 +91,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  *  }</pre>
  */
 @SuppressWarnings({"PMD.TooManyStaticImports", "PMD.CompareObjectsWithEquals"})
-public class QueryPredicateSimplificationRule extends ExplorationCascadesRule<SelectExpression> {
+public class QueryPredicateSimplificationRule extends AbstractCascadesRule<SelectExpression> implements ExplorationCascadesRule<SelectExpression> {
     @Nonnull
     private static final CollectionMatcher<QueryPredicate> predicateMatcher = atLeastOne(anyPredicate());
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/RemoveProjectionRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/RemoveProjectionRule.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
@@ -41,7 +42,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  * if all fields needed by the projection are already available prior to the fetch.
  */
 @API(API.Status.EXPERIMENTAL)
-public class RemoveProjectionRule extends ImplementationCascadesRule<LogicalProjectionExpression> {
+public class RemoveProjectionRule extends AbstractCascadesRule<LogicalProjectionExpression> implements ImplementationCascadesRule<LogicalProjectionExpression> {
     @Nonnull
     private static final BindingMatcher<RecordQueryPlan> innerPlanMatcher = anyPlan();
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/RemoveRangeOneRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/RemoveRangeOneRule.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.ExplorationCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ExplorationCascadesRuleCall;
@@ -42,7 +43,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
 import static com.apple.foundationdb.record.query.plan.cascades.matching.structure.RelationalExpressionMatchers.tableFunctionExpression;
 
 @SuppressWarnings("PMD.TooManyStaticImports")
-public class RemoveRangeOneRule extends ExplorationCascadesRule<SelectExpression> {
+public class RemoveRangeOneRule extends AbstractCascadesRule<SelectExpression> implements ExplorationCascadesRule<SelectExpression> {
     @Nonnull
     private static final BindingMatcher<TableFunctionExpression> tfExpression = tableFunctionExpression();
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/RemoveSortRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/RemoveSortRule.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.LinkedIdentitySet;
@@ -59,7 +60,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  */
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("PMD.TooManyStaticImports")
-public class RemoveSortRule extends ImplementationCascadesRule<LogicalSortExpression> {
+public class RemoveSortRule extends AbstractCascadesRule<LogicalSortExpression> implements ImplementationCascadesRule<LogicalSortExpression> {
     @Nonnull
     private static final BindingMatcher<PlanPartition> innerPlanPartitionMatcher = PlanPartitionMatchers.anyPlanPartition();
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/RewriteOuterJoinRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/RewriteOuterJoinRule.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ExplorationCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.ExplorationCascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
@@ -65,7 +66,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  * directly into it (sharing its quantifiers and result value) instead of introducing another select box.
  */
 @API(API.Status.EXPERIMENTAL)
-public class RewriteOuterJoinRule extends ExplorationCascadesRule<OuterJoinExpression> {
+public class RewriteOuterJoinRule extends AbstractCascadesRule<OuterJoinExpression> implements ExplorationCascadesRule<OuterJoinExpression> {
 
     @Nonnull
     private static final BindingMatcher<OuterJoinExpression> root =

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/SelectMergeRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/SelectMergeRule.java
@@ -22,6 +22,7 @@ package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.record.query.combinatorics.TopologicalSort;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
 import com.apple.foundationdb.record.query.plan.cascades.ExpressionPartition;
 import com.apple.foundationdb.record.query.plan.cascades.ImplementationCascadesRule;
@@ -74,7 +75,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  * and (3) the child expression is a {@link SelectExpression} or a {@link LogicalFilterExpression}.
  */
 @SuppressWarnings("PMD.TooManyStaticImports")
-public class SelectMergeRule extends ImplementationCascadesRule<SelectExpression> {
+public class SelectMergeRule extends AbstractCascadesRule<SelectExpression> implements ImplementationCascadesRule<SelectExpression> {
     @Nonnull
     private static final BindingMatcher<RelationalExpressionWithPredicates> childExpressionMatcher = withPredicatesExpression();
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/SplitSelectExtractIndependentQuantifiersRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/rules/SplitSelectExtractIndependentQuantifiersRule.java
@@ -22,9 +22,10 @@ package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.query.combinatorics.PartiallyOrderedSet;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
-import com.apple.foundationdb.record.query.plan.cascades.ExplorationCascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.ExplorationCascadesRule;
+import com.apple.foundationdb.record.query.plan.cascades.ExplorationCascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.ExplodeExpression;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.SelectExpression;
@@ -70,7 +71,7 @@ import static com.apple.foundationdb.record.query.plan.cascades.matching.structu
  */
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("PMD.TooManyStaticImports")
-public class SplitSelectExtractIndependentQuantifiersRule extends ExplorationCascadesRule<SelectExpression> {
+public class SplitSelectExtractIndependentQuantifiersRule extends AbstractCascadesRule<SelectExpression> implements ExplorationCascadesRule<SelectExpression> {
     private static final BindingMatcher<ExplodeExpression> explodeExpressionMatcher = explodeExpression();
     private static final CollectionMatcher<Quantifier.ForEach> explodeQuantifiersMatcher = some(forEachQuantifier(explodeExpressionMatcher));
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryPlan.java
@@ -259,7 +259,7 @@ public interface RecordQueryPlan extends QueryPlan<FDBQueriedRecord<Message>>, P
         // of the experimental planner. However, they provide access to the underlying groups, which allow us to
         // substitute children without adding additional mutable access to the children of a query plan.
         // This makes some amount of conceptual sense, too, since we're performing the same kind of substitution
-        // that a CascadesRule would provide.
+        // that a AbstractCascadesRule would provide.
 
         for (Quantifier childQuantifier : getQuantifiers()) {
             if (!(childQuantifier instanceof Quantifier.Physical)) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/MemoExpressionTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/MemoExpressionTest.java
@@ -102,7 +102,7 @@ public class MemoExpressionTest {
 
     @Nonnull
     private static Memoizer createMemoizer(@Nonnull Reference root) {
-        CascadesRule<?> rule = new FinalizeExpressionsRule(); // doesn't matter for memoization
+        AbstractCascadesRule<?> rule = new FinalizeExpressionsRule(); // doesn't matter for memoization
         return new CascadesRuleCall(PlannerPhase.REWRITING, new FakePlanContext(), rule, root, Traversal.withRoot(root), new ArrayDeque<>(), PlannerBindings.empty(), EvaluationContext.empty());
     }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/RuleTestHelper.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/RuleTestHelper.java
@@ -138,12 +138,12 @@ public class RuleTestHelper {
     }
 
     @Nonnull
-    private final CascadesRule<? extends RelationalExpression> rule;
+    private final AbstractCascadesRule<? extends RelationalExpression> rule;
 
     @Nonnull
     private final PlannerPhase plannerPhase;
 
-    public RuleTestHelper(@Nonnull CascadesRule<? extends RelationalExpression> rule, @Nonnull PlannerPhase plannerPhase) {
+    public RuleTestHelper(@Nonnull AbstractCascadesRule<? extends RelationalExpression> rule, @Nonnull PlannerPhase plannerPhase) {
         this.rule = rule;
         this.plannerPhase = plannerPhase;
     }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/rules/TestRuleExecution.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/rules/TestRuleExecution.java
@@ -21,7 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.rules;
 
 import com.apple.foundationdb.record.EvaluationContext;
-import com.apple.foundationdb.record.query.plan.cascades.CascadesRule;
+import com.apple.foundationdb.record.query.plan.cascades.AbstractCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.CascadesRuleCall;
 import com.apple.foundationdb.record.query.plan.cascades.PlanContext;
 import com.apple.foundationdb.record.query.plan.cascades.PlannerPhase;
@@ -81,7 +81,7 @@ public class TestRuleExecution {
     }
 
     public static TestRuleExecution applyRule(@Nonnull PlanContext context,
-                                              @Nonnull CascadesRule<? extends RelationalExpression> rule,
+                                              @Nonnull AbstractCascadesRule<? extends RelationalExpression> rule,
                                               @Nonnull Reference group,
                                               @Nonnull final EvaluationContext evaluationContext,
                                               @Nonnull final PlannerPhase plannerPhase) {


### PR DESCRIPTION
Convert `CascadesRule`, `ExplorationCascadesRule`, and `ImplementationCascadesRule` from abstract classes to interfaces, and add a new `AbstractCascadesRule` abstract base class implementing `CascadesRule`. Concrete rules now extend `AbstractCascadesRule` and implement the appropriate rule-kind interface. This opens the door to rules that satisfy more than one kind.

The change is mechanical across the rule files. Type signatures that previously took `CascadesRule` and only carried concrete (i.e., `AbstractCascadesRule`-derived) instances are tightened to `AbstractCascadesRule`.