### PR TITLE
Gradle/Groovy code quality improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,6 @@ plugins {
 }
 
 ext {
-    SpotBugsTask = com.github.spotbugs.snom.SpotBugsTask
     fdbEnvironment = [:]
 }
 
@@ -97,7 +96,7 @@ allprojects {
         dependsOn("sourcesJar")
     }
 
-    buildDir = ".out"
+    layout.buildDirectory.set(layout.projectDirectory.dir(".out"))
     ext {
         distDir = ".dist"
     }
@@ -112,7 +111,7 @@ allprojects {
 
     // Configure JUnit tests
     tasks.withType(Test) {
-        reports.junitXml.outputLocation = project.file("${->project.buildDir}/test-results")
+        reports.junitXml.outputLocation = project.layout.buildDirectory.dir("test-results")
     }
 
     def projectName = it.name
@@ -302,7 +301,7 @@ subprojects {
                     tree.each { yamsql ->
                         def original = yamsql.text
                         def updated = original.replaceAll("(?<!\")!current_version(?!\")", projectVersion)
-                        if (!original.equals(updated)) {
+                        if (original != updated) {
                             println("Replacing !current_version in " + yamsql)
                             // Replace !current_version in all yamsql, unless it is surrounded by ", allowing it to be used in
                             // comments, without issue, e.g. in showcasing-tests
@@ -367,7 +366,10 @@ def fdbEnvironmentFile = new File("${rootProject.projectDir}/fdb-environment.pro
 if (fdbEnvironmentFile.exists()) {
     fdbEnvironmentFile.eachLine { line ->
         def eq = line.indexOf('=')
-        if (eq > 0) ext.fdbEnvironment.put(line.substring(0, eq), line.substring(eq + 1))
+        if (eq > 0) {
+            ext.fdbEnvironment.put(line.substring(0, eq), line.substring(eq + 1))
+        }
+        return
     }
 }
 if (!ext.fdbEnvironment.isEmpty()) {

--- a/examples/examples.gradle
+++ b/examples/examples.gradle
@@ -18,6 +18,8 @@
  * limitations under the License.
  */
 
+import com.github.spotbugs.snom.SpotBugsTask
+
 apply from: rootProject.file('gradle/proto.gradle')
 apply plugin: 'application'
 
@@ -45,7 +47,7 @@ application {
 tasks.withType(Pmd).configureEach {
     enabled = false
 }
-tasks.withType(com.github.spotbugs.snom.SpotBugsTask).configureEach {
+tasks.withType(SpotBugsTask).configureEach {
     enabled = false
 }
 tasks.withType(Checkstyle).configureEach {

--- a/fdb-extensions/fdb-extensions.gradle
+++ b/fdb-extensions/fdb-extensions.gradle
@@ -18,6 +18,9 @@
  * limitations under the License.
  */
 
+import de.undercouch.gradle.tasks.download.Download
+import de.undercouch.gradle.tasks.download.Verify
+
 apply plugin: 'java-test-fixtures'
 apply from: rootProject.file('gradle/publishing.gradle')
 
@@ -78,7 +81,7 @@ def downloadsDir = project.ext.downloadsDirectory
 // so downstream wiring can depend on "this dataset is present and validated". downloadTaskDir lives
 // under the cached downloads dir too, so onlyIfModified ETag state also survives `clean`.
 def siftTasks = siftDownloads.collectEntries { name, cfg ->
-    def download = tasks.register("download${name.capitalize()}", de.undercouch.gradle.tasks.download.Download) {
+    def download = tasks.register("download${name.capitalize()}", Download) {
         src cfg.url
         dest downloadsDir.file(cfg.file).asFile
         downloadTaskDir downloadsDir.dir("downloads-task")
@@ -89,7 +92,7 @@ def siftTasks = siftDownloads.collectEntries { name, cfg ->
     }
     def terminal = download
     if (cfg.sha256) {
-        terminal = tasks.register("verify${name.capitalize()}", de.undercouch.gradle.tasks.download.Verify) {
+        terminal = tasks.register("verify${name.capitalize()}", Verify) {
             dependsOn download
             src downloadsDir.file(cfg.file).asFile
             algorithm 'SHA256'

--- a/fdb-record-layer-core-shaded/fdb-record-layer-core-shaded.gradle
+++ b/fdb-record-layer-core-shaded/fdb-record-layer-core-shaded.gradle
@@ -91,7 +91,7 @@ apply from: rootProject.file('gradle/publishing.gradle')
 
 publishing {
     publications {
-        shadow(MavenPublication) { publication ->
+        shadow(MavenPublication) { MavenPublication publication ->
             from components.shadow
             addPublishingInfo(publication) // function imported from publishing.gradle
             publication.pom { pom ->
@@ -99,9 +99,9 @@ publishing {
                 pom.withXml { xml ->
                     // Remove any existing dependencies sections
                     def childNodes = xml.asNode().children()
-                    def dependenciesNodes = new ArrayList<groovy.util.Node>()
-                    childNodes.forEach { childNode ->
-                        if (childNode.name().equals('dependencies')) {
+                    def dependenciesNodes = new ArrayList<Node>()
+                    childNodes.forEach { Node childNode ->
+                        if (childNode.name() == 'dependencies') {
                             dependenciesNodes.add(childNode)
                         }
                     }

--- a/fdb-record-layer-core/fdb-record-layer-core.gradle
+++ b/fdb-record-layer-core/fdb-record-layer-core.gradle
@@ -18,6 +18,8 @@
  * limitations under the License.
  */
 
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+
 plugins {
     id 'java-test-fixtures'
     alias(libs.plugins.shadow)
@@ -68,7 +70,7 @@ sourceSets {
     }
 }
 
-task testShadowJar(type: com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
+task testShadowJar(type: ShadowJar) {
     archiveClassifier = 'standalone-tests'
     from sourceSets.main.output
     from sourceSets.test.output

--- a/fdb-record-layer-spatial/fdb-record-layer-spatial.gradle
+++ b/fdb-record-layer-spatial/fdb-record-layer-spatial.gradle
@@ -18,6 +18,9 @@
  * limitations under the License.
  */
 
+import de.undercouch.gradle.tasks.download.Download
+import de.undercouch.gradle.tasks.download.Verify
+
 apply from: rootProject.file('gradle/proto.gradle')
 apply from: rootProject.file('gradle/publishing.gradle')
 
@@ -57,7 +60,7 @@ def geonamesFilesWithChecksums = [
         ]
 ]
 
-tasks.register("downloadGeonames", de.undercouch.gradle.tasks.download.Download) {
+tasks.register("downloadGeonames", Download) {
     // src geonamesFiles.collect { file -> "http://download.geonames.org/export/dump/${file}" }
     /* some times geonames times out or is otherwise unreliable, move files to
     an s3 bucket that we control for more consistent download behavior */
@@ -69,7 +72,7 @@ tasks.register("downloadGeonames", de.undercouch.gradle.tasks.download.Download)
 }
 
 def verifyGeonamesFilesTasks = geonamesFilesWithChecksums.collect { fileWithChecksum ->
-    tasks.register("verifyGeonamesFile-${fileWithChecksum.name}", de.undercouch.gradle.tasks.download.Verify) {
+    tasks.register("verifyGeonamesFile-${fileWithChecksum.name}", Verify) {
         dependsOn 'downloadGeonames'
         src geonamesFilesDirectory.file(fileWithChecksum.name).asFile
         algorithm 'SHA256'

--- a/fdb-relational-api/fdb-relational-api.gradle
+++ b/fdb-relational-api/fdb-relational-api.gradle
@@ -18,6 +18,8 @@
  * limitations under the License.
  */
 
+import java.time.Instant
+
 plugins {
     alias(libs.plugins.gitversion)
     id 'java-test-fixtures'
@@ -49,7 +51,7 @@ branch=${gitDetails.branchName}
 # Returned as RelationalDatabaseMetaData#getUrl()
 url=${projectUrl.replace('\'', '')}
 user=${System.getProperty("user.name")}
-buildtime=${java.time.Instant.now()}
+buildtime=${Instant.now()}
 buildHost=${InetAddress.getLocalHost().getCanonicalHostName()}
 """
     }

--- a/gradle/check.gradle
+++ b/gradle/check.gradle
@@ -71,7 +71,8 @@ apply plugin: 'com.github.spotbugs'
 // It looks like there is an issue with having spotbugs in a separate file
 // https://github.com/spotbugs/spotbugs-gradle-plugin/issues/972
 def classLoader = plugins['com.github.spotbugs'].class.classLoader
-def SpotBugsEffort = classLoader.findLoadedClass( 'com.github.spotbugs.snom.Effort' )
+def SpotBugsEffort = classLoader.findLoadedClass('com.github.spotbugs.snom.Effort')
+def SpotBugsTaskClass = classLoader.findLoadedClass('com.github.spotbugs.snom.SpotBugsTask')
 spotbugs {
     toolVersion = libs.versions.spotbugs.get()
     ignoreFailures = false
@@ -93,7 +94,7 @@ def printInstructionsOnRunningWithHtmlOutput = task('printInstructionsOnRunningW
     }
 }
 
-tasks.withType(rootProject.SpotBugsTask) { task ->
+tasks.withType(SpotBugsTaskClass) { task ->
     if (project.hasProperty('spotbugsEnableHtmlReport')) {
         // SpotBugs task can only have one report type enabled at a time
         reports {

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -21,7 +21,7 @@
 apply plugin: 'signing'
 
 // Add various details to the pom file to allow for publishing
-def addPublishingInfo(publication) {
+def addPublishingInfo(MavenPublication publication) {
     publication.pom {
         name = project.name
         url = 'https://foundationdb.github.io/fdb-record-layer/'
@@ -50,7 +50,7 @@ def addPublishingInfo(publication) {
 if (ext.publishLibrary) {
     publishing {
         publications {
-            library(MavenPublication) { publication ->
+            library(MavenPublication) { MavenPublication publication ->
                 from components.java
 
                 // Test fixtures appear to be placing their dependencies in the wrong scope

--- a/gradle/root.gradle
+++ b/gradle/root.gradle
@@ -35,13 +35,13 @@ dependencyReport {
     projects = project.allprojects
 }
 
-def generateMD5(File file) {
+static def generateMD5(File file) {
     def digest = MessageDigest.getInstance("MD5")
     file.withInputStream() { is ->
         byte[] buffer = new byte[8192]
-        int read = 0
+        int read
         while ((read = is.read(buffer)) > 0) {
-            digest.update(buffer, 0, read);
+            digest.update(buffer, 0, read)
         }
     }
     byte[] md5sum = digest.digest()
@@ -63,7 +63,7 @@ task checksumsVerify {
             if (!md5.equalsIgnoreCase(checksum)) {
                 failed.add(name)
             }
-
+            return
         }
         if (!failed.empty) {
             throw new RuntimeException("Some MD5 sums failed to verify: " + failed)

--- a/gradle/sphinx.gradle
+++ b/gradle/sphinx.gradle
@@ -25,7 +25,7 @@ var sphinxBuildDir = "${sphinxRoot}/.out"
 // Gives tasks access to an injected `ExecOperations` for running external processes from a `doLast` block.
 interface InjectedExecOps {
     @javax.inject.Inject
-    org.gradle.process.ExecOperations getExecOps()
+    ExecOperations getExecOps()
 }
 
 var documented_subprojects = [

--- a/gradle/testing.gradle
+++ b/gradle/testing.gradle
@@ -1,6 +1,7 @@
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 
+import org.gradle.api.tasks.testing.TestDescriptor
 import org.gradle.api.tasks.testing.TestListener
 
 /*
@@ -56,7 +57,7 @@ task destructiveTest(type: Test) {
         maxParallelForks = 1
     }
     reports {
-        junitXml.outputLocation = file("${buildDir}/test-results/destructive")
+        junitXml.outputLocation = layout.buildDirectory.dir("test-results/destructive")
     }
 }
 
@@ -92,7 +93,7 @@ task singleVersionTest(type: Test) {
 
 // if you add to or modify these testing configurations, make sure to update the CONTRIBUTING.md to include any updates
 
-def getMixedModeVersion(descriptor) {
+static def getMixedModeVersion(descriptor) {
     while (descriptor != null) {
         // don't display this or any of the parents. Let's assume that nobody ever
         // sets the display name in code to start with "Gradle Test Executor".
@@ -133,10 +134,10 @@ task mixedModeTest(type: Test) {
         }
     }
     addTestListener([
-        beforeSuite: { suite -> },
-        afterSuite: { suite, result -> },
-        beforeTest: { descriptor -> },
-        afterTest: { descriptor, result ->
+        beforeSuite: { TestDescriptor suite -> },
+        afterSuite: { TestDescriptor suite, TestResult result -> },
+        beforeTest: { TestDescriptor descriptor -> },
+        afterTest: { TestDescriptor descriptor, TestResult result ->
             def version = getMixedModeVersion(descriptor)
             if (version == null) {
                 throw new RuntimeException("Could not find version " + getFullDisplayName(descriptor))
@@ -147,7 +148,7 @@ task mixedModeTest(type: Test) {
     ] as TestListener)
 }
 
-def getFullDisplayName(descriptor) {
+static def getFullDisplayName(TestDescriptor descriptor) {
     def fullName = descriptor.displayName
     descriptor = descriptor.parent
     while (descriptor != null) {
@@ -179,7 +180,7 @@ abstract class TestTmpDirCleaner {
 
 def testTmpDirCleaner = objects.newInstance(TestTmpDirCleaner)
 
-def configureTestTask = { propertyPrefix, task ->
+def configureTestTask = { String propertyPrefix, Task task ->
     def handled = [propertyPrefix + '.ignoreFailures',
                    propertyPrefix + '.debug',
                    propertyPrefix + '.single',
@@ -190,14 +191,15 @@ def configureTestTask = { propertyPrefix, task ->
         def prefix = "${propertyPrefix}.sysProp."
         if (!prop.key.startsWith(prefix.toString())) {
             return
-        };
+        }
         def setkey = prop.key.substring(prefix.length())
         task.systemProperties[setkey] = prop.value
         logger.debug "Set system property ${setkey} = ${prop.value} on ${propertyPrefix}"
         handled.add(prop.key)
+        return
     }
 
-    def tmpdir = file("$buildDir/tmp-${task.name}")
+    def tmpdir = layout.buildDirectory.dir("tmp-${task.name}").get().asFile
     task.doFirst {
         testTmpDirCleaner.fs.delete { delete(tmpdir) }
         tmpdir.mkdirs()
@@ -239,6 +241,7 @@ def configureTestTask = { propertyPrefix, task ->
         if (prop.key.startsWith(propertyPrefix + '.') && !handled.contains(prop.key)) {
             logger.warn "Unknown system property that looks like it was intended to configure this task: ${prop.key}=${prop.value}"
         }
+        return
     }
 }
 
@@ -255,7 +258,7 @@ def betterException(String exception) {
     return skippedStackTraceEntries.matcher(exception).replaceAll("\n\${indent}... junit stack ...")
 }
 
-tasks.withType(Test) { theTask ->
+tasks.withType(Test) { Test theTask ->
     // Point the `Test` task at the compiled classes and the runtime classpath of the test source-set.
     testClassesDirs = sourceSets.test.output.classesDirs
     classpath = sourceSets.test.runtimeClasspath
@@ -288,11 +291,11 @@ tasks.withType(Test) { theTask ->
     }
 
     addTestListener([
-        beforeSuite: { suite -> },
-        beforeTest: { descriptor ->
+        beforeSuite: { TestDescriptor suite -> },
+        beforeTest: { TestDescriptor descriptor ->
             println "${Instant.now()} ${getFullDisplayName(descriptor)} STARTED"
         },
-        afterTest: { descriptor, result ->
+        afterTest: { TestDescriptor descriptor, TestResult result ->
             def duration = String.format(Locale.ROOT, "%,d", result.endTime - result.startTime)
             println "${Instant.now()} ${getFullDisplayName(descriptor)} ${result.resultType} (${duration}ms)"
             println()

--- a/yaml-tests/yaml-tests.gradle
+++ b/yaml-tests/yaml-tests.gradle
@@ -148,8 +148,8 @@ static def getAttributesFromJar(File file) {
 }
 
 ext.resolveManyServers = { ->
-    Set<File> selectedServers = new HashSet<>();
-    Set<String> rejectedVersions = new HashSet<>();
+    Set<File> selectedServers = new HashSet<>()
+    Set<String> rejectedVersions = new HashSet<>()
     while (selectedServers.size() < 10) {
         def serverFile = resolveOtherServer(rejectedVersions)
         def attributes = getAttributesFromJar(serverFile)
@@ -285,7 +285,7 @@ test {
     if (project.hasProperty('tests.yaml.seed')) {
         seed = Long.parseLong(project.getProperty('tests.yaml.seed'))
     } else {
-        seed = ThreadLocalRandom.current().nextLong();
+        seed = ThreadLocalRandom.current().nextLong()
     }
     println("Using seed for yaml-tests: ${seed}")
     systemProperty('tests.yaml.seed', seed)


### PR DESCRIPTION
* Address a batch of Gradle and Groovy issues raised by IntelliJs "Gradle" code inspection, such as: return-value ambiguities, null-safety issues, deprecated Gradle APIs, and various style nits.
* Remove the cross-file ext property used to smuggle the `SpotBugsTask` class between build scripts. Instead, resolve it directly from the plugins classloader where it is needed.
* In some places we can add explicit types to variables to help the code analyzer (and human readers).