### PR TITLE
Remove usage of List.getFirst() from test

### DIFF
--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/functions/UserDefinedMacroFunctionBuilderTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/functions/UserDefinedMacroFunctionBuilderTest.java
@@ -85,7 +85,7 @@ final class UserDefinedMacroFunctionBuilderTest {
 
         final var arguments = ImmutableList.of(LiteralValue.ofScalar("hello"));
         assertThat(macroIdentityFunction.encapsulate(arguments))
-                .isEqualTo(arguments.getFirst());
+                .isEqualTo(arguments.get(0));
     }
 
     @Test


### PR DESCRIPTION
getFirst is added in JDK 21, and we are targeting source/binary compatibility with JDK 17