### PR TITLE
Avoid unnecessary configuration of Gradle tasks (lazy realization)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,7 @@ allprojects {
     project.tasks.withType(Javadoc) {
         options.encoding = "utf-8"
     }
-    project.tasks.withType(Test) {
+    project.tasks.withType(Test).configureEach {
         systemProperty "file.encoding", "utf-8"
         if (project.hasProperty("apiVersion")) {
             systemProperty "com.apple.foundationdb.apiVersion", project.getProperty("apiVersion")
@@ -91,7 +91,7 @@ allprojects {
     // though this requires making sure that we set 'debugBuild' to false explicitly when producing a release
     // or snapshot build to make sure that the tests are _not_ running in that mode and rather running in prod-like
     // environment.
-    project.tasks.withType(Test) {
+    project.tasks.withType(Test).configureEach {
         systemProperty "debugBuild", System.getProperty("debugBuild", "true")
         dependsOn("sourcesJar")
     }
@@ -110,7 +110,7 @@ allprojects {
     }
 
     // Configure JUnit tests
-    tasks.withType(Test) {
+    tasks.withType(Test).configureEach {
         reports.junitXml.outputLocation = project.layout.buildDirectory.dir("test-results")
     }
 
@@ -138,7 +138,8 @@ allprojects {
     }
 
     // Create the sources jar
-    task sourcesJar(type: Jar, dependsOn: 'compileJava') {
+    tasks.register('sourcesJar', Jar) {
+        dependsOn 'compileJava'
         description = "Assembles a Jar archive containing the main sources."
         group = JavaBasePlugin.DOCUMENTATION_GROUP
         archiveAppendix = null
@@ -147,28 +148,28 @@ allprojects {
     }
 
     // Create the Javadoc jar
-    task javadocJar(type: Jar) {
+    tasks.register('javadocJar', Jar) {
         description = "Assembles a Jar archive containing the main Javadoc."
         group = JavaBasePlugin.DOCUMENTATION_GROUP
         archiveAppendix = null
         archiveClassifier = "javadoc"
-        from tasks.javadoc
+        from tasks.named('javadoc')
     }
 
     // Distribution
-    task createDistribution(type: Sync) {
+    tasks.register('createDistribution', Sync) {
         // source directory depends on the subproject
         into distDir
     }
 
     // Create umbrella task for all packaging operations
-    tasks.create("package", DefaultTask) {
+    tasks.register('package', DefaultTask) {
         description = "Produces main, sources, and Javadoc artifacts in .dist/."
-        dependsOn createDistribution
+        dependsOn 'createDistribution'
     }
 
     build {
-        dependsOn tasks.jar, tasks.package
+        dependsOn tasks.named('jar'), tasks.named('package')
     }
 
     signing {
@@ -229,7 +230,7 @@ subprojects {
     }
 
     tasks.named('assemble') {
-        dependsOn tasks.sourcesJar, tasks.javadocJar, tasks.testJar
+        dependsOn tasks.named('sourcesJar'), tasks.named('javadocJar'), tasks.named('testJar')
     }
 
     afterEvaluate { project ->
@@ -282,14 +283,14 @@ subprojects {
     apply from: rootProject.file('gradle/strict.gradle')
 
     if(System.getenv("DO_NOT_CHECK") != null) {
-        task check(overwrite: true, dependsOn: quickCheck) { }
+        task check(overwrite: true, dependsOn: 'quickCheck') { }
     }
 
-    check.dependsOn quickCheck
+    check.dependsOn 'quickCheck'
 
     // At the end of a release build, we want to update all the yamsql files to replace !current_version with the
     // version being built
-    task updateYamsql(type: Task) {
+    tasks.register('updateYamsql') {
         mustRunAfter 'test'
         mustRunAfter 'build'
         def execOps = objects.newInstance(InjectedExecOps).execOps
@@ -380,7 +381,7 @@ if (fdbEnvironmentFile.exists()) {
 if (!ext.fdbEnvironment.isEmpty()) {
     def fdbenv = ext.fdbEnvironment
     allprojects {
-        tasks.withType(Test) { task ->
+        tasks.withType(Test).configureEach { task ->
             task.environment(fdbenv)
         }
     }
@@ -391,7 +392,7 @@ if (fdbEnvironmentYamlFile.exists()) {
     def libraryPath = new Yaml().loadAll(fdbEnvironmentYamlFile.newInputStream()).first().libraryPath
     def libraryPathVariable = Os.isFamily(Os.FAMILY_MAC) ? "DYLD_LIBRARY_PATH" : "LD_LIBRARY_PATH"
     allprojects {
-        tasks.withType(Test) { task ->
+        tasks.withType(Test).configureEach { task ->
             task.environment([(libraryPathVariable): libraryPath])
             task.environment(FDB_ENVIRONMENT_YAML: fdbEnvironmentYamlFile.absolutePath)
         }

--- a/fdb-extensions/fdb-extensions.gradle
+++ b/fdb-extensions/fdb-extensions.gradle
@@ -207,7 +207,7 @@ afterEvaluate {
 // fdb.vector.simd=scalar system property also forces scalar selection (so RealVectorPrimitives
 // resolves to the scalar backend even though the SIMD class is technically on the classpath).
 //
-task scalarFallbackTest(type: Test) {
+tasks.register('scalarFallbackTest', Test) {
     description = 'Runs the RequiresScalar and DualScalarSIMD tagged tests without --add-modules to exercise the scalar fallback.'
     group = 'verification'
     useJUnitPlatform {

--- a/fdb-record-layer-core-shaded/fdb-record-layer-core-shaded.gradle
+++ b/fdb-record-layer-core-shaded/fdb-record-layer-core-shaded.gradle
@@ -47,9 +47,9 @@ build.dependsOn {
     shadowJar
 }
 
-createDistribution {dependsOn('shadowJar')}
+tasks.named('createDistribution') { dependsOn('shadowJar') }
 
-task shadedSourcesJar(type: Jar) {
+tasks.register('shadedSourcesJar', Jar) {
     description = "Assembles a Jar archive containing the main sources."
     group = JavaBasePlugin.DOCUMENTATION_GROUP
     archiveAppendix = null
@@ -60,7 +60,7 @@ task shadedSourcesJar(type: Jar) {
     dependsOn(project(coreProject).tasks.compileJava)
 }
 
-task shadedJavadocJar(type: Jar) {
+tasks.register('shadedJavadocJar', Jar) {
     description = "Assembles a Jar archive containing the main Javadoc."
     group = JavaBasePlugin.DOCUMENTATION_GROUP
     archiveAppendix = null
@@ -114,8 +114,8 @@ publishing {
                     addDependencies(project(':fdb-extensions'), dependenciesNode)
                 }
             }
-            artifact tasks.shadedSourcesJar
-            artifact tasks.shadedJavadocJar
+            artifact tasks.named('shadedSourcesJar')
+            artifact tasks.named('shadedJavadocJar')
         }
 
     }

--- a/fdb-record-layer-core/fdb-record-layer-core.gradle
+++ b/fdb-record-layer-core/fdb-record-layer-core.gradle
@@ -70,7 +70,7 @@ sourceSets {
     }
 }
 
-task testShadowJar(type: ShadowJar) {
+tasks.register('testShadowJar', ShadowJar) {
     archiveClassifier = 'standalone-tests'
     from sourceSets.main.output
     from sourceSets.test.output

--- a/fdb-relational-api/fdb-relational-api.gradle
+++ b/fdb-relational-api/fdb-relational-api.gradle
@@ -28,7 +28,7 @@ plugins {
 apply from: rootProject.file('gradle/publishing.gradle')
 
 
-task createVersionPropertiesFile()  {
+tasks.register('createVersionPropertiesFile') {
     // Write a file of version and build info for the java processes to read
     // from their classpaths.
     def versionsFile = new File(projectDir, "src/gen/main/resources/version.properties")
@@ -84,7 +84,7 @@ sourceSets {
     }
 }
 
-sourcesJar {
+tasks.named('sourcesJar') {
     dependsOn "createVersionPropertiesFile"
 }
 

--- a/fdb-relational-cli/fdb-relational-cli.gradle
+++ b/fdb-relational-cli/fdb-relational-cli.gradle
@@ -78,7 +78,7 @@ def fdbEnvironmentYamlFile = new File("${rootProject.projectDir}/fdb-environment
 if (fdbEnvironmentYamlFile.exists()) {
     def firstClusterFile = new Yaml().loadAll(fdbEnvironmentYamlFile.newInputStream()).first().clusterFiles.first()
     allprojects {
-        tasks.withType(Test) { task ->
+        tasks.withType(Test).configureEach { task ->
             task.environment(FDB_CLUSTER_FILE: firstClusterFile)
         }
     }
@@ -103,7 +103,7 @@ shadowJar {
 
 build.dependsOn(shadowJar)
 
-tasks.withType(Jar) { task ->
+tasks.withType(Jar).configureEach { task ->
     dependsOn(tasks.withType(AntlrTask))
 }
 
@@ -152,10 +152,10 @@ distTar {
     archiveExtension = "tar.gz"
 }
 
-createDistribution.configure {
-    afterEvaluate {
-        dependsOn shadowJar
-        from tasks.shadowJar
+afterEvaluate {
+    tasks.named('createDistribution').configure {
+        dependsOn tasks.named('shadowJar')
+        from tasks.named('shadowJar')
     }
 }
 

--- a/fdb-relational-jdbc/fdb-relational-jdbc.gradle
+++ b/fdb-relational-jdbc/fdb-relational-jdbc.gradle
@@ -57,7 +57,7 @@ def fdbEnvironmentYamlFile = new File("${rootProject.projectDir}/fdb-environment
 if (fdbEnvironmentYamlFile.exists()) {
     def firstClusterFile = new Yaml().loadAll(fdbEnvironmentYamlFile.newInputStream()).first().clusterFiles.first()
     allprojects {
-        tasks.withType(Test) { task ->
+        tasks.withType(Test).configureEach { task ->
             task.environment(FDB_CLUSTER_FILE: firstClusterFile)
         }
     }
@@ -77,10 +77,10 @@ build.dependsOn {
     shadowJar
 }
 
-createDistribution.configure {
-    afterEvaluate {
-        dependsOn shadowJar
-        from tasks.shadowJar
+afterEvaluate {
+    tasks.named('createDistribution').configure {
+        dependsOn tasks.named('shadowJar')
+        from tasks.named('shadowJar')
     }
 }
 

--- a/fdb-relational-server/fdb-relational-server.gradle
+++ b/fdb-relational-server/fdb-relational-server.gradle
@@ -66,10 +66,10 @@ build.dependsOn {
     shadowJar
 }
 
-createDistribution.configure {
-    afterEvaluate {
-        dependsOn shadowJar
-        from tasks.shadowJar
+afterEvaluate {
+    tasks.named('createDistribution').configure {
+        dependsOn tasks.named('shadowJar')
+        from tasks.named('shadowJar')
     }
 }
 

--- a/gradle/antlr.gradle
+++ b/gradle/antlr.gradle
@@ -53,7 +53,7 @@ generateGrammarSource.doLast {
     }
 }
 
-task cleanUpTokenFiles(type: Delete) {
+tasks.register('cleanUpTokenFiles', Delete) {
     final tokenFilesDir = layout.projectDirectory.dir('src/main/antlr')
     delete fileTree(tokenFilesDir) { include '*.tokens' }
 }

--- a/gradle/check.gradle
+++ b/gradle/check.gradle
@@ -37,10 +37,11 @@ def BANNED_IMPORTS = [
     'org.apache.log4j'                           // log4j logging: use slf4j instead
 ]
 
-task checkstyleAll
+tasks.register('checkstyleAll') {
+    dependsOn(tasks.withType(Checkstyle))
+}
 
-tasks.withType(Checkstyle) { task ->
-    checkstyleAll.dependsOn task
+tasks.withType(Checkstyle).configureEach { task ->
     task.exclude '**/protogen/**'
     task.configProperties = ["projectDir" : rootProject.projectDir, 'bannedImports': BANNED_IMPORTS.join(',')]
     task.maxHeapSize.set("1g")
@@ -52,7 +53,7 @@ checkstyle {
     toolVersion = "10.20.1"
 }
 
-task checkstyleMandatory(type: Checkstyle) { task ->
+tasks.register('checkstyleMandatory', Checkstyle) { task ->
     group = 'Verification'
     description = 'Perform subset of Checkstyle checks that must pass in order for the build to be successful'
 
@@ -64,7 +65,7 @@ task checkstyleMandatory(type: Checkstyle) { task ->
     }
 }
 
-quickCheck.dependsOn checkstyleMandatory
+tasks.named('quickCheck') { dependsOn 'checkstyleMandatory' }
 
 // SpotBugs
 apply plugin: 'com.github.spotbugs'
@@ -86,7 +87,7 @@ def spotbugsFailed = false
 
 // TODO we may be able to remove this, as it should now print to stdout
 // https://github.com/spotbugs/spotbugs-gradle-plugin/commit/b78a1b349487031590e281fe17c7ed5c245d42ae
-def printInstructionsOnRunningWithHtmlOutput = task('printInstructionsOnRunningWithHtmlOutput') {
+def printInstructionsOnRunningWithHtmlOutput = tasks.register('printInstructionsOnRunningWithHtmlOutput') {
     doLast {
         if (spotbugsFailed) {
             logger.error "*** SPOTBUGS FAILED: you can generate the HTML report by adding -PspotbugsEnableHtmlReport"
@@ -133,7 +134,7 @@ tasks.withType(Pmd) { task ->
     task.setSource 'src/main/java'
 }
 
-task banSnapshots {
+tasks.register('banSnapshots') {
     doLast {
         // configurations.compile is included in runtime & we don't really care about snapshots in testCompile and testRuntime
         def resolved = configurations.runtime.resolvedConfiguration
@@ -146,5 +147,5 @@ task banSnapshots {
 }
 
 if (!Boolean.parseBoolean(allowSnapshots)) {
-    quickCheck.dependsOn banSnapshots
+    tasks.named('quickCheck') { dependsOn 'banSnapshots' }
 }

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -66,21 +66,21 @@ if (ext.publishLibrary) {
                     }
                 }
 
-                artifact tasks.sourcesJar
-                artifact tasks.javadocJar
-                artifact tasks.testJar
+                artifact tasks.named('sourcesJar')
+                artifact tasks.named('javadocJar')
+                artifact tasks.named('testJar')
                 addPublishingInfo(publication)
             }
         }
     }
-    createDistribution.configure {
-        afterEvaluate {
-            dependsOn generatePomFileForLibraryPublication
-            from tasks.jar, tasks.sourcesJar, tasks.javadocJar, tasks.testJar, tasks.generatePomFileForLibraryPublication
+    afterEvaluate {
+        tasks.named('createDistribution').configure {
+            dependsOn tasks.named('generatePomFileForLibraryPublication')
+            from tasks.named('jar'), tasks.named('sourcesJar'), tasks.named('javadocJar'), tasks.named('testJar'), tasks.named('generatePomFileForLibraryPublication')
             // Capture the names at configuration time so the rename closure does not reach into `tasks` at execution
             // time (which is incompatible with the configuration cache).
-            String pomDestinationName = tasks.generatePomFileForLibraryPublication.destination.name
-            String jarArchiveFileName = tasks.jar.archiveFileName.get()
+            String pomDestinationName = tasks.named('generatePomFileForLibraryPublication').get().destination.name
+            String jarArchiveFileName = tasks.named('jar').get().archiveFileName.get()
             rename { filename ->
                 if (filename == pomDestinationName) {
                     jarArchiveFileName.replace("jar", "pom")

--- a/gradle/root.gradle
+++ b/gradle/root.gradle
@@ -49,7 +49,7 @@ static def generateMD5(File file) {
     bigInt.toString(16).padLeft(32, '0')
 }
 
-task checksumsVerify {
+tasks.register('checksumsVerify') {
 
     doLast {
         def checksumsFile = file('.checksum')

--- a/gradle/sphinx.gradle
+++ b/gradle/sphinx.gradle
@@ -42,7 +42,7 @@ var documented_subprojects = [
         "fdb-relational-jdbc",
 ]
 
-task sphinxEnv {
+tasks.register('sphinxEnv') {
     inputs.file("${sphinxRoot}/requirements.txt")
     outputs.dir(venvDir)
 
@@ -59,7 +59,7 @@ task sphinxEnv {
 
 // Create svg files for railroad diagrams from specification files. These images are included
 // in the docs
-task generateRailroadDiagrams(type: Exec) {
+tasks.register('generateRailroadDiagrams', Exec) {
     inputs.file("${sphinxRoot}/generate_railroad_svg.py")
     fileTree("${sphinxRoot}/source") {
         include("**/*.diagram")
@@ -76,7 +76,7 @@ task generateRailroadDiagrams(type: Exec) {
 // to link to. Create temporary placeholders for each one. Later, we will override the location
 // with the generated javadoc. Also, generates a table of contents so that we have all of the
 // subprojects listed
-task createSphinxApiPlaceholders {
+tasks.register('createSphinxApiPlaceholders') {
     var apiTemplatePath = "${sphinxRoot}/source/api/api.md.template"
     inputs.file(apiTemplatePath)
     var inputPath = "${sphinxRoot}/source/api/index.md.template"
@@ -110,7 +110,7 @@ task createSphinxApiPlaceholders {
 }
 
 // Build the sphinx documentation
-task sphinxDocs(type: Exec) {
+tasks.register('sphinxDocs', Exec) {
     inputs.dir(venvDir)
     inputs.dir("${sphinxRoot}/source")
     outputs.dir("${sphinxBuildDir}/html")
@@ -124,7 +124,7 @@ task sphinxDocs(type: Exec) {
 
 // Compile the final documentation site by copying the generated javadoc into the appropriate
 // location in the build
-task documentationSite(type: Copy) {
+tasks.register('documentationSite', Copy) {
     dependsOn(tasks.javadoc)
     dependsOn(tasks.sphinxDocs)
 
@@ -137,7 +137,7 @@ task documentationSite(type: Copy) {
 }
 
 // Clean the sphinx build
-task sphinxClean(type: Delete) {
+tasks.register('sphinxClean', Delete) {
     delete(sphinxBuildDir)
     delete fileTree("${sphinxRoot}/source") {
         include "**/*.diagram.svg"
@@ -148,4 +148,4 @@ task sphinxClean(type: Delete) {
         }
     }
 }
-clean.dependsOn(sphinxClean)
+clean.dependsOn('sphinxClean')

--- a/gradle/testing.gradle
+++ b/gradle/testing.gradle
@@ -51,7 +51,7 @@ test {
     }
 }
 
-task destructiveTest(type: Test) {
+tasks.register('destructiveTest', Test) {
     useJUnitPlatform {
         includeTags 'WipesFDB'
         maxParallelForks = 1
@@ -61,14 +61,14 @@ task destructiveTest(type: Test) {
     }
 }
 
-task performanceTest(type: Test) {
+tasks.register('performanceTest', Test) {
     useJUnitPlatform {
         includeTags 'Performance'
         enableAssertions = false
     }
 }
 
-task quickTest(type: Test) {
+tasks.register('quickTest', Test) {
     systemProperties["tests.runQuick"] = true
     useJUnitPlatform {
         excludeTags 'WipesFDB'
@@ -76,7 +76,7 @@ task quickTest(type: Test) {
 }
 
 // Tests that run similarly to quickTest, but with an embedded RPC server instead of embedded connection
-task rpcTest(type: Test) {
+tasks.register('rpcTest', Test) {
     systemProperties["tests.runRPC"] = true
     useJUnitPlatform {
         excludeTags 'WipesFDB'
@@ -84,7 +84,7 @@ task rpcTest(type: Test) {
 }
 
 // Tests that run a single version on multiple external servers
-task singleVersionTest(type: Test) {
+tasks.register('singleVersionTest', Test) {
     systemProperties["tests.singleVersion"] = true
     useJUnitPlatform {
         excludeTags 'WipesFDB'
@@ -115,7 +115,7 @@ static def getMixedModeVersion(descriptor) {
     return null
 }
 
-task mixedModeTest(type: Test) {
+tasks.register('mixedModeTest', Test) {
     useJUnitPlatform {
         includeTags 'MixedMode'
     }
@@ -258,7 +258,7 @@ def betterException(String exception) {
     return skippedStackTraceEntries.matcher(exception).replaceAll("\n\${indent}... junit stack ...")
 }
 
-tasks.withType(Test) { Test theTask ->
+tasks.withType(Test).configureEach { Test theTask ->
     // Point the `Test` task at the compiled classes and the runtime classpath of the test source-set.
     testClassesDirs = sourceSets.test.output.classesDirs
     classpath = sourceSets.test.runtimeClasspath
@@ -410,7 +410,8 @@ tasks.withType(Test).configureEach { task ->
 
 }
 
-task testJar(type: Jar, dependsOn: testClasses) {
+tasks.register('testJar', Jar) {
+    dependsOn 'testClasses'
     group = 'Build'
     description = 'Build a jar file of test classes as an exported artifact'
     archiveClassifier = 'test'
@@ -424,10 +425,10 @@ configurations {
 }
 
 artifacts {
-    tests testJar
+    tests tasks.named('testJar')
 }
 
-task quickCheck {
+tasks.register('quickCheck') {
     group = 'Verification'
     description = 'Perform fast build verification'
 

--- a/yaml-tests/yaml-tests.gradle
+++ b/yaml-tests/yaml-tests.gradle
@@ -115,7 +115,7 @@ ext.resolveOtherServer = { Set<String> rejectedVersions ->
                     // grpc dependency.
                     transitive=false
                 })
-        def configuration = configurations.getByName(configurationName, { })
+        def configuration = configurations.named(configurationName).get()
 
         File resolution = configuration.resolve()[0]
         Matcher versionMatch = resolution.getName() =~ /^fdb-relational-server-(.*-SNAPSHOT)-all.jar$/
@@ -177,7 +177,7 @@ ext.resolveSpecificServer = { String version ->
                     }
                     transitive = false
                 })
-        def configuration = configurations.getByName(configurationName, { })
+        def configuration = configurations.named(configurationName).get()
         File resolution = configuration.resolve()[0]
         println("Downloaded specific external server: " + resolution.getName())
         return resolution
@@ -197,11 +197,11 @@ ext.resolveRecentVersionStrings = { int n ->
     return resolvedVersions
 }
 
-task cleanExternalServerDirectory(type: Delete) {
+tasks.register('cleanExternalServerDirectory', Delete) {
     delete project.layout.buildDirectory.dir('externalServer')
 }
 
-task serverJars(type: Copy) {
+tasks.register('serverJars', Copy) {
     notCompatibleWithConfigurationCache("Resolves dynamic external server versions at execution time")
     dependsOn ":fdb-relational-server:package", "cleanExternalServerDirectory"
     into project.layout.buildDirectory.dir('externalServer')
@@ -211,7 +211,7 @@ task serverJars(type: Copy) {
     }
 }
 
-task downloadManyExternalServers(type: Copy) {
+tasks.register('downloadManyExternalServers', Copy) {
     notCompatibleWithConfigurationCache("Resolves dynamic external server versions at execution time")
     dependsOn "cleanExternalServerDirectory"
     from { resolveManyServers() }
@@ -221,7 +221,7 @@ task downloadManyExternalServers(type: Copy) {
 // Resolves the n most-recent released version strings and writes them to a file, comma-separated.
 // n defaults to 10 and can be overridden with -Ptests.listVersionsCount=<n>.
 // Output file: <buildDir>/recentVersions.txt
-task listRecentVersions {
+tasks.register('listRecentVersions') {
     notCompatibleWithConfigurationCache("Resolves dynamic external server versions at execution time")
     def listVersionsCountProvider = providers.gradleProperty('tests.listVersionsCount')
     def outputFileProvider = layout.buildDirectory.file('recentVersions.txt')
@@ -243,7 +243,7 @@ task listRecentVersions {
 //
 //   -Ptests.mixedModeVersion=4.10.3.0
 //
-task downloadSpecificExternalServer(type: Copy) {
+tasks.register('downloadSpecificExternalServer', Copy) {
     notCompatibleWithConfigurationCache("Resolves dynamic external server versions at execution time")
     dependsOn "cleanExternalServerDirectory"
     into project.layout.buildDirectory.dir('externalServer')
@@ -264,7 +264,7 @@ task downloadSpecificExternalServer(type: Copy) {
     })
 }
 
-mixedModeTest {
+tasks.named('mixedModeTest') {
     if (project.hasProperty('tests.mixedModeVersion')) {
         dependsOn("downloadSpecificExternalServer")
     } else {
@@ -273,12 +273,12 @@ mixedModeTest {
     systemProperty("yaml_testing_external_server", project.layout.buildDirectory.dir('externalServer').get().asFile)
 }
 
-singleVersionTest {
+tasks.named('singleVersionTest') {
     dependsOn("downloadManyExternalServers")
     systemProperty("yaml_testing_external_server", project.layout.buildDirectory.dir('externalServer').get().asFile)
 }
 
-test {
+tasks.named('test') {
     dependsOn "serverJars"
     systemProperty("yaml_testing_external_server", project.layout.buildDirectory.dir('externalServer').get().asFile)
     def seed


### PR DESCRIPTION
* Convert custom task declarations across the build from the eager Groovy DSL form `task «name»(type: «type») { … }` to the lazy form `tasks.register('«name»', «type») { … }`.
* Apply recommendations from the Gradle guide to avoid forcing the eager realization of otherwise lazily registered tasks. This includes replacing bare task-name references (such as `sourcesJar.dependsOn(…)`, `tasks.jar`) with `tasks.named(…)`; converting bare `tasks.withType(…) { }` blocks, which realize every matching task immediately, to `tasks.withType(…).configureEach { }`; and migrating eager `configurations.getByName(«name», …)` calls to `configurations.named(«name»)`.

The eager form causes Gradle to realize (i.e., to instantiate and configure) the task even when it is not in the graph of requested tasks. With `tasks.register()`, the configuration block does not run until something actually asks for the task. This speeds up the configuration time. It has been available and recommended as the idiomatic pattern since Gradle 4.9.

One place we are skipping for now is the `task check(overwrite: true, dependsOn: quickCheck) { }` in build.gradle, because the `overwrite: true` feature is specific to the eager task DSL. Overriding an existing task with `tasks.register()` requires a different idiom and is left for a separate change.

**Benchmark:** Running Gradle’s `help` task with the configuration cache disabled, the number of tasks realized during configuration drops from 698 to 332 (-52%).

**Reference:** [Gradle User Manual › Avoiding Unnecessary Task Configuration](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html)