### PR TITLE
Cleanups and micro-optimizations around `deserializeRecordMetaData()`

### DIFF
--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/RecordLayerIndex.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/RecordLayerIndex.java
@@ -125,13 +125,13 @@ public final class RecordLayerIndex implements Index  {
 
     @Nonnull
     public static RecordLayerIndex from(@Nonnull final String tableName, @Nonnull String tableStorageName, @Nonnull final com.apple.foundationdb.record.metadata.Index index) {
-        final var indexProto = index.toProto();
-        return newBuilder().setName(index.getName())
+        return newBuilder()
+                .setName(index.getName())
                 .setIndexType(index.getType())
                 .setTableName(tableName)
                 .setTableStorageName(tableStorageName)
                 .setKeyExpression(index.getRootExpression())
-                .setPredicate(indexProto.hasPredicate() ? indexProto.getPredicate() : null)
+                .setPredicate(index.hasPredicate() ? index.getPredicate().toProto() : null)
                 .setOptions(index.getOptions())
                 .build();
     }

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/RecordLayerTable.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/RecordLayerTable.java
@@ -400,6 +400,10 @@ public final class RecordLayerTable implements Table {
             final var relationalType = DataTypeUtils.toRelationalType(record);
             Assert.thatUnchecked(relationalType instanceof DataType.StructType);
             final var asStruct = (DataType.StructType) relationalType;
+            // todo (yhatem): we can avoid regenerating the corresponding record layer Record
+            //       when we know that the passed record matches _exactly_ the corresponding Relational type.
+            //       this could be achieved by checking whether the record has an explicit name and all of its
+            //       fields (recursively) have explicit names, this seems to be mostly equally expensive though.
             return from(asStruct).setRecord(record);
         }
 

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/RecordLayerTable.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/RecordLayerTable.java
@@ -53,7 +53,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * Represents a {@link com.apple.foundationdb.relational.api.metadata.Table} that is backed by the Record Layer.
+ * Represents a {@link Table} that is backed by the Record Layer.
  */
 @API(API.Status.EXPERIMENTAL)
 public final class RecordLayerTable implements Table {
@@ -208,16 +208,16 @@ public final class RecordLayerTable implements Table {
         private String name;
 
         @Nonnull
-        private Set<RecordLayerIndex> indexes;
+        private final Set<RecordLayerIndex> indexes;
 
         @Nonnull
-        private ImmutableList.Builder<RecordLayerColumn> columns;
+        private final ImmutableList.Builder<RecordLayerColumn> columns;
 
         @Nonnull
         private List<KeyExpression> primaryKeyParts;
 
         @Nonnull
-        private Map<Integer, DescriptorProtos.FieldOptions> generations;
+        private final Map<Integer, DescriptorProtos.FieldOptions> generations;
 
         private DataType.StructType dataType;
 
@@ -346,7 +346,7 @@ public final class RecordLayerTable implements Table {
             }
             Type fieldType = field.getFieldType();
             if (!(fieldType instanceof Type.Record)) {
-                Assert.failUnchecked(ErrorCode.INVALID_COLUMN_REFERENCE, "Field '" + field.getFieldName() + "' on type '" + (recordType == null ? "UNKNONW" : recordType.getName()) + "' is not a struct");
+                Assert.failUnchecked(ErrorCode.INVALID_COLUMN_REFERENCE, "Field '" + field.getFieldName() + "' on type '" + (recordType == null ? "UNKNOWN" : recordType.getName()) + "' is not a struct");
             }
             return (Type.Record) fieldType;
         }
@@ -400,10 +400,6 @@ public final class RecordLayerTable implements Table {
             final var relationalType = DataTypeUtils.toRelationalType(record);
             Assert.thatUnchecked(relationalType instanceof DataType.StructType);
             final var asStruct = (DataType.StructType) relationalType;
-            // todo (yhatem): we can avoid regenerating the corresponding record layer Record
-            //       when we know that the passed record matches _exactly_ the corresponding Relational type.
-            //       this could be achieved by checking whether the record has an explicit name and all of its
-            //       fields (recursively) have explicit names, this seems to be mostly equally expensive though.
             return from(asStruct).setRecord(record);
         }
 

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/serde/RecordMetadataDeserializer.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/serde/RecordMetadataDeserializer.java
@@ -91,7 +91,7 @@ public class RecordMetadataDeserializer {
                     final String storageName = registeredType.getMessageType().getName();
                     final String userName = ProtoUtils.toUserIdentifier(storageName);
                     nameToTableBuilder
-                            .computeIfAbsent(userName, userName_ -> generateTableBuilder(recordMetaData, userName_, storageName))
+                            .computeIfAbsent(userName, key -> generateTableBuilder(recordMetaData, key, storageName))
                             .addGeneration(registeredType.getNumber(), registeredType.getOptions());
                     break;
                 case ENUM:
@@ -109,12 +109,12 @@ public class RecordMetadataDeserializer {
         if (!recordMetaData.getUserDefinedFunctionMap().isEmpty()) {
             // TODO: topsort deps of functions.
             for (final var function : recordMetaData.getUserDefinedFunctionMap().entrySet()) {
-                if (function.getValue() instanceof RawSqlFunction) {
+                if (function.getValue() instanceof RawSqlFunction rawSqlFunction) {
                     schemaTemplateBuilder.addInvokedRoutine(generateInvokedRoutineBuilder(metadataProvider, function.getKey(),
-                            Assert.castUnchecked(function.getValue(), RawSqlFunction.class).getDefinition()).build());
-                } else if (function.getValue() instanceof UserDefinedMacroFunction) {
-                    schemaTemplateBuilder.addInvokedRoutine(generateInvokedRoutineBuilder(function.getKey(), function.getValue().toString(),
-                            Assert.castUnchecked(function.getValue(), UserDefinedMacroFunction.class)).build());
+                            rawSqlFunction.getDefinition()).build());
+                } else if (function.getValue() instanceof UserDefinedMacroFunction userDefinedMacroFunction) {
+                    schemaTemplateBuilder.addInvokedRoutine(generateInvokedRoutineBuilder(function.getKey(), userDefinedMacroFunction.toString(),
+                            userDefinedMacroFunction).build());
                 }
             }
         }

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/serde/RecordMetadataDeserializer.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/serde/RecordMetadataDeserializer.java
@@ -90,10 +90,9 @@ public class RecordMetadataDeserializer {
                 case MESSAGE:
                     final String storageName = registeredType.getMessageType().getName();
                     final String userName = ProtoUtils.toUserIdentifier(storageName);
-                    if (!nameToTableBuilder.containsKey(userName)) {
-                        nameToTableBuilder.put(userName, generateTableBuilder(recordMetaData, userName, storageName));
-                    }
-                    nameToTableBuilder.get(userName).addGeneration(registeredType.getNumber(), registeredType.getOptions());
+                    nameToTableBuilder
+                            .computeIfAbsent(userName, userName_ -> generateTableBuilder(recordMetaData, userName_, storageName))
+                            .addGeneration(registeredType.getNumber(), registeredType.getOptions());
                     break;
                 case ENUM:
                     // todo (yhatem) this is temporary, we rely on rec layer type system to deserialize protobuf descriptors.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/serde/RecordMetadataDeserializer.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/serde/RecordMetadataDeserializer.java
@@ -105,8 +105,8 @@ public class RecordMetadataDeserializer {
             }
         }
         nameToTableBuilder.values().stream().map(RecordLayerTable.Builder::build).forEach(schemaTemplateBuilder::addTable);
+        final var metadataProvider = Suppliers.memoize(schemaTemplateBuilder::build);
         if (!recordMetaData.getUserDefinedFunctionMap().isEmpty()) {
-            final var metadataProvider = Suppliers.memoize(schemaTemplateBuilder::build);
             // TODO: topsort deps of functions.
             for (final var function : recordMetaData.getUserDefinedFunctionMap().entrySet()) {
                 if (function.getValue() instanceof RawSqlFunction) {
@@ -119,7 +119,6 @@ public class RecordMetadataDeserializer {
             }
         }
         if (!recordMetaData.getViewMap().isEmpty()) {
-            final var metadataProvider = Suppliers.memoize(schemaTemplateBuilder::build);
             for (final var view : recordMetaData.getViewMap().entrySet()) {
                 schemaTemplateBuilder.addView(generateViewBuilder(metadataProvider, view.getKey(), view.getValue().getDefinition()).build());
             }


### PR DESCRIPTION
* In `RecordLayerIndex.from()`, remove the call to `index.toProto()`, which serializes the entire root key expression and options even though we only need the resulting predicate field. Instead, read the predicate directly.
* In `deserializeRecordMetaData()`, replace `containsKey()`+`put()`+`get()` by just `computeIfAbsent()`.
* Also collapse two identical `schemaTemplateBuilder::build()` suppliers into one.
* Plus minor drive-by cleanups.