### PR TITLE
Change syntax to CREATE STORED QUERY

### DIFF
--- a/fdb-relational-core/src/main/antlr/RelationalParser.g4
+++ b/fdb-relational-core/src/main/antlr/RelationalParser.g4
@@ -91,7 +91,7 @@ utilityStatement
 
 templateClause
     :
-        CREATE ( structDefinition | tableDefinition | enumDefinition | indexDefinition | sqlInvokedFunction | viewDefinition | queryDefinition )
+        CREATE ( structDefinition | tableDefinition | enumDefinition | indexDefinition | sqlInvokedFunction | viewDefinition | storedQueryDefinition )
     ;
 
 createStatement
@@ -246,8 +246,8 @@ viewDefinition
     : VIEW viewName=fullId AS viewQuery=query
     ;
 
-queryDefinition
-    : QUERY queryName=uid declareBlock? AS storedQuery=query
+storedQueryDefinition
+    : STORED QUERY queryName=uid declareBlock? AS storedQuery=query
     ;
 
 declareBlock

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DdlVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DdlVisitor.java
@@ -414,8 +414,8 @@ public final class DdlVisitor extends DelegatingVisitor<BaseVisitor> {
                 sqlInvokedFunctionClauses.add(templateClause.sqlInvokedFunction());
             } else if (templateClause.viewDefinition() != null) {
                 viewClauses.add(templateClause.viewDefinition());
-            } else if (templateClause.queryDefinition() != null) {
-                final var queryCtx = templateClause.queryDefinition();
+            } else if (templateClause.storedQueryDefinition() != null) {
+                final var queryCtx = templateClause.storedQueryDefinition();
                 final var name = visitUid(queryCtx.queryName).getName();
                 final var sourceText = getDelegate().getPlanGenerationContext().getQuery();
                 final var start = queryCtx.storedQuery.start.getStartIndex();

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DelegatingVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DelegatingVisitor.java
@@ -305,8 +305,8 @@ public class DelegatingVisitor<D extends TypedVisitor> implements TypedVisitor {
     }
 
     @Override
-    public Object visitQueryDefinition(final RelationalParser.QueryDefinitionContext ctx) {
-        return getDelegate().visitQueryDefinition(ctx);
+    public Object visitStoredQueryDefinition(final RelationalParser.StoredQueryDefinitionContext ctx) {
+        return getDelegate().visitStoredQueryDefinition(ctx);
     }
 
     @Override

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/DelegatingVisitorTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/DelegatingVisitorTest.java
@@ -230,14 +230,14 @@ public class DelegatingVisitorTest {
     }
 
     @Test
-    void visitQueryDefinitionTest() {
-        testSimple("QUERY q AS SELECT * FROM table1",
-                RelationalParser::queryDefinition,
-                DelegatingVisitor::visitQueryDefinition,
+    void visitStoredQueryDefinitionTest() {
+        testSimple("STORED QUERY q AS SELECT * FROM table1",
+                RelationalParser::storedQueryDefinition,
+                DelegatingVisitor::visitStoredQueryDefinition,
                 called -> new BaseVisitor(new MutablePlanGenerationContext(PreparedParams.empty(), PlanHashable.PlanHashMode.VC0, "", "", 42),
                         generateMetadata(), NoOpQueryFactory.INSTANCE, NoOpMetadataOperationsFactory.INSTANCE, URI.create("/FDB/FRL1"), false) {
                     @Override
-                    public Object visitQueryDefinition(RelationalParser.QueryDefinitionContext ctx) {
+                    public Object visitStoredQueryDefinition(RelationalParser.StoredQueryDefinitionContext ctx) {
                         called.setTrue();
                         return null;
                     }

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/StoredQueriesTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/StoredQueriesTest.java
@@ -47,31 +47,31 @@ public class StoredQueriesTest {
     private static final String SCHEMA_TEMPLATE =
             "CREATE TABLE t1(id bigint, col1 bigint, col2 bigint, PRIMARY KEY(id))" +
                     " CREATE INDEX i1 AS SELECT col1 FROM t1" +
-                    " CREATE QUERY by_col1 AS select * from t1 where col1 = 10" +
-                    " CREATE QUERY by_id AS select * from t1 where id = 1";
+                    " CREATE STORED QUERY by_col1 AS select * from t1 where col1 = 10" +
+                    " CREATE STORED QUERY by_id AS select * from t1 where id = 1";
 
     /** Stored query body has a typo (`select1` rather than `select`) — DDL fails to parse. */
     private static final String SCHEMA_TEMPLATE_BAD_SYNTAX =
             "CREATE TABLE t1(id bigint, col1 bigint, col2 bigint, PRIMARY KEY(id))" +
-                    " CREATE QUERY by_col1 AS select1 * from t1 where col1 = 10";
+                    " CREATE STORED QUERY by_col1 AS select1 * from t1 where col1 = 10";
 
     /** Stored query body is itself a DDL statement — rejected by the grammar. */
     private static final String SCHEMA_TEMPLATE_DDL_IN_QUERY =
             "CREATE TABLE t1(id bigint, col1 bigint, col2 bigint, PRIMARY KEY(id))" +
-                    " CREATE QUERY ddl_t AS CREATE TABLE t2(id bigint, col1 bigint, PRIMARY KEY(id))";
+                    " CREATE STORED QUERY ddl_t AS CREATE TABLE t2(id bigint, col1 bigint, PRIMARY KEY(id))";
 
     /** Stored query references a column that does not exist on the table. */
     private static final String SCHEMA_TEMPLATE_BAD_COLUMN =
             "CREATE TABLE t1(id bigint, col1 bigint, col2 bigint, PRIMARY KEY(id))" +
                     " CREATE INDEX i1 AS SELECT col1 FROM t1" +
-                    " CREATE QUERY by_col1 AS select * from t1 where col3 = 10" + // col3 does not exit
-                    " CREATE QUERY by_id AS select * from t1 where id = 1";
+                    " CREATE STORED QUERY by_col1 AS select * from t1 where col3 = 10" + // col3 does not exit
+                    " CREATE STORED QUERY by_id AS select * from t1 where id = 1";
 
     /** One stored query whose body calls a single temp function. */
     private static final String SCHEMA_TEMPLATE_TF_SINGLE =
             "CREATE TABLE t1(id bigint, col1 bigint, col2 bigint, PRIMARY KEY(id))" +
                     " CREATE INDEX i1 AS SELECT col1 FROM t1" +
-                    " CREATE QUERY by_x" +
+                    " CREATE STORED QUERY by_x" +
                     "   DECLARE" +
                     "       FUNCTION sq1(in x bigint) AS (SELECT * FROM t1 WHERE col1 < 40 + x)" +
                     " AS SELECT * FROM sq1(10)";
@@ -82,7 +82,7 @@ public class StoredQueriesTest {
     private static final String SCHEMA_TEMPLATE_TF_CHAINED =
             "CREATE TABLE t1(id bigint, col1 bigint, col2 bigint, PRIMARY KEY(id))" +
                     " CREATE INDEX i1 AS SELECT col1 FROM t1" +
-                    " CREATE QUERY by_chained" +
+                    " CREATE STORED QUERY by_chained" +
                     "   DECLARE" +
                     "       FUNCTION sq1(in x bigint) AS (SELECT * FROM t1 WHERE col1 < x);" +
                     "       FUNCTION sq2(in x bigint) AS (SELECT * FROM sq1(x + 1))" +
@@ -92,11 +92,11 @@ public class StoredQueriesTest {
     private static final String SCHEMA_TEMPLATE_TF_BAD =
             "CREATE TABLE t1(id bigint, col1 bigint, col2 bigint, PRIMARY KEY(id))" +
                     " CREATE INDEX i1 AS SELECT col1 FROM t1" +
-                    " CREATE QUERY by_bad" +
+                    " CREATE STORED QUERY by_bad" +
                     "   DECLARE" +
                     "       FUNCTION sq_bad() AS (SELECT * FROM t1 WHERE col_does_not_exist = 1)" +
                     " AS SELECT * FROM sq_bad()" +
-                    " CREATE QUERY by_good" +
+                    " CREATE STORED QUERY by_good" +
                     "   DECLARE" +
                     "       FUNCTION sq_good() AS (SELECT * FROM t1 WHERE col1 = 10)" +
                     " AS SELECT * FROM sq_good()";
@@ -104,7 +104,7 @@ public class StoredQueriesTest {
     /** Typo in the temp-function keyword  — DDL fails to parse. */
     private static final String SCHEMA_TEMPLATE_TF_BAD_SYNTAX =
             "CREATE TABLE t1(id bigint, col1 bigint, col2 bigint, PRIMARY KEY(id))" +
-                    " CREATE QUERY by_x" +
+                    " CREATE STORED QUERY by_x" +
                     "   DECLARE" +
                     "       FUNCTION1 sq1(in x bigint) AS (SELECT * FROM t1 WHERE col1 < x)" +
                     " AS SELECT * FROM sq1(10)";

--- a/yaml-tests/src/test/resources/schema-template-stored-queries.yamsql
+++ b/yaml-tests/src/test/resources/schema-template-stored-queries.yamsql
@@ -17,7 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# NOTE: this test only covers the SYNTAX and execution of `CREATE QUERY` statements -
+# NOTE: this test only covers the SYNTAX and execution of `CREATE STORED QUERY` statements -
 # it does NOT verify the plan-cache warm-up that `OfflineStoredQueriesProcessor` performs.
 # The warm-up runs once, when the engine is constructed, against the templates already in
 # the catalog at that moment. yamsql tests create their schema template after the engine
@@ -36,20 +36,20 @@ schema_template:
     create index parentIdx as select parent, id from tree order by parent, id
     create table dept(id bigint, name string, primary key(id))
     create index deptName as select name from dept
-    create query by_col1 as select * from t1 where col1 = 1
-    create query by_id as select * from t1 where id = 1
-    create query syntax_with_temp_funcs
+    create stored query by_col1 as select * from t1 where col1 = 1
+    create stored query by_id as select * from t1 where id = 1
+    create stored query syntax_with_temp_funcs
         declare
             function helper1() as (select id from t1 where id = 1);
             function helper2(in x bigint) as (select id from t1 where id = x)
     as
         select id from t1 where id = 999
-    create query by_cte as with c1 as (select col1, col2 from t1) select col1, col2 from c1
-    create query tree_traversal as with recursive c1 as (
+    create stored query by_cte as with c1 as (select col1, col2 from t1) select col1, col2 from c1
+    create stored query tree_traversal as with recursive c1 as (
         select id, parent from tree where parent = -1
         union all
         select b.id, b.parent from c1 as a, tree as b where a.id = b.parent) select id from c1
-    create query by_dept_join as select t1.id, dept.name from t1 inner join dept on t1.col1 = dept.id
+    create stored query by_dept_join as select t1.id, dept.name from t1 inner join dept on t1.col1 = dept.id
 ---
 setup:
   steps:


### PR DESCRIPTION
Renames the recently-added `CREATE QUERY` DDL statement to `CREATE STORED QUERY` for clarity, as we discussed recently.

  - Grammar: `queryDefinition` rule now matches `STORED QUERY ...` and is renamed to `storedQueryDefinition` (RelationalParser.g4). No lexer change needed - `STORED` and `QUERY` tokens already exist.
  - Visitors: `DdlVisitor` and `DelegatingVisitor` updated for the renamed rule (`storedQueryDefinition()` / `visitStoredQueryDefinition` / `StoredQueryDefinitionContext`).
  - Tests: `StoredQueriesTest`, `DelegatingVisitorTest`, and `schema-template-stored-queries.yamsql` updated to the new syntax.
