### PR TITLE
GuardiANN DDL

### DIFF
--- a/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/util/Assert.java
+++ b/fdb-relational-api/src/main/java/com/apple/foundationdb/relational/util/Assert.java
@@ -207,6 +207,12 @@ public final class Assert {
     }
 
     @Nonnull
+    public static UncheckedRelationalException failUnchecked(@Nonnull final ErrorCode failErrorCode, @Nonnull final String failMessage,
+                                                             @Nonnull final Throwable cause) {
+        throw new RelationalException(failMessage, failErrorCode, cause).toUncheckedWrappedException();
+    }
+
+    @Nonnull
     public static <S, T> S castUnchecked(T object, Class<S> clazz) {
         return castUnchecked(object, clazz, ErrorCode.INTERNAL_ERROR, () -> "expected " + clazz.getSimpleName() +
                 " but got " + (object == null ? "null" : object.getClass().getSimpleName()));

--- a/fdb-relational-core/src/main/antlr/RelationalLexer.g4
+++ b/fdb-relational-core/src/main/antlr/RelationalLexer.g4
@@ -114,6 +114,7 @@ GRANT:                               'GRANT';
 GROUP:                               'GROUP';
 HAVING:                              'HAVING';
 HNSW:                                'HNSW';
+GUARDIANN:                           'GUARDIANN';
 HIGH_PRIORITY:                       'HIGH_PRIORITY';
 HISTOGRAM:                           'HISTOGRAM';
 IF:                                  'IF';

--- a/fdb-relational-core/src/main/antlr/RelationalParser.g4
+++ b/fdb-relational-core/src/main/antlr/RelationalParser.g4
@@ -171,7 +171,7 @@ enumDefinition
 indexDefinition
     : (UNIQUE)? INDEX indexName=uid AS queryTerm indexAttributes?                                                                  #indexAsSelectDefinition
     | (UNIQUE)? INDEX indexName=uid ON source=fullId indexColumnList includeClause? indexOptions?                                  #indexOnSourceDefinition
-    | VECTOR INDEX indexName=uid USING HNSW ON source=fullId indexColumnList includeClause? indexPartitionClause? vectorIndexOptions?   #vectorIndexDefinition
+    | VECTOR INDEX indexName=uid USING engine=vectorEngine ON source=fullId indexColumnList includeClause? indexPartitionClause? vectorIndexOptions?   #vectorIndexDefinition
     ;
 
 indexColumnList
@@ -202,21 +202,24 @@ indexOption
     : LEGACY_EXTREMUM_EVER
     ;
 
+vectorEngine
+    : HNSW
+    | GUARDIANN
+    ;
+
 vectorIndexOptions
     : OPTIONS '(' vectorIndexOption (COMMA vectorIndexOption)* ')'
     ;
 
 vectorIndexOption
-    : EF_CONSTRUCTION '=' efConstruction=DECIMAL_LITERAL
-    | CONNECTIVITY '=' connectivity=DECIMAL_LITERAL
-    | M_MAX '=' mMax=DECIMAL_LITERAL
-    | M_MAX_0 '=' mMaxZero=DECIMAL_LITERAL
-    | MAINTAIN_STATS_PROBABILITY '=' maintainStatsProbability=REAL_LITERAL
-    | METRIC '=' metric=hnswMetric
-    | RABITQ_NUM_EX_BITS '=' rabitQNumExBits=DECIMAL_LITERAL
-    | SAMPLE_VECTOR_STATS_PROBABILITY '=' statsProbability=REAL_LITERAL
-    | STATS_THRESHOLD '=' statsThreshold=DECIMAL_LITERAL
-    | USE_RABITQ '=' useRabitQ=booleanLiteral
+    : optionName=uid '=' optionValue=vectorIndexOptionValue
+    ;
+
+vectorIndexOptionValue
+    : DECIMAL_LITERAL
+    | REAL_LITERAL
+    | booleanLiteral
+    | hnswMetric
     ;
 
 hnswMetric
@@ -1308,7 +1311,9 @@ intervalTypeBase
     ;
 
 keywordsCanBeId
-    : ACCOUNT | ACTION | ADMIN | AFTER | AGGREGATE | ALGORITHM | ANY
+    : CONNECTIVITY | EF_CONSTRUCTION | M_MAX | M_MAX_0 | MAINTAIN_STATS_PROBABILITY | METRIC
+    | RABITQ_NUM_EX_BITS | SAMPLE_VECTOR_STATS_PROBABILITY | STATS_THRESHOLD | USE_RABITQ
+    | ACCOUNT | ACTION | ADMIN | AFTER | AGGREGATE | ALGORITHM | ANY
     | AT | AUDIT_ADMIN | AUTHORS | AUTOCOMMIT | AUTOEXTEND_SIZE
     | AUTO_INCREMENT | AVG | AVG_ROW_LENGTH | BACKUP_ADMIN | BEGIN | BINLOG | BINLOG_ADMIN | BINLOG_ENCRYPTION_ADMIN | BIT | BIT_AND | BIT_OR | BIT_XOR
     | BLOCK | BOOL | BTREE | CACHE | CASCADED | CHAIN | CHANGED

--- a/fdb-relational-core/src/main/antlr/RelationalParser.g4
+++ b/fdb-relational-core/src/main/antlr/RelationalParser.g4
@@ -212,7 +212,7 @@ vectorIndexOptions
     ;
 
 vectorIndexOption
-    : optionName=uid '=' optionValue=vectorIndexOptionValue
+    : optionName=simpleId '=' optionValue=vectorIndexOptionValue
     ;
 
 vectorIndexOptionValue

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DdlVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DdlVisitor.java
@@ -22,8 +22,10 @@ package com.apple.foundationdb.relational.recordlayer.query.visitors;
 
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.linear.Metric;
+import com.apple.foundationdb.record.metadata.IndexOptions;
 import com.apple.foundationdb.record.metadata.IndexTypes;
 import com.apple.foundationdb.record.provider.foundationdb.indexes.VectorIndexOptionKeys;
+import com.apple.foundationdb.record.provider.foundationdb.indexes.VectorOptionKey;
 import com.apple.foundationdb.record.query.plan.cascades.RawSqlFunction;
 import com.apple.foundationdb.record.query.plan.cascades.UserDefinedFunction;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.LogicalSortExpression;
@@ -66,16 +68,25 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @API(API.Status.EXPERIMENTAL)
 public final class DdlVisitor extends DelegatingVisitor<BaseVisitor> {
+    // Engine names as stored in the IndexOptions.VECTOR_ENGINE option (mirrors VectorIndexEngine.Kind, which is not
+    // visible from this module). HNSW is the engine used when the option is absent.
+    private static final String HNSW_ENGINE = "HNSW";
+    private static final String GUARDIANN_ENGINE = "GUARDIANN";
+    private static final Set<String> ANY_ENGINE = ImmutableSet.of(HNSW_ENGINE, GUARDIANN_ENGINE);
+    private static final Set<String> HNSW_ONLY = ImmutableSet.of(HNSW_ENGINE);
+    private static final Set<String> GUARDIANN_ONLY = ImmutableSet.of(GUARDIANN_ENGINE);
 
     @Nonnull
     private final RecordLayerSchemaTemplate.Builder metadataBuilder;
@@ -235,7 +246,8 @@ public final class DdlVisitor extends DelegatingVisitor<BaseVisitor> {
         getDelegate().getCurrentPlanFragment().setOperator(logicalOperator);
 
         final Identifier indexId = visitUid(indexDefinitionContext.indexName);
-        final var indexOptions = parseVectorOptions(indexDefinitionContext.vectorIndexOptions());
+        final var engine = parseVectorEngine(indexDefinitionContext.engine);
+        final var indexOptions = parseVectorOptions(engine, indexDefinitionContext.vectorIndexOptions());
         final var indexGeneratorBuilder = OnSourceIndexGenerator.newBuilder()
                 .setIndexName(indexId)
                 .setIndexSource(getDelegate().getCurrentPlanFragment())
@@ -291,40 +303,127 @@ public final class DdlVisitor extends DelegatingVisitor<BaseVisitor> {
         return logicalOperator;
     }
 
+    /**
+     * The SQL-facing binding of a single vector index option: the typed record-layer {@code key} it maps to, the vector
+     * engine(s) it is valid for, and how to {@code coerce} the parsed SQL value into the key's value type. This wrapper
+     * (rather than a bare {@link VectorOptionKey}) is what lets the DDL layer (a) reject an option used with the wrong
+     * engine — engine applicability is DDL policy that the engine-agnostic key does not carry — and (b) turn the parsed
+     * grammar value into the key's typed value (the key's own parser is for the stored wire form, and some values, such
+     * as the metric, arrive as a typed sub-rule). Keeping {@code T} on the record also lets {@link #writeTo} call
+     * {@code key.put(...)} without the wildcard-capture problem a bare {@code VectorOptionKey<?>} map would hit at the
+     * call site. Curating {@link #SUPPORTED_VECTOR_OPTIONS} is how the SQL option surface is curated.
+     *
+     * @param <T> the option's value type
+     */
+    private record VectorSqlOption<T>(@Nonnull VectorOptionKey<T> key,
+                                      @Nonnull Set<String> engines,
+                                      @Nonnull Function<RelationalParser.VectorIndexOptionValueContext, T> coerce) {
+        void writeTo(@Nonnull final BiConsumer<String, String> sink,
+                     @Nonnull final RelationalParser.VectorIndexOptionValueContext value) {
+            key.put(sink, coerce.apply(value));
+        }
+    }
+
+    // The curated set of vector index options exposed through SQL DDL, keyed by their (lower-cased) SQL option name.
+    // Adding or removing an option, or changing which engine it applies to, is a one-line change here and needs no
+    // grammar change.
+    private static final Map<String, VectorSqlOption<?>> SUPPORTED_VECTOR_OPTIONS =
+            ImmutableMap.<String, VectorSqlOption<?>>builder()
+                    // shared by both engines
+                    .put("metric", new VectorSqlOption<>(VectorIndexOptionKeys.METRIC, ANY_ENGINE,
+                            value -> parseMetric(value.hnswMetric())))
+                    .put("use_rabitq", new VectorSqlOption<>(VectorIndexOptionKeys.USE_RABITQ, ANY_ENGINE,
+                            DdlVisitor::parseOptionBoolean))
+                    .put("rabitq_num_ex_bits", new VectorSqlOption<>(VectorIndexOptionKeys.RABITQ_NUM_EX_BITS,
+                            ANY_ENGINE, DdlVisitor::parseOptionInt))
+                    .put("maintain_stats_probability", new VectorSqlOption<>(VectorIndexOptionKeys.MAINTAIN_STATS_PROBABILITY,
+                            ANY_ENGINE, DdlVisitor::parseOptionDouble))
+                    .put("sample_vector_stats_probability", new VectorSqlOption<>(VectorIndexOptionKeys.SAMPLE_VECTOR_STATS_PROBABILITY,
+                            ANY_ENGINE, DdlVisitor::parseOptionDouble))
+                    .put("stats_threshold", new VectorSqlOption<>(VectorIndexOptionKeys.STATS_THRESHOLD, ANY_ENGINE,
+                            DdlVisitor::parseOptionInt))
+                    // HNSW-only
+                    .put("connectivity", new VectorSqlOption<>(VectorIndexOptionKeys.HNSW_M, HNSW_ONLY,
+                            DdlVisitor::parseOptionInt))
+                    .put("ef_construction", new VectorSqlOption<>(VectorIndexOptionKeys.HNSW_EF_CONSTRUCTION, HNSW_ONLY,
+                            DdlVisitor::parseOptionInt))
+                    .put("m_max", new VectorSqlOption<>(VectorIndexOptionKeys.HNSW_M_MAX, HNSW_ONLY,
+                            DdlVisitor::parseOptionInt))
+                    .put("m_max_0", new VectorSqlOption<>(VectorIndexOptionKeys.HNSW_M_MAX_0, HNSW_ONLY,
+                            DdlVisitor::parseOptionInt))
+                    // Guardiann-only (curated subset)
+                    .put("primary_cluster_min", new VectorSqlOption<>(VectorIndexOptionKeys.GUARDIANN_PRIMARY_CLUSTER_MIN,
+                            GUARDIANN_ONLY, DdlVisitor::parseOptionInt))
+                    .put("primary_cluster_max", new VectorSqlOption<>(VectorIndexOptionKeys.GUARDIANN_PRIMARY_CLUSTER_MAX,
+                            GUARDIANN_ONLY, DdlVisitor::parseOptionInt))
+                    .put("underreplicated_primary_cluster_max", new VectorSqlOption<>(VectorIndexOptionKeys.GUARDIANN_UNDERREPLICATED_PRIMARY_CLUSTER_MAX,
+                            GUARDIANN_ONLY, DdlVisitor::parseOptionInt))
+                    .put("replicated_cluster_max_writes", new VectorSqlOption<>(VectorIndexOptionKeys.GUARDIANN_REPLICATED_CLUSTER_MAX_WRITES,
+                            GUARDIANN_ONLY, DdlVisitor::parseOptionInt))
+                    .put("replicated_cluster_target", new VectorSqlOption<>(VectorIndexOptionKeys.GUARDIANN_REPLICATED_CLUSTER_TARGET,
+                            GUARDIANN_ONLY, DdlVisitor::parseOptionInt))
+                    .put("replication_priority_min", new VectorSqlOption<>(VectorIndexOptionKeys.GUARDIANN_REPLICATION_PRIORITY_MIN,
+                            GUARDIANN_ONLY, DdlVisitor::parseOptionDouble))
+                    .put("insert_max_candidate_clusters", new VectorSqlOption<>(VectorIndexOptionKeys.GUARDIANN_INSERT_MAX_CANDIDATE_CLUSTERS,
+                            GUARDIANN_ONLY, DdlVisitor::parseOptionInt))
+                    .put("delete_max_candidate_clusters", new VectorSqlOption<>(VectorIndexOptionKeys.GUARDIANN_DELETE_MAX_CANDIDATE_CLUSTERS,
+                            GUARDIANN_ONLY, DdlVisitor::parseOptionInt))
+                    .put("split_num_nearest_clusters", new VectorSqlOption<>(VectorIndexOptionKeys.GUARDIANN_SPLIT_NUM_NEAREST_CLUSTERS,
+                            GUARDIANN_ONLY, DdlVisitor::parseOptionInt))
+                    .put("merge_num_nearest_clusters", new VectorSqlOption<>(VectorIndexOptionKeys.GUARDIANN_MERGE_NUM_NEAREST_CLUSTERS,
+                            GUARDIANN_ONLY, DdlVisitor::parseOptionInt))
+                    .put("reassign_num_neighboring_clusters", new VectorSqlOption<>(VectorIndexOptionKeys.GUARDIANN_REASSIGN_NUM_NEIGHBORING_CLUSTERS,
+                            GUARDIANN_ONLY, DdlVisitor::parseOptionInt))
+                    .put("collapse_min_duplicates", new VectorSqlOption<>(VectorIndexOptionKeys.GUARDIANN_COLLAPSE_MIN_DUPLICATES,
+                            GUARDIANN_ONLY, DdlVisitor::parseOptionInt))
+                    .build();
+
     @Nonnull
-    private Map<String, String> parseVectorOptions(@Nullable final RelationalParser.VectorIndexOptionsContext indexOptionsContext) {
+    private static String parseVectorEngine(@Nonnull final RelationalParser.VectorEngineContext engineContext) {
+        return engineContext.GUARDIANN() != null ? GUARDIANN_ENGINE : HNSW_ENGINE;
+    }
+
+    private static int parseOptionInt(@Nonnull final RelationalParser.VectorIndexOptionValueContext value) {
+        return Integer.parseInt(value.getText());
+    }
+
+    private static double parseOptionDouble(@Nonnull final RelationalParser.VectorIndexOptionValueContext value) {
+        return Double.parseDouble(value.getText());
+    }
+
+    private static boolean parseOptionBoolean(@Nonnull final RelationalParser.VectorIndexOptionValueContext value) {
+        return Boolean.parseBoolean(value.getText());
+    }
+
+    @Nonnull
+    private Map<String, String> parseVectorOptions(@Nonnull final String engine,
+                                                   @Nullable final RelationalParser.VectorIndexOptionsContext indexOptionsContext) {
         final var indexOptionsBuilder = ImmutableMap.<String, String>builder();
+        // Guardiann must be recorded explicitly; HNSW is the default when the engine option is absent, so leave it
+        // implicit (keeps HNSW index metadata unchanged and readable by nodes that predate the engine option).
+        if (GUARDIANN_ENGINE.equals(engine)) {
+            indexOptionsBuilder.put(IndexOptions.VECTOR_ENGINE, engine);
+        }
         if (indexOptionsContext == null) {
             return indexOptionsBuilder.build();
         }
-
+        final Set<String> seen = new HashSet<>();
         for (final var option : indexOptionsContext.vectorIndexOption()) {
-            if (option.EF_CONSTRUCTION() != null) {
-                VectorIndexOptionKeys.HNSW_EF_CONSTRUCTION.put(indexOptionsBuilder::put,
-                        Integer.parseInt(option.efConstruction.getText()));
-            } else if (option.CONNECTIVITY() != null) {
-                VectorIndexOptionKeys.HNSW_M.put(indexOptionsBuilder::put,
-                        Integer.parseInt(option.connectivity.getText()));
-            } else if (option.M_MAX() != null) {
-                VectorIndexOptionKeys.HNSW_M_MAX.put(indexOptionsBuilder::put,
-                        Integer.parseInt(option.mMax.getText()));
-            } else if (option.MAINTAIN_STATS_PROBABILITY() != null) {
-                VectorIndexOptionKeys.MAINTAIN_STATS_PROBABILITY.put(indexOptionsBuilder::put,
-                        Double.parseDouble(option.maintainStatsProbability.getText()));
-            } else if (option.METRIC() != null) {
-                VectorIndexOptionKeys.METRIC.put(indexOptionsBuilder::put, parseMetric(option.metric));
-            } else if (option.RABITQ_NUM_EX_BITS() != null) {
-                VectorIndexOptionKeys.RABITQ_NUM_EX_BITS.put(indexOptionsBuilder::put,
-                        Integer.parseInt(option.rabitQNumExBits.getText()));
-            } else if (option.SAMPLE_VECTOR_STATS_PROBABILITY() != null) {
-                VectorIndexOptionKeys.SAMPLE_VECTOR_STATS_PROBABILITY.put(indexOptionsBuilder::put,
-                        Double.parseDouble(option.statsProbability.getText()));
-            } else if (option.STATS_THRESHOLD() != null) {
-                VectorIndexOptionKeys.STATS_THRESHOLD.put(indexOptionsBuilder::put,
-                        Integer.parseInt(option.statsThreshold.getText()));
-            } else if (option.USE_RABITQ() != null) {
-                VectorIndexOptionKeys.USE_RABITQ.put(indexOptionsBuilder::put,
-                        Boolean.parseBoolean(option.useRabitQ.getText()));
+            final String name = option.optionName.getText().toLowerCase(Locale.ROOT);
+            final var spec = SUPPORTED_VECTOR_OPTIONS.get(name);
+            if (spec == null) {
+                throw Assert.failUnchecked(ErrorCode.UNSUPPORTED_OPERATION,
+                        "unsupported vector index option '" + name + "'");
+            }
+            Assert.thatUnchecked(spec.engines().contains(engine), ErrorCode.UNSUPPORTED_OPERATION,
+                    () -> "vector index option '" + name + "' is not valid for the " + engine + " vector engine");
+            Assert.thatUnchecked(seen.add(name), ErrorCode.SYNTAX_ERROR,
+                    () -> "duplicate vector index option '" + name + "'");
+            try {
+                spec.writeTo(indexOptionsBuilder::put, option.optionValue);
+            } catch (final NumberFormatException e) {
+                throw Assert.failUnchecked(ErrorCode.SYNTAX_ERROR,
+                        "invalid value '" + option.optionValue.getText() + "' for vector index option '" + name + "'");
             }
         }
         return indexOptionsBuilder.build();

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DdlVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DdlVisitor.java
@@ -88,6 +88,60 @@ public final class DdlVisitor extends DelegatingVisitor<BaseVisitor> {
     private static final Set<String> HNSW_ONLY = ImmutableSet.of(HNSW_ENGINE);
     private static final Set<String> GUARDIANN_ONLY = ImmutableSet.of(GUARDIANN_ENGINE);
 
+    // The curated set of vector index options exposed through SQL DDL, keyed by their (lower-cased) SQL option name.
+    // Adding or removing an option, or changing which engine it applies to, is a one-line change here and needs no
+    // grammar change.
+    private static final Map<String, VectorSqlOption<?>> SUPPORTED_VECTOR_OPTIONS =
+            ImmutableMap.<String, VectorSqlOption<?>>builder()
+                    // shared by both engines
+                    .put("metric", new VectorSqlOption<>(VectorIndexOptionKeys.METRIC, ANY_ENGINE,
+                            value -> parseMetric(value.hnswMetric())))
+                    .put("use_rabitq", new VectorSqlOption<>(VectorIndexOptionKeys.USE_RABITQ, ANY_ENGINE,
+                            DdlVisitor::parseOptionBoolean))
+                    .put("rabitq_num_ex_bits", new VectorSqlOption<>(VectorIndexOptionKeys.RABITQ_NUM_EX_BITS,
+                            ANY_ENGINE, DdlVisitor::parseOptionInt))
+                    .put("maintain_stats_probability", new VectorSqlOption<>(VectorIndexOptionKeys.MAINTAIN_STATS_PROBABILITY,
+                            ANY_ENGINE, DdlVisitor::parseOptionDouble))
+                    .put("sample_vector_stats_probability", new VectorSqlOption<>(VectorIndexOptionKeys.SAMPLE_VECTOR_STATS_PROBABILITY,
+                            ANY_ENGINE, DdlVisitor::parseOptionDouble))
+                    .put("stats_threshold", new VectorSqlOption<>(VectorIndexOptionKeys.STATS_THRESHOLD, ANY_ENGINE,
+                            DdlVisitor::parseOptionInt))
+                    // HNSW-only
+                    .put("connectivity", new VectorSqlOption<>(VectorIndexOptionKeys.HNSW_M, HNSW_ONLY,
+                            DdlVisitor::parseOptionInt))
+                    .put("ef_construction", new VectorSqlOption<>(VectorIndexOptionKeys.HNSW_EF_CONSTRUCTION, HNSW_ONLY,
+                            DdlVisitor::parseOptionInt))
+                    .put("m_max", new VectorSqlOption<>(VectorIndexOptionKeys.HNSW_M_MAX, HNSW_ONLY,
+                            DdlVisitor::parseOptionInt))
+                    .put("m_max_0", new VectorSqlOption<>(VectorIndexOptionKeys.HNSW_M_MAX_0, HNSW_ONLY,
+                            DdlVisitor::parseOptionInt))
+                    // Guardiann-only (curated subset)
+                    .put("primary_cluster_min", new VectorSqlOption<>(VectorIndexOptionKeys.GUARDIANN_PRIMARY_CLUSTER_MIN,
+                            GUARDIANN_ONLY, DdlVisitor::parseOptionInt))
+                    .put("primary_cluster_max", new VectorSqlOption<>(VectorIndexOptionKeys.GUARDIANN_PRIMARY_CLUSTER_MAX,
+                            GUARDIANN_ONLY, DdlVisitor::parseOptionInt))
+                    .put("underreplicated_primary_cluster_max", new VectorSqlOption<>(VectorIndexOptionKeys.GUARDIANN_UNDERREPLICATED_PRIMARY_CLUSTER_MAX,
+                            GUARDIANN_ONLY, DdlVisitor::parseOptionInt))
+                    .put("replicated_cluster_max_writes", new VectorSqlOption<>(VectorIndexOptionKeys.GUARDIANN_REPLICATED_CLUSTER_MAX_WRITES,
+                            GUARDIANN_ONLY, DdlVisitor::parseOptionInt))
+                    .put("replicated_cluster_target", new VectorSqlOption<>(VectorIndexOptionKeys.GUARDIANN_REPLICATED_CLUSTER_TARGET,
+                            GUARDIANN_ONLY, DdlVisitor::parseOptionInt))
+                    .put("replication_priority_min", new VectorSqlOption<>(VectorIndexOptionKeys.GUARDIANN_REPLICATION_PRIORITY_MIN,
+                            GUARDIANN_ONLY, DdlVisitor::parseOptionDouble))
+                    .put("insert_max_candidate_clusters", new VectorSqlOption<>(VectorIndexOptionKeys.GUARDIANN_INSERT_MAX_CANDIDATE_CLUSTERS,
+                            GUARDIANN_ONLY, DdlVisitor::parseOptionInt))
+                    .put("delete_max_candidate_clusters", new VectorSqlOption<>(VectorIndexOptionKeys.GUARDIANN_DELETE_MAX_CANDIDATE_CLUSTERS,
+                            GUARDIANN_ONLY, DdlVisitor::parseOptionInt))
+                    .put("split_num_nearest_clusters", new VectorSqlOption<>(VectorIndexOptionKeys.GUARDIANN_SPLIT_NUM_NEAREST_CLUSTERS,
+                            GUARDIANN_ONLY, DdlVisitor::parseOptionInt))
+                    .put("merge_num_nearest_clusters", new VectorSqlOption<>(VectorIndexOptionKeys.GUARDIANN_MERGE_NUM_NEAREST_CLUSTERS,
+                            GUARDIANN_ONLY, DdlVisitor::parseOptionInt))
+                    .put("reassign_num_neighboring_clusters", new VectorSqlOption<>(VectorIndexOptionKeys.GUARDIANN_REASSIGN_NUM_NEIGHBORING_CLUSTERS,
+                            GUARDIANN_ONLY, DdlVisitor::parseOptionInt))
+                    .put("collapse_min_duplicates", new VectorSqlOption<>(VectorIndexOptionKeys.GUARDIANN_COLLAPSE_MIN_DUPLICATES,
+                            GUARDIANN_ONLY, DdlVisitor::parseOptionInt))
+                    .build();
+
     @Nonnull
     private final RecordLayerSchemaTemplate.Builder metadataBuilder;
 
@@ -324,60 +378,6 @@ public final class DdlVisitor extends DelegatingVisitor<BaseVisitor> {
         }
     }
 
-    // The curated set of vector index options exposed through SQL DDL, keyed by their (lower-cased) SQL option name.
-    // Adding or removing an option, or changing which engine it applies to, is a one-line change here and needs no
-    // grammar change.
-    private static final Map<String, VectorSqlOption<?>> SUPPORTED_VECTOR_OPTIONS =
-            ImmutableMap.<String, VectorSqlOption<?>>builder()
-                    // shared by both engines
-                    .put("metric", new VectorSqlOption<>(VectorIndexOptionKeys.METRIC, ANY_ENGINE,
-                            value -> parseMetric(value.hnswMetric())))
-                    .put("use_rabitq", new VectorSqlOption<>(VectorIndexOptionKeys.USE_RABITQ, ANY_ENGINE,
-                            DdlVisitor::parseOptionBoolean))
-                    .put("rabitq_num_ex_bits", new VectorSqlOption<>(VectorIndexOptionKeys.RABITQ_NUM_EX_BITS,
-                            ANY_ENGINE, DdlVisitor::parseOptionInt))
-                    .put("maintain_stats_probability", new VectorSqlOption<>(VectorIndexOptionKeys.MAINTAIN_STATS_PROBABILITY,
-                            ANY_ENGINE, DdlVisitor::parseOptionDouble))
-                    .put("sample_vector_stats_probability", new VectorSqlOption<>(VectorIndexOptionKeys.SAMPLE_VECTOR_STATS_PROBABILITY,
-                            ANY_ENGINE, DdlVisitor::parseOptionDouble))
-                    .put("stats_threshold", new VectorSqlOption<>(VectorIndexOptionKeys.STATS_THRESHOLD, ANY_ENGINE,
-                            DdlVisitor::parseOptionInt))
-                    // HNSW-only
-                    .put("connectivity", new VectorSqlOption<>(VectorIndexOptionKeys.HNSW_M, HNSW_ONLY,
-                            DdlVisitor::parseOptionInt))
-                    .put("ef_construction", new VectorSqlOption<>(VectorIndexOptionKeys.HNSW_EF_CONSTRUCTION, HNSW_ONLY,
-                            DdlVisitor::parseOptionInt))
-                    .put("m_max", new VectorSqlOption<>(VectorIndexOptionKeys.HNSW_M_MAX, HNSW_ONLY,
-                            DdlVisitor::parseOptionInt))
-                    .put("m_max_0", new VectorSqlOption<>(VectorIndexOptionKeys.HNSW_M_MAX_0, HNSW_ONLY,
-                            DdlVisitor::parseOptionInt))
-                    // Guardiann-only (curated subset)
-                    .put("primary_cluster_min", new VectorSqlOption<>(VectorIndexOptionKeys.GUARDIANN_PRIMARY_CLUSTER_MIN,
-                            GUARDIANN_ONLY, DdlVisitor::parseOptionInt))
-                    .put("primary_cluster_max", new VectorSqlOption<>(VectorIndexOptionKeys.GUARDIANN_PRIMARY_CLUSTER_MAX,
-                            GUARDIANN_ONLY, DdlVisitor::parseOptionInt))
-                    .put("underreplicated_primary_cluster_max", new VectorSqlOption<>(VectorIndexOptionKeys.GUARDIANN_UNDERREPLICATED_PRIMARY_CLUSTER_MAX,
-                            GUARDIANN_ONLY, DdlVisitor::parseOptionInt))
-                    .put("replicated_cluster_max_writes", new VectorSqlOption<>(VectorIndexOptionKeys.GUARDIANN_REPLICATED_CLUSTER_MAX_WRITES,
-                            GUARDIANN_ONLY, DdlVisitor::parseOptionInt))
-                    .put("replicated_cluster_target", new VectorSqlOption<>(VectorIndexOptionKeys.GUARDIANN_REPLICATED_CLUSTER_TARGET,
-                            GUARDIANN_ONLY, DdlVisitor::parseOptionInt))
-                    .put("replication_priority_min", new VectorSqlOption<>(VectorIndexOptionKeys.GUARDIANN_REPLICATION_PRIORITY_MIN,
-                            GUARDIANN_ONLY, DdlVisitor::parseOptionDouble))
-                    .put("insert_max_candidate_clusters", new VectorSqlOption<>(VectorIndexOptionKeys.GUARDIANN_INSERT_MAX_CANDIDATE_CLUSTERS,
-                            GUARDIANN_ONLY, DdlVisitor::parseOptionInt))
-                    .put("delete_max_candidate_clusters", new VectorSqlOption<>(VectorIndexOptionKeys.GUARDIANN_DELETE_MAX_CANDIDATE_CLUSTERS,
-                            GUARDIANN_ONLY, DdlVisitor::parseOptionInt))
-                    .put("split_num_nearest_clusters", new VectorSqlOption<>(VectorIndexOptionKeys.GUARDIANN_SPLIT_NUM_NEAREST_CLUSTERS,
-                            GUARDIANN_ONLY, DdlVisitor::parseOptionInt))
-                    .put("merge_num_nearest_clusters", new VectorSqlOption<>(VectorIndexOptionKeys.GUARDIANN_MERGE_NUM_NEAREST_CLUSTERS,
-                            GUARDIANN_ONLY, DdlVisitor::parseOptionInt))
-                    .put("reassign_num_neighboring_clusters", new VectorSqlOption<>(VectorIndexOptionKeys.GUARDIANN_REASSIGN_NUM_NEIGHBORING_CLUSTERS,
-                            GUARDIANN_ONLY, DdlVisitor::parseOptionInt))
-                    .put("collapse_min_duplicates", new VectorSqlOption<>(VectorIndexOptionKeys.GUARDIANN_COLLAPSE_MIN_DUPLICATES,
-                            GUARDIANN_ONLY, DdlVisitor::parseOptionInt))
-                    .build();
-
     @Nonnull
     private static String parseVectorEngine(@Nonnull final RelationalParser.VectorEngineContext engineContext) {
         return engineContext.GUARDIANN() != null ? GUARDIANN_ENGINE : HNSW_ENGINE;
@@ -423,7 +423,7 @@ public final class DdlVisitor extends DelegatingVisitor<BaseVisitor> {
                 spec.writeTo(indexOptionsBuilder::put, option.optionValue);
             } catch (final NumberFormatException e) {
                 throw Assert.failUnchecked(ErrorCode.SYNTAX_ERROR,
-                        "invalid value '" + option.optionValue.getText() + "' for vector index option '" + name + "'");
+                        "invalid value '" + option.optionValue.getText() + "' for vector index option '" + name + "'", e);
             }
         }
         return indexOptionsBuilder.build();

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DelegatingVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DelegatingVisitor.java
@@ -277,6 +277,16 @@ public class DelegatingVisitor<D extends TypedVisitor> implements TypedVisitor {
         return getDelegate().visitHnswMetric(ctx);
     }
 
+    @Override
+    public Object visitVectorEngine(final RelationalParser.VectorEngineContext ctx) {
+        return getDelegate().visitVectorEngine(ctx);
+    }
+
+    @Override
+    public Object visitVectorIndexOptionValue(final RelationalParser.VectorIndexOptionValueContext ctx) {
+        return getDelegate().visitVectorIndexOptionValue(ctx);
+    }
+
     @Nonnull
     @Override
     public Object visitIndexAttributes(@Nonnull RelationalParser.IndexAttributesContext ctx) {

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/api/ddl/IndexTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/api/ddl/IndexTest.java
@@ -1446,6 +1446,17 @@ public class IndexTest {
     }
 
     @Test
+    void createGuardiannVectorIndexWithNonNumericOptionValueIsRejected() throws Exception {
+        // PRIMARY_CLUSTER_MAX expects an integer. 1.5 is a valid vectorIndexOptionValue (a REAL_LITERAL) but cannot be
+        // coerced to an int, so option parsing surfaces a syntax error rather than letting the NumberFormatException
+        // escape.
+        final String stmt = "CREATE SCHEMA TEMPLATE test_template " +
+                "CREATE TABLE T(p bigint, b vector(3, float), primary key(p))" +
+                "CREATE VECTOR INDEX MV1 USING GUARDIANN ON T(b) PARTITION BY (p) OPTIONS (PRIMARY_CLUSTER_MAX = 1.5)";
+        shouldFailWith(stmt, ErrorCode.SYNTAX_ERROR, "invalid value");
+    }
+
+    @Test
     void createHnswVectorIndexWithGuardiannOnlyOptionIsRejected() throws Exception {
         final String stmt = "CREATE SCHEMA TEMPLATE test_template " +
                 "CREATE TABLE T(p bigint, b vector(3, float), primary key(p))" +

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/api/ddl/IndexTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/api/ddl/IndexTest.java
@@ -1404,6 +1404,64 @@ public class IndexTest {
     }
 
     @Test
+    void createGuardiannVectorIndexWithOptionsWorksCorrectly() throws Exception {
+        final String stmt = "CREATE SCHEMA TEMPLATE test_template " +
+                "CREATE TABLE T(p bigint, b vector(3, float), primary key(p))" +
+                "CREATE VECTOR INDEX MV1 USING GUARDIANN ON T(b) PARTITION BY (p) " +
+                "OPTIONS (METRIC = COSINE_METRIC, PRIMARY_CLUSTER_MIN = 20, PRIMARY_CLUSTER_MAX = 200, " +
+                "REPLICATED_CLUSTER_TARGET = 50, REPLICATION_PRIORITY_MIN = 0.75, COLLAPSE_MIN_DUPLICATES = 100)";
+        indexIs(stmt,
+                keyWithValue(concat(field("P"), field("B")), 1),
+                IndexTypes.VECTOR,
+                idx -> {
+                    final var options = idx.getOptions();
+                    Assertions.assertEquals("GUARDIANN", options.get(IndexOptions.VECTOR_ENGINE));
+                    // shared options are written under their (currently canonical) hnsw* wire names
+                    Assertions.assertEquals("3", options.get(IndexOptions.HNSW_NUM_DIMENSIONS));
+                    Assertions.assertEquals("COSINE_METRIC", options.get(IndexOptions.HNSW_METRIC));
+                    Assertions.assertEquals("20", options.get(IndexOptions.GUARDIANN_PRIMARY_CLUSTER_MIN));
+                    Assertions.assertEquals("200", options.get(IndexOptions.GUARDIANN_PRIMARY_CLUSTER_MAX));
+                    Assertions.assertEquals("50", options.get(IndexOptions.GUARDIANN_REPLICATED_CLUSTER_TARGET));
+                    Assertions.assertEquals("0.75", options.get(IndexOptions.GUARDIANN_REPLICATION_PRIORITY_MIN));
+                    Assertions.assertEquals("100", options.get(IndexOptions.GUARDIANN_COLLAPSE_MIN_DUPLICATES));
+                    // and the same values read back through the typed option keys
+                    final var coreIndex = toCoreIndex(idx);
+                    Assertions.assertEquals(3, VectorIndexOptionKeys.NUM_DIMENSIONS.read(coreIndex));
+                    Assertions.assertEquals(Metric.COSINE_METRIC, VectorIndexOptionKeys.METRIC.read(coreIndex));
+                    Assertions.assertEquals(20, VectorIndexOptionKeys.GUARDIANN_PRIMARY_CLUSTER_MIN.read(coreIndex));
+                    Assertions.assertEquals(200, VectorIndexOptionKeys.GUARDIANN_PRIMARY_CLUSTER_MAX.read(coreIndex));
+                    Assertions.assertEquals(50, VectorIndexOptionKeys.GUARDIANN_REPLICATED_CLUSTER_TARGET.read(coreIndex));
+                    Assertions.assertEquals(0.75, VectorIndexOptionKeys.GUARDIANN_REPLICATION_PRIORITY_MIN.read(coreIndex));
+                    Assertions.assertEquals(100, VectorIndexOptionKeys.GUARDIANN_COLLAPSE_MIN_DUPLICATES.read(coreIndex));
+                    validateVectorIndex(idx);
+                });
+    }
+
+    @Test
+    void createGuardiannVectorIndexWithHnswOnlyOptionIsRejected() throws Exception {
+        final String stmt = "CREATE SCHEMA TEMPLATE test_template " +
+                "CREATE TABLE T(p bigint, b vector(3, float), primary key(p))" +
+                "CREATE VECTOR INDEX MV1 USING GUARDIANN ON T(b) PARTITION BY (p) OPTIONS (CONNECTIVITY = 16)";
+        shouldFailWith(stmt, ErrorCode.UNSUPPORTED_OPERATION, "not valid for the GUARDIANN vector engine");
+    }
+
+    @Test
+    void createHnswVectorIndexWithGuardiannOnlyOptionIsRejected() throws Exception {
+        final String stmt = "CREATE SCHEMA TEMPLATE test_template " +
+                "CREATE TABLE T(p bigint, b vector(3, float), primary key(p))" +
+                "CREATE VECTOR INDEX MV1 USING HNSW ON T(b) PARTITION BY (p) OPTIONS (PRIMARY_CLUSTER_MIN = 20)";
+        shouldFailWith(stmt, ErrorCode.UNSUPPORTED_OPERATION, "not valid for the HNSW vector engine");
+    }
+
+    @Test
+    void createVectorIndexWithUnknownOptionIsRejected() throws Exception {
+        final String stmt = "CREATE SCHEMA TEMPLATE test_template " +
+                "CREATE TABLE T(p bigint, b vector(3, float), primary key(p))" +
+                "CREATE VECTOR INDEX MV1 USING HNSW ON T(b) PARTITION BY (p) OPTIONS (BOGUS_OPTION = 5)";
+        shouldFailWith(stmt, ErrorCode.UNSUPPORTED_OPERATION, "unsupported vector index option 'bogus_option'");
+    }
+
+    @Test
     void createVectorIndexOnMultipleColumnsFails() throws Exception {
         final String stmt = "CREATE SCHEMA TEMPLATE test_template " +
                 "CREATE TABLE T(p bigint, b vector(3, float), c vector(3, float), primary key(p))" +

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/DelegatingVisitorTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/DelegatingVisitorTest.java
@@ -539,6 +539,36 @@ public class DelegatingVisitorTest {
     }
 
     @Test
+    void visitVectorEngineTest() {
+        testSimple("GUARDIANN",
+                RelationalParser::vectorEngine,
+                DelegatingVisitor::visitVectorEngine,
+                called -> new BaseVisitor(new MutablePlanGenerationContext(PreparedParams.empty(), PlanHashable.PlanHashMode.VC0, "", "", 42),
+                        generateMetadata(), NoOpQueryFactory.INSTANCE, NoOpMetadataOperationsFactory.INSTANCE, URI.create("/FDB/FRL1"), false) {
+                    @Override
+                    public Object visitVectorEngine(@Nonnull RelationalParser.VectorEngineContext ctx) {
+                        called.set(true);
+                        return null;
+                    }
+                });
+    }
+
+    @Test
+    void visitVectorIndexOptionValueTest() {
+        testSimple("16",
+                RelationalParser::vectorIndexOptionValue,
+                DelegatingVisitor::visitVectorIndexOptionValue,
+                called -> new BaseVisitor(new MutablePlanGenerationContext(PreparedParams.empty(), PlanHashable.PlanHashMode.VC0, "", "", 42),
+                        generateMetadata(), NoOpQueryFactory.INSTANCE, NoOpMetadataOperationsFactory.INSTANCE, URI.create("/FDB/FRL1"), false) {
+                    @Override
+                    public Object visitVectorIndexOptionValue(@Nonnull RelationalParser.VectorIndexOptionValueContext ctx) {
+                        called.set(true);
+                        return null;
+                    }
+                });
+    }
+
+    @Test
     void visitVectorIndexOptionTest() {
         testSimple("EF_CONSTRUCTION = 100",
                 RelationalParser::vectorIndexOption,

--- a/yaml-tests/src/test/java/YamlIntegrationTests.java
+++ b/yaml-tests/src/test/java/YamlIntegrationTests.java
@@ -203,6 +203,11 @@ public class YamlIntegrationTests {
     }
 
     @TestTemplate
+    public void guardiannSemanticSearchTest(YamlTest.Runner runner) throws Exception {
+        runner.runYamsql("guardiann-semantic-search.yamsql");
+    }
+
+    @TestTemplate
     public void inPredicate(YamlTest.Runner runner) throws Exception {
         runner.runYamsql("in-predicate.yamsql");
     }

--- a/yaml-tests/src/test/resources/guardiann-semantic-search.metrics.binpb
+++ b/yaml-tests/src/test/resources/guardiann-semantic-search.metrics.binpb
@@ -1,0 +1,38 @@
+—
+í
+guardiann-semantic-search-testsÓEXPLAIN select docId, euclidean_distance(embedding, ?) as distance from documents where zone = 'zone1' and bookshelf = 'fiction' qualify row_number() over ( partition by zone, bookshelf order by euclidean_distance(embedding, ?) asc ) <= 1π
+À«Äﬁ-> ﬂ⁄ê (0Ôä¢8@ÊISCAN(DOCUMENTSGUARDIANNINDEX [EQUALS promote(@c16 AS STRING), EQUALS promote(@c20 AS STRING)]:{DISTANCE_RANK_LESS_THAN_OR_EQUAL @c7: @c44}:[] BY_DISTANCE) | MAP (_.DOCID AS DOCID, (_.EMBEDDING) euclidean_distance @c7 AS DISTANCE)±digraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=line;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q2.DOCID AS DOCID, (q2.EMBEDDING) euclidean_distance @c7 AS DISTANCE)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(STRING AS DOCID, DOUBLE AS DISTANCE)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">prefix comparisons: [EQUALS promote(@c16 AS STRING), EQUALS promote(@c20 AS STRING)]</td></tr><tr><td align="left">distanceRank: DISTANCE_RANK_LESS_THAN_OR_EQUAL @c7: @c44</td></tr><tr><td align="left">scan options: []</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(STRING AS ZONE, STRING AS DOCID, STRING AS BOOKSHELF, STRING AS TITLE, VECTOR(16, 3) AS EMBEDDING)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">DOCUMENTSGUARDIANNINDEX</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(STRING AS ZONE, STRING AS DOCID, STRING AS BOOKSHELF, STRING AS TITLE, VECTOR(16, 3) AS EMBEDDING)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}—
+í
+guardiann-semantic-search-testsÓEXPLAIN select docId, euclidean_distance(embedding, ?) as distance from documents where zone = 'zone1' and bookshelf = 'fiction' qualify row_number() over ( partition by zone, bookshelf order by euclidean_distance(embedding, ?) asc ) <= 3π
+À«Äﬁ-> ﬂ⁄ê (0Ôä¢8@ÊISCAN(DOCUMENTSGUARDIANNINDEX [EQUALS promote(@c16 AS STRING), EQUALS promote(@c20 AS STRING)]:{DISTANCE_RANK_LESS_THAN_OR_EQUAL @c7: @c44}:[] BY_DISTANCE) | MAP (_.DOCID AS DOCID, (_.EMBEDDING) euclidean_distance @c7 AS DISTANCE)±digraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=line;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q2.DOCID AS DOCID, (q2.EMBEDDING) euclidean_distance @c7 AS DISTANCE)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(STRING AS DOCID, DOUBLE AS DISTANCE)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">prefix comparisons: [EQUALS promote(@c16 AS STRING), EQUALS promote(@c20 AS STRING)]</td></tr><tr><td align="left">distanceRank: DISTANCE_RANK_LESS_THAN_OR_EQUAL @c7: @c44</td></tr><tr><td align="left">scan options: []</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(STRING AS ZONE, STRING AS DOCID, STRING AS BOOKSHELF, STRING AS TITLE, VECTOR(16, 3) AS EMBEDDING)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">DOCUMENTSGUARDIANNINDEX</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(STRING AS ZONE, STRING AS DOCID, STRING AS BOOKSHELF, STRING AS TITLE, VECTOR(16, 3) AS EMBEDDING)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}©
+‰
+guardiann-semantic-search-tests¿EXPLAIN select docId from documents where zone = 'zone1' and bookshelf = 'science' qualify row_number() over ( partition by zone, bookshelf order by euclidean_distance(embedding, ?) asc ) <= 2ø
+ÀÉé¬
+> ıø≠(0Ìà28@¥ISCAN(DOCUMENTSGUARDIANNINDEX [EQUALS promote(@c7 AS STRING), EQUALS promote(@c11 AS STRING)]:{DISTANCE_RANK_LESS_THAN_OR_EQUAL @c29: @c35}:[] BY_DISTANCE) | MAP (_.DOCID AS DOCID)Ídigraph G {
+  fontname=courier;
+  rankdir=BT;
+  splines=line;
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q2.DOCID AS DOCID)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(STRING AS DOCID)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">prefix comparisons: [EQUALS promote(@c7 AS STRING), EQUALS promote(@c11 AS STRING)]</td></tr><tr><td align="left">distanceRank: DISTANCE_RANK_LESS_THAN_OR_EQUAL @c29: @c35</td></tr><tr><td align="left">scan options: []</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(STRING AS ZONE, STRING AS DOCID, STRING AS BOOKSHELF, STRING AS TITLE, VECTOR(16, 3) AS EMBEDDING)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">DOCUMENTSGUARDIANNINDEX</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(STRING AS ZONE, STRING AS DOCID, STRING AS BOOKSHELF, STRING AS TITLE, VECTOR(16, 3) AS EMBEDDING)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}

--- a/yaml-tests/src/test/resources/guardiann-semantic-search.metrics.yaml
+++ b/yaml-tests/src/test/resources/guardiann-semantic-search.metrics.yaml
@@ -1,0 +1,48 @@
+guardiann-semantic-search-tests:
+-   query: EXPLAIN select docId, euclidean_distance(embedding, ?) as distance from
+        documents where zone = 'zone1' and bookshelf = 'fiction' qualify row_number()
+        over ( partition by zone, bookshelf order by euclidean_distance(embedding,
+        ?) asc ) <= 1
+    ref: guardiann-semantic-search.yamsql:60
+    explain: 'ISCAN(DOCUMENTSGUARDIANNINDEX [EQUALS promote(@c16 AS STRING), EQUALS
+        promote(@c20 AS STRING)]:{DISTANCE_RANK_LESS_THAN_OR_EQUAL @c7: @c44}:[] BY_DISTANCE)
+        | MAP (_.DOCID AS DOCID, (_.EMBEDDING) euclidean_distance @c7 AS DISTANCE)'
+    task_count: 203
+    task_total_time_ms: 95
+    transform_count: 62
+    transform_time_ms: 67
+    transform_yield_count: 22
+    insert_time_ms: 4
+    insert_new_count: 17
+    insert_reused_count: 1
+-   query: EXPLAIN select docId, euclidean_distance(embedding, ?) as distance from
+        documents where zone = 'zone1' and bookshelf = 'fiction' qualify row_number()
+        over ( partition by zone, bookshelf order by euclidean_distance(embedding,
+        ?) asc ) <= 3
+    ref: guardiann-semantic-search.yamsql:72
+    explain: 'ISCAN(DOCUMENTSGUARDIANNINDEX [EQUALS promote(@c16 AS STRING), EQUALS
+        promote(@c20 AS STRING)]:{DISTANCE_RANK_LESS_THAN_OR_EQUAL @c7: @c44}:[] BY_DISTANCE)
+        | MAP (_.DOCID AS DOCID, (_.EMBEDDING) euclidean_distance @c7 AS DISTANCE)'
+    task_count: 203
+    task_total_time_ms: 95
+    transform_count: 62
+    transform_time_ms: 67
+    transform_yield_count: 22
+    insert_time_ms: 4
+    insert_new_count: 17
+    insert_reused_count: 1
+-   query: EXPLAIN select docId from documents where zone = 'zone1' and bookshelf
+        = 'science' qualify row_number() over ( partition by zone, bookshelf order
+        by euclidean_distance(embedding, ?) asc ) <= 2
+    ref: guardiann-semantic-search.yamsql:86
+    explain: 'ISCAN(DOCUMENTSGUARDIANNINDEX [EQUALS promote(@c7 AS STRING), EQUALS
+        promote(@c11 AS STRING)]:{DISTANCE_RANK_LESS_THAN_OR_EQUAL @c29: @c35}:[]
+        BY_DISTANCE) | MAP (_.DOCID AS DOCID)'
+    task_count: 203
+    task_total_time_ms: 22
+    transform_count: 62
+    transform_time_ms: 13
+    transform_yield_count: 22
+    insert_time_ms: 0
+    insert_new_count: 17
+    insert_reused_count: 1

--- a/yaml-tests/src/test/resources/guardiann-semantic-search.yamsql
+++ b/yaml-tests/src/test/resources/guardiann-semantic-search.yamsql
@@ -57,6 +57,7 @@ test_block:
                     partition by zone, bookshelf
                     order by euclidean_distance(embedding, !! !v16 [1.0, 0.0, 0.0] !!) asc
                 ) <= 1
+      - explain: "ISCAN(DOCUMENTSGUARDIANNINDEX [EQUALS promote(@c16 AS STRING), EQUALS promote(@c20 AS STRING)]:{DISTANCE_RANK_LESS_THAN_OR_EQUAL @c7: @c44}:[] BY_DISTANCE) | MAP (_.DOCID AS DOCID, (_.EMBEDDING) euclidean_distance @c7 AS DISTANCE)"
       - result: [{docId: 'd1', distance: 0.0}]
 
     # Top-3 nearest neighbors in the fiction partition.
@@ -68,6 +69,7 @@ test_block:
                     partition by zone, bookshelf
                     order by euclidean_distance(embedding, !! !v16 [1.0, 0.0, 0.0] !!) asc
                 ) <= 3
+      - explain: "ISCAN(DOCUMENTSGUARDIANNINDEX [EQUALS promote(@c16 AS STRING), EQUALS promote(@c20 AS STRING)]:{DISTANCE_RANK_LESS_THAN_OR_EQUAL @c7: @c44}:[] BY_DISTANCE) | MAP (_.DOCID AS DOCID, (_.EMBEDDING) euclidean_distance @c7 AS DISTANCE)"
       - result: [{docId: 'd1', distance: 0.0},
                  {docId: 'd2', distance: 0.14147317261689443},
                  {docId: 'd3', distance: 0.28294634523378887}]
@@ -81,4 +83,5 @@ test_block:
                     partition by zone, bookshelf
                     order by euclidean_distance(embedding, !! !v16 [0.0, 1.0, 0.0] !!) asc
                 ) <= 2
+      - explain: "ISCAN(DOCUMENTSGUARDIANNINDEX [EQUALS promote(@c7 AS STRING), EQUALS promote(@c11 AS STRING)]:{DISTANCE_RANK_LESS_THAN_OR_EQUAL @c29: @c35}:[] BY_DISTANCE) | MAP (_.DOCID AS DOCID)"
       - result: [{docId: 'd6'}, {docId: 'd7'}]

--- a/yaml-tests/src/test/resources/guardiann-semantic-search.yamsql
+++ b/yaml-tests/src/test/resources/guardiann-semantic-search.yamsql
@@ -1,0 +1,84 @@
+#
+# guardiann-semantic-search.yamsql
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2021-2026 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# End-to-end SQL coverage for a vector index backed by the Guardiann engine, created through the DDL
+# ('USING GUARDIANN' with the guardiann-only 'primary_cluster_*' options plus the shared 'metric' option). The dataset
+# is small and well-separated so it forms a single cluster per partition, making the k-nearest-neighbor results exact.
+#
+# supported_version is !current_version because the Guardiann engine is new: no released server understands
+# 'USING GUARDIANN', so this file only runs against the current build (and is skipped in mixed-version mode).
+---
+options:
+  supported_version: !current_version
+---
+schema_template:
+    create table documents(zone string, docId string, bookshelf string, title string, embedding vector(3, half), primary key (zone, docId))
+    create view documentsView as select embedding, zone, bookshelf, docId, title from documents
+    create vector index documentsGuardiannIndex using guardiann on documentsView(embedding) partition by(zone, bookshelf) options (metric = euclidean_metric, primary_cluster_min = 1, primary_cluster_max = 100)
+---
+test_block:
+  name: guardiann-semantic-search-tests
+  preset: single_repetition_ordered
+  options:
+    statement_type: prepared
+  tests:
+    # Seed two partitions: (zone1, fiction) and (zone1, science).
+    -
+      - query: insert into documents values
+              ('zone1', 'd1', 'fiction', 'The Great Gatsby', !! !v16 [1.0, 0.0, 0.0] !!),
+              ('zone1', 'd2', 'fiction', '1984', !! !v16 [0.9, 0.1, 0.0] !!),
+              ('zone1', 'd3', 'fiction', 'To Kill a Mockingbird', !! !v16 [0.8, 0.2, 0.0] !!),
+              ('zone1', 'd6', 'science', 'A Brief History of Time', !! !v16 [0.0, 1.0, 0.0] !!),
+              ('zone1', 'd7', 'science', 'The Selfish Gene', !! !v16 [0.1, 0.9, 0.0] !!)
+      - count: 5
+
+    # Top-1 nearest neighbor in the fiction partition — an exact match, so distance is 0.
+    -
+      - query: select docId, euclidean_distance(embedding, !! !v16 [1.0, 0.0, 0.0] !!) as distance
+              from documents
+              where zone = 'zone1' and bookshelf = 'fiction'
+              qualify row_number() over (
+                    partition by zone, bookshelf
+                    order by euclidean_distance(embedding, !! !v16 [1.0, 0.0, 0.0] !!) asc
+                ) <= 1
+      - result: [{docId: 'd1', distance: 0.0}]
+
+    # Top-3 nearest neighbors in the fiction partition.
+    -
+      - query: select docId, euclidean_distance(embedding, !! !v16 [1.0, 0.0, 0.0] !!) as distance
+              from documents
+              where zone = 'zone1' and bookshelf = 'fiction'
+              qualify row_number() over (
+                    partition by zone, bookshelf
+                    order by euclidean_distance(embedding, !! !v16 [1.0, 0.0, 0.0] !!) asc
+                ) <= 3
+      - result: [{docId: 'd1', distance: 0.0},
+                 {docId: 'd2', distance: 0.14147317261689443},
+                 {docId: 'd3', distance: 0.28294634523378887}]
+
+    # Top-2 nearest neighbors in the science partition.
+    -
+      - query: select docId
+              from documents
+              where zone = 'zone1' and bookshelf = 'science'
+              qualify row_number() over (
+                    partition by zone, bookshelf
+                    order by euclidean_distance(embedding, !! !v16 [0.0, 1.0, 0.0] !!) asc
+                ) <= 2
+      - result: [{docId: 'd6'}, {docId: 'd7'}]


### PR DESCRIPTION
Makes the vector engine selectable in DDL, so `CREATE VECTOR INDEX ... USING GUARDIANN` works alongside the existing USING HNSW, and GuardiANN's tuning options are reachable from SQL. This is what lets us write real end-to-end tests against the engine and gives customers a way to actually use it.

The bigger change underneath is how vector options get parsed. Instead of every option being its own keyword alternative in the grammar, the parser now takes a generic `name = value` pair and the DDL visitor decides what's valid, driven by a table mapping each SQL option name to its typed record-layer key plus the engines it applies to. Adding an option, dropping one, or moving it between engines is a one-line edit with no grammar change. Using an HNSW-only option on a GuardiANN index (or the reverse) gets rejected with a clear error, as does an unknown option name. Pleasant side effect: the ten former option keywords are no longer reserved words, so they work as ordinary identifiers now.

HNSW stays implicit in the stored metadata, only GuardiANN writes the engine option, so HNSW index metadata is byte-identical to before and still readable by nodes that predate the option. Coverage is a handful of DDL tests for the happy path and both engine-mismatch rejections, plus a `guardiann-semantic-search.yamsql` suite that goes end to end through inserts and k-nearest-neighbor queries. That one's pinned to the current version, since no released server understands `USING GUARDIANN` just yet.

This resolves #4407 