### PR TITLE
Skip subproject tests during PRB if the code is unaffected

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -72,9 +72,9 @@ jobs:
       - name: Compute plan
         id: plan
         env:
-          # The subset of subprojects with their own `tests` matrix entry below. This is the
-          # one place that knowledge lives -- neither the Gradle task nor affected_subprojects.py
-          # need to know it. Keep in sync with the `tests` job's matrix list.
+          # The subset of subprojects that should be executed in their own job by the `tests` matrix.
+          # The `other-tests` and `coverage` steps below need to be kept in sync, the former to ensure that
+          # no subproject is tested twice, and the latter to ensure that we collect all coverage reports.
           MATRIX_CANDIDATES: '["fdb-extensions","fdb-record-layer-core","fdb-record-layer-lucene","yaml-tests"]'
         run: |
           python3 build/affected_subprojects.py subproject_deps.json \
@@ -229,39 +229,43 @@ jobs:
       - name: Check coverage report was generated
         id: coverage_report
         run: |
-          # codeCoverageReport has an onlyIf guard that skips it (not a failure) when none of its
-          # execution data files exist -- e.g. when the `plan` job determined nothing was affected,
-          # so `tests` and `other-tests` were both skipped and produced no JaCoCo data to merge.
-          if [[ -f .out/reports/jacoco/codeCoverageReport/codeCoverageReport.xml ]]; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
+          # If we skipped all of the tests, we may not have a code coverage report file, so skip
+          # the report if the file doesn't actually exist. However, while we're here, protect against
+          # a case where we should have generated a report but didn't by also overriding should_exist
+          # to true if any of the conditions that should have resulted in tests being run are true.
+          if [[ -f '${{ github.workspace }}/.out/reports/jacoco/codeCoverageReport/codeCoverageReport.xml'
+                || '${{ needs.plan.outputs.run_all }}' == 'true'
+                || '${{ needs.plan.outputs.matrix }}' != '[]'
+                || '${{ needs.plan.outputs.run_other_tests }}' == 'true' ] ; then
+            echo "should_exist=true" >> "$GITHUB_OUTPUT"
           else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "should_exist=false" >> "$GITHUB_OUTPUT"
             echo "### Coverage Note" >> "$GITHUB_STEP_SUMMARY"
             echo "No coverage report was generated: no subprojects were tested this run." >> "$GITHUB_STEP_SUMMARY"
           fi
       - name: Publish Coverage Report
-        if: steps.coverage_report.outputs.exists == 'true'
+        if: steps.coverage_report.outputs.should_exist == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-report
           path: |
             ${{ github.workspace }}/.out/reports/jacoco/codeCoverageReport/
       - name: Note Skipped Subprojects
-        if: steps.coverage_report.outputs.exists == 'true' && needs.plan.outputs.run_all != 'true'
+        if: steps.coverage_report.outputs.should_exist == 'true' && needs.plan.outputs.run_all != 'true'
         env:
           AFFECTED_SUBPROJECTS: ${{ needs.plan.outputs.affected }}
         run: |
           echo "### Coverage Note" >> "$GITHUB_STEP_SUMMARY"
           echo "Only subprojects affected by this PR's diff were tested this run: ${AFFECTED_SUBPROJECTS}" >> "$GITHUB_STEP_SUMMARY"
       - name: Get PR Diff
-        if: steps.coverage_report.outputs.exists == 'true'
+        if: steps.coverage_report.outputs.should_exist == 'true'
         run: |
           # `gh pr diff` uses the GitHub API .diff media type, which returns HTTP 406 once the diff exceeds
           # 20000 lines. Compute the same three-dot (merge-base..head) diff with git, which has no such limit;
           # fetch-depth: 0 on the checkout above ensures both commits and their merge-base are present.
           git diff "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" > pr_diff.patch
       - name: Annotate Coverage
-        if: steps.coverage_report.outputs.exists == 'true'
+        if: steps.coverage_report.outputs.should_exist == 'true'
         run: |
           python3 build/coverage_annotations.py \
             --report .out/reports/jacoco/codeCoverageReport/codeCoverageReport.xml \

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -103,13 +103,6 @@ jobs:
     strategy:
       matrix:
         subproject: ${{ fromJSON(needs.plan.outputs.matrix) }}
-        # fdb-extensions also runs its scalar-fallback test task here (not in the style job, which
-        # is test-free) so its JaCoCo execution data is produced alongside the other test tasks and
-        # picked up by the coverage-data upload below. matrix.extra_tasks is unset (empty) for the
-        # other subprojects.
-        include:
-          - subproject: fdb-extensions
-            extra_tasks: ':fdb-extensions:scalarFallbackTest'
     runs-on: ubuntu-latest
     permissions:
       checks: write
@@ -123,10 +116,20 @@ jobs:
         uses: ./actions/setup-base-env
       - name: Setup FDB
         uses: ./actions/setup-fdb
+      - name: Compute extra tasks
+        id: extra_tasks
+        run: |
+          # fdb-extensions also runs its scalar-fallback test task here (not in the style job, which
+          # is test-free) so its JaCoCo execution data is produced alongside the other test tasks and
+          # picked up by the coverage-data upload below. matrix.extra_tasks is unset (empty) for the
+          # other subprojects.
+          if [[ ${{ matrix.subproject }} == 'fdb-extensions' ]] ; then
+            echo "task=:fdb-extensions:scalarFallbackTest" >> "$GITHUB_OUTPUT"
+          fi
       - name: Run Gradle Test
         uses: ./actions/gradle-test
         with:
-          gradle_command: :${{ matrix.subproject }}:jar :${{ matrix.subproject }}:test :${{ matrix.subproject }}:destructiveTest ${{ matrix.extra_tasks }}
+          gradle_command: :${{ matrix.subproject }}:jar :${{ matrix.subproject }}:test :${{ matrix.subproject }}:destructiveTest ${{ steps.extra_tasks.task }}
           gradle_args: -PreleaseBuild=false -PpublishBuild=false
           report_name: ${{ matrix.subproject }}-test-reports
       - name: Publish Coverage Data

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -121,15 +121,14 @@ jobs:
         run: |
           # fdb-extensions also runs its scalar-fallback test task here (not in the style job, which
           # is test-free) so its JaCoCo execution data is produced alongside the other test tasks and
-          # picked up by the coverage-data upload below. matrix.extra_tasks is unset (empty) for the
-          # other subprojects.
+          # picked up by the coverage-data upload below.
           if [[ ${{ matrix.subproject }} == 'fdb-extensions' ]] ; then
             echo "task=:fdb-extensions:scalarFallbackTest" >> "$GITHUB_OUTPUT"
           fi
       - name: Run Gradle Test
         uses: ./actions/gradle-test
         with:
-          gradle_command: :${{ matrix.subproject }}:jar :${{ matrix.subproject }}:test :${{ matrix.subproject }}:destructiveTest ${{ steps.extra_tasks.task }}
+          gradle_command: :${{ matrix.subproject }}:jar :${{ matrix.subproject }}:test :${{ matrix.subproject }}:destructiveTest ${{ steps.extra_tasks.outputs.task }}
           gradle_args: -PreleaseBuild=false -PpublishBuild=false
           report_name: ${{ matrix.subproject }}-test-reports
       - name: Publish Coverage Data

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,12 +12,20 @@ jobs:
   #  1. style: Runs all checks on the build (including compilation static analysis) except the tests
   #     This allows us to catch anything related to build and style faster, as we don't have to wait
   #     on tests to complete. It also allows the test jobs to continue even if there's a style failure.
-  #  2. tests: Runs the tests for a subset of subprojects in parallel. These are the most intensive
+  #  2. plan: Computes which subprojects (and their transitive dependents) are affected by this PR's
+  #     changed files, using the subproject dependency graph exposed by the printDependentSubprojects
+  #     Gradle task. This lets jobs 3 and 4 skip subprojects that can't have been affected by the
+  #     diff, since those are the most expensive jobs in this workflow.
+  #  3. tests: Runs the tests for a subset of subprojects in parallel. These are the most intensive
   #     subprojects, so separating them out allows us to run those parts of the build in parallel, and
   #     it also allows us to ensure they get run even if there are failures in other subprojects,
-  #     giving us more insight into the types of test failures that a PR might have induced.
-  #  3. other-tests: Runs the rest of the tests. This tests all the remaining subprojects.
-  #  4. coverage: Merges the JaCoCo output of 2 and 3 and generates reports.
+  #     giving us more insight into the types of test failures that a PR might have induced. The
+  #     matrix is narrowed to the subprojects the `plan` job determined are affected; the whole job
+  #     is skipped if none of them are.
+  #  4. other-tests: Runs the rest of the tests. This tests all the remaining subprojects. Skipped
+  #     entirely if the `plan` job determined none of these subprojects are affected.
+  #  5. coverage: Merges the JaCoCo output of 3 and 4 and generates reports. Tolerates 3 and/or 4
+  #     having been skipped or having skipped some matrix legs.
 
   style:
     runs-on: ubuntu-latest
@@ -36,10 +44,65 @@ jobs:
         with:
           gradle_command: build -x test -x destructiveTest -x scalarFallbackTest -PreleaseBuild=false -PpublishBuild=false -PspotbugsEnableHtmlReport
 
+  plan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    timeout-minutes: 5
+    outputs:
+      run_all: ${{ steps.plan.outputs.run_all }}
+      affected: ${{ steps.plan.outputs.affected }}
+      matrix: ${{ steps.plan.outputs.matrix }}
+      run_other_tests: ${{ steps.plan.outputs.run_other_tests }}
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup Base Environment
+        uses: ./actions/setup-base-env
+      - name: Get Changed Files
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr diff ${{ github.event.pull_request.number }} --name-only | tee changed_files.txt
+      - name: Get subproject dependency graph
+        uses: ./actions/run-gradle
+        with:
+          gradle_command: printDependentSubprojects -PsubprojectDeps.output=subproject_deps.json
+      - name: Compute plan
+        id: plan
+        env:
+          # The subset of subprojects with their own `tests` matrix entry below. This is the
+          # one place that knowledge lives -- neither the Gradle task nor affected_subprojects.py
+          # need to know it. Keep in sync with the `tests` job's matrix list.
+          MATRIX_CANDIDATES: '["fdb-extensions","fdb-record-layer-core","fdb-record-layer-lucene","yaml-tests"]'
+        run: |
+          PLAN_JSON=$(python3 build/affected_subprojects.py subproject_deps.json \
+            --changed-files-file changed_files.txt)
+          echo "$PLAN_JSON"
+          echo "run_all=$(jq -r '.run_all' <<< "$PLAN_JSON")" >> "$GITHUB_OUTPUT"
+          echo "affected=$(jq -c '.affected' <<< "$PLAN_JSON")" >> "$GITHUB_OUTPUT"
+          echo "matrix=$(jq -cn --argjson candidates "$MATRIX_CANDIDATES" --argjson plan "$PLAN_JSON" \
+            'if $plan.run_all then $candidates else ($candidates - ($candidates - $plan.affected)) end')" >> "$GITHUB_OUTPUT"
+          echo "run_other_tests=$(jq -cn --argjson candidates "$MATRIX_CANDIDATES" --argjson plan "$PLAN_JSON" \
+            'if $plan.run_all then true else (($plan.affected - $candidates) | length) > 0 end')" >> "$GITHUB_OUTPUT"
+      - name: Summarize plan
+        run: |
+          echo "### CI Plan" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Based on the set of changed files, the following test plan made:" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Affected subprojects: `${{ steps.plan.outputs.affected }}`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Subprojects to test in individual jobs: `${{ steps.plan.outputs.matrix }}`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Remaining subprojects tested in a combined job: `${{ steps.plan.outputs.run_other_tests }}`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- All tests need to be run: `${{ steps.plan.outputs.run_all }}`" >> "$GITHUB_STEP_SUMMARY"
+
   tests:
+    needs: plan
+    if: needs.plan.outputs.matrix != '[]'
     strategy:
       matrix:
-        subproject: [fdb-extensions, fdb-record-layer-core, fdb-record-layer-lucene, yaml-tests]
+        subproject: ${{ fromJSON(needs.plan.outputs.matrix) }}
         # fdb-extensions also runs its scalar-fallback test task here (not in the style job, which
         # is test-free) so its JaCoCo execution data is produced alongside the other test tasks and
         # picked up by the coverage-data upload below. matrix.extra_tasks is unset (empty) for the
@@ -77,6 +140,8 @@ jobs:
           retention-days: 1
 
   other-tests:
+    needs: plan
+    if: needs.plan.outputs.run_other_tests == 'true'
     runs-on: ubuntu-latest
     permissions:
       checks: write
@@ -118,7 +183,12 @@ jobs:
           retention-days: 1
 
   coverage:
-    needs: [tests, other-tests]
+    needs: [plan, tests, other-tests]
+    if: >-
+      always() &&
+      needs.plan.result == 'success' &&
+      (needs.tests.result == 'success' || needs.tests.result == 'skipped') &&
+      (needs.other-tests.result == 'success' || needs.other-tests.result == 'skipped')
     runs-on: ubuntu-latest
     permissions:
       checks: write
@@ -137,22 +207,27 @@ jobs:
       # It looks like, if you try to download them all as a pattern, the nested directories get stripped
       # so the coverage data (for e.g. lucene) does not end up in the appropirate subproject directory
       - name: 'Download lucene'
+        if: contains(fromJSON(needs.plan.outputs.matrix), 'fdb-record-layer-lucene')
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
           name: fdb-record-layer-lucene-coverage-data
       - name: 'Download extensions'
+        if: contains(fromJSON(needs.plan.outputs.matrix), 'fdb-extensions')
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
           name: fdb-extensions-coverage-data
       - name: 'Download core'
+        if: contains(fromJSON(needs.plan.outputs.matrix), 'fdb-record-layer-core')
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
           name: fdb-record-layer-core-coverage-data
       - name: 'Download yaml'
+        if: contains(fromJSON(needs.plan.outputs.matrix), 'yaml-tests')
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
           name: yaml-tests-coverage-data
       - name: 'Download other'
+        if: needs.plan.outputs.run_other_tests == 'true'
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
           name: other-coverage-data
@@ -166,6 +241,13 @@ jobs:
           name: coverage-report
           path: |
             ${{ github.workspace }}/.out/reports/jacoco/codeCoverageReport/
+      - name: Note Skipped Subprojects
+        if: needs.plan.outputs.run_all != 'true'
+        env:
+          AFFECTED_SUBPROJECTS: ${{ needs.plan.outputs.affected }}
+        run: |
+          echo "### Coverage Note" >> "$GITHUB_STEP_SUMMARY"
+          echo "Only subprojects affected by this PR's diff were tested this run: ${AFFECTED_SUBPROJECTS}" >> "$GITHUB_STEP_SUMMARY"
       - name: Get PR Diff
         run: |
           # `gh pr diff` uses the GitHub API .diff media type, which returns HTTP 406 once the diff exceeds

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -77,25 +77,14 @@ jobs:
           # need to know it. Keep in sync with the `tests` job's matrix list.
           MATRIX_CANDIDATES: '["fdb-extensions","fdb-record-layer-core","fdb-record-layer-lucene","yaml-tests"]'
         run: |
-          PLAN_JSON=$(python3 build/affected_subprojects.py subproject_deps.json \
-            --changed-files-file changed_files.txt)
-          echo "$PLAN_JSON"
-          echo "run_all=$(jq -r '.run_all' <<< "$PLAN_JSON")" >> "$GITHUB_OUTPUT"
-          echo "affected=$(jq -c '.affected' <<< "$PLAN_JSON")" >> "$GITHUB_OUTPUT"
-          echo "matrix=$(jq -cn --argjson candidates "$MATRIX_CANDIDATES" --argjson plan "$PLAN_JSON" \
-            'if $plan.run_all then $candidates else ($candidates - ($candidates - $plan.affected)) end')" >> "$GITHUB_OUTPUT"
-          echo "run_other_tests=$(jq -cn --argjson candidates "$MATRIX_CANDIDATES" --argjson plan "$PLAN_JSON" \
-            'if $plan.run_all then true else (($plan.affected - $candidates) | length) > 0 end')" >> "$GITHUB_OUTPUT"
-      - name: Summarize plan
-        run: |
-          echo "### CI Plan" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "Based on the set of changed files, the following test plan made:" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Affected subprojects: `${{ steps.plan.outputs.affected }}`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Subprojects to test in individual jobs: `${{ steps.plan.outputs.matrix }}`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Remaining subprojects tested in a combined job: `${{ steps.plan.outputs.run_other_tests }}`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- All tests need to be run: `${{ steps.plan.outputs.run_all }}`" >> "$GITHUB_STEP_SUMMARY"
+          python3 build/affected_subprojects.py subproject_deps.json \
+            --changed-files-file changed_files.txt \
+            --matrix-candidates "$MATRIX_CANDIDATES" \
+            --output subproject_plan.json >> "$GITHUB_STEP_SUMMARY"
+          echo "run_all=$(jq -r '.run_all' subproject_plan.json)" >> "$GITHUB_OUTPUT"
+          echo "affected=$(jq -c '.affected' subproject_plan.json)" >> "$GITHUB_OUTPUT"
+          echo "matrix=$(jq -c '.matrix' subproject_plan.json)" >> "$GITHUB_OUTPUT"
+          echo "run_other_tests=$(jq -c '.run_other_tests' subproject_plan.json)" >> "$GITHUB_OUTPUT"
 
   tests:
     needs: plan
@@ -237,26 +226,42 @@ jobs:
         uses: ./actions/run-gradle
         with:
           gradle_command: codeCoverageReport
+      - name: Check coverage report was generated
+        id: coverage_report
+        run: |
+          # codeCoverageReport has an onlyIf guard that skips it (not a failure) when none of its
+          # execution data files exist -- e.g. when the `plan` job determined nothing was affected,
+          # so `tests` and `other-tests` were both skipped and produced no JaCoCo data to merge.
+          if [[ -f .out/reports/jacoco/codeCoverageReport/codeCoverageReport.xml ]]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "### Coverage Note" >> "$GITHUB_STEP_SUMMARY"
+            echo "No coverage report was generated: no subprojects were tested this run." >> "$GITHUB_STEP_SUMMARY"
+          fi
       - name: Publish Coverage Report
+        if: steps.coverage_report.outputs.exists == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-report
           path: |
             ${{ github.workspace }}/.out/reports/jacoco/codeCoverageReport/
       - name: Note Skipped Subprojects
-        if: needs.plan.outputs.run_all != 'true'
+        if: steps.coverage_report.outputs.exists == 'true' && needs.plan.outputs.run_all != 'true'
         env:
           AFFECTED_SUBPROJECTS: ${{ needs.plan.outputs.affected }}
         run: |
           echo "### Coverage Note" >> "$GITHUB_STEP_SUMMARY"
           echo "Only subprojects affected by this PR's diff were tested this run: ${AFFECTED_SUBPROJECTS}" >> "$GITHUB_STEP_SUMMARY"
       - name: Get PR Diff
+        if: steps.coverage_report.outputs.exists == 'true'
         run: |
           # `gh pr diff` uses the GitHub API .diff media type, which returns HTTP 406 once the diff exceeds
           # 20000 lines. Compute the same three-dot (merge-base..head) diff with git, which has no such limit;
           # fetch-depth: 0 on the checkout above ensures both commits and their merge-base are present.
           git diff "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" > pr_diff.patch
       - name: Annotate Coverage
+        if: steps.coverage_report.outputs.exists == 'true'
         run: |
           python3 build/coverage_annotations.py \
             --report .out/reports/jacoco/codeCoverageReport/codeCoverageReport.xml \

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -233,10 +233,10 @@ jobs:
           # the report if the file doesn't actually exist. However, while we're here, protect against
           # a case where we should have generated a report but didn't by also overriding should_exist
           # to true if any of the conditions that should have resulted in tests being run are true.
-          if [[ -f '${{ github.workspace }}/.out/reports/jacoco/codeCoverageReport/codeCoverageReport.xml'
-                || '${{ needs.plan.outputs.run_all }}' == 'true'
-                || '${{ needs.plan.outputs.matrix }}' != '[]'
-                || '${{ needs.plan.outputs.run_other_tests }}' == 'true' ] ; then
+          if [[ -f '${{ github.workspace }}/.out/reports/jacoco/codeCoverageReport/codeCoverageReport.xml' \
+                || '${{ needs.plan.outputs.run_all }}' == 'true' \
+                || '${{ needs.plan.outputs.matrix }}' != '[]' \
+                || '${{ needs.plan.outputs.run_other_tests }}' == 'true' ]] ; then
             echo "should_exist=true" >> "$GITHUB_OUTPUT"
           else
             echo "should_exist=false" >> "$GITHUB_OUTPUT"

--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,7 @@ fdb-relational-core/src/main/antlr/*.tokens
 /changed_files.txt
 /mixed-mode-results.md
 /subproject_deps.json
+/subproject_plan.json
 
 # AI assistant local analysis artifacts
 /claude-analysis/

--- a/.gitignore
+++ b/.gitignore
@@ -89,11 +89,16 @@ run/
 # Token files required for parsing Antlr files correctly in the IDE
 fdb-relational-core/src/main/antlr/*.tokens
 
-# output during release build process
+# Output during CI build processes
+/changed_files.txt
 /mixed-mode-results.md
+/subproject_deps.json
 
 # AI assistant local analysis artifacts
 /claude-analysis/
 
 # Claude Code local settings (personal permissions and hooks)
 .claude/settings.local.json
+
+# Byte-compiled Python, generated when running build/*.py scripts locally
+__pycache__/

--- a/build/affected_subprojects.py
+++ b/build/affected_subprojects.py
@@ -133,21 +133,71 @@ def map_changed_file_to_subproject(path: str, known_subprojects: Iterable[str]) 
     return top_level if top_level in known_subprojects else None
 
 
-def compute_affected(changed_files: list[str], subproject_deps: dict[str, list[str]]) -> dict:
+class TestPlan(object):
+    def __init__(self, known_subprojects: set[str], matrix_candidates: set[str]):
+        self.known_subprojects = known_subprojects
+        self.matrix_candidates = matrix_candidates
+        self.run_all = False
+        self.affected_subprojects = set()
+        self.unknown_paths = set()
+        self.reason = None
+        self.matrix = set()
+        self.run_other_tests = False
+
+    def to_dict(self) -> dict:
+        return {
+            'run_all': self.run_all,
+            'affected': sorted(self.affected_subprojects),
+            'unknown_paths': sorted(self.unknown_paths),
+            'reason': self.get_reason(),
+            'matrix': sorted(self.matrix),
+            'run_other_tests': self.run_other_tests,
+        }
+
+    def get_reason(self):
+        return self.reason or ('Detected changes affecting given subprojects' if self.run_all or self.affected_subprojects else 'No changes found requiring testing')
+
+    def set_run_all(self, reason: str):
+        self.run_all = True
+        self.affected_subprojects = set(self.known_subprojects)
+        self.matrix = set(self.matrix_candidates)
+        self.run_other_tests = True
+        self.reason = self.reason or reason
+
+    def mark_build_affecting(self):
+        self.set_run_all('Build affecting file modified')
+
+    def add_unknown_path(self, path: str):
+        self.unknown_paths.add(path)
+        self.set_run_all('Electing to run all tests as a file was modified with unknown impact')
+
+    def add_affected_subprojects(self, subprojects: iterable[str]):
+        self.affected_subprojects.update(subprojects)
+        for subproject in subprojects:
+            if subproject in self.matrix_candidates:
+                self.matrix.add(subproject)
+            else:
+                self.run_other_tests = True
+        self.run_all = self.run_all or len(self.known_subprojects) == len(self.affected_subprojects)
+
+
+def compute_plan(changed_files: list[str], subproject_deps: dict[str, list[str]], matrix_candidates: set[str]) -> TestPlan:
     """
-    Decide which subprojects are affected by a set of changed files, given the precomputed
-    subproject -> affected-subprojects mapping.
+    Compute a test plan based on the list of changed files. For each file, it decides what subprojects
+    are affected by it (based on the downstream dependency map). It also uses the `matrix_candidates`
+    set to determine in turn which jobs need to be run.
 
     Returns:
-        dict with keys 'run_all' and 'affected'.
+        An instance of TestPlan with a set of tests to run based on which subprojects were affected
     """
     known_subprojects = set(subproject_deps)
+    plan = TestPlan(known_subprojects, matrix_candidates)
 
     if any(is_build_affecting(path) for path in changed_files):
         # Modified file is part of the build. Run all tests to be conservative
-        return {'run_all': True, 'affected': sorted(known_subprojects)}
+        plan.mark_build_affecting()
+        return plan
 
-    affected: set[str] = set()
     for path in changed_files:
         if is_ignored(path):
             # Known ignored path. Continue.
@@ -155,47 +205,38 @@ def compute_affected(changed_files: list[str], subproject_deps: dict[str, list[s
 
         subproject = map_changed_file_to_subproject(path, known_subprojects)
         if subproject is None:
-            # Unknown file path. Fail safe.
-            return {'run_all': True, 'affected': sorted(known_subprojects)}
+            # File is not ignored but it is not in any known subproject. Note the unknown path
+            # and continue
+            plan.add_unknown_path(path)
         else:
             # Modified file is in a subproject. Register it and its downstream dependencies as affected.
             # If the file is not in a subproject (e.g., because it is docs or a readme), we ignore it.
-            affected.update(subproject_deps[subproject])
+            plan.add_affected_subprojects(subproject_deps[subproject])
 
-    return {'run_all': len(affected) == len(known_subprojects), 'affected': sorted(affected)}
-
-
-def compute_matrix_plan(plan: dict, matrix_candidates: Iterable[str]) -> dict:
-    """
-    Layer CI matrix planning on top of a base plan from compute_affected(): which of the fixed
-    set of subprojects with their own CI matrix leg need to run, and whether any other
-    (non-matrix) subproject also needs testing via a combined job.
-
-    Returns:
-        plan, with 'matrix' and 'run_other_tests' keys added.
-    """
-    candidates = set(matrix_candidates)
-    if plan['run_all']:
-        matrix, run_other_tests = sorted(candidates), True
-    else:
-        affected = set(plan['affected'])
-        matrix, run_other_tests = sorted(affected & candidates), bool(affected - candidates)
-    return {**plan, 'matrix': matrix, 'run_other_tests': run_other_tests}
+    return plan
 
 
-def render_markdown(plan: dict) -> str:
+def render_markdown(plan: TestPlan) -> str:
     """Render a plan as a human-readable Markdown summary, e.g. for a GitHub Actions step summary."""
     lines = [
         '### CI Plan',
         '',
         "Based on the set of changed files, the following test plan was made:",
         '',
-        f"- All tests need to be run: `{str(plan['run_all']).lower()}`",
-        f"- Affected subprojects: `{', '.join(plan['affected']) or '(none)'}`",
+        f"- Test plan justification: {plan.get_reason()}",
+        f"- All tests need to be run: `{str(plan.run_all).lower()}`",
+        f"- Affected subprojects: `{', '.join(sorted(plan.affected_subprojects)) or '(none)'}`",
     ]
-    if 'matrix' in plan:
-        lines.append(f"- Subprojects to test in individual jobs: `{', '.join(plan['matrix']) or '(none)'}`")
-        lines.append(f"- Remaining subprojects tested in a combined job: `{str(plan['run_other_tests']).lower()}`")
+    if plan.unknown_paths:
+        # Include the first 5 unknown paths in the summary. We want these logged so that the user
+        # has an idea about what files are causing this to run all, but we don't want to fill up
+        # summary with too many paths
+        unknown_path_str = ', '.join(sorted(plan.unknown_paths)[:5])
+        if len(plan.unknown_paths) > 5:
+            unknown_path_str = unknown_path_str + ', ...'
+        lines.append(f"- Paths from unknown subprojects: `{unknown_path_str}`")
+    lines.append(f"- Subprojects to test in individual jobs: `{', '.join(sorted(plan.matrix)) or '(none)'}`")
+    lines.append(f"- Remaining subprojects tested in a combined job: `{str(plan.run_other_tests).lower()}`")
     return '\n'.join(lines) + '\n'
 
 
@@ -216,27 +257,29 @@ def get_changed_files(changed_files_file: str | None, base_ref: str, head_ref: s
     return nonempty_stripped_lines(result.stdout.splitlines())
 
 
-def fail_safe_result(reason: str) -> dict:
-    """A conservative 'run everything' result, used when we can't determine the graph."""
+def fail_safe_result(reason: str, matrix_candidates: set[str]) -> TestPlan:
+    """A conservative 'run everything' result, used when we can't determine the graph or change set."""
     print(f'::warning::{reason} -- defaulting to running everything', file=sys.stderr)
-    return {'run_all': True, 'affected': []}
+    plan = TestPlan({}, matrix_candidates)
+    plan.set_run_all(reason)
+    return plan
 
 
-def determine_base_plan(args: argparse.Namespace) -> dict:
+def determine_plan(args: argparse.Namespace, matrix_candidates: set[str]) -> TestPlan:
     """Compute the base plan (before any matrix-specific layering), failing safe on any error."""
     try:
         with open(args.subproject_deps_file, encoding='utf-8') as f:
             subproject_deps = parse_subproject_deps(f.read())
     except (OSError, ValueError, json.JSONDecodeError) as e:
-        return fail_safe_result(f'Could not determine subproject dependency graph ({e})')
+        return fail_safe_result(f'Could not determine subproject dependency graph ({e})', matrix_candidates)
 
     try:
         changed_files = get_changed_files(
             args.changed_files_file, args.base_ref, args.head_ref, args.root_dir)
     except (OSError, subprocess.CalledProcessError) as e:
-        return fail_safe_result(f'Could not determine changed files ({e})')
+        return fail_safe_result(f'Could not determine changed files ({e})', matrix_candidates)
 
-    return compute_affected(changed_files, subproject_deps)
+    return compute_plan(changed_files, subproject_deps, matrix_candidates)
 
 
 def main(argv: list[str]) -> None:
@@ -265,12 +308,15 @@ def main(argv: list[str]) -> None:
                          help=f'Path to write the plan as JSON (default: {DEFAULT_OUTPUT_FILE})')
     args = parser.parse_args(argv)
 
-    plan = determine_base_plan(args)
     if args.matrix_candidates:
-        plan = compute_matrix_plan(plan, json.loads(args.matrix_candidates))
+        matrix_candidates = set(json.loads(args.matrix_candidates))
+    else:
+        matrix_candidates = set()
+
+    plan = determine_plan(args, matrix_candidates)
 
     with open(args.output, 'w', encoding='utf-8') as f:
-        json.dump(plan, f)
+        json.dump(plan.to_dict(), f)
     print(render_markdown(plan), end='')
 
 

--- a/build/affected_subprojects.py
+++ b/build/affected_subprojects.py
@@ -39,17 +39,20 @@ to any failure parsing the subproject dependency data or the changed-files list:
 safe to "run everything", never to "run nothing".
 
 Usage:
-    # In CI: subproject dependency data and changed-files list are precomputed.
+    # In CI: subproject dependency data and changed-files list are precomputed, and the CI-specific
+    # matrix legs are known, so the plan also reports which of them need to run.
     python build/affected_subprojects.py subproject_deps.json \
-        --changed-files-file changed_files.txt
+        --changed-files-file changed_files.txt \
+        --matrix-candidates '["fdb-extensions","fdb-record-layer-core","fdb-record-layer-lucene","yaml-tests"]'
 
     # Local dry run: diff against origin/main for changed files, using an already
     # generated subproject dependency graph, e.g. via
     # `./gradlew printDependentSubprojects -PsubprojectDeps.output=subproject_deps.json`.
     python build/affected_subprojects.py subproject_deps.json
 
-Output is a single-line JSON object to stdout:
-    {"run_all": false, "affected": [...]}
+The plan is written as JSON to --output (default: subproject_plan.json). A human-readable
+Markdown rendering of the same plan -- suitable for piping straight into a GitHub Actions step
+summary -- is printed to stdout.
 """
 
 import argparse
@@ -75,6 +78,9 @@ BUILD_AFFECTING_PREFIXES: list[str] = [
     'actions/',
     'build/',
 ]
+
+# Default path for the --output plan file; a build artifact, so it's gitignored.
+DEFAULT_OUTPUT_FILE = 'subproject_plan.json'
 
 
 def parse_subproject_deps(text: str) -> dict[str, list[str]]:
@@ -134,6 +140,40 @@ def compute_affected(changed_files: list[str], subproject_deps: dict[str, list[s
     return {'run_all': False, 'affected': sorted(affected)}
 
 
+def compute_matrix_plan(plan: dict, matrix_candidates: Iterable[str]) -> dict:
+    """
+    Layer CI matrix planning on top of a base plan from compute_affected(): which of the fixed
+    set of subprojects with their own CI matrix leg need to run, and whether any other
+    (non-matrix) subproject also needs testing via a combined job.
+
+    Returns:
+        plan, with 'matrix' and 'run_other_tests' keys added.
+    """
+    candidates = set(matrix_candidates)
+    if plan['run_all']:
+        matrix, run_other_tests = sorted(candidates), True
+    else:
+        affected = set(plan['affected'])
+        matrix, run_other_tests = sorted(affected & candidates), bool(affected - candidates)
+    return {**plan, 'matrix': matrix, 'run_other_tests': run_other_tests}
+
+
+def render_markdown(plan: dict) -> str:
+    """Render a plan as a human-readable Markdown summary, e.g. for a GitHub Actions step summary."""
+    lines = [
+        '### CI Plan',
+        '',
+        "Based on the set of changed files, the following test plan was made:",
+        '',
+        f"- All tests need to be run: `{str(plan['run_all']).lower()}`",
+        f"- Affected subprojects: `{', '.join(plan['affected']) or '(none)'}`",
+    ]
+    if 'matrix' in plan:
+        lines.append(f"- Subprojects to test in individual jobs: `{', '.join(plan['matrix']) or '(none)'}`")
+        lines.append(f"- Remaining subprojects tested in a combined job: `{str(plan['run_other_tests']).lower()}`")
+    return '\n'.join(lines) + '\n'
+
+
 def nonempty_stripped_lines(lines: Iterable[str]) -> list[str]:
     """Strip and return all non-empty lines from an iterable of lines."""
     return list(filter(bool, map(str.strip, lines)))
@@ -157,6 +197,23 @@ def fail_safe_result(reason: str) -> dict:
     return {'run_all': True, 'affected': []}
 
 
+def determine_base_plan(args: argparse.Namespace) -> dict:
+    """Compute the base plan (before any matrix-specific layering), failing safe on any error."""
+    try:
+        with open(args.subproject_deps_file, encoding='utf-8') as f:
+            subproject_deps = parse_subproject_deps(f.read())
+    except (OSError, ValueError, json.JSONDecodeError) as e:
+        return fail_safe_result(f'Could not determine subproject dependency graph ({e})')
+
+    try:
+        changed_files = get_changed_files(
+            args.changed_files_file, args.base_ref, args.head_ref, args.root_dir)
+    except (OSError, subprocess.CalledProcessError) as e:
+        return fail_safe_result(f'Could not determine changed files ({e})')
+
+    return compute_affected(changed_files, subproject_deps)
+
+
 def main(argv: list[str]) -> None:
     """Main entry point for the affected subprojects script."""
     parser = argparse.ArgumentParser(
@@ -174,23 +231,22 @@ def main(argv: list[str]) -> None:
                          help='Head ref for the local dry-run git diff fallback (default: HEAD)')
     parser.add_argument('--root-dir', default='.',
                          help='Repository root directory (default: current directory)')
+    parser.add_argument('--matrix-candidates',
+                         help='JSON array of subprojects that have their own CI matrix leg. If given, the '
+                              'plan additionally reports which of those need to run and whether any other '
+                              'subproject needs a combined test job -- a CI-specific concern that local dry '
+                              'runs can skip.')
+    parser.add_argument('-o', '--output', default=DEFAULT_OUTPUT_FILE,
+                         help=f'Path to write the plan as JSON (default: {DEFAULT_OUTPUT_FILE})')
     args = parser.parse_args(argv)
 
-    try:
-        with open(args.subproject_deps_file, encoding='utf-8') as f:
-            subproject_deps = parse_subproject_deps(f.read())
-    except (OSError, ValueError, json.JSONDecodeError) as e:
-        print(json.dumps(fail_safe_result(f'Could not determine subproject dependency graph ({e})')))
-        return
+    plan = determine_base_plan(args)
+    if args.matrix_candidates:
+        plan = compute_matrix_plan(plan, json.loads(args.matrix_candidates))
 
-    try:
-        changed_files = get_changed_files(
-            args.changed_files_file, args.base_ref, args.head_ref, args.root_dir)
-    except (OSError, subprocess.CalledProcessError) as e:
-        print(json.dumps(fail_safe_result(f'Could not determine changed files ({e})')))
-        return
-
-    print(json.dumps(compute_affected(changed_files, subproject_deps)))
+    with open(args.output, 'w', encoding='utf-8') as f:
+        json.dump(plan, f)
+    print(render_markdown(plan), end='')
 
 
 if __name__ == '__main__':

--- a/build/affected_subprojects.py
+++ b/build/affected_subprojects.py
@@ -32,11 +32,9 @@ computed here -- it's read from the output of the `printDependentSubprojects` Gr
 impact set (itself plus everything that depends on it). Keeping the graph traversal in
 Gradle means it can never drift out of sync with the real build.
 
-Any change that isn't clearly confined to a single known subproject -- e.g. a change to
-the root build files, the Gradle wrapper, shared CI actions, or a path this script
-doesn't recognize -- is treated conservatively as affecting everything. The same applies
-to any failure parsing the subproject dependency data or the changed-files list: fail
-safe to "run everything", never to "run nothing".
+Any change that is isolated to the build or not in an explicit ignore list is treated
+conservatively as affecting everything. The same applies to any failure parsing the subproject
+dependency data or the changed-files list: fail safe to "run everything", never to "run nothing".
 
 Usage:
     # In CI: subproject dependency data and changed-files list are precomputed, and the CI-specific
@@ -58,13 +56,13 @@ summary -- is printed to stdout.
 import argparse
 import json
 import os.path
+import re
 import subprocess
 import sys
 from collections.abc import Iterable
 
 # Paths that, if touched, mean we can't reason about affected subprojects from the
-# dependency graph alone -- e.g. changes to the build itself, the CI plumbing that
-# computes this very answer, or the Gradle wrapper. Treat any of these as "run
+# dependency graph alone -- e.g., changes to the build. Treat any of these as "run
 # everything". Entries are path prefixes (checked against '/'-joined repo-relative
 # paths), so a trailing '/' matches a whole directory.
 BUILD_AFFECTING_PREFIXES: list[str] = [
@@ -78,6 +76,21 @@ BUILD_AFFECTING_PREFIXES: list[str] = [
     'actions/',
     'build/',
 ]
+
+
+# Path patterns that, if touched, we can assume do *not* affect the build. Ignore
+# these paths. Note that as this script is itself not one of these patterns, to
+# update this list, it must be modified, the change merged on a PR which runs
+# all tests, and then that file pattern will be ignored on future builds.
+IGNORED_PATTERNS: list[re.Pattern] = list(map(re.compile, [
+    r'.*\.md$',
+    r'^\.gitignore$',
+    r'^\.idea\/.*',
+    r'^ACKNOWLEDGEMENTS$',
+    r'^LICENSE$',
+    r'^docs\/.*',
+]))
+
 
 # Default path for the --output plan file; a build artifact, so it's gitignored.
 DEFAULT_OUTPUT_FILE = 'subproject_plan.json'
@@ -102,6 +115,11 @@ def is_build_affecting(path: str) -> bool:
     """Whether a changed path means we should conservatively run everything."""
     return any(path == prefix or path.startswith(prefix)
                for prefix in BUILD_AFFECTING_PREFIXES)
+
+
+def is_ignored(path: str) -> bool:
+    """Whether a changed path should be ignored."""
+    return any(pattern.match(path) for pattern in IGNORED_PATTERNS)
 
 
 def map_changed_file_to_subproject(path: str, known_subprojects: Iterable[str]) -> str | None:
@@ -131,13 +149,20 @@ def compute_affected(changed_files: list[str], subproject_deps: dict[str, list[s
 
     affected: set[str] = set()
     for path in changed_files:
+        if is_ignored(path):
+            # Known ignored path. Continue.
+            continue
+
         subproject = map_changed_file_to_subproject(path, known_subprojects)
-        if subproject is not None:
+        if subproject is None:
+            # Unknown file path. Fail safe.
+            return {'run_all': True, 'affected': sorted(known_subprojects)}
+        else:
             # Modified file is in a subproject. Register it and its downstream dependencies as affected.
             # If the file is not in a subproject (e.g., because it is docs or a readme), we ignore it.
             affected.update(subproject_deps[subproject])
 
-    return {'run_all': False, 'affected': sorted(affected)}
+    return {'run_all': len(affected) == len(known_subprojects), 'affected': sorted(affected)}
 
 
 def compute_matrix_plan(plan: dict, matrix_candidates: Iterable[str]) -> dict:

--- a/build/affected_subprojects.py
+++ b/build/affected_subprojects.py
@@ -154,13 +154,13 @@ class TestPlan(object):
             'run_other_tests': self.run_other_tests,
         }
 
-    def get_reason(self):
+    def get_reason(self) -> str:
         return self.reason or ('Detected changes affecting given subprojects' if self.run_all or self.affected_subprojects else 'No changes found requiring testing')
 
     def set_run_all(self, reason: str):
         self.run_all = True
-        self.affected_subprojects = set(self.known_subprojects)
-        self.matrix = set(self.matrix_candidates)
+        self.affected_subprojects.update(self.known_subprojects)
+        self.matrix.update(self.matrix_candidates)
         self.run_other_tests = True
         self.reason = self.reason or reason
 

--- a/build/affected_subprojects.py
+++ b/build/affected_subprojects.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+
+#
+# affected_subprojects.py
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Determine which Gradle subprojects are affected by a pull request's changed files,
+so that CI can skip expensive per-subproject test jobs for subprojects that couldn't
+possibly have been affected.
+
+A subproject is "affected" if it was changed directly, or if it (transitively) depends
+on a subproject that was changed. The subproject-to-affected-subprojects mapping is not
+computed here -- it's read from the output of the `printDependentSubprojects` Gradle task
+(see gradle/root.gradle), which precomputes, for every subproject, the full transitive
+impact set (itself plus everything that depends on it). Keeping the graph traversal in
+Gradle means it can never drift out of sync with the real build.
+
+Any change that isn't clearly confined to a single known subproject -- e.g. a change to
+the root build files, the Gradle wrapper, shared CI actions, or a path this script
+doesn't recognize -- is treated conservatively as affecting everything. The same applies
+to any failure parsing the subproject dependency data or the changed-files list: fail
+safe to "run everything", never to "run nothing".
+
+Usage:
+    # In CI: subproject dependency data and changed-files list are precomputed.
+    python build/affected_subprojects.py subproject_deps.json \
+        --changed-files-file changed_files.txt
+
+    # Local dry run: diff against origin/main for changed files, using an already
+    # generated subproject dependency graph, e.g. via
+    # `./gradlew printDependentSubprojects -PsubprojectDeps.output=subproject_deps.json`.
+    python build/affected_subprojects.py subproject_deps.json
+
+Output is a single-line JSON object to stdout:
+    {"run_all": false, "affected": [...]}
+"""
+
+import argparse
+import json
+import os.path
+import subprocess
+import sys
+from collections.abc import Iterable
+
+# Paths that, if touched, mean we can't reason about affected subprojects from the
+# dependency graph alone -- e.g. changes to the build itself, the CI plumbing that
+# computes this very answer, or the Gradle wrapper. Treat any of these as "run
+# everything". Entries are path prefixes (checked against '/'-joined repo-relative
+# paths), so a trailing '/' matches a whole directory.
+BUILD_AFFECTING_PREFIXES: list[str] = [
+    'build.gradle',
+    'settings.gradle',
+    'gradle.properties',
+    'gradle/',
+    'gradlew',
+    'gradlew.bat',
+    '.github/workflows/pull_request.yml',
+    'actions/',
+    'build/',
+]
+
+
+def parse_subproject_deps(text: str) -> dict[str, list[str]]:
+    """
+    Parse the output of the `printDependentSubprojects` Gradle task: a JSON object mapping
+    each subproject name to the sorted list of subprojects affected by a change to it
+    (itself plus every transitive dependent).
+    """
+    data = json.loads(text)
+    if not isinstance(data, dict) or not data:
+        raise ValueError('Subproject dependency data must be a non-empty JSON object')
+    for subproject, affected in data.items():
+        if not isinstance(subproject, str) or not isinstance(affected, list):
+            raise ValueError(f'Malformed subproject dependency entry: {subproject!r}: {affected!r}')
+    return data
+
+
+def is_build_affecting(path: str) -> bool:
+    """Whether a changed path means we should conservatively run everything."""
+    return any(path == prefix or path.startswith(prefix)
+               for prefix in BUILD_AFFECTING_PREFIXES)
+
+
+def map_changed_file_to_subproject(path: str, known_subprojects: Iterable[str]) -> str | None:
+    """
+    Map a repo-relative changed file path to the subproject it belongs to, based on its
+    top-level path component. Returns None if the path isn't under any known subproject.
+    """
+    head, top_level = path, ''
+    while head:
+        head, top_level = os.path.split(head)
+    return top_level if top_level in known_subprojects else None
+
+
+def compute_affected(changed_files: list[str], subproject_deps: dict[str, list[str]]) -> dict:
+    """
+    Decide which subprojects are affected by a set of changed files, given the precomputed
+    subproject -> affected-subprojects mapping.
+
+    Returns:
+        dict with keys 'run_all' and 'affected'.
+    """
+    known_subprojects = set(subproject_deps)
+
+    if any(is_build_affecting(path) for path in changed_files):
+        # Modified file is part of the build. Run all tests to be conservative
+        return {'run_all': True, 'affected': sorted(known_subprojects)}
+
+    affected: set[str] = set()
+    for path in changed_files:
+        subproject = map_changed_file_to_subproject(path, known_subprojects)
+        if subproject is not None:
+            # Modified file is in a subproject. Register it and its downstream dependencies as affected.
+            # If the file is not in a subproject (e.g., because it is docs or a readme), we ignore it.
+            affected.update(subproject_deps[subproject])
+
+    return {'run_all': False, 'affected': sorted(affected)}
+
+
+def nonempty_stripped_lines(lines: Iterable[str]) -> list[str]:
+    """Strip and return all non-empty lines from an iterable of lines."""
+    return list(filter(bool, map(str.strip, lines)))
+
+
+def get_changed_files(changed_files_file: str | None, base_ref: str, head_ref: str,
+                       root_dir: str) -> list[str]:
+    """Get the list of changed repo-relative file paths, from a file or from git."""
+    if changed_files_file:
+        with open(changed_files_file, encoding='utf-8') as f:
+            return nonempty_stripped_lines(f)
+    result = subprocess.run(
+        ['git', 'diff', '--name-only', f'{base_ref}...{head_ref}'],
+        cwd=root_dir, capture_output=True, text=True, check=True)
+    return nonempty_stripped_lines(result.stdout.splitlines())
+
+
+def fail_safe_result(reason: str) -> dict:
+    """A conservative 'run everything' result, used when we can't determine the graph."""
+    print(f'::warning::{reason} -- defaulting to running everything', file=sys.stderr)
+    return {'run_all': True, 'affected': []}
+
+
+def main(argv: list[str]) -> None:
+    """Main entry point for the affected subprojects script."""
+    parser = argparse.ArgumentParser(
+        prog='affected_subprojects',
+        description='Determine which Gradle subprojects are affected by a set of changed files'
+    )
+    parser.add_argument('subproject_deps_file',
+                         help='Path to the output of the printDependentSubprojects Gradle task.')
+    parser.add_argument('--changed-files-file',
+                         help='Path to a newline-separated list of changed repo-relative paths. '
+                              'If omitted, uses `git diff --name-only <base>...<head>`.')
+    parser.add_argument('--base-ref', default='origin/main',
+                         help='Base ref for the local dry-run git diff fallback (default: origin/main)')
+    parser.add_argument('--head-ref', default='HEAD',
+                         help='Head ref for the local dry-run git diff fallback (default: HEAD)')
+    parser.add_argument('--root-dir', default='.',
+                         help='Repository root directory (default: current directory)')
+    args = parser.parse_args(argv)
+
+    try:
+        with open(args.subproject_deps_file, encoding='utf-8') as f:
+            subproject_deps = parse_subproject_deps(f.read())
+    except (OSError, ValueError, json.JSONDecodeError) as e:
+        print(json.dumps(fail_safe_result(f'Could not determine subproject dependency graph ({e})')))
+        return
+
+    try:
+        changed_files = get_changed_files(
+            args.changed_files_file, args.base_ref, args.head_ref, args.root_dir)
+    except (OSError, subprocess.CalledProcessError) as e:
+        print(json.dumps(fail_safe_result(f'Could not determine changed files ({e})')))
+        return
+
+    print(json.dumps(compute_affected(changed_files, subproject_deps)))
+
+
+if __name__ == '__main__':
+    main(sys.argv[1:])

--- a/build/affected_subprojects.py
+++ b/build/affected_subprojects.py
@@ -171,7 +171,7 @@ class TestPlan(object):
         self.unknown_paths.add(path)
         self.set_run_all('Electing to run all tests as a file was modified with unknown impact')
 
-    def add_affected_subprojects(self, subprojects: iterable[str]):
+    def add_affected_subprojects(self, subprojects: Iterable[str]):
         self.affected_subprojects.update(subprojects)
         for subproject in subprojects:
             if subproject in self.matrix_candidates:

--- a/build/test_affected_subprojects.py
+++ b/build/test_affected_subprojects.py
@@ -31,9 +31,11 @@ import unittest
 sys.path.insert(0, os.path.dirname(__file__))
 from affected_subprojects import (
     compute_affected,
+    compute_matrix_plan,
     is_build_affecting,
     map_changed_file_to_subproject,
     parse_subproject_deps,
+    render_markdown,
 )
 
 # A trimmed-down but shape-accurate stand-in for the real printDependentSubprojects output:
@@ -190,6 +192,69 @@ class TestComputeAffected(unittest.TestCase):
         self.assertEqual(result['affected'], [])
 
 
+class TestComputeMatrixPlan(unittest.TestCase):
+    """Tests for compute_matrix_plan()"""
+
+    MATRIX_CANDIDATES = ['fdb-extensions', 'fdb-record-layer-core', 'fdb-record-layer-lucene', 'yaml-tests']
+
+    def test_run_all_selects_every_candidate(self):
+        plan = compute_matrix_plan({'run_all': True, 'affected': []}, self.MATRIX_CANDIDATES)
+        self.assertEqual(plan['matrix'], sorted(self.MATRIX_CANDIDATES))
+        self.assertTrue(plan['run_other_tests'])
+
+    def test_affected_confined_to_candidates(self):
+        plan = compute_matrix_plan(
+            {'run_all': False, 'affected': ['fdb-record-layer-lucene']}, self.MATRIX_CANDIDATES)
+        self.assertEqual(plan['matrix'], ['fdb-record-layer-lucene'])
+        self.assertFalse(plan['run_other_tests'])
+
+    def test_affected_outside_candidates_needs_other_tests(self):
+        plan = compute_matrix_plan(
+            {'run_all': False, 'affected': ['fdb-relational-api']}, self.MATRIX_CANDIDATES)
+        self.assertEqual(plan['matrix'], [])
+        self.assertTrue(plan['run_other_tests'])
+
+    def test_no_affected_subprojects(self):
+        plan = compute_matrix_plan({'run_all': False, 'affected': []}, self.MATRIX_CANDIDATES)
+        self.assertEqual(plan['matrix'], [])
+        self.assertFalse(plan['run_other_tests'])
+
+    def test_preserves_base_plan_keys(self):
+        plan = compute_matrix_plan({'run_all': False, 'affected': ['yaml-tests']}, self.MATRIX_CANDIDATES)
+        self.assertEqual(plan['run_all'], False)
+        self.assertEqual(plan['affected'], ['yaml-tests'])
+
+
+class TestRenderMarkdown(unittest.TestCase):
+    """Tests for render_markdown()"""
+
+    def test_renders_base_plan_without_matrix_fields(self):
+        text = render_markdown({'run_all': True, 'affected': ['fdb-record-layer-lucene']})
+        self.assertIn('### CI Plan', text)
+        self.assertIn('All tests need to be run: `true`', text)
+        self.assertIn('Affected subprojects: `fdb-record-layer-lucene`', text)
+        self.assertNotIn('individual jobs', text)
+
+    def test_renders_matrix_fields_when_present(self):
+        text = render_markdown({
+            'run_all': False,
+            'affected': ['fdb-record-layer-lucene'],
+            'matrix': ['fdb-record-layer-lucene'],
+            'run_other_tests': False,
+        })
+        self.assertIn('Subprojects to test in individual jobs: `fdb-record-layer-lucene`', text)
+        self.assertIn('Remaining subprojects tested in a combined job: `false`', text)
+
+    def test_renders_none_placeholder_for_empty_lists(self):
+        text = render_markdown({'run_all': False, 'affected': []})
+        self.assertIn('Affected subprojects: `(none)`', text)
+
+    def test_output_ends_with_single_newline(self):
+        text = render_markdown({'run_all': False, 'affected': []})
+        self.assertTrue(text.endswith('\n'))
+        self.assertFalse(text.endswith('\n\n'))
+
+
 class TestMainEndToEnd(unittest.TestCase):
     """End-to-end tests using main() against fixture files, with captured output."""
 
@@ -204,9 +269,14 @@ class TestMainEndToEnd(unittest.TestCase):
         self.changed_file.write('fdb-record-layer-lucene/src/main/java/Foo.java\n')
         self.changed_file.close()
 
+        self.output_file = tempfile.NamedTemporaryFile(
+            mode='w', suffix='.json', delete=False)
+        self.output_file.close()
+
     def tearDown(self):
         os.unlink(self.deps_file.name)
         os.unlink(self.changed_file.name)
+        os.unlink(self.output_file.name)
 
     def test_main_runs_without_error(self):
         from io import StringIO
@@ -215,9 +285,12 @@ class TestMainEndToEnd(unittest.TestCase):
         from affected_subprojects import main
 
         with patch('sys.stdout', new_callable=StringIO) as mock_out:
-            main([self.deps_file.name, '--changed-files-file', self.changed_file.name])
+            main([self.deps_file.name, '--changed-files-file', self.changed_file.name,
+                  '--output', self.output_file.name])
 
-        result = json.loads(mock_out.getvalue())
+        self.assertIn('### CI Plan', mock_out.getvalue())
+        with open(self.output_file.name, encoding='utf-8') as f:
+            result = json.load(f)
         self.assertFalse(result['run_all'])
         self.assertEqual(result['affected'], ['fdb-record-layer-lucene'])
 
@@ -227,12 +300,31 @@ class TestMainEndToEnd(unittest.TestCase):
 
         from affected_subprojects import main
 
-        with patch('sys.stdout', new_callable=StringIO) as mock_out:
+        with patch('sys.stdout', new_callable=StringIO):
             main(['/nonexistent/path/subproject_deps.json',
-                  '--changed-files-file', self.changed_file.name])
+                  '--changed-files-file', self.changed_file.name,
+                  '--output', self.output_file.name])
 
-        result = json.loads(mock_out.getvalue())
+        with open(self.output_file.name, encoding='utf-8') as f:
+            result = json.load(f)
         self.assertTrue(result['run_all'])
+
+    def test_main_with_matrix_candidates(self):
+        from io import StringIO
+        from unittest.mock import patch
+
+        from affected_subprojects import main
+
+        with patch('sys.stdout', new_callable=StringIO) as mock_out:
+            main([self.deps_file.name, '--changed-files-file', self.changed_file.name,
+                  '--matrix-candidates', '["fdb-record-layer-lucene", "yaml-tests"]',
+                  '--output', self.output_file.name])
+
+        self.assertIn('individual jobs', mock_out.getvalue())
+        with open(self.output_file.name, encoding='utf-8') as f:
+            result = json.load(f)
+        self.assertEqual(result['matrix'], ['fdb-record-layer-lucene'])
+        self.assertFalse(result['run_other_tests'])
 
 
 if __name__ == '__main__':

--- a/build/test_affected_subprojects.py
+++ b/build/test_affected_subprojects.py
@@ -107,6 +107,12 @@ class TestIsBuildAffecting(unittest.TestCase):
     def test_settings_gradle(self):
         self.assertTrue(is_build_affecting('settings.gradle'))
 
+    def test_project_gradle(self):
+        # Individual project gradle files are not build affecting. They only affect their
+        # subproject (and downstream dependencies), and so this doesn't need to result
+        # in a full retest of everything
+        self.assertFalse(is_build_affecting('fdb-record-layer-core/fdb-record-layer-core.gradle'))
+
     def test_gradle_directory(self):
         self.assertTrue(is_build_affecting('gradle/testing.gradle'))
 
@@ -245,6 +251,11 @@ class TestComputeAffected(unittest.TestCase):
             set(result['affected']),
             set(SAMPLE_AFFECTED_MAP['fdb-record-layer-lucene'])
             | set(SAMPLE_AFFECTED_MAP['fdb-relational-api']))
+
+    def test_project_gradle_affected_sets(self):
+        result = compute_affected(['fdb-relational-core/fdb-relational-core.gradle'], SAMPLE_AFFECTED_MAP)
+        self.assertFalse(result['run_all'])
+        self.assertEqual(result['affected'], SAMPLE_AFFECTED_MAP['fdb-relational-core'])
 
     def test_no_changed_files(self):
         result = compute_affected([], SAMPLE_AFFECTED_MAP)

--- a/build/test_affected_subprojects.py
+++ b/build/test_affected_subprojects.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+
+#
+# test_affected_subprojects.py
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Unit tests for affected_subprojects.py"""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(__file__))
+from affected_subprojects import (
+    compute_affected,
+    is_build_affecting,
+    map_changed_file_to_subproject,
+    parse_subproject_deps,
+)
+
+# A trimmed-down but shape-accurate stand-in for the real printDependentSubprojects output:
+# leaf subprojects, a core subproject most things depend on, and a couple of subprojects that
+# only depend on core. Each value is the precomputed transitive impact set (subproject itself
+# plus everything that depends on it) that the real Gradle task would compute.
+SAMPLE_AFFECTED_MAP = {
+    'fdb-java-annotations': [
+        'fdb-extensions', 'fdb-java-annotations', 'fdb-record-layer-core',
+        'fdb-record-layer-lucene', 'fdb-relational-api', 'fdb-relational-core', 'yaml-tests',
+    ],
+    'fdb-test-utils': [
+        'fdb-extensions', 'fdb-record-layer-core', 'fdb-record-layer-lucene',
+        'fdb-relational-api', 'fdb-relational-core', 'fdb-test-utils', 'yaml-tests',
+    ],
+    'fdb-extensions': [
+        'fdb-extensions', 'fdb-record-layer-core', 'fdb-record-layer-lucene',
+        'fdb-relational-api', 'fdb-relational-core', 'yaml-tests',
+    ],
+    'fdb-record-layer-core': [
+        'fdb-record-layer-core', 'fdb-record-layer-lucene', 'fdb-relational-core', 'yaml-tests',
+    ],
+    'fdb-record-layer-lucene': ['fdb-record-layer-lucene'],
+    'fdb-relational-api': ['fdb-relational-api', 'fdb-relational-core', 'yaml-tests'],
+    'fdb-relational-core': ['fdb-relational-core', 'yaml-tests'],
+    'yaml-tests': ['yaml-tests'],
+}
+
+SAMPLE_AFFECTED_MAP_TEXT = json.dumps(SAMPLE_AFFECTED_MAP)
+
+ALL_SUBPROJECTS = set(SAMPLE_AFFECTED_MAP)
+
+
+class TestParseSubprojectDeps(unittest.TestCase):
+    """Tests for parse_subproject_deps()"""
+
+    def test_parses_all_subprojects(self):
+        result = parse_subproject_deps(SAMPLE_AFFECTED_MAP_TEXT)
+        self.assertEqual(set(result), ALL_SUBPROJECTS)
+
+    def test_preserves_affected_lists(self):
+        result = parse_subproject_deps(SAMPLE_AFFECTED_MAP_TEXT)
+        self.assertEqual(result['fdb-record-layer-lucene'], ['fdb-record-layer-lucene'])
+
+    def test_not_an_object_raises(self):
+        with self.assertRaises(ValueError):
+            parse_subproject_deps('["not", "an", "object"]')
+
+    def test_empty_object_raises(self):
+        with self.assertRaises(ValueError):
+            parse_subproject_deps('{}')
+
+    def test_malformed_value_raises(self):
+        with self.assertRaises(ValueError):
+            parse_subproject_deps('{"fdb-test-utils": "not-a-list"}')
+
+    def test_invalid_json_raises(self):
+        with self.assertRaises(json.JSONDecodeError):
+            parse_subproject_deps('not valid json')
+
+
+class TestIsBuildAffecting(unittest.TestCase):
+    """Tests for is_build_affecting()"""
+
+    def test_root_build_gradle(self):
+        self.assertTrue(is_build_affecting('build.gradle'))
+
+    def test_settings_gradle(self):
+        self.assertTrue(is_build_affecting('settings.gradle'))
+
+    def test_gradle_directory(self):
+        self.assertTrue(is_build_affecting('gradle/testing.gradle'))
+
+    def test_gradle_wrapper(self):
+        self.assertTrue(is_build_affecting('gradlew'))
+        self.assertTrue(is_build_affecting('gradlew.bat'))
+
+    def test_pull_request_workflow(self):
+        self.assertTrue(is_build_affecting('.github/workflows/pull_request.yml'))
+
+    def test_composite_actions(self):
+        self.assertTrue(is_build_affecting('actions/run-gradle/action.yml'))
+
+    def test_self_reference(self):
+        self.assertTrue(is_build_affecting('build/affected_subprojects.py'))
+
+    def test_subproject_source_is_not_build_affecting(self):
+        path = 'fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/Foo.java'
+        self.assertFalse(is_build_affecting(path))
+
+    def test_unrelated_workflow_is_not_build_affecting(self):
+        self.assertFalse(is_build_affecting('.github/workflows/nightly.yml'))
+
+
+class TestMapChangedFileToSubproject(unittest.TestCase):
+    """Tests for map_changed_file_to_subproject()"""
+
+    def test_maps_to_known_subproject(self):
+        path = 'fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/Foo.java'
+        self.assertEqual(
+            map_changed_file_to_subproject(path, ALL_SUBPROJECTS), 'fdb-record-layer-core')
+
+    def test_unmapped_top_level_file(self):
+        self.assertIsNone(map_changed_file_to_subproject('README.md', ALL_SUBPROJECTS))
+
+    def test_unmapped_new_top_level_directory(self):
+        self.assertIsNone(
+            map_changed_file_to_subproject('some-new-subproject/build.gradle', ALL_SUBPROJECTS))
+
+
+class TestComputeAffected(unittest.TestCase):
+    """Tests for compute_affected()"""
+
+    def test_build_affecting_change_runs_all(self):
+        result = compute_affected(['build.gradle'], SAMPLE_AFFECTED_MAP)
+        self.assertTrue(result['run_all'])
+        self.assertEqual(set(result['affected']), ALL_SUBPROJECTS)
+
+    def test_readme_change_runs_nothing(self):
+        result = compute_affected(['README.md'], SAMPLE_AFFECTED_MAP)
+        self.assertFalse(result['run_all'])
+        self.assertEqual(result['affected'], [])
+
+    def test_docs_change_runs_nothing(self):
+        result = compute_affected(['docs/sphinx/source/ReleaseNotes.md'], SAMPLE_AFFECTED_MAP)
+        self.assertFalse(result['run_all'])
+        self.assertEqual(result['affected'], [])
+
+    def test_change_confined_to_subproject_with_no_dependents(self):
+        result = compute_affected(
+            ['fdb-record-layer-lucene/src/main/java/Foo.java'], SAMPLE_AFFECTED_MAP)
+        self.assertFalse(result['run_all'])
+        self.assertEqual(result['affected'], ['fdb-record-layer-lucene'])
+
+    def test_change_to_widely_depended_on_subproject(self):
+        result = compute_affected(
+            ['fdb-test-utils/src/main/java/Foo.java'], SAMPLE_AFFECTED_MAP)
+        self.assertFalse(result['run_all'])
+        self.assertEqual(result['affected'], SAMPLE_AFFECTED_MAP['fdb-test-utils'])
+
+    def test_multiple_changed_files_union_affected_sets(self):
+        result = compute_affected(
+            ['fdb-record-layer-lucene/Foo.java', 'fdb-relational-api/Bar.java'],
+            SAMPLE_AFFECTED_MAP)
+        self.assertFalse(result['run_all'])
+        self.assertEqual(
+            set(result['affected']),
+            set(SAMPLE_AFFECTED_MAP['fdb-record-layer-lucene'])
+            | set(SAMPLE_AFFECTED_MAP['fdb-relational-api']))
+
+    def test_no_changed_files(self):
+        result = compute_affected([], SAMPLE_AFFECTED_MAP)
+        self.assertFalse(result['run_all'])
+        self.assertEqual(result['affected'], [])
+
+
+class TestMainEndToEnd(unittest.TestCase):
+    """End-to-end tests using main() against fixture files, with captured output."""
+
+    def setUp(self):
+        self.deps_file = tempfile.NamedTemporaryFile(
+            mode='w', suffix='.json', delete=False)
+        self.deps_file.write(SAMPLE_AFFECTED_MAP_TEXT)
+        self.deps_file.close()
+
+        self.changed_file = tempfile.NamedTemporaryFile(
+            mode='w', suffix='.txt', delete=False)
+        self.changed_file.write('fdb-record-layer-lucene/src/main/java/Foo.java\n')
+        self.changed_file.close()
+
+    def tearDown(self):
+        os.unlink(self.deps_file.name)
+        os.unlink(self.changed_file.name)
+
+    def test_main_runs_without_error(self):
+        from io import StringIO
+        from unittest.mock import patch
+
+        from affected_subprojects import main
+
+        with patch('sys.stdout', new_callable=StringIO) as mock_out:
+            main([self.deps_file.name, '--changed-files-file', self.changed_file.name])
+
+        result = json.loads(mock_out.getvalue())
+        self.assertFalse(result['run_all'])
+        self.assertEqual(result['affected'], ['fdb-record-layer-lucene'])
+
+    def test_main_missing_deps_file_fails_safe(self):
+        from io import StringIO
+        from unittest.mock import patch
+
+        from affected_subprojects import main
+
+        with patch('sys.stdout', new_callable=StringIO) as mock_out:
+            main(['/nonexistent/path/subproject_deps.json',
+                  '--changed-files-file', self.changed_file.name])
+
+        result = json.loads(mock_out.getvalue())
+        self.assertTrue(result['run_all'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/build/test_affected_subprojects.py
+++ b/build/test_affected_subprojects.py
@@ -30,8 +30,8 @@ import unittest
 
 sys.path.insert(0, os.path.dirname(__file__))
 from affected_subprojects import (
-    compute_affected,
-    compute_matrix_plan,
+    TestPlan,
+    compute_plan,
     is_ignored,
     is_build_affecting,
     map_changed_file_to_subproject,
@@ -199,8 +199,8 @@ class TestMapChangedFileToSubproject(unittest.TestCase):
             map_changed_file_to_subproject('some-new-subproject/build.gradle', ALL_SUBPROJECTS))
 
 
-class TestComputeAffected(unittest.TestCase):
-    """Tests for compute_affected()"""
+class TestComputePlan(unittest.TestCase):
+    """Tests for compute_plan()"""
 
     TO_BE_IGNORED = [
         'README.md',
@@ -215,125 +215,165 @@ class TestComputeAffected(unittest.TestCase):
     ]
 
     def test_build_affecting_change_runs_all(self):
-        result = compute_affected(['build.gradle'], SAMPLE_AFFECTED_MAP)
-        self.assertTrue(result['run_all'])
-        self.assertEqual(set(result['affected']), ALL_SUBPROJECTS)
+        result = compute_plan(['build.gradle'], SAMPLE_AFFECTED_MAP, set())
+        self.assertTrue(result.run_all)
+        self.assertEqual(result.affected_subprojects, ALL_SUBPROJECTS)
 
     def test_ignored_file_change_runs_nothing(self):
-        for path in TestComputeAffected.TO_BE_IGNORED:
-            result = compute_affected([path], SAMPLE_AFFECTED_MAP)
-            self.assertFalse(result['run_all'])
-            self.assertEqual(result['affected'], [])
+        for path in TestComputePlan.TO_BE_IGNORED:
+            result = compute_plan([path], SAMPLE_AFFECTED_MAP, set())
+            self.assertFalse(result.run_all)
+            self.assertEqual(result.affected_subprojects, set())
 
     def test_only_ignored_files_run_nothing(self):
-        result = compute_affected(TestComputeAffected.TO_BE_IGNORED, SAMPLE_AFFECTED_MAP)
-        self.assertFalse(result['run_all'])
-        self.assertEqual(result['affected'], [])
+        result = compute_plan(TestComputePlan.TO_BE_IGNORED, SAMPLE_AFFECTED_MAP, set())
+        self.assertFalse(result.run_all)
+        self.assertEqual(result.affected_subprojects, set())
 
     def test_change_confined_to_subproject_with_no_dependents(self):
-        result = compute_affected(
-            ['fdb-record-layer-lucene/src/main/java/Foo.java'], SAMPLE_AFFECTED_MAP)
-        self.assertFalse(result['run_all'])
-        self.assertEqual(result['affected'], ['fdb-record-layer-lucene'])
+        result = compute_plan(
+            ['fdb-record-layer-lucene/src/main/java/Foo.java'], SAMPLE_AFFECTED_MAP, set())
+        self.assertFalse(result.run_all)
+        self.assertEqual(result.affected_subprojects, {'fdb-record-layer-lucene'})
 
     def test_change_to_widely_depended_on_subproject(self):
-        result = compute_affected(
-            ['fdb-test-utils/src/main/java/Foo.java'], SAMPLE_AFFECTED_MAP)
-        self.assertFalse(result['run_all'])
-        self.assertEqual(result['affected'], SAMPLE_AFFECTED_MAP['fdb-test-utils'])
+        result = compute_plan(
+            ['fdb-test-utils/src/main/java/Foo.java'], SAMPLE_AFFECTED_MAP, set())
+        self.assertFalse(result.run_all)
+        self.assertEqual(result.affected_subprojects, set(SAMPLE_AFFECTED_MAP['fdb-test-utils']))
 
     def test_multiple_changed_files_union_affected_sets(self):
-        result = compute_affected(
+        result = compute_plan(
             ['fdb-record-layer-lucene/Foo.java', 'fdb-relational-api/Bar.java'],
-            SAMPLE_AFFECTED_MAP)
-        self.assertFalse(result['run_all'])
+            SAMPLE_AFFECTED_MAP, set())
+        self.assertFalse(result.run_all)
         self.assertEqual(
-            set(result['affected']),
+            result.affected_subprojects,
             set(SAMPLE_AFFECTED_MAP['fdb-record-layer-lucene'])
             | set(SAMPLE_AFFECTED_MAP['fdb-relational-api']))
 
     def test_project_gradle_affected_sets(self):
-        result = compute_affected(['fdb-relational-core/fdb-relational-core.gradle'], SAMPLE_AFFECTED_MAP)
-        self.assertFalse(result['run_all'])
-        self.assertEqual(result['affected'], SAMPLE_AFFECTED_MAP['fdb-relational-core'])
+        result = compute_plan(['fdb-relational-core/fdb-relational-core.gradle'], SAMPLE_AFFECTED_MAP, set())
+        self.assertFalse(result.run_all)
+        self.assertEqual(result.affected_subprojects, set(SAMPLE_AFFECTED_MAP['fdb-relational-core']))
 
     def test_no_changed_files(self):
-        result = compute_affected([], SAMPLE_AFFECTED_MAP)
-        self.assertFalse(result['run_all'])
-        self.assertEqual(result['affected'], [])
+        result = compute_plan([], SAMPLE_AFFECTED_MAP, set())
+        self.assertFalse(result.run_all)
+        self.assertEqual(result.affected_subprojects, set())
 
     def test_mark_run_all_if_all_affected(self):
-        result = compute_affected(['fdb-java-annotations/src/main/java/API.java', 'fdb-test-utils/src/test/java/Utils.java'],
-              SAMPLE_AFFECTED_MAP)
-        self.assertTrue(result['run_all'])
-        self.assertEqual(result['affected'], sorted(SAMPLE_AFFECTED_MAP.keys()))
+        result = compute_plan(['fdb-java-annotations/src/main/java/API.java', 'fdb-test-utils/src/test/java/Utils.java'],
+              SAMPLE_AFFECTED_MAP, set())
+        self.assertTrue(result.run_all)
+        self.assertEqual(result.affected_subprojects, SAMPLE_AFFECTED_MAP.keys())
 
     def test_run_all_if_from_unknown(self):
-        result = compute_affected(['new-subproject/src/main/java/Foo.java'],
-              SAMPLE_AFFECTED_MAP)
-        self.assertTrue(result['run_all'])
-        self.assertEqual(result['affected'], sorted(SAMPLE_AFFECTED_MAP.keys()))
+        result = compute_plan(['new-subproject/src/main/java/Foo.java'],
+              SAMPLE_AFFECTED_MAP, set())
+        self.assertTrue(result.run_all)
+        self.assertEqual(result.unknown_paths, {'new-subproject/src/main/java/Foo.java'})
+        self.assertEqual(result.affected_subprojects, SAMPLE_AFFECTED_MAP.keys())
 
 
-class TestComputeMatrixPlan(unittest.TestCase):
-    """Tests for compute_matrix_plan()"""
+class TestTestPlanWithMatrixCandidates(unittest.TestCase):
+    """Tests for how the set of matrix candidates affects the results of TestPlan"""
 
-    MATRIX_CANDIDATES = ['fdb-extensions', 'fdb-record-layer-core', 'fdb-record-layer-lucene', 'yaml-tests']
+    MATRIX_CANDIDATES = {'fdb-extensions', 'fdb-record-layer-core', 'fdb-record-layer-lucene', 'yaml-tests'}
 
     def test_run_all_selects_every_candidate(self):
-        plan = compute_matrix_plan({'run_all': True, 'affected': []}, self.MATRIX_CANDIDATES)
-        self.assertEqual(plan['matrix'], sorted(self.MATRIX_CANDIDATES))
-        self.assertTrue(plan['run_other_tests'])
+        plan = TestPlan(SAMPLE_AFFECTED_MAP.keys(), self.MATRIX_CANDIDATES)
+        plan.set_run_all('Testing with run all but no other info')
+        self.assertEqual(plan.matrix, self.MATRIX_CANDIDATES)
+        self.assertTrue(plan.run_other_tests)
 
     def test_affected_confined_to_candidates(self):
-        plan = compute_matrix_plan(
-            {'run_all': False, 'affected': ['fdb-record-layer-lucene']}, self.MATRIX_CANDIDATES)
-        self.assertEqual(plan['matrix'], ['fdb-record-layer-lucene'])
-        self.assertFalse(plan['run_other_tests'])
+        plan = TestPlan(SAMPLE_AFFECTED_MAP.keys(), self.MATRIX_CANDIDATES)
+        plan.add_affected_subprojects(['fdb-record-layer-lucene'])
+        self.assertEqual(plan.matrix, {'fdb-record-layer-lucene'})
+        self.assertFalse(plan.run_other_tests)
 
     def test_affected_outside_candidates_needs_other_tests(self):
-        plan = compute_matrix_plan(
-            {'run_all': False, 'affected': ['fdb-relational-api']}, self.MATRIX_CANDIDATES)
-        self.assertEqual(plan['matrix'], [])
-        self.assertTrue(plan['run_other_tests'])
+        plan = TestPlan(SAMPLE_AFFECTED_MAP.keys(), self.MATRIX_CANDIDATES)
+        plan.add_affected_subprojects(['fdb-relational-api'])
+        self.assertEqual(plan.matrix, set())
+        self.assertTrue(plan.run_other_tests)
+
+    def test_affected_both_matrix_and_other_subprojects(self):
+        plan = TestPlan(SAMPLE_AFFECTED_MAP.keys(), self.MATRIX_CANDIDATES)
+        plan.add_affected_subprojects(['fdb-record-layer-lucene', 'fdb-java-annotations', 'fdb-extensions'])
+        self.assertEqual(plan.matrix, {'fdb-record-layer-lucene', 'fdb-extensions'})
+        self.assertTrue(plan.run_other_tests)
+
+    def test_affected_unknown_path(self):
+        plan = TestPlan(SAMPLE_AFFECTED_MAP.keys(), self.MATRIX_CANDIDATES)
+        plan.add_unknown_path('some/unknown/path')
+        self.assertTrue(plan.run_all)
+        self.assertEqual(plan.matrix, self.MATRIX_CANDIDATES)
+        self.assertTrue(plan.run_other_tests)
 
     def test_no_affected_subprojects(self):
-        plan = compute_matrix_plan({'run_all': False, 'affected': []}, self.MATRIX_CANDIDATES)
-        self.assertEqual(plan['matrix'], [])
-        self.assertFalse(plan['run_other_tests'])
-
-    def test_preserves_base_plan_keys(self):
-        plan = compute_matrix_plan({'run_all': False, 'affected': ['yaml-tests']}, self.MATRIX_CANDIDATES)
-        self.assertFalse(plan['run_all'])
-        self.assertEqual(plan['affected'], ['yaml-tests'])
+        plan = TestPlan(SAMPLE_AFFECTED_MAP.keys(), self.MATRIX_CANDIDATES)
+        self.assertEqual(plan.matrix, set())
+        self.assertFalse(plan.run_other_tests)
 
 
 class TestRenderMarkdown(unittest.TestCase):
     """Tests for render_markdown()"""
 
-    def test_renders_base_plan_without_matrix_fields(self):
-        text = render_markdown({'run_all': True, 'affected': ['fdb-record-layer-lucene']})
+    def test_renders_plan_with_no_matrix_jobs(self):
+        plan = TestPlan(SAMPLE_AFFECTED_MAP.keys(), set())
+        plan.add_affected_subprojects(['fdb-record-layer-lucene'])
+        text = render_markdown(plan)
+
         self.assertIn('### CI Plan', text)
-        self.assertIn('All tests need to be run: `true`', text)
+        self.assertIn('Test plan justification: Detected changes affecting given subprojects', text)
+        self.assertIn('All tests need to be run: `false`', text)
         self.assertIn('Affected subprojects: `fdb-record-layer-lucene`', text)
-        self.assertNotIn('individual jobs', text)
+        self.assertIn('Subprojects to test in individual jobs: `(none)`', text)
+
+    def test_renders_unknown_paths(self):
+        plan = TestPlan(SAMPLE_AFFECTED_MAP.keys(), set())
+        plan.add_unknown_path('some/unknown/path')
+        plan.add_unknown_path('another/unknown/path')
+        text = render_markdown(plan)
+
+        self.assertIn('Test plan justification: Electing to run all tests as a file was modified with unknown impact', text)
+        self.assertIn('All tests need to be run: `true`', text)
+        self.assertIn('Paths from unknown subprojects: `another/unknown/path, some/unknown/path`', text)
+
+    def test_truncates_too_many_unknown_paths(self):
+        plan = TestPlan(SAMPLE_AFFECTED_MAP.keys(), set())
+        for i in range(10):
+            plan.add_unknown_path(f'some/unknown/path_{i}')
+        text = render_markdown(plan)
+
+        self.assertIn('Test plan justification: Electing to run all tests as a file was modified with unknown impact', text)
+        self.assertIn('All tests need to be run: `true`', text)
+        self.assertIn('Paths from unknown subprojects: `some/unknown/path_0, some/unknown/path_1, some/unknown/path_2, some/unknown/path_3, some/unknown/path_4, ...`', text)
+
+    def test_skips_unknown_paths_if_none(self):
+        plan = TestPlan(SAMPLE_AFFECTED_MAP.keys(), set())
+        text = render_markdown(plan)
+        self.assertNotIn('Paths from unknown subprojects:', text)
 
     def test_renders_matrix_fields_when_present(self):
-        text = render_markdown({
-            'run_all': False,
-            'affected': ['fdb-record-layer-lucene'],
-            'matrix': ['fdb-record-layer-lucene'],
-            'run_other_tests': False,
-        })
+        plan = TestPlan(SAMPLE_AFFECTED_MAP.keys(), {'fdb-record-layer-lucene'})
+        plan.add_affected_subprojects(['fdb-record-layer-lucene'])
+
+        text = render_markdown(plan)
+        self.assertIn('Test plan justification: Detected changes affecting given subprojects', text)
         self.assertIn('Subprojects to test in individual jobs: `fdb-record-layer-lucene`', text)
         self.assertIn('Remaining subprojects tested in a combined job: `false`', text)
 
     def test_renders_none_placeholder_for_empty_lists(self):
-        text = render_markdown({'run_all': False, 'affected': []})
+        text = render_markdown(TestPlan(set(), set()))
+        self.assertIn('Test plan justification: No changes found requiring testing', text)
         self.assertIn('Affected subprojects: `(none)`', text)
+        self.assertIn('Subprojects to test in individual jobs: `(none)`', text)
 
     def test_output_ends_with_single_newline(self):
-        text = render_markdown({'run_all': False, 'affected': []})
+        text = render_markdown(TestPlan(set(), set()))
         self.assertTrue(text.endswith('\n'))
         self.assertFalse(text.endswith('\n\n'))
 

--- a/build/test_affected_subprojects.py
+++ b/build/test_affected_subprojects.py
@@ -32,6 +32,7 @@ sys.path.insert(0, os.path.dirname(__file__))
 from affected_subprojects import (
     compute_affected,
     compute_matrix_plan,
+    is_ignored,
     is_build_affecting,
     map_changed_file_to_subproject,
     parse_subproject_deps,
@@ -130,6 +131,52 @@ class TestIsBuildAffecting(unittest.TestCase):
         self.assertFalse(is_build_affecting('.github/workflows/nightly.yml'))
 
 
+class TestIsIgnored(unittest.TestCase):
+    """Tests for is_ignored()"""
+
+    def test_build_gradle_not_ignored(self):
+        self.assertFalse(is_ignored('build.gradle'))
+
+    def test_subproject_gradle_not_ignored(self):
+        self.assertFalse(is_ignored('fdb-record-layer-core/fdb-record-layer-core.gradle'))
+
+    def test_java_not_ignored(self):
+        self.assertFalse(is_ignored('fdb-record-layer-core/src/main/java/Foo.java'))
+
+    def test_proto_not_ignored(self):
+        self.assertFalse(is_ignored('fdb-record-layer-core/src/test/proto/test_records_1.proto'))
+
+    def test_readme_ignored(self):
+        self.assertTrue(is_ignored('README.md'))
+
+    def test_subproject_readme_ignored(self):
+        self.assertTrue(is_ignored('fdb-record-layer-core/README.md'))
+
+    def test_idea_ignored(self):
+        self.assertTrue(is_ignored('.idea/compiler.xml'))
+
+    def test_gitignore_ignored(self):
+        self.assertTrue(is_ignored('.gitignore'))
+
+    def test_agitignore_not_ignored(self):
+        self.assertFalse(is_ignored('agitignore'))
+
+    def test_docs_content_ignored(self):
+        self.assertTrue(is_ignored('docs/sphinx/source/ReleaseNotes.md'))
+
+    def test_docs_script_ignored(self):
+        self.assertTrue(is_ignored('docs/sphinx/source/generate_railroad_svg.py'))
+
+    def test_license_ignored(self):
+        self.assertTrue(is_ignored('LICENSE'))
+
+    def test_acknowledgements_ignored(self):
+        self.assertTrue(is_ignored('ACKNOWLEDGEMENTS'))
+
+    def test_license_suffix_not_ignored(self):
+        self.assertFalse(is_ignored('fdb-relational-server/LICENSE'))
+
+
 class TestMapChangedFileToSubproject(unittest.TestCase):
     """Tests for map_changed_file_to_subproject()"""
 
@@ -149,18 +196,31 @@ class TestMapChangedFileToSubproject(unittest.TestCase):
 class TestComputeAffected(unittest.TestCase):
     """Tests for compute_affected()"""
 
+    TO_BE_IGNORED = [
+        'README.md',
+        'CODE_OF_CONDUCT.md',
+        'LICENSE',
+        'ACKNOWLEDGEMENTS',
+        '.gitignore',
+        '.idea/misc.xml',
+        'AGENTS.md',
+        'docs/sphinx/source/ReleaseNotes.md',
+        'docs/sphinx/generate_railroad_svg.py',
+    ]
+
     def test_build_affecting_change_runs_all(self):
         result = compute_affected(['build.gradle'], SAMPLE_AFFECTED_MAP)
         self.assertTrue(result['run_all'])
         self.assertEqual(set(result['affected']), ALL_SUBPROJECTS)
 
-    def test_readme_change_runs_nothing(self):
-        result = compute_affected(['README.md'], SAMPLE_AFFECTED_MAP)
-        self.assertFalse(result['run_all'])
-        self.assertEqual(result['affected'], [])
+    def test_ignored_file_change_runs_nothing(self):
+        for path in TestComputeAffected.TO_BE_IGNORED:
+            result = compute_affected([path], SAMPLE_AFFECTED_MAP)
+            self.assertFalse(result['run_all'])
+            self.assertEqual(result['affected'], [])
 
-    def test_docs_change_runs_nothing(self):
-        result = compute_affected(['docs/sphinx/source/ReleaseNotes.md'], SAMPLE_AFFECTED_MAP)
+    def test_only_ignored_files_run_nothing(self):
+        result = compute_affected(TestComputeAffected.TO_BE_IGNORED, SAMPLE_AFFECTED_MAP)
         self.assertFalse(result['run_all'])
         self.assertEqual(result['affected'], [])
 
@@ -190,6 +250,18 @@ class TestComputeAffected(unittest.TestCase):
         result = compute_affected([], SAMPLE_AFFECTED_MAP)
         self.assertFalse(result['run_all'])
         self.assertEqual(result['affected'], [])
+
+    def test_mark_run_all_if_all_affected(self):
+        result = compute_affected(['fdb-java-annotations/src/main/java/API.java', 'fdb-test-utils/src/test/java/Utils.java'],
+              SAMPLE_AFFECTED_MAP)
+        self.assertTrue(result['run_all'])
+        self.assertEqual(result['affected'], sorted(SAMPLE_AFFECTED_MAP.keys()))
+
+    def test_run_all_if_from_unknown(self):
+        result = compute_affected(['new-subproject/src/main/java/Foo.java'],
+              SAMPLE_AFFECTED_MAP)
+        self.assertTrue(result['run_all'])
+        self.assertEqual(result['affected'], sorted(SAMPLE_AFFECTED_MAP.keys()))
 
 
 class TestComputeMatrixPlan(unittest.TestCase):

--- a/build/test_affected_subprojects.py
+++ b/build/test_affected_subprojects.py
@@ -268,6 +268,13 @@ class TestComputePlan(unittest.TestCase):
         self.assertTrue(result.run_all)
         self.assertEqual(result.affected_subprojects, SAMPLE_AFFECTED_MAP.keys())
 
+    def test_do_not_mark_run_all_if_only_matrix_affected(self):
+        result = compute_plan(['fdb-record-layer-core/src/main/java/Foo.java', 'fdb-record-layer-core/src/test/java/Utils.java'],
+              SAMPLE_AFFECTED_MAP, set(SAMPLE_AFFECTED_MAP['fdb-record-layer-core']))
+        self.assertFalse(result.run_all)
+        self.assertEqual(result.affected_subprojects, set(SAMPLE_AFFECTED_MAP['fdb-record-layer-core']))
+        self.assertEqual(result.matrix, set(SAMPLE_AFFECTED_MAP['fdb-record-layer-core']))
+
     def test_run_all_if_from_unknown(self):
         result = compute_plan(['new-subproject/src/main/java/Foo.java'],
               SAMPLE_AFFECTED_MAP, set())

--- a/build/test_affected_subprojects.py
+++ b/build/test_affected_subprojects.py
@@ -304,7 +304,7 @@ class TestComputeMatrixPlan(unittest.TestCase):
 
     def test_preserves_base_plan_keys(self):
         plan = compute_matrix_plan({'run_all': False, 'affected': ['yaml-tests']}, self.MATRIX_CANDIDATES)
-        self.assertEqual(plan['run_all'], False)
+        self.assertFalse(plan['run_all'])
         self.assertEqual(plan['affected'], ['yaml-tests'])
 
 
@@ -384,7 +384,7 @@ class TestMainEndToEnd(unittest.TestCase):
         from affected_subprojects import main
 
         with patch('sys.stdout', new_callable=StringIO):
-            main(['/nonexistent/path/subproject_deps.json',
+            main(['nonexistent/path/subproject_deps.json',
                   '--changed-files-file', self.changed_file.name,
                   '--output', self.output_file.name])
 

--- a/gradle/root.gradle
+++ b/gradle/root.gradle
@@ -72,11 +72,10 @@ task checksumsVerify {
 }
 
 // Computes, for every subproject, the full set of subprojects that would be affected by a
-// change to it -- itself plus every (transitive) dependent -- and emits the result as a JSON
-// object mapping subproject name -> sorted list of affected subproject names. This reads
-// Gradle's own configured model and then recursively explores the graph. Used by CI (see
-// .github/workflows/pull_request.yml) to determine which subprojects are affected by a PR's
-// changes, so that expensive test jobs can be skipped for unaffected subprojects.
+// change to it (including itself), and emits the result as a JSON object. This uses
+// the configured dependencies and then recursively explores the graph so that it stays up
+// to date as dependencies are added. Used in CI (see .github/workflows/pull_request.yml)
+// to determine which subprojects are affected by a PR's changes.
 tasks.register('printDependentSubprojects') {
     doLast {
         // Direct forward graph: subproject name -> set of subproject names it depends on.
@@ -96,8 +95,7 @@ tasks.register('printDependentSubprojects') {
             deps.each { dep -> reverse[dep]?.add(name) }
         }
 
-        // For each subproject, BFS over the reverse graph to find its full transitive impact
-        // set: itself, plus everything that (transitively) depends on it.
+        // For each subproject, BFS over the reverse graph to find its full transitive impact set
         def affected = forward.keySet().collectEntries { subproject ->
             def seen = new TreeSet<String>([subproject])
             Queue<String> queue = new LinkedList<String>([subproject])
@@ -156,11 +154,10 @@ tasks.register('codeCoverageReport', JacocoReport) {
         "**/generated/*", "**/grpc/v1/**/*"
     ]
 
-    // Since CI now skips building/testing subprojects that a PR's diff couldn't have affected
+    // Since CI skips building/testing subprojects that a PR's diff couldn't have affected
     // (see the `plan` job in pull_request.yml), not every coverageSubproject's jar is guaranteed
-    // to exist when this task runs against downloaded artifacts -- referencing a missing one via
-    // zipTree fails the build outright, unlike missing execution data above, which JaCoCo already
-    // tolerates on its own.
+    // to exist when this task runs against downloaded artifacts. Referencing a missing one via
+    // zipTree fails the build outright, so only include the built ones.
     def builtSubprojects = coverageSubprojects.findAll { sp ->
         sp.layout.buildDirectory.file("libs/${sp.name}-${sp.version}.jar").get().asFile.exists()
     }

--- a/gradle/root.gradle
+++ b/gradle/root.gradle
@@ -19,6 +19,7 @@
  */
 
 import java.security.MessageDigest
+import groovy.json.JsonOutput
 
 /**
  * Build configuration specially for the root project only.
@@ -66,6 +67,57 @@ task checksumsVerify {
         }
         if (!failed.empty) {
             throw new RuntimeException("Some MD5 sums failed to verify: " + failed)
+        }
+    }
+}
+
+// Computes, for every subproject, the full set of subprojects that would be affected by a
+// change to it -- itself plus every (transitive) dependent -- and emits the result as a JSON
+// object mapping subproject name -> sorted list of affected subproject names. This reads
+// Gradle's own configured model and then recursively explores the graph. Used by CI (see
+// .github/workflows/pull_request.yml) to determine which subprojects are affected by a PR's
+// changes, so that expensive test jobs can be skipped for unaffected subprojects.
+tasks.register('printDependentSubprojects') {
+    doLast {
+        // Direct forward graph: subproject name -> set of subproject names it depends on.
+        def forward = subprojects.collectEntries { sp ->
+            def deps = new TreeSet<String>()
+            sp.configurations.each { cfg ->
+                cfg.dependencies.withType(ProjectDependency).each { dep ->
+                    deps.add(dep.path.replaceFirst(/^:/, ''))
+                }
+            }
+            [sp.name, deps]
+        }
+
+        // Reverse graph: subproject name -> set of subprojects that directly depend on it.
+        def reverse = forward.keySet().collectEntries { [it, new TreeSet<String>()] }
+        forward.each { name, deps ->
+            deps.each { dep -> reverse[dep]?.add(name) }
+        }
+
+        // For each subproject, BFS over the reverse graph to find its full transitive impact
+        // set: itself, plus everything that (transitively) depends on it.
+        def affected = forward.keySet().collectEntries { subproject ->
+            def seen = new TreeSet<String>([subproject])
+            Queue<String> queue = new LinkedList<String>([subproject])
+            while (!queue.isEmpty()) {
+                def current = queue.poll()
+                reverse[current]?.each { dependent ->
+                    if (seen.add(dependent)) {
+                        queue.add(dependent)
+                    }
+                }
+            }
+            [subproject, seen.toList()]
+        }
+
+        def json = JsonOutput.toJson(affected)
+        def outputPath = findProperty('subprojectDeps.output')
+        if (outputPath) {
+            file(outputPath).text = json
+        } else {
+            println json
         }
     }
 }

--- a/gradle/root.gradle
+++ b/gradle/root.gradle
@@ -92,7 +92,7 @@ tasks.register('printDependentSubprojects') {
         // Reverse graph: subproject name -> set of subprojects that directly depend on it.
         def reverse = forward.keySet().collectEntries { [it, new TreeSet<String>()] }
         forward.each { name, deps ->
-            deps.each { dep -> reverse[dep]?.add(name) }
+            deps.each { dep -> reverse[dep].add(name) }
         }
 
         // For each subproject, BFS over the reverse graph to find its full transitive impact set
@@ -101,7 +101,7 @@ tasks.register('printDependentSubprojects') {
             Queue<String> queue = new LinkedList<String>([subproject])
             while (!queue.isEmpty()) {
                 def current = queue.poll()
-                reverse[current]?.each { dependent ->
+                reverse[current].each { dependent ->
                     if (seen.add(dependent)) {
                         queue.add(dependent)
                     }

--- a/gradle/root.gradle
+++ b/gradle/root.gradle
@@ -156,7 +156,16 @@ tasks.register('codeCoverageReport', JacocoReport) {
         "**/generated/*", "**/grpc/v1/**/*"
     ]
 
-    classDirectories.setFrom(coverageSubprojects.collect { sp ->
+    // Since CI now skips building/testing subprojects that a PR's diff couldn't have affected
+    // (see the `plan` job in pull_request.yml), not every coverageSubproject's jar is guaranteed
+    // to exist when this task runs against downloaded artifacts -- referencing a missing one via
+    // zipTree fails the build outright, unlike missing execution data above, which JaCoCo already
+    // tolerates on its own.
+    def builtSubprojects = coverageSubprojects.findAll { sp ->
+        sp.layout.buildDirectory.file("libs/${sp.name}-${sp.version}.jar").get().asFile.exists()
+    }
+
+    classDirectories.setFrom(builtSubprojects.collect { sp ->
         sp.layout.buildDirectory.file("libs/${sp.name}-${sp.version}.jar").map { jf ->
             zipTree(jf).matching {
                 exclude exclusions
@@ -165,7 +174,7 @@ tasks.register('codeCoverageReport', JacocoReport) {
     })
 
     // These can come from source tree.
-    sourceDirectories.setFrom(files(coverageSubprojects.sourceSets.main.allSource.srcDirs))
+    sourceDirectories.setFrom(files(builtSubprojects.sourceSets.main.allSource.srcDirs))
 
     reports {
         xml.required = true


### PR DESCRIPTION
This adds an additional step to our PRB config. It looks at the change set, and from that, it computes a list of subprojects that have been directly affected. It combines that with a list of dependent subprojects to produce a full set of tests that need to be run. If a subproject is not affected by a change (directly or indirectly), then it gets skipped.

This has a few safe-guards:

1. If a build file (as determined by the file being in the `build` or `gradle` directory or one of the top-level `gradle` files) is modified, then all of the tests get run
1. If we have errors parsing anything or determinging the changes, then we fallback to running all tests
1. This isn't perfect, but teamscale enforces that we have coverage of a function, so if there's a bug that somehow results in modified code being skipped, we should still get teamscale warnings about it
1. We continue to run all of the tests in the nightly and release jobs, so if this skips an affected module, we will still know within a day or a release, whichever is sooner
1. The plan job logs which subprojects it is running, and the coverage job notes if any subprojects were skipped

The benefit, though, is that we can skip a lot of work for certain kinds of changes. For example, `fdb-extensions` has grown quite a bit with recent vector work, and this protects other PRs from needing to run that test suite. Documentation only changes can avoid testing all together (unless and until we add a documentation build, which may be a good idea), and changes to subprojects like `fdb-record-layer-lucene` or `yaml-tests` which are not dependend on by anything only need to run their own tests.

Note that the list of subprojects and their downstream dependencies is now computed in `printDependentSubprojects`. This means that if a gradle change results in the dependency graph changing, those changes will be reflected automatically in picking better tests.

To show how this works, I've created a few test PRs against my fork, with PRBs running only selective builds:

1. https://github.com/alecgrieser/fdb-record-layer/pull/4: Modifies just the README. PRB run https://github.com/alecgrieser/fdb-record-layer/actions/runs/29430521593?pr=4 validates that no tests are run (though `style` currently is)
2. https://github.com/alecgrieser/fdb-record-layer/pull/5: Modifies a file in `fdb-record-layer-core`. PRB run https://github.com/alecgrieser/fdb-record-layer/actions/runs/29430592325?pr=5 validates that the `fdb-extensions` tests are skipped
3. https://github.com/alecgrieser/fdb-record-layer/pull/6: Modifies a file in `fdb-record-layer-lucene`. PRB run https://github.com/alecgrieser/fdb-record-layer/actions/runs/29430388383?pr=6 validates that only the `fdb-record-layer-lucene` tests are run in this case
4. https://github.com/alecgrieser/fdb-record-layer/pull/7: Modifies some files in no known subproject. PRB run https://github.com/alecgrieser/fdb-record-layer/actions/runs/29431057921?pr=7 validates that all of the tests run with a disclaimer as to how we wound up in that state

Those are the end-to-end tests. There are also unit tests of the various scenarios in `test_affected_subprojects.py`, which was run during the development process.