### PR TITLE
Set a multi-thread scheduled executor for tests

### DIFF
--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/LocatableResolverTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/keyspace/LocatableResolverTest.java
@@ -39,6 +39,7 @@ import com.apple.foundationdb.record.provider.foundationdb.keyspace.ResolverCrea
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.ResolverCreateHooks.PreWriteCheck;
 import com.apple.foundationdb.record.test.FDBDatabaseExtension;
 import com.apple.foundationdb.record.util.pair.Pair;
+import com.apple.foundationdb.test.TestExecutors;
 import com.apple.foundationdb.tuple.ByteArrayUtil2;
 import com.apple.foundationdb.tuple.Tuple;
 import com.apple.test.BooleanSource;
@@ -896,6 +897,9 @@ public abstract class LocatableResolverTest {
         final FDBDatabaseFactory parallelFactory = new FDBDatabaseFactoryImpl();
         parallelFactory.setStateRefreshTimeMillis(100);
         parallelFactory.setAPIVersion(dbExtension.getAPIVersion());
+        // The whole point of this test is parallelism; use a multi-thread scheduler so timers
+        // don't back up on MoreAsyncUtil's single-thread default (see #4333).
+        parallelFactory.setScheduledExecutor(TestExecutors.defaultScheduledThreadPool());
         String clusterFile = database.getClusterFile();
         Supplier<FDBDatabase> databaseSupplier = () -> new FDBDatabase(parallelFactory, clusterFile);
         consistently("uninitialized version is 0", () -> {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/storestate/FDBRecordStoreStateCacheTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/storestate/FDBRecordStoreStateCacheTest.java
@@ -25,8 +25,8 @@ import com.apple.foundationdb.record.RecordCoreArgumentException;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.RecordMetaDataBuilder;
-import com.apple.foundationdb.record.expressions.RecordKeyExpressionProto;
 import com.apple.foundationdb.record.TestRecords1Proto;
+import com.apple.foundationdb.record.expressions.RecordKeyExpressionProto;
 import com.apple.foundationdb.record.metadata.Key;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.provider.foundationdb.FDBDatabase;
@@ -1179,8 +1179,8 @@ public class FDBRecordStoreStateCacheTest extends FDBRecordStoreTestBase {
     public void useWithDifferentDatabase(FDBRecordStoreStateCacheFactory storeStateCacheFactory) throws Exception {
         final FDBDatabaseFactory factory = dbExtension.getDatabaseFactory();
         String clusterFile = FakeClusterFileUtil.createFakeClusterFile("record_store_cache_");
-        FDBDatabaseFactory.instance().setStoreStateCacheFactory(readVersionCacheFactory);
-        FDBDatabase secondDatabase = FDBDatabaseFactory.instance().getDatabase(clusterFile);
+        factory.setStoreStateCacheFactory(readVersionCacheFactory);
+        FDBDatabase secondDatabase = factory.getDatabase(clusterFile);
 
         // Using the cache with a context from the wrong database shouldn't work
         try (FDBRecordContext context = openContext()) {

--- a/fdb-record-layer-core/src/testFixtures/java/com/apple/foundationdb/record/test/FDBDatabaseExtension.java
+++ b/fdb-record-layer-core/src/testFixtures/java/com/apple/foundationdb/record/test/FDBDatabaseExtension.java
@@ -43,8 +43,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -86,16 +84,6 @@ public class FDBDatabaseExtension implements AfterEachCallback {
 
     @Nonnull
     private static final Executor threadPoolExecutor = TestExecutors.newThreadPool("fdb-record-layer-test");
-    // Override the per-factory scheduled executor so parallel tests don't fight over the
-    // JVM-wide single-thread ScheduledThreadPoolExecutor that MoreAsyncUtil installs by
-    // default. When the suite runs N tests concurrently and they each schedule deadline
-    // timers on a single shared thread, the timers fire late and trigger spurious
-    // DeadlineExceededException from places like AsyncLoadingCache (e.g.
-    // FDBDatabase.resolverStateCache during KeySpacePath.toTuple cleanup).
-    @Nonnull
-    private static final ScheduledExecutorService scheduledThreadPoolExecutor = Executors.newScheduledThreadPool(
-            Math.max(Runtime.getRuntime().availableProcessors(), 4),
-            new TestExecutors.TestThreadFactory("fdb-record-layer-test-scheduled"));
 
     public static APIVersion getAPIVersion() {
         String apiVersionStr = System.getProperty(API_VERSION_PROPERTY);
@@ -161,7 +149,12 @@ public class FDBDatabaseExtension implements AfterEachCallback {
             }
             setupBlockingInAsyncDetection(databaseFactory);
             databaseFactory.setExecutor(threadPoolExecutor);
-            databaseFactory.setScheduledExecutor(scheduledThreadPoolExecutor);
+            // Override the per-factory scheduled executor so parallel tests don't fight over the
+            // JVM-wide single-thread ScheduledThreadPoolExecutor that MoreAsyncUtil installs by
+            // default. Under N-way JUnit parallelism the single-thread default falls behind and
+            // triggers spurious DeadlineExceededException from AsyncLoadingCache (most
+            // prominently FDBDatabase.resolverStateCache during KeySpacePath.toTuple cleanup).
+            databaseFactory.setScheduledExecutor(TestExecutors.defaultScheduledThreadPool());
         }
         return databaseFactory;
     }

--- a/fdb-record-layer-core/src/testFixtures/java/com/apple/foundationdb/record/test/FDBDatabaseExtension.java
+++ b/fdb-record-layer-core/src/testFixtures/java/com/apple/foundationdb/record/test/FDBDatabaseExtension.java
@@ -43,6 +43,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -84,6 +86,16 @@ public class FDBDatabaseExtension implements AfterEachCallback {
 
     @Nonnull
     private static final Executor threadPoolExecutor = TestExecutors.newThreadPool("fdb-record-layer-test");
+    // Override the per-factory scheduled executor so parallel tests don't fight over the
+    // JVM-wide single-thread ScheduledThreadPoolExecutor that MoreAsyncUtil installs by
+    // default. When the suite runs N tests concurrently and they each schedule deadline
+    // timers on a single shared thread, the timers fire late and trigger spurious
+    // DeadlineExceededException from places like AsyncLoadingCache (e.g.
+    // FDBDatabase.resolverStateCache during KeySpacePath.toTuple cleanup).
+    @Nonnull
+    private static final ScheduledExecutorService scheduledThreadPoolExecutor = Executors.newScheduledThreadPool(
+            Math.max(Runtime.getRuntime().availableProcessors(), 4),
+            new TestExecutors.TestThreadFactory("fdb-record-layer-test-scheduled"));
 
     public static APIVersion getAPIVersion() {
         String apiVersionStr = System.getProperty(API_VERSION_PROPERTY);
@@ -149,6 +161,7 @@ public class FDBDatabaseExtension implements AfterEachCallback {
             }
             setupBlockingInAsyncDetection(databaseFactory);
             databaseFactory.setExecutor(threadPoolExecutor);
+            databaseFactory.setScheduledExecutor(scheduledThreadPoolExecutor);
         }
         return databaseFactory;
     }

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/jdbc/JDBCEmbedDriverTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/jdbc/JDBCEmbedDriverTest.java
@@ -23,8 +23,6 @@ package com.apple.foundationdb.relational.jdbc;
 import com.apple.foundationdb.record.provider.foundationdb.APIVersion;
 import com.apple.foundationdb.record.provider.foundationdb.FDBDatabase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBDatabaseFactory;
-import com.apple.foundationdb.test.FDBTestEnvironment;
-import com.apple.foundationdb.test.TestExecutors;
 import com.apple.foundationdb.relational.api.EmbeddedRelationalDriver;
 import com.apple.foundationdb.relational.api.Options;
 import com.apple.foundationdb.relational.api.RelationalDriver;
@@ -38,7 +36,8 @@ import com.apple.foundationdb.relational.recordlayer.catalog.StoreCatalogProvide
 import com.apple.foundationdb.relational.recordlayer.ddl.RecordLayerMetadataOperationsFactory;
 import com.apple.foundationdb.relational.recordlayer.query.cache.RelationalPlanCache;
 import com.apple.foundationdb.relational.util.BuildVersion;
-
+import com.apple.foundationdb.test.FDBTestEnvironment;
+import com.apple.foundationdb.test.TestExecutors;
 import com.codahale.metrics.MetricRegistry;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
@@ -68,7 +67,6 @@ public class JDBCEmbedDriverTest {
     public static void beforeAll() throws SQLException, RelationalException {
         RelationalKeyspaceProvider.instance().registerDomainIfNotExists("FRL");
 
-        RecordLayerConfig rlCfg = RecordLayerConfig.getDefault();
         //here we are extending the StorageCluster so that we can track which internal Databases were
         // connected to and we can validate that they were all closed properly
 
@@ -85,6 +83,7 @@ public class JDBCEmbedDriverTest {
             txn.commit();
         }
 
+        RecordLayerConfig rlCfg = RecordLayerConfig.getDefault();
         RecordLayerMetadataOperationsFactory ddlFactory = RecordLayerMetadataOperationsFactory.defaultFactory()
                 .setBaseKeySpace(RelationalKeyspaceProvider.instance().getKeySpace())
                 .setRlConfig(rlCfg)

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/jdbc/JDBCEmbedDriverTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/jdbc/JDBCEmbedDriverTest.java
@@ -24,6 +24,7 @@ import com.apple.foundationdb.record.provider.foundationdb.APIVersion;
 import com.apple.foundationdb.record.provider.foundationdb.FDBDatabase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBDatabaseFactory;
 import com.apple.foundationdb.test.FDBTestEnvironment;
+import com.apple.foundationdb.test.TestExecutors;
 import com.apple.foundationdb.relational.api.EmbeddedRelationalDriver;
 import com.apple.foundationdb.relational.api.Options;
 import com.apple.foundationdb.relational.api.RelationalDriver;
@@ -73,6 +74,9 @@ public class JDBCEmbedDriverTest {
 
         // This needs to be done prior to the first call to factory.getDatabase()
         FDBDatabaseFactory.instance().setAPIVersion(APIVersion.API_VERSION_7_1);
+        // Install a multi-thread scheduler so JUnit-parallel tests don't fight over
+        // MoreAsyncUtil's single-thread default (see #4333).
+        FDBDatabaseFactory.instance().setScheduledExecutor(TestExecutors.defaultScheduledThreadPool());
 
         final FDBDatabase database = FDBDatabaseFactory.instance().getDatabase(FDBTestEnvironment.randomClusterFile());
         StoreCatalog storeCatalog;

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/EmbeddedRelationalExtension.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/EmbeddedRelationalExtension.java
@@ -29,6 +29,7 @@ import com.apple.foundationdb.relational.api.EmbeddedRelationalDriver;
 import com.apple.foundationdb.relational.api.EmbeddedRelationalEngine;
 import com.apple.foundationdb.relational.api.Options;
 import com.apple.foundationdb.relational.api.RelationalDriver;
+import com.apple.foundationdb.test.TestExecutors;
 import com.apple.foundationdb.relational.api.Transaction;
 import com.apple.foundationdb.relational.api.catalog.StoreCatalog;
 import com.apple.foundationdb.relational.api.exceptions.RelationalException;
@@ -108,6 +109,10 @@ public class EmbeddedRelationalExtension implements RelationalExtension, BeforeE
 
         // This needs to be done prior to the first call to factory.getDatabase()
         FDBDatabaseFactory.instance().setAPIVersion(APIVersion.API_VERSION_7_1);
+        // Override MoreAsyncUtil's single-thread default scheduler so JUnit-parallel tests don't
+        // trigger spurious DeadlineExceededException from AsyncLoadingCache (see #4333 and
+        // TestExecutors.defaultScheduledThreadPool javadoc).
+        FDBDatabaseFactory.instance().setScheduledExecutor(TestExecutors.defaultScheduledThreadPool());
 
         makeDatabase(clusterFile);
 

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/catalog/CatalogMetaDataProviderTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/catalog/CatalogMetaDataProviderTest.java
@@ -24,6 +24,7 @@ import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.RecordMetaDataProto;
 import com.apple.foundationdb.record.provider.foundationdb.FDBDatabaseFactory;
 import com.apple.foundationdb.test.FDBTestEnvironment;
+import com.apple.foundationdb.test.TestExecutors;
 import com.apple.foundationdb.relational.api.Options;
 import com.apple.foundationdb.relational.api.Transaction;
 import com.apple.foundationdb.relational.api.catalog.StoreCatalog;
@@ -54,6 +55,9 @@ class CatalogMetaDataProviderTest {
 
         //now create a RecordStore in that Catalog
         FDBDatabaseFactory factory = FDBDatabaseFactory.instance();
+        // Install a multi-thread scheduler so JUnit-parallel tests don't fight over
+        // MoreAsyncUtil's single-thread default (see #4333).
+        factory.setScheduledExecutor(TestExecutors.defaultScheduledThreadPool());
         FdbConnection fdbConn = new DirectFdbConnection(factory.getDatabase(FDBTestEnvironment.randomClusterFile()));
         StoreCatalog storeCatalog;
         try (Transaction txn = fdbConn.getTransactionManager().createTransaction(Options.NONE)) {

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/catalog/RecordLayerStoreCatalogImplTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/catalog/RecordLayerStoreCatalogImplTest.java
@@ -25,6 +25,7 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStore;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpacePath;
 import com.apple.foundationdb.test.FDBTestEnvironment;
+import com.apple.foundationdb.test.TestExecutors;
 import com.apple.foundationdb.relational.api.Transaction;
 import com.apple.foundationdb.relational.api.exceptions.ErrorCode;
 import com.apple.foundationdb.relational.api.exceptions.RelationalException;
@@ -49,6 +50,9 @@ public class RecordLayerStoreCatalogImplTest extends RecordLayerStoreCatalogTest
 
     @BeforeEach
     void setUpCatalog() throws RelationalException {
+        // Install a multi-thread scheduler so JUnit-parallel tests don't fight over
+        // MoreAsyncUtil's single-thread default (see #4333).
+        FDBDatabaseFactory.instance().setScheduledExecutor(TestExecutors.defaultScheduledThreadPool());
         fdb = FDBDatabaseFactory.instance().getDatabase(FDBTestEnvironment.randomClusterFile());
         // create a FDBRecordStore
         try (Transaction txn = new RecordContextTransaction(fdb.openContext())) {

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/catalog/RecordLayerStoreCatalogWithNoTemplateOperationsTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/catalog/RecordLayerStoreCatalogWithNoTemplateOperationsTest.java
@@ -25,6 +25,7 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStore;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpacePath;
 import com.apple.foundationdb.test.FDBTestEnvironment;
+import com.apple.foundationdb.test.TestExecutors;
 import com.apple.foundationdb.relational.api.Transaction;
 import com.apple.foundationdb.relational.api.exceptions.ErrorCode;
 import com.apple.foundationdb.relational.api.exceptions.RelationalException;
@@ -44,6 +45,9 @@ public class RecordLayerStoreCatalogWithNoTemplateOperationsTest extends RecordL
 
     @BeforeEach
     void setUpCatalog() throws RelationalException {
+        // Install a multi-thread scheduler so JUnit-parallel tests don't fight over
+        // MoreAsyncUtil's single-thread default (see #4333).
+        FDBDatabaseFactory.instance().setScheduledExecutor(TestExecutors.defaultScheduledThreadPool());
         fdb = FDBDatabaseFactory.instance().getDatabase(FDBTestEnvironment.randomClusterFile());
         // create a FDBRecordStore
         try (Transaction txn = new RecordContextTransaction(fdb.openContext())) {

--- a/fdb-test-utils/src/main/java/com/apple/foundationdb/test/TestExecutors.java
+++ b/fdb-test-utils/src/main/java/com/apple/foundationdb/test/TestExecutors.java
@@ -23,6 +23,7 @@ package com.apple.foundationdb.test;
 import javax.annotation.Nonnull;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -32,6 +33,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 public final class TestExecutors {
     @Nonnull
     private static final Executor DEFAULT_THREAD_POOL = newThreadPool("fdb-unit-test");
+    @Nonnull
+    private static final ScheduledExecutorService DEFAULT_SCHEDULED_THREAD_POOL =
+            newScheduledThreadPool("fdb-unit-test-scheduled");
 
     private TestExecutors() {
     }
@@ -64,5 +68,34 @@ public final class TestExecutors {
     @Nonnull
     public static Executor defaultThreadPool() {
         return DEFAULT_THREAD_POOL;
+    }
+
+    /**
+     * Create a new {@link ScheduledExecutorService} with at least four threads (or one per
+     * available CPU, whichever is larger). Test code that installs a scheduler on an
+     * {@code FDBDatabaseFactory} should use this rather than the single-thread scheduler
+     * {@code MoreAsyncUtil} installs by default — under JUnit-parallel execution the
+     * single-thread default falls behind, causing {@code DeadlineExceededException}s from
+     * {@code AsyncLoadingCache}.
+     *
+     * @param namePrefix prefix for thread names created by this pool
+     * @return a fresh scheduled executor sized for the current JVM
+     */
+    @Nonnull
+    private static ScheduledExecutorService newScheduledThreadPool(@Nonnull String namePrefix) {
+        return Executors.newScheduledThreadPool(
+                Math.max(Runtime.getRuntime().availableProcessors(), 4),
+                new TestThreadFactory(namePrefix));
+    }
+
+    /**
+     * JVM-wide singleton scheduled executor for test code. Many test extensions install this as the scheduled executor
+     * on their own {@code FDBDatabaseFactory}.
+     *
+     * @return the shared singleton scheduled executor
+     */
+    @Nonnull
+    public static ScheduledExecutorService defaultScheduledThreadPool() {
+        return DEFAULT_SCHEDULED_THREAD_POOL;
     }
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/Command.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/Command.java
@@ -25,6 +25,7 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBDatabaseFactory;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContextConfig;
 import com.apple.foundationdb.record.provider.foundationdb.FormatVersion;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpace;
+import com.apple.foundationdb.test.TestExecutors;
 import com.apple.foundationdb.relational.api.Options;
 import com.apple.foundationdb.relational.api.Transaction;
 import com.apple.foundationdb.relational.api.catalog.StoreCatalog;
@@ -131,6 +132,9 @@ public abstract class Command {
 
     private static void applyMetadataOperationDirectly(@Nonnull RecordLayerConfig rlConfig, @Nonnull ApplyState applyState,
                                                        @Nullable String clusterFile) throws RelationalException {
+        // Install a multi-thread scheduler so JUnit-parallel yaml-tests don't fight over
+        // MoreAsyncUtil's single-thread default (see #4333).
+        FDBDatabaseFactory.instance().setScheduledExecutor(TestExecutors.defaultScheduledThreadPool());
         final FDBDatabase fdbDb = FDBDatabaseFactory.instance().getDatabase(clusterFile);
         final RelationalKeyspaceProvider keyspaceProvider = RelationalKeyspaceProvider.instance();
         keyspaceProvider.registerDomainIfNotExists("FRL");


### PR DESCRIPTION
MoreAsyncUtil installs a JVM-wide single-thread ScheduledThreadPoolExecutor by default. When the suite runs N tests concurrently and they each schedule deadline timers on that single shared thread, the timers fire late and produce spurious DeadlineExceededException from AsyncLoadingCache -- most prominently FDBDatabase.resolverStateCache during KeySpacePath.toTuple cleanup.

Override the FDBDatabaseFactory default scheduled executor in FDBDatabaseExtension and other tests with a multi-threaded pool (max(availableProcessors, 4)) shared across all tests.

Closes #4333