### PR TITLE
Skip over external server version 4.12.14.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@
 #
 
 rootProject.name=fdb-record-layer
-version=4.12.13.0
+version=4.12.14.0
 releaseBuild=false
 
 # this should be false for release branches (i.e. if there is no -SNAPSHOT on the above version)

--- a/yaml-tests/yaml-tests.gradle
+++ b/yaml-tests/yaml-tests.gradle
@@ -150,6 +150,7 @@ static def getAttributesFromJar(File file) {
 ext.resolveManyServers = { ->
     Set<File> selectedServers = new HashSet<>()
     Set<String> rejectedVersions = new HashSet<>()
+    rejectedVersions.add("4.12.14.0")
     while (selectedServers.size() < 10) {
         def serverFile = resolveOtherServer(rejectedVersions)
         def attributes = getAttributesFromJar(serverFile)
@@ -205,7 +206,7 @@ tasks.register('serverJars', Copy) {
     notCompatibleWithConfigurationCache("Resolves dynamic external server versions at execution time")
     dependsOn ":fdb-relational-server:package", "cleanExternalServerDirectory"
     into project.layout.buildDirectory.dir('externalServer')
-    from { resolveOtherServer(["4.2.3.0", "4.2.4.0"].toSet()) }
+    from { resolveOtherServer(["4.12.14.0"].toSet()) }
     from (rootProject.project("fdb-relational-server").layout.files('.dist')) {
         include("fdb-relational-server-${rootProject.version}-all.jar")
     }

--- a/yaml-tests/yaml-tests.gradle
+++ b/yaml-tests/yaml-tests.gradle
@@ -74,6 +74,12 @@ dependencies {
     annotationProcessor(libs.autoService)
 }
 
+// Versions that should never be selected as an "other" external server when resolving dynamic versions for
+// compatibility testing, because they are broken in some way. For example, 4.12.14.0 was published in an incomplete
+// state (see: https://github.com/FoundationDB/fdb-record-layer/actions/runs/30123182087): we didn't fully publish
+// it, including no release notes, but somehow the artifacts are available in maven central.
+ext.permanentlyRejectedServerVersions = ["4.12.14.0"].toSet().asImmutable()
+
 // This "method" resolves the latest shadowJar version of the relational-server, and returns the file reference to it
 // which can be used in `Copy` tasks.
 ext.resolveOtherServer = { Set<String> rejectedVersions ->
@@ -149,8 +155,7 @@ static def getAttributesFromJar(File file) {
 
 ext.resolveManyServers = { ->
     Set<File> selectedServers = new HashSet<>()
-    Set<String> rejectedVersions = new HashSet<>()
-    rejectedVersions.add("4.12.14.0")
+    Set<String> rejectedVersions = new HashSet<>(permanentlyRejectedServerVersions)
     while (selectedServers.size() < 10) {
         def serverFile = resolveOtherServer(rejectedVersions)
         def attributes = getAttributesFromJar(serverFile)
@@ -188,7 +193,7 @@ ext.resolveSpecificServer = { String version ->
 // Resolves the n most-recent released version strings in descending order (most recent first).
 ext.resolveRecentVersionStrings = { int n ->
     List<String> resolvedVersions = new ArrayList<>()
-    Set<String> rejectedVersions = new HashSet<>()
+    Set<String> rejectedVersions = new HashSet<>(permanentlyRejectedServerVersions)
     while (resolvedVersions.size() < n) {
         def serverFile = resolveOtherServer(rejectedVersions)
         def attributes = getAttributesFromJar(serverFile)
@@ -206,7 +211,7 @@ tasks.register('serverJars', Copy) {
     notCompatibleWithConfigurationCache("Resolves dynamic external server versions at execution time")
     dependsOn ":fdb-relational-server:package", "cleanExternalServerDirectory"
     into project.layout.buildDirectory.dir('externalServer')
-    from { resolveOtherServer(["4.12.14.0"].toSet()) }
+    from { resolveOtherServer(new HashSet<>(permanentlyRejectedServerVersions)) }
     from (rootProject.project("fdb-relational-server").layout.files('.dist')) {
         include("fdb-relational-server-${rootProject.version}-all.jar")
     }


### PR DESCRIPTION
This rejects version 4.12.14.0 when looking at external servers. This is because the publishing for 4.12.14.0 put it into an incomplete state (see: https://github.com/FoundationDB/fdb-record-layer/actions/runs/30123182087). We didn't fully publish it, including no release notes, but somehow the artifacts are available in maven central. Skip over that version when resolving external server versions. Also, update the version in `gradle.properties` so that the next time we run a release, we'll try and publish 4.12.15.0.