### PR TITLE
Fix issue with drain always conflicting with enqueues

### DIFF
--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/PendingWriteQueue.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/PendingWriteQueue.java
@@ -21,8 +21,10 @@
 package com.apple.foundationdb.record.lucene.directory;
 
 import com.apple.foundationdb.MutationType;
+import com.apple.foundationdb.Range;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.ExecuteProperties;
+import com.apple.foundationdb.record.IsolationLevel;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.RecordCoreInternalException;
 import com.apple.foundationdb.record.RecordCoreStorageException;
@@ -179,8 +181,16 @@ public class PendingWriteQueue {
     /**
      * Return a cursor that iterates through the queue elements.
      *
+     * <p>The scan always reads at {@link IsolationLevel#SNAPSHOT}, regardless of the isolation level in
+     * {@code scanProperties}. This is intentional: a drain transaction iterates the queue and clears entries,
+     * and a serializable read would install a read-conflict range over the queue subspace, causing the drain
+     * to conflict with any concurrent enqueue.
+     * A caller that needs to fail if writes arrived concurrently must instead gate on
+     * {@link #isQueueEmpty(FDBRecordContext)}, which is the intended (and only) conflict point.</p>
+     *
      * @param context the record context to use
-     * @param scanProperties the scan properties for the cursor
+     * @param scanProperties the scan properties for the cursor; the isolation level is always forced to
+     * {@link IsolationLevel#SNAPSHOT}, while row/byte/skip limits are still honored at the entry level
      * @param continuation the continuation to continue from (null means start from the beginning)
      *
      * @return a record cursor that iterates through the elements of the queue, in order
@@ -190,12 +200,19 @@ public class PendingWriteQueue {
             @Nonnull FDBRecordContext context,
             @Nonnull ScanProperties scanProperties,
             @Nullable byte[] continuation) {
+        // Force snapshot isolation on the inner cursor (the only component that issues FDB reads) so the drain
+        // never installs a read-conflict range over the queue subspace. The unsplitter still receives the
+        // original scanProperties, so the caller's row/byte/skip limits are honored (it issues no reads itself,
+        // so its isolation level is irrelevant).
         KeyValueCursor inner = KeyValueCursor.Builder.newBuilder(queueSubspace)
                 .setContext(context)
                 .setScanProperties(scanProperties
                         .with(ExecuteProperties::clearRowAndTimeLimits)
                         .with(ExecuteProperties::clearSkipAndLimit)
-                        .with(ExecuteProperties::clearState))
+                        .with(ExecuteProperties::clearState)
+                        .with(executeProperties -> executeProperties.toBuilder()
+                                .setIsolationLevel(IsolationLevel.SNAPSHOT)
+                                .build()))
                 .setContinuation(continuation)
                 .build();
         RecordCursor<FDBRawRecord> unsplitter = new SplitHelper.KeyValueUnsplitter(
@@ -234,7 +251,14 @@ public class PendingWriteQueue {
      * @param entry the entry to remove
      */
     public void clearEntry(@Nonnull FDBRecordContext context, @Nonnull QueueEntry entry) {
-        SplitHelper.deleteSplit(context, queueSubspace, entry.getKeyTuple(), true, false, false, null);
+        // Install a read-conflict range over the keys this entry occupies. Clears are blind writes that do not
+        // conflict with each other, so without this two transactions could concurrently clear the same entry and
+        // each decrement the size counter, making it drift. The read conflict ensures at most one clear of
+        // a given entry commits.
+        final Tuple key = entry.getKeyTuple();
+        final Range entryRange = Range.startsWith(queueSubspace.pack(key));
+        context.ensureActive().addReadConflictRange(entryRange.begin, entryRange.end);
+        SplitHelper.deleteSplit(context, queueSubspace, key, true, false, false, null);
 
         // Atomically decrement the queue size counter
         mutateQueueSizeCounter(context, -1);

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/PendingWriteQueueTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/PendingWriteQueueTest.java
@@ -33,6 +33,7 @@ import com.apple.foundationdb.record.lucene.LuceneDocumentFromRecord;
 import com.apple.foundationdb.record.lucene.LuceneEvents;
 import com.apple.foundationdb.record.lucene.LuceneIndexExpressions;
 import com.apple.foundationdb.record.lucene.LucenePendingWriteQueueProto;
+import com.apple.foundationdb.record.provider.foundationdb.FDBExceptions;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreTestBase;
 import com.apple.foundationdb.subspace.Subspace;
@@ -406,6 +407,221 @@ class PendingWriteQueueTest extends FDBRecordStoreTestBase {
             throw new RecordCoreException("Cannot clear queue usage indicator: pending write queue is not empty");
         }
         context.ensureActive().clear(markerKey(context));
+    }
+
+    /**
+     * {@code isQueueEmpty} must conflict with a concurrent enqueue. A transaction that observes an empty queue
+     * and then commits a close-out write (here: setting the marker) must fail if another transaction enqueued
+     * into that (empty) range in the meantime - otherwise it would wrongly conclude no writes are pending.
+     */
+    @Test
+    void testIsEmptyConflictsConcurrentEnqueue() {
+        final int incarnation = 0;
+        final List<TestDocument> lateArrivals = createTestDocuments();
+
+        PendingWriteQueue queue;
+        try (FDBRecordContext context = openContext()) {
+            queue = getQueue(context); // queue starts empty
+            commit(context);
+        }
+
+        try (FDBRecordContext txA = openContext()) {
+            // TX_A observes the queue is empty (installs a read-conflict range over the queue subspace)...
+            assertTrue(queue.isQueueEmpty(txA).join());
+            // ...and marks the operation complete. A write is required, since a read-only transaction's commit
+            // performs no conflict check.
+            setMarker(txA);
+
+            // While TX_A is open, TX_B enqueues into the queue and commits.
+            try (FDBRecordContext txB = openContext()) {
+                for (TestDocument lateArrival : lateArrivals) {
+                    queue.enqueueInsert(txB, lateArrival.getPrimaryKey(), lateArrival.getFields(), incarnation);
+                }
+                commit(txB);
+            }
+
+            // TX_A's commit must conflict: the (empty) range it scanned was written into by TX_B.
+            assertThrows(FDBExceptions.FDBStoreTransactionConflictException.class, () -> commit(txA));
+        }
+
+        // The late-arrival enqueues landed.
+        assertQueueEntries(queue, lateArrivals,
+                LucenePendingWriteQueueProto.PendingWriteItem.OperationType.INSERT);
+    }
+
+    /**
+     * A drain that clears every visible entry, then asserts the queue is empty and commits a close-out write,
+     * must still conflict with a concurrent enqueue - otherwise it would clear the ongoing-merge marker while a
+     * write slipped in behind it. The snapshot drain scan alone does not conflict (see
+     * {@link #testDrainScanAndClearDoesNotConflictWithConcurrentEnqueue}); the conflict comes from the
+     * {@code isQueueEmpty} close-out read.
+     */
+    @Test
+    void testDrainThenIsEmptyConflictsConcurrentEnqueue() {
+        final int incarnation = 0;
+        final List<TestDocument> seeds = createTestDocuments();
+        final List<TestDocument> lateArrivals = createTestDocuments();
+
+        PendingWriteQueue queue;
+        try (FDBRecordContext context = openContext()) {
+            queue = getQueue(context);
+            for (TestDocument seed : seeds) {
+                queue.enqueueInsert(context, seed.getPrimaryKey(), seed.getFields(), incarnation);
+            }
+            commit(context);
+        }
+
+        try (FDBRecordContext txA = openContext()) {
+            // TX_A drains every entry it can see...
+            List<PendingWriteQueue.QueueEntry> entries =
+                    queue.getQueueCursor(txA, ScanProperties.FORWARD_SCAN, null).asList().join();
+            assertEquals(seeds.size(), entries.size());
+            for (PendingWriteQueue.QueueEntry entry : entries) {
+                queue.clearEntry(txA, entry);
+            }
+            // ...then asserts the queue is now empty (installs a read-conflict range over the queue) and marks
+            // the operation complete.
+            assertTrue(queue.isQueueEmpty(txA).join());
+            setMarker(txA); // This is not strictly necessary but is what production code is doing
+
+            // While TX_A is open, TX_B enqueues a new item and commits.
+            try (FDBRecordContext txB = openContext()) {
+                for (TestDocument lateArrival : lateArrivals) {
+                    queue.enqueueInsert(txB, lateArrival.getPrimaryKey(), lateArrival.getFields(), incarnation);
+                }
+                commit(txB);
+            }
+
+            // TX_A's commit must conflict: the range it scanned in isQueueEmpty was written into by TX_B.
+            assertThrows(FDBExceptions.FDBStoreTransactionConflictException.class, () -> commit(txA));
+        }
+
+        // TX_A rolled back, so its drain never happened: the seeds plus the late arrivals are all present.
+        final List<TestDocument> expected = new ArrayList<>(seeds);
+        expected.addAll(lateArrivals);
+        assertQueueEntries(queue, expected,
+                LucenePendingWriteQueueProto.PendingWriteItem.OperationType.INSERT);
+    }
+
+    /**
+     * The happy path: a single transaction can drain and then assert emptiness without conflict, because there
+     * is no external writer to conflict with.
+     */
+    @Test
+    void testIsEmptyDoesNotConflictWithDrainerInSameTx() {
+        final int incarnation = 0;
+        final List<TestDocument> docs = createTestDocuments();
+
+        PendingWriteQueue queue;
+        try (FDBRecordContext context = openContext()) {
+            queue = getQueue(context);
+            for (TestDocument document : docs) {
+                queue.enqueueInsert(context, document.getPrimaryKey(), document.getFields(), incarnation);
+            }
+            commit(context);
+        }
+
+        try (FDBRecordContext context = openContext()) {
+            List<PendingWriteQueue.QueueEntry> entries =
+                    queue.getQueueCursor(context, ScanProperties.FORWARD_SCAN, null).asList().join();
+            assertEquals(docs.size(), entries.size());
+            for (PendingWriteQueue.QueueEntry entry : entries) {
+                queue.clearEntry(context, entry);
+            }
+            // Asserting emptiness in the same transaction that drained is fine - there is no other writer.
+            assertTrue(queue.isQueueEmpty(context).join());
+            commit(context);
+        }
+
+        try (FDBRecordContext context = openContext()) {
+            assertTrue(queue.isQueueEmpty(context).join());
+            commit(context);
+        }
+    }
+
+    /**
+     * Two drains that clear the same entries must not both commit.
+     * Both drains clear all entries; the second commit conflicts.
+     */
+    @Test
+    void testConcurrentDrainsOfSameEntriesConflict() {
+        final int incarnation = 0;
+        final List<TestDocument> seeds = createTestDocuments();
+
+        PendingWriteQueue queue;
+        try (FDBRecordContext context = openContext()) {
+            queue = getQueue(context);
+            for (TestDocument seed : seeds) {
+                queue.enqueueInsert(context, seed.getPrimaryKey(), seed.getFields(), incarnation);
+            }
+            commit(context);
+        }
+
+        try (FDBRecordContext txA = openContext();
+                FDBRecordContext txB = openContext()) {
+            List<PendingWriteQueue.QueueEntry> entriesA =
+                    queue.getQueueCursor(txA, ScanProperties.FORWARD_SCAN, null).asList().join();
+            List<PendingWriteQueue.QueueEntry> entriesB =
+                    queue.getQueueCursor(txB, ScanProperties.FORWARD_SCAN, null).asList().join();
+            assertEquals(seeds.size(), entriesA.size());
+            assertEquals(seeds.size(), entriesB.size());
+
+            for (PendingWriteQueue.QueueEntry entry : entriesA) {
+                queue.clearEntry(txA, entry);
+            }
+            for (PendingWriteQueue.QueueEntry entry : entriesB) {
+                queue.clearEntry(txB, entry);
+            }
+
+            // The first drain commits; the second conflicts on the entry keys it also cleared.
+            commit(txA);
+            assertThrows(FDBExceptions.FDBStoreTransactionConflictException.class, () -> commit(txB));
+        }
+
+        // Exactly one drain took effect: the queue is empty and the size counter did not drift below zero.
+        try (FDBRecordContext context = openContext()) {
+            assertTrue(queue.isQueueEmpty(context).join());
+            final Long size = queue.getQueueSize(context).join();
+            assertEquals(0L, size == null ? 0L : (long)size);
+            commit(context);
+        }
+    }
+
+    /**
+     * Two drains that clear DISJOINT entries must both commit.
+     */
+    @Test
+    void testConcurrentDrainsOfDisjointEntriesDoNotConflict() {
+        final int incarnation = 0;
+        final List<TestDocument> seeds = createTestDocuments();
+
+        PendingWriteQueue queue;
+        try (FDBRecordContext context = openContext()) {
+            queue = getQueue(context);
+            for (TestDocument seed : seeds) {
+                queue.enqueueInsert(context, seed.getPrimaryKey(), seed.getFields(), incarnation);
+            }
+            commit(context);
+        }
+
+        final List<PendingWriteQueue.QueueEntry> entries;
+        try (FDBRecordContext context = openContext()) {
+            entries = queue.getQueueCursor(context, ScanProperties.FORWARD_SCAN, null).asList().join();
+            assertEquals(seeds.size(), entries.size());
+        }
+
+        // Two drains each clear a DIFFERENT entry; both must commit.
+        try (FDBRecordContext txA = openContext();
+                FDBRecordContext txB = openContext()) {
+            queue.clearEntry(txA, entries.get(0));
+            queue.clearEntry(txB, entries.get(1));
+            commit(txA);
+            assertDoesNotThrow(() -> commit(txB));
+        }
+
+        // The two cleared entries are gone; the remaining entries stay.
+        assertQueueEntries(queue, seeds.subList(2, seeds.size()),
+                LucenePendingWriteQueueProto.PendingWriteItem.OperationType.INSERT);
     }
 
     @Test

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/PendingWriteQueueTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/PendingWriteQueueTest.java
@@ -23,6 +23,7 @@ package com.apple.foundationdb.record.lucene.directory;
 import com.apple.foundationdb.record.ExecuteProperties;
 import com.apple.foundationdb.record.IsolationLevel;
 import com.apple.foundationdb.record.RecordCoreArgumentException;
+import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.RecordCoreInternalException;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordCursorContinuation;
@@ -64,8 +65,10 @@ import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -299,6 +302,110 @@ class PendingWriteQueueTest extends FDBRecordStoreTestBase {
         // Final state: only the late-arrival entry remains.
         assertQueueEntries(queue, List.of(lateArrival),
                 LucenePendingWriteQueueProto.PendingWriteItem.OperationType.INSERT);
+    }
+
+    /**
+     * End-to-end test for non-conflicting drain and enqueue.
+     */
+    @Test
+    void testDrainAndClearMarkerConvergesUnderConcurrentEnqueue() {
+        final int incarnation = 0;
+        final TestDocument seed1 = new TestDocument(primaryKey("seed-1"),
+                List.of(createField("f", "s1", LuceneIndexExpressions.DocumentFieldType.STRING, false, false)));
+        final TestDocument seed2 = new TestDocument(primaryKey("seed-2"),
+                List.of(createField("f", "s2", LuceneIndexExpressions.DocumentFieldType.STRING, false, false)));
+        final TestDocument seed3 = new TestDocument(primaryKey("seed-3"),
+                List.of(createField("f", "s3", LuceneIndexExpressions.DocumentFieldType.STRING, false, false)));
+        final TestDocument lateArrival = new TestDocument(primaryKey("late-arrival"),
+                List.of(createField("f", "late", LuceneIndexExpressions.DocumentFieldType.STRING, false, false)));
+
+        // Set the marker (ongoing-merge indicator) and seed the queue.
+        PendingWriteQueue queue;
+        try (FDBRecordContext context = openContext()) {
+            queue = getQueue(context);
+            setMarker(context);
+            queue.enqueueInsert(context, seed1.getPrimaryKey(), seed1.getFields(), incarnation);
+            queue.enqueueInsert(context, seed2.getPrimaryKey(), seed2.getFields(), incarnation);
+            queue.enqueueInsert(context, seed3.getPrimaryKey(), seed3.getFields(), incarnation);
+            commit(context);
+        }
+
+        // Round 1: drain from queue while a concurrent enqueue commits a late arrival. The drain requests
+        // FORWARD_SCAN (SERIALIZABLE), but getQueueCursor forces SNAPSHOT, so the drain commit must NOT conflict
+        // with the concurrent enqueue.
+        try (FDBRecordContext drainTx = openContext()) {
+            List<PendingWriteQueue.QueueEntry> drained =
+                    queue.getQueueCursor(drainTx, ScanProperties.FORWARD_SCAN, null).asList().join();
+            assertEquals(3, drained.size());
+            for (PendingWriteQueue.QueueEntry entry : drained) {
+                queue.clearEntry(drainTx, entry);
+            }
+            try (FDBRecordContext enqueueTx = openContext()) {
+                queue.enqueueInsert(enqueueTx, lateArrival.getPrimaryKey(), lateArrival.getFields(), incarnation);
+                commit(enqueueTx);
+            }
+            assertDoesNotThrow(() -> commit(drainTx),
+                    "the snapshot drain must commit despite a concurrent enqueue");
+        }
+
+        // The three seeds were removed; only the late arrival remains.
+        assertQueueEntries(queue, List.of(lateArrival),
+                LucenePendingWriteQueueProto.PendingWriteItem.OperationType.INSERT);
+
+        // Clearing the marker must fail now: the queue is not empty (the late arrival is still pending).
+        try (FDBRecordContext clearTx = openContext()) {
+            assertThrows(RecordCoreException.class, () -> clearMarkerIfQueueEmpty(clearTx, queue),
+                    "the marker must not be clearable while the queue is non-empty");
+        }
+        try (FDBRecordContext context = openContext()) {
+            assertTrue(markerExists(context), "the marker must still be set after a failed clear");
+            commit(context);
+        }
+
+        // Round 2: a subsequent drain empties the queue...
+        try (FDBRecordContext drainTx = openContext()) {
+            List<PendingWriteQueue.QueueEntry> drained =
+                    queue.getQueueCursor(drainTx, ScanProperties.FORWARD_SCAN, null).asList().join();
+            assertEquals(1, drained.size());
+            queue.clearEntry(drainTx, drained.get(0));
+            commit(drainTx);
+        }
+
+        // ...and now clearing the marker succeeds.
+        try (FDBRecordContext clearTx = openContext()) {
+            assertDoesNotThrow(() -> clearMarkerIfQueueEmpty(clearTx, queue));
+            commit(clearTx);
+        }
+        try (FDBRecordContext context = openContext()) {
+            assertTrue(queue.isQueueEmpty(context).join(), "the queue must be empty after the second drain");
+            assertFalse(markerExists(context), "the marker must be cleared once the queue is empty");
+            commit(context);
+        }
+    }
+
+    /** Key backing the marker that models {@code FDBDirectory}'s ongoing-merge indicator (subspace index 2). */
+    @Nonnull
+    private byte[] markerKey(@Nonnull FDBRecordContext context) {
+        return path.toSubspace(context).subspace(Tuple.from(2)).pack();
+    }
+
+    private void setMarker(@Nonnull FDBRecordContext context) {
+        context.ensureActive().set(markerKey(context), new byte[] {1});
+    }
+
+    private boolean markerExists(@Nonnull FDBRecordContext context) {
+        return context.ensureActive().get(markerKey(context)).join() != null;
+    }
+
+    /**
+     * Mirrors {@code FDBDirectory.clearOngoingMergeIndicatorIfQueueEmptyAsync}: clears the marker only if the
+     * queue is empty, otherwise throws so the caller drains more and retries.
+     */
+    private void clearMarkerIfQueueEmpty(@Nonnull FDBRecordContext context, @Nonnull PendingWriteQueue queue) {
+        if (!queue.isQueueEmpty(context).join()) {
+            throw new RecordCoreException("Cannot clear queue usage indicator: pending write queue is not empty");
+        }
+        context.ensureActive().clear(markerKey(context));
     }
 
     @Test

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/PendingWriteQueueTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/PendingWriteQueueTest.java
@@ -504,8 +504,7 @@ class PendingWriteQueueTest extends FDBRecordStoreTestBase {
     }
 
     /**
-     * The happy path: a single transaction can drain and then assert emptiness without conflict, because there
-     * is no external writer to conflict with.
+     * The happy path: a single transaction can drain and then assert emptiness.
      */
     @Test
     void testIsEmptyDoesNotConflictWithDrainerInSameTx() {


### PR DESCRIPTION
Make the `cursor` SNAPSHOT reads such that concurrent enqueues do not conflict, make the `clear` conflict with another clears.
