### PR TITLE
Pin the Java toolchain to JDK 21 using `java { toolchain {…} }`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -198,6 +198,13 @@ subprojects {
     apply from: rootProject.file('gradle/testing.gradle')
 
     java {
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(21)
+        }
+
+        // Pin `sourceCompatibility`/`targetCompatibility` to match the bytecode and API target that we set for
+        // `JavaCompile` tasks via `options.release` below. This also makes IntelliJ’s Gradle importer set the
+        // appropriate `languageLevel` in `.idea/misc.xml`.
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
@@ -257,14 +264,16 @@ subprojects {
                     linksOffline "https://foundationdb.github.io/fdb-record-layer/api/fdb-record-layer-core/", "${packageListDir}/fdb-record-layer-core/"
                 }
             }
-            compileJava {
-                //enable compilation in a separate daemon process
+
+            // Override some options on every compile task (main and test).
+            tasks.withType(JavaCompile).configureEach {
+                // Enable compilation in a separate daemon process.
                 options.fork = true
 
-                //enable incremental compilation
+                // Enable incremental compilation.
                 options.incremental = true
 
-                //target byte-code compatibility with Java 17 (regardless of build JDK)
+                // Compile against the Java 17 API and emit Java 17 bytecode.
                 options.release = 17
             }
         }
@@ -353,10 +362,6 @@ clean.doLast {
 }
 
 apply from: 'gradle/sphinx.gradle'
-
-if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
-    throw new Exception("Java 17 is required to build fdb-record-layer")
-}
 
 // fdb-environment.properties is the old way we configured the library path and cluster file, it does not scale well
 // to multiple cluster files, so is being replaced with a yaml file.

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/queue/PendingWritesQueueConcurrencyTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/queue/PendingWritesQueueConcurrencyTest.java
@@ -90,24 +90,23 @@ class PendingWritesQueueConcurrencyTest extends FDBRecordStoreTestBase {
         // list append, so commit order and list order agree.
         final Object commitLock = new Object();
 
-        try (ExecutorService executor = Executors.newFixedThreadPool(WORKER_COUNT)) {
-            List<Future<?>> futures = new ArrayList<>(WORKER_COUNT);
-            try {
-                for (int worker = 0; worker < WORKER_COUNT; worker++) {
-                    final int workerId = worker;
-                    // Per-worker Random seeded deterministically from the global seed + workerId
-                    futures.add(executor.submit(() -> {
-                        workerLoop(queue, workerId, new Random(seed + workerId), recorded, drained, commitLock);
-                        return null;
-                    }));
-                }
-                for (Future<?> future : futures) {
-                    future.get(120, TimeUnit.SECONDS);
-                }
-            } finally {
-                executor.shutdownNow();
-                assertTrue(executor.awaitTermination(30, TimeUnit.SECONDS), "executor did not shut down");
+        final ExecutorService executor = Executors.newFixedThreadPool(WORKER_COUNT);
+        List<Future<?>> futures = new ArrayList<>(WORKER_COUNT);
+        try {
+            for (int worker = 0; worker < WORKER_COUNT; worker++) {
+                final int workerId = worker;
+                // Per-worker Random seeded deterministically from the global seed + workerId
+                futures.add(executor.submit(() -> {
+                    workerLoop(queue, workerId, new Random(seed + workerId), recorded, drained, commitLock);
+                    return null;
+                }));
             }
+            for (Future<?> future : futures) {
+                future.get(120, TimeUnit.SECONDS);
+            }
+        } finally {
+            executor.shutdownNow();
+            assertTrue(executor.awaitTermination(30, TimeUnit.SECONDS), "executor did not shut down");
         }
 
         // Drain whatever the workers left behind, in a single consistent snapshot, recording

--- a/gradle.properties
+++ b/gradle.properties
@@ -36,6 +36,9 @@ apiVersion=710
 mavenLocalEnabled=false
 org.gradle.daemon=true
 
+# Don’t try to auto-provision JDKs. We prefer to only resolve Java toolchains from locally installed JDKs.
+org.gradle.java.installations.auto-download=false
+
 url = 'https://github.com/FoundationDB/fdb-record-layer/'
 
 # Control which places we attempt to publish to


### PR DESCRIPTION
* Use `toolchain { languageVersion = … }` to reliably pin the Java toolchain to JDK 21. This decouples the build from whatever JDK the developer happens to have on `PATH`.
* Disable auto-provisioning of JDKs. Gradle will pick a matching JDK from its detected local JDK installations.
* Drop the manual `JavaVersion.current().isCompatibleWith(VERSION_17)` guard. It is no longer necessary because the toolchain already ensures an appropriate JDK will be used.
* Apply `options.release = 17` to **every** `JavaCompile` task. Previously it was only `compileJava`, so tests were actually targeting Java 21.
* In `PendingWritesQueueConcurrencyTest`, remove an inadvertent dependency on the JDK 19 API (namely, a try-with-resources statement taking advantage of `ExecutorService` being auto-closeable) in order to make it compile under `--release 17`.

Apart from pinning the JDK cleanly, toolchains also interact better with the Build Cache. Gradle folds the toolchain JDK identity into the build cache key, so cached compile outputs are tied to the JDK that produced them rather than just to `javac` arguments.