### PR TITLE
Disable on queue full

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/FDBRecordStoreProperties.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/FDBRecordStoreProperties.java
@@ -63,6 +63,20 @@ public final class FDBRecordStoreProperties {
     public static final RecordLayerPropertyKey<Boolean> LOAD_RECORDS_VIA_GETS = RecordLayerPropertyKey.booleanPropertyKey(
             "com.apple.foundationdb.record.recordstore.load_records_via_gets", false);
 
+    /**
+     * How a user write should react when it cannot append to the pending-writes queue of an index in the
+     * {@link IndexState#WRITE_ONLY_WITH_QUEUE} state because the queue is full (see
+     * {@link com.apple.foundationdb.record.provider.foundationdb.queue.PendingWritesQueue}). When {@code false}
+     * (the default), the queue overflow surfaces as a
+     * {@link com.apple.foundationdb.record.provider.foundationdb.queue.PendingWritesQueue.PendingWritesQueueTooLargeException}
+     * and the user transaction fails. When {@code true}, the offending index is instead disabled within the same user
+     * transaction, so the user write still succeeds. This is intended for the case where the online indexer has stalled
+     * and can no longer drain the queue: a background-indexing problem should not permanently break user writes.
+     */
+    @API(API.Status.EXPERIMENTAL)
+    public static final RecordLayerPropertyKey<Boolean> DISABLE_INDEX_ON_PENDING_WRITE_QUEUE_OVERFLOW = RecordLayerPropertyKey.booleanPropertyKey(
+            "com.apple.foundationdb.record.recordstore.disable_index_on_pending_write_queue_overflow", false);
+
     private FDBRecordStoreProperties() {
         throw new RecordCoreException("should not instantiate class of static prop");
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/FDBRecordStoreProperties.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/FDBRecordStoreProperties.java
@@ -75,7 +75,7 @@ public final class FDBRecordStoreProperties {
      */
     @API(API.Status.EXPERIMENTAL)
     public static final RecordLayerPropertyKey<Boolean> DISABLE_INDEX_ON_PENDING_WRITE_QUEUE_OVERFLOW = RecordLayerPropertyKey.booleanPropertyKey(
-            "com.apple.foundationdb.record.recordstore.disable_index_on_pending_write_queue_overflow", false);
+            "com.apple.foundationdb.record.recordstore.disable_index_on_pending_write_queue_overflow", true);
 
     private FDBRecordStoreProperties() {
         throw new RecordCoreException("should not instantiate class of static prop");

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBStoreTimer.java
@@ -777,6 +777,8 @@ public class FDBStoreTimer extends StoreTimer {
         PENDING_WRITES_QUEUE_WRITE("pending writes queue writes", false),
         /** Count of the entries cleared from a {@code PendingWritesQueue}. */
         PENDING_WRITES_QUEUE_CLEAR("pending writes queue clears", false),
+        /** Count of the indexes disabled because their {@code PendingWritesQueue} overflowed. */
+        PENDING_WRITES_QUEUE_OVERFLOW_DISABLED_INDEX("indexes disabled on pending writes queue overflow", false),
         ;
 
         private final String title;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingPendingWriteQueue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingPendingWriteQueue.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.provider.foundationdb;
 
+import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.record.FDBRecordStoreProperties;
 import com.apple.foundationdb.record.IndexBuildProto;
@@ -48,6 +49,7 @@ import java.util.concurrent.CompletableFuture;
  * Indexing maintainer: will use this module to push items to the queue
  * Online indexer: will use this module to drain the queue and update the index
  */
+@API(API.Status.INTERNAL)
 @ParametersAreNonnullByDefault
 public final class IndexingPendingWriteQueue {
     private static final Logger LOGGER = LoggerFactory.getLogger(IndexingPendingWriteQueue.class);
@@ -71,12 +73,12 @@ public final class IndexingPendingWriteQueue {
     }
 
     @VisibleForTesting
-    public static void setMaxQueueSizeForTesting(final int size) {
+    static void setMaxQueueSizeForTesting(final int size) {
         maxQueueSize = size;
     }
 
     @VisibleForTesting
-    public static void resetMaxQueueSizeForTesting() {
+    static void resetMaxQueueSizeForTesting() {
         maxQueueSize = DEFAULT_MAX_QUEUE_SIZE;
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingPendingWriteQueue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingPendingWriteQueue.java
@@ -21,16 +21,22 @@
 package com.apple.foundationdb.record.provider.foundationdb;
 
 import com.apple.foundationdb.async.AsyncUtil;
+import com.apple.foundationdb.record.FDBRecordStoreProperties;
 import com.apple.foundationdb.record.IndexBuildProto;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.RecordCursorResult;
 import com.apple.foundationdb.record.ScanProperties;
+import com.apple.foundationdb.record.logging.KeyValueLogMessage;
+import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.provider.foundationdb.queue.PendingWritesQueue;
 import com.apple.foundationdb.record.provider.foundationdb.queue.PendingWritesQueueEntry;
 import com.apple.foundationdb.record.provider.foundationdb.runners.throttled.CursorFactory;
 import com.apple.foundationdb.record.provider.foundationdb.runners.throttled.ThrottledRetryingIterator;
 import com.apple.foundationdb.util.CloseException;
+import com.google.common.annotations.VisibleForTesting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -44,9 +50,17 @@ import java.util.concurrent.CompletableFuture;
  */
 @ParametersAreNonnullByDefault
 public final class IndexingPendingWriteQueue {
+    private static final Logger LOGGER = LoggerFactory.getLogger(IndexingPendingWriteQueue.class);
+
     // TODO: configurable maxQueueSize
-    private static final int MAX_QUEUE_SIZE = 100_000;
+    private static final int DEFAULT_MAX_QUEUE_SIZE = 100_000;
     private static final int MAX_RECORDS_DELETE_PER_SECOND = 10_000;
+
+    private static final String DISABLE_INDEX_COMMIT_HOOK = "disableIndexPendingWriteQueueOverflow:";
+
+    // The effective queue capacity. Overridable only for testing, so that a test can force an overflow without
+    // enqueuing lots of entries.
+    private static int maxQueueSize = DEFAULT_MAX_QUEUE_SIZE;
 
     private final Index index;
     private final IndexingCommon common;
@@ -54,6 +68,16 @@ public final class IndexingPendingWriteQueue {
     public IndexingPendingWriteQueue(final Index index, final IndexingCommon common) {
         this.index = index;
         this.common = common;
+    }
+
+    @VisibleForTesting
+    public static void setMaxQueueSizeForTesting(final int size) {
+        maxQueueSize = size;
+    }
+
+    @VisibleForTesting
+    public static void resetMaxQueueSizeForTesting() {
+        maxQueueSize = DEFAULT_MAX_QUEUE_SIZE;
     }
 
     CompletableFuture<Boolean> isQueueEmpty(FDBRecordStore store) {
@@ -117,7 +141,7 @@ public final class IndexingPendingWriteQueue {
         return new PendingWritesQueue<>(
                 IndexingSubspaces.indexPendingWriteQueueSubspace(store, index),
                 IndexingSubspaces.indexPendingWriteQueueSizeSubspace(store, index),
-                MAX_QUEUE_SIZE,
+                maxQueueSize,
                 IndexBuildProto.PendingWritesQueueEntry.class
         );
     }
@@ -148,7 +172,48 @@ public final class IndexingPendingWriteQueue {
             final FDBRecordStore store,
             final Index index,
             final IndexBuildProto.PendingWritesQueueEntry entry) {
-        return getIndexingQueue(store, index).enqueue(store.getContext(), entry, store.getIncarnation());
+        final CompletableFuture<Void> enqueueFuture =
+                getIndexingQueue(store, index).enqueue(store.getContext(), entry, store.getIncarnation());
+        if (!Boolean.TRUE.equals(store.getContext().getPropertyStorage()
+                .getPropertyValue(FDBRecordStoreProperties.DISABLE_INDEX_ON_PENDING_WRITE_QUEUE_OVERFLOW))) {
+            // Default behavior: a full queue fails the transaction.
+            return enqueueFuture;
+        }
+        // With the flag enabled, a full queue disables the index instead of failing the user write.
+        return enqueueFuture.exceptionallyCompose(ex -> {
+            if (IndexingBase.findException(ex, PendingWritesQueue.PendingWritesQueueTooLargeException.class) != null) {
+                // The queue is full: disable the index within this transaction so that the write still succeeds.
+                // The disable is deferred to a commit hook because it takes the record-store-state write lock, which
+                // cannot be acquired while this index update runs under the state read lock.
+                registerDisableOnOverflowCommitCheck(store, index);
+                return AsyncUtil.DONE;
+            }
+            // Not a queue-overflow failure: propagate the original exception
+            return CompletableFuture.failedFuture(ex);
+        });
+    }
+
+    private static void registerDisableOnOverflowCommitCheck(final FDBRecordStore store, final Index index) {
+        store.getContext().getOrCreateCommitCheck(DISABLE_INDEX_COMMIT_HOOK + index.getName(),
+                name -> () -> disableOverflowingIndex(store, index));
+    }
+
+    @Nonnull
+    private static CompletableFuture<Void> disableOverflowingIndex(final FDBRecordStore store, final Index index) {
+        return store.markIndexDisabled(index).thenAccept(changed -> {
+            if (Boolean.TRUE.equals(changed)) {
+                store.getContext().increment(FDBStoreTimer.Counts.PENDING_WRITES_QUEUE_OVERFLOW_DISABLED_INDEX);
+                if (LOGGER.isInfoEnabled()) {
+                    LOGGER.info(KeyValueLogMessage.of("disabled index because its pending writes queue overflowed",
+                            LogMessageKeys.INDEX_NAME, index.getName(),
+                            LogMessageKeys.MAX_QUEUE_SIZE, maxQueueSize));
+                }
+            } else if (LOGGER.isInfoEnabled()) {
+                LOGGER.info(KeyValueLogMessage.of("pending writes queue overflowed but the index was already disabled",
+                        LogMessageKeys.INDEX_NAME, index.getName(),
+                        LogMessageKeys.MAX_QUEUE_SIZE, maxQueueSize));
+            }
+        });
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingPendingWriteQueue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingPendingWriteQueue.java
@@ -205,13 +205,13 @@ public final class IndexingPendingWriteQueue {
         return store.markIndexDisabled(index).thenAccept(changed -> {
             if (Boolean.TRUE.equals(changed)) {
                 store.getContext().increment(FDBStoreTimer.Counts.PENDING_WRITES_QUEUE_OVERFLOW_DISABLED_INDEX);
-                if (LOGGER.isInfoEnabled()) {
-                    LOGGER.info(KeyValueLogMessage.of("disabled index because its pending writes queue overflowed",
+                if (LOGGER.isWarnEnabled()) {
+                    LOGGER.warn(KeyValueLogMessage.of("disabled index because its pending writes queue overflowed",
                             LogMessageKeys.INDEX_NAME, index.getName(),
                             LogMessageKeys.MAX_QUEUE_SIZE, maxQueueSize));
                 }
-            } else if (LOGGER.isInfoEnabled()) {
-                LOGGER.info(KeyValueLogMessage.of("pending writes queue overflowed but the index was already disabled",
+            } else if (LOGGER.isWarnEnabled()) {
+                LOGGER.warn(KeyValueLogMessage.of("pending writes queue overflowed but the index was already disabled",
                         LogMessageKeys.INDEX_NAME, index.getName(),
                         LogMessageKeys.MAX_QUEUE_SIZE, maxQueueSize));
             }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerPendingWriteQueueTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerPendingWriteQueueTest.java
@@ -122,7 +122,7 @@ class OnlineIndexerPendingWriteQueueTest extends OnlineIndexerTest {
         assertEquals(2L, queueSizeCounter(index), "the queue should be exactly full before the overflow");
 
         // The overflowing save (flag enabled) must succeed rather than throw.
-        try (FDBRecordContext context = openFlaggedContext(overflowTimer)) {
+        try (FDBRecordContext context = openContextWithDisableOnQueueFull(overflowTimer, true)) {
             final FDBRecordStore store = createStoreBuilder().setContext(context)
                     .createOrOpen(FDBRecordStoreBase.StoreExistenceCheck.NONE);
             assertTrue(store.isIndexWriteOnlyWithQueue(index));
@@ -154,7 +154,7 @@ class OnlineIndexerPendingWriteQueueTest extends OnlineIndexerTest {
     }
 
     @Test
-    void testFullQueueWithoutFlagFailsUserWrite() throws Exception {
+    void testFullQueueWithoutDisableFailsUserWrite() throws Exception {
         final int numInitialRecords = 6;
         populateEvenRecords(numInitialRecords);
         openSimpleMetaData(allIndexesHook(List.of(index)));
@@ -169,11 +169,13 @@ class OnlineIndexerPendingWriteQueueTest extends OnlineIndexerTest {
             }
         }
         assertThrows(PendingWritesQueue.PendingWritesQueueTooLargeException.class, () -> {
-            try (FDBRecordContext context = openContext()) {
-                saveSimpleRecord(recordStore, 5, 5 * 19);
+            try (FDBRecordContext context = openContextWithDisableOnQueueFull(null, false)) {
+                final FDBRecordStore store = createStoreBuilder().setContext(context)
+                        .createOrOpen(FDBRecordStoreBase.StoreExistenceCheck.NONE);
+                saveSimpleRecord(store, 5, 5 * 19);
                 context.commit();
             }
-        }, "without the flag, an overflowing write must fail");
+        }, "with option FALSE, an overflowing write must fail");
 
         // The index was not disabled; it is still in the queue state.
         try (FDBRecordContext context = openContext()) {
@@ -213,7 +215,7 @@ class OnlineIndexerPendingWriteQueueTest extends OnlineIndexerTest {
                     barrier.await();
                     boolean committed = false;
                     while (!committed) {
-                        try (FDBRecordContext context = openFlaggedContext(null)) {
+                        try (FDBRecordContext context = openContextWithDisableOnQueueFull(null, true)) {
                             final FDBRecordStore store = createStoreBuilder().setContext(context)
                                     .createOrOpen(FDBRecordStoreBase.StoreExistenceCheck.NONE);
                             saveSimpleRecord(store, recNo, recNo * 19);
@@ -1381,10 +1383,10 @@ class OnlineIndexerPendingWriteQueueTest extends OnlineIndexerTest {
      * Open a context whose properties enable {@link FDBRecordStoreProperties#DISABLE_INDEX_ON_PENDING_WRITE_QUEUE_OVERFLOW}.
      */
     @Nonnull
-    private FDBRecordContext openFlaggedContext(@Nullable final FDBStoreTimer timer) {
+    private FDBRecordContext openContextWithDisableOnQueueFull(@Nullable final FDBStoreTimer timer, final boolean disableIndexOnQueueFull) {
         final FDBRecordContextConfig.Builder configBuilder = FDBRecordContextConfig.newBuilder()
                 .setRecordContextProperties(RecordLayerPropertyStorage.newBuilder()
-                        .addProp(FDBRecordStoreProperties.DISABLE_INDEX_ON_PENDING_WRITE_QUEUE_OVERFLOW, true)
+                        .addProp(FDBRecordStoreProperties.DISABLE_INDEX_ON_PENDING_WRITE_QUEUE_OVERFLOW, disableIndexOnQueueFull)
                         .build());
         if (timer != null) {
             configBuilder.setTimer(timer);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerPendingWriteQueueTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerPendingWriteQueueTest.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.provider.foundationdb;
 
+import com.apple.foundationdb.record.FDBRecordStoreProperties;
 import com.apple.foundationdb.record.FunctionNames;
 import com.apple.foundationdb.record.IndexBuildProto;
 import com.apple.foundationdb.record.IndexScanType;
@@ -38,6 +39,7 @@ import com.apple.foundationdb.record.metadata.expressions.GroupingKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.VersionKeyExpression;
 import com.apple.foundationdb.record.provider.foundationdb.indexes.ValueIndexMaintainer;
 import com.apple.foundationdb.record.provider.foundationdb.indexes.ValueIndexMaintainerFactory;
+import com.apple.foundationdb.record.provider.foundationdb.properties.RecordLayerPropertyStorage;
 import com.apple.foundationdb.record.provider.foundationdb.queue.PendingWritesQueue;
 import com.apple.foundationdb.tuple.Tuple;
 import com.apple.foundationdb.tuple.TupleHelpers;
@@ -47,6 +49,7 @@ import com.google.auto.service.AutoService;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -55,10 +58,12 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -80,6 +85,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class OnlineIndexerPendingWriteQueueTest extends OnlineIndexerTest {
 
+    private final Index index = new Index("simple$num_value_2_queue", field("num_value_2"), IndexTypes.VALUE);
+
     private static IndexBuildProto.OldAndNewRecords oldAndNewRecords(final IndexBuildProto.PendingWritesQueueEntry payload) {
         assertEquals(IndexBuildProto.PendingWritesQueueEntry.Operation.UPDATE, payload.getOperation());
         try {
@@ -87,6 +94,161 @@ class OnlineIndexerPendingWriteQueueTest extends OnlineIndexerTest {
         } catch (InvalidProtocolBufferException e) {
             throw new RecordCoreException("failed to parse pending write queue entry data", e);
         }
+    }
+
+    @AfterEach
+    void resetPendingWriteQueueMaxSize() {
+        // Safety net: these tests shrink the (global) queue cap to force an overflow; always restore the default.
+        IndexingPendingWriteQueue.resetMaxQueueSizeForTesting();
+    }
+
+    @Test
+    void testFullQueueDisablesIndexAndUserWriteSucceeds() throws Exception {
+        final int numInitialRecords = 6; // even recNos 0,2,4,6,8,10
+        populateEvenRecords(numInitialRecords);
+        openSimpleMetaData(allIndexesHook(List.of(index)));
+        disableAll(List.of(index));
+        markWriteOnlyWithQueue(index);
+
+        IndexingPendingWriteQueue.setMaxQueueSizeForTesting(2);
+        final FDBStoreTimer overflowTimer = new FDBStoreTimer();
+        // Fill the queue to capacity: each of these saves is deferred to the queue (counter 1, then 2).
+        for (int recNo : List.of(1, 3)) {
+            try (FDBRecordContext context = openContext()) {
+                saveSimpleRecord(recordStore, recNo, recNo * 19);
+                context.commit();
+            }
+        }
+        assertEquals(2L, queueSizeCounter(index), "the queue should be exactly full before the overflow");
+
+        // The overflowing save (flag enabled) must succeed rather than throw.
+        try (FDBRecordContext context = openFlaggedContext(overflowTimer)) {
+            final FDBRecordStore store = createStoreBuilder().setContext(context)
+                    .createOrOpen(FDBRecordStoreBase.StoreExistenceCheck.NONE);
+            assertTrue(store.isIndexWriteOnlyWithQueue(index));
+            saveSimpleRecord(store, 5, 5 * 19);
+            context.commit();
+        }
+        assertEquals(1, overflowTimer.getCount(FDBStoreTimer.Counts.PENDING_WRITES_QUEUE_OVERFLOW_DISABLED_INDEX),
+                "the overflow should have disabled exactly one index");
+
+        // The index is now disabled and its queue data cleared.
+        try (FDBRecordContext context = openContext()) {
+            assertTrue(recordStore.isIndexDisabled(index), "the overflowing index should be disabled");
+            assertNotNull(recordStore.loadRecord(Tuple.from(5L)), "the overflow record must have been saved");
+            // A readable index on the same record type was still maintained in that same transaction.
+            final Index uniqueIndex = recordStore.getRecordMetaData().getIndex("MySimpleRecord$num_value_unique");
+            assertEquals(List.of(5L), indexPrimaryKeysForValue(uniqueIndex, 5 * 1139),
+                    "a readable index must still be updated by the overflowing write");
+            context.commit();
+        }
+        assertNull(queueSizeCounter(index), "disabling the index should have cleared its queue size counter");
+
+        // Rebuilding from scratch indexes every persisted record, including the ones that were only ever queued.
+        try (OnlineIndexer indexer = newIndexerBuilder(index).build()) {
+            indexer.buildIndex(true);
+        }
+        assertReadable(index);
+        assertEquals(numInitialRecords + 3, indexEntryCount(index), "the rebuild must index every persisted record");
+        scrubAndValidate(List.of(index));
+    }
+
+    @Test
+    void testFullQueueWithoutFlagFailsUserWrite() throws Exception {
+        final int numInitialRecords = 6;
+        populateEvenRecords(numInitialRecords);
+        openSimpleMetaData(allIndexesHook(List.of(index)));
+        disableAll(List.of(index));
+        markWriteOnlyWithQueue(index);
+
+        IndexingPendingWriteQueue.setMaxQueueSizeForTesting(2);
+        for (int recNo : List.of(1, 3)) {
+            try (FDBRecordContext context = openContext()) {
+                saveSimpleRecord(recordStore, recNo, recNo * 19);
+                context.commit();
+            }
+        }
+        assertThrows(PendingWritesQueue.PendingWritesQueueTooLargeException.class, () -> {
+            try (FDBRecordContext context = openContext()) {
+                saveSimpleRecord(recordStore, 5, 5 * 19);
+                context.commit();
+            }
+        }, "without the flag, an overflowing write must fail");
+
+        // The index was not disabled; it is still in the queue state.
+        try (FDBRecordContext context = openContext()) {
+            assertTrue(recordStore.isIndexWriteOnlyWithQueue(index), "the index must remain in the queue state");
+            context.commit();
+        }
+    }
+
+    @Test
+    void testConcurrentFullQueueWritesConvergeToDisabled() throws Exception {
+        // Several writers hit the full queue at once. Each tries to disable the index; the index-state read conflict
+        // means at most one commits the disable and the others conflict and retry. On retry the index is DISABLED, so
+        // their write is a no-op for it and still commits. Every writer eventually succeeds and the index converges.
+        final int numInitialRecords = 10;
+        populateEvenRecords(numInitialRecords);
+        openSimpleMetaData(allIndexesHook(List.of(index)));
+        disableAll(List.of(index));
+        markWriteOnlyWithQueue(index);
+
+        final List<Integer> fillRecNos = List.of(101, 103);
+        final List<Integer> writerRecNos = List.of(201, 203, 205, 207);
+        IndexingPendingWriteQueue.setMaxQueueSizeForTesting(fillRecNos.size());
+        for (int recNo : fillRecNos) {
+            try (FDBRecordContext context = openContext()) {
+                saveSimpleRecord(recordStore, recNo, recNo * 19);
+                context.commit();
+            }
+        }
+        assertEquals((long)fillRecNos.size(), (long)queueSizeCounter(index));
+
+        final AtomicReference<Throwable> failure = new AtomicReference<>();
+        final CyclicBarrier barrier = new CyclicBarrier(writerRecNos.size());
+        final List<Thread> threads = new ArrayList<>();
+        for (final int recNo : writerRecNos) {
+            final Thread thread = new Thread(() -> {
+                try {
+                    barrier.await();
+                    boolean committed = false;
+                    while (!committed) {
+                        try (FDBRecordContext context = openFlaggedContext(null)) {
+                            final FDBRecordStore store = createStoreBuilder().setContext(context)
+                                    .createOrOpen(FDBRecordStoreBase.StoreExistenceCheck.NONE);
+                            saveSimpleRecord(store, recNo, recNo * 19);
+                            context.commit();
+                            committed = true;
+                        } catch (FDBExceptions.FDBStoreTransactionConflictException conflict) {
+                            // Lost the race to disable the index; retry - it is (or will be) DISABLED.
+                        }
+                    }
+                } catch (Throwable t) {
+                    failure.set(t);
+                }
+            });
+            threads.add(thread);
+            thread.start();
+        }
+        for (final Thread thread : threads) {
+            thread.join();
+        }
+        assertNull(failure.get(), () -> "a concurrent writer failed: " + failure.get());
+
+        // The index converged to DISABLED and its queue was cleared.
+        try (FDBRecordContext context = openContext()) {
+            assertTrue(recordStore.isIndexDisabled(index), "the index should converge to disabled");
+            context.commit();
+        }
+        assertNull(queueSizeCounter(index));
+
+        // Rebuilding indexes every persisted record: initial + the fill writes + every concurrent write.
+        try (OnlineIndexer indexer = newIndexerBuilder(index).build()) {
+            indexer.buildIndex(true);
+        }
+        assertReadable(index);
+        assertEquals(numInitialRecords + fillRecNos.size() + writerRecNos.size(), indexEntryCount(index));
+        scrubAndValidate(List.of(index));
     }
 
     @ParameterizedTest
@@ -1212,6 +1374,28 @@ class OnlineIndexerPendingWriteQueueTest extends OnlineIndexerTest {
                     .getQueueSizeNoConflict(context).join();
             context.commit();
             return size;
+        }
+    }
+
+    /**
+     * Open a context whose properties enable {@link FDBRecordStoreProperties#DISABLE_INDEX_ON_PENDING_WRITE_QUEUE_OVERFLOW}.
+     */
+    @Nonnull
+    private FDBRecordContext openFlaggedContext(@Nullable final FDBStoreTimer timer) {
+        final FDBRecordContextConfig.Builder configBuilder = FDBRecordContextConfig.newBuilder()
+                .setRecordContextProperties(RecordLayerPropertyStorage.newBuilder()
+                        .addProp(FDBRecordStoreProperties.DISABLE_INDEX_ON_PENDING_WRITE_QUEUE_OVERFLOW, true)
+                        .build());
+        if (timer != null) {
+            configBuilder.setTimer(timer);
+        }
+        return fdb.openContext(configBuilder.build());
+    }
+
+    private void markWriteOnlyWithQueue(@Nonnull final Index index) {
+        try (FDBRecordContext context = openContext()) {
+            recordStore.markIndexWriteOnlyWithQueue(index).join();
+            context.commit();
         }
     }
 


### PR DESCRIPTION
**Problem**
While an index builds in WRITE_ONLY_WITH_QUEUE state, user writes defer their index updates to a per-index pending-writes queue that the online indexer drains. The queue is capped at 100_000. Today, hitting the cap throws PendingWritesQueueTooLargeException, which permanently fails the user's save/delete — exactly when the indexer has stalled or writes outpace draining. A background-indexing problem shouldn't break user IO.

**Approach**
Add an opt-in behavior (new context property, default off): when a user write hits a full queue, instead of failing, disable the offending index within the same user transaction so the write succeeds; the index is later rebuilt from scratch.

**Key design points**

- Commit check, not inline. Disabling needs the state write lock, which can't be taken while the update runs under the state read lock — so it's deferred to a commit check that runs after the read lock is released, atomically with the write.

- Disabling is cheap. markIndexDisabled → clearIndexData is a handful of constant-size range clears (independent of index size) and already clears the queue + size counter.

- No dependence on the indexer — driven entirely from the user IO path, so it works even when the indexer that filled the queue is dead.

**Special conditions & edge cases**

- Concurrent overflowing writers → conflict, not exception. The disable writes the index-state key with a read-conflict, so only one writer commits it; the rest get a normal FDB not_committed conflict. 

- Idempotent. If the index is already DISABLED (e.g. a concurrent writer won), markIndexDisabled reports no change — logged, no-op. The commit check also registers at most once per index per transaction.

- Other indexes unaffected — only the overflowing index is disabled; everything else on the record updates normally.

- Non-overflow errors unchanged — propagated verbatim, so retryable detection behaves as before.

- Flag off = no behavior change — still throws PendingWritesQueueTooLargeException.

**Testing**

- OnlineIndexerPendingWriteQueueTest: overflow disables the index and the write succeeds in one transaction; concurrent overflowing writers converge to DISABLED; and a subsequent rebuild returns the index to READABLE with every persisted record indexed.