### PR TITLE
Install Mockito as a JVM -javaagent on every Test task

### DIFF
--- a/gradle/testing.gradle
+++ b/gradle/testing.gradle
@@ -324,13 +324,15 @@ tasks.withType(Test).configureEach { task ->
         // useJUnitPlatform() here is a no-op for tasks that already have it.
         task.useJUnitPlatform()
 
-        // Install Mockito as a JVM agent on every Test task. See the comment on the
+        // Install Mockito as a JVM agent on every non-performance Test task. See the comment on the
         // `mockitoAgent` configuration above for why this is necessary. Deferred to `doFirst`
         // so that the `mockitoAgent` configuration is not resolved during evaluation (which
         // would prevent the root build's `resolutionStrategy.eachDependency` callback from
         // attaching to it).
+        // extract during configuration to be cache friendly
+        def mockitoAgent = configurations.mockitoAgent
         task.doFirst {
-            task.jvmArgs("-javaagent:${configurations.mockitoAgent.asPath}")
+            task.jvmArgs("-javaagent:${mockitoAgent.asPath}")
         }
 
         // Configure whether or not tests will validate that asyncToSync isn't being called in async

--- a/gradle/testing.gradle
+++ b/gradle/testing.gradle
@@ -29,6 +29,19 @@ jacoco {
     toolVersion = libs.versions.jacoco.get()
 }
 
+// Resolved to the mockito-core jar so it can be installed as a -javaagent on every Test JVM.
+// Required on JDK 21+ because Mockito's inline mock maker can no longer self-attach to a
+// running VM (see https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html#0.3).
+// Under parallel JUnit class execution this also avoids the Byte-Buddy self-attach race that
+// manifests as `IllegalStateException: Could not initialize plugin: interface
+// org.mockito.plugins.MockMaker`. Hooked into every Test task in `tasks.withType(Test)` below.
+configurations {
+    mockitoAgent
+}
+dependencies {
+    mockitoAgent(libs.mockito) { transitive = false }
+}
+
 // if you add to or modify these testing configurations, make sure to update the CONTRIBUTING.md to include any updates
 test {
     useJUnitPlatform {
@@ -310,6 +323,15 @@ tasks.withType(Test).configureEach { task ->
         // would still be on the JUnit4 default (which has no excludeTags) without this. Calling
         // useJUnitPlatform() here is a no-op for tasks that already have it.
         task.useJUnitPlatform()
+
+        // Install Mockito as a JVM agent on every Test task. See the comment on the
+        // `mockitoAgent` configuration above for why this is necessary. Deferred to `doFirst`
+        // so that the `mockitoAgent` configuration is not resolved during evaluation (which
+        // would prevent the root build's `resolutionStrategy.eachDependency` callback from
+        // attaching to it).
+        task.doFirst {
+            task.jvmArgs("-javaagent:${configurations.mockitoAgent.asPath}")
+        }
 
         // Configure whether or not tests will validate that asyncToSync isn't being called in async
         // context.  See BlockingInAsyncDetection class for details on values.


### PR DESCRIPTION
Mockito's inline mock maker can no longer self-attach to a running JVM on JDK 21+, which (a) emits a warning that is scheduled to become an error and (b) races under parallel JUnit class execution, manifesting as `IllegalStateException: Could not initialize plugin: interface org.mockito.plugins.MockMaker.`

Following Mockito's own [JDK 21+ recommendation](https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html#0.3), declare a resolvable `mockitoAgent` configuration that resolves to the `mockito-core` jar and attach it via `-javaagent `to every Test JVM. The -javaagent flag is added inside a `doFirst` block so the `mockitoAgent` configuration is not resolved during evaluation, which would prevent the root build's `resolutionStrategy.eachDependency` callback from attaching to it.

Closes #4334