### PR TITLE
Update the `shadow` Gradle plugin

### DIFF
--- a/fdb-record-layer-core/fdb-record-layer-core.gradle
+++ b/fdb-record-layer-core/fdb-record-layer-core.gradle
@@ -80,6 +80,9 @@ tasks.register('testShadowJar', ShadowJar) {
         attributes 'Main-Class': 'com.apple.foundationdb.record.provider.foundationdb.FDBRecordStorePerformanceTest',
                    'Multi-Release': 'true' // https://github.com/johnrengelman/shadow/issues/449
     }
+    // Override the duplicates strategy from the EXCLUDE default to INCLUDE, so that duplicate `META-INF/services/*`
+    // files reach `mergeServiceFiles()` and their registries merge properly rather than collapse to a single provider.
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
     mergeServiceFiles()
 }
 

--- a/fdb-relational-cli/fdb-relational-cli.gradle
+++ b/fdb-relational-cli/fdb-relational-cli.gradle
@@ -98,6 +98,9 @@ shadowJar {
     application {
         mainClass = mainCliClass
     }
+    // Override the duplicates strategy from the EXCLUDE default to INCLUDE, so that duplicate `META-INF/services/*`
+    // files reach `mergeServiceFiles()` and their registries merge properly rather than collapse to a single provider.
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
     mergeServiceFiles()
 }
 

--- a/fdb-relational-jdbc/fdb-relational-jdbc.gradle
+++ b/fdb-relational-jdbc/fdb-relational-jdbc.gradle
@@ -70,6 +70,9 @@ jar {
 // Task to build a fat jar, one w/ all dependencies; good for handing out as the 'jdbc' jar.
 shadowJar {
     archiveClassifier.set('driver')
+    // Override the duplicates strategy from the EXCLUDE default to INCLUDE, so that duplicate `META-INF/services/*`
+    // files reach `mergeServiceFiles()` and their registries merge properly rather than collapse to a single provider.
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
     mergeServiceFiles()
 }
 

--- a/fdb-relational-server/fdb-relational-server.gradle
+++ b/fdb-relational-server/fdb-relational-server.gradle
@@ -59,6 +59,10 @@ shadowJar {
     application {
         mainClass = mainServerClass
     }
+    // Override the duplicates strategy from the EXCLUDE default to INCLUDE, so that duplicate `META-INF/services/*`
+    // files reach `mergeServiceFiles()` and their registries (e.g. `PlanDeserializer`) merge properly rather than
+    // collapse to a single provider.
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
     mergeServiceFiles()
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -148,5 +148,5 @@ gitversion = { id = "com.palantir.git-version", version = "5.0.0" }
 jmh = { id = "me.champeau.jmh", version = "0.7.3" }
 nexus = { id = "io.github.gradle-nexus.publish-plugin", version = "2.0.0" }
 protobuf = { id = "com.google.protobuf", version = "0.9.6" }
-shadow = { id = "com.gradleup.shadow", version = "8.3.10" }
+shadow = { id = "com.gradleup.shadow", version = "9.6.1" }
 spotbugs = { id = "com.github.spotbugs", version = "6.5.5" }


### PR DESCRIPTION
* Update the `com.gradleup.shadow` plugin from 8.3.10 to 9.6.1 (released 2026-07-22).
* Override the `duplicatesStrategy` from `EXCLUDE` (the default as of Shadow 9) to `INCLUDE` on every `shadowJar`/`testShadowJar` task that calls `mergeServiceFiles()`. Without this, duplicate `META-INF/services/*` service files are just dropped and `mergeServiceFiles()` doesn’t get to properly merge them.

**Validation**

* The `shadowJar` and `testShadowJar` tasks in `fdb-record-layer-core-shaded`, `fdb-relational-cli`, `fdb-relational-jdbc`, `fdb-relational-server`, and `fdb-record-layer-core` all build successfully, with no service-file drop warnings.
* Package relocation is preserved; no `com.google.protobuf` leakage.
* Merged service files match the 8.3.10 output (e.g., `PlanDeserializer` has all 153 providers), and the `yaml-tests` multi-server forced-continuation tests pass.