### PR TITLE
Allow for the `MetaDataEvolutionValidator` to be configured to ignore a fixed set of options

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/IndexValidator.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/IndexValidator.java
@@ -28,9 +28,6 @@ import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.KeyWithValueExpression;
 
 import javax.annotation.Nonnull;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -168,35 +165,6 @@ public class IndexValidator {
     }
 
     /**
-     * Get a set containing all changed index options. This compares the options map of the
-     * index associated with this validator with the options map of an older version of that
-     * index. Any option whose value has been changed (including options that have been added
-     * or removed) are added to the set.
-     *
-     * @param oldIndex an older version of the index associated with this validator
-     * @return a set of option names that have had their value changed
-     * @see #validateChangedOptions(Index)
-     */
-    @Nonnull
-    private Set<String> getChangedOptions(@Nonnull Index oldIndex) {
-        Set<String> changedOptions = new HashSet<>();
-        for (Map.Entry<String, String> oldOptionEntry : oldIndex.getOptions().entrySet()) {
-            final String optionName = oldOptionEntry.getKey();
-            final String newOptionValue = index.getOption(optionName);
-            if (!Objects.equals(oldOptionEntry.getValue(), newOptionValue)) {
-                changedOptions.add(optionName);
-            }
-        }
-        for (Map.Entry<String, String> newOptionEntry : index.getOptions().entrySet()) {
-            final String optionName = newOptionEntry.getKey();
-            if (!oldIndex.getOptions().containsKey(optionName) && newOptionEntry.getValue() != null) {
-                changedOptions.add(optionName);
-            }
-        }
-        return changedOptions;
-    }
-
-    /**
      * Validate any option changes included in the set of changed options provided.
      * This is a natural extension point for subclasses which may wish to override how
      * certain options are handled. This function should look at <em>only</em> the options
@@ -211,11 +179,19 @@ public class IndexValidator {
      *     <li>Call {@code super.validateChangedOptions(oldIndex, changedOptions} to handle common options.</li>
      * </ol>
      *
+     * <p>
+     * In general, an option should be considered safe to mutate if it does not impact the
+     * stored data. For example, {@link IndexOptions#ALLOWED_FOR_QUERY_OPTION} only determines
+     * whether an index may be selected by the planner, so it safe to mutate at any time. Some
+     * options, like {@link IndexOptions#UNIQUE_OPTION}, may be safe to mutate but only in certain
+     * ways (e.g., it is safe to <em>remove</em> a uniqueness constraint, but not to add one).
+     * </p>
+     *
      * @param oldIndex an older version of this validator's index
      * @param changedOptions the set of changed options to inspect
      */
     @API(API.Status.EXPERIMENTAL)
-    protected void validateChangedOptions(@Nonnull Index oldIndex, @Nonnull Set<String> changedOptions) {
+    public void validateChangedOptions(@Nonnull Index oldIndex, @Nonnull Set<String> changedOptions) {
         for (String changedOption : changedOptions) {
             if (changedOption.startsWith(IndexOptions.REPLACED_BY_OPTION_PREFIX)) {
                 // The set of replacement indexes can be safely added or removed on existing indexes as it
@@ -244,31 +220,5 @@ public class IndexValidator {
                             LogMessageKeys.NEW_OPTION, newValue);
             }
         }
-    }
-
-    /**
-     * Validate any options that have changed. This should inspect the options of {@code oldIndex},
-     * which will be an older version of this index, and determine if all index option changes
-     * are valid. In particular, this should validate that none of the changes necessitate any
-     * on-disk changes or index rebuilds. For example, it is generally legal to drop a
-     * {@linkplain IndexOptions#UNIQUE_OPTION uniqueness} constraint from an index, but it is
-     * not legal to change the {@linkplain IndexOptions#TEXT_TOKENIZER_NAME_OPTION tokenizer}
-     * of a text index.
-     *
-     * <p>
-     * The default behavior is to allow the index to go from having a uniqueness constraint to not
-     * having one as well as allowing any change to the option specifying whether the index may be
-     * {@linkplain IndexOptions#ALLOWED_FOR_QUERY_OPTION used for queries}, but all other changes are
-     * rejected. If an index type would like to different behavior because some options specific
-     * to it may be safely changed, the validator for that type should either override this method
-     * or {@link #validateChangedOptions(Index, Set)}.
-     * </p>
-     *
-     * @param oldIndex an older version of this validator's index
-     * @see #validateChangedOptions(Index, Set)
-     */
-    @API(API.Status.EXPERIMENTAL)
-    public void validateChangedOptions(@Nonnull Index oldIndex) {
-        validateChangedOptions(oldIndex, getChangedOptions(oldIndex));
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/MetaDataEvolutionValidator.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/MetaDataEvolutionValidator.java
@@ -32,6 +32,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Verify;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.protobuf.Descriptors;
@@ -41,6 +42,7 @@ import com.google.protobuf.Descriptors.FieldDescriptor;
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -107,6 +109,8 @@ public class MetaDataEvolutionValidator {
     private final boolean allowOlderFormerIndexAddedVersions;
     private final boolean allowUnsplitToSplit;
     private final boolean disallowTypeRenames;
+    @Nonnull
+    private final Set<String> ignoredIndexOptions;
 
     private MetaDataEvolutionValidator() {
         this.indexValidatorRegistry = IndexMaintainerFactoryRegistryImpl.instance();
@@ -120,6 +124,7 @@ public class MetaDataEvolutionValidator {
         this.allowOlderFormerIndexAddedVersions = false;
         this.allowUnsplitToSplit = false;
         this.disallowTypeRenames = false;
+        this.ignoredIndexOptions = ImmutableSet.of();
     }
 
     private MetaDataEvolutionValidator(@Nonnull Builder builder) {
@@ -134,6 +139,7 @@ public class MetaDataEvolutionValidator {
         this.allowOlderFormerIndexAddedVersions = builder.allowOlderFormerIndexAddedVersions;
         this.allowUnsplitToSplit = builder.allowUnsplitToSplit;
         this.disallowTypeRenames = builder.disallowTypeRenames;
+        this.ignoredIndexOptions = ImmutableSet.copyOf(builder.ignoredIndexOptions);
     }
 
     /**
@@ -743,10 +749,50 @@ public class MetaDataEvolutionValidator {
         }
         // If there have been any changes to the index options, ask the index validator for that type
         // to validate the changed options.
-        if (!oldIndex.getOptions().equals(newIndex.getOptions())) {
+        Set<String> changedOptions = getChangedOptions(oldIndex, newIndex);
+        if (!changedOptions.isEmpty()) {
             IndexValidator validatorForIndex = indexValidatorRegistry.getIndexValidator(newIndex);
-            validatorForIndex.validateChangedOptions(oldIndex);
+            validatorForIndex.validateChangedOptions(oldIndex, changedOptions);
         }
+    }
+
+    /**
+     * Get a set containing all changed index options. This compares the options map of the
+     * two versions of the index and returns any that have changed, including options that
+     * are set in only one version and keys in both where the value has changed. It ignores
+     * any options that are in the {@code ignoredIndexOptions} set.
+     *
+     * <p>
+     * This returns a mutable set. This is important, as it is handed to {@link IndexValidator#validateChangedOptions(Index, Set)},
+     * which requires in its contract that the set it is given is mutable.
+     * </p>
+     *
+     * @param oldIndex an older version of the index
+     * @param newIndex a newer version of the same index
+     * @return a mutable set of option names that have had their value changed
+     */
+    @Nonnull
+    private Set<String> getChangedOptions(@Nonnull Index oldIndex, @Nonnull Index newIndex) {
+        Set<String> changedOptions = new HashSet<>();
+        for (Map.Entry<String, String> oldOptionEntry : oldIndex.getOptions().entrySet()) {
+            final String optionName = oldOptionEntry.getKey();
+            if (ignoredIndexOptions.contains(optionName)) {
+                continue;
+            }
+            final String newOptionValue = newIndex.getOption(optionName);
+            if (!Objects.equals(oldOptionEntry.getValue(), newOptionValue)) {
+                changedOptions.add(optionName);
+            }
+        }
+        for (Map.Entry<String, String> newOptionEntry : newIndex.getOptions().entrySet()) {
+            final String optionName = newOptionEntry.getKey();
+            if (!ignoredIndexOptions.contains(optionName)
+                    && !oldIndex.getOptions().containsKey(optionName)
+                    && newOptionEntry.getValue() != null) {
+                changedOptions.add(optionName);
+            }
+        }
+        return changedOptions;
     }
 
     /**
@@ -943,7 +989,7 @@ public class MetaDataEvolutionValidator {
     /**
      * Whether this validator disallows record types from being renamed. The record type name is not
      * persisted to the database with any record, so renaming a record type is generally possible
-     * as long as one also updates the record type's name in the any referencing index. Note, however,
+     * as long as one also updates the record type's name in any referencing index. Note, however,
      * that renaming a record type also requires that the user modify any existing queries that are
      * restricted to that record type. As a result, the user may elect to disallow renaming record types
      * to avoid needing to audit and update any references to the changed record type name.
@@ -952,6 +998,28 @@ public class MetaDataEvolutionValidator {
      */
     public boolean disallowsTypeRenames() {
         return disallowTypeRenames;
+    }
+
+    /**
+     * Get the set of index options that are ignored when validating an index's evolution.
+     * In general, index option validation is handled by the appropriate {@link IndexValidator} for
+     * the index, which is determined by its type. However, if there are any index options that are
+     * ignored by the index maintainer implementations but that the adopter uses for their own
+     * bookkeeping purposes, they may need to configure this validator to ignore any changes to
+     * those index options.
+     *
+     * <p>
+     * This returns an immutable collection. The caller should not attempt to add or remove elements
+     * from the returned set.
+     * </p>
+     *
+     * @return the set of index options that this validator ignores any changes to
+     * @see IndexValidator#validateChangedOptions(Index, Set)
+     * @see #getIndexValidatorRegistry()
+     */
+    @Nonnull
+    public Set<String> getIgnoredIndexOptions() {
+        return ignoredIndexOptions;
     }
 
     /**
@@ -1003,6 +1071,8 @@ public class MetaDataEvolutionValidator {
         private boolean allowOlderFormerIndexAddedVersions;
         private boolean allowUnsplitToSplit;
         private boolean disallowTypeRenames;
+        @Nonnull
+        private Set<String> ignoredIndexOptions;
 
         private Builder(@Nonnull MetaDataEvolutionValidator validator) {
             this.indexValidatorRegistry = validator.indexValidatorRegistry;
@@ -1016,6 +1086,7 @@ public class MetaDataEvolutionValidator {
             this.allowOlderFormerIndexAddedVersions = validator.allowOlderFormerIndexAddedVersions;
             this.allowUnsplitToSplit = validator.allowUnsplitToSplit;
             this.disallowTypeRenames = validator.disallowTypeRenames;
+            this.ignoredIndexOptions = ImmutableSet.copyOf(validator.ignoredIndexOptions);
         }
 
         /**
@@ -1279,6 +1350,38 @@ public class MetaDataEvolutionValidator {
          */
         public boolean disallowsTypeRenames() {
             return disallowTypeRenames;
+        }
+
+        /**
+         * Sets which index options (if any) should be ignored during index evolution validation.
+         * This copies the data into the builder, so any mutations made to the original collection
+         * after calling this method will not be reflected in the final validator.
+         *
+         * @param ignoredIndexOptions a collection of options that will be ignored during validation
+         * @return this builder
+         * @see MetaDataEvolutionValidator#getIgnoredIndexOptions()
+         */
+        @CanIgnoreReturnValue
+        @Nonnull
+        public Builder setIgnoredIndexOptions(@Nonnull Collection<String> ignoredIndexOptions) {
+            this.ignoredIndexOptions = ImmutableSet.copyOf(ignoredIndexOptions);
+            return this;
+        }
+
+        /**
+         * Get the set of index options that are ignored when validating an index's evolution.
+         *
+         * <p>
+         * This returns an immutable collection. The caller should not attempt to add or remove elements
+         * from the returned set.
+         * </p>
+         *
+         * @return the set of index options that this validator ignores any changes to
+         * @see MetaDataEvolutionValidator#getIgnoredIndexOptions()
+         */
+        @Nonnull
+        public Set<String> getIgnoredIndexOptions() {
+            return ignoredIndexOptions;
         }
 
         /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexMaintainerFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/TextIndexMaintainerFactory.java
@@ -150,7 +150,7 @@ public class TextIndexMaintainerFactory implements IndexMaintainerFactory {
              * @param changedOptions the set of changed options
              */
             @Override
-            protected void validateChangedOptions(@Nonnull Index oldIndex, @Nonnull Set<String> changedOptions) {
+            public void validateChangedOptions(@Nonnull Index oldIndex, @Nonnull Set<String> changedOptions) {
                 for (String changedOption : changedOptions) {
                     switch (changedOption) {
                         case IndexOptions.TEXT_ADD_AGGRESSIVE_CONFLICT_RANGES_OPTION:

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/MetaDataEvolutionValidatorBuilderTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/MetaDataEvolutionValidatorBuilderTest.java
@@ -24,11 +24,15 @@ import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerFactor
 import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests of the {@link MetaDataEvolutionValidator.Builder} class. These tests are mainly present to make sure
@@ -164,5 +168,39 @@ class MetaDataEvolutionValidatorBuilderTest {
                 MetaDataEvolutionValidator.Builder::setDisallowTypeRenames,
                 MetaDataEvolutionValidator.Builder::disallowsTypeRenames,
                 MetaDataEvolutionValidator::disallowsTypeRenames);
+    }
+
+    @Test
+    void ignoredIndexOptions() {
+        testSettingOption("ignoredIndexOptions",
+                MetaDataEvolutionValidator.Builder::setIgnoredIndexOptions,
+                MetaDataEvolutionValidator.Builder::getIgnoredIndexOptions,
+                MetaDataEvolutionValidator::getIgnoredIndexOptions,
+                List.of(Collections.emptySet(), Collections.singleton("blah"), Set.of("a", "b", "c")));
+
+        // Data structure is copied, so it should not reflect mutations after calling "set"
+        final Set<String> mutableSet = new HashSet<>(List.of("a", "b", "c"));
+        final MetaDataEvolutionValidator.Builder builder = MetaDataEvolutionValidator.newBuilder()
+                .setIgnoredIndexOptions(mutableSet);
+        mutableSet.add("d");
+        assertThat(builder.getIgnoredIndexOptions())
+                .isNotEqualTo(mutableSet)
+                .containsExactlyInAnyOrder("a", "b", "c");
+        final MetaDataEvolutionValidator validator = builder.build();
+        assertThat(validator.getIgnoredIndexOptions())
+                .isNotEqualTo(mutableSet)
+                .containsExactlyInAnyOrder("a", "b", "c");
+
+        // Should not be able to mutate the return value of getIgnoredIndexOptions()
+        assertThatThrownBy(() -> builder.getIgnoredIndexOptions().add("e"))
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> validator.getIgnoredIndexOptions().add("f"))
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThat(mutableSet)
+                .containsExactlyInAnyOrder("a", "b", "c", "d");
+        assertThat(builder.getIgnoredIndexOptions())
+                .containsExactlyInAnyOrder("a", "b", "c");
+        assertThat(validator.getIgnoredIndexOptions())
+                .containsExactlyInAnyOrder("a", "b", "c");
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/MetaDataEvolutionValidatorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/metadata/MetaDataEvolutionValidatorTest.java
@@ -30,6 +30,7 @@ import com.apple.foundationdb.record.TestRecords1Proto;
 import com.apple.foundationdb.record.TestRecords4Proto;
 import com.apple.foundationdb.record.TestRecordsEnumProto;
 import com.apple.foundationdb.record.TestRecordsIdenticalTypesProto;
+import com.apple.foundationdb.record.TestRecordsMultidimensionalProto;
 import com.apple.foundationdb.record.TestRecordsWithHeaderProto;
 import com.apple.foundationdb.record.evolution.TestHeaderAsGroupProto;
 import com.apple.foundationdb.record.evolution.TestMergedNestedTypesProto;
@@ -39,6 +40,7 @@ import com.apple.foundationdb.record.evolution.TestSelfReferenceUnspooledProto;
 import com.apple.foundationdb.record.evolution.TestSplitNestedTypesProto;
 import com.apple.foundationdb.record.evolution.TestUnmergedNestedTypesProto;
 import com.apple.foundationdb.record.expressions.RecordKeyExpressionProto;
+import com.apple.foundationdb.record.metadata.expressions.DimensionsKeyExpression;
 import com.apple.foundationdb.record.provider.common.text.AllSuffixesTextTokenizer;
 import com.apple.foundationdb.record.provider.common.text.DefaultTextTokenizer;
 import com.apple.foundationdb.record.provider.common.text.PrefixTextTokenizer;
@@ -46,6 +48,7 @@ import com.apple.foundationdb.record.provider.common.text.TextTokenizer;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerFactoryRegistryImpl;
 import com.apple.foundationdb.tuple.Tuple;
 import com.apple.test.ParameterizedTestUtils;
+import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.DescriptorProtos;
 import com.google.protobuf.Descriptors;
@@ -64,6 +67,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
@@ -2142,12 +2146,20 @@ class MetaDataEvolutionValidatorTest {
         RecordMetaData metaData1 = RecordMetaData.build(TestRecords1Proto.getDescriptor());
         validateIndexMutation("index adds uniqueness constraint", metaData1, "MySimpleRecord$str_value_indexed", this::makeUnique);
 
-        // Removing the uniqueness constraint is fine
+        // If we ignore the unique option, then it succeeds
         RecordMetaData metaData2 = replaceIndex(metaData1, "MySimpleRecord$str_value_indexed", this::makeUnique);
+        final MetaDataEvolutionValidator laxerValidator = validator.asBuilder()
+                .setIgnoredIndexOptions(Set.of(IndexOptions.UNIQUE_OPTION))
+                .build();
+        laxerValidator.validate(metaData1, metaData2);
+
+        // Removing the uniqueness constraint is fine
         RecordMetaData metaData3 = replaceIndex(metaData2, "MySimpleRecord$str_value_indexed", this::clearOptions);
         validator.validate(metaData2, metaData3);
+        laxerValidator.validate(metaData2, metaData3);
         RecordMetaData metaData4 = replaceIndex(metaData2, "MySimpleRecord$str_value_indexed", indexProto -> changeOption(indexProto, IndexOptions.UNIQUE_OPTION, "false"));
         validator.validate(metaData2, metaData4);
+        laxerValidator.validate(metaData2, metaData4);
     }
 
     @Test
@@ -2204,8 +2216,16 @@ class MetaDataEvolutionValidatorTest {
         RecordMetaData metaData3 = replaceIndex(metaData2, "MySimpleRecord$str_value_indexed",
                 indexProto -> changeOption(indexProto, IndexOptions.UNIQUE_OPTION, null));
         validator.validate(metaData2, metaData3);
-        validateIndexMutation("index option changed", metaData3, "MySimpleRecord$str_value_indexed",
-                indexProto -> changeOption(indexProto, "dummyOption", "dummyValue2"));
+
+        final UnaryOperator<RecordMetaDataProto.Index> dummyOptionMutation = indexProto -> changeOption(indexProto, "dummyOption", "dummyValue2");
+        validateIndexMutation("index option changed", metaData3, "MySimpleRecord$str_value_indexed", dummyOptionMutation);
+
+        // Ignore the unknown option completely. Validation should now pass
+        final MetaDataEvolutionValidator laxerValidator = validator.asBuilder()
+                .setIgnoredIndexOptions(Set.of("dummyOption"))
+                .build();
+        final RecordMetaData metaData4 = replaceIndex(metaData3, "MySimpleRecord$str_value_indexed", dummyOptionMutation);
+        laxerValidator.validate(metaData3, metaData4);
     }
 
     @Test
@@ -2275,6 +2295,45 @@ class MetaDataEvolutionValidatorTest {
     }
 
     @Test
+    void ignoreSomeButNotAllDisallowedChanges() {
+        final String indexName = "MyMultidimensionalRecord$(start, end)+domain_by_calendar";
+        RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder().setRecords(TestRecordsMultidimensionalProto.getDescriptor());
+        RecordTypeBuilder typeBuilder = metaDataBuilder.getRecordType("MyMultidimensionalRecord");
+        typeBuilder.setPrimaryKey(Key.Expressions.field("rec_no"));
+        metaDataBuilder.addIndex(typeBuilder,
+                new Index(indexName,
+                        DimensionsKeyExpression.of(Key.Expressions.field("calendar_name"), Key.Expressions.concatenateFields("start_epoch", "end_epoch"), Key.Expressions.field("info").nest("rec_domain")),
+                        IndexTypes.MULTIDIMENSIONAL,
+                        Map.of(IndexOptions.RTREE_STORAGE, "BY_SLOT", IndexOptions.RTREE_USE_NODE_SLOT_INDEX, "false", IndexOptions.ALLOWED_FOR_QUERY_OPTION, "true")));
+        RecordMetaData metaData1 = metaDataBuilder.getRecordMetaData();
+
+        // Change three options. The two R-tree specific options are not allowed to change (unless we ignore them), while
+        // the "allowed for query" option can be arbitrarily modified.
+        // The error we get back should reflect that one of the two R-tree options changed, though it isn't strictly important which
+        RecordMetaData metaData2 = replaceIndex(metaData1, indexName, indexProto ->
+                changeOption(changeOption(changeOption(indexProto, IndexOptions.RTREE_STORAGE, "BY_NODE"), IndexOptions.RTREE_USE_NODE_SLOT_INDEX, "true"), IndexOptions.ALLOWED_FOR_QUERY_OPTION, "false"));
+        assertInvalid("rtree storage changed", metaData1, metaData2);
+
+        // Ignore one of the options. The error should reflect the change in the other option
+        MetaDataEvolutionValidator ignoreSlotIndexValidator = validator.asBuilder()
+                .setIgnoredIndexOptions(ImmutableSet.of(IndexOptions.RTREE_USE_NODE_SLOT_INDEX))
+                .build();
+        assertInvalid("rtree storage changed", ignoreSlotIndexValidator, metaData1, metaData2);
+
+        // Ignore the other option. The error should reflect the change in the first option now
+        MetaDataEvolutionValidator ignoreStorageValidator = validator.asBuilder()
+                .setIgnoredIndexOptions(ImmutableSet.of(IndexOptions.RTREE_STORAGE))
+                .build();
+        assertInvalid("rtree use node slot index changed", ignoreStorageValidator, metaData1, metaData2);
+
+        // Ignore both R-tree options. We should now validate.
+        MetaDataEvolutionValidator ignoreBothOptionsValidator = validator.asBuilder()
+                .setIgnoredIndexOptions(ImmutableSet.of(IndexOptions.RTREE_STORAGE, IndexOptions.RTREE_USE_NODE_SLOT_INDEX))
+                .build();
+        ignoreBothOptionsValidator.validate(metaData1, metaData2);
+    }
+
+    @Test
     void optionChangeAllowedWithCustomIndexValidatorRegistry() {
         RecordMetaData metaData1 = RecordMetaData.build(TestRecords1Proto.getDescriptor());
         RecordMetaData metaData2 = replaceIndex(metaData1, "MySimpleRecord$str_value_indexed", this::makeUnique);
@@ -2295,7 +2354,7 @@ class MetaDataEvolutionValidatorTest {
         }
 
         @Override
-        protected void validateChangedOptions(@Nonnull final Index oldIndex, @Nonnull final Set<String> changedOptions) {
+        public void validateChangedOptions(@Nonnull final Index oldIndex, @Nonnull final Set<String> changedOptions) {
             // Always say it's good to go
         }
     }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/GuardiannVectorIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/GuardiannVectorIndexTest.java
@@ -21,27 +21,16 @@
 package com.apple.foundationdb.record.provider.foundationdb.indexes;
 
 import com.apple.foundationdb.linear.Metric;
+import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.IndexOptions;
-import com.apple.foundationdb.record.metadata.IndexTypes;
-import com.apple.foundationdb.record.metadata.IndexValidator;
-import com.apple.foundationdb.record.metadata.MetaDataException;
-import com.apple.foundationdb.record.metadata.MetaDataValidator;
-import com.apple.foundationdb.record.metadata.expressions.KeyWithValueExpression;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
-import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerFactory;
-import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerFactoryRegistry;
 import com.google.common.collect.ImmutableMap;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
-
-import static com.apple.foundationdb.record.metadata.Key.Expressions.concat;
-import static com.apple.foundationdb.record.metadata.Key.Expressions.field;
 
 /**
  * Vector index tests against the Guardiann engine. The behavioral scenarios are inherited from
@@ -68,21 +57,16 @@ class GuardiannVectorIndexTest extends VectorIndexEngineTestSuite {
     }
 
     @Test
-    void directIndexValidatorTest() throws Exception {
+    void optionsEvolutionTest() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openRecordStore(context, this::addGroupedVectorIndex);
 
-            final Index index =
-                    Objects.requireNonNull(recordStore.getMetaDataProvider())
-                            .getRecordMetaData().getIndex("GroupedVectorIndex");
-            final IndexMaintainerFactoryRegistry indexMaintainerRegistry = recordStore.getIndexMaintainerRegistry();
-            final MetaDataValidator metaDataValidator =
-                    new MetaDataValidator(recordStore.getRecordMetaData(), indexMaintainerRegistry);
-            metaDataValidator.validate();
+            final RecordMetaData metaData = recordStore.getRecordMetaData();
+            final Index index = metaData.getIndex("GroupedVectorIndex");
 
             // re-specifying every option at its current value is always allowed, and the mutable (stats/concurrency)
             // knobs may take new values
-            validateIndexEvolution(metaDataValidator, index,
+            validateOptionsEvolution(metaData, index,
                     ImmutableMap.<String, String>builder()
                             // immutable — must be re-specified at the same value
                             .put(IndexOptions.VECTOR_ENGINE, VectorIndexEngine.Kind.GUARDIANN.name())
@@ -103,40 +87,33 @@ class GuardiannVectorIndexTest extends VectorIndexEngineTestSuite {
                             .put(IndexOptions.GUARDIANN_BOUNCE_CONCURRENCY, "5").build());
 
             // switching the engine is never allowed
-            Assertions.assertThatThrownBy(() -> validateIndexEvolution(metaDataValidator, index,
-                    optionsWith(IndexOptions.VECTOR_ENGINE, VectorIndexEngine.Kind.HNSW.name())))
-                    .isInstanceOf(MetaDataException.class);
+            assertInvalidOptionsEvolution(metaData, index,
+                    optionsWith(IndexOptions.VECTOR_ENGINE, VectorIndexEngine.Kind.HNSW.name()));
 
             // changing an immutable encoding option is not allowed
-            Assertions.assertThatThrownBy(() -> validateIndexEvolution(metaDataValidator, index,
-                    optionsWith(IndexOptions.VECTOR_METRIC, Metric.COSINE_METRIC.name())))
-                    .isInstanceOf(MetaDataException.class);
+            assertInvalidOptionsEvolution(metaData, index,
+                    optionsWith(IndexOptions.VECTOR_METRIC, Metric.COSINE_METRIC.name()));
 
-            Assertions.assertThatThrownBy(() -> validateIndexEvolution(metaDataValidator, index,
-                    optionsWith(IndexOptions.VECTOR_NUM_DIMENSIONS, "768")))
-                    .isInstanceOf(MetaDataException.class);
+            assertInvalidOptionsEvolution(metaData, index,
+                    optionsWith(IndexOptions.VECTOR_NUM_DIMENSIONS, "768"));
 
             // changing an immutable cluster-shape knob is not allowed
-            Assertions.assertThatThrownBy(() -> validateIndexEvolution(metaDataValidator, index,
-                    optionsWith(IndexOptions.GUARDIANN_PRIMARY_CLUSTER_MAX, "500")))
-                    .isInstanceOf(MetaDataException.class);
+            assertInvalidOptionsEvolution(metaData, index,
+                    optionsWith(IndexOptions.GUARDIANN_PRIMARY_CLUSTER_MAX, "500"));
 
-            Assertions.assertThatThrownBy(() -> validateIndexEvolution(metaDataValidator, index,
-                    optionsWith(IndexOptions.GUARDIANN_PRIMARY_CLUSTER_MIN, "50")))
-                    .isInstanceOf(MetaDataException.class);
+            assertInvalidOptionsEvolution(metaData, index,
+                    optionsWith(IndexOptions.GUARDIANN_PRIMARY_CLUSTER_MIN, "50"));
 
             // changing an immutable construction-time centroid-walk knob is not allowed: an index must be built with a
             // single, fixed set of construction tuning
-            Assertions.assertThatThrownBy(() -> validateIndexEvolution(metaDataValidator, index,
-                    optionsWith(IndexOptions.GUARDIANN_CONSTRUCTION_CENTROID_EF_RING_SEARCH, "250")))
-                    .isInstanceOf(MetaDataException.class);
+            assertInvalidOptionsEvolution(metaData, index,
+                    optionsWith(IndexOptions.GUARDIANN_CONSTRUCTION_CENTROID_EF_RING_SEARCH, "250"));
 
-            Assertions.assertThatThrownBy(() -> validateIndexEvolution(metaDataValidator, index,
-                    optionsWith(IndexOptions.GUARDIANN_CONSTRUCTION_CENTROID_EF_OUTWARD_SEARCH, "800")))
-                    .isInstanceOf(MetaDataException.class);
+            assertInvalidOptionsEvolution(metaData, index,
+                    optionsWith(IndexOptions.GUARDIANN_CONSTRUCTION_CENTROID_EF_OUTWARD_SEARCH, "800"));
 
             // a mutable knob may change on its own
-            validateIndexEvolution(metaDataValidator, index,
+            validateOptionsEvolution(metaData, index,
                     optionsWith(IndexOptions.GUARDIANN_SPLIT_MERGE_CONCURRENCY, "7"));
         }
     }
@@ -155,23 +132,5 @@ class GuardiannVectorIndexTest extends VectorIndexEngineTestSuite {
         final Map<String, String> merged = new HashMap<>(indexOptions());
         merged.put(key, value);
         return ImmutableMap.copyOf(merged);
-    }
-
-    private void validateIndexEvolution(@Nonnull final MetaDataValidator metaDataValidator,
-                                        @Nonnull final Index oldIndex, @Nonnull final Map<String, String> optionsMap) {
-        final Index newIndex =
-                new Index("GroupedVectorIndex",
-                        new KeyWithValueExpression(concat(field("group_id"), field("vector_data")), 1),
-                        IndexTypes.VECTOR,
-                        optionsMap);
-
-        final IndexMaintainerFactoryRegistry indexMaintainerRegistry = recordStore.getIndexMaintainerRegistry();
-        final IndexMaintainerFactory indexMaintainerFactory =
-                indexMaintainerRegistry.getIndexMaintainerFactory(oldIndex);
-
-        final IndexValidator validatorForCompatibleNewIndex =
-                indexMaintainerFactory.getIndexValidator(newIndex);
-        validatorForCompatibleNewIndex.validate(metaDataValidator);
-        validatorForCompatibleNewIndex.validateChangedOptions(oldIndex);
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/HnswVectorIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/HnswVectorIndexTest.java
@@ -21,26 +21,15 @@
 package com.apple.foundationdb.record.provider.foundationdb.indexes;
 
 import com.apple.foundationdb.linear.Metric;
+import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.IndexOptions;
-import com.apple.foundationdb.record.metadata.IndexTypes;
-import com.apple.foundationdb.record.metadata.IndexValidator;
-import com.apple.foundationdb.record.metadata.MetaDataException;
-import com.apple.foundationdb.record.metadata.MetaDataValidator;
-import com.apple.foundationdb.record.metadata.expressions.KeyWithValueExpression;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
-import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerFactory;
-import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerFactoryRegistry;
 import com.google.common.collect.ImmutableMap;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import java.util.Map;
-import java.util.Objects;
-
-import static com.apple.foundationdb.record.metadata.Key.Expressions.concat;
-import static com.apple.foundationdb.record.metadata.Key.Expressions.field;
 
 /**
  * Vector index tests against the HNSW engine. The behavioral scenarios are inherited from
@@ -58,20 +47,15 @@ class HnswVectorIndexTest extends VectorIndexEngineTestSuite {
     }
 
     @Test
-    void directIndexValidatorTest() throws Exception {
+    void optionsEvolutionTest() throws Exception {
         try (FDBRecordContext context = openContext()) {
             openRecordStore(context, this::addGroupedVectorIndex);
 
-            final Index index =
-                    Objects.requireNonNull(recordStore.getMetaDataProvider())
-                            .getRecordMetaData().getIndex("GroupedVectorIndex");
-            final IndexMaintainerFactoryRegistry indexMaintainerRegistry = recordStore.getIndexMaintainerRegistry();
-            final MetaDataValidator metaDataValidator =
-                    new MetaDataValidator(recordStore.getRecordMetaData(), indexMaintainerRegistry);
-            metaDataValidator.validate();
+            final RecordMetaData metaData = recordStore.getRecordMetaData();
+            final Index index = metaData.getIndex("GroupedVectorIndex");
 
             // validate the allowed changes all at once
-            validateIndexEvolution(metaDataValidator, index,
+            validateOptionsEvolution(metaData, index,
                     ImmutableMap.<String, String>builder()
                             .put(IndexOptions.VECTOR_ENGINE, VectorIndexEngine.Kind.HNSW.name())
                             // cannot change those per se but must accept same value
@@ -96,79 +80,57 @@ class HnswVectorIndexTest extends VectorIndexEngineTestSuite {
                             .put(IndexOptions.HNSW_MAX_NUM_CONCURRENT_NEIGHBORHOOD_FETCHES, "9")
                             .put(IndexOptions.HNSW_MAX_NUM_CONCURRENT_DELETE_FROM_LAYER, "5").build());
 
-            Assertions.assertThatThrownBy(() -> validateIndexEvolution(metaDataValidator, index,
+            assertInvalidOptionsEvolution(metaData, index,
                     ImmutableMap.of(IndexOptions.VECTOR_NUM_DIMENSIONS, "128",
-                            IndexOptions.VECTOR_METRIC, Metric.EUCLIDEAN_SQUARE_METRIC.name())))
-                    .isInstanceOf(MetaDataException.class);
+                            IndexOptions.VECTOR_METRIC, Metric.EUCLIDEAN_SQUARE_METRIC.name()));
 
-            Assertions.assertThatThrownBy(() -> validateIndexEvolution(metaDataValidator, index,
-                    ImmutableMap.of(IndexOptions.VECTOR_NUM_DIMENSIONS, "768")))
-                    .isInstanceOf(MetaDataException.class);
+            assertInvalidOptionsEvolution(metaData, index,
+                    ImmutableMap.of(IndexOptions.VECTOR_NUM_DIMENSIONS, "768"));
 
             // switching the engine is never allowed
-            Assertions.assertThatThrownBy(() -> validateIndexEvolution(metaDataValidator, index,
+            assertInvalidOptionsEvolution(metaData, index,
                     ImmutableMap.of(IndexOptions.VECTOR_NUM_DIMENSIONS, "128",
-                            IndexOptions.VECTOR_ENGINE, VectorIndexEngine.Kind.GUARDIANN.name())))
-                    .isInstanceOf(MetaDataException.class);
+                            IndexOptions.VECTOR_ENGINE, VectorIndexEngine.Kind.GUARDIANN.name()));
 
-            Assertions.assertThatThrownBy(() -> validateIndexEvolution(metaDataValidator, index,
+            assertInvalidOptionsEvolution(metaData, index,
                     ImmutableMap.of(IndexOptions.VECTOR_NUM_DIMENSIONS, "128",
-                            IndexOptions.HNSW_USE_INLINING, "true"))).isInstanceOf(MetaDataException.class);
+                            IndexOptions.HNSW_USE_INLINING, "true"));
 
-            Assertions.assertThatThrownBy(() -> validateIndexEvolution(metaDataValidator, index,
+            assertInvalidOptionsEvolution(metaData, index,
                     ImmutableMap.of(IndexOptions.VECTOR_NUM_DIMENSIONS, "128",
-                            IndexOptions.HNSW_M, "8"))).isInstanceOf(MetaDataException.class);
+                            IndexOptions.HNSW_M, "8"));
 
-            Assertions.assertThatThrownBy(() -> validateIndexEvolution(metaDataValidator, index,
+            assertInvalidOptionsEvolution(metaData, index,
                     ImmutableMap.of(IndexOptions.VECTOR_NUM_DIMENSIONS, "128",
-                            IndexOptions.HNSW_M_MAX, "8"))).isInstanceOf(MetaDataException.class);
+                            IndexOptions.HNSW_M_MAX, "8"));
 
-            Assertions.assertThatThrownBy(() -> validateIndexEvolution(metaDataValidator, index,
+            assertInvalidOptionsEvolution(metaData, index,
                     ImmutableMap.of(IndexOptions.VECTOR_NUM_DIMENSIONS, "128",
-                            IndexOptions.HNSW_M_MAX_0, "16"))).isInstanceOf(MetaDataException.class);
+                            IndexOptions.HNSW_M_MAX_0, "16"));
 
-            Assertions.assertThatThrownBy(() -> validateIndexEvolution(metaDataValidator, index,
+            assertInvalidOptionsEvolution(metaData, index,
                     ImmutableMap.of(IndexOptions.VECTOR_NUM_DIMENSIONS, "128",
-                            IndexOptions.HNSW_EF_CONSTRUCTION, "500"))).isInstanceOf(MetaDataException.class);
+                            IndexOptions.HNSW_EF_CONSTRUCTION, "500"));
 
-            Assertions.assertThatThrownBy(() -> validateIndexEvolution(metaDataValidator, index,
+            assertInvalidOptionsEvolution(metaData, index,
                     ImmutableMap.of(IndexOptions.VECTOR_NUM_DIMENSIONS, "128",
-                            IndexOptions.HNSW_EF_REPAIR, "500"))).isInstanceOf(MetaDataException.class);
+                            IndexOptions.HNSW_EF_REPAIR, "500"));
 
-            Assertions.assertThatThrownBy(() -> validateIndexEvolution(metaDataValidator, index,
+            assertInvalidOptionsEvolution(metaData, index,
                     ImmutableMap.of(IndexOptions.VECTOR_NUM_DIMENSIONS, "128",
-                            IndexOptions.HNSW_EXTEND_CANDIDATES, "true"))).isInstanceOf(MetaDataException.class);
+                            IndexOptions.HNSW_EXTEND_CANDIDATES, "true"));
 
-            Assertions.assertThatThrownBy(() -> validateIndexEvolution(metaDataValidator, index,
+            assertInvalidOptionsEvolution(metaData, index,
                     ImmutableMap.of(IndexOptions.VECTOR_NUM_DIMENSIONS, "128",
-                            IndexOptions.HNSW_KEEP_PRUNED_CONNECTIONS, "true")))
-                    .isInstanceOf(MetaDataException.class);
+                            IndexOptions.HNSW_KEEP_PRUNED_CONNECTIONS, "true"));
 
-            Assertions.assertThatThrownBy(() -> validateIndexEvolution(metaDataValidator, index,
+            assertInvalidOptionsEvolution(metaData, index,
                     ImmutableMap.of(IndexOptions.VECTOR_NUM_DIMENSIONS, "128",
-                            IndexOptions.VECTOR_USE_RABITQ, "true"))).isInstanceOf(MetaDataException.class);
+                            IndexOptions.VECTOR_USE_RABITQ, "true"));
 
-            Assertions.assertThatThrownBy(() -> validateIndexEvolution(metaDataValidator, index,
+            assertInvalidOptionsEvolution(metaData, index,
                     ImmutableMap.of(IndexOptions.VECTOR_NUM_DIMENSIONS, "128",
-                            IndexOptions.VECTOR_RABITQ_NUM_EX_BITS, "1"))).isInstanceOf(MetaDataException.class);
+                            IndexOptions.VECTOR_RABITQ_NUM_EX_BITS, "1"));
         }
-    }
-
-    private void validateIndexEvolution(@Nonnull final MetaDataValidator metaDataValidator,
-                                        @Nonnull final Index oldIndex, @Nonnull final Map<String, String> optionsMap) {
-        final Index newIndex =
-                new Index("GroupedVectorIndex",
-                        new KeyWithValueExpression(concat(field("group_id"), field("vector_data")), 1),
-                        IndexTypes.VECTOR,
-                        optionsMap);
-
-        final IndexMaintainerFactoryRegistry indexMaintainerRegistry = recordStore.getIndexMaintainerRegistry();
-        final IndexMaintainerFactory indexMaintainerFactory =
-                indexMaintainerRegistry.getIndexMaintainerFactory(oldIndex);
-
-        final IndexValidator validatorForCompatibleNewIndex =
-                indexMaintainerFactory.getIndexValidator(newIndex);
-        validatorForCompatibleNewIndex.validate(metaDataValidator);
-        validatorForCompatibleNewIndex.validateChangedOptions(oldIndex);
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VectorIndexEngineTestSuite.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VectorIndexEngineTestSuite.java
@@ -31,11 +31,15 @@ import com.apple.foundationdb.record.IndexScanType;
 import com.apple.foundationdb.record.IsolationLevel;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordCursorIterator;
+import com.apple.foundationdb.record.RecordMetaData;
+import com.apple.foundationdb.record.RecordMetaDataProto;
 import com.apple.foundationdb.record.ScanProperties;
 import com.apple.foundationdb.record.TupleRange;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.IndexTypes;
 import com.apple.foundationdb.record.metadata.Key;
+import com.apple.foundationdb.record.metadata.MetaDataEvolutionValidator;
+import com.apple.foundationdb.record.metadata.MetaDataException;
 import com.apple.foundationdb.record.provider.foundationdb.FDBQueriedRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoredRecord;
@@ -721,5 +725,29 @@ abstract class VectorIndexEngineTestSuite extends VectorIndexTestBase {
             assertThat(recordStore.isIndexReadable(recordStore.getRecordMetaData().getIndex(indexName))).isTrue();
             commit(context);
         }
+    }
+
+    protected void validateOptionsEvolution(@Nonnull RecordMetaData oldMetaData,
+                                            @Nonnull Index oldIndex,
+                                            @Nonnull Map<String, String> newOptions) {
+        final RecordMetaDataProto.MetaData.Builder protoBuilder = oldMetaData.toProto().toBuilder()
+                .setVersion(oldMetaData.getVersion() + 1);
+        for (RecordMetaDataProto.Index.Builder indexBuilder : protoBuilder.getIndexesBuilderList()) {
+            if (indexBuilder.getName().equals(oldIndex.getName())) {
+                indexBuilder.clearOptions();
+                newOptions.forEach((key, value) -> indexBuilder.addOptionsBuilder().setKey(key).setValue(value));
+            }
+        }
+
+        final RecordMetaData newMetaData = RecordMetaData.build(protoBuilder.build());
+        final MetaDataEvolutionValidator evolutionValidator = MetaDataEvolutionValidator.getDefaultInstance();
+        evolutionValidator.validate(oldMetaData, newMetaData);
+    }
+
+    protected void assertInvalidOptionsEvolution(@Nonnull RecordMetaData oldMetaData,
+                                                 @Nonnull Index oldIndex,
+                                                 @Nonnull Map<String, String> newOptions) {
+        Assertions.assertThatThrownBy(() -> validateOptionsEvolution(oldMetaData, oldIndex, newOptions))
+                .isInstanceOf(MetaDataException.class);
     }
 }


### PR DESCRIPTION
The `MetaDataEvolutionValidator` is now configurable to ignore a set of index options. This is done so that if the user is using additional index options that are not defined in the core codebase but do not affect an index's structure, they can configure the evolution validator to ignore those options.

This will conflict with #4121, so whichever goes second will need to respond to the other one going in.

This fixes #4393.