### PR TITLE
Remove the `asciitable` dependency

### DIFF
--- a/fdb-relational-cli/fdb-relational-cli.gradle
+++ b/fdb-relational-cli/fdb-relational-cli.gradle
@@ -49,9 +49,6 @@ dependencies {
     implementation(libs.dropwizard) {
         exclude group: 'org.slf4j'
     }
-    implementation(libs.asciitable) {
-        exclude group: 'org.slf4j'
-    }
     implementation(libs.sqlline)
     implementation(libs.protobuf.util)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,7 +27,6 @@ antlr = "4.13.2"
 autoService = "1.0-rc6"
 # AutoService for development which enables incremental builds, cannot be enabled for production builds due to downstream dependencies
 autoService-development = "1.0.1"
-asciitable = "0.3.2"
 caffeine = "3.1.8"
 commonscli = "1.5.0"
 dropwizard = "4.2.28"
@@ -75,7 +74,6 @@ spotbugs = "4.9.0"
 antlr = { module = "org.antlr:antlr4", version.ref = "antlr" }
 autoService = { module = "com.google.auto.service:auto-service", version.ref = "autoService" }
 autoService-development = { module = "com.google.auto.service:auto-service", version.ref = "autoService-development" }
-asciitable = { module = "de.vandermeer:asciitable", version.ref = "asciitable" }
 fdbJava = { module = "org.foundationdb:fdb-java", version.ref = "fdb" }
 caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version.ref = "caffeine"}
 caffeine-guava = { module = "com.github.ben-manes.caffeine:guava", version.ref = "caffeine"}

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/Matchers.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/Matchers.java
@@ -42,7 +42,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multiset;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
-import de.vandermeer.asciitable.AsciiTable;
 import org.yaml.snakeyaml.nodes.ScalarNode;
 import org.yaml.snakeyaml.nodes.SequenceNode;
 
@@ -57,7 +56,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -400,8 +398,6 @@ public class Matchers {
             if (resultSet.isEmpty()) {
                 return "<EMPTY>";
             }
-            final AsciiTable at = new AsciiTable();
-            at.addRule();
             for (final var row : resultSet) {
                 if (row.isEmpty()) {
                     // strange behavior from record-layer, sometimes it returns a result set with 0 columns
@@ -409,15 +405,66 @@ public class Matchers {
                     row.add("<EMPTY_ROW_RETURNED_FROM_RECORD_LAYER>");
                 }
             }
-            for (final var row : resultSet) {
-                at.addRow(row.stream().map(String::trim).collect(Collectors.toList()));
-                at.addRule();
+            return renderTable(resultSet);
+        }
+
+        /**
+         * Renders the given rows as a plain-text table, with each column sized to its widest cell and every row wrapped
+         * in horizontal rules. Used to present result sets for comparison/diagnostics.
+         *
+         * @param rows the rows to render, each a list of already-stringified cell values
+         * @return the rendered table
+         */
+        @Nonnull
+        private static String renderTable(@Nonnull final List<List<String>> rows) {
+            final int columnCount = rows.stream().mapToInt(List::size).max().orElse(0);
+            final int[] columnWidths = new int[columnCount];
+            for (final var row : rows) {
+                for (int i = 0; i < row.size(); i++) {
+                    columnWidths[i] = Math.max(columnWidths[i], row.get(i).trim().length());
+                }
             }
-            if (at.getRawContent().size() == 1) { //workaround for /0 bug in AsciiTable
-                return "<EMPTY>";
-            } else {
-                return at.render();
+            final String rule = buildRule(columnWidths);
+            final var sb = new StringBuilder();
+            sb.append(rule);
+            for (final var row : rows) {
+                sb.append(buildRow(row, columnWidths));
+                sb.append(rule);
             }
+            return sb.toString();
+        }
+
+        /**
+         * Builds a horizontal rule (e.g., {@code +----+------+}) matching the given column widths.
+         *
+         * @param columnWidths the rendered width of each column, excluding cell padding
+         * @return the rule line, terminated with a newline
+         */
+        @Nonnull
+        private static String buildRule(@Nonnull final int[] columnWidths) {
+            final var sb = new StringBuilder();
+            for (final int width : columnWidths) {
+                sb.append('+').append("-".repeat(width + 2));
+            }
+            return sb.append("+\n").toString();
+        }
+
+        /**
+         * Builds a single table row, trimming and left-aligning each cell within its column width and padding short
+         * rows with empty cells so the output stays rectangular.
+         *
+         * @param row the cell values for this row
+         * @param columnWidths the rendered width of each column, excluding cell padding
+         * @return the row line, terminated with a newline
+         */
+        @Nonnull
+        private static String buildRow(@Nonnull final List<String> row, @Nonnull final int[] columnWidths) {
+            final var sb = new StringBuilder();
+            for (int i = 0; i < columnWidths.length; i++) {
+                final String cell = i < row.size() ? row.get(i).trim() : "";
+                sb.append("| ").append(cell).append(" ".repeat(columnWidths[i] - cell.length())).append(' ');
+            }
+            return sb.append("|\n").toString();
         }
     }
 

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/Matchers.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/Matchers.java
@@ -421,7 +421,7 @@ public class Matchers {
             final int[] columnWidths = new int[columnCount];
             for (final var row : rows) {
                 for (int i = 0; i < row.size(); i++) {
-                    columnWidths[i] = Math.max(columnWidths[i], row.get(i).trim().length());
+                    columnWidths[i] = Math.max(columnWidths[i], row.get(i).length());
                 }
             }
             final String rule = buildRule(columnWidths);
@@ -450,8 +450,8 @@ public class Matchers {
         }
 
         /**
-         * Builds a single table row, trimming and left-aligning each cell within its column width and padding short
-         * rows with empty cells so the output stays rectangular.
+         * Builds a single table row, left-aligning each cell within its column width and padding short rows with empty
+         * cells so the output stays rectangular.
          *
          * @param row the cell values for this row
          * @param columnWidths the rendered width of each column, excluding cell padding
@@ -461,7 +461,7 @@ public class Matchers {
         private static String buildRow(@Nonnull final List<String> row, @Nonnull final int[] columnWidths) {
             final var sb = new StringBuilder();
             for (int i = 0; i < columnWidths.length; i++) {
-                final String cell = i < row.size() ? row.get(i).trim() : "";
+                final String cell = i < row.size() ? row.get(i) : "";
                 sb.append("| ").append(cell).append(" ".repeat(columnWidths[i] - cell.length())).append(' ');
             }
             return sb.append("|\n").toString();

--- a/yaml-tests/src/test/java/com/apple/foundationdb/relational/yamltests/ResultSetPrettyPrinterTest.java
+++ b/yaml-tests/src/test/java/com/apple/foundationdb/relational/yamltests/ResultSetPrettyPrinterTest.java
@@ -1,0 +1,138 @@
+/*
+ * ResultSetPrettyPrinterTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.relational.yamltests;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ResultSetPrettyPrinterTest {
+
+    @Test
+    void toStringOnEmptyResultSetReturnsEmptyMarker() {
+        final var printer = new Matchers.ResultSetPrettyPrinter();
+
+        assertThat(printer.toString()).isEqualTo("<EMPTY>");
+    }
+
+    @Test
+    void toStringOnSingleRowRendersTableWithRules() {
+        final var printer = new Matchers.ResultSetPrettyPrinter();
+        printer.newRow();
+        printer.addCell("a");
+        printer.addCell("bb");
+
+        assertThat(printer.toString()).isEqualTo("""
+                +---+----+
+                | a | bb |
+                +---+----+
+                """);
+    }
+
+    @Test
+    void toStringOnMultipleRowsSizesColumnsToWidestCell() {
+        final var printer = new Matchers.ResultSetPrettyPrinter();
+        printer.newRow();
+        printer.addCell("a");
+        printer.addCell("y");
+        printer.newRow();
+        printer.addCell("aaaa");
+        printer.addCell("y");
+
+        assertThat(printer.toString()).isEqualTo("""
+                +------+---+
+                | a    | y |
+                +------+---+
+                | aaaa | y |
+                +------+---+
+                """);
+    }
+
+    @Test
+    void toStringOnRaggedRowsPadsShorterRowsWithEmptyCells() {
+        final var printer = new Matchers.ResultSetPrettyPrinter();
+        printer.newRow();
+        printer.addCell("aaa");
+        printer.addCell("b");
+        printer.newRow();
+        printer.addCell("c");
+
+        assertThat(printer.toString()).isEqualTo("""
+                +-----+---+
+                | aaa | b |
+                +-----+---+
+                | c   |   |
+                +-----+---+
+                """);
+    }
+
+    @Test
+    void toStringOnCellWithLeadingOrTrailingWhitespacePreservesIt() {
+        // Whitespace is preserved (not trimmed) so that whitespace-only mismatches between
+        // expected and actual values remain visible when diagnosing a failed match.
+        final var printer = new Matchers.ResultSetPrettyPrinter();
+        printer.newRow();
+        printer.addCell(" a ");
+        printer.addCell("b");
+
+        assertThat(printer.toString()).isEqualTo("""
+                +-----+---+
+                |  a  | b |
+                +-----+---+
+                """);
+    }
+
+    @Test
+    void addCellOnNullValueRendersNullMarker() {
+        final var printer = new Matchers.ResultSetPrettyPrinter();
+        printer.newRow();
+        printer.addCell(null);
+
+        assertThat(printer.toString()).isEqualTo("""
+                +--------+
+                | <NULL> |
+                +--------+
+                """);
+    }
+
+    @Test
+    void toStringOnEmptyRowRendersRecordLayerMarker() {
+        final var printer = new Matchers.ResultSetPrettyPrinter();
+        printer.newRow();
+
+        assertThat(printer.toString()).isEqualTo("""
+                +----------------------------------------+
+                | <EMPTY_ROW_RETURNED_FROM_RECORD_LAYER> |
+                +----------------------------------------+
+                """);
+    }
+
+    @Test
+    void getRowCountReturnsNumberOfRowsAdded() {
+        final var printer = new Matchers.ResultSetPrettyPrinter();
+        printer.newRow();
+        printer.addCell("a");
+        printer.newRow();
+        printer.addCell("b");
+
+        assertThat(printer.getRowCount()).isEqualTo(2);
+    }
+}

--- a/yaml-tests/yaml-tests.gradle
+++ b/yaml-tests/yaml-tests.gradle
@@ -49,7 +49,6 @@ dependencies {
     implementation project(":fdb-relational-jdbc")
     implementation project(":fdb-relational-server")
     implementation(libs.jline)
-    implementation(libs.asciitable)
     implementation(libs.jsr305)
     implementation(libs.junit.api)
     implementation(libs.junit.params)


### PR DESCRIPTION
* Replace `asciitable` with a small, handwritten table renderer in `yamltests.Matchers`.

The `asciitable` library transitively pulls in `commons-lang3` version 3.8.1 (via `ascii-utf-themes` › `skb-interfaces`), which has known CVEs. The project appears to be abandoned with no patched release available. Its only usage is for rendering yaml-tests result sets for comparison and diagnostics. We can achieve this with a small handwritten renderer instead.