### PR TITLE
Update the `protobuf` Gradle plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,9 +63,6 @@ atlassian-ide-plugin.xml
 # NetBeans specific files/directories
 .nbattrs
 
-protogen/
-/protogen/
-*/protogen/*
 **/gen/*
 
 *.orig

--- a/gradle/check.gradle
+++ b/gradle/check.gradle
@@ -42,7 +42,7 @@ tasks.register('checkstyleAll') {
 }
 
 tasks.withType(Checkstyle).configureEach { task ->
-    task.exclude '**/protogen/**'
+    task.exclude '**/generated/**'
     task.configProperties = ["projectDir" : rootProject.projectDir, 'bannedImports': BANNED_IMPORTS.join(',')]
     task.maxHeapSize.set("1g")
 }
@@ -128,7 +128,7 @@ pmd {
     ruleSetFiles = rootProject.files("gradle/codequality/pmd-rules.xml")
 }
 tasks.withType(Pmd) { task ->
-    task.exclude '**/protogen/**'
+    task.exclude '**/generated/**'
     task.exclude '**/generated-src/**'
     // the PMD plugin doesn't respect above exclusion, so we manually set the source directory instead
     task.setSource 'src/main/java'

--- a/gradle/codequality/spotbugs_exclude.xml
+++ b/gradle/codequality/spotbugs_exclude.xml
@@ -3,10 +3,6 @@
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
     <Match>
-        <Source name="~.*/protogen/.*" />
-    </Match>
-
-    <Match>
         <Source name="~.*/generated/.*" />
     </Match>
 

--- a/gradle/codequality/suppressions.xml
+++ b/gradle/codequality/suppressions.xml
@@ -5,8 +5,6 @@
 
 <suppressions>
     <suppress checks=".*"
-        files=".*[\\/]protogen[\\/].*"/>
-    <suppress checks=".*"
               files=".*[\\/]generated-src[\\/].*"/>
     <suppress checks="JavadocPackage"
         files=".*[\\/]test[\\/].*|.*[\\/]java-proto[23][\\/].*[\\/]metadata[\\/].*"/>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -147,6 +147,6 @@ download = { id = "de.undercouch.download", version = "5.7.0" }
 gitversion = { id = "com.palantir.git-version", version = "5.0.0" }
 jmh = { id = "me.champeau.jmh", version = "0.7.3" }
 nexus = { id = "io.github.gradle-nexus.publish-plugin", version = "2.0.0" }
-protobuf = { id = "com.google.protobuf", version = "0.9.6" }
+protobuf = { id = "com.google.protobuf", version = "0.10.0" }
 shadow = { id = "com.gradleup.shadow", version = "8.3.10" }
 spotbugs = { id = "com.github.spotbugs", version = "6.5.5" }

--- a/gradle/proto.gradle
+++ b/gradle/proto.gradle
@@ -29,10 +29,6 @@ configurations {
 }
 
 protobuf {
-    generatedFilesBaseDir = "${projectDir}/protogen"
-    clean {
-        delete generatedFilesBaseDir
-    }
     protoc {
         artifact = "com.google.protobuf:protoc:${libs.versions.protobuf.get()}"
     }


### PR DESCRIPTION
* Update the `com.google.protobuf` plugin to 0.10.0 (the latest release).
* Drop the override of `generatedFilesBaseDir` to `"${projectDir}/protogen"` along with the matching `clean { delete generatedFilesBaseDir }` step. The plugin now writes generated proto sources to the default location under the build directory (`${buildDir}/generated/sources/proto/…`), which Gradle’s built-in `clean` task already handles. Source sets still pick up the generated outputs automatically, as before.
* Update the Checkstyle/PMD `**/protogen/**` excludes to `**/generated/**`, and remove the now-redundant `protogen` entries in the Checkstyle suppressions and SpotBugs exclude filter.
* Drop `protogen/` from `.gitignore` as well, since the files now land under the already-ignored build directory.