### PR TITLE
Use the new Sonatype API for publishing instead of the legacy publishing plugin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -315,7 +315,7 @@ jobs:
         id: publish_artifacts
         uses: ./actions/run-gradle
         with:
-          gradle_command: publish closeAndReleaseStagingRepositories -PreleaseBuild=true -PpublishBuild=true -PgithubPublish=true -PcentralPublish=true
+          gradle_command: publish publishMavenCentralBundle -PreleaseBuild=true -PpublishBuild=true -PgithubPublish=true -PcentralPublish=true
         env:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.GPG_PRIVATE_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_PASSPHRASE }}

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,8 @@
 
 import org.yaml.snakeyaml.Yaml
 
+import groovy.json.JsonSlurper
+
 import org.apache.tools.ant.taskdefs.condition.Os
 
 import javax.inject.Inject
@@ -327,12 +329,86 @@ subprojects {
     }
 }
 
+// Polls the Maven Central Portal status endpoint until the given deployment reaches the
+// terminal PUBLISHED state. If the portal reports that publishing FAILED, this throws an error
+// and reports back to the user what has gone wrong. If publishing has not completed before the
+// timeout elapses, this moves on to avoid blocking the build on a slow connection. Publishing
+// will then continue asynchronously on the portal server, and it is the user's responsibility
+// to monitor for success or failure.
+// See: https://central.sonatype.org/publish/publish-portal-api/#verify-status-of-the-deployment
+def waitForCentralDeploymentToPublish(String deploymentId, String encodedCredentials, int timeoutSeconds = 600, int pollIntervalSeconds = 10) {
+    logger.lifecycle("Validating ${deploymentId} deployment state")
+
+    def statusUrl = new URL("https://central.sonatype.com/api/v1/publisher/status?id=${deploymentId}")
+    def deadline = System.currentTimeMillis() + timeoutSeconds * 1000L
+    def lastKnownState = 'UNKNOWN'
+    def waiting = false
+
+    while (true) {
+        def connection = statusUrl.openConnection() as HttpURLConnection
+        try {
+            connection.setRequestMethod('POST')
+            connection.setRequestProperty('Authorization', "Bearer ${encodedCredentials}")
+            connection.setConnectTimeout(30_000)
+            connection.setReadTimeout(30_000)
+
+            def responseCode = connection.responseCode
+            if (responseCode != 200) {
+                def errorResponse = connection.errorStream?.text ?: connection.responseMessage
+                throw new GradleException("Failed to query deployment status (HTTP ${responseCode}): ${errorResponse}")
+            }
+
+            def status = new JsonSlurper().parseText(connection.inputStream.text)
+            def deploymentState = status.deploymentState
+            if (deploymentState != lastKnownState) {
+                if (waiting) {
+                    println()
+                    waiting = false
+                }
+                println("Deployment ${deploymentId} is now in state: ${deploymentState}")
+            } else {
+                if (!waiting) {
+                    print("Waiting for state update...")
+                    waiting = true
+                }
+                print(".")
+            }
+            lastKnownState = deploymentState
+
+            if (lastKnownState == 'PUBLISHED') {
+                return
+            }
+            if (lastKnownState == 'FAILED') {
+                throw new GradleException("Deployment ${deploymentId} failed to publish: ${status.errors}")
+            }
+        } finally {
+            connection.disconnect()
+        }
+
+        if (System.currentTimeMillis() > deadline) {
+            if (waiting) {
+                println()
+            }
+            logger.warn("Artifact deployment ${deploymentId} still publishing after ${timeoutSeconds} seconds " +
+                    "(last known state: ${lastKnownState}). Check status manually via: " +
+                    "https://central.sonatype.com/api/v1/publisher/status?id=${deploymentId}")
+            logger.warn("Publishing will continue asynchronously. Continuing on.")
+            return
+        }
+        sleep(pollIntervalSeconds * 1000L)
+    }
+}
+
 // Configure publishing for maven central. This is done in the top-level build.gradle, and then
 // all of the subprojects configure the artifacts they want published by applying
 // ${rootDir}/gradle/publishing.gradle in the project gradle. By default, we publish a library
 // from each package, but this can be configured by adjusting the publishLibrary variable.
 // Each subproject will place its artifacts into the central staging repository,
-// which will then be picked up by the bundle task
+// which will then be picked up by the bundle task.
+//
+// Both publishBuild and centralPublish must be set for these tasks to be registered at all -
+// the release workflow always passes both together, so this just avoids registering
+// publish-only tasks on builds that never intend to invoke them.
 if (Boolean.parseBoolean(publishBuild) && Boolean.parseBoolean(centralPublish)) {
     var stagingRepo = layout.buildDirectory.dir('staging-repo')
 
@@ -341,7 +417,7 @@ if (Boolean.parseBoolean(publishBuild) && Boolean.parseBoolean(centralPublish)) 
         description = "Creates a bundle zip of all artifacts for Maven Central upload"
         group = "publishing"
 
-        dependsOn subprojects.collect { it.tasks.matching { it.name == 'publish' } }
+        dependsOn subprojects.collect { it.tasks.named('publish') }
 
         archiveBaseName = "${rootProject.group}-${rootProject.name}"
         archiveVersion = project.version
@@ -349,7 +425,7 @@ if (Boolean.parseBoolean(publishBuild) && Boolean.parseBoolean(centralPublish)) 
         destinationDirectory = layout.buildDirectory.dir('distributions')
 
         from(stagingRepo) {
-            include "${rootProject.group.replaceAll('.', '/')}/**/${project.version}/*"
+            include "${rootProject.group.replace('.', '/')}/**/${project.version}/*"
             exclude '**/maven-metadata*'
         }
 
@@ -393,6 +469,11 @@ if (Boolean.parseBoolean(publishBuild) && Boolean.parseBoolean(centralPublish)) 
                 connection.setRequestMethod('POST')
                 connection.setDoOutput(true)
                 connection.setRequestProperty('Authorization', "Bearer ${encodedCredentials}")
+                // Connecting should be quick, but the read timeout also bounds how long we wait for
+                // the server to acknowledge the upload once the bundle has been fully streamed, so it
+                // needs to be generous enough to cover large bundles.
+                connection.setConnectTimeout(30_000)
+                connection.setReadTimeout(10 * 60_000)
 
                 def boundary = "----GradleBoundary${UUID.randomUUID().toString()}"
                 connection.setRequestProperty('Content-Type', "multipart/form-data; boundary=${boundary}")
@@ -427,6 +508,13 @@ if (Boolean.parseBoolean(publishBuild) && Boolean.parseBoolean(centralPublish)) 
                     logger.lifecycle("Upload successful!")
                     logger.lifecycle("Deployment ID: ${deploymentId}")
                     logger.lifecycle("You can check the status at: https://central.sonatype.com/api/v1/publisher/status?id=${deploymentId}")
+
+                    // The upload endpoint only confirms that the bundle was received. With
+                    // publishingType=AUTOMATIC, Central still validates the bundle and releases it
+                    // asynchronously, so poll the status endpoint until it reaches a terminal state to
+                    // catch validation failures instead of leaving this task green while the deployment
+                    // silently fails behind the scenes.
+                    waitForCentralDeploymentToPublish(deploymentId, encodedCredentials)
                 } else {
                     def errorResponse = connection.errorStream?.text ?: responseMessage
                     throw new GradleException("Upload failed with status ${responseCode}: ${errorResponse}")

--- a/build.gradle
+++ b/build.gradle
@@ -18,14 +18,10 @@
  * limitations under the License.
  */
 
+import org.apache.tools.ant.taskdefs.condition.Os
 import org.yaml.snakeyaml.Yaml
 
-import groovy.json.JsonSlurper
-
-import org.apache.tools.ant.taskdefs.condition.Os
-
 import javax.inject.Inject
-import org.gradle.process.ExecOperations
 
 // Gives tasks access to an injected `ExecOperations` for running external processes from a `doLast` block.
 interface InjectedExecOps {
@@ -56,6 +52,17 @@ plugins {
 
 ext {
     fdbEnvironment = [:]
+    // Name of the directory (under the root project's build directory) that subprojects publish
+    // their artifacts into for publishing to Maven Central
+    stagingRepoDirName = 'staging-repo'
+}
+
+// Configure publishing to maven central.
+//
+// Both publishBuild and centralPublish must be set for these tasks to be registered at all.
+// This avoids registering the tasks if we are not going to be publishing to maven central
+if (Boolean.parseBoolean(publishBuild) && Boolean.parseBoolean(centralPublish)) {
+    apply from: rootProject.file('gradle/central-publishing.gradle')
 }
 
 defaultTasks 'build'
@@ -324,203 +331,6 @@ subprojects {
                         }
                     }
                 }
-            }
-        }
-    }
-}
-
-// Polls the Maven Central Portal status endpoint until the given deployment reaches the
-// terminal PUBLISHED state. If the portal reports that publishing FAILED, this throws an error
-// and reports back to the user what has gone wrong. If publishing has not completed before the
-// timeout elapses, this moves on to avoid blocking the build on a slow connection. Publishing
-// will then continue asynchronously on the portal server, and it is the user's responsibility
-// to monitor for success or failure.
-// See: https://central.sonatype.org/publish/publish-portal-api/#verify-status-of-the-deployment
-def waitForCentralDeploymentToPublish(String deploymentId, String encodedCredentials, int timeoutSeconds = 600, int pollIntervalSeconds = 10) {
-    logger.lifecycle("Validating ${deploymentId} deployment state")
-
-    def statusUrl = new URL("https://central.sonatype.com/api/v1/publisher/status?id=${deploymentId}")
-    def deadline = System.currentTimeMillis() + timeoutSeconds * 1000L
-    def lastKnownState = 'UNKNOWN'
-    def waiting = false
-
-    while (true) {
-        def connection = statusUrl.openConnection() as HttpURLConnection
-        try {
-            connection.setRequestMethod('POST')
-            connection.setRequestProperty('Authorization', "Bearer ${encodedCredentials}")
-            connection.setConnectTimeout(30_000)
-            connection.setReadTimeout(30_000)
-
-            def responseCode = connection.responseCode
-            if (responseCode != 200) {
-                def errorResponse = connection.errorStream?.text ?: connection.responseMessage
-                throw new GradleException("Failed to query deployment status (HTTP ${responseCode}): ${errorResponse}")
-            }
-
-            def status = new JsonSlurper().parseText(connection.inputStream.text)
-            def deploymentState = status.deploymentState
-            if (deploymentState != lastKnownState) {
-                if (waiting) {
-                    println()
-                    waiting = false
-                }
-                println("Deployment ${deploymentId} is now in state: ${deploymentState}")
-            } else {
-                if (!waiting) {
-                    print("Waiting for state update...")
-                    waiting = true
-                }
-                print(".")
-            }
-            lastKnownState = deploymentState
-
-            if (lastKnownState == 'PUBLISHED') {
-                return
-            }
-            if (lastKnownState == 'FAILED') {
-                throw new GradleException("Deployment ${deploymentId} failed to publish: ${status.errors}")
-            }
-        } finally {
-            connection.disconnect()
-        }
-
-        if (System.currentTimeMillis() > deadline) {
-            if (waiting) {
-                println()
-            }
-            logger.warn("Artifact deployment ${deploymentId} still publishing after ${timeoutSeconds} seconds " +
-                    "(last known state: ${lastKnownState}). Check status manually via: " +
-                    "https://central.sonatype.com/api/v1/publisher/status?id=${deploymentId}")
-            logger.warn("Publishing will continue asynchronously. Continuing on.")
-            return
-        }
-        sleep(pollIntervalSeconds * 1000L)
-    }
-}
-
-// Configure publishing for maven central. This is done in the top-level build.gradle, and then
-// all of the subprojects configure the artifacts they want published by applying
-// ${rootDir}/gradle/publishing.gradle in the project gradle. By default, we publish a library
-// from each package, but this can be configured by adjusting the publishLibrary variable.
-// Each subproject will place its artifacts into the central staging repository,
-// which will then be picked up by the bundle task.
-//
-// Both publishBuild and centralPublish must be set for these tasks to be registered at all -
-// the release workflow always passes both together, so this just avoids registering
-// publish-only tasks on builds that never intend to invoke them.
-if (Boolean.parseBoolean(publishBuild) && Boolean.parseBoolean(centralPublish)) {
-    var stagingRepo = layout.buildDirectory.dir('staging-repo')
-
-    // Task to create a bundle zip of all published artifacts
-    tasks.register('createMavenCentralBundle', Zip) {
-        description = "Creates a bundle zip of all artifacts for Maven Central upload"
-        group = "publishing"
-
-        dependsOn subprojects.collect { it.tasks.named('publish') }
-
-        archiveBaseName = "${rootProject.group}-${rootProject.name}"
-        archiveVersion = project.version
-        archiveClassifier = 'bundle'
-        destinationDirectory = layout.buildDirectory.dir('distributions')
-
-        from(stagingRepo) {
-            include "${rootProject.group.replace('.', '/')}/**/${project.version}/*"
-            exclude '**/maven-metadata*'
-        }
-
-        includeEmptyDirs = false
-    }
-
-    // Task to upload the bundle to Maven Central
-    tasks.register('publishMavenCentralBundle') {
-        description = "Uploads the bundle zip to Maven Central Portal"
-        group = "publishing"
-
-        dependsOn tasks.named('createMavenCentralBundle')
-
-        doLast {
-            def sonatypeUsername = findProperty('sonatypeUsername')
-            def sonatypePassword = findProperty('sonatypePassword')
-
-            if (sonatypeUsername == null || sonatypePassword == null) {
-                throw new GradleException("sonatypeUsername and sonatypePassword properties must be set")
-            }
-
-            // Create base64 encoded credentials
-            def credentials = "${sonatypeUsername}:${sonatypePassword}"
-            def encodedCredentials = Base64.getEncoder().encodeToString(credentials.getBytes('UTF-8'))
-
-            // Get the bundle file
-            def bundleTask = tasks.named('createMavenCentralBundle').get()
-            def bundleFile = bundleTask.archiveFile.get().asFile
-
-            if (!bundleFile.exists()) {
-                throw new GradleException("Bundle file does not exist: ${bundleFile}")
-            }
-
-            logger.lifecycle("Uploading bundle: ${bundleFile.name} (${bundleFile.length() / 1024 / 1024} MB)")
-
-            // Upload using HttpURLConnection for multipart/form-data
-            def url = new URL('https://central.sonatype.com/api/v1/publisher/upload?publishingType=AUTOMATIC')
-            def connection = url.openConnection() as HttpURLConnection
-
-            try {
-                connection.setRequestMethod('POST')
-                connection.setDoOutput(true)
-                connection.setRequestProperty('Authorization', "Bearer ${encodedCredentials}")
-                // Connecting should be quick, but the read timeout also bounds how long we wait for
-                // the server to acknowledge the upload once the bundle has been fully streamed, so it
-                // needs to be generous enough to cover large bundles.
-                connection.setConnectTimeout(30_000)
-                connection.setReadTimeout(10 * 60_000)
-
-                def boundary = "----GradleBoundary${UUID.randomUUID().toString()}"
-                connection.setRequestProperty('Content-Type', "multipart/form-data; boundary=${boundary}")
-
-                // Use a chunked streaming mode to break data up into smaller chunks to avoid needing to load everything into memory
-                connection.setChunkedStreamingMode(8192)
-
-                // Use buffered output stream and write directly to avoid loading entire file into memory
-                connection.outputStream.withStream { output ->
-                    def CRLF = "\r\n"
-
-                    // Write multipart headers
-                    output.write("--${boundary}${CRLF}".getBytes('UTF-8'))
-                    output.write("Content-Disposition: form-data; name=\"bundle\"; filename=\"${bundleFile.name}\"${CRLF}".getBytes('UTF-8'))
-                    output.write("Content-Type: application/octet-stream${CRLF}".getBytes('UTF-8'))
-                    output.write(CRLF.getBytes('UTF-8'))
-
-                    // Next write the bundle data to the stream
-                    bundleFile.withInputStream { InputStream input -> output << input }
-
-                    // Write multipart closing boundary
-                    output.write(CRLF.getBytes('UTF-8'))
-                    output.write("--${boundary}--${CRLF}".getBytes('UTF-8'))
-                    output.flush()
-                }
-
-                def responseCode = connection.responseCode
-                def responseMessage = connection.responseMessage
-
-                if (responseCode >= 200 && responseCode < 300) {
-                    def deploymentId = connection.inputStream.text.trim()
-                    logger.lifecycle("Upload successful!")
-                    logger.lifecycle("Deployment ID: ${deploymentId}")
-                    logger.lifecycle("You can check the status at: https://central.sonatype.com/api/v1/publisher/status?id=${deploymentId}")
-
-                    // The upload endpoint only confirms that the bundle was received. With
-                    // publishingType=AUTOMATIC, Central still validates the bundle and releases it
-                    // asynchronously, so poll the status endpoint until it reaches a terminal state to
-                    // catch validation failures instead of leaving this task green while the deployment
-                    // silently fails behind the scenes.
-                    waitForCentralDeploymentToPublish(deploymentId, encodedCredentials)
-                } else {
-                    def errorResponse = connection.errorStream?.text ?: responseMessage
-                    throw new GradleException("Upload failed with status ${responseCode}: ${errorResponse}")
-                }
-            } finally {
-                connection.disconnect()
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,6 @@ buildscript {
 plugins {
     alias(libs.plugins.protobuf)
     alias(libs.plugins.spotbugs)
-    alias(libs.plugins.nexus)
     alias(libs.plugins.download)
 }
 
@@ -331,13 +330,109 @@ subprojects {
 // Configure publishing for maven central. This is done in the top-level build.gradle, and then
 // all of the subprojects configure the artifacts they want published by applying
 // ${rootDir}/gradle/publishing.gradle in the project gradle. By default, we publish a library
-// from each package, but this can be configured by adjusting the publishLibrary variable
-if (Boolean.parseBoolean(centralPublish)) {
-    nexusPublishing {
-        repositories {
-            sonatype {
-                // Update the URL now that the OSSRH service has been sunset: https://central.sonatype.org/news/20250326_ossrh_sunset/
-                nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+// from each package, but this can be configured by adjusting the publishLibrary variable.
+// Each subproject will place its artifacts into the central staging repository,
+// which will then be picked up by the bundle task
+if (Boolean.parseBoolean(publishBuild) && Boolean.parseBoolean(centralPublish)) {
+    var stagingRepo = layout.buildDirectory.dir('staging-repo')
+
+    // Task to create a bundle zip of all published artifacts
+    tasks.register('createMavenCentralBundle', Zip) {
+        description = "Creates a bundle zip of all artifacts for Maven Central upload"
+        group = "publishing"
+
+        dependsOn subprojects.collect { it.tasks.matching { it.name == 'publish' } }
+
+        archiveBaseName = "${rootProject.group}-${rootProject.name}"
+        archiveVersion = project.version
+        archiveClassifier = 'bundle'
+        destinationDirectory = layout.buildDirectory.dir('distributions')
+
+        from(stagingRepo) {
+            include "${rootProject.group.replaceAll('.', '/')}/**/${project.version}/*"
+            exclude '**/maven-metadata*'
+        }
+
+        includeEmptyDirs = false
+    }
+
+    // Task to upload the bundle to Maven Central
+    tasks.register('publishMavenCentralBundle') {
+        description = "Uploads the bundle zip to Maven Central Portal"
+        group = "publishing"
+
+        dependsOn tasks.named('createMavenCentralBundle')
+
+        doLast {
+            def sonatypeUsername = findProperty('sonatypeUsername')
+            def sonatypePassword = findProperty('sonatypePassword')
+
+            if (sonatypeUsername == null || sonatypePassword == null) {
+                throw new GradleException("sonatypeUsername and sonatypePassword properties must be set")
+            }
+
+            // Create base64 encoded credentials
+            def credentials = "${sonatypeUsername}:${sonatypePassword}"
+            def encodedCredentials = Base64.getEncoder().encodeToString(credentials.getBytes('UTF-8'))
+
+            // Get the bundle file
+            def bundleTask = tasks.named('createMavenCentralBundle').get()
+            def bundleFile = bundleTask.archiveFile.get().asFile
+
+            if (!bundleFile.exists()) {
+                throw new GradleException("Bundle file does not exist: ${bundleFile}")
+            }
+
+            logger.lifecycle("Uploading bundle: ${bundleFile.name} (${bundleFile.length() / 1024 / 1024} MB)")
+
+            // Upload using HttpURLConnection for multipart/form-data
+            def url = new URL('https://central.sonatype.com/api/v1/publisher/upload?publishingType=AUTOMATIC')
+            def connection = url.openConnection() as HttpURLConnection
+
+            try {
+                connection.setRequestMethod('POST')
+                connection.setDoOutput(true)
+                connection.setRequestProperty('Authorization', "Bearer ${encodedCredentials}")
+
+                def boundary = "----GradleBoundary${UUID.randomUUID().toString()}"
+                connection.setRequestProperty('Content-Type', "multipart/form-data; boundary=${boundary}")
+
+                // Use a chunked streaming mode to break data up into smaller chunks to avoid needing to load everything into memory
+                connection.setChunkedStreamingMode(8192)
+
+                // Use buffered output stream and write directly to avoid loading entire file into memory
+                connection.outputStream.withStream { output ->
+                    def CRLF = "\r\n"
+
+                    // Write multipart headers
+                    output.write("--${boundary}${CRLF}".getBytes('UTF-8'))
+                    output.write("Content-Disposition: form-data; name=\"bundle\"; filename=\"${bundleFile.name}\"${CRLF}".getBytes('UTF-8'))
+                    output.write("Content-Type: application/octet-stream${CRLF}".getBytes('UTF-8'))
+                    output.write(CRLF.getBytes('UTF-8'))
+
+                    // Next write the bundle data to the stream
+                    bundleFile.withInputStream { InputStream input -> output << input }
+
+                    // Write multipart closing boundary
+                    output.write(CRLF.getBytes('UTF-8'))
+                    output.write("--${boundary}--${CRLF}".getBytes('UTF-8'))
+                    output.flush()
+                }
+
+                def responseCode = connection.responseCode
+                def responseMessage = connection.responseMessage
+
+                if (responseCode >= 200 && responseCode < 300) {
+                    def deploymentId = connection.inputStream.text.trim()
+                    logger.lifecycle("Upload successful!")
+                    logger.lifecycle("Deployment ID: ${deploymentId}")
+                    logger.lifecycle("You can check the status at: https://central.sonatype.com/api/v1/publisher/status?id=${deploymentId}")
+                } else {
+                    def errorResponse = connection.errorStream?.text ?: responseMessage
+                    throw new GradleException("Upload failed with status ${responseCode}: ${errorResponse}")
+                }
+            } finally {
+                connection.disconnect()
             }
         }
     }

--- a/gradle/central-publishing.gradle
+++ b/gradle/central-publishing.gradle
@@ -1,0 +1,236 @@
+/*
+ * central-publishing.gradle
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import groovy.json.JsonSlurper
+
+// Configure publishing to the Maven Central repository.
+//
+// For this to work, the caller should set the following properties:
+//
+//  - `signingKey` to the GPG secret key used to sign artifacts
+//  - `signingPassword` to that GPG key's password
+//  - `sonatypeUsername` to the maven central publisher user name
+//  - `sonatypePassword` to the maven central publisher password
+//  - `publishBuild` to `true` (to indicate that we're publishing the artifacts at all)
+//  - `centralPublish` to `true` (to indicate that we're publishing to maven central)
+//
+// Note that some of those (like the GPG key and sonatype credentials) are secrets and
+// thus should be handled by the CI system's secret management system.
+//
+// This file should be applied in the root `build.gradle`, and then all the
+// subprojects should configure the artifacts they want published by applying
+// `gradle/publishing.gradle` in their project's gradle config. This results in the subproject
+// publishing to the staging repo. Those artifacts are bundled up in `createMavenCentralBundle`,
+// and then that bundle is uploaded by `publishMavenCentralBundle`. By default,
+// each subproject publishes a library, but this can be configured by adjusting the
+// publishLibrary variable.
+
+// Polls the Maven Central Portal status endpoint until the given deployment reaches the
+// terminal PUBLISHED state. If the portal reports that publishing FAILED, this throws an error
+// and reports back to the user what has gone wrong. If publishing has not completed before the
+// timeout elapses, this moves on to avoid blocking the build on a slow connection. Publishing
+// will then continue asynchronously on the portal server, and it is the user's responsibility
+// to monitor for success or failure.
+// See: https://central.sonatype.org/publish/publish-portal-api/#verify-status-of-the-deployment
+def waitForCentralDeploymentToPublish(String deploymentId, String encodedCredentials, int timeoutSeconds = 600, int pollIntervalSeconds = 10) {
+    logger.lifecycle("Validating ${deploymentId} deployment state")
+
+    def statusUrl = new URI("https://central.sonatype.com/api/v1/publisher/status?id=${deploymentId}").toURL()
+    def deadline = System.currentTimeMillis() + timeoutSeconds * 1000L
+    def lastKnownState = 'UNKNOWN'
+    def waiting = false
+
+    while (true) {
+        def connection = statusUrl.openConnection() as HttpURLConnection
+        try {
+            connection.setRequestMethod('POST')
+            connection.setRequestProperty('Authorization', "Bearer ${encodedCredentials}")
+            connection.setConnectTimeout(30_000)
+            connection.setReadTimeout(30_000)
+
+            def responseCode = connection.responseCode
+            if (responseCode != 200) {
+                def errorResponse = connection.errorStream?.text ?: connection.responseMessage
+                throw new GradleException("Failed to query deployment status (HTTP ${responseCode}): ${errorResponse}")
+            }
+
+            def status = new JsonSlurper().parseText(connection.inputStream.text)
+            def deploymentState = status.deploymentState
+            if (deploymentState != lastKnownState) {
+                if (waiting) {
+                    println()
+                    waiting = false
+                }
+                println("Deployment ${deploymentId} is now in state: ${deploymentState}")
+            } else {
+                if (!waiting) {
+                    print("Waiting for state update...")
+                    waiting = true
+                }
+                print(".")
+            }
+            lastKnownState = deploymentState
+
+            if (lastKnownState == 'PUBLISHED') {
+                return
+            }
+            if (lastKnownState == 'FAILED') {
+                throw new GradleException("Deployment ${deploymentId} failed to publish: ${status.errors}")
+            }
+        } catch (IOException e) {
+            // Transient network hiccups shouldn't abort the build while we're in a retry loop.
+            // Log a warning and let the loop below retry after the poll interval.
+            if (waiting) {
+                println()
+                waiting = false
+            }
+            logger.warn("Failed to query deployment status for ${deploymentId}, will retry: ${e.message}")
+        } finally {
+            connection.disconnect()
+        }
+
+        if (System.currentTimeMillis() > deadline) {
+            if (waiting) {
+                println()
+            }
+            logger.warn("Artifact deployment ${deploymentId} still publishing after ${timeoutSeconds} seconds " +
+                    "(last known state: ${lastKnownState}). Check status manually via: " +
+                    "https://central.sonatype.com/api/v1/publisher/status?id=${deploymentId}")
+            logger.warn("Publishing will continue asynchronously. Continuing on.")
+            return
+        }
+        Thread.sleep(pollIntervalSeconds * 1000L)
+    }
+}
+
+var stagingRepo = rootProject.layout.buildDirectory.dir(rootProject.ext.stagingRepoDirName)
+
+// Task to create a bundle zip of all published artifacts
+tasks.register('createMavenCentralBundle', Zip) {
+    description = "Creates a bundle zip of all artifacts for Maven Central upload"
+    group = "publishing"
+
+    dependsOn subprojects.collect { it.tasks.named('publish') }
+
+    archiveBaseName = "${rootProject.group}-${rootProject.name}"
+    archiveVersion = project.version
+    archiveClassifier = 'bundle'
+    destinationDirectory = layout.buildDirectory.dir('distributions')
+
+    from(stagingRepo) {
+        include "${rootProject.group.replace('.', '/')}/**/${project.version}/*"
+        exclude '**/maven-metadata*'
+    }
+
+    includeEmptyDirs = false
+}
+
+// Task to upload the bundle to Maven Central
+tasks.register('publishMavenCentralBundle') {
+    description = "Uploads the bundle zip to Maven Central Portal"
+    group = "publishing"
+
+    dependsOn tasks.named('createMavenCentralBundle')
+
+    doLast {
+        def sonatypeUsername = findProperty('sonatypeUsername')
+        def sonatypePassword = findProperty('sonatypePassword')
+
+        if (sonatypeUsername == null || sonatypePassword == null) {
+            throw new GradleException("sonatypeUsername and sonatypePassword properties must be set")
+        }
+
+        // Create base64 encoded credentials
+        def credentials = "${sonatypeUsername}:${sonatypePassword}"
+        def encodedCredentials = Base64.getEncoder().encodeToString(credentials.getBytes('UTF-8'))
+
+        // Get the bundle file
+        def bundleTask = tasks.named('createMavenCentralBundle').get()
+        def bundleFile = bundleTask.archiveFile.get().asFile
+
+        if (!bundleFile.exists()) {
+            throw new GradleException("Bundle file does not exist: ${bundleFile}")
+        }
+
+        logger.lifecycle("Uploading bundle: ${bundleFile.name} (${bundleFile.length() / 1024 / 1024} MB)")
+
+        // Upload using HttpURLConnection for multipart/form-data
+        def url = new URI('https://central.sonatype.com/api/v1/publisher/upload?publishingType=AUTOMATIC').toURL()
+        def connection = url.openConnection() as HttpURLConnection
+        def deploymentId = ""
+
+        try {
+            connection.setRequestMethod('POST')
+            connection.setDoOutput(true)
+            connection.setRequestProperty('Authorization', "Bearer ${encodedCredentials}")
+            // Connecting should be quick, but the read timeout also bounds how long we wait for
+            // the server to acknowledge the upload once the bundle has been fully streamed, so it
+            // needs to be generous enough to cover large bundles.
+            connection.setConnectTimeout(30_000)
+            connection.setReadTimeout(10 * 60_000)
+
+            def boundary = "----GradleBoundary${UUID.randomUUID().toString()}"
+            connection.setRequestProperty('Content-Type', "multipart/form-data; boundary=${boundary}")
+
+            // Use a chunked streaming mode to break data up into smaller chunks to avoid needing to load everything into memory
+            connection.setChunkedStreamingMode(8192)
+
+            // Use buffered output stream and write directly to avoid loading entire file into memory
+            connection.outputStream.withStream { output ->
+                def CRLF = "\r\n"
+
+                // Write multipart headers
+                output.write("--${boundary}${CRLF}".getBytes('UTF-8'))
+                output.write("Content-Disposition: form-data; name=\"bundle\"; filename=\"${bundleFile.name}\"${CRLF}".getBytes('UTF-8'))
+                output.write("Content-Type: application/octet-stream${CRLF}".getBytes('UTF-8'))
+                output.write(CRLF.getBytes('UTF-8'))
+
+                // Next write the bundle data to the stream
+                bundleFile.withInputStream { InputStream input -> output << input }
+
+                // Write multipart closing boundary
+                output.write(CRLF.getBytes('UTF-8'))
+                output.write("--${boundary}--${CRLF}".getBytes('UTF-8'))
+                output.flush()
+            }
+
+            def responseCode = connection.responseCode
+            def responseMessage = connection.responseMessage
+
+            if (responseCode >= 200 && responseCode < 300) {
+                deploymentId = connection.inputStream.text.trim()
+                logger.lifecycle("Upload successful!")
+                logger.lifecycle("Deployment ID: ${deploymentId}")
+            } else {
+                def errorResponse = connection.errorStream?.text ?: responseMessage
+                throw new GradleException("Upload failed with status ${responseCode}: ${errorResponse}")
+            }
+        } finally {
+            connection.disconnect()
+        }
+
+        // The upload endpoint only confirms that the bundle was received. With
+        // publishingType=AUTOMATIC, Central still validates the bundle and releases it
+        // asynchronously, so poll the status endpoint until it reaches a terminal state to
+        // catch validation failures instead of leaving this task green while the deployment
+        // silently fails behind the scenes.
+        waitForCentralDeploymentToPublish(deploymentId, encodedCredentials)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -146,7 +146,6 @@ test-compileOnly = [ "autoService", "jsr305" ]
 download = { id = "de.undercouch.download", version = "5.7.0" }
 gitversion = { id = "com.palantir.git-version", version = "5.0.0" }
 jmh = { id = "me.champeau.jmh", version = "0.7.3" }
-nexus = { id = "io.github.gradle-nexus.publish-plugin", version = "2.0.0" }
 protobuf = { id = "com.google.protobuf", version = "0.9.6" }
 shadow = { id = "com.gradleup.shadow", version = "8.3.10" }
 spotbugs = { id = "com.github.spotbugs", version = "6.5.5" }

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -117,10 +117,10 @@ publishing {
             }
 
             if (Boolean.parseBoolean(centralPublish)) {
-                // Publish this project to the root project's staging repo. This will be
-                // bundled up by createMavenCentralBundle for publishing
+                // Publish this project to the root project's staging repo
+                // See: central-publishing.gradle
                 maven {
-                    url = rootProject.layout.buildDirectory.dir("staging-repo")
+                    url = rootProject.layout.buildDirectory.dir(rootProject.ext.stagingRepoDirName)
                 }
             }
         }

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -115,6 +115,14 @@ publishing {
                     }
                 }
             }
+
+            if (Boolean.parseBoolean(centralPublish)) {
+                // Publish this project to the root project's staging repo. This will be
+                // bundled up by createMavenCentralBundle for publishing
+                maven {
+                    url = rootProject.layout.buildDirectory.dir("staging-repo")
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
This removes the nexus publishing plugin. This was added in #3723 and #3724 and then reverted in #3728. Some of that history is no longer present, but I believe the revert happened because we had problems that were ultimately caused by a server-side issue that was actually unrelated to our switch to the new API, but we reverted back to the legacy plugin in order to have fewer variables. This now proposes moving over to the new API (which is just an upload of a big zip), partially because we hit problems in the publishing step during: https://github.com/FoundationDB/fdb-record-layer/actions/runs/30123182087 And it would be nice to remove that somewhat fiddly part of the build, if we can

This does two things:

1. It reverts #3728 (commit: 345de8dddf2a27fa413c85175260778b1cfe3a94).
2. It refines the change a bit, so that after the initial upload, we poll the status for 10 minutes. That way, if the asynchronous publishing job fails its validation early on, we can report that to the user. If publishing does not complete in 10 minutes, we move on to avoid blocking the build

See the API docs for more info on the calls that are being made here: https://central.sonatype.org/publish/publish-portal-api/