### PR TITLE
Convert queryOptions to statementOptions

### DIFF
--- a/fdb-relational-core/src/main/antlr/RelationalParser.g4
+++ b/fdb-relational-core/src/main/antlr/RelationalParser.g4
@@ -388,14 +388,14 @@ deleteStatement
       (WHERE whereExpr)?
       orderByClause? limitClause?
       (RETURNING selectElements)?
-      queryOptions?
+      statementOptions?
     ;
 
 insertStatement
     : INSERT
       INTO? tableName
       (columns=uidListWithNestingsInParens)? insertStatementValue
-      queryOptions?
+      statementOptions?
     ;
 
 continuationAtom
@@ -404,7 +404,7 @@ continuationAtom
     ;
 
 selectStatement
-    : query
+    : query statementOptions?
     ;
 
 query
@@ -465,7 +465,7 @@ updateStatement
       SET updatedElement (',' updatedElement)*
       (WHERE whereExpr)?
       (RETURNING selectElements)?
-      queryOptions?
+      statementOptions?
     ;
 
 // details
@@ -539,8 +539,7 @@ queryTerm
     qualifyClause?
     /*windowClause?*/
     orderByClause?
-    limitClause?
-    queryOptions?                                                  #simpleTable
+    limitClause?                                                   #simpleTable
     | '(' query ')'                                                #parenthesisQuery
     ;
 
@@ -596,11 +595,11 @@ limitClauseAtom
     | preparedStatementParameter
     ;
 
-queryOptions
-    : OPTIONS '(' queryOption (',' queryOption)* ')'
+statementOptions
+    : OPTIONS '(' statementOption (',' statementOption)* ')'
     ;
 
-queryOption
+statementOption
     : NOCACHE
     | LOG QUERY
     | DRY RUN
@@ -694,7 +693,7 @@ resetStatement
 
 executeContinuationStatement
     : EXECUTE CONTINUATION packageBytes=continuationAtom
-      queryOptions?
+      statementOptions?
     ;
 
 copyStatement
@@ -748,7 +747,7 @@ helpStatement
 
 describeObjectClause
     : (
-        query | deleteStatement | insertStatement
+        query statementOptions? | deleteStatement | insertStatement
         | updateStatement | executeContinuationStatement
       )                                                             #describeStatements
     | FOR CONNECTION uid                                            #describeConnection

--- a/fdb-relational-core/src/main/antlr/RelationalParser.g4
+++ b/fdb-relational-core/src/main/antlr/RelationalParser.g4
@@ -747,7 +747,7 @@ helpStatement
 
 describeObjectClause
     : (
-        selectStatement | deleteStatement | insertStatement
+        query statementOptions? | deleteStatement | insertStatement
         | updateStatement | executeContinuationStatement
       )                                                             #describeStatements
     | FOR CONNECTION uid                                            #describeConnection

--- a/fdb-relational-core/src/main/antlr/RelationalParser.g4
+++ b/fdb-relational-core/src/main/antlr/RelationalParser.g4
@@ -604,7 +604,6 @@ queryOption
     : NOCACHE
     | LOG QUERY
     | DRY RUN
-    | EF_SEARCH decimalLiteral
     | PLAN RIGHT DEEP
     ;
 

--- a/fdb-relational-core/src/main/antlr/RelationalParser.g4
+++ b/fdb-relational-core/src/main/antlr/RelationalParser.g4
@@ -747,7 +747,7 @@ helpStatement
 
 describeObjectClause
     : (
-        query statementOptions? | deleteStatement | insertStatement
+        selectStatement | deleteStatement | insertStatement
         | updateStatement | executeContinuationStatement
       )                                                             #describeStatements
     | FOR CONNECTION uid                                            #describeConnection

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/AstNormalizer.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/AstNormalizer.java
@@ -261,15 +261,15 @@ public final class AstNormalizer extends RelationalParserBaseVisitor<Object> {
     }
 
     @Override
-    public RelationalExpression visitQueryOptions(@Nonnull RelationalParser.QueryOptionsContext ctx) {
-        for (final var opt : ctx.queryOption()) {
+    public RelationalExpression visitStatementOptions(@Nonnull RelationalParser.StatementOptionsContext ctx) {
+        for (final var opt : ctx.statementOption()) {
             visit(opt);
         }
         return null;
     }
 
     @Override
-    public Object visitQueryOption(@Nonnull RelationalParser.QueryOptionContext ctx) {
+    public Object visitStatementOption(@Nonnull RelationalParser.StatementOptionContext ctx) {
         try {
             if (ctx.NOCACHE() != null) {
                 queryCachingFlags.add(NormalizationResult.QueryCachingFlags.WITH_NO_CACHE_OPTION);
@@ -466,8 +466,8 @@ public final class AstNormalizer extends RelationalParserBaseVisitor<Object> {
     public Object visitExecuteContinuationStatement(@Nonnull RelationalParser.ExecuteContinuationStatementContext ctx) {
         queryCachingFlags.add(NormalizationResult.QueryCachingFlags.IS_EXECUTE_CONTINUATION_STATEMENT);
         queryCachingFlags.add(NormalizationResult.QueryCachingFlags.WITH_NO_CACHE_OPTION);
-        if (ctx.queryOptions() != null) {
-            ctx.queryOptions().accept(this);
+        if (ctx.statementOptions() != null) {
+            ctx.statementOptions().accept(this);
         }
         return ctx.packageBytes.accept(this);
     }

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/BaseVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/BaseVisitor.java
@@ -895,13 +895,13 @@ public class BaseVisitor extends RelationalParserBaseVisitor<Object> implements 
 
     @Nonnull
     @Override
-    public Object visitQueryOptions(@Nonnull RelationalParser.QueryOptionsContext ctx) {
+    public Object visitStatementOptions(@Nonnull RelationalParser.StatementOptionsContext ctx) {
         return visitChildren(ctx);
     }
 
     @Nonnull
     @Override
-    public Object visitQueryOption(@Nonnull RelationalParser.QueryOptionContext ctx) {
+    public Object visitStatementOption(@Nonnull RelationalParser.StatementOptionContext ctx) {
         return visitChildren(ctx);
     }
 

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DelegatingVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DelegatingVisitor.java
@@ -779,14 +779,14 @@ public class DelegatingVisitor<D extends TypedVisitor> implements TypedVisitor {
 
     @Nonnull
     @Override
-    public Object visitQueryOptions(@Nonnull RelationalParser.QueryOptionsContext ctx) {
-        return getDelegate().visitQueryOptions(ctx);
+    public Object visitStatementOptions(@Nonnull RelationalParser.StatementOptionsContext ctx) {
+        return getDelegate().visitStatementOptions(ctx);
     }
 
     @Nonnull
     @Override
-    public Object visitQueryOption(@Nonnull RelationalParser.QueryOptionContext ctx) {
-        return getDelegate().visitQueryOption(ctx);
+    public Object visitStatementOption(@Nonnull RelationalParser.StatementOptionContext ctx) {
+        return getDelegate().visitStatementOption(ctx);
     }
 
     @Nonnull

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/TypedVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/TypedVisitor.java
@@ -435,11 +435,11 @@ public interface TypedVisitor extends RelationalParserVisitor<Object> {
 
     @Nonnull
     @Override
-    Object visitQueryOptions(@Nonnull RelationalParser.QueryOptionsContext ctx);
+    Object visitStatementOptions(@Nonnull RelationalParser.StatementOptionsContext ctx);
 
     @Nonnull
     @Override
-    Object visitQueryOption(@Nonnull RelationalParser.QueryOptionContext ctx);
+    Object visitStatementOption(@Nonnull RelationalParser.StatementOptionContext ctx);
 
     @Nonnull
     @Override

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/structuredsql/statement/UpdateStatementImpl.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/structuredsql/statement/UpdateStatementImpl.java
@@ -452,14 +452,14 @@ public class UpdateStatementImpl implements UpdateStatement {
                     }
                 }
 
-                if (ctx.queryOptions() != null) {
-                    visit(ctx.queryOptions());
+                if (ctx.statementOptions() != null) {
+                    visit(ctx.statementOptions());
                 }
                 return null;
             }
 
             @Override
-            public Void visitQueryOption(RelationalParser.QueryOptionContext ctx) {
+            public Void visitStatementOption(RelationalParser.StatementOptionContext ctx) {
                 if (ctx.NOCACHE() != null) {
                     updateBuilder.withOption(QueryOptions.NOCACHE);
                 } else if (ctx.LOG() != null) {

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/DelegatingVisitorTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/DelegatingVisitorTest.java
@@ -321,6 +321,36 @@ public class DelegatingVisitorTest {
     }
 
     @Test
+    void visitStatementOptionsTest() {
+        testSimple("OPTIONS (NOCACHE)",
+                RelationalParser::statementOptions,
+                DelegatingVisitor::visitStatementOptions,
+                called -> new BaseVisitor(new MutablePlanGenerationContext(PreparedParams.empty(), PlanHashable.PlanHashMode.VC0, "", "", 42),
+                        generateMetadata(), NoOpQueryFactory.INSTANCE, NoOpMetadataOperationsFactory.INSTANCE, URI.create("/FDB/FRL1"), false) {
+                    @Override
+                    public Object visitStatementOptions(@Nonnull RelationalParser.StatementOptionsContext ctx) {
+                        called.setTrue();
+                        return null;
+                    }
+                });
+    }
+
+    @Test
+    void visitStatementOptionTest() {
+        testSimple("NOCACHE",
+                RelationalParser::statementOption,
+                DelegatingVisitor::visitStatementOption,
+                called -> new BaseVisitor(new MutablePlanGenerationContext(PreparedParams.empty(), PlanHashable.PlanHashMode.VC0, "", "", 42),
+                        generateMetadata(), NoOpQueryFactory.INSTANCE, NoOpMetadataOperationsFactory.INSTANCE, URI.create("/FDB/FRL1"), false) {
+                    @Override
+                    public Object visitStatementOption(@Nonnull RelationalParser.StatementOptionContext ctx) {
+                        called.setTrue();
+                        return null;
+                    }
+                });
+    }
+
+    @Test
     void visitVectorIndexDefinitionTest() {
         final var query = "VECTOR INDEX myIndex USING HNSW ON table1 (R)";
         testVisitor(query,


### PR DESCRIPTION
Rename the `queryOptions`/`queryOption` grammar rules to `statementOptions`/`statementOption` and move the clause from the query-specification level (simpleTable) up to the statement level:
`selectStatement`, the DML statements (insert/update/delete), and `executeContinuationStatement`. `EXPLAIN`/`DESCRIBE` of a SELECT (describeObjectClause) likewise accepts the clause on its query.

Additionally, drop `queryOption`: 'EF_SEARCH decimalLiteral'. No visitor consumed it, and it has been replaced by `EF_SEARCH` in `windowOption` ('OVER (... OPTIONS EF_SEARCH = n)'), which is consumed by `ExpressionVisitor.visitWindowOption`.

This should not be of any concern to anyone as long as the followed the convention of adding `OPTIONS` at the end of a query. 

This is, in part, being done because #4361 will require a new option where it could be legitimately confusing to have the options at the query level. 