### PR TITLE
Make the pending write queue max queue size configurable.

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/FDBRecordStoreProperties.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/FDBRecordStoreProperties.java
@@ -77,6 +77,19 @@ public final class FDBRecordStoreProperties {
     public static final RecordLayerPropertyKey<Boolean> DISABLE_INDEX_ON_PENDING_WRITE_QUEUE_OVERFLOW = RecordLayerPropertyKey.booleanPropertyKey(
             "com.apple.foundationdb.record.recordstore.disable_index_on_pending_write_queue_overflow", true);
 
+    /**
+     * The maximum number of entries that the pending-writes queue of an index in the
+     * {@link IndexState#WRITE_ONLY_WITH_QUEUE} state may hold before it is considered full (see
+     * {@link com.apple.foundationdb.record.provider.foundationdb.queue.PendingWritesQueue}). While such an index is
+     * being built, user writes are deferred to this queue instead of maintaining the index directly. Once the queue
+     * reaches this size, further writes overflow, which either fails the user transaction or disables the index
+     * depending on {@link #DISABLE_INDEX_ON_PENDING_WRITE_QUEUE_OVERFLOW}. A larger value tolerates a slower or stalled
+     * online indexer at the cost of more accumulated queue data; a value of {@code 0} disables the cap entirely.
+     */
+    @API(API.Status.EXPERIMENTAL)
+    public static final RecordLayerPropertyKey<Integer> MAX_PENDING_WRITE_QUEUE_SIZE = RecordLayerPropertyKey.integerPropertyKey(
+            "com.apple.foundationdb.record.recordstore.max_pending_write_queue_size", 100_000);
+
     private FDBRecordStoreProperties() {
         throw new RecordCoreException("should not instantiate class of static prop");
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingPendingWriteQueue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingPendingWriteQueue.java
@@ -35,13 +35,13 @@ import com.apple.foundationdb.record.provider.foundationdb.queue.PendingWritesQu
 import com.apple.foundationdb.record.provider.foundationdb.runners.throttled.CursorFactory;
 import com.apple.foundationdb.record.provider.foundationdb.runners.throttled.ThrottledRetryingIterator;
 import com.apple.foundationdb.util.CloseException;
-import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.io.Serial;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -54,15 +54,9 @@ import java.util.concurrent.CompletableFuture;
 public final class IndexingPendingWriteQueue {
     private static final Logger LOGGER = LoggerFactory.getLogger(IndexingPendingWriteQueue.class);
 
-    // TODO: configurable maxQueueSize
-    private static final int DEFAULT_MAX_QUEUE_SIZE = 100_000;
     private static final int MAX_RECORDS_DELETE_PER_SECOND = 10_000;
 
     private static final String DISABLE_INDEX_COMMIT_HOOK = "disableIndexPendingWriteQueueOverflow:";
-
-    // The effective queue capacity. Overridable only for testing, so that a test can force an overflow without
-    // enqueuing lots of entries.
-    private static int maxQueueSize = DEFAULT_MAX_QUEUE_SIZE;
 
     private final Index index;
     private final IndexingCommon common;
@@ -72,18 +66,8 @@ public final class IndexingPendingWriteQueue {
         this.common = common;
     }
 
-    @VisibleForTesting
-    static void setMaxQueueSizeForTesting(final int size) {
-        maxQueueSize = size;
-    }
-
-    @VisibleForTesting
-    static void resetMaxQueueSizeForTesting() {
-        maxQueueSize = DEFAULT_MAX_QUEUE_SIZE;
-    }
-
     CompletableFuture<Boolean> isQueueEmpty(FDBRecordStore store) {
-        return getIndexingQueue(store, index).isQueueEmpty(store.getContext());
+        return getIndexingQueue(store).isQueueEmpty(store.getContext());
     }
 
     @SuppressWarnings("PMD.CloseResource")
@@ -114,7 +98,7 @@ public final class IndexingPendingWriteQueue {
         return (store, lastResult, rowLimit) -> {
             final byte[] continuation = lastResult == null ? null : lastResult.getContinuation().toBytes();
             final ScanProperties scanProperties = ScanProperties.FORWARD_SCAN.with(props -> props.setReturnedRowLimit(rowLimit));
-            return getIndexingQueue(store, index).getQueueCursor(store.getContext(), scanProperties, continuation);
+            return getIndexingQueue(store).getQueueCursor(store.getContext(), scanProperties, continuation);
         };
     }
 
@@ -134,8 +118,13 @@ public final class IndexingPendingWriteQueue {
                 .updateFromQueue(payload.getData())
                 .thenAccept(ignore -> {
                     quotaManager.deleteCountInc();
-                    getIndexingQueue(store, index).clearEntry(store.getContext(), entry);
+                    getIndexingQueue(store).clearEntry(store.getContext(), entry);
                 });
+    }
+
+    @Nonnull
+    private PendingWritesQueue<IndexBuildProto.PendingWritesQueueEntry> getIndexingQueue(final FDBRecordStore store) {
+        return getIndexingQueue(store, index);
     }
 
     @Nonnull
@@ -143,9 +132,14 @@ public final class IndexingPendingWriteQueue {
         return new PendingWritesQueue<>(
                 IndexingSubspaces.indexPendingWriteQueueSubspace(store, index),
                 IndexingSubspaces.indexPendingWriteQueueSizeSubspace(store, index),
-                maxQueueSize,
+                maxQueueSize(store),
                 IndexBuildProto.PendingWritesQueueEntry.class
         );
+    }
+
+    private static int maxQueueSize(final FDBRecordStore store) {
+        return Objects.requireNonNull(store.getContext().getPropertyStorage()
+                .getPropertyValue(FDBRecordStoreProperties.MAX_PENDING_WRITE_QUEUE_SIZE));
     }
 
     /**
@@ -203,6 +197,7 @@ public final class IndexingPendingWriteQueue {
     @Nonnull
     private static CompletableFuture<Void> disableOverflowingIndex(final FDBRecordStore store, final Index index) {
         return store.markIndexDisabled(index).thenAccept(changed -> {
+            final int maxQueueSize = maxQueueSize(store);
             if (Boolean.TRUE.equals(changed)) {
                 store.getContext().increment(FDBStoreTimer.Counts.PENDING_WRITES_QUEUE_OVERFLOW_DISABLED_INDEX);
                 if (LOGGER.isWarnEnabled()) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerPendingWriteQueueTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerPendingWriteQueueTest.java
@@ -49,7 +49,6 @@ import com.google.auto.service.AutoService;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -96,12 +95,6 @@ class OnlineIndexerPendingWriteQueueTest extends OnlineIndexerTest {
         }
     }
 
-    @AfterEach
-    void resetPendingWriteQueueMaxSize() {
-        // Safety net: these tests shrink the (global) queue cap to force an overflow; always restore the default.
-        IndexingPendingWriteQueue.resetMaxQueueSizeForTesting();
-    }
-
     @Test
     void testFullQueueDisablesIndexAndUserWriteSucceeds() throws Exception {
         final int numInitialRecords = 6; // even recNos 0,2,4,6,8,10
@@ -110,7 +103,6 @@ class OnlineIndexerPendingWriteQueueTest extends OnlineIndexerTest {
         disableAll(List.of(index));
         markWriteOnlyWithQueue(index);
 
-        IndexingPendingWriteQueue.setMaxQueueSizeForTesting(2);
         final FDBStoreTimer overflowTimer = new FDBStoreTimer();
         // Fill the queue to capacity: each of these saves is deferred to the queue (counter 1, then 2).
         for (int recNo : List.of(1, 3)) {
@@ -122,7 +114,7 @@ class OnlineIndexerPendingWriteQueueTest extends OnlineIndexerTest {
         assertEquals(2L, queueSizeCounter(index), "the queue should be exactly full before the overflow");
 
         // The overflowing save (flag enabled) must succeed rather than throw.
-        try (FDBRecordContext context = openContextWithDisableOnQueueFull(overflowTimer, true)) {
+        try (FDBRecordContext context = openContextWithDisableOnQueueFull(overflowTimer, true, 2)) {
             final FDBRecordStore store = createStoreBuilder().setContext(context)
                     .createOrOpen(FDBRecordStoreBase.StoreExistenceCheck.NONE);
             assertTrue(store.isIndexWriteOnlyWithQueue(index));
@@ -161,7 +153,6 @@ class OnlineIndexerPendingWriteQueueTest extends OnlineIndexerTest {
         disableAll(List.of(index));
         markWriteOnlyWithQueue(index);
 
-        IndexingPendingWriteQueue.setMaxQueueSizeForTesting(2);
         for (int recNo : List.of(1, 3)) {
             try (FDBRecordContext context = openContext()) {
                 saveSimpleRecord(recordStore, recNo, recNo * 19);
@@ -169,7 +160,7 @@ class OnlineIndexerPendingWriteQueueTest extends OnlineIndexerTest {
             }
         }
         assertThrows(PendingWritesQueue.PendingWritesQueueTooLargeException.class, () -> {
-            try (FDBRecordContext context = openContextWithDisableOnQueueFull(null, false)) {
+            try (FDBRecordContext context = openContextWithDisableOnQueueFull(null, false, 2)) {
                 final FDBRecordStore store = createStoreBuilder().setContext(context)
                         .createOrOpen(FDBRecordStoreBase.StoreExistenceCheck.NONE);
                 saveSimpleRecord(store, 5, 5 * 19);
@@ -197,7 +188,7 @@ class OnlineIndexerPendingWriteQueueTest extends OnlineIndexerTest {
 
         final List<Integer> fillRecNos = List.of(101, 103);
         final List<Integer> writerRecNos = List.of(201, 203, 205, 207);
-        IndexingPendingWriteQueue.setMaxQueueSizeForTesting(fillRecNos.size());
+        final int maxQueueSize = fillRecNos.size();
         for (int recNo : fillRecNos) {
             try (FDBRecordContext context = openContext()) {
                 saveSimpleRecord(recordStore, recNo, recNo * 19);
@@ -215,7 +206,7 @@ class OnlineIndexerPendingWriteQueueTest extends OnlineIndexerTest {
                     barrier.await();
                     boolean committed = false;
                     while (!committed) {
-                        try (FDBRecordContext context = openContextWithDisableOnQueueFull(null, true)) {
+                        try (FDBRecordContext context = openContextWithDisableOnQueueFull(null, true, maxQueueSize)) {
                             final FDBRecordStore store = createStoreBuilder().setContext(context)
                                     .createOrOpen(FDBRecordStoreBase.StoreExistenceCheck.NONE);
                             saveSimpleRecord(store, recNo, recNo * 19);
@@ -1380,13 +1371,15 @@ class OnlineIndexerPendingWriteQueueTest extends OnlineIndexerTest {
     }
 
     /**
-     * Open a context whose properties enable {@link FDBRecordStoreProperties#DISABLE_INDEX_ON_PENDING_WRITE_QUEUE_OVERFLOW}.
+     * Open a context whose properties enable {@link FDBRecordStoreProperties#DISABLE_INDEX_ON_PENDING_WRITE_QUEUE_OVERFLOW}
+     * and cap the pending-writes queue at {@code maxQueueSize} so an overflow can be forced without enqueuing many entries.
      */
     @Nonnull
-    private FDBRecordContext openContextWithDisableOnQueueFull(@Nullable final FDBStoreTimer timer, final boolean disableIndexOnQueueFull) {
+    private FDBRecordContext openContextWithDisableOnQueueFull(@Nullable final FDBStoreTimer timer, final boolean disableIndexOnQueueFull, final int maxQueueSize) {
         final FDBRecordContextConfig.Builder configBuilder = FDBRecordContextConfig.newBuilder()
                 .setRecordContextProperties(RecordLayerPropertyStorage.newBuilder()
                         .addProp(FDBRecordStoreProperties.DISABLE_INDEX_ON_PENDING_WRITE_QUEUE_OVERFLOW, disableIndexOnQueueFull)
+                        .addProp(FDBRecordStoreProperties.MAX_PENDING_WRITE_QUEUE_SIZE, maxQueueSize)
                         .build());
         if (timer != null) {
             configBuilder.setTimer(timer);


### PR DESCRIPTION
Allow the max indexing pending write queue size a context property. This property can be used by tests and (if ever needed) in production to change the max value. 
Note that when the queue is full - either the user transactions will be rejected or the index will be disabled. 