### PR TITLE
Introduce conditional planner rules (`ConditionalCascadesRule`)

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CascadesPlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CascadesPlanner.java
@@ -61,6 +61,7 @@ import com.apple.foundationdb.record.query.plan.cascades.matching.structure.Bind
 import com.apple.foundationdb.record.query.plan.cascades.matching.structure.PlannerBindings;
 import com.apple.foundationdb.record.query.plan.cascades.matching.structure.ReferenceMatchers;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Suppliers;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
@@ -322,6 +323,12 @@ public class CascadesPlanner implements QueryPlanner {
     @Override
     public void setConfiguration(@Nonnull final RecordQueryPlannerConfiguration configuration) {
         this.configuration = configuration;
+    }
+
+    @Nonnull
+    @VisibleForTesting
+    Deque<Task> getTaskStack() {
+        return taskStack;
     }
 
     private boolean isTaskQueueSizeExceeded(final RecordQueryPlannerConfiguration configuration, final int queueSize) {
@@ -822,7 +829,8 @@ public class CascadesPlanner implements QueryPlanner {
      *         {@link ExploreGroup} for all ranged over groups
      * </pre>
      */
-    private abstract class AbstractExploreExpression extends ExploreTask {
+    @VisibleForTesting
+    abstract class AbstractExploreExpression extends ExploreTask {
         public AbstractExploreExpression(@Nonnull final PlannerPhase plannerPhase,
                                          @Nonnull final Reference group,
                                          @Nonnull final RelationalExpression expression) {
@@ -868,7 +876,8 @@ public class CascadesPlanner implements QueryPlanner {
          * pushes a {@link TransformExpression} task. For a {@link ConditionalCascadesRule}, pushes a single
          * {@link ConditionalTransformExpression} task holding the enabled inner rules (but only if there are any).
          */
-        private void pushTransformTask(@Nonnull CascadesRule<? extends RelationalExpression> rule) {
+        @VisibleForTesting
+        void pushTransformTask(@Nonnull CascadesRule<? extends RelationalExpression> rule) {
             final PlannerPhase phase = getPlannerPhase();
             final Reference group = getGroup();
             final RelationalExpression expression = getExpression();
@@ -888,7 +897,8 @@ public class CascadesPlanner implements QueryPlanner {
          * Returns the inner rules of the given {@link ConditionalCascadesRule} that are currently enabled according to
          * the planner {@link #configuration}, preserving their order.
          */
-        private <T extends RelationalExpression> List<AbstractCascadesRule<T>> getEnabledRules(ConditionalCascadesRule<?, ?> rule) {
+        @VisibleForTesting
+        <T extends RelationalExpression> List<AbstractCascadesRule<T>> getEnabledRules(ConditionalCascadesRule<?, ?> rule) {
             final var rules = rule.getRules(configuration::isRuleEnabled);
             @SuppressWarnings("unchecked") final var result = (List<AbstractCascadesRule<T>>)rules;
             return result;
@@ -956,7 +966,8 @@ public class CascadesPlanner implements QueryPlanner {
      *         {@link ExploreGroup} for all ranged over groups
      * </pre>
      */
-    private class ExploreExpression extends AbstractExploreExpression {
+    @VisibleForTesting
+    class ExploreExpression extends AbstractExploreExpression {
         public ExploreExpression(@Nonnull final PlannerPhase plannerPhase,
                                  @Nonnull final Reference group,
                                  @Nonnull final RelationalExpression expression) {
@@ -1188,7 +1199,8 @@ public class CascadesPlanner implements QueryPlanner {
      * {@code index} (by delegating to the {@link TransformExpression} superclass). If that rule makes no progress,
      * it pushes a follow-up {@code ConditionalTransformExpression} that resumes at the next index.
      */
-    private class ConditionalTransformExpression extends TransformExpression {
+    @VisibleForTesting
+    class ConditionalTransformExpression extends TransformExpression {
         @Nonnull
         private final List<AbstractCascadesRule<? extends RelationalExpression>> rules;
         private final int index;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CascadesPlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CascadesPlanner.java
@@ -1224,6 +1224,12 @@ public class CascadesPlanner implements QueryPlanner {
 
         @Override
         public boolean execute() {
+            // If `shouldExecute()` returns false for the group/expression pair, skip this rule and the rest of the
+            // chain immediately. There is no point continuing, as `shouldExecute()` does not depend on `index` and
+            // would just remain false.
+            if (!shouldExecute()) {
+                return false;
+            }
             if (super.execute()) {
                 return true;
             }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CascadesPlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CascadesPlanner.java
@@ -63,6 +63,7 @@ import com.apple.foundationdb.record.query.plan.cascades.matching.structure.Refe
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 import com.google.common.base.Suppliers;
 import com.google.common.base.Verify;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -71,10 +72,10 @@ import javax.annotation.Nonnull;
 import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.Deque;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -544,7 +545,12 @@ public class CascadesPlanner implements QueryPlanner {
         @Nonnull
         PlannerPhase getPlannerPhase();
 
-        void execute();
+        /**
+         * Executes this task, mutating the planner state (the memo and the task stack) as appropriate for the kind of
+         * task. The returned boolean reports whether the task made progress, that is, whether it changed planner state,
+         * for example by yielding new expressions, pushing planner requirements, or pushing more tasks onto the stack.
+         */
+        boolean execute();
 
         PlannerEvent toTaskEvent(Location location);
     }
@@ -576,13 +582,14 @@ public class CascadesPlanner implements QueryPlanner {
         }
 
         @Override
-        public void execute() {
+        public boolean execute() {
             if (plannerPhase.hasNextPhase()) {
                 // if there is another phase push it first so it gets executed at the very end
                 taskStack.push(new InitiatePlannerPhase(plannerPhase.getNextPhase()));
             }
             taskStack.push(new OptimizeGroup(plannerPhase, currentRoot));
             taskStack.push(new ExploreGroup(plannerPhase, currentRoot));
+            return true;
         }
 
         @Override
@@ -630,7 +637,7 @@ public class CascadesPlanner implements QueryPlanner {
         }
 
         @Override
-        public void execute() {
+        public boolean execute() {
             RelationalExpression bestFinalExpression = null;
             final var costModel = plannerPhase.createCostModel(configuration);
             for (final var finalExpression : group.getFinalExpressions()) {
@@ -671,6 +678,7 @@ public class CascadesPlanner implements QueryPlanner {
             } else {
                 group.pruneWith(bestFinalExpression);
             }
+            return true;
         }
 
         @Override
@@ -713,13 +721,13 @@ public class CascadesPlanner implements QueryPlanner {
         }
 
         @Override
-        public void execute() {
+        public boolean execute() {
             final var targetPlannerStage = plannerPhase.getTargetPlannerStage();
             final var groupPlannerStage = group.getPlannerStage();
             if (targetPlannerStage != groupPlannerStage) {
                 if (targetPlannerStage.precedes(groupPlannerStage)) {
                     // group is further along in the planning process, do not re-explore
-                    return;
+                    return false;
                 } else {
                     //
                     // targetPlannerStage succeeds groupPlannerStage
@@ -753,6 +761,7 @@ public class CascadesPlanner implements QueryPlanner {
             } else {
                 group.commitExploration();
             }
+            return true;
         }
 
         @Override
@@ -821,11 +830,11 @@ public class CascadesPlanner implements QueryPlanner {
         }
 
         @Override
-        public void execute() {
+        public boolean execute() {
             final var ruleSet = getPlannerPhase().getRuleSet();
 
             // push all rules that need to run after all exploration for a (group, expression) pair is done.
-            ruleSet.getMatchPartitionRules(rule -> configuration.isRuleEnabled(rule))
+            ruleSet.getMatchPartitionRules(configuration::isRuleEnabled)
                     .filter(this::shouldPushRule)
                     .forEach(this::pushTransformMatchPartition);
 
@@ -833,7 +842,7 @@ public class CascadesPlanner implements QueryPlanner {
             // by the type of their _root_, not any of the stuff lower down. As a result, we have enough information
             // right here to determine the set of all possible rules that could ever be applied here, regardless of
             // what happens towards the leaves of the tree.
-            ruleSet.getRules(getExpression(), rule -> configuration.isRuleEnabled(rule))
+            ruleSet.getRules(getExpression(), configuration::isRuleEnabled)
                     .filter(rule -> !(rule instanceof PreOrderRule) &&
                             shouldPushRule(rule))
                     .forEach(this::pushTransformTask);
@@ -845,16 +854,44 @@ public class CascadesPlanner implements QueryPlanner {
                     .map(Quantifier::getRangesOver)
                     .forEach(this::pushExploreGroup);
 
-            ruleSet.getRules(getExpression(), rule -> configuration.isRuleEnabled(rule))
+            ruleSet.getRules(getExpression(), configuration::isRuleEnabled)
                     .filter(rule -> rule instanceof PreOrderRule &&
                             shouldPushRule(rule))
                     .forEach(this::pushTransformTask);
+            return true;
         }
 
         protected abstract boolean shouldPushRule(@Nonnull CascadesRule<?> rule);
 
+        /**
+         * Pushes a task that transforms the current group/expression pair using the given rule. For an ordinary rule,
+         * pushes a {@link TransformExpression} task. For a {@link ConditionalCascadesRule}, pushes a single
+         * {@link ConditionalTransformExpression} task holding the enabled inner rules (but only if there are any).
+         */
         private void pushTransformTask(@Nonnull CascadesRule<? extends RelationalExpression> rule) {
-            taskStack.push(new TransformExpression(getPlannerPhase(), getGroup(), getExpression(), rule));
+            final PlannerPhase phase = getPlannerPhase();
+            final Reference group = getGroup();
+            final RelationalExpression expression = getExpression();
+            if (rule instanceof final ConditionalCascadesRule<?, ?> conditionalRule) {
+                // Filter the individual inner rules by `configuration::isRuleEnabled` here, since the filter that is
+                // applied earlier at `ruleSet.getRules()` pertains only to the `ConditionalCascadesRule` wrapper.
+                final var enabledRules = getEnabledRules(conditionalRule);
+                if (!enabledRules.isEmpty()) {
+                    taskStack.push(new ConditionalTransformExpression(phase, group, expression, enabledRules));
+                }
+            } else {
+                taskStack.push(new TransformExpression(phase, group, expression, rule));
+            }
+        }
+
+        /**
+         * Returns the inner rules of the given {@link ConditionalCascadesRule} that are currently enabled according to
+         * the planner {@link #configuration}, preserving their order.
+         */
+        private <T extends RelationalExpression> List<AbstractCascadesRule<T>> getEnabledRules(ConditionalCascadesRule<?, ?> rule) {
+            final var rules = rule.getRules(configuration::isRuleEnabled);
+            @SuppressWarnings("unchecked") final var result = (List<AbstractCascadesRule<T>>)rules;
+            return result;
         }
 
         private void pushTransformMatchPartition(AbstractCascadesRule<? extends MatchPartition> rule) {
@@ -1007,43 +1044,45 @@ public class CascadesPlanner implements QueryPlanner {
          */
         @Override
         @SuppressWarnings("java:S1117")
-        public void execute() {
+        public boolean execute() {
             if (!shouldExecute()) {
-                return;
+                return false;
             }
-
             final PlannerBindings initialBindings = getInitialBindings();
-
-            final AtomicInteger numMatches = new AtomicInteger(0);
-
-            rule.getMatcher()
-                    .bindMatches(getConfiguration(), initialBindings, getBindable())
-                    .map(bindings -> new CascadesRuleCall(plannerPhase, planContext, rule, group,
-                            traversal, taskStack, bindings, evaluationContext))
-                    .forEach(ruleCall -> {
-                        int ruleMatchesCount = numMatches.incrementAndGet();
-                        if (isMaxNumMatchesPerRuleCallExceeded(configuration, ruleMatchesCount)) {
-                            throw new RecordQueryPlanComplexityException("Maximum number of matches per rule call has been exceeded")
-                                    .addLogInfo(LogMessageKeys.RULE, ruleCall)
-                                    .addLogInfo(LogMessageKeys.RULE_MATCHES_COUNT, ruleMatchesCount)
-                                    .addLogInfo(LogMessageKeys.MAX_RULE_MATCHES_COUNT,
-                                            configuration.getMaxNumMatchesPerRuleCall());
-                        }
-                        // we notify the debugger (if installed) that the transform task is succeeding and
-                        // about begin and end of the rule call event
-                        PlannerEventListeners.dispatchEvent(() -> toTaskEvent(Location.MATCH_PRE));
-                        PlannerEventListeners.dispatchEvent(() -> new TransformRuleCallPlannerEvent(plannerPhase, currentRoot,
-                                        taskStack, Location.BEGIN, group, getBindable(), rule, ruleCall));
-                        try {
-                            executeRuleCall(ruleCall);
-                        } finally {
-                            PlannerEventListeners.dispatchEvent(() -> new TransformRuleCallPlannerEvent(plannerPhase, currentRoot,
-                                            taskStack, Location.END, group, getBindable(), rule, ruleCall));
-                        }
-                    });
+            final Object bindable = getBindable();
+            final Iterable<PlannerBindings> boundMatches =
+                    rule.getMatcher().bindMatches(getConfiguration(), initialBindings, bindable)::iterator;
+            int numMatches = 0;
+            boolean hasMadeProgress = false;
+            for (final var bindings : boundMatches) {
+                final var ruleCall = new CascadesRuleCall(plannerPhase, planContext, rule, group, traversal, taskStack,
+                        bindings, evaluationContext);
+                ++numMatches;
+                if (isMaxNumMatchesPerRuleCallExceeded(configuration, numMatches)) {
+                    throw new RecordQueryPlanComplexityException("Maximum number of matches per rule call has been exceeded")
+                            .addLogInfo(LogMessageKeys.RULE, ruleCall)
+                            .addLogInfo(LogMessageKeys.RULE_MATCHES_COUNT, numMatches)
+                            .addLogInfo(LogMessageKeys.MAX_RULE_MATCHES_COUNT,
+                                    configuration.getMaxNumMatchesPerRuleCall());
+                }
+                // we notify the debugger (if installed) that the transform task is succeeding and
+                // about begin and end of the rule call event
+                PlannerEventListeners.dispatchEvent(() -> toTaskEvent(Location.MATCH_PRE));
+                PlannerEventListeners.dispatchEvent(() -> new TransformRuleCallPlannerEvent(plannerPhase, currentRoot,
+                                taskStack, Location.BEGIN, group, bindable, rule, ruleCall));
+                try {
+                    hasMadeProgress |= executeRuleCall(ruleCall);
+                } finally {
+                    PlannerEventListeners.dispatchEvent(() -> new TransformRuleCallPlannerEvent(plannerPhase, currentRoot,
+                                    taskStack, Location.END, group, bindable, rule, ruleCall));
+                }
+            }
+            return hasMadeProgress;
         }
 
-        protected void executeRuleCall(@Nonnull CascadesRuleCall ruleCall) {
+        protected boolean executeRuleCall(@Nonnull CascadesRuleCall ruleCall) {
+            boolean hasMadeProgress = false;
+
             ruleCall.run();
 
             //
@@ -1059,18 +1098,21 @@ public class CascadesPlanner implements QueryPlanner {
                 PlannerEventListeners.dispatchEvent(() -> new TransformRuleCallPlannerEvent(plannerPhase, currentRoot, taskStack,
                                 Location.YIELD, group, getBindable(), rule, ruleCall));
                 taskStack.push(new AdjustMatch(getPlannerPhase(), getGroup(), getExpression(), newPartialMatch));
+                hasMadeProgress = true;
             }
 
             for (final RelationalExpression newExpression : ruleCall.getNewFinalExpressions()) {
                 PlannerEventListeners.dispatchEvent(() -> new TransformRuleCallPlannerEvent(plannerPhase, currentRoot, taskStack,
                                 Location.YIELD, group, getBindable(), rule, ruleCall));
                 exploreExpressionAndOptimizeInputs(plannerPhase, getGroup(), newExpression, true);
+                hasMadeProgress = true;
             }
 
             for (final RelationalExpression newExpression : ruleCall.getNewExploratoryExpressions()) {
                 PlannerEventListeners.dispatchEvent(() -> new TransformRuleCallPlannerEvent(plannerPhase, currentRoot, taskStack,
                                 Location.YIELD, group, getBindable(), rule, ruleCall));
                 exploreExpression(plannerPhase, group, newExpression, true);
+                hasMadeProgress = true;
             }
 
             final var referencesWithPushedRequirements = ruleCall.getReferencesWithPushedConstraints();
@@ -1084,13 +1126,16 @@ public class CascadesPlanner implements QueryPlanner {
                 //
                 if (!(rule instanceof PreOrderRule)) {
                     taskStack.push(this);
+                    hasMadeProgress = true;
                 }
                 for (final Reference reference : referencesWithPushedRequirements) {
                     if (!reference.hasNeverBeenExplored()) {
                         taskStack.push(new ExploreGroup(plannerPhase, reference));
+                        hasMadeProgress = true;
                     }
                 }
             }
+            return hasMadeProgress;
         }
 
         @Override
@@ -1134,6 +1179,47 @@ public class CascadesPlanner implements QueryPlanner {
             return PlannerBindings.newBuilder()   // TODO either put other bindings in here OR just call super
                     .putAll(super.getInitialBindings())
                     .build();
+        }
+    }
+
+    /**
+     * Class to transform an expression using the first applicable rule out of an ordered list of rules, as produced by
+     * a {@link ConditionalCascadesRule}. The rules are tried one at a time. This task first applies the rule at
+     * {@code index} (by delegating to the {@link TransformExpression} superclass). If that rule makes no progress,
+     * it pushes a follow-up {@code ConditionalTransformExpression} that resumes at the next index.
+     */
+    private class ConditionalTransformExpression extends TransformExpression {
+        @Nonnull
+        private final List<AbstractCascadesRule<? extends RelationalExpression>> rules;
+        private final int index;
+
+        public ConditionalTransformExpression(@Nonnull final PlannerPhase plannerPhase,
+                                              @Nonnull final Reference group,
+                                              @Nonnull final RelationalExpression expression,
+                                              @Nonnull final List<? extends AbstractCascadesRule<? extends RelationalExpression>> rules) {
+            this(plannerPhase, group, expression, ImmutableList.copyOf(rules), 0);
+        }
+
+        private ConditionalTransformExpression(@Nonnull final PlannerPhase plannerPhase,
+                                               @Nonnull final Reference group,
+                                               @Nonnull final RelationalExpression expression,
+                                               @Nonnull final List<AbstractCascadesRule<? extends RelationalExpression>> rules,
+                                               final int index) {
+            super(plannerPhase, group, expression, rules.get(index));
+            this.rules = rules;
+            this.index = index;
+        }
+
+        @Override
+        public boolean execute() {
+            if (super.execute()) {
+                return true;
+            }
+            if (index + 1 < rules.size()) {
+                taskStack.push(new ConditionalTransformExpression(getPlannerPhase(), getGroup(), getExpression(),
+                        rules, index + 1));
+            }
+            return false;
         }
     }
 
@@ -1205,12 +1291,13 @@ public class CascadesPlanner implements QueryPlanner {
         }
 
         @Override
-        public void execute() {
+        public boolean execute() {
             final var ruleSet = getPlannerPhase().getRuleSet();
-            ruleSet.getPartialMatchRules(rule -> configuration.isRuleEnabled(rule))
+            ruleSet.getPartialMatchRules(configuration::isRuleEnabled)
                     .forEach(rule ->
                             taskStack.push(new TransformPartialMatch(getPlannerPhase(), getGroup(), getExpression(),
                                     partialMatch, rule)));
+            return true;
         }
 
         @Override
@@ -1260,14 +1347,15 @@ public class CascadesPlanner implements QueryPlanner {
         }
 
         @Override
-        public void execute() {
+        public boolean execute() {
             if (!group.containsExactly(expression)) {
-                return;
+                return false;
             }
             for (final Quantifier quantifier : expression.getQuantifiers()) {
                 final Reference rangesOver = quantifier.getRangesOver();
                 taskStack.push(new OptimizeGroup(plannerPhase, rangesOver));
             }
+            return true;
         }
 
         @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CascadesPlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CascadesPlanner.java
@@ -554,8 +554,10 @@ public class CascadesPlanner implements QueryPlanner {
 
         /**
          * Executes this task, mutating the planner state (the memo and the task stack) as appropriate for the kind of
-         * task. The returned boolean reports whether the task made progress, that is, whether it changed planner state,
-         * for example by yielding new expressions, pushing planner requirements, or pushing more tasks onto the stack.
+         * task.
+         *
+         * @return whether the task made progress, that is, whether it changed planner state, for example by yielding
+         * new expressions, pushing planner requirements, or pushing more tasks onto the stack
          */
         boolean execute();
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CascadesPlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CascadesPlanner.java
@@ -845,7 +845,7 @@ public class CascadesPlanner implements QueryPlanner {
             final CascadesRuleSet ruleSet = getPlannerPhase().getRuleSet();
 
             // Push all rules that need to run after all exploration for a (group, expression) pair is done.
-            ruleSet.getMatchPartitionRules().forEach(this::pushTransformMatchPartitionMaybe);
+            ruleSet.getMatchPartitionRules().forEach(this::pushTransformMatchPartitionIfNeeded);
 
             // Push `TransformExpression` tasks for non-pre-order rules.
             //
@@ -855,7 +855,7 @@ public class CascadesPlanner implements QueryPlanner {
             // what happens towards the leaves of the tree.
             ruleSet.getRules(expression)
                     .filter(rule -> !(rule instanceof PreOrderRule))
-                    .forEach(this::pushTransformTaskMaybe);
+                    .forEach(this::pushTransformExpressionIfNeeded);
 
             // Push `ExploreGroup` tasks for all groups this expression ranges over.
             expression.getQuantifiers().stream()
@@ -865,7 +865,7 @@ public class CascadesPlanner implements QueryPlanner {
             // Push `TransformExpression` tasks for pre-order rules.
             ruleSet.getRules(expression)
                     .filter(rule -> rule instanceof PreOrderRule)
-                    .forEach(this::pushTransformTaskMaybe);
+                    .forEach(this::pushTransformExpressionIfNeeded);
 
             return true;
         }
@@ -880,7 +880,7 @@ public class CascadesPlanner implements QueryPlanner {
          * trying; if that subset is empty, no task is pushed.
          */
         @VisibleForTesting
-        void pushTransformTaskMaybe(@Nonnull CascadesRule<? extends RelationalExpression> rule) {
+        void pushTransformExpressionIfNeeded(@Nonnull CascadesRule<? extends RelationalExpression> rule) {
             if (!configuration.isRuleEnabled(rule) || !shouldPushRule(rule)) {
                 return;
             }
@@ -892,9 +892,7 @@ public class CascadesPlanner implements QueryPlanner {
                 // wrapper) so that on re-exploration only the inner rules that are actually sensitive to a newly-stale
                 // constraint get another chance to fire, instead of unconditionally restarting the whole chain from the
                 // first rule.
-                @SuppressWarnings("unchecked")
-                final var innerRules = (List<CascadesRule<? extends RelationalExpression>>)conditionalRule.getRules();
-                final var rules = innerRules.stream()
+                final var rules = conditionalRule.getRules().stream()
                         .filter(innerRule ->
                                 configuration.isRuleEnabled(innerRule) && shouldPushRule(innerRule))
                         .collect(ImmutableList.toImmutableList());
@@ -906,7 +904,7 @@ public class CascadesPlanner implements QueryPlanner {
             }
         }
 
-        private void pushTransformMatchPartitionMaybe(AbstractCascadesRule<? extends MatchPartition> rule) {
+        private void pushTransformMatchPartitionIfNeeded(AbstractCascadesRule<? extends MatchPartition> rule) {
             if (!configuration.isRuleEnabled(rule) || !shouldPushRule(rule)) {
                 return;
             }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CascadesPlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CascadesPlanner.java
@@ -900,9 +900,9 @@ public class CascadesPlanner implements QueryPlanner {
          * the planner {@link #configuration}, preserving their order.
          */
         @VisibleForTesting
-        <T extends RelationalExpression> List<AbstractCascadesRule<T>> getEnabledRules(ConditionalCascadesRule<?, ?> rule) {
+        <T extends RelationalExpression> List<CascadesRule<T>> getEnabledRules(ConditionalCascadesRule<?, ?> rule) {
             final var rules = rule.getRules(configuration::isRuleEnabled);
-            @SuppressWarnings("unchecked") final var result = (List<AbstractCascadesRule<T>>)rules;
+            @SuppressWarnings("unchecked") final var result = (List<CascadesRule<T>>)rules;
             return result;
         }
 
@@ -1204,20 +1204,20 @@ public class CascadesPlanner implements QueryPlanner {
     @VisibleForTesting
     class ConditionalTransformExpression extends TransformExpression {
         @Nonnull
-        private final List<AbstractCascadesRule<? extends RelationalExpression>> rules;
+        private final List<CascadesRule<? extends RelationalExpression>> rules;
         private final int index;
 
         public ConditionalTransformExpression(@Nonnull final PlannerPhase plannerPhase,
                                               @Nonnull final Reference group,
                                               @Nonnull final RelationalExpression expression,
-                                              @Nonnull final List<? extends AbstractCascadesRule<? extends RelationalExpression>> rules) {
+                                              @Nonnull final List<? extends CascadesRule<? extends RelationalExpression>> rules) {
             this(plannerPhase, group, expression, ImmutableList.copyOf(rules), 0);
         }
 
         private ConditionalTransformExpression(@Nonnull final PlannerPhase plannerPhase,
                                                @Nonnull final Reference group,
                                                @Nonnull final RelationalExpression expression,
-                                               @Nonnull final List<AbstractCascadesRule<? extends RelationalExpression>> rules,
+                                               @Nonnull final List<CascadesRule<? extends RelationalExpression>> rules,
                                                final int index) {
             super(plannerPhase, group, expression, rules.get(index));
             this.rules = rules;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CascadesPlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CascadesPlanner.java
@@ -876,7 +876,8 @@ public class CascadesPlanner implements QueryPlanner {
         /**
          * Pushes a task that transforms the current group/expression pair using the given rule. For an ordinary rule,
          * pushes a {@link TransformExpression} task. For a {@link ConditionalCascadesRule}, pushes a single
-         * {@link ConditionalTransformExpression} task holding the enabled inner rules (but only if there are any).
+         * {@link ConditionalTransformExpression} task holding the subset of inner rules that are both enabled and
+         * currently worth trying according to {@code shouldPushRule()}. If that subset is empty, no task is pushed.
          */
         @VisibleForTesting
         void pushTransformTask(@Nonnull CascadesRule<? extends RelationalExpression> rule) {
@@ -886,9 +887,14 @@ public class CascadesPlanner implements QueryPlanner {
             if (rule instanceof final ConditionalCascadesRule<?, ?> conditionalRule) {
                 // Filter the individual inner rules by `configuration::isRuleEnabled` here, since the filter that is
                 // applied earlier at `ruleSet.getRules()` pertains only to the `ConditionalCascadesRule` wrapper.
-                final var enabledRules = getEnabledRules(conditionalRule);
-                if (!enabledRules.isEmpty()) {
-                    taskStack.push(new ConditionalTransformExpression(phase, group, expression, enabledRules));
+                // Also re-apply `shouldPushRule()` to each inner rule (rather than just the wrapper) so that on
+                // re-exploration only the inner rules that are actually sensitive to a newly-stale constraint get
+                // another chance to fire, instead of unconditionally restarting the whole chain from the first rule.
+                final var rules = getEnabledRules(conditionalRule).stream()
+                        .filter(this::shouldPushRule)
+                        .collect(ImmutableList.<CascadesRule<? extends RelationalExpression>>toImmutableList());
+                if (!rules.isEmpty()) {
+                    taskStack.push(new ConditionalTransformExpression(phase, group, expression, rules));
                 }
             } else {
                 taskStack.push(new TransformExpression(phase, group, expression, rule));

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CascadesPlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/CascadesPlanner.java
@@ -841,58 +841,63 @@ public class CascadesPlanner implements QueryPlanner {
 
         @Override
         public boolean execute() {
-            final var ruleSet = getPlannerPhase().getRuleSet();
+            final RelationalExpression expression = getExpression();
+            final CascadesRuleSet ruleSet = getPlannerPhase().getRuleSet();
 
-            // push all rules that need to run after all exploration for a (group, expression) pair is done.
-            ruleSet.getMatchPartitionRules(configuration::isRuleEnabled)
-                    .filter(this::shouldPushRule)
-                    .forEach(this::pushTransformMatchPartition);
+            // Push all rules that need to run after all exploration for a (group, expression) pair is done.
+            ruleSet.getMatchPartitionRules().forEach(this::pushTransformMatchPartitionMaybe);
 
+            // Push `TransformExpression` tasks for non-pre-order rules.
+            //
             // This is closely tied to the way that rule finding works _now_. Specifically, rules are indexed only
             // by the type of their _root_, not any of the stuff lower down. As a result, we have enough information
             // right here to determine the set of all possible rules that could ever be applied here, regardless of
             // what happens towards the leaves of the tree.
-            ruleSet.getRules(getExpression(), configuration::isRuleEnabled)
-                    .filter(rule -> !(rule instanceof PreOrderRule) &&
-                            shouldPushRule(rule))
-                    .forEach(this::pushTransformTask);
+            ruleSet.getRules(expression)
+                    .filter(rule -> !(rule instanceof PreOrderRule))
+                    .forEach(this::pushTransformTaskMaybe);
 
-            // push explore group for all groups this expression ranges over
-            getExpression()
-                    .getQuantifiers()
-                    .stream()
+            // Push `ExploreGroup` tasks for all groups this expression ranges over.
+            expression.getQuantifiers().stream()
                     .map(Quantifier::getRangesOver)
                     .forEach(this::pushExploreGroup);
 
-            ruleSet.getRules(getExpression(), configuration::isRuleEnabled)
-                    .filter(rule -> rule instanceof PreOrderRule &&
-                            shouldPushRule(rule))
-                    .forEach(this::pushTransformTask);
+            // Push `TransformExpression` tasks for pre-order rules.
+            ruleSet.getRules(expression)
+                    .filter(rule -> rule instanceof PreOrderRule)
+                    .forEach(this::pushTransformTaskMaybe);
+
             return true;
         }
 
         protected abstract boolean shouldPushRule(@Nonnull CascadesRule<?> rule);
 
         /**
-         * Pushes a task that transforms the current group/expression pair using the given rule. For an ordinary rule,
-         * pushes a {@link TransformExpression} task. For a {@link ConditionalCascadesRule}, pushes a single
-         * {@link ConditionalTransformExpression} task holding the subset of inner rules that are both enabled and
-         * currently worth trying according to {@code shouldPushRule()}. If that subset is empty, no task is pushed.
+         * Pushes a task that transforms the current group/expression pair using the given rule, if that rule is
+         * currently enabled and worth trying according to {@link #shouldPushRule}. For an ordinary rule, pushes a
+         * {@link TransformExpression} task. For a {@link ConditionalCascadesRule}, pushes a single
+         * {@link ConditionalTransformExpression} task holding the subset of inner rules that are enabled and worth
+         * trying; if that subset is empty, no task is pushed.
          */
         @VisibleForTesting
-        void pushTransformTask(@Nonnull CascadesRule<? extends RelationalExpression> rule) {
+        void pushTransformTaskMaybe(@Nonnull CascadesRule<? extends RelationalExpression> rule) {
+            if (!configuration.isRuleEnabled(rule) || !shouldPushRule(rule)) {
+                return;
+            }
             final PlannerPhase phase = getPlannerPhase();
             final Reference group = getGroup();
             final RelationalExpression expression = getExpression();
             if (rule instanceof final ConditionalCascadesRule<?, ?> conditionalRule) {
-                // Filter the individual inner rules by `configuration::isRuleEnabled` here, since the filter that is
-                // applied earlier at `ruleSet.getRules()` pertains only to the `ConditionalCascadesRule` wrapper.
-                // Also re-apply `shouldPushRule()` to each inner rule (rather than just the wrapper) so that on
-                // re-exploration only the inner rules that are actually sensitive to a newly-stale constraint get
-                // another chance to fire, instead of unconditionally restarting the whole chain from the first rule.
-                final var rules = getEnabledRules(conditionalRule).stream()
-                        .filter(this::shouldPushRule)
-                        .collect(ImmutableList.<CascadesRule<? extends RelationalExpression>>toImmutableList());
+                // Check `shouldPushRule()` and `isRuleEnabled()` for each inner rule as well (rather than just the
+                // wrapper) so that on re-exploration only the inner rules that are actually sensitive to a newly-stale
+                // constraint get another chance to fire, instead of unconditionally restarting the whole chain from the
+                // first rule.
+                @SuppressWarnings("unchecked")
+                final var innerRules = (List<CascadesRule<? extends RelationalExpression>>)conditionalRule.getRules();
+                final var rules = innerRules.stream()
+                        .filter(innerRule ->
+                                configuration.isRuleEnabled(innerRule) && shouldPushRule(innerRule))
+                        .collect(ImmutableList.toImmutableList());
                 if (!rules.isEmpty()) {
                     taskStack.push(new ConditionalTransformExpression(phase, group, expression, rules));
                 }
@@ -901,18 +906,10 @@ public class CascadesPlanner implements QueryPlanner {
             }
         }
 
-        /**
-         * Returns the inner rules of the given {@link ConditionalCascadesRule} that are currently enabled according to
-         * the planner {@link #configuration}, preserving their order.
-         */
-        @VisibleForTesting
-        <T extends RelationalExpression> List<CascadesRule<T>> getEnabledRules(ConditionalCascadesRule<?, ?> rule) {
-            final var rules = rule.getRules(configuration::isRuleEnabled);
-            @SuppressWarnings("unchecked") final var result = (List<CascadesRule<T>>)rules;
-            return result;
-        }
-
-        private void pushTransformMatchPartition(AbstractCascadesRule<? extends MatchPartition> rule) {
+        private void pushTransformMatchPartitionMaybe(AbstractCascadesRule<? extends MatchPartition> rule) {
+            if (!configuration.isRuleEnabled(rule) || !shouldPushRule(rule)) {
+                return;
+            }
             taskStack.push(new TransformMatchPartition(getPlannerPhase(), getGroup(), getExpression(), rule));
         }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ConditionalCascadesRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ConditionalCascadesRule.java
@@ -24,6 +24,7 @@ import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpression;
 import com.apple.foundationdb.record.query.plan.cascades.matching.structure.BindingMatcher;
+import com.apple.foundationdb.record.query.plan.cascades.matching.structure.TypedMatcher;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -122,6 +123,8 @@ public class ConditionalCascadesRule<T, R extends CascadesRule<T>> extends Abstr
 
     @Override
     public void onMatch(@Nonnull final CascadesRuleCall call) {
+        // `onMatch()` must never actually be invoked. A `ConditionalCascadesRule` only groups inner rules for the
+        // planner to schedule conditionally; it never matches or applies transformations on its own.
         throw new RecordCoreException("cannot call this method directly");
     }
 
@@ -136,16 +139,18 @@ public class ConditionalCascadesRule<T, R extends CascadesRule<T>> extends Abstr
 
     /**
      * Derives the common binding matcher for a group of inner rules. All rules are expected to share a binding matcher
-     * with the same root class; this is verified, and the first matcher is returned as the representative.
+     * with the same root class; this is verified, and a {@link TypedMatcher} on that root class is returned.
+     * (Note that {@link #onMatch} is never actually invoked on a {@code ConditionalCascadesRule}. The matcher only
+     * communicates the common root class.)
      */
     @Nonnull
     private static <T, R extends PlannerRule<CascadesRuleCall, T>> BindingMatcher<T> deriveBindingMatcher(@Nonnull final List<R> rules) {
         Verify.verify(!rules.isEmpty(), "`ConditionalCascadesRule` must contain at least one rule");
-        final BindingMatcher<T> matcher = rules.get(0).getMatcher();
+        final Class<T> rootClass = rules.get(0).getMatcher().getRootClass();
         for (final R rule : rules) {
-            Verify.verify(rule.getMatcher().getRootClass() == matcher.getRootClass());
+            Verify.verify(rule.getMatcher().getRootClass() == rootClass);
         }
-        return matcher;
+        return TypedMatcher.typed(rootClass);
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ConditionalCascadesRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ConditionalCascadesRule.java
@@ -1,0 +1,221 @@
+/*
+ * ConditionalCascadesRule.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.cascades;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpression;
+import com.apple.foundationdb.record.query.plan.cascades.matching.structure.BindingMatcher;
+import com.google.common.base.Verify;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+/**
+ * A {@link CascadesRule} that groups together an ordered sequence of related inner rules for improved planning
+ * efficiency.
+ *
+ * <p>Instead of letting the planner fire each of the grouped rules independently—with every matching rule
+ * producing new expressions that then have to be explored and costed—a {@code ConditionalCascadesRule} asks the
+ * planner to try the inner rules in order and to stop as soon as one of them makes progress, only falling through to
+ * the next rule when the current one yields nothing. By arranging strictly-prioritized or mutually-exclusive
+ * transformations in such a conditional chain we can prune the planner’s search space. The alternatives that the later
+ * rules would have produced are never generated, which keeps the memo smaller and makes planning faster.
+ *
+ * <p>A conditional rule is never applied directly; attempting to call {@link #onMatch} results in a
+ * {@link RecordCoreException}. Instead, the planner treats conditional rules specially: When it encounters one, it
+ * selects the subset of inner rules that are currently enabled (via the planner configuration) and schedules those,
+ * in order, for the conditional application just described.
+ *
+ * <p>All inner rules must agree on the root class of their root binding matcher and on their root operator.
+ * The wrapping conditional rule exposes a single binding matcher and root operator that stands in for the whole group.
+ *
+ * @param <T> a parent planner expression type of all possible root planner expressions that this rule could match
+ * @param <R> the kind of inner {@link CascadesRule} grouped by this rule
+ */
+@API(API.Status.EXPERIMENTAL)
+public class ConditionalCascadesRule<T, R extends CascadesRule<T>> extends AbstractCascadesRule<T> {
+    /**
+     * The grouped inner rules, as an immutable list.
+     */
+    @Nonnull
+    final List<R> rules;
+
+    /**
+     * The root operator common to all inner rules, or {@code null} if the inner rules do not declare a root operator.
+     * All inner rules are required to agree on this value (verified at construction), so this single class stands in
+     * for the whole group.
+     */
+    @Nullable
+    final Class<?> rootOperator;
+
+    /**
+     * Creates a rule that groups the given inner rules. The list of rules must be non-empty. All rules must agree on
+     * their root operator and on the root class of their binding matcher.
+     */
+    public ConditionalCascadesRule(@Nonnull final List<R> rules) {
+        super(deriveBindingMatcher(rules), ImmutableSet.of());
+        this.rules = ImmutableList.copyOf(rules);
+        this.rootOperator = deriveRootOperator(rules);
+    }
+
+    /**
+     * Creates a rule that groups the given inner rules. This is a convenience overload of
+     * {@link #ConditionalCascadesRule(List)}.
+     */
+    @SafeVarargs
+    @SuppressWarnings("varargs")
+    public ConditionalCascadesRule(@Nonnull final R... rules) {
+        this(ImmutableList.copyOf(rules));
+    }
+
+    /**
+     * Returns the inner rules grouped by this rule as an immutable list.
+     */
+    @Nonnull
+    public List<R> getRules() {
+        return rules;
+    }
+
+    /**
+     * Returns the inner rules grouped by this rule that satisfy the given predicate, preserving their order.
+     */
+    @Nonnull
+    public List<R> getRules(@Nonnull final Predicate<? super R> rulePredicate) {
+        return rules.stream()
+                .filter(rulePredicate)
+                .collect(ImmutableList.toImmutableList());
+    }
+
+    /**
+     * Returns the root operator shared by all inner rules. If the inner rules do not declare a root operator, returns
+     * an empty {@link Optional}.
+     */
+    @Nonnull
+    @Override
+    public Optional<Class<?>> getRootOperator() {
+        return Optional.ofNullable(rootOperator);
+    }
+
+    @Override
+    public void onMatch(@Nonnull final CascadesRuleCall call) {
+        throw new RecordCoreException("cannot call this method directly");
+    }
+
+    /**
+     * Returns a string representation of this rule. The string consists of its simple class name followed by its inner
+     * rules; for example, {@code ConditionalExplorationCascadesRule[DecorrelateValuesRule, …]}.
+     */
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + rules;
+    }
+
+    /**
+     * Derives the common binding matcher for a group of inner rules. All rules are expected to share a binding matcher
+     * with the same root class; this is verified, and the first matcher is returned as the representative.
+     */
+    @Nonnull
+    private static <T, R extends PlannerRule<CascadesRuleCall, T>> BindingMatcher<T> deriveBindingMatcher(@Nonnull final List<R> rules) {
+        Verify.verify(!rules.isEmpty(), "`ConditionalCascadesRule` must contain at least one rule");
+        final BindingMatcher<T> matcher = rules.get(0).getMatcher();
+        for (final R rule : rules) {
+            Verify.verify(rule.getMatcher().getRootClass() == matcher.getRootClass());
+        }
+        return matcher;
+    }
+
+    /**
+     * Derives the common root operator for a group of inner rules. All rules are expected to agree on their root
+     * operator (either the same class, or all empty). This is verified, and the common value is returned.
+     */
+    @Nullable
+    private static <T, R extends PlannerRule<CascadesRuleCall, T>> Class<?> deriveRootOperator(@Nonnull final List<R> rules) {
+        Verify.verify(!rules.isEmpty(), "`ConditionalCascadesRule` must contain at least one rule");
+        final Class<?> op = rules.get(0).getRootOperator().orElse(null);
+        for (final R rule : rules) {
+            Verify.verify(rule.getRootOperator().orElse(null) == op);
+        }
+        return op;
+    }
+
+    /**
+     * A {@link ConditionalCascadesRule} that groups exploration rules and is itself an {@link ExplorationCascadesRule}.
+     *
+     * @param <T> a parent planner expression type of all possible root planner expressions that this rule could match
+     */
+    public static class ConditionalExplorationCascadesRule<T extends RelationalExpression> extends ConditionalCascadesRule<T, ExplorationCascadesRule<T>> implements ExplorationCascadesRule<T> {
+        /**
+         * Creates a rule that groups the given inner exploration rules.
+         */
+        public ConditionalExplorationCascadesRule(@Nonnull final List<ExplorationCascadesRule<T>> rules) {
+            super(rules);
+        }
+
+        /**
+         * Creates a rule that groups the given inner exploration rules.
+         */
+        @SafeVarargs
+        @SuppressWarnings("varargs")
+        public ConditionalExplorationCascadesRule(@Nonnull final ExplorationCascadesRule<T>... rules) {
+            super(rules);
+        }
+
+        @Override
+        public void onMatch(@Nonnull final ExplorationCascadesRuleCall call) {
+            throw new RecordCoreException("cannot call this method directly");
+        }
+    }
+
+    /**
+     * A {@link ConditionalCascadesRule} that groups implementation rules and is itself an
+     * {@link ImplementationCascadesRule}.
+     *
+     * @param <T> a parent planner expression type of all possible root planner expressions that this rule could match
+     */
+    public static class ConditionalImplementationCascadesRule<T extends RelationalExpression> extends ConditionalCascadesRule<T, ImplementationCascadesRule<T>> implements ImplementationCascadesRule<T> {
+        /**
+         * Creates a rule that groups the given inner implementation rules.
+         */
+        public ConditionalImplementationCascadesRule(@Nonnull final List<ImplementationCascadesRule<T>> rules) {
+            super(rules);
+        }
+
+        /**
+         * Creates a rule that groups the given inner implementation rules.
+         */
+        @SafeVarargs
+        @SuppressWarnings("varargs")
+        public ConditionalImplementationCascadesRule(@Nonnull final ImplementationCascadesRule<T>... rules) {
+            super(rules);
+        }
+
+        @Override
+        public void onMatch(@Nonnull final ImplementationCascadesRuleCall call) {
+            throw new RecordCoreException("cannot call this method directly");
+        }
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ConditionalCascadesRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ConditionalCascadesRule.java
@@ -33,6 +33,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Predicate;
 
 /**
@@ -78,7 +79,7 @@ public class ConditionalCascadesRule<T, R extends CascadesRule<T>> extends Abstr
      * their root operator and on the root class of their binding matcher.
      */
     public ConditionalCascadesRule(@Nonnull final List<R> rules) {
-        super(deriveBindingMatcher(rules), ImmutableSet.of());
+        super(deriveBindingMatcher(rules), deriveConstraintDependencies(rules));
         this.rules = ImmutableList.copyOf(rules);
         this.rootOperator = deriveRootOperator(rules);
     }
@@ -165,6 +166,21 @@ public class ConditionalCascadesRule<T, R extends CascadesRule<T>> extends Abstr
             Verify.verify(rule.getRootOperator().orElse(null) == op);
         }
         return op;
+    }
+
+    /**
+     * Derives the constraint dependencies for a group of inner rules, as the union of each rule’s own
+     * {@link CascadesRule#getConstraintDependencies()}. This ensures that the planner re-explores a group containing
+     * this conditional rule whenever any of its inner rules is sensitive to a newly-pushed requirement, even though
+     * only the wrapping conditional rule (and not the inner rules individually) is registered in the ruleset.
+     */
+    @Nonnull
+    private static <T> Set<PlannerConstraint<?>> deriveConstraintDependencies(@Nonnull final List<? extends CascadesRule<T>> rules) {
+        final ImmutableSet.Builder<PlannerConstraint<?>> dependencies = ImmutableSet.builder();
+        for (final CascadesRule<T> rule : rules) {
+            dependencies.addAll(rule.getConstraintDependencies());
+        }
+        return dependencies.build();
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ConditionalCascadesRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ConditionalCascadesRule.java
@@ -54,11 +54,13 @@ import java.util.Set;
  * <p>All inner rules must agree on the root class of their root binding matcher and on their root operator.
  * The wrapping conditional rule exposes a single binding matcher and root operator that stands in for the whole group.
  *
- * @param <T> a parent planner expression type of all possible root planner expressions that this rule could match
+ * @param <T> a parent planner expression type of all possible root planner expressions that this rule could match;
+ *            bounded by {@link RelationalExpression} because conditional rules only ever group expression-transform
+ *            rules, letting callers treat the grouped rules as {@code CascadesRule<? extends RelationalExpression>}
  * @param <R> the kind of inner {@link CascadesRule} grouped by this rule
  */
 @API(API.Status.EXPERIMENTAL)
-public class ConditionalCascadesRule<T, R extends CascadesRule<T>> extends AbstractCascadesRule<T> {
+public class ConditionalCascadesRule<T extends RelationalExpression, R extends CascadesRule<T>> extends AbstractCascadesRule<T> {
     /**
      * The grouped inner rules, as an immutable list.
      */

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ConditionalCascadesRule.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ConditionalCascadesRule.java
@@ -34,7 +34,6 @@ import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Predicate;
 
 /**
  * A {@link CascadesRule} that groups together an ordered sequence of related inner rules for improved planning
@@ -100,16 +99,6 @@ public class ConditionalCascadesRule<T, R extends CascadesRule<T>> extends Abstr
     @Nonnull
     public List<R> getRules() {
         return rules;
-    }
-
-    /**
-     * Returns the inner rules grouped by this rule that satisfy the given predicate, preserving their order.
-     */
-    @Nonnull
-    public List<R> getRules(@Nonnull final Predicate<? super R> rulePredicate) {
-        return rules.stream()
-                .filter(rulePredicate)
-                .collect(ImmutableList.toImmutableList());
     }
 
     /**

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/CascadesPlannerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/CascadesPlannerTest.java
@@ -1,0 +1,191 @@
+/*
+ * CascadesPlannerTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.cascades;
+
+import com.apple.foundationdb.record.RecordMetaData;
+import com.apple.foundationdb.record.RecordStoreState;
+import com.apple.foundationdb.record.TestRecords1Proto;
+import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerFactoryRegistryImpl;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.FullUnorderedScanExpression;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpression;
+import com.apple.foundationdb.record.query.plan.cascades.matching.structure.BindingMatcher;
+import com.apple.foundationdb.record.query.plan.cascades.matching.structure.RelationalExpressionMatchers;
+import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link CascadesPlanner}.
+ *
+ * <p>The tests drive the planner’s rule dispatching logic directly, by constructing and executing planner tasks
+ * directly (as opposed to going through a query).
+ */
+class CascadesPlannerTest {
+    /**
+     * If the first inner rule of a {@link ConditionalCascadesRule} makes progress, the remaining rules are not tried.
+     */
+    @Test
+    void testConditionalCascadesRule1() {
+        final RelationalExpression expression = scanExpression("A");
+        final Reference group = Reference.initialOf(expression);
+        final CascadesPlanner planner = newPlanner();
+
+        final RecordingExplorationCascadesRule first = new RecordingExplorationCascadesRule(true);
+        final RecordingExplorationCascadesRule second = new RecordingExplorationCascadesRule(true);
+        final CascadesPlanner.ConditionalTransformExpression task = planner.new ConditionalTransformExpression(
+                PlannerPhase.REWRITING, group, expression, ImmutableList.of(first, second));
+
+        assertThat(task.execute()).isTrue();
+        assertThat(first.matchCount).isEqualTo(1);
+        assertThat(second.matchCount).isEqualTo(0);
+        assertThat(planner.getTaskStack()).noneMatch(CascadesPlanner.ConditionalTransformExpression.class::isInstance);
+    }
+
+    /**
+     * If an inner rule of a {@link ConditionalCascadesRule} makes no progress, the next rule is tried.
+     */
+    @Test
+    void testConditionalCascadesRule2() {
+        final RelationalExpression expression = scanExpression("A");
+        final Reference group = Reference.initialOf(expression);
+        final CascadesPlanner planner = newPlanner();
+
+        final RecordingExplorationCascadesRule noProgress = new RecordingExplorationCascadesRule(false);
+        final RecordingExplorationCascadesRule successful = new RecordingExplorationCascadesRule(true);
+        final CascadesPlanner.ConditionalTransformExpression task = planner.new ConditionalTransformExpression(
+                PlannerPhase.REWRITING, group, expression, ImmutableList.of(noProgress, successful));
+
+        assertThat(task.execute()).isFalse();
+        assertThat(noProgress.matchCount).isEqualTo(1);
+        assertThat(successful.matchCount).isEqualTo(0);
+
+        final CascadesPlanner.Task followUp = planner.getTaskStack().pop();
+        assertThat(followUp).isInstanceOf(CascadesPlanner.ConditionalTransformExpression.class);
+        assertThat(followUp.execute()).isTrue();
+        assertThat(successful.matchCount).isEqualTo(1);
+    }
+
+    /**
+     * If the last (or only) inner rule of a {@link ConditionalCascadesRule} makes no progress, no follow-up task is
+     * pushed.
+     */
+    @Test
+    void testConditionalCascadesRule3() {
+        final RelationalExpression expression = scanExpression("A");
+        final Reference group = Reference.initialOf(expression);
+        final CascadesPlanner planner = newPlanner();
+
+        final RecordingExplorationCascadesRule onlyRule = new RecordingExplorationCascadesRule(false);
+        final CascadesPlanner.ConditionalTransformExpression task = planner.new ConditionalTransformExpression(
+                PlannerPhase.REWRITING, group, expression, ImmutableList.of(onlyRule));
+
+        assertThat(task.execute()).isFalse();
+        assertThat(planner.getTaskStack()).isEmpty();
+    }
+
+    /**
+     * The inner rules of a {@link ConditionalCascadesRule} that are disabled via the planner configuration are filtered
+     * out.
+     */
+    @Test
+    void testConditionalCascadesRule4() {
+        final RelationalExpression expression = scanExpression("A");
+        final Reference group = Reference.initialOf(expression);
+        final CascadesPlanner planner = newPlanner();
+        planner.setConfiguration(planner.getConfiguration().asBuilder()
+                .disableTransformationRule(RecordingExplorationCascadesRule.class)
+                .build());
+
+        final RecordingExplorationCascadesRule disabled = new RecordingExplorationCascadesRule(true);
+        final OtherRecordingExplorationCascadesRule enabled = new OtherRecordingExplorationCascadesRule(true);
+        final ConditionalCascadesRule<RelationalExpression, RecordingExplorationCascadesRule> conditionalRule =
+                new ConditionalCascadesRule<>(ImmutableList.of(disabled, enabled));
+        final CascadesPlanner.ExploreExpression explore =
+                planner.new ExploreExpression(PlannerPhase.REWRITING, group, expression);
+
+        assertThat(explore.<RelationalExpression>getEnabledRules(conditionalRule)).containsExactly(enabled);
+    }
+
+    /**
+     * Creates a {@link CascadesPlanner} over an empty {@link TestRecords1Proto}-based store.
+     */
+    @Nonnull
+    private static CascadesPlanner newPlanner() {
+        final RecordMetaData metaData =
+                RecordMetaData.newBuilder().setRecords(TestRecords1Proto.getDescriptor()).getRecordMetaData();
+        return new CascadesPlanner(metaData, new RecordStoreState(null, null), IndexMaintainerFactoryRegistryImpl.instance());
+    }
+
+    /**
+     * Creates a leaf {@link RelationalExpression} for the given record type, with no quantifiers.
+     */
+    @Nonnull
+    private static FullUnorderedScanExpression scanExpression(@Nonnull final String recordType) {
+        return new FullUnorderedScanExpression(ImmutableSet.of(recordType), new Type.AnyRecord(false), new AccessHints());
+    }
+
+    /**
+     * A minimal {@link ExplorationCascadesRule} for testing purposes. Matches any {@link FullUnorderedScanExpression},
+     * records how many times it was matched, and either yields a new expression (signaling progress) or does nothing,
+     * depending on how it was constructed.
+     */
+    private static class RecordingExplorationCascadesRule
+            extends AbstractCascadesRule<RelationalExpression>
+            implements ExplorationCascadesRule<RelationalExpression> {
+        private final boolean shouldYield;
+        private int matchCount;
+
+        RecordingExplorationCascadesRule(final boolean shouldYield) {
+            super(matcher());
+            this.shouldYield = shouldYield;
+        }
+
+        @Override
+        public void onMatch(@Nonnull final ExplorationCascadesRuleCall call) {
+            matchCount++;
+            if (shouldYield) {
+                call.yieldExploratoryExpression(scanExpression("B"));
+            }
+        }
+
+        @Nonnull
+        @SuppressWarnings("unchecked")
+        private static BindingMatcher<RelationalExpression> matcher() {
+            return (BindingMatcher<RelationalExpression>)(BindingMatcher<?>)
+                    RelationalExpressionMatchers.ofType(FullUnorderedScanExpression.class);
+        }
+    }
+
+    /**
+     * A rule identical to {@link RecordingExplorationCascadesRule} except for its class, so that it can be disabled
+     * independently via {@code RecordQueryPlannerConfiguration}, which disables rules by their simple class name.
+     */
+    private static final class OtherRecordingExplorationCascadesRule extends RecordingExplorationCascadesRule {
+        OtherRecordingExplorationCascadesRule(final boolean shouldYield) {
+            super(shouldYield);
+        }
+    }
+}

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/CascadesPlannerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/CascadesPlannerTest.java
@@ -130,6 +130,27 @@ class CascadesPlannerTest {
     }
 
     /**
+     * If {@code shouldExecute()} returns {@code false} for the group/expression pair, no rule is tried and no follow-up
+     * task is pushed, even though more than one rule remains.
+     */
+    @Test
+    void testConditionalCascadesRule5() {
+        final Reference group = Reference.initialOf(scanExpression("A"));
+        final RelationalExpression expressionNotInGroup = scanExpression("C");
+        final CascadesPlanner planner = newPlanner();
+
+        final RecordingExplorationCascadesRule first = new RecordingExplorationCascadesRule(true);
+        final RecordingExplorationCascadesRule second = new RecordingExplorationCascadesRule(true);
+        final CascadesPlanner.ConditionalTransformExpression task = planner.new ConditionalTransformExpression(
+                PlannerPhase.REWRITING, group, expressionNotInGroup, ImmutableList.of(first, second));
+
+        assertThat(task.execute()).isFalse();
+        assertThat(first.matchCount).isEqualTo(0);
+        assertThat(second.matchCount).isEqualTo(0);
+        assertThat(planner.getTaskStack()).isEmpty();
+    }
+
+    /**
      * Creates a {@link CascadesPlanner} over an empty {@link TestRecords1Proto}-based store.
      */
     @Nonnull

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/CascadesPlannerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/CascadesPlannerTest.java
@@ -34,6 +34,8 @@ import com.google.common.collect.ImmutableSet;
 import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
+import java.util.Optional;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -151,6 +153,74 @@ class CascadesPlannerTest {
     }
 
     /**
+     * On re-exploration, only the inner rules of a {@link ConditionalCascadesRule} whose own constraint dependencies
+     * are actually stale get pushed into the chain; inner rules that are not sensitive to the constraint that changed
+     * are filtered out entirely, rather than being tried (and failing to match anything new) regardless.
+     */
+    @Test
+    void testConditionalCascadesRule6() {
+        final RelationalExpression expression = scanExpression("A");
+        final Reference group = Reference.initialOf(expression);
+        final CascadesPlanner planner = newPlanner();
+
+        // Simulate a group that has already been fully explored and committed once.
+        group.setExplored();
+        // Push a new value for CONSTRAINT_A only; CONSTRAINT_B is left untouched, so only CONSTRAINT_A is stale
+        // relative to the committed exploration.
+        group.getConstraintsMap().pushProperty(CONSTRAINT_A, new Object());
+        group.startExploration();
+
+        final RecordingExplorationCascadesRule staleRule =
+                new RecordingExplorationCascadesRule(true, ImmutableSet.<PlannerConstraint<?>>of(CONSTRAINT_A));
+        final RecordingExplorationCascadesRule notStaleRule =
+                new RecordingExplorationCascadesRule(true, ImmutableSet.<PlannerConstraint<?>>of(CONSTRAINT_B));
+        // `notStaleRule` is listed *first*: if it weren't filtered out, it would match and short-circuit the chain
+        // before `staleRule` (listed second) is ever reached, since `notStaleRule` also yields on a match. So this
+        // ordering is what actually distinguishes "filtered out" from "chain just moved on past it".
+        final ConditionalCascadesRule<RelationalExpression, RecordingExplorationCascadesRule> conditionalRule =
+                new ConditionalCascadesRule<>(ImmutableList.of(notStaleRule, staleRule));
+        // `ReExploreExpression` itself is not visible here; this reproduces its `shouldPushRule()` logic (staleness
+        // with respect to the group's committed exploration) on top of the otherwise-testable base class.
+        final CascadesPlanner.AbstractExploreExpression reExplore =
+                planner.new AbstractExploreExpression(PlannerPhase.REWRITING, group, expression) {
+                    @Override
+                    protected boolean shouldPushRule(@Nonnull final CascadesRule<?> rule) {
+                        return group.isFullyExploring() || !group.isExploredForAttributes(rule.getConstraintDependencies());
+                    }
+                };
+
+        reExplore.pushTransformTask(conditionalRule);
+
+        final CascadesPlanner.Task pushedTask = planner.getTaskStack().pop();
+        assertThat(pushedTask).isInstanceOf(CascadesPlanner.ConditionalTransformExpression.class);
+        assertThat(pushedTask.execute()).isTrue();
+        assertThat(staleRule.matchCount).isEqualTo(1);
+        assertThat(notStaleRule.matchCount).isEqualTo(0);
+        assertThat(planner.getTaskStack()).noneMatch(CascadesPlanner.ConditionalTransformExpression.class::isInstance);
+    }
+
+    /**
+     * A stub {@link PlannerConstraint} used to exercise the per-inner-rule staleness filtering in
+     * {@link CascadesPlanner.AbstractExploreExpression#pushTransformTask}. Its {@code combine()} method is never
+     * invoked by these tests; identity is all that matters.
+     */
+    private static final PlannerConstraint<Object> CONSTRAINT_A = new PlannerConstraint<Object>() {
+        @Nonnull
+        @Override
+        public Optional<Object> combine(@Nonnull final Object currentConstraint, @Nonnull final Object newConstraint) {
+            return Optional.empty();
+        }
+    };
+
+    private static final PlannerConstraint<Object> CONSTRAINT_B = new PlannerConstraint<Object>() {
+        @Nonnull
+        @Override
+        public Optional<Object> combine(@Nonnull final Object currentConstraint, @Nonnull final Object newConstraint) {
+            return Optional.empty();
+        }
+    };
+
+    /**
      * Creates a {@link CascadesPlanner} over an empty {@link TestRecords1Proto}-based store.
      */
     @Nonnull
@@ -180,7 +250,11 @@ class CascadesPlannerTest {
         private int matchCount;
 
         RecordingExplorationCascadesRule(final boolean shouldYield) {
-            super(matcher());
+            this(shouldYield, ImmutableSet.of());
+        }
+
+        RecordingExplorationCascadesRule(final boolean shouldYield, @Nonnull final Set<PlannerConstraint<?>> constraintDependencies) {
+            super(matcher(), constraintDependencies);
             this.shouldYield = shouldYield;
         }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/CascadesPlannerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/CascadesPlannerTest.java
@@ -122,13 +122,22 @@ class CascadesPlannerTest {
                 .build());
 
         final RecordingExplorationCascadesRule disabled = new RecordingExplorationCascadesRule(true);
-        final OtherRecordingExplorationCascadesRule enabled = new OtherRecordingExplorationCascadesRule(true);
+        final RecordingExplorationCascadesRule enabled = new OtherRecordingExplorationCascadesRule(true);
+        // Make `disabled` the *first* inner rule. If it weren't filtered out, it would match and short-circuit the
+        // chain before `enabled` (listed second) is ever reached, since `disabled` also yields on a match. So this
+        // ordering is what actually distinguishes “filtered out” from “chain just moved on past it”.
         final ConditionalCascadesRule<RelationalExpression, RecordingExplorationCascadesRule> conditionalRule =
                 new ConditionalCascadesRule<>(ImmutableList.of(disabled, enabled));
         final CascadesPlanner.ExploreExpression explore =
                 planner.new ExploreExpression(PlannerPhase.REWRITING, group, expression);
 
-        assertThat(explore.<RelationalExpression>getEnabledRules(conditionalRule)).containsExactly(enabled);
+        explore.pushTransformTaskMaybe(conditionalRule);
+
+        final CascadesPlanner.Task pushedTask = planner.getTaskStack().pop();
+        assertThat(pushedTask).isInstanceOf(CascadesPlanner.ConditionalTransformExpression.class);
+        assertThat(pushedTask.execute()).isTrue();
+        assertThat(enabled.matchCount).isEqualTo(1);
+        assertThat(disabled.matchCount).isEqualTo(0);
     }
 
     /**
@@ -189,7 +198,7 @@ class CascadesPlannerTest {
                     }
                 };
 
-        reExplore.pushTransformTask(conditionalRule);
+        reExplore.pushTransformTaskMaybe(conditionalRule);
 
         final CascadesPlanner.Task pushedTask = planner.getTaskStack().pop();
         assertThat(pushedTask).isInstanceOf(CascadesPlanner.ConditionalTransformExpression.class);
@@ -201,7 +210,7 @@ class CascadesPlannerTest {
 
     /**
      * A stub {@link PlannerConstraint} used to exercise the per-inner-rule staleness filtering in
-     * {@link CascadesPlanner.AbstractExploreExpression#pushTransformTask}. Its {@code combine()} method is never
+     * {@link CascadesPlanner.AbstractExploreExpression#pushTransformTaskMaybe}. Its {@code combine()} method is never
      * invoked by these tests; identity is all that matters.
      */
     private static final PlannerConstraint<Object> CONSTRAINT_A = new PlannerConstraint<Object>() {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/CascadesPlannerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/CascadesPlannerTest.java
@@ -131,7 +131,7 @@ class CascadesPlannerTest {
         final CascadesPlanner.ExploreExpression explore =
                 planner.new ExploreExpression(PlannerPhase.REWRITING, group, expression);
 
-        explore.pushTransformTaskMaybe(conditionalRule);
+        explore.pushTransformExpressionIfNeeded(conditionalRule);
 
         final CascadesPlanner.Task pushedTask = planner.getTaskStack().pop();
         assertThat(pushedTask).isInstanceOf(CascadesPlanner.ConditionalTransformExpression.class);
@@ -198,7 +198,7 @@ class CascadesPlannerTest {
                     }
                 };
 
-        reExplore.pushTransformTaskMaybe(conditionalRule);
+        reExplore.pushTransformExpressionIfNeeded(conditionalRule);
 
         final CascadesPlanner.Task pushedTask = planner.getTaskStack().pop();
         assertThat(pushedTask).isInstanceOf(CascadesPlanner.ConditionalTransformExpression.class);
@@ -210,7 +210,7 @@ class CascadesPlannerTest {
 
     /**
      * A stub {@link PlannerConstraint} used to exercise the per-inner-rule staleness filtering in
-     * {@link CascadesPlanner.AbstractExploreExpression#pushTransformTaskMaybe}. Its {@code combine()} method is never
+     * {@link CascadesPlanner.AbstractExploreExpression#pushTransformExpressionIfNeeded}. Its {@code combine()} method is never
      * invoked by these tests; identity is all that matters.
      */
     private static final PlannerConstraint<Object> CONSTRAINT_A = new PlannerConstraint<Object>() {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/ConditionalCascadesRuleTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/ConditionalCascadesRuleTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/ConditionalCascadesRuleTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/ConditionalCascadesRuleTest.java
@@ -30,10 +30,12 @@ import com.apple.foundationdb.record.query.plan.cascades.matching.structure.Bind
 import com.apple.foundationdb.record.query.plan.cascades.matching.structure.RelationalExpressionMatchers;
 import com.google.common.base.VerifyException;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -42,6 +44,26 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * Tests for {@link ConditionalCascadesRule}.
  */
 class ConditionalCascadesRuleTest {
+
+    /**
+     * A stub {@link PlannerConstraint} used to exercise constraint-dependency derivation. Its {@code combine()} method
+     * is never invoked by these tests; identity is all that matters.
+     */
+    private static final PlannerConstraint<?> CONSTRAINT_A = new PlannerConstraint<Object>() {
+        @Nonnull
+        @Override
+        public Optional<Object> combine(@Nonnull final Object currentConstraint, @Nonnull final Object newConstraint) {
+            return Optional.empty();
+        }
+    };
+
+    private static final PlannerConstraint<?> CONSTRAINT_B = new PlannerConstraint<Object>() {
+        @Nonnull
+        @Override
+        public Optional<Object> combine(@Nonnull final Object currentConstraint, @Nonnull final Object newConstraint) {
+            return Optional.empty();
+        }
+    };
 
     @Test
     void constructorDerivesCommonRootOperator() {
@@ -106,6 +128,43 @@ class ConditionalCascadesRuleTest {
         final StubRule second = stubRule(SelectExpression.class, Optional.empty());
         final ConditionalCascadesRule<RelationalExpression, StubRule> rule = conditionalRuleOf(first, second);
         assertThat(rule.getRootOperator()).isEmpty();
+    }
+
+    /**
+     * The conditional rule advertises the union of the constraint dependencies of its inner rules. This is what makes
+     * the re-exploration gate ({@code ReExploreExpression.shouldPushRule()}) re-schedule the whole conditional
+     * chain whenever <em>any</em> inner rule is sensitive to a newly-pushed requirement, even though only the wrapper
+     * (and not the inner rules individually) is registered in the ruleset.
+     */
+    @Test
+    void constructorDerivesUnionOfConstraintDependencies() {
+        final StubRule first = stubRule(SelectExpression.class, ImmutableSet.of(CONSTRAINT_A));
+        final StubRule second = stubRule(SelectExpression.class, ImmutableSet.of(CONSTRAINT_B));
+        final ConditionalCascadesRule<RelationalExpression, StubRule> rule = conditionalRuleOf(first, second);
+        assertThat(rule.getConstraintDependencies()).containsExactlyInAnyOrder(CONSTRAINT_A, CONSTRAINT_B);
+    }
+
+    /**
+     * If none of the inner rules is sensitive to any requirement, neither is the conditional rule. (Before the union
+     * was derived, the wrapper always advertised an empty dependency set, which caused it to be skipped on
+     * re-exploration even when an inner rule was in fact sensitive.)
+     */
+    @Test
+    void constructorWithNoConstraintDependenciesHasEmptyDependencies() {
+        final ConditionalCascadesRule<RelationalExpression, StubRule> rule =
+                conditionalRuleOf(stubRule(SelectExpression.class), stubRule(SelectExpression.class));
+        assertThat(rule.getConstraintDependencies()).isEmpty();
+    }
+
+    /**
+     * A constraint that more than one inner rule depends on appears only once in the derived union.
+     */
+    @Test
+    void constructorDeduplicatesSharedConstraintDependencies() {
+        final StubRule first = stubRule(SelectExpression.class, ImmutableSet.of(CONSTRAINT_A, CONSTRAINT_B));
+        final StubRule second = stubRule(SelectExpression.class, ImmutableSet.of(CONSTRAINT_B));
+        final ConditionalCascadesRule<RelationalExpression, StubRule> rule = conditionalRuleOf(first, second);
+        assertThat(rule.getConstraintDependencies()).containsExactlyInAnyOrder(CONSTRAINT_A, CONSTRAINT_B);
     }
 
     @Test
@@ -214,6 +273,12 @@ class ConditionalCascadesRuleTest {
     }
 
     @Nonnull
+    private static StubRule stubRule(@Nonnull final Class<? extends RelationalExpression> rootClass,
+                                     @Nonnull final Set<PlannerConstraint<?>> constraintDependencies) {
+        return new StubRule(matcherFor(rootClass), Optional.of(rootClass), constraintDependencies);
+    }
+
+    @Nonnull
     private static StubExplorationRule stubExplorationRule(@Nonnull final Class<? extends RelationalExpression> rootClass) {
         return new StubExplorationRule(matcherFor(rootClass));
     }
@@ -239,7 +304,13 @@ class ConditionalCascadesRuleTest {
 
         private StubRule(@Nonnull final BindingMatcher<RelationalExpression> matcher,
                          @Nonnull final Optional<Class<?>> rootOperator) {
-            super(matcher);
+            this(matcher, rootOperator, ImmutableSet.of());
+        }
+
+        private StubRule(@Nonnull final BindingMatcher<RelationalExpression> matcher,
+                         @Nonnull final Optional<Class<?>> rootOperator,
+                         @Nonnull final Set<PlannerConstraint<?>> constraintDependencies) {
+            super(matcher, constraintDependencies);
             this.rootOperator = rootOperator;
         }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/ConditionalCascadesRuleTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/ConditionalCascadesRuleTest.java
@@ -1,0 +1,289 @@
+/*
+ * ConditionalCascadesRuleTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.cascades;
+
+import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.query.plan.cascades.ConditionalCascadesRule.ConditionalExplorationCascadesRule;
+import com.apple.foundationdb.record.query.plan.cascades.ConditionalCascadesRule.ConditionalImplementationCascadesRule;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.LogicalFilterExpression;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpression;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.SelectExpression;
+import com.apple.foundationdb.record.query.plan.cascades.matching.structure.BindingMatcher;
+import com.apple.foundationdb.record.query.plan.cascades.matching.structure.RelationalExpressionMatchers;
+import com.google.common.base.VerifyException;
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@link ConditionalCascadesRule}.
+ */
+class ConditionalCascadesRuleTest {
+
+    @Test
+    void constructorDerivesCommonRootOperator() {
+        final StubRule first = stubRule(SelectExpression.class);
+        final StubRule second = stubRule(SelectExpression.class);
+        final ConditionalCascadesRule<RelationalExpression, StubRule> rule = conditionalRuleOf(first, second);
+        assertThat(rule.getRootOperator()).contains(SelectExpression.class);
+        assertThat(rule.getRules()).containsExactly(first, second);
+    }
+
+    @Test
+    void varargsConstructorDerivesCommonRootOperator() {
+        // Exercises the varargs constructor directly, rather than the list constructor used by `conditionalRuleOf()`.
+        final StubRule first = stubRule(SelectExpression.class);
+        final StubRule second = stubRule(SelectExpression.class);
+        final ConditionalCascadesRule<RelationalExpression, StubRule> rule = new ConditionalCascadesRule<>(first, second);
+        assertThat(rule.getRules()).containsExactly(first, second);
+        assertThat(rule.getRootOperator()).contains(SelectExpression.class);
+    }
+
+    @Test
+    void constructorWithSingleRuleSucceeds() {
+        final StubRule only = stubRule(SelectExpression.class);
+        final ConditionalCascadesRule<RelationalExpression, StubRule> rule = conditionalRuleOf(only);
+        assertThat(rule.getRules()).containsExactly(only);
+        assertThat(rule.getRootOperator()).contains(SelectExpression.class);
+    }
+
+    @Test
+    void constructorWithEmptyListThrows() {
+        assertThatThrownBy(() -> new ConditionalCascadesRule<>(ImmutableList.<StubRule>of()))
+                .isInstanceOf(VerifyException.class)
+                .hasMessageContaining("must contain at least one rule");
+    }
+
+    @Test
+    void constructorWithMismatchedRootClassThrows() {
+        final StubRule selectRule = stubRule(SelectExpression.class);
+        final StubRule filterRule = stubRule(LogicalFilterExpression.class);
+        assertThatThrownBy(() -> conditionalRuleOf(selectRule, filterRule)).isInstanceOf(VerifyException.class);
+    }
+
+    @Test
+    void constructorWithMismatchedRootOperatorThrows() {
+        // Both rules match the same root class, so the binding-matcher check passes, but they advertise different
+        // root operators, which the root-operator check must reject.
+        final StubRule first = stubRule(SelectExpression.class, Optional.of(SelectExpression.class));
+        final StubRule second = stubRule(SelectExpression.class, Optional.of(LogicalFilterExpression.class));
+        assertThatThrownBy(() -> conditionalRuleOf(first, second)).isInstanceOf(VerifyException.class);
+    }
+
+    @Test
+    void constructorWithPresentAndEmptyRootOperatorThrows() {
+        final StubRule present = stubRule(SelectExpression.class, Optional.of(SelectExpression.class));
+        final StubRule empty = stubRule(SelectExpression.class, Optional.empty());
+        assertThatThrownBy(() -> conditionalRuleOf(present, empty)).isInstanceOf(VerifyException.class);
+    }
+
+    @Test
+    void constructorWithAllEmptyRootOperatorsHasEmptyRootOperator() {
+        final StubRule first = stubRule(SelectExpression.class, Optional.empty());
+        final StubRule second = stubRule(SelectExpression.class, Optional.empty());
+        final ConditionalCascadesRule<RelationalExpression, StubRule> rule = conditionalRuleOf(first, second);
+        assertThat(rule.getRootOperator()).isEmpty();
+    }
+
+    @Test
+    void getRulesReturnsRulesInOrder() {
+        final StubRule first = stubRule(SelectExpression.class);
+        final StubRule second = stubRule(SelectExpression.class);
+        final StubRule third = stubRule(SelectExpression.class);
+        final ConditionalCascadesRule<RelationalExpression, StubRule> rule = conditionalRuleOf(first, second, third);
+        assertThat(rule.getRules()).containsExactly(first, second, third);
+    }
+
+    @Test
+    void getRulesWithPredicateFiltersInOrder() {
+        final StubRule first = stubRule(SelectExpression.class);
+        final StubRule second = stubRule(SelectExpression.class);
+        final StubRule third = stubRule(SelectExpression.class);
+        final ConditionalCascadesRule<RelationalExpression, StubRule> rule = conditionalRuleOf(first, second, third);
+        assertThat(rule.getRules(candidate -> candidate == first || candidate == third)).containsExactly(first, third);
+    }
+
+    @Test
+    void getRulesWithNeverMatchingPredicateReturnsEmpty() {
+        final ConditionalCascadesRule<RelationalExpression, StubRule> rule =
+                conditionalRuleOf(stubRule(SelectExpression.class), stubRule(SelectExpression.class));
+        assertThat(rule.getRules(candidate -> false)).isEmpty();
+    }
+
+    @Test
+    void onMatchThrows() {
+        final ConditionalCascadesRule<RelationalExpression, StubRule> rule =
+                conditionalRuleOf(stubRule(SelectExpression.class));
+        assertThatThrownBy(() -> rule.onMatch((CascadesRuleCall) null))
+                .isInstanceOf(RecordCoreException.class)
+                .hasMessageContaining("cannot call this method directly");
+    }
+
+    @Test
+    void explorationVariantOnMatchThrows() {
+        final ConditionalExplorationCascadesRule<RelationalExpression> rule =
+                new ConditionalExplorationCascadesRule<>(ImmutableList.of(stubExplorationRule(SelectExpression.class)));
+        assertThat(rule.getRootOperator()).contains(SelectExpression.class);
+        assertThatThrownBy(() -> rule.onMatch((ExplorationCascadesRuleCall) null))
+                .isInstanceOf(RecordCoreException.class)
+                .hasMessageContaining("cannot call this method directly");
+        assertThatThrownBy(() -> rule.onMatch((CascadesRuleCall) null))
+                .isInstanceOf(RecordCoreException.class)
+                .hasMessageContaining("cannot call this method directly");
+    }
+
+    @Test
+    void explorationVariantVarargsConstructor() {
+        final StubExplorationRule first = stubExplorationRule(SelectExpression.class);
+        final StubExplorationRule second = stubExplorationRule(SelectExpression.class);
+        final ConditionalExplorationCascadesRule<RelationalExpression> rule =
+                new ConditionalExplorationCascadesRule<>(first, second);
+        assertThat(rule.getRules()).containsExactly(first, second);
+        assertThat(rule.getRootOperator()).contains(SelectExpression.class);
+    }
+
+    @Test
+    void implementationVariantListConstructorAndOnMatchThrows() {
+        final ConditionalImplementationCascadesRule<RelationalExpression> rule =
+                new ConditionalImplementationCascadesRule<>(ImmutableList.of(stubImplementationRule(SelectExpression.class)));
+        assertThat(rule.getRootOperator()).contains(SelectExpression.class);
+        assertThatThrownBy(() -> rule.onMatch((ImplementationCascadesRuleCall) null))
+                .isInstanceOf(RecordCoreException.class)
+                .hasMessageContaining("cannot call this method directly");
+        assertThatThrownBy(() -> rule.onMatch((CascadesRuleCall) null))
+                .isInstanceOf(RecordCoreException.class)
+                .hasMessageContaining("cannot call this method directly");
+    }
+
+    @Test
+    void implementationVariantVarargsConstructor() {
+        final StubImplementationRule first = stubImplementationRule(SelectExpression.class);
+        final StubImplementationRule second = stubImplementationRule(SelectExpression.class);
+        final ConditionalImplementationCascadesRule<RelationalExpression> rule =
+                new ConditionalImplementationCascadesRule<>(first, second);
+        assertThat(rule.getRules()).containsExactly(first, second);
+        assertThat(rule.getRootOperator()).contains(SelectExpression.class);
+    }
+
+    @Test
+    void toStringContainsClassNameAndRules() {
+        final ConditionalCascadesRule<RelationalExpression, StubRule> rule =
+                conditionalRuleOf(stubRule(SelectExpression.class));
+        assertThat(rule.toString())
+                .startsWith("ConditionalCascadesRule[")
+                .contains(StubRule.class.getSimpleName());
+    }
+
+    @Nonnull
+    private static ConditionalCascadesRule<RelationalExpression, StubRule> conditionalRuleOf(@Nonnull final StubRule... rules) {
+        return new ConditionalCascadesRule<>(ImmutableList.copyOf(rules));
+    }
+
+    @Nonnull
+    private static StubRule stubRule(@Nonnull final Class<? extends RelationalExpression> rootClass) {
+        return stubRule(rootClass, Optional.of(rootClass));
+    }
+
+    @Nonnull
+    private static StubRule stubRule(@Nonnull final Class<? extends RelationalExpression> rootClass,
+                                     @Nonnull final Optional<Class<?>> rootOperator) {
+        return new StubRule(matcherFor(rootClass), rootOperator);
+    }
+
+    @Nonnull
+    private static StubExplorationRule stubExplorationRule(@Nonnull final Class<? extends RelationalExpression> rootClass) {
+        return new StubExplorationRule(matcherFor(rootClass));
+    }
+
+    @Nonnull
+    private static StubImplementationRule stubImplementationRule(@Nonnull final Class<? extends RelationalExpression> rootClass) {
+        return new StubImplementationRule(matcherFor(rootClass));
+    }
+
+    @Nonnull
+    @SuppressWarnings("unchecked")
+    private static BindingMatcher<RelationalExpression> matcherFor(@Nonnull final Class<? extends RelationalExpression> rootClass) {
+        return (BindingMatcher<RelationalExpression>) (BindingMatcher<?>) RelationalExpressionMatchers.ofType(rootClass);
+    }
+
+    /**
+     * A minimal {@link CascadesRule} whose matcher root class and advertised root operator can be set independently,
+     * so the construction-time invariants of {@link ConditionalCascadesRule} can be exercised in isolation.
+     */
+    private static final class StubRule extends AbstractCascadesRule<RelationalExpression> {
+        @Nonnull
+        private final Optional<Class<?>> rootOperator;
+
+        private StubRule(@Nonnull final BindingMatcher<RelationalExpression> matcher,
+                         @Nonnull final Optional<Class<?>> rootOperator) {
+            super(matcher);
+            this.rootOperator = rootOperator;
+        }
+
+        @Nonnull
+        @Override
+        public Optional<Class<?>> getRootOperator() {
+            return rootOperator;
+        }
+
+        @Override
+        public void onMatch(@Nonnull final CascadesRuleCall call) {
+            throw new UnsupportedOperationException("stub rule should not be executed");
+        }
+    }
+
+    /**
+     * A minimal {@link ExplorationCascadesRule} used to exercise the {@link ConditionalExplorationCascadesRule}
+     * variant. Its root operator is derived from its matcher, like an ordinary rule.
+     */
+    private static final class StubExplorationRule extends AbstractCascadesRule<RelationalExpression>
+            implements ExplorationCascadesRule<RelationalExpression> {
+        private StubExplorationRule(@Nonnull final BindingMatcher<RelationalExpression> matcher) {
+            super(matcher);
+        }
+
+        @Override
+        public void onMatch(@Nonnull final ExplorationCascadesRuleCall call) {
+            throw new UnsupportedOperationException("stub rule should not be executed");
+        }
+    }
+
+    /**
+     * A minimal {@link ImplementationCascadesRule} used to exercise the {@link ConditionalImplementationCascadesRule}
+     * variant. Its root operator is derived from its matcher, like an ordinary rule.
+     */
+    private static final class StubImplementationRule extends AbstractCascadesRule<RelationalExpression>
+            implements ImplementationCascadesRule<RelationalExpression> {
+        private StubImplementationRule(@Nonnull final BindingMatcher<RelationalExpression> matcher) {
+            super(matcher);
+        }
+
+        @Override
+        public void onMatch(@Nonnull final ImplementationCascadesRuleCall call) {
+            throw new UnsupportedOperationException("stub rule should not be executed");
+        }
+    }
+}

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/ConditionalCascadesRuleTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/ConditionalCascadesRuleTest.java
@@ -177,22 +177,6 @@ class ConditionalCascadesRuleTest {
     }
 
     @Test
-    void getRulesWithPredicateFiltersInOrder() {
-        final StubRule first = stubRule(SelectExpression.class);
-        final StubRule second = stubRule(SelectExpression.class);
-        final StubRule third = stubRule(SelectExpression.class);
-        final ConditionalCascadesRule<RelationalExpression, StubRule> rule = conditionalRuleOf(first, second, third);
-        assertThat(rule.getRules(candidate -> candidate == first || candidate == third)).containsExactly(first, third);
-    }
-
-    @Test
-    void getRulesWithNeverMatchingPredicateReturnsEmpty() {
-        final ConditionalCascadesRule<RelationalExpression, StubRule> rule =
-                conditionalRuleOf(stubRule(SelectExpression.class), stubRule(SelectExpression.class));
-        assertThat(rule.getRules(candidate -> false)).isEmpty();
-    }
-
-    @Test
     void onMatchThrows() {
         final ConditionalCascadesRule<RelationalExpression, StubRule> rule =
                 conditionalRuleOf(stubRule(SelectExpression.class));

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/events/PlannerEventSerializationTests.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/events/PlannerEventSerializationTests.java
@@ -127,7 +127,8 @@ class PlannerEventSerializationTests {
                     }
 
                     @Override
-                    public void execute() {
+                    public boolean execute() {
+                        return false;
                     }
 
                     @Override

--- a/fdb-record-layer-debugger/src/test/java/com/apple/foundationdb/record/query/plan/cascades/debug/CommandsTest.java
+++ b/fdb-record-layer-debugger/src/test/java/com/apple/foundationdb/record/query/plan/cascades/debug/CommandsTest.java
@@ -614,7 +614,8 @@ class CommandsTest {
         }
 
         @Override
-        public void execute() {
+        public boolean execute() {
+            return false;
         }
 
         @Override


### PR DESCRIPTION
A conditional rule bundles an ordered list of inner rules. It acts as one rule that receives special treatment by the planner. The inner rules are tried in order, stopping as soon as one rule yielded a new expression and falling through to the next rule only when the current on made no progress. In other words, each inner rule runs only under the “condition” that no prior rule made any progress. In effect, only the _first_ useful rule is applied.

The motivation behind this is that, by carefully grouping strictly prioritized or mutually exclusive transformations this way, we can substantially prune the planner search space and reduce the memo size.

This change adds only the `ConditionalCascadesRule` abstraction and the necessary planner plumbing to dispatch such rules. It is not added to any rule set.

* Add a new `ConditionalCascadesRule` class, as well as `ConditionalExplorationCascadesRule` and `ConditionalImplementationCascadesRule` subclasses.
* Add a corresponding `ConditionalTransformExpression` task that implements the mechanism of trying the rules in the conditional chain one at a time.
* Change all `Task.execute()` implementations to return a boolean signaling whether the task made progress.
* Propagate that boolean through `executeRuleCall()` so the surrounding `Transform` task can report whether any change to the planner state was made.