### PR TITLE
Match `!current_version` when displaying mixed mode results.

### DIFF
--- a/gradle/testing.gradle
+++ b/gradle/testing.gradle
@@ -102,7 +102,7 @@ static def getMixedModeVersion(descriptor) {
             break
         }
 
-        Matcher versionMatch = descriptor.displayName =~ /^MultiServer \((?:((?:\d+\.)+\d+) then JDBC In-Process|JDBC In-Process then ((?:\d+\.)+\d+))\)/
+        Matcher versionMatch = descriptor.displayName =~ /^MultiServer \((?:((?:\d+\.)+\d+|!current_version) then JDBC In-Process|JDBC In-Process then ((?:\d+\.)+\d+|!current_version))\)/
         if (versionMatch.size() != 0) {
             def version = versionMatch[0][1]
             if (version == null) {


### PR DESCRIPTION
The regex fix is verified with this Groovy unit test

```groovy
// Original regex (fails)
def originalRegex = /^MultiServer \((?:((?:\d+\.)+\d+) then JDBC In-Process|JDBC In-Process then ((?:\d+\.)+\d+))\)/

// Fixed regex (should work)
def fixedRegex = /^MultiServer \((?:((?:\d+\.)+\d+|!current_version) then JDBC In-Process|JDBC In-Process then ((?:\d+\.)+\d+|!current_version))\)/

// Test cases
def testCases = [
    'MultiServer (7.3.42 then JDBC In-Process)',           // Should match
    'MultiServer (JDBC In-Process then 7.3.42)',           // Should match
    'MultiServer (JDBC In-Process then !current_version)', // FAILS with original, PASSES with fixed
    'MultiServer (7.3.42 then !current_version)',          // FAILS with original, PASSES with fixed
]

println "=== ORIGINAL REGEX ==="
testCases.each { test ->
    def match = test =~ originalRegex
    println "${test}: ${match.size() != 0 ? 'MATCH' : 'NO MATCH'}"
}

println "\n=== FIXED REGEX ==="
testCases.each { test ->
    def match = test =~ fixedRegex
    println "${test}: ${match.size() != 0 ? 'MATCH' : 'NO MATCH'}"
```