### PR TITLE
Fix merge skew

### DIFF
--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/DelegatingVisitorTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/DelegatingVisitorTest.java
@@ -329,7 +329,7 @@ public class DelegatingVisitorTest {
                         generateMetadata(), NoOpQueryFactory.INSTANCE, NoOpMetadataOperationsFactory.INSTANCE, URI.create("/FDB/FRL1"), false) {
                     @Override
                     public Object visitStatementOptions(@Nonnull RelationalParser.StatementOptionsContext ctx) {
-                        called.setTrue();
+                        called.set(true);
                         return null;
                     }
                 });
@@ -344,7 +344,7 @@ public class DelegatingVisitorTest {
                         generateMetadata(), NoOpQueryFactory.INSTANCE, NoOpMetadataOperationsFactory.INSTANCE, URI.create("/FDB/FRL1"), false) {
                     @Override
                     public Object visitStatementOption(@Nonnull RelationalParser.StatementOptionContext ctx) {
-                        called.setTrue();
+                        called.set(true);
                         return null;
                     }
                 });


### PR DESCRIPTION
Fix compile failure in DelegatingVisitorTest after Apache Commons Lang removal
  
`DelegatingVisitorTest` was calling `MutableBoolean.setTrue()`, a method from Apache Commons Lang that was removed in #4378. Replace with the standard `AtomicBoolean.set(true)`.
