### PR TITLE
Use IndexState predicates instead of comparing index states directly

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/IndexState.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/IndexState.java
@@ -98,8 +98,16 @@ public enum IndexState {
         return logName;
     }
 
+    public boolean isReadable() {
+        return this.equals(READABLE);
+    }
+
+    public boolean isReadableUniquePending() {
+        return this.equals(READABLE_UNIQUE_PENDING);
+    }
+
     public boolean isScannable() {
-        return this.equals(READABLE) || this.equals(READABLE_UNIQUE_PENDING);
+        return isReadable() || isReadableUniquePending();
     }
 
     public boolean isWriteOnlyNoQueue() {
@@ -112,6 +120,10 @@ public enum IndexState {
 
     public boolean isWriteOnly() {
         return isWriteOnlyNoQueue() || isWriteOnlyWithQueue();
+    }
+
+    public boolean isDisabled() {
+        return this.equals(DISABLED);
     }
 
     public static IndexState fromCode(@Nonnull Object code) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/IndexState.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/IndexState.java
@@ -98,30 +98,70 @@ public enum IndexState {
         return logName;
     }
 
+    /**
+     * Determine if an index in this state is readable.
+     *
+     * @return <code>true</code> if this state is {@link #READABLE} and <code>false</code> otherwise
+     */
     public boolean isReadable() {
         return this.equals(READABLE);
     }
 
+    /**
+     * Determine if an index in this state is readable-unique-pending.
+     * The readable-unique-pending index state may happen after a unique index is built, but duplications are
+     * found. The index will be maintained in this mode until the last duplication is resolved, then its state
+     * can be changed to {@link #READABLE}.
+     *
+     * @return <code>true</code> if this state is {@link #READABLE_UNIQUE_PENDING} and <code>false</code> otherwise
+     */
     public boolean isReadableUniquePending() {
         return this.equals(READABLE_UNIQUE_PENDING);
     }
 
+    /**
+     * Determine if an index in this state is scannable - i.e. either {@link #isReadable()} or
+     * {@link #isReadableUniquePending()}.
+     *
+     * @return <code>true</code> if this state is scannable and <code>false</code> otherwise
+     */
     public boolean isScannable() {
         return isReadable() || isReadableUniquePending();
     }
 
+    /**
+     * Determine if an index in this state is write-only (but not write-only-with-queue).
+     *
+     * @return <code>true</code> if this state is {@link #WRITE_ONLY} and <code>false</code> otherwise
+     */
     public boolean isWriteOnlyNoQueue() {
         return this.equals(WRITE_ONLY);
     }
 
+    /**
+     * Determine if an index in this state is write-only with a pending queue.
+     *
+     * @return <code>true</code> if this state is {@link #WRITE_ONLY_WITH_QUEUE} and <code>false</code> otherwise
+     */
     public boolean isWriteOnlyWithQueue() {
         return this.equals(WRITE_ONLY_WITH_QUEUE);
     }
 
+    /**
+     * Determine if an index in this state is write-only in any form ({@link #WRITE_ONLY} or
+     * {@link #WRITE_ONLY_WITH_QUEUE}).
+     *
+     * @return <code>true</code> if this state is write-only in any form and <code>false</code> otherwise
+     */
     public boolean isWriteOnly() {
         return isWriteOnlyNoQueue() || isWriteOnlyWithQueue();
     }
 
+    /**
+     * Determine if an index in this state is disabled.
+     *
+     * @return <code>true</code> if this state is {@link #DISABLED} and <code>false</code> otherwise
+     */
     public boolean isDisabled() {
         return this.equals(DISABLED);
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/MutableRecordStoreState.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/MutableRecordStoreState.java
@@ -132,7 +132,7 @@ public class MutableRecordStoreState extends RecordStoreState {
     public IndexState setState(@Nonnull String indexName, @Nonnull IndexState state) {
         verifyWritable();
         IndexState previous;
-        if (state == IndexState.READABLE) {
+        if (state.isReadable()) {
             previous = indexStateMap.get().remove(indexName);
         } else {
             previous = indexStateMap.get().put(indexName, state);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordStoreState.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/RecordStoreState.java
@@ -150,7 +150,7 @@ public class RecordStoreState {
      * @return <code>true</code> if the given index is disabled and <code>false</code> otherwise
      */
     public boolean isDisabled(@Nonnull String indexName) {
-        return getState(indexName).equals(IndexState.DISABLED);
+        return getState(indexName).isDisabled();
     }
 
     /**
@@ -170,7 +170,7 @@ public class RecordStoreState {
      * @return <code>true</code> if the given index is readable and <code>false</code> otherwise
      */
     public boolean isReadable(@Nonnull String indexName) {
-        return getState(indexName).equals(IndexState.READABLE);
+        return getState(indexName).isReadable();
     }
 
 
@@ -182,7 +182,7 @@ public class RecordStoreState {
      * @return <code>true</code> if the given index is readable-unique-pending and <code>false</code> otherwise
      */
     public boolean isReadableUniquePending(@Nonnull String indexName) {
-        return getState(indexName).equals(IndexState.READABLE_UNIQUE_PENDING);
+        return getState(indexName).isReadableUniquePending();
     }
 
 
@@ -226,7 +226,7 @@ public class RecordStoreState {
      * @return <code>true</code> if all of the indexes are readable and <code>false</code> otherwise
      */
     public boolean allIndexesReadable() {
-        return indexStateMap.get().isEmpty() || indexStateMap.get().values().stream().allMatch(state -> state.equals(IndexState.READABLE));
+        return indexStateMap.get().isEmpty() || indexStateMap.get().values().stream().allMatch(IndexState::isReadable);
     }
 
     /**
@@ -241,8 +241,8 @@ public class RecordStoreState {
      */
     public boolean compatibleWith(@Nonnull RecordStoreState other) {
         return indexStateMap.get().entrySet().stream().allMatch(entry -> {
-            boolean readableInOther = other.getState(entry.getKey()).equals(IndexState.READABLE);
-            return entry.getValue().equals(IndexState.READABLE) == readableInOther;
+            boolean readableInOther = other.getState(entry.getKey()).isReadable();
+            return entry.getValue().isReadable() == readableInOther;
         });
     }
 
@@ -263,7 +263,7 @@ public class RecordStoreState {
      */
     public Set<String> getDisabledIndexNames() {
         return indexStateMap.get().entrySet().stream()
-                .filter(entry -> entry.getValue() == IndexState.DISABLED)
+                .filter(entry -> entry.getValue().isDisabled())
                 .map(Map.Entry::getKey)
                 .collect(Collectors.toSet());
     }
@@ -279,7 +279,7 @@ public class RecordStoreState {
     public RecordStoreState withIndexesInState(@Nonnull final List<String> indexNames,
                                                @Nonnull IndexState state) {
         HashMap<String, IndexState> indexStateMapBuilder = new HashMap<>(getIndexStates());
-        if (state == IndexState.READABLE) {
+        if (state.isReadable()) {
             indexNames.forEach(indexStateMapBuilder::remove);
         } else {
             indexNames.forEach(indexName -> indexStateMapBuilder.put(indexName, state));

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -4244,12 +4244,14 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     }
 
     /**
-     * TODO: This function will be deprecated soon.
      * Determine if the index is readable for this record store. This method will not perform
      * any queries to the underlying database and instead satisfies the answer based on the
      * in-memory cache of store state. However, if another operation in a different transaction
      * happens concurrently that changes the index's state, operations using the same {@link FDBRecordContext}
      * as this record store will fail to commit due to conflicts.
+     * <p>
+     *     TODO: This function will be deprecated soon.
+     * </p>
      *
      * @param index the index to check for readability
      * @return <code>true</code> if the index is readable and <code>false</code> otherwise
@@ -4260,10 +4262,12 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     }
 
     /**
-     * TODO: This function will be deprecated soon.
      * Determine if the index with the given name is readable for this record store.
      * This method will not perform any queries to the underlying database and instead
      * satisfies the answer based on the in-memory cache of store state.
+     * <p>
+     *     TODO: This function will be deprecated soon.
+     * </p>
      *
      * @param indexName the name of the index to check for readability
      * @return <code>true</code> if the named index is readable and <code>false</code> otherwise
@@ -4274,7 +4278,6 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     }
 
     /**
-     * TODO: This function will be deprecated soon.
      * Determine if the index is readable-unique-pending for this record store. This method will not perform
      * any queries to the underlying database and instead satisfies the answer based on the
      * in-memory cache of store state. However, if another operation in a different transaction
@@ -4283,6 +4286,9 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
      * The readable-unique-pending index state may happen after a unique index is built, but duplications are
      * found. The index will be maintained in this mode until the last duplication is resolved, then its state
      * will be changed to READABLE.
+     * <p>
+     *     TODO: This function will be deprecated soon.
+     * </p>
      *
      * @param index the index to check for readability
      * @return <code>true</code> if the index is readable-unique-pending and <code>false</code> otherwise
@@ -4293,13 +4299,15 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     }
 
     /**
-     * TODO: This function will be deprecated soon.
      * Determine if the index with the given name is readable-unique-pending for this record store.
      * This method will not perform any queries to the underlying database and instead
      * satisfies the answer based on the in-memory cache of store state.
      * The readable-unique-pending index state may happen after a unique index is built, but duplications are
      * found. The index will be maintained in this mode until the last duplication is resolved, then its state
      * will be changed to READABLE.
+     * <p>
+     *     TODO: This function will be deprecated soon.
+     * </p>
      *
      * @param indexName the name of the index to check for readability
      * @return <code>true</code> if the named index is readable-unique-pending and <code>false</code> otherwise
@@ -4310,11 +4318,13 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     }
 
     /**
-     * TODO: This function will be deprecated soon.
      * Determine if the index with the given name is scannable - i.e. either {@link #isIndexReadable(Index)} or
      * {@link #isIndexReadableUniquePending(Index)} for this record store.
      * This method will not perform any queries to the underlying database and instead
      * satisfies the answer based on the in-memory cache of store state.
+     * <p>
+     *     TODO: This function will be deprecated soon.
+     * </p>
      *
      * @param index the index to check
      * @return <code>true</code> if the named index is scannable and <code>false</code> otherwise
@@ -4325,11 +4335,13 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     }
 
     /**
-     * TODO: This function will be deprecated soon.
      * Determine if the index with the given name is scannable - i.e. either {@link #isIndexReadable(String)} or
      * {@link #isIndexReadableUniquePending(String)} for this record store.
      * This method will not perform any queries to the underlying database and instead
      * satisfies the answer based on the in-memory cache of store state.
+     * <p>
+     *     TODO: This function will be deprecated soon.
+     * </p>
      *
      * @param indexName the name of the index to check
      * @return <code>true</code> if the named index is scannable and <code>false</code> otherwise
@@ -4340,12 +4352,14 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     }
 
     /**
-     * TODO: This function will be deprecated soon.
      * Determine if the index is write-only (but not write-only-with-queue) for this record store. This method will not perform
      * any queries to the underlying database and instead satisfies the answer based on the
      * in-memory cache of store state. However, if another operation in a different transaction
      * happens concurrently that changes the index's state, operations using the same {@link FDBRecordContext}
      * as this record store will fail to commit due to conflicts.
+     * <p>
+     *     TODO: This function will be deprecated soon.
+     * </p>
      *
      * @param index the index to check if write-only
      * @return <code>true</code> if the index is write-only and <code>false</code> otherwise
@@ -4356,10 +4370,12 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     }
 
     /**
-     * TODO: This function will be deprecated soon.
      * Determine if the index with the given name is write-only (but not write-only-with-queue) for this record store.
      * This method will not perform any queries to the underlying database and instead
      * satisfies the answer based on the in-memory cache of store state.
+     * <p>
+     *     TODO: This function will be deprecated soon.
+     * </p>
      *
      * @param indexName the name of the index to check if write-only
      * @return <code>true</code> if the named index is write-only and <code>false</code> otherwise
@@ -4370,12 +4386,14 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     }
 
     /**
-     * TODO: This function will be deprecated soon.
      * Determine if the index is write-only with a pending queue for this record store. This method will not perform
      * any queries to the underlying database and instead satisfies the answer based on the
      * in-memory cache of store state. However, if another operation in a different transaction
      * happens concurrently that changes the index's state, operations using the same {@link FDBRecordContext}
      * as this record store will fail to commit due to conflicts.
+     * <p>
+     *     TODO: This function will be deprecated soon.
+     * </p>
      *
      * @param index the index to check if write-only with a queue
      * @return <code>true</code> if the index is write-only with a queue and <code>false</code> otherwise
@@ -4386,10 +4404,12 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     }
 
     /**
-     * TODO: This function will be deprecated soon.
      * Determine if the index with the given name is write-only with a pending queue for this record store.
      * This method will not perform any queries to the underlying database and instead
      * satisfies the answer based on the in-memory cache of store state.
+     * <p>
+     *     TODO: This function will be deprecated soon.
+     * </p>
      *
      * @param indexName the name of the index to check if write-only with a queue
      * @return <code>true</code> if the named index is write-only with a queue and <code>false</code> otherwise
@@ -4400,13 +4420,15 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     }
 
     /**
-     * TODO: This function will be deprecated soon.
      * Determine if the index is write-only in any form ({@link IndexState#WRITE_ONLY} or
      * {@link IndexState#WRITE_ONLY_WITH_QUEUE}) for this record store. This method will not perform
      * any queries to the underlying database and instead satisfies the answer based on the
      * in-memory cache of store state. However, if another operation in a different transaction
      * happens concurrently that changes the index's state, operations using the same {@link FDBRecordContext}
      * as this record store will fail to commit due to conflicts.
+     * <p>
+     *     TODO: This function will be deprecated soon.
+     * </p>
      *
      * @param index the index to check if write-only in any form
      * @return <code>true</code> if the index is write-only in any form and <code>false</code> otherwise
@@ -4417,11 +4439,13 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     }
 
     /**
-     * TODO: This function will be deprecated soon.
      * Determine if the index with the given name is write-only in any form ({@link IndexState#WRITE_ONLY} or
      * {@link IndexState#WRITE_ONLY_WITH_QUEUE}) for this record store. This method will not perform
      * any queries to the underlying database and instead satisfies the answer based on the
      * in-memory cache of store state.
+     * <p>
+     *     TODO: This function will be deprecated soon.
+     * </p>
      *
      * @param indexName the name of the index to check if write-only in any form
      * @return <code>true</code> if the named index is write-only in any form and <code>false</code> otherwise
@@ -4432,12 +4456,14 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     }
 
     /**
-     * TODO: This function will be deprecated soon.
      * Determine if the index is disabled for this record store. This method will not perform
      * any queries to the underlying database and instead satisfies the answer based on the
      * in-memory cache of store state. However, if another operation in a different transaction
      * happens concurrently that changes the index's state, operations using the same {@link FDBRecordContext}
      * as this record store will fail to commit due to conflicts.
+     * <p>
+     *     TODO: This function will be deprecated soon.
+     * </p>
      *
      * @param index the index to check if write-only
      * @return <code>true</code> if the index is disabled and <code>false</code> otherwise
@@ -4448,10 +4474,12 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     }
 
     /**
-     * TODO: This function will be deprecated soon.
      * Determine if the index with the given name is disabled for this record store.
      * This method will not perform any queries to the underlying database and instead
      * satisfies the answer based on the in-memory cache of store state.
+     * <p>
+     *     TODO: This function will be deprecated soon.
+     * </p>
      *
      * @param indexName the name of the index to check if disabled
      * @return <code>true</code> if the named index is disabled and <code>false</code> otherwise
@@ -5209,7 +5237,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
                         && oldFormatVersion < SAVE_VERSION_WITH_RECORD_FORMAT_VERSION
                         && !useOldVersionFormat()) {
                     stateFuture = stateFuture.thenApply(state -> {
-                        if (IndexState.READABLE.equals(state)) {
+                        if (state != null && state.isReadable()) {
                             // Do not rebuild any version indexes while the format conversion is going on.
                             // Otherwise, the process moving the versions might race against the index
                             // build and some versions won't be indexed correctly.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -4249,14 +4249,12 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
      * in-memory cache of store state. However, if another operation in a different transaction
      * happens concurrently that changes the index's state, operations using the same {@link FDBRecordContext}
      * as this record store will fail to commit due to conflicts.
-     * <p>
-     *     TODO: This function will be deprecated soon.
-     * </p>
      *
      * @param index the index to check for readability
      * @return <code>true</code> if the index is readable and <code>false</code> otherwise
      * @throws IllegalArgumentException if no index in the metadata has the same name as this index
      */
+    @API(API.Status.DEPRECATED)
     public boolean isIndexReadable(@Nonnull Index index) {
         return isIndexReadable(index.getName());
     }
@@ -4265,14 +4263,12 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
      * Determine if the index with the given name is readable for this record store.
      * This method will not perform any queries to the underlying database and instead
      * satisfies the answer based on the in-memory cache of store state.
-     * <p>
-     *     TODO: This function will be deprecated soon.
-     * </p>
      *
      * @param indexName the name of the index to check for readability
      * @return <code>true</code> if the named index is readable and <code>false</code> otherwise
      * @throws IllegalArgumentException if no index in the metadata has the given name
      */
+    @API(API.Status.DEPRECATED)
     public boolean isIndexReadable(@Nonnull String indexName) {
         return getIndexState(indexName).isReadable();
     }
@@ -4286,14 +4282,12 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
      * The readable-unique-pending index state may happen after a unique index is built, but duplications are
      * found. The index will be maintained in this mode until the last duplication is resolved, then its state
      * will be changed to READABLE.
-     * <p>
-     *     TODO: This function will be deprecated soon.
-     * </p>
      *
      * @param index the index to check for readability
      * @return <code>true</code> if the index is readable-unique-pending and <code>false</code> otherwise
      * @throws IllegalArgumentException if no index in the metadata has the same name as this index
      */
+    @API(API.Status.DEPRECATED)
     public boolean isIndexReadableUniquePending(@Nonnull Index index) {
         return isIndexReadableUniquePending(index.getName());
     }
@@ -4305,14 +4299,12 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
      * The readable-unique-pending index state may happen after a unique index is built, but duplications are
      * found. The index will be maintained in this mode until the last duplication is resolved, then its state
      * will be changed to READABLE.
-     * <p>
-     *     TODO: This function will be deprecated soon.
-     * </p>
      *
      * @param indexName the name of the index to check for readability
      * @return <code>true</code> if the named index is readable-unique-pending and <code>false</code> otherwise
      * @throws IllegalArgumentException if no index in the metadata has the given name
      */
+    @API(API.Status.DEPRECATED)
     public boolean isIndexReadableUniquePending(@Nonnull String indexName) {
         return getIndexState(indexName).isReadableUniquePending();
     }
@@ -4322,14 +4314,12 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
      * {@link #isIndexReadableUniquePending(Index)} for this record store.
      * This method will not perform any queries to the underlying database and instead
      * satisfies the answer based on the in-memory cache of store state.
-     * <p>
-     *     TODO: This function will be deprecated soon.
-     * </p>
      *
      * @param index the index to check
      * @return <code>true</code> if the named index is scannable and <code>false</code> otherwise
      * @throws IllegalArgumentException if no index in the metadata has the given name
      */
+    @API(API.Status.DEPRECATED)
     public boolean isIndexScannable(@Nonnull Index index) {
         return isIndexScannable(index.getName());
     }
@@ -4339,14 +4329,12 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
      * {@link #isIndexReadableUniquePending(String)} for this record store.
      * This method will not perform any queries to the underlying database and instead
      * satisfies the answer based on the in-memory cache of store state.
-     * <p>
-     *     TODO: This function will be deprecated soon.
-     * </p>
      *
      * @param indexName the name of the index to check
      * @return <code>true</code> if the named index is scannable and <code>false</code> otherwise
      * @throws IllegalArgumentException if no index in the metadata has the given name
      */
+    @API(API.Status.DEPRECATED)
     public boolean isIndexScannable(@Nonnull String indexName) {
         return getIndexState(indexName).isScannable();
     }
@@ -4357,14 +4345,12 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
      * in-memory cache of store state. However, if another operation in a different transaction
      * happens concurrently that changes the index's state, operations using the same {@link FDBRecordContext}
      * as this record store will fail to commit due to conflicts.
-     * <p>
-     *     TODO: This function will be deprecated soon.
-     * </p>
      *
      * @param index the index to check if write-only
      * @return <code>true</code> if the index is write-only and <code>false</code> otherwise
      * @throws IllegalArgumentException if no index in the metadata has the same name as this index
      */
+    @API(API.Status.DEPRECATED)
     public boolean isIndexWriteOnlyNoQueue(@Nonnull Index index) {
         return isIndexWriteOnlyNoQueue(index.getName());
     }
@@ -4373,14 +4359,12 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
      * Determine if the index with the given name is write-only (but not write-only-with-queue) for this record store.
      * This method will not perform any queries to the underlying database and instead
      * satisfies the answer based on the in-memory cache of store state.
-     * <p>
-     *     TODO: This function will be deprecated soon.
-     * </p>
      *
      * @param indexName the name of the index to check if write-only
      * @return <code>true</code> if the named index is write-only and <code>false</code> otherwise
      * @throws IllegalArgumentException if no index in the metadata has the given name
      */
+    @API(API.Status.DEPRECATED)
     public boolean isIndexWriteOnlyNoQueue(@Nonnull String indexName) {
         return getIndexState(indexName).isWriteOnlyNoQueue();
     }
@@ -4391,14 +4375,12 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
      * in-memory cache of store state. However, if another operation in a different transaction
      * happens concurrently that changes the index's state, operations using the same {@link FDBRecordContext}
      * as this record store will fail to commit due to conflicts.
-     * <p>
-     *     TODO: This function will be deprecated soon.
-     * </p>
      *
      * @param index the index to check if write-only with a queue
      * @return <code>true</code> if the index is write-only with a queue and <code>false</code> otherwise
      * @throws IllegalArgumentException if no index in the metadata has the same name as this index
      */
+    @API(API.Status.DEPRECATED)
     public boolean isIndexWriteOnlyWithQueue(@Nonnull Index index) {
         return isIndexWriteOnlyWithQueue(index.getName());
     }
@@ -4407,14 +4389,12 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
      * Determine if the index with the given name is write-only with a pending queue for this record store.
      * This method will not perform any queries to the underlying database and instead
      * satisfies the answer based on the in-memory cache of store state.
-     * <p>
-     *     TODO: This function will be deprecated soon.
-     * </p>
      *
      * @param indexName the name of the index to check if write-only with a queue
      * @return <code>true</code> if the named index is write-only with a queue and <code>false</code> otherwise
      * @throws IllegalArgumentException if no index in the metadata has the given name
      */
+    @API(API.Status.DEPRECATED)
     public boolean isIndexWriteOnlyWithQueue(@Nonnull String indexName) {
         return getIndexState(indexName).isWriteOnlyWithQueue();
     }
@@ -4426,14 +4406,12 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
      * in-memory cache of store state. However, if another operation in a different transaction
      * happens concurrently that changes the index's state, operations using the same {@link FDBRecordContext}
      * as this record store will fail to commit due to conflicts.
-     * <p>
-     *     TODO: This function will be deprecated soon.
-     * </p>
      *
      * @param index the index to check if write-only in any form
      * @return <code>true</code> if the index is write-only in any form and <code>false</code> otherwise
      * @throws IllegalArgumentException if no index in the metadata has the same name as this index
      */
+    @API(API.Status.DEPRECATED)
     public boolean isIndexWriteOnly(@Nonnull Index index) {
         return isIndexWriteOnly(index.getName());
     }
@@ -4443,14 +4421,12 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
      * {@link IndexState#WRITE_ONLY_WITH_QUEUE}) for this record store. This method will not perform
      * any queries to the underlying database and instead satisfies the answer based on the
      * in-memory cache of store state.
-     * <p>
-     *     TODO: This function will be deprecated soon.
-     * </p>
      *
      * @param indexName the name of the index to check if write-only in any form
      * @return <code>true</code> if the named index is write-only in any form and <code>false</code> otherwise
      * @throws IllegalArgumentException if no index in the metadata has the given name
      */
+    @API(API.Status.DEPRECATED)
     public boolean isIndexWriteOnly(@Nonnull String indexName) {
         return getIndexState(indexName).isWriteOnly();
     }
@@ -4461,14 +4437,12 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
      * in-memory cache of store state. However, if another operation in a different transaction
      * happens concurrently that changes the index's state, operations using the same {@link FDBRecordContext}
      * as this record store will fail to commit due to conflicts.
-     * <p>
-     *     TODO: This function will be deprecated soon.
-     * </p>
      *
      * @param index the index to check if write-only
      * @return <code>true</code> if the index is disabled and <code>false</code> otherwise
      * @throws IllegalArgumentException if no index in the metadata has the same name as this index
      */
+    @API(API.Status.DEPRECATED)
     public boolean isIndexDisabled(@Nonnull Index index) {
         return isIndexDisabled(index.getName());
     }
@@ -4477,14 +4451,12 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
      * Determine if the index with the given name is disabled for this record store.
      * This method will not perform any queries to the underlying database and instead
      * satisfies the answer based on the in-memory cache of store state.
-     * <p>
-     *     TODO: This function will be deprecated soon.
-     * </p>
      *
      * @param indexName the name of the index to check if disabled
      * @return <code>true</code> if the named index is disabled and <code>false</code> otherwise
      * @throws IllegalArgumentException if no index in the metadata has the given name
      */
+    @API(API.Status.DEPRECATED)
     public boolean isIndexDisabled(@Nonnull String indexName) {
         return getIndexState(indexName).isDisabled();
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -882,8 +882,8 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
         return syntheticRecordTypes.stream()
                 .map(metaData::getSyntheticRecordType).collect(Collectors.toMap(Function.identity(), syntheticRecordType -> {
                     List<IndexMaintainer> indexMaintainers = new ArrayList<>();
-                    syntheticRecordType.getIndexes().stream().filter(index -> !isIndexDisabled(index)).map(this::getIndexMaintainer).forEach(indexMaintainers::add);
-                    syntheticRecordType.getMultiTypeIndexes().stream().filter(index -> !isIndexDisabled(index)).map(this::getIndexMaintainer).forEach(indexMaintainers::add);
+                    syntheticRecordType.getIndexes().stream().filter(index -> !getIndexState(index).isDisabled()).map(this::getIndexMaintainer).forEach(indexMaintainers::add);
+                    syntheticRecordType.getMultiTypeIndexes().stream().filter(index -> !getIndexState(index).isDisabled()).map(this::getIndexMaintainer).forEach(indexMaintainers::add);
                     return indexMaintainers;
                 }));
     }
@@ -1497,7 +1497,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     @SuppressWarnings("PMD.CloseResource")
     public RecordCursor<IndexEntry> scanIndex(@Nonnull Index index, @Nonnull IndexScanBounds scanBounds,
                                               @Nullable byte[] continuation, @Nonnull ScanProperties scanProperties) {
-        if (!isIndexScannable(index)) {
+        if (!getIndexState(index).isScannable()) {
             throw new ScanNonReadableIndexException("Cannot scan non-readable index",
                     LogMessageKeys.INDEX_NAME, index.getName(),
                     subspaceProvider.logKey(), subspaceProvider.toString(context));
@@ -1531,7 +1531,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
         if (commonPrimaryKeyLength <= 0) {
             throw new RecordCoreArgumentException("commonPrimaryKeyLength has to be a positive number", LogMessageKeys.INDEX_NAME, index.getName());
         }
-        if (!isIndexScannable(index)) {
+        if (!getIndexState(index).isScannable()) {
             throw new ScanNonReadableIndexException("Cannot scan non-readable index",
                     LogMessageKeys.INDEX_NAME, index.getName(),
                     subspaceProvider.logKey(), subspaceProvider.toString(context));
@@ -2032,7 +2032,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
             }
 
             indexMaintainers = allIndexes.stream()
-                    .filter(index -> !isIndexDisabled(index))
+                    .filter(index -> !getIndexState(index).isDisabled())
                     .map(FDBRecordStore.this::getIndexMaintainer)
                     .collect(Collectors.toList());
 
@@ -2993,7 +2993,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
                 if (!replacedByNames.isEmpty()) {
                     // Check if all of the replaced by index names are readable
                     if (replacedByNames.stream()
-                            .allMatch(replacedByName -> metaData.hasIndex(replacedByName) && isIndexReadable(replacedByName))) {
+                            .allMatch(replacedByName -> metaData.hasIndex(replacedByName) && getIndexState(replacedByName).isReadable())) {
                         indexesToRemove.add(index);
                     }
                 }
@@ -3167,7 +3167,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
         final Map<Index, List<RecordType>> indexesToBuild = getRecordMetaData().getIndexesToBuildSince(-1);
         beginRecordStoreStateRead();
         try {
-            indexesToBuild.keySet().removeIf(this::isIndexReadable);
+            indexesToBuild.keySet().removeIf(index -> getIndexState(index).isReadable());
             return indexesToBuild;
         } finally {
             endRecordStoreStateRead();
@@ -3671,7 +3671,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
                 context.setMetaDataVersionStamp();
             }
             Transaction tr = context.ensureActive();
-            if (IndexState.READABLE.equals(indexState)) {
+            if (indexState.isReadable()) {
                 tr.clear(indexKey);
             } else {
                 tr.set(indexKey, Tuple.from(indexState.code()).pack());
@@ -3988,7 +3988,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
                         LogMessageKeys.SUBSPACE_KEY, index.getSubspaceKey());
             } else if (uniquenessViolation.isPresent()) {
                 if (allowUniquePending) {
-                    if (isIndexReadableUniquePending(index)) {
+                    if (getIndexState(index).isReadableUniquePending()) {
                         return false;   // Unchanged
                     }
                     updateIndexState(index.getName(), indexKey, IndexState.READABLE_UNIQUE_PENDING);
@@ -4244,6 +4244,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     }
 
     /**
+     * TODO: This function will be deprecated soon.
      * Determine if the index is readable for this record store. This method will not perform
      * any queries to the underlying database and instead satisfies the answer based on the
      * in-memory cache of store state. However, if another operation in a different transaction
@@ -4259,6 +4260,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     }
 
     /**
+     * TODO: This function will be deprecated soon.
      * Determine if the index with the given name is readable for this record store.
      * This method will not perform any queries to the underlying database and instead
      * satisfies the answer based on the in-memory cache of store state.
@@ -4268,10 +4270,11 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
      * @throws IllegalArgumentException if no index in the metadata has the given name
      */
     public boolean isIndexReadable(@Nonnull String indexName) {
-        return getIndexState(indexName).equals(IndexState.READABLE);
+        return getIndexState(indexName).isReadable();
     }
 
     /**
+     * TODO: This function will be deprecated soon.
      * Determine if the index is readable-unique-pending for this record store. This method will not perform
      * any queries to the underlying database and instead satisfies the answer based on the
      * in-memory cache of store state. However, if another operation in a different transaction
@@ -4290,6 +4293,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     }
 
     /**
+     * TODO: This function will be deprecated soon.
      * Determine if the index with the given name is readable-unique-pending for this record store.
      * This method will not perform any queries to the underlying database and instead
      * satisfies the answer based on the in-memory cache of store state.
@@ -4302,10 +4306,11 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
      * @throws IllegalArgumentException if no index in the metadata has the given name
      */
     public boolean isIndexReadableUniquePending(@Nonnull String indexName) {
-        return getIndexState(indexName).equals(IndexState.READABLE_UNIQUE_PENDING);
+        return getIndexState(indexName).isReadableUniquePending();
     }
 
     /**
+     * TODO: This function will be deprecated soon.
      * Determine if the index with the given name is scannable - i.e. either {@link #isIndexReadable(Index)} or
      * {@link #isIndexReadableUniquePending(Index)} for this record store.
      * This method will not perform any queries to the underlying database and instead
@@ -4320,6 +4325,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     }
 
     /**
+     * TODO: This function will be deprecated soon.
      * Determine if the index with the given name is scannable - i.e. either {@link #isIndexReadable(String)} or
      * {@link #isIndexReadableUniquePending(String)} for this record store.
      * This method will not perform any queries to the underlying database and instead
@@ -4334,6 +4340,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     }
 
     /**
+     * TODO: This function will be deprecated soon.
      * Determine if the index is write-only (but not write-only-with-queue) for this record store. This method will not perform
      * any queries to the underlying database and instead satisfies the answer based on the
      * in-memory cache of store state. However, if another operation in a different transaction
@@ -4349,6 +4356,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     }
 
     /**
+     * TODO: This function will be deprecated soon.
      * Determine if the index with the given name is write-only (but not write-only-with-queue) for this record store.
      * This method will not perform any queries to the underlying database and instead
      * satisfies the answer based on the in-memory cache of store state.
@@ -4362,6 +4370,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     }
 
     /**
+     * TODO: This function will be deprecated soon.
      * Determine if the index is write-only with a pending queue for this record store. This method will not perform
      * any queries to the underlying database and instead satisfies the answer based on the
      * in-memory cache of store state. However, if another operation in a different transaction
@@ -4377,6 +4386,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     }
 
     /**
+     * TODO: This function will be deprecated soon.
      * Determine if the index with the given name is write-only with a pending queue for this record store.
      * This method will not perform any queries to the underlying database and instead
      * satisfies the answer based on the in-memory cache of store state.
@@ -4386,10 +4396,11 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
      * @throws IllegalArgumentException if no index in the metadata has the given name
      */
     public boolean isIndexWriteOnlyWithQueue(@Nonnull String indexName) {
-        return getIndexState(indexName).equals(IndexState.WRITE_ONLY_WITH_QUEUE);
+        return getIndexState(indexName).isWriteOnlyWithQueue();
     }
 
     /**
+     * TODO: This function will be deprecated soon.
      * Determine if the index is write-only in any form ({@link IndexState#WRITE_ONLY} or
      * {@link IndexState#WRITE_ONLY_WITH_QUEUE}) for this record store. This method will not perform
      * any queries to the underlying database and instead satisfies the answer based on the
@@ -4406,6 +4417,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     }
 
     /**
+     * TODO: This function will be deprecated soon.
      * Determine if the index with the given name is write-only in any form ({@link IndexState#WRITE_ONLY} or
      * {@link IndexState#WRITE_ONLY_WITH_QUEUE}) for this record store. This method will not perform
      * any queries to the underlying database and instead satisfies the answer based on the
@@ -4420,6 +4432,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     }
 
     /**
+     * TODO: This function will be deprecated soon.
      * Determine if the index is disabled for this record store. This method will not perform
      * any queries to the underlying database and instead satisfies the answer based on the
      * in-memory cache of store state. However, if another operation in a different transaction
@@ -4435,6 +4448,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     }
 
     /**
+     * TODO: This function will be deprecated soon.
      * Determine if the index with the given name is disabled for this record store.
      * This method will not perform any queries to the underlying database and instead
      * satisfies the answer based on the in-memory cache of store state.
@@ -4444,7 +4458,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
      * @throws IllegalArgumentException if no index in the metadata has the given name
      */
     public boolean isIndexDisabled(@Nonnull String indexName) {
-        return getIndexState(indexName).equals(IndexState.DISABLED);
+        return getIndexState(indexName).isDisabled();
     }
 
     /**
@@ -4526,7 +4540,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
      */
     @Nonnull
     public List<Index> getReadableIndexes(@Nonnull RecordTypeOrBuilder recordType) {
-        return sanitizeIndexes(recordType.getIndexes(), this::isIndexReadable);
+        return sanitizeIndexes(recordType.getIndexes(), index -> getIndexState(index).isReadable());
     }
 
     /**
@@ -4538,7 +4552,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
      */
     @Nonnull
     public List<Index> getEnabledIndexes(@Nonnull RecordTypeOrBuilder recordType) {
-        return sanitizeIndexes(recordType.getIndexes(), index -> !isIndexDisabled(index));
+        return sanitizeIndexes(recordType.getIndexes(), index -> !getIndexState(index).isDisabled());
     }
 
     /**
@@ -4550,7 +4564,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
      */
     @Nonnull
     public List<Index> getReadableMultiTypeIndexes(@Nonnull RecordTypeOrBuilder recordType) {
-        return sanitizeIndexes(recordType.getMultiTypeIndexes(), this::isIndexReadable);
+        return sanitizeIndexes(recordType.getMultiTypeIndexes(), index -> getIndexState(index).isReadable());
     }
 
     /**
@@ -4562,7 +4576,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
      */
     @Nonnull
     public List<Index> getEnabledMultiTypeIndexes(@Nonnull RecordTypeOrBuilder recordType) {
-        return sanitizeIndexes(recordType.getMultiTypeIndexes(), index -> !isIndexDisabled(index));
+        return sanitizeIndexes(recordType.getMultiTypeIndexes(), index -> !getIndexState(index).isDisabled());
     }
 
     /**
@@ -4573,7 +4587,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
      */
     @Nonnull
     public List<Index> getReadableUniversalIndexes() {
-        return sanitizeIndexes(getRecordMetaData().getUniversalIndexes(), this::isIndexReadable);
+        return sanitizeIndexes(getRecordMetaData().getUniversalIndexes(), index -> getIndexState(index).isReadable());
     }
 
     /**
@@ -4584,7 +4598,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
      */
     @Nonnull
     public List<Index> getEnabledUniversalIndexes() {
-        return sanitizeIndexes(getRecordMetaData().getUniversalIndexes(), index -> !isIndexDisabled(index));
+        return sanitizeIndexes(getRecordMetaData().getUniversalIndexes(), index -> !getIndexState(index).isDisabled());
     }
 
     /**
@@ -4707,7 +4721,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
                                                          @Nonnull StringBuilder errMessageBuilder) {
         // Skip index rebuild if the index is on new record types. This may fail because of reusing an index name whose
         // state hasn't been cleared.
-        if (indexState != IndexState.DISABLED && areAllRecordTypesSince(recordTypes, oldMetaDataVersion)) {
+        if (!indexState.isDisabled() && areAllRecordTypesSince(recordTypes, oldMetaDataVersion)) {
             errMessageBuilder.append("rebuild index with no records");
             return rebuildIndexWithNoRecord(index, reason);
         }
@@ -4995,7 +5009,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
             if (!indexesToBuildSince.containsKey(index) &&
                     !index.isUnique()) {
                 final IndexState indexState = getIndexState(index);
-                if (indexState == IndexState.READABLE_UNIQUE_PENDING || indexState.isWriteOnly()) {
+                if (indexState.isReadableUniquePending() || indexState.isWriteOnly()) {
                     final CompletableFuture<Void> uniquenessFuture = AsyncUtil.getAll(getRecordContext().removeCommitChecks(
                             commitCheck -> {
                                 if (commitCheck instanceof IndexUniquenessCommitCheck) {
@@ -5008,7 +5022,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
                             err -> err instanceof RecordIndexUniquenessViolation))
                             // Regardless, we want to clear any existing uniqueness violations on disk
                             .thenCompose(vignore -> getIndexMaintainer(index).clearUniquenessViolations());
-                    if (indexState == IndexState.READABLE_UNIQUE_PENDING) {
+                    if (indexState.isReadableUniquePending()) {
                         work.add(uniquenessFuture
                                 .thenCompose(vignore -> markIndexReadable(index, false))
                                 .thenApply(vignore2 -> null));
@@ -5317,7 +5331,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
     public void vacuumReadableIndexesBuildData() {
         Map<Index, IndexState> indexStates = getAllIndexStates(); // also adds state to read conflicts
         for (Map.Entry<Index, IndexState> entry : indexStates.entrySet()) {
-            if (entry.getValue().equals(IndexState.READABLE)) {
+            if (entry.getValue().isReadable()) {
                 clearReadableIndexBuildData(entry.getKey());
             }
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexFunctionHelper.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexFunctionHelper.java
@@ -95,7 +95,7 @@ public class IndexFunctionHelper {
             }
         }
         return indexesForRecordTypes(store, recordTypeNames)
-                .filter(store::isIndexReadable)
+                .filter(index -> store.getIndexState(index).isReadable())
                 .map(store::getIndexMaintainer)
                 .filter(i -> i.canEvaluateRecordFunction(function))
                 // Prefer the one that does it in the fewest number of columns.
@@ -114,7 +114,7 @@ public class IndexFunctionHelper {
             }
         }
         return indexesForRecordTypes(store, recordTypeNames)
-                .filter(store::isIndexReadable)
+                .filter(index -> store.getIndexState(index).isReadable())
                 .filter(indexFilter::isQueryable)
                 .map(store::getIndexMaintainer)
                 .filter(i -> i.canEvaluateAggregateFunction(function))
@@ -141,7 +141,7 @@ public class IndexFunctionHelper {
             @Nonnull IndexQueryabilityFilter indexFilter) {
         Verify.verify(functionCall.isGroupingPermutable());
         return indexesForRecordTypes(store, recordTypeNames)
-                .filter(store::isIndexReadable)
+                .filter(index -> store.getIndexState(index).isReadable())
                 .filter(indexFilter::isQueryable)
                 .flatMap(index ->
                         functionCall.enumerateIndexAggregateFunctionCandidates(index.getName())

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
@@ -211,7 +211,7 @@ public abstract class IndexingBase {
                         .thenCompose(ignore -> AsyncUtil.READY_FALSE);
             }
             boolean shouldClear = desiredAction == OnlineIndexer.IndexingPolicy.DesiredAction.REBUILD;
-            boolean shouldBuild = shouldClear || indexState != IndexState.READABLE;
+            boolean shouldBuild = shouldClear || !indexState.isReadable();
             message.addKeyAndValue(LogMessageKeys.INITIAL_INDEX_STATE, indexState);
             message.addKeyAndValue(LogMessageKeys.INDEXING_POLICY_DESIRED_ACTION, desiredAction);
             message.addKeyAndValue(LogMessageKeys.SHOULD_BUILD_INDEX, shouldBuild);
@@ -301,7 +301,7 @@ public abstract class IndexingBase {
         AtomicBoolean allReadable = new AtomicBoolean(true);
         return getRunner().runAsync(context -> openRecordStore(context).thenCompose(store ->
             forEachTargetIndex(index -> {
-                if (store.isIndexReadable(index)) {
+                if (store.getIndexState(index).isReadable()) {
                     return AsyncUtil.DONE;
                 }
                 final IndexingRangeSet rangeSet = IndexingRangeSet.forIndexBuild(store, index);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingByIndex.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingByIndex.java
@@ -135,7 +135,7 @@ public class IndexingByIndex extends IndexingBase {
 
         // readability - This method shouldn't block if one has already opened the record store (as we did)
         Index srcIndex = getSourceIndex(store.getRecordMetaData());
-        validateOrThrowEx(store.isIndexScannable(srcIndex), "source index is not scannable");
+        validateOrThrowEx(store.getIndexState(srcIndex).isScannable(), "source index is not scannable");
         boolean isIdempotent = maintainer.isIdempotent();
         final ScanProperties scanProperties = scanPropertiesWithLimits(isIdempotent);
 
@@ -212,7 +212,7 @@ public class IndexingByIndex extends IndexingBase {
 
         // readability - This method shouldn't block if one has already opened the record store (as we did)
         final Index srcIndex = getSourceIndex(store.getRecordMetaData());
-        validateOrThrowEx(store.isIndexScannable(srcIndex), "source index is not scannable");
+        validateOrThrowEx(store.getIndexState(srcIndex).isScannable(), "source index is not scannable");
 
         final ExecuteProperties.Builder executeProperties = ExecuteProperties.newBuilder()
                 .setIsolationLevel(maintainer.isIdempotent() ? IsolationLevel.SNAPSHOT : IsolationLevel.SERIALIZABLE);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/BitmapValueIndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/BitmapValueIndexMaintainer.java
@@ -202,7 +202,7 @@ public class BitmapValueIndexMaintainer extends StandardIndexMaintainer {
             // We really could use a new mutation that took a linear bit position to set / clear and only did length extension or something like that.
             final byte[] bitmap = new byte[(entrySize + 7) / 8];
             if (remove) {
-                if (state.store.isIndexWriteOnly(state.index)) {
+                if (state.store.getIndexState(state.index).isWriteOnly()) {
                     // If the index isn't built, it's possible this key wasn't reached.
                     // So initialize it to zeros (or leave it alone).
                     state.transaction.mutate(MutationType.BIT_OR, key, bitmap);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankedSetIndexHelper.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/RankedSetIndexHelper.java
@@ -276,7 +276,7 @@ public class RankedSetIndexHelper {
             // It is okay if the score isn't in the ranked set yet if the index is
             // write only because this means that the score just hasn't yet
             // been added by some record. We still want the conflict ranges, though.
-            if (!exists && !state.store.isIndexWriteOnly(state.index)) {
+            if (!exists && !state.store.getIndexState(state.index).isWriteOnly()) {
                 throw new RecordCoreException("Score was not present in ranked set.",
                         "rankSubspace", ByteArrayUtil2.loggable(rankedSet.getSubspace().getKey()));
             }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/StandardIndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/StandardIndexMaintainer.java
@@ -33,6 +33,7 @@ import com.apple.foundationdb.record.EvaluationContext;
 import com.apple.foundationdb.record.ExecuteProperties;
 import com.apple.foundationdb.record.IndexEntry;
 import com.apple.foundationdb.record.IndexScanType;
+import com.apple.foundationdb.record.IndexState;
 import com.apple.foundationdb.record.IsolationLevel;
 import com.apple.foundationdb.record.PipelineOperation;
 import com.apple.foundationdb.record.RecordCoreArgumentException;
@@ -493,7 +494,7 @@ public abstract class StandardIndexMaintainer extends IndexMaintainer {
                     Tuple existingEntry = unpackKey(getIndexSubspace(), kv);
                     Tuple existingKey = state.index.getEntryPrimaryKey(existingEntry);
                     if (!TupleHelpers.equals(primaryKey, existingKey)) {
-                        if (state.store.isIndexWriteOnly(state.index)) {
+                        if (state.store.getIndexState(state.index).isWriteOnly()) {
                             addUniquenessViolation(valueKey, primaryKey, existingKey);
                             addUniquenessViolation(valueKey, existingKey, primaryKey);
                         } else {
@@ -506,7 +507,8 @@ public abstract class StandardIndexMaintainer extends IndexMaintainer {
     }
 
     private boolean isWriteOnlyOrUniquePending() {
-        return state.store.isIndexWriteOnly(state.index) || state.store.isIndexReadableUniquePending(state.index);
+        final IndexState indexState = state.store.getIndexState(state.index);
+        return indexState.isWriteOnly() || indexState.isReadableUniquePending();
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/synthetic/SyntheticRecordPlanner.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/synthetic/SyntheticRecordPlanner.java
@@ -228,7 +228,7 @@ public class SyntheticRecordPlanner {
         if (indexes.isEmpty()) {
             return true;
         }
-        return indexes.stream().allMatch(recordStore::isIndexDisabled);
+        return indexes.stream().allMatch(index -> recordStore.getIndexState(index).isDisabled());
     }
 
     /**

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/IndexStateTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/IndexStateTest.java
@@ -1,0 +1,260 @@
+/*
+ * IndexStateTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record;
+
+import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.metadata.IndexOptions;
+import com.apple.foundationdb.record.metadata.IndexTypes;
+import com.apple.foundationdb.record.metadata.RecordType;
+import com.apple.foundationdb.record.metadata.expressions.EmptyKeyExpression;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreTestBase;
+import com.apple.test.Tags;
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static com.apple.foundationdb.record.metadata.Key.Expressions.field;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link IndexState} and for the index-state accessors that delegate to its predicates.
+ */
+@Tag(Tags.RequiresFDB)
+class IndexStateTest extends FDBRecordStoreTestBase {
+
+    private static final String UNIQUE_INDEX = "MySimpleRecord$num_value_unique";
+    private static final String STR_INDEX = "MySimpleRecord$str_value_indexed";
+    private static final String NUM_3_INDEX = "MySimpleRecord$num_value_3_indexed";
+    private static final String MULTI_TYPE_INDEX = "simple&other$num_value_2";
+    private static final String UNIVERSAL_INDEX = COUNT_INDEX_NAME;
+    private static final String NEW_UNIQUE_INDEX = "simple$num_value_2_unique";
+
+    /**
+     * The expected value of every predicate, per state. Deliberately spelled out rather than derived, so that a
+     * change in {@link IndexState} has to be restated here.
+     */
+    static Stream<Arguments> predicateMatrix() {
+        return Stream.of(
+                //            state                                 readable uniquePending scannable writeOnlyNoQueue writeOnlyWithQueue writeOnly disabled
+                Arguments.of(IndexState.READABLE,                   true,    false,        true,     false,           false,             false,    false),
+                Arguments.of(IndexState.READABLE_UNIQUE_PENDING,    false,   true,         true,     false,           false,             false,    false),
+                Arguments.of(IndexState.WRITE_ONLY,                 false,   false,        false,    true,            false,             true,     false),
+                Arguments.of(IndexState.WRITE_ONLY_WITH_QUEUE,      false,   false,        false,    false,           true,              true,     false),
+                Arguments.of(IndexState.DISABLED,                   false,   false,        false,    false,           false,             false,    true));
+    }
+
+    @ParameterizedTest
+    @MethodSource("predicateMatrix")
+    void predicatesMatchTheState(IndexState state, boolean readable, boolean uniquePending, boolean scannable,
+                                 boolean writeOnlyNoQueue, boolean writeOnlyWithQueue, boolean writeOnly,
+                                 boolean disabled) {
+        assertThat(state.isReadable()).as("isReadable").isEqualTo(readable);
+        assertThat(state.isReadableUniquePending()).as("isReadableUniquePending").isEqualTo(uniquePending);
+        assertThat(state.isScannable()).as("isScannable").isEqualTo(scannable);
+        assertThat(state.isWriteOnlyNoQueue()).as("isWriteOnlyNoQueue").isEqualTo(writeOnlyNoQueue);
+        assertThat(state.isWriteOnlyWithQueue()).as("isWriteOnlyWithQueue").isEqualTo(writeOnlyWithQueue);
+        assertThat(state.isWriteOnly()).as("isWriteOnly").isEqualTo(writeOnly);
+        assertThat(state.isDisabled()).as("isDisabled").isEqualTo(disabled);
+    }
+
+    @Test
+    void predicateMatrixCoversEveryState() {
+        assertThat(predicateMatrix().map(args -> args.get()[0]))
+                .containsExactlyInAnyOrder((Object[])IndexState.values());
+    }
+
+    /**
+     * A new state must not slip in without its own predicate.
+     */
+    @ParameterizedTest
+    @EnumSource(IndexState.class)
+    void exactlyOnePrimaryPredicateHolds(IndexState state) {
+        final List<Boolean> primaries = List.of(state.isReadable(), state.isReadableUniquePending(),
+                state.isWriteOnlyNoQueue(), state.isWriteOnlyWithQueue(), state.isDisabled());
+        assertThat(primaries.stream().filter(Boolean::booleanValue)).hasSize(1);
+    }
+
+    @ParameterizedTest
+    @EnumSource(IndexState.class)
+    void fromCodeRoundTrips(IndexState state) {
+        assertThat(IndexState.fromCode(state.code())).isSameAs(state);
+    }
+
+    @Test
+    void recordStoreStatePredicatesFollowTheState() {
+        final RecordStoreState storeState = new RecordStoreState(null, ImmutableMap.of(
+                STR_INDEX, IndexState.DISABLED,
+                NUM_3_INDEX, IndexState.WRITE_ONLY_WITH_QUEUE,
+                NEW_UNIQUE_INDEX, IndexState.READABLE_UNIQUE_PENDING));
+
+        assertThat(storeState.isReadableUniquePending(NEW_UNIQUE_INDEX)).isTrue();
+        assertThat(storeState.isScannable(NEW_UNIQUE_INDEX)).isTrue();
+        assertThat(storeState.isReadable(NEW_UNIQUE_INDEX)).isFalse();
+        assertThat(storeState.isWriteOnly(NUM_3_INDEX)).isTrue();
+        assertThat(storeState.isDisabled(STR_INDEX)).isTrue();
+        assertThat(storeState.isReadableUniquePending(STR_INDEX)).isFalse();
+        // An index absent from the map defaults to READABLE.
+        assertThat(storeState.isReadable(UNIQUE_INDEX)).isTrue();
+        assertThat(storeState.isReadableUniquePending(UNIQUE_INDEX)).isFalse();
+    }
+
+    @Test
+    void withIndexesInStateSetsNonReadableAndClearsReadable() {
+        final RecordStoreState empty = new RecordStoreState(null, null);
+
+        final RecordStoreState disabled = empty.withIndexesInState(List.of(STR_INDEX, NUM_3_INDEX),
+                IndexState.DISABLED);
+        assertThat(disabled.getIndexStates())
+                .containsOnlyKeys(STR_INDEX, NUM_3_INDEX)
+                .containsValue(IndexState.DISABLED);
+
+        // READABLE is the default, so those entries are removed rather than stored.
+        final RecordStoreState restored = disabled.withIndexesInState(List.of(STR_INDEX), IndexState.READABLE);
+        assertThat(restored.getIndexStates()).containsOnlyKeys(NUM_3_INDEX);
+        assertThat(restored.isReadable(STR_INDEX)).isTrue();
+        assertThat(restored.isDisabled(NUM_3_INDEX)).isTrue();
+    }
+
+    @Test
+    void storeIndexStateFollowsTheMarkedState() throws Exception {
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context);
+            recordStore.markIndexDisabled(STR_INDEX).join();
+            recordStore.markIndexWriteOnlyWithQueue(NUM_3_INDEX).join();
+
+            assertThat(recordStore.getIndexState(UNIQUE_INDEX).isReadable()).isTrue();
+            assertThat(recordStore.getIndexState(STR_INDEX).isDisabled()).isTrue();
+            assertThat(recordStore.getIndexState(NUM_3_INDEX).isWriteOnlyWithQueue()).isTrue();
+            assertThat(recordStore.getIndexState(NUM_3_INDEX).isWriteOnly()).isTrue();
+            assertThat(recordStore.getIndexState(NUM_3_INDEX).isWriteOnlyNoQueue()).isFalse();
+
+            // Testing a deprecated function.
+            assertThat(recordStore.isIndexReadable(UNIQUE_INDEX)).isTrue();
+            assertThat(recordStore.isIndexReadable(index(UNIQUE_INDEX))).isTrue();
+            assertThat(recordStore.isIndexReadable(STR_INDEX)).isFalse();
+            // Testing a deprecated function.
+            assertThat(recordStore.isIndexDisabled(STR_INDEX)).isTrue();
+            assertThat(recordStore.isIndexDisabled(index(STR_INDEX))).isTrue();
+            assertThat(recordStore.isIndexDisabled(UNIQUE_INDEX)).isFalse();
+            // Testing a deprecated function.
+            assertThat(recordStore.isIndexWriteOnlyWithQueue(NUM_3_INDEX)).isTrue();
+            assertThat(recordStore.isIndexWriteOnlyWithQueue(index(NUM_3_INDEX))).isTrue();
+            assertThat(recordStore.isIndexWriteOnlyWithQueue(UNIQUE_INDEX)).isFalse();
+            // Testing a deprecated function.
+            assertThat(recordStore.isIndexWriteOnly(NUM_3_INDEX)).isTrue();
+            assertThat(recordStore.isIndexWriteOnlyNoQueue(NUM_3_INDEX)).isFalse();
+            assertThat(recordStore.isIndexScannable(UNIQUE_INDEX)).isTrue();
+            assertThat(recordStore.isIndexReadableUniquePending(UNIQUE_INDEX)).isFalse();
+            commit(context);
+        }
+    }
+
+    @Test
+    void storeIndexStateReadableUniquePending() throws Exception {
+        final Index uniqueIndex = new Index(NEW_UNIQUE_INDEX, field("num_value_2"), EmptyKeyExpression.EMPTY,
+                IndexTypes.VALUE, IndexOptions.UNIQUE_OPTIONS);
+        final RecordMetaDataHook hook = metaData -> metaData.addIndex("MySimpleRecord", uniqueIndex);
+
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, hook);
+            // markIndexWriteOnly keeps the built range, so the index stays markable as readable later.
+            recordStore.markIndexWriteOnly(uniqueIndex).join();
+            commit(context);
+        }
+
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, hook);
+            recordStore.saveRecord(TestRecords1Proto.MySimpleRecord.newBuilder()
+                    .setRecNo(1L).setNumValue2(42).build());
+            recordStore.saveRecord(TestRecords1Proto.MySimpleRecord.newBuilder()
+                    .setRecNo(2L).setNumValue2(42).build());
+            commit(context);
+        }
+
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, hook);
+            assertThat(recordStore.markIndexReadableOrUniquePending(uniqueIndex).join()).isTrue();
+
+            final IndexState state = recordStore.getIndexState(NEW_UNIQUE_INDEX);
+            assertThat(state).isEqualTo(IndexState.READABLE_UNIQUE_PENDING);
+            assertThat(state.isReadableUniquePending()).isTrue();
+            assertThat(state.isScannable()).isTrue();
+            assertThat(state.isReadable()).isFalse();
+            assertThat(recordStore.getRecordStoreState().isReadableUniquePending(NEW_UNIQUE_INDEX)).isTrue();
+
+            // Testing a deprecated function.
+            assertThat(recordStore.isIndexReadableUniquePending(NEW_UNIQUE_INDEX)).isTrue();
+            assertThat(recordStore.isIndexReadableUniquePending(uniqueIndex)).isTrue();
+            assertThat(recordStore.isIndexScannable(NEW_UNIQUE_INDEX)).isTrue();
+            assertThat(recordStore.isIndexReadable(NEW_UNIQUE_INDEX)).isFalse();
+
+            // Not readable, so it is not among the readable indexes.
+            assertThat(recordStore.getReadableIndexes(simpleRecordType())).doesNotContain(uniqueIndex);
+            commit(context);
+        }
+    }
+
+    @Test
+    void readableIndexAccessorsExcludeNonReadableIndexes() throws Exception {
+        final Index multiTypeIndex = new Index(MULTI_TYPE_INDEX, "num_value_2");
+        // The simple meta-data already carries the universal count indexes.
+        final RecordMetaDataHook hook = metaData -> metaData.addMultiTypeIndex(
+                List.of(metaData.getRecordType("MySimpleRecord"), metaData.getRecordType("MyOtherRecord")),
+                multiTypeIndex);
+
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context, hook);
+            // Without a non-readable index the accessors short-circuit and return everything.
+            recordStore.markIndexDisabled(STR_INDEX).join();
+
+            assertThat(recordStore.getReadableIndexes(simpleRecordType()))
+                    .contains(index(UNIQUE_INDEX), index(NUM_3_INDEX))
+                    .doesNotContain(index(STR_INDEX));
+            assertThat(recordStore.getReadableMultiTypeIndexes(simpleRecordType())).contains(multiTypeIndex);
+            assertThat(recordStore.getReadableUniversalIndexes()).contains(index(UNIVERSAL_INDEX));
+
+            recordStore.markIndexDisabled(MULTI_TYPE_INDEX).join();
+            recordStore.markIndexDisabled(UNIVERSAL_INDEX).join();
+            assertThat(recordStore.getReadableMultiTypeIndexes(simpleRecordType())).doesNotContain(multiTypeIndex);
+            assertThat(recordStore.getReadableUniversalIndexes()).doesNotContain(index(UNIVERSAL_INDEX));
+            commit(context);
+        }
+    }
+
+    @Nonnull
+    private Index index(@Nonnull final String indexName) {
+        return recordStore.getRecordMetaData().getIndex(indexName);
+    }
+
+    @Nonnull
+    private RecordType simpleRecordType() {
+        return recordStore.getRecordMetaData().getRecordType("MySimpleRecord");
+    }
+}

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreCountRecordsTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreCountRecordsTest.java
@@ -308,7 +308,7 @@ public class FDBRecordStoreCountRecordsTest extends FDBRecordStoreTestBase {
                 // Need to manually rebuild index in this case.
                 Index index = recordStore.getRecordMetaData().getIndex("record_count");
                 recordStore.rebuildIndex(index).get();
-                assertThat(recordStore.isIndexReadable(index), is(true));
+                assertThat(recordStore.getIndexState(index).isReadable(), is(true));
             }
 
             assertEquals(100, recordStore.getSnapshotRecordCount().join().longValue(), "should see all records");
@@ -338,7 +338,7 @@ public class FDBRecordStoreCountRecordsTest extends FDBRecordStoreTestBase {
                 // Need to manually rebuild index in this case.
                 Index index = recordStore.getRecordMetaData().getIndex("record_count");
                 recordStore.rebuildIndex(index).get();
-                assertThat(recordStore.isIndexReadable(index), is(true));
+                assertThat(recordStore.getIndexState(index).isReadable(), is(true));
             }
 
             assertUngroupedCount(132);

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreIndexTest.java
@@ -907,8 +907,8 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
             recordStore.markIndexWriteOnly(indexName).get();
-            assertThat(recordStore.isIndexReadable(indexName), is(false));
-            assertThat(recordStore.isIndexWriteOnly(indexName), is(true));
+            assertThat(recordStore.getIndexState(indexName).isReadable(), is(false));
+            assertThat(recordStore.getIndexState(indexName).isWriteOnly(), is(true));
 
             try {
                 recordStore.scanIndexRecords(indexName);
@@ -939,8 +939,8 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
             recordStore.uncheckedMarkIndexReadable(indexName).get();
-            assertThat(recordStore.isIndexReadable(indexName), is(true));
-            assertThat(recordStore.isIndexWriteOnly(indexName), is(false));
+            assertThat(recordStore.getIndexState(indexName).isReadable(), is(true));
+            assertThat(recordStore.getIndexState(indexName).isWriteOnly(), is(false));
             assertEquals(Collections.singletonList(1066L),
                     recordStore.scanIndexRecords(indexName)
                             .map(rec -> TestRecords1Proto.MySimpleRecord.newBuilder().mergeFrom(rec.getRecord()).getRecNo()).asList().get());
@@ -978,13 +978,13 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
             recordStore.markIndexWriteOnlyWithQueue(standardIndex).get();
             recordStore.markIndexWriteOnlyWithQueue(permissiveIndexName).get();
 
-            // Exercise both the Index and String overloads of isIndexWriteOnlyWithQueue.
-            assertThat(recordStore.isIndexWriteOnlyWithQueue(standardIndex), is(true));
-            assertThat(recordStore.isIndexWriteOnlyWithQueue(standardIndexName), is(true));
-            assertThat(recordStore.isIndexWriteOnlyWithQueue(permissiveIndex), is(true));
-            assertThat(recordStore.isIndexWriteOnlyWithQueue(permissiveIndexName), is(true));
-            assertThat(recordStore.isIndexWriteOnlyNoQueue(standardIndexName), is(false));
-            assertThat(recordStore.isIndexReadable(standardIndexName), is(false));
+            // Exercise both the Index and String overloads of getIndexState.
+            assertThat(recordStore.getIndexState(standardIndex).isWriteOnlyWithQueue(), is(true));
+            assertThat(recordStore.getIndexState(standardIndexName).isWriteOnlyWithQueue(), is(true));
+            assertThat(recordStore.getIndexState(permissiveIndex).isWriteOnlyWithQueue(), is(true));
+            assertThat(recordStore.getIndexState(permissiveIndexName).isWriteOnlyWithQueue(), is(true));
+            assertThat(recordStore.getIndexState(standardIndexName).isWriteOnlyNoQueue(), is(false));
+            assertThat(recordStore.getIndexState(standardIndexName).isReadable(), is(false));
 
             // The NoOp-backed permissive index does not allow the pending write queue, so saving a record while it is
             // in WRITE_ONLY_WITH_QUEUE is rejected: serializePendingWriteQueue throws UnsupportedOperationException.
@@ -1080,8 +1080,8 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
             recordStore.markIndexDisabled(indexName).get();
-            assertThat(recordStore.isIndexReadable(indexName), is(false));
-            assertThat(recordStore.isIndexDisabled(indexName), is(true));
+            assertThat(recordStore.getIndexState(indexName).isReadable(), is(false));
+            assertThat(recordStore.getIndexState(indexName).isDisabled(), is(true));
 
             try {
                 recordStore.scanIndexRecords(indexName);
@@ -1112,8 +1112,8 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
             recordStore.uncheckedMarkIndexReadable(indexName).get();
-            assertThat(recordStore.isIndexReadable(indexName), is(true));
-            assertThat(recordStore.isIndexDisabled(indexName), is(false));
+            assertThat(recordStore.getIndexState(indexName).isReadable(), is(true));
+            assertThat(recordStore.getIndexState(indexName).isDisabled(), is(false));
             assertEquals(0, (int)recordStore.scanIndexRecords(indexName).getCount().get());
             commit(context);
         }
@@ -1151,8 +1151,8 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
             assertThat(recordStore.markIndexDisabled(indexName).join(), is(true));
-            assertThat(recordStore.isIndexReadable(indexName), is(false));
-            assertThat(recordStore.isIndexDisabled(indexName), is(true));
+            assertThat(recordStore.getIndexState(indexName).isReadable(), is(false));
+            assertThat(recordStore.getIndexState(indexName).isDisabled(), is(true));
             commit(context);
         }
 
@@ -1189,13 +1189,13 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
         // uncommitted transaction.
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
-            assertTrue(recordStore.isIndexDisabled(disabledIndex));
-            assertTrue(recordStore.isIndexWriteOnly(writeOnlyIndex));
+            assertTrue(recordStore.getIndexState(disabledIndex).isDisabled());
+            assertTrue(recordStore.getIndexState(writeOnlyIndex).isWriteOnly());
             assertTrue(recordStore.recordExists(Tuple.from(1066L)));
 
             recordStore.deleteAllRecords();
-            assertTrue(recordStore.isIndexDisabled(disabledIndex));
-            assertTrue(recordStore.isIndexWriteOnly(writeOnlyIndex));
+            assertTrue(recordStore.getIndexState(disabledIndex).isDisabled());
+            assertTrue(recordStore.getIndexState(writeOnlyIndex).isWriteOnly());
             assertFalse(recordStore.recordExists(Tuple.from(1066L)));
             commit(context);
         }
@@ -1203,27 +1203,27 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
         // Ensure that this is still true after the transaction commits.
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
-            assertTrue(recordStore.isIndexDisabled(disabledIndex));
-            assertTrue(recordStore.isIndexWriteOnly(writeOnlyIndex));
+            assertTrue(recordStore.getIndexState(disabledIndex).isDisabled());
+            assertTrue(recordStore.getIndexState(writeOnlyIndex).isWriteOnly());
             assertFalse(recordStore.recordExists(Tuple.from(1066L)));
         }
 
         // Rebuild all indexes to reset the index states.
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
-            assertTrue(recordStore.isIndexDisabled(disabledIndex));
-            assertTrue(recordStore.isIndexWriteOnly(writeOnlyIndex));
+            assertTrue(recordStore.getIndexState(disabledIndex).isDisabled());
+            assertTrue(recordStore.getIndexState(writeOnlyIndex).isWriteOnly());
             recordStore.rebuildAllIndexes().get();
-            assertTrue(recordStore.isIndexReadable(disabledIndex));
-            assertTrue(recordStore.isIndexReadable(writeOnlyIndex));
+            assertTrue(recordStore.getIndexState(disabledIndex).isReadable());
+            assertTrue(recordStore.getIndexState(writeOnlyIndex).isReadable());
             commit(context);
         }
 
         // Verify that the index states are, in fact, updated.
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
-            assertTrue(recordStore.isIndexReadable(disabledIndex));
-            assertTrue(recordStore.isIndexReadable(writeOnlyIndex));
+            assertTrue(recordStore.getIndexState(disabledIndex).isReadable());
+            assertTrue(recordStore.getIndexState(writeOnlyIndex).isReadable());
             commit(context);
         }
     }
@@ -1325,16 +1325,16 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
         final String indexName = "MySimpleRecord$str_value_indexed";
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
-            assertThat(recordStore.isIndexWriteOnly(indexName), is(false));
+            assertThat(recordStore.getIndexState(indexName).isWriteOnly(), is(false));
             recordStore.clearAndMarkIndexWriteOnly(indexName).get();
-            assertThat(recordStore.isIndexWriteOnly(indexName), is(true));
+            assertThat(recordStore.getIndexState(indexName).isWriteOnly(), is(true));
             commit(context);
         }
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
             Index index = recordStore.getRecordMetaData().getIndex(indexName);
-            assertThat(recordStore.isIndexReadable(index), is(false));
+            assertThat(recordStore.getIndexState(index).isReadable(), is(false));
             buildIndexAndCrashHalfway(indexName, 4);
             Optional<Range> firstUnbuilt = recordStore.firstUnbuiltRange(index).get();
             assertTrue(firstUnbuilt.isPresent());
@@ -1345,12 +1345,12 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
                 assertThat(e.getCause(), instanceOf(FDBRecordStore.IndexNotBuiltException.class));
                 return null;
             }).get();
-            assertThat(recordStore.isIndexReadable(index), is(false));
+            assertThat(recordStore.getIndexState(index).isReadable(), is(false));
         }
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
             Index index = recordStore.getRecordMetaData().getIndex(indexName);
-            assertThat(recordStore.isIndexReadable(index), is(false));
+            assertThat(recordStore.getIndexState(index).isReadable(), is(false));
             try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder().setRecordStore(recordStore).setIndex(index)
                     .build()) {
                 indexBuilder.buildIndex(false);
@@ -1360,39 +1360,39 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
             Index index = recordStore.getRecordMetaData().getIndex(indexName);
-            assertThat(recordStore.isIndexReadable(index), is(false));
+            assertThat(recordStore.getIndexState(index).isReadable(), is(false));
             assertFalse(recordStore.firstUnbuiltRange(index).get().isPresent());
             assertTrue(recordStore.markIndexReadable(index).get());
             assertFalse(recordStore.markIndexReadable(index).get());
-            assertThat(recordStore.isIndexReadable(index), is(true));
+            assertThat(recordStore.getIndexState(index).isReadable(), is(true));
             commit(context);
         }
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
-            assertFalse(recordStore.isIndexWriteOnly(indexName));
+            assertFalse(recordStore.getIndexState(indexName).isWriteOnly());
             recordStore.markIndexDisabled(indexName).get();
-            assertTrue(recordStore.isIndexDisabled(indexName));
+            assertTrue(recordStore.getIndexState(indexName).isDisabled());
             commit(context);
         }
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
             Index index = recordStore.getRecordMetaData().getIndex(indexName);
-            assertThat(recordStore.isIndexReadable(index), is(false));
+            assertThat(recordStore.getIndexState(index).isReadable(), is(false));
             buildIndexAndCrashHalfway(indexName, 7);
             Optional<Range> firstUnbuilt = recordStore.firstUnbuiltRange(index).get();
             assertTrue(firstUnbuilt.isPresent());
             assertTrue(recordStore.uncheckedMarkIndexReadable(index.getName()).get());
             assertFalse(recordStore.uncheckedMarkIndexReadable(index.getName()).get());
-            assertThat(recordStore.isIndexReadable(index), is(true));
+            assertThat(recordStore.getIndexState(index).isReadable(), is(true));
 
             // Purposefully, checking to mark an index readable that is already
             // readable does not throw an error.
             firstUnbuilt = recordStore.firstUnbuiltRange(index).get();
             assertTrue(firstUnbuilt.isPresent());
             assertFalse(recordStore.markIndexReadable(index.getName()).get());
-            assertThat(recordStore.isIndexReadable(index), is(true));
+            assertThat(recordStore.getIndexState(index).isReadable(), is(true));
         }
     }
 
@@ -1422,9 +1422,9 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
-            assertThat(recordStore.isIndexDisabled(indexName), is(false));
+            assertThat(recordStore.getIndexState(indexName).isDisabled(), is(false));
             recordStore.markIndexDisabled(indexName).get();
-            assertThat(recordStore.isIndexDisabled(indexName), is(true));
+            assertThat(recordStore.getIndexState(indexName).isDisabled(), is(true));
             context.commit();
         }
 
@@ -1458,7 +1458,7 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
                 List<Index> shouldBeDisabled = new ArrayList<>();
                 // Expected contract: only use isIndexXXX and markIndexXXX and wait for all futures when done.
                 for (int i = 0; i < indexes.length; i++) {
-                    if ((i % 2 == 0) || (i == 99 && recordStore.isIndexDisabled(indexes[i]))) {
+                    if ((i % 2 == 0) || (i == 99 && recordStore.getIndexState(indexes[i]).isDisabled())) {
                         futures.add(recordStore.markIndexDisabled(indexes[i]));
                         shouldBeDisabled.add(indexes[i]);
                     }
@@ -1468,7 +1468,7 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
                     assertThat(index, new TypeSafeMatcher<Index>() {
                         @Override
                         protected boolean matchesSafely(Index item) {
-                            return recordStore.isIndexDisabled(index);
+                            return recordStore.getIndexState(index).isDisabled();
                         }
 
                         @Override
@@ -1487,15 +1487,15 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
-            assertFalse(recordStore.isIndexWriteOnly(indexName));
+            assertFalse(recordStore.getIndexState(indexName).isWriteOnly());
             recordStore.markIndexWriteOnly(indexName).get();
-            assertTrue(recordStore.isIndexWriteOnly(indexName));
+            assertTrue(recordStore.getIndexState(indexName).isWriteOnly());
             commit(context);
         }
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
-            assertTrue(recordStore.isIndexWriteOnly(indexName));
+            assertTrue(recordStore.getIndexState(indexName).isWriteOnly());
         }
 
         try (FDBRecordContext context = openContext()) {
@@ -1503,7 +1503,7 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
             recordStore.rebuildIndex(recordStore.getRecordMetaData().getIndex(indexName), FDBRecordStore.RebuildIndexReason.TEST).get();
             assertEquals(1, timer.getCount(FDBStoreTimer.Events.REBUILD_INDEX_TEST), "should build new index");
             assertEquals(1, timer.getCount(FDBStoreTimer.Events.REBUILD_INDEX), "should build new index");
-            assertTrue(recordStore.isIndexReadable(indexName));
+            assertTrue(recordStore.getIndexState(indexName).isReadable());
             commit(context);
         }
 
@@ -1531,7 +1531,7 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, hook1);
             metaDataVersion1 = recordStore.getRecordMetaData().getVersion();
-            assertTrue(recordStore.isIndexReadable(indexName));
+            assertTrue(recordStore.getIndexState(indexName).isReadable());
             recordStore.markIndexDisabled(indexName).join();
             commit(context);
         }
@@ -1647,7 +1647,7 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
             openSimpleRecordStore(context, hook1);
             metaDataVersion1 = recordStore.getRecordMetaData().getVersion();
             recordStore.markIndexWriteOnly(reusedIndexName).join();
-            assertTrue(recordStore.isIndexWriteOnly(reusedIndexName));
+            assertTrue(recordStore.getIndexState(reusedIndexName).isWriteOnly());
             commit(context);
         }
 
@@ -1678,7 +1678,7 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
         //  2. If the desired index state is READABLE_UNIQUE_PENDING, then that also gets upgraded to READABLE as the
         //     index is not unique
         final IndexState expectedIndexState;
-        if (onNewType && desiredIndexState != IndexState.DISABLED || desiredIndexState == IndexState.READABLE_UNIQUE_PENDING) {
+        if (onNewType && !desiredIndexState.isDisabled() || desiredIndexState.isReadableUniquePending()) {
             expectedIndexState = IndexState.READABLE;
         } else {
             expectedIndexState = desiredIndexState;
@@ -1762,7 +1762,7 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
             assertEquals(Tuple.from(saved.getStrValueIndexed(), saved.getRecNo()), indexedRecord.getIndexEntry().getKey());
 
             recordStore.markIndexWriteOnly(reusedIndexName).join();
-            assertTrue(recordStore.isIndexWriteOnly(reusedIndexName));
+            assertTrue(recordStore.getIndexState(reusedIndexName).isWriteOnly());
 
             commit(context);
         }
@@ -1796,9 +1796,9 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
                 // index as read only (with no data) is confused by the index state not being set.
                 // This results in it falling back to alternative logic, which sets the index state
                 // to DISABLED just to get things to a more defined state.
-                assertTrue(recordStore.isIndexDisabled(reusedIndexName));
+                assertTrue(recordStore.getIndexState(reusedIndexName).isDisabled());
             } else {
-                assertTrue(recordStore.isIndexReadable(reusedIndexName));
+                assertTrue(recordStore.getIndexState(reusedIndexName).isReadable());
 
                 // Validate that we can scan the index, and that it contains the saved record with the new index's entry
                 final List<FDBIndexedRecord<Message>> records = recordStore.scanIndexRecords(reusedIndexName)
@@ -1914,12 +1914,12 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
-            assertTrue(recordStore.isIndexReadable(disabledIndex));
-            assertTrue(recordStore.isIndexReadable(writeOnlyIndex));
+            assertTrue(recordStore.getIndexState(disabledIndex).isReadable());
+            assertTrue(recordStore.getIndexState(writeOnlyIndex).isReadable());
             recordStore.markIndexDisabled(disabledIndex).get();
             recordStore.markIndexWriteOnly(writeOnlyIndex).get();
-            assertTrue(recordStore.isIndexDisabled(disabledIndex));
-            assertTrue(recordStore.isIndexWriteOnly(writeOnlyIndex));
+            assertTrue(recordStore.getIndexState(disabledIndex).isDisabled());
+            assertTrue(recordStore.getIndexState(writeOnlyIndex).isWriteOnly());
             recordStore.saveRecord(record);
             commit(context);
         }
@@ -1939,8 +1939,8 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
             recordStore.rebuildAllIndexes().get();
-            assertTrue(recordStore.isIndexReadable(disabledIndex));
-            assertTrue(recordStore.isIndexReadable(writeOnlyIndex));
+            assertTrue(recordStore.getIndexState(disabledIndex).isReadable());
+            assertTrue(recordStore.getIndexState(writeOnlyIndex).isReadable());
             assertEquals(Collections.singletonList(record),
                     recordStore.scanIndexRecords(disabledIndex).map(FDBIndexedRecord::getRecord).asList().get());
             assertEquals(Collections.singletonList(record),
@@ -1951,8 +1951,8 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
         // Validate that the index state updates carry over into the next transaction
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
-            assertTrue(recordStore.isIndexReadable(disabledIndex));
-            assertTrue(recordStore.isIndexReadable(writeOnlyIndex));
+            assertTrue(recordStore.getIndexState(disabledIndex).isReadable());
+            assertTrue(recordStore.getIndexState(writeOnlyIndex).isReadable());
             assertTrue(recordStore.getRecordStoreState().allIndexesReadable());
         }
     }
@@ -2075,9 +2075,9 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
-            assertThat(recordStore.isIndexDisabled(indexName), is(false));
+            assertThat(recordStore.getIndexState(indexName).isDisabled(), is(false));
             recordStore.markIndexDisabled(indexName).get();
-            assertThat(recordStore.isIndexDisabled(indexName), is(true));
+            assertThat(recordStore.getIndexState(indexName).isDisabled(), is(true));
             commit(context);
         }
 
@@ -2104,9 +2104,9 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
-            assertThat(recordStore.isIndexWriteOnly(indexName), is(false));
+            assertThat(recordStore.getIndexState(indexName).isWriteOnly(), is(false));
             recordStore.markIndexWriteOnly(indexName).get();
-            assertThat(recordStore.isIndexWriteOnly(indexName), is(true));
+            assertThat(recordStore.getIndexState(indexName).isWriteOnly(), is(true));
             context.commit();
         }
 
@@ -2209,9 +2209,9 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, hook);
-            assertThat(recordStore.isIndexWriteOnly(index), is(false));
+            assertThat(recordStore.getIndexState(index).isWriteOnly(), is(false));
             recordStore.markIndexWriteOnly(index).get();
-            assertThat(recordStore.isIndexWriteOnly(index), is(true));
+            assertThat(recordStore.getIndexState(index).isWriteOnly(), is(true));
             context.commit();
         }
 
@@ -3176,7 +3176,7 @@ public class FDBRecordStoreIndexTest extends FDBRecordStoreTestBase {
             assertThat(context.ensureActive().getRange(recordStore.getSubspace().range(Tuple.from(FDBRecordStoreKeyspace.INDEX.key(), subspaceKey1))).asList().join(), empty());
 
             // Make sure the new index subspace key is used for the index now
-            if (!recordStore.isIndexReadable(index2)) {
+            if (!recordStore.getIndexState(index2).isReadable()) {
                 recordStore.rebuildIndex(index2).join();
             }
             List<FDBIndexedRecord<Message>> indexedRecords = recordStore.scanIndexRecords(index1.getName())

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreOpeningTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreOpeningTest.java
@@ -1108,7 +1108,7 @@ public class FDBRecordStoreOpeningTest extends FDBRecordStoreTestBase {
             assertEquals(Map.of(index.getName(), Long.MAX_VALUE, countIndexName, Long.MAX_VALUE),
                     userVersionChecker.needRebuildIndexes);
             assertEquals(IndexState.DISABLED, recordStore.getAllIndexStates().get(index));
-            assertTrue(recordStore.isIndexDisabled(countIndexName));
+            assertTrue(recordStore.getIndexState(countIndexName).isDisabled());
             commit(context);
         }
     }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreReplaceIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreReplaceIndexTest.java
@@ -248,7 +248,7 @@ public class FDBRecordStoreReplaceIndexTest extends FDBRecordStoreTestBase {
     private void assertIndexStateAndContents(@Nonnull Index index, @Nonnull IndexState expectedState, @Nonnull Tuple expectedKey) {
         assertEquals(expectedState, recordStore.getIndexState(index.getName()),
                 "Index " + index.getName() + " should be " + expectedState);
-        if (expectedState == IndexState.READABLE) {
+        if (expectedState.isReadable()) {
             final List<IndexEntry> entries = scanIndex(index);
             assertThat("Readable index " + index.getName() + " should contain the saved record", entries, hasSize(1));
             assertEquals(PRIMARY_KEY, entries.get(0).getPrimaryKey());
@@ -264,8 +264,8 @@ public class FDBRecordStoreReplaceIndexTest extends FDBRecordStoreTestBase {
         final RecordMetaDataHook addBothIndexes = composeHooks(addIndexHook(recordTypeName, origIndex), addIndexHook(recordTypeName, newIndex));
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, addBothIndexes);
-            assertTrue(recordStore.isIndexReadable(origIndex), "Old index should be readable at start");
-            assertTrue(recordStore.isIndexReadable(newIndex), "New index should be readable at start");
+            assertTrue(recordStore.getIndexState(origIndex).isReadable(), "Old index should be readable at start");
+            assertTrue(recordStore.getIndexState(newIndex).isReadable(), "New index should be readable at start");
 
             recordStore.saveRecord(TestRecords1Proto.MyOtherRecord.newBuilder()
                     .setRecNo(1415L)
@@ -283,7 +283,7 @@ public class FDBRecordStoreReplaceIndexTest extends FDBRecordStoreTestBase {
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, composeHooks(addIndexAndReplacements(recordTypeName, origIndex, newIndex), bumpMetaDataVersionHook()));
-            assertTrue(recordStore.isIndexDisabled(origIndex.getName()));
+            assertTrue(recordStore.getIndexState(origIndex.getName()).isDisabled());
             commit(context);
         }
 
@@ -303,7 +303,7 @@ public class FDBRecordStoreReplaceIndexTest extends FDBRecordStoreTestBase {
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, addBothIndexes);
             assertTrue(disableIndex(newIndex));
-            assertTrue(recordStore.isIndexReadable(origIndex), "Old index should be readable at start");
+            assertTrue(recordStore.getIndexState(origIndex).isReadable(), "Old index should be readable at start");
 
             recordStore.saveRecord(TestRecords1Proto.MySimpleRecord.newBuilder()
                     .setRecNo(1066L)
@@ -317,7 +317,7 @@ public class FDBRecordStoreReplaceIndexTest extends FDBRecordStoreTestBase {
         final RecordMetaDataHook withReplacementsHook = composeHooks(addIndexAndReplacements(recordTypeName, origIndex, newIndex), bumpMetaDataVersionHook());
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, withReplacementsHook);
-            assertTrue(recordStore.isIndexReadable(origIndex.getName()), "Old index should be readable until replacement index is built");
+            assertTrue(recordStore.getIndexState(origIndex.getName()).isReadable(), "Old index should be readable until replacement index is built");
             final List<IndexEntry> oldIndexEntries = scanIndex(origIndex);
             assertThat(oldIndexEntries, hasSize(1));
             assertEquals(Tuple.from(1066L), oldIndexEntries.get(0).getPrimaryKey());
@@ -329,7 +329,7 @@ public class FDBRecordStoreReplaceIndexTest extends FDBRecordStoreTestBase {
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, withReplacementsHook);
-            assertTrue(recordStore.isIndexDisabled(origIndex.getName()), "Old index should be disabled once replacement index is built");
+            assertTrue(recordStore.getIndexState(origIndex.getName()).isDisabled(), "Old index should be disabled once replacement index is built");
             commit(context);
         }
 
@@ -352,7 +352,7 @@ public class FDBRecordStoreReplaceIndexTest extends FDBRecordStoreTestBase {
         // Start with only the original index present and readable, then save a record
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, addIndexHook(RECORD_TYPE, origIndex));
-            assertTrue(recordStore.isIndexReadable(origIndex), "Old index should be readable at start");
+            assertTrue(recordStore.getIndexState(origIndex).isReadable(), "Old index should be readable at start");
             recordStore.saveRecord(sampleRecord());
             commit(context);
         }
@@ -387,7 +387,7 @@ public class FDBRecordStoreReplaceIndexTest extends FDBRecordStoreTestBase {
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, addIndexHook(RECORD_TYPE, origIndex));
             assertTrue(disableIndex(origIndex));
-            assertTrue(recordStore.isIndexDisabled(origIndex), "Old index should be disabled at start");
+            assertTrue(recordStore.getIndexState(origIndex).isDisabled(), "Old index should be disabled at start");
             recordStore.saveRecord(sampleRecord());
             commit(context);
         }
@@ -476,7 +476,7 @@ public class FDBRecordStoreReplaceIndexTest extends FDBRecordStoreTestBase {
             openSimpleRecordStore(context, addIndexHook(RECORD_TYPE, origIndex));
             recordStore.saveRecord(TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(1L).setNumValue2(10).setNumValueUnique(901).build());
             recordStore.saveRecord(TestRecords1Proto.MySimpleRecord.newBuilder().setRecNo(2L).setNumValue2(10).setNumValueUnique(902).build());
-            assertTrue(recordStore.isIndexReadable(origIndex), "original index should be readable at start");
+            assertTrue(recordStore.getIndexState(origIndex).isReadable(), "original index should be readable at start");
             commit(context);
         }
 
@@ -485,7 +485,7 @@ public class FDBRecordStoreReplaceIndexTest extends FDBRecordStoreTestBase {
         final RecordMetaDataHook withReplacementHook = composeHooks(addIndexAndReplacements(RECORD_TYPE, origIndex, replacementUnique), bumpMetaDataVersionHook());
         try (FDBRecordContext context = openContext()) {
             openWithChecker(context, withReplacementHook, new SelectiveUserVersionChecker(ImmutableMap.of(replacementUnique.getName(), IndexState.WRITE_ONLY)));
-            assertTrue(recordStore.isIndexReadable(origIndex), "original index should remain readable");
+            assertTrue(recordStore.getIndexState(origIndex).isReadable(), "original index should remain readable");
             assertEquals(IndexState.WRITE_ONLY, recordStore.getIndexState(replacementUnique.getName()));
             commit(context);
 
@@ -506,7 +506,7 @@ public class FDBRecordStoreReplaceIndexTest extends FDBRecordStoreTestBase {
             openSimpleRecordStore(context, composeHooks(withReplacementHook, bumpMetaDataVersionHook()));
             assertEquals(IndexState.READABLE_UNIQUE_PENDING, recordStore.getIndexState(replacementUnique.getName()),
                     "replacement should be readable-unique-pending because of the duplicate values");
-            assertTrue(recordStore.isIndexReadable(origIndex),
+            assertTrue(recordStore.getIndexState(origIndex).isReadable(),
                     "original index must not be dropped while its replacement is only unique-pending");
             assertThat(scanIndex(origIndex), hasSize(2));
             commit(context);
@@ -540,7 +540,7 @@ public class FDBRecordStoreReplaceIndexTest extends FDBRecordStoreTestBase {
         // check, which drops the replaced original when that build's transaction commits.
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, withReplacementHook);
-            assertTrue(recordStore.isIndexReadable(origIndex), "original readable before the replacement is built");
+            assertTrue(recordStore.getIndexState(origIndex).isReadable(), "original readable before the replacement is built");
             if (useOnlineIndexer) {
                 // The OnlineIndexer runs its own transactions, so persist the replacedBy meta-data first; it then
                 // drops the original in the transaction where it marks the replacement readable.
@@ -553,7 +553,7 @@ public class FDBRecordStoreReplaceIndexTest extends FDBRecordStoreTestBase {
                 }
             } else {
                 buildIndex(newIndex); // builds + marks readable in this transaction
-                assertTrue(recordStore.isIndexReadable(origIndex), "original is not dropped until the transaction commits");
+                assertTrue(recordStore.getIndexState(origIndex).isReadable(), "original is not dropped until the transaction commits");
                 commit(context);
             }
         }
@@ -561,8 +561,8 @@ public class FDBRecordStoreReplaceIndexTest extends FDBRecordStoreTestBase {
         // Reopen with the SAME version (no additional bump), so checkVersion does not trigger removeReplacedIndexes.
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, withReplacementHook);
-            assertTrue(recordStore.isIndexDisabled(origIndex), "original should have been dropped at commit time");
-            assertTrue(recordStore.isIndexReadable(newIndex), "replacement should be readable");
+            assertTrue(recordStore.getIndexState(origIndex).isDisabled(), "original should have been dropped at commit time");
+            assertTrue(recordStore.getIndexState(newIndex).isReadable(), "replacement should be readable");
             commit(context);
         }
     }
@@ -676,9 +676,9 @@ public class FDBRecordStoreReplaceIndexTest extends FDBRecordStoreTestBase {
                 openSimpleRecordStore(context, withReplacementHook);
                 forEachStore(multiStoreRoot, stores, (storePathName, subStore) -> {
                     if (storesToBuild.contains(storePathName)) {
-                        assertTrue(subStore.isIndexDisabled(origIndex.getName()), storePathName + ": original should be dropped once its replacement is built");
+                        assertTrue(subStore.getIndexState(origIndex.getName()).isDisabled(), storePathName + ": original should be dropped once its replacement is built");
                     } else {
-                        assertTrue(subStore.isIndexReadable(origIndex.getName()), storePathName + ": original should still be readable where the replacement was not built");
+                        assertTrue(subStore.getIndexState(origIndex.getName()).isReadable(), storePathName + ": original should still be readable where the replacement was not built");
                         assertThat(context.asyncToSync(FDBStoreTimer.Waits.WAIT_SCAN_RECORDS, subStore.scanIndexRecords(origIndex.getName()).asList()), hasSize(2));
                     }
                 });
@@ -745,7 +745,7 @@ public class FDBRecordStoreReplaceIndexTest extends FDBRecordStoreTestBase {
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, withReplacementsHook);
 
-            assertTrue(recordStore.isIndexReadable(origIndex));
+            assertTrue(recordStore.getIndexState(origIndex).isReadable());
             origEntries = scanIndex(origIndex);
             assertThat(origEntries, hasSize(1));
             assertEquals(Tuple.from(800L), origEntries.get(0).getPrimaryKey());
@@ -758,7 +758,7 @@ public class FDBRecordStoreReplaceIndexTest extends FDBRecordStoreTestBase {
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, withReplacementsHook);
 
-            assertTrue(recordStore.isIndexReadable(origIndex));
+            assertTrue(recordStore.getIndexState(origIndex).isReadable());
             assertEquals(origEntries, scanIndex(origIndex));
 
             disableIndex(newIndex1);
@@ -770,7 +770,7 @@ public class FDBRecordStoreReplaceIndexTest extends FDBRecordStoreTestBase {
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, withReplacementsHook);
 
-            assertTrue(recordStore.isIndexReadable(origIndex));
+            assertTrue(recordStore.getIndexState(origIndex).isReadable());
             assertEquals(origEntries, scanIndex(origIndex));
 
             buildIndex(newIndex1);
@@ -779,7 +779,7 @@ public class FDBRecordStoreReplaceIndexTest extends FDBRecordStoreTestBase {
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, withReplacementsHook);
-            assertTrue(recordStore.isIndexDisabled(origIndex));
+            assertTrue(recordStore.getIndexState(origIndex).isDisabled());
             commit(context);
         }
 
@@ -799,9 +799,9 @@ public class FDBRecordStoreReplaceIndexTest extends FDBRecordStoreTestBase {
         final RecordMetaDataHook metaDataHook = addIndexAndReplacements(recordTypeName, origIndex, newIndex);
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, metaDataHook);
-            assertTrue(recordStore.isIndexDisabled(origIndex), "index with replacements should begin disabled");
+            assertTrue(recordStore.getIndexState(origIndex).isDisabled(), "index with replacements should begin disabled");
             recordStore.rebuildAllIndexes().join();
-            assertTrue(recordStore.isIndexDisabled(origIndex), "index with replacements should not be built with all indexes");
+            assertTrue(recordStore.getIndexState(origIndex).isDisabled(), "index with replacements should not be built with all indexes");
             commit(context);
         }
     }
@@ -814,8 +814,8 @@ public class FDBRecordStoreReplaceIndexTest extends FDBRecordStoreTestBase {
         final RecordMetaDataHook metaDataHook = addIndexAndReplacements(recordTypeName, origIndex, newIndex);
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, metaDataHook);
-            assertTrue(recordStore.isIndexDisabled(origIndex), "index with replacements should begin disabled");
-            assertTrue(recordStore.isIndexReadable(newIndex), "newIndex should begin built");
+            assertTrue(recordStore.getIndexState(origIndex).isDisabled(), "index with replacements should begin disabled");
+            assertTrue(recordStore.getIndexState(newIndex).isReadable(), "newIndex should begin built");
             assertTrue(recordStore.getIndexesToBuild().keySet().stream().noneMatch(index -> index.getName().equals(origIndex.getName())),
                     "index with replacements should not be listed as index to build even if unbuilt");
             commit(context);
@@ -840,7 +840,7 @@ public class FDBRecordStoreReplaceIndexTest extends FDBRecordStoreTestBase {
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, metaDataHook);
-            assertTrue(recordStore.isIndexDisabled(origIndex), "replaced index should begin disabled");
+            assertTrue(recordStore.getIndexState(origIndex).isDisabled(), "replaced index should begin disabled");
             // Make the replacement need building, so rebuildAllIndexes has real work to do while still skipping the original.
             assertTrue(disableIndex(newIndex));
             commit(context);
@@ -856,7 +856,7 @@ public class FDBRecordStoreReplaceIndexTest extends FDBRecordStoreTestBase {
             recordStore.rebuildAllIndexes().join();
 
             // Still disabled in the same transaction (before the commit-check could re-disable it): it was never built.
-            assertTrue(recordStore.isIndexDisabled(origIndex),
+            assertTrue(recordStore.getIndexState(origIndex).isDisabled(),
                     "rebuildAllIndexes must not attempt to build the replaced index");
             commit(context);
         }
@@ -875,7 +875,7 @@ public class FDBRecordStoreReplaceIndexTest extends FDBRecordStoreTestBase {
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, metaDataHook);
-            assertTrue(recordStore.isIndexDisabled(origIndex), "replaced index should begin disabled");
+            assertTrue(recordStore.getIndexState(origIndex).isDisabled(), "replaced index should begin disabled");
             // Disable the replacement, so building the original is not undone by removeReplacedIndexes.
             assertTrue(disableIndex(newIndex));
             commit(context);
@@ -899,7 +899,7 @@ public class FDBRecordStoreReplaceIndexTest extends FDBRecordStoreTestBase {
 
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, metaDataHook);
-            assertTrue(recordStore.isIndexReadable(origIndex),
+            assertTrue(recordStore.getIndexState(origIndex).isReadable(),
                     "explicitly building a replaced index while its replacement is unbuilt should leave it readable");
             commit(context);
         }
@@ -1028,7 +1028,7 @@ public class FDBRecordStoreReplaceIndexTest extends FDBRecordStoreTestBase {
         }
 
         boolean buildsNewIndex() {
-            return expectedReplacementState == IndexState.READABLE;
+            return expectedReplacementState.isReadable();
         }
 
         IndexState expectedOriginalState() {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreUniqueIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStoreUniqueIndexTest.java
@@ -220,7 +220,7 @@ public class FDBRecordStoreUniqueIndexTest extends FDBRecordStoreTestBase {
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context, metaDataBuilder -> metaDataBuilder.addIndex("MySimpleRecord", uniqueIndex));
 
-            assertFalse(recordStore.isIndexReadable(uniqueIndex), "index with uniqueness violations should not be readable after being added to the meta-data");
+            assertFalse(recordStore.getIndexState(uniqueIndex).isReadable(), "index with uniqueness violations should not be readable after being added to the meta-data");
             final List<RecordIndexUniquenessViolation> uniquenessViolations = recordStore.scanUniquenessViolations(uniqueIndex).asList().get();
             assertThat(uniquenessViolations, not(empty()));
             for (RecordIndexUniquenessViolation uniquenessViolation : uniquenessViolations) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerBuildIndexTest.java
@@ -128,7 +128,7 @@ abstract class OnlineIndexerBuildIndexTest extends OnlineIndexerTest {
 
         final boolean isAlwaysReadable;
         try (FDBRecordContext context = openContext()) {
-            isAlwaysReadable = recordStore.isIndexReadable(index);
+            isAlwaysReadable = recordStore.getIndexState(index).isReadable();
             context.commit();
         }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerIndexFromIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerIndexFromIndexTest.java
@@ -317,7 +317,7 @@ class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
                 recordStore.markIndexWriteOnly(srcIndex).join();
                 indexBuilder.rebuildIndex(recordStore);
                 context.commit();
-                assertFalse(recordStore.isIndexReadable(srcIndex));
+                assertFalse(recordStore.getIndexState(srcIndex).isReadable());
             }
         }
 
@@ -984,7 +984,7 @@ class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
                 recordStore.markIndexWriteOnly(srcIndex).join();
                 indexBuilder.rebuildIndex(recordStore);
                 context.commit();
-                assertFalse(recordStore.isIndexReadable(srcIndex));
+                assertFalse(recordStore.getIndexState(srcIndex).isReadable());
             }
         }
 
@@ -1133,7 +1133,7 @@ class OnlineIndexerIndexFromIndexTest extends OnlineIndexerTest {
             assertTrue(e.getMessage().contains("This index was partly built, and blocked"));
         }
         try (FDBRecordContext context = openContext()) {
-            assertTrue(recordStore.isIndexWriteOnly(tgtIndex));
+            assertTrue(recordStore.getIndexState(tgtIndex).isWriteOnly());
             context.commit();
         }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMultiTargetTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMultiTargetTest.java
@@ -556,7 +556,7 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
             indexBuilder.buildIndex();
         }
         try (FDBRecordContext context = openContext()) {
-            assertTrue(recordStore.isIndexReadable(indexes.get(0)));
+            assertTrue(recordStore.getIndexState(indexes.get(0)).isReadable());
             context.commit();
         }
 
@@ -583,7 +583,7 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
             indexBuilder.buildIndex();
         }
         try (FDBRecordContext context = openContext()) {
-            assertTrue(recordStore.isIndexReadable(indexes.get(1)));
+            assertTrue(recordStore.getIndexState(indexes.get(1)).isReadable());
             context.commit();
         }
     }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMutualTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMutualTest.java
@@ -342,7 +342,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
         }
         openSimpleMetaData(allIndexesHook(indexes));
         try (FDBRecordContext context = openContext()) {
-            final boolean allReadable = indexes.stream().allMatch(i -> recordStore.isIndexReadable(i));
+            final boolean allReadable = indexes.stream().allMatch(i -> recordStore.getIndexState(i).isReadable());
             context.commit();
             return allReadable;
         }
@@ -1182,7 +1182,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
             // unique index with uniqueness violation:
             assertEquals(numRecords, (int)recordStore.scanUniquenessViolations(indexes.get(0)).getCount().join());
             if (allowUniquePending) {
-                assertTrue(recordStore.isIndexReadableUniquePending(indexes.get(0)));
+                assertTrue(recordStore.getIndexState(indexes.get(0)).isReadableUniquePending());
                 final List<IndexEntry> scanned = recordStore.scanIndex(indexes.get(0), IndexScanType.BY_VALUE, TupleRange.ALL, null, ScanProperties.FORWARD_SCAN)
                         .asList().join();
                 assertEquals(scanned.size(), records.size());
@@ -1191,15 +1191,15 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
                 assertTrue(numValues.containsAll(scannedValues));
                 assertTrue(scannedValues.containsAll(numValues));
             } else {
-                assertTrue(recordStore.isIndexWriteOnly(indexes.get(0)));
+                assertTrue(recordStore.getIndexState(indexes.get(0)).isWriteOnly());
                 RecordCoreException e = assertThrows(ScanNonReadableIndexException.class,
                         () -> recordStore.scanIndex(indexes.get(0), IndexScanType.BY_VALUE, TupleRange.ALL, null, ScanProperties.FORWARD_SCAN));
                 assertTrue(e.getMessage().contains("Cannot scan non-readable index"));
             }
             // non-unique index:
-            assertTrue(recordStore.isIndexReadable(indexes.get(1)));
+            assertTrue(recordStore.getIndexState(indexes.get(1)).isReadable());
             // unique index of unique numbers:
-            assertTrue(recordStore.isIndexReadable(indexes.get(2)));
+            assertTrue(recordStore.getIndexState(indexes.get(2)).isReadable());
             context.commit();
         }
 
@@ -1462,7 +1462,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
         openSimpleMetaData(allIndexesHook(indexes));
         try (FDBRecordContext context = openContext()) {
             for (Index index : indexes) {
-                assertTrue(recordStore.isIndexWriteOnly(index));
+                assertTrue(recordStore.getIndexState(index).isWriteOnly());
             }
             context.commit();
         }
@@ -1770,7 +1770,7 @@ class OnlineIndexerMutualTest extends OnlineIndexerTest  {
         openSimpleMetaData(allIndexesHook(indexes));
         try (FDBRecordContext context = openContext()) {
             for (Index index : indexes) {
-                assertTrue(recordStore.isIndexWriteOnly(index));
+                assertTrue(recordStore.getIndexState(index).isWriteOnly());
             }
             context.commit();
         }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerPendingWriteQueueTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerPendingWriteQueueTest.java
@@ -120,7 +120,7 @@ class OnlineIndexerPendingWriteQueueTest extends OnlineIndexerTest {
         try (FDBRecordContext context = openContextWithDisableOnQueueFull(overflowTimer, true, 2)) {
             final FDBRecordStore store = createStoreBuilder().setContext(context)
                     .createOrOpen(FDBRecordStoreBase.StoreExistenceCheck.NONE);
-            assertTrue(store.isIndexWriteOnlyWithQueue(myIndex));
+            assertTrue(store.getIndexState(myIndex).isWriteOnlyWithQueue());
             saveSimpleRecord(store, 5, 5 * 19);
             context.commit();
         }
@@ -129,7 +129,7 @@ class OnlineIndexerPendingWriteQueueTest extends OnlineIndexerTest {
 
         // The index is now disabled and its queue data cleared.
         try (FDBRecordContext context = openContext()) {
-            assertTrue(recordStore.isIndexDisabled(myIndex), "the overflowing index should be disabled");
+            assertTrue(recordStore.getIndexState(myIndex).isDisabled(), "the overflowing index should be disabled");
             assertNotNull(recordStore.loadRecord(Tuple.from(5L)), "the overflow record must have been saved");
             // A readable index on the same record type was still maintained in that same transaction.
             final Index uniqueIndex = recordStore.getRecordMetaData().getIndex("MySimpleRecord$num_value_unique");
@@ -173,7 +173,7 @@ class OnlineIndexerPendingWriteQueueTest extends OnlineIndexerTest {
 
         // The index was not disabled; it is still in the queue state.
         try (FDBRecordContext context = openContext()) {
-            assertTrue(recordStore.isIndexWriteOnlyWithQueue(myIndex), "the index must remain in the queue state");
+            assertTrue(recordStore.getIndexState(myIndex).isWriteOnlyWithQueue(), "the index must remain in the queue state");
             context.commit();
         }
     }
@@ -233,7 +233,7 @@ class OnlineIndexerPendingWriteQueueTest extends OnlineIndexerTest {
 
         // The index converged to DISABLED and its queue was cleared.
         try (FDBRecordContext context = openContext()) {
-            assertTrue(recordStore.isIndexDisabled(myIndex), "the index should converge to disabled");
+            assertTrue(recordStore.getIndexState(myIndex).isDisabled(), "the index should converge to disabled");
             context.commit();
         }
         assertNull(queueSizeCounter(myIndex));
@@ -267,7 +267,7 @@ class OnlineIndexerPendingWriteQueueTest extends OnlineIndexerTest {
                     try (FDBRecordContext context = fdb.openContext(null, writeTimer)) {
                         final FDBRecordStore store = createStoreBuilder().setContext(context)
                                 .createOrOpen(FDBRecordStoreBase.StoreExistenceCheck.NONE);
-                        assertTrue(store.isIndexWriteOnlyWithQueue(index));
+                        assertTrue(store.getIndexState(index).isWriteOnlyWithQueue());
                         for (int recNo : queuedRecNos) {
                             store.saveRecord(TestRecords1Proto.MySimpleRecord.newBuilder()
                                     .setRecNo(recNo)
@@ -332,7 +332,7 @@ class OnlineIndexerPendingWriteQueueTest extends OnlineIndexerTest {
                     try (FDBRecordContext context = fdb.openContext(null, writeTimer)) {
                         final FDBRecordStore store = createStoreBuilder().setContext(context)
                                 .createOrOpen(FDBRecordStoreBase.StoreExistenceCheck.NONE);
-                        assertTrue(store.isIndexWriteOnlyWithQueue(index));
+                        assertTrue(store.getIndexState(index).isWriteOnlyWithQueue());
                         for (int recNo : queuedRecNos) {
                             store.saveRecord(TestRecords1Proto.MySimpleRecord.newBuilder()
                                     .setRecNo(recNo)
@@ -526,8 +526,8 @@ class OnlineIndexerPendingWriteQueueTest extends OnlineIndexerTest {
                     try (FDBRecordContext context = fdb.openContext(null, writeTimer)) {
                         final FDBRecordStore store = createStoreBuilder().setContext(context)
                                 .createOrOpen(FDBRecordStoreBase.StoreExistenceCheck.NONE);
-                        assertTrue(store.isIndexWriteOnlyNoQueue(index));
-                        assertFalse(store.isIndexWriteOnlyWithQueue(index));
+                        assertTrue(store.getIndexState(index).isWriteOnlyNoQueue());
+                        assertFalse(store.getIndexState(index).isWriteOnlyWithQueue());
                         saveSimpleRecord(store, 1, 19);
                         saveSimpleRecord(store, 3, 57);
                         context.commit();
@@ -560,8 +560,8 @@ class OnlineIndexerPendingWriteQueueTest extends OnlineIndexerTest {
                     try (FDBRecordContext context = fdb.openContext(null, writeTimer)) {
                         final FDBRecordStore store = createStoreBuilder().setContext(context)
                                 .createOrOpen(FDBRecordStoreBase.StoreExistenceCheck.NONE);
-                        assertTrue(store.isIndexWriteOnlyNoQueue(index));
-                        assertFalse(store.isIndexWriteOnlyWithQueue(index));
+                        assertTrue(store.getIndexState(index).isWriteOnlyNoQueue());
+                        assertFalse(store.getIndexState(index).isWriteOnlyWithQueue());
                         saveSimpleRecord(store, 1, 19);
                         saveSimpleRecord(store, 3, 57);
                         context.commit();
@@ -572,7 +572,7 @@ class OnlineIndexerPendingWriteQueueTest extends OnlineIndexerTest {
         // The build still completes as a normal write-only version index.
         openSimpleMetaData(hook);
         try (FDBRecordContext context = openContext()) {
-            assertTrue(recordStore.isIndexReadable(index));
+            assertTrue(recordStore.getIndexState(index).isReadable());
             context.commit();
         }
     }
@@ -590,8 +590,8 @@ class OnlineIndexerPendingWriteQueueTest extends OnlineIndexerTest {
                 queueIndexerBuilder(index, List.of(index)),
                 () -> {
                     try (FDBRecordContext context = openContext()) {
-                        assertTrue(recordStore.isIndexWriteOnlyWithQueue(index));
-                        assertFalse(recordStore.isIndexReadable(index));
+                        assertTrue(recordStore.getIndexState(index).isWriteOnlyWithQueue());
+                        assertFalse(recordStore.getIndexState(index).isReadable());
                         assertThrows(ScanNonReadableIndexException.class, () ->
                                         recordStore.scanIndex(index, IndexScanType.BY_VALUE, TupleRange.ALL, null, ScanProperties.FORWARD_SCAN),
                                 "queries must not be able to scan the index while it is in the queue state");
@@ -623,9 +623,9 @@ class OnlineIndexerPendingWriteQueueTest extends OnlineIndexerTest {
                     try (FDBRecordContext context = fdb.openContext(null, writeTimer)) {
                         final FDBRecordStore store = createStoreBuilder().setContext(context)
                                 .createOrOpen(FDBRecordStoreBase.StoreExistenceCheck.NONE);
-                        assertTrue(store.isIndexWriteOnlyWithQueue(queuedIndex));
-                        assertTrue(store.isIndexWriteOnlyNoQueue(directIndex));
-                        assertFalse(store.isIndexWriteOnlyWithQueue(directIndex));
+                        assertTrue(store.getIndexState(queuedIndex).isWriteOnlyWithQueue());
+                        assertTrue(store.getIndexState(directIndex).isWriteOnlyNoQueue());
+                        assertFalse(store.getIndexState(directIndex).isWriteOnlyWithQueue());
                         for (int recNo : newRecNos) {
                             saveSimpleRecord(store, recNo, recNo * 19);
                         }
@@ -674,11 +674,11 @@ class OnlineIndexerPendingWriteQueueTest extends OnlineIndexerTest {
                         // The two queued indexes enter the queue state; every other index (including the SUM index) is
                         // plain write-only.
                         for (Index queued : queuedIndexes) {
-                            assertTrue(store.isIndexWriteOnlyWithQueue(queued), queued.getName());
+                            assertTrue(store.getIndexState(queued).isWriteOnlyWithQueue(), queued.getName());
                         }
                         for (Index direct : directIndexes) {
-                            assertTrue(store.isIndexWriteOnlyNoQueue(direct), direct.getName());
-                            assertFalse(store.isIndexWriteOnlyWithQueue(direct), direct.getName());
+                            assertTrue(store.getIndexState(direct).isWriteOnlyNoQueue(), direct.getName());
+                            assertFalse(store.getIndexState(direct).isWriteOnlyWithQueue(), direct.getName());
                         }
                         for (int recNo : newRecNos) {
                             saveSimpleRecord(store, recNo, recNo * 19);
@@ -735,9 +735,9 @@ class OnlineIndexerPendingWriteQueueTest extends OnlineIndexerTest {
                 queueIndexerBuilder(indexes, indexes),
                 () -> {
                     try (FDBRecordContext context = openContext()) {
-                        statesAsExpected.set(recordStore.isIndexWriteOnlyWithQueue(valueIndex)
-                                && recordStore.isIndexWriteOnlyNoQueue(countIndex)
-                                && !recordStore.isIndexWriteOnlyWithQueue(countIndex));
+                        statesAsExpected.set(recordStore.getIndexState(valueIndex).isWriteOnlyWithQueue()
+                                && recordStore.getIndexState(countIndex).isWriteOnlyNoQueue()
+                                && !recordStore.getIndexState(countIndex).isWriteOnlyWithQueue());
                         context.commit();
                     }
                 });
@@ -784,7 +784,7 @@ class OnlineIndexerPendingWriteQueueTest extends OnlineIndexerTest {
         // The drain recorded the violation and the build completed (no crash) into readable-unique-pending.
         openSimpleMetaData(allIndexesHook(List.of(index)));
         try (FDBRecordContext context = openContext()) {
-            assertTrue(recordStore.isIndexReadableUniquePending(index),
+            assertTrue(recordStore.getIndexState(index).isReadableUniquePending(),
                     "the index should be readable-unique-pending after a conflict among drained writes");
             assertTrue(recordStore.scanUniquenessViolations(index).getCount().join() > 0,
                     "the uniqueness conflict should have been recorded, not thrown, during the drain");
@@ -869,9 +869,9 @@ class OnlineIndexerPendingWriteQueueTest extends OnlineIndexerTest {
                     try (FDBRecordContext context = fdb.openContext(null, writeTimer)) {
                         final FDBRecordStore store = createStoreBuilder().setContext(context)
                                 .createOrOpen(FDBRecordStoreBase.StoreExistenceCheck.NONE);
-                        assertFalse(store.isIndexWriteOnlyWithQueue(index),
+                        assertFalse(store.getIndexState(index).isWriteOnlyWithQueue(),
                                 "below the required format version the index must not enter the queue state");
-                        assertTrue(store.isIndexWriteOnlyNoQueue(index), "the index should fall back to plain write-only");
+                        assertTrue(store.getIndexState(index).isWriteOnlyNoQueue(), "the index should fall back to plain write-only");
                         for (int recNo : newRecNos) {
                             saveSimpleRecord(store, recNo, recNo * 19);
                         }
@@ -1105,9 +1105,9 @@ class OnlineIndexerPendingWriteQueueTest extends OnlineIndexerTest {
                         final FDBRecordStore store = createStoreBuilder().setContext(context)
                                 .createOrOpen(FDBRecordStoreBase.StoreExistenceCheck.NONE);
                         // Despite requesting the queue, mutual indexing marks the index plain write-only.
-                        assertTrue(store.isIndexWriteOnlyNoQueue(index),
+                        assertTrue(store.getIndexState(index).isWriteOnlyNoQueue(),
                                 "a mutually-built index should fall back to plain write-only");
-                        assertFalse(store.isIndexWriteOnlyWithQueue(index),
+                        assertFalse(store.getIndexState(index).isWriteOnlyWithQueue(),
                                 "mutual indexing must not enter the queue state");
                         for (int recNo : newRecNos) {
                             saveSimpleRecord(store, recNo, recNo * 19);
@@ -1150,7 +1150,7 @@ class OnlineIndexerPendingWriteQueueTest extends OnlineIndexerTest {
         // the just-deleted group 1. Drained in order, the trailing insert must survive the range delete.
         try (FDBRecordContext context = openContext()) {
             recordStore.markIndexWriteOnlyWithQueue(valueIndexName).join();
-            assertTrue(recordStore.isIndexWriteOnlyWithQueue(valueIndexName));
+            assertTrue(recordStore.getIndexState(valueIndexName).isWriteOnlyWithQueue());
             saveBasicRecord(5, 1);   // queued ahead of the delete
             saveBasicRecord(6, 2);   // queued ahead of the delete
             recordStore.deleteRecordsWhere(Query.field("num_value_2").equalsValue(1));
@@ -1167,7 +1167,7 @@ class OnlineIndexerPendingWriteQueueTest extends OnlineIndexerTest {
         assertEquals(4L, queueSize == null ? 0L : queueSize,
                 "the three inserts and the range delete should be deferred onto the queue");
         try (FDBRecordContext context = openContext()) {
-            assertTrue(recordStore.isIndexWriteOnlyWithQueue(valueIndexName));
+            assertTrue(recordStore.getIndexState(valueIndexName).isWriteOnlyWithQueue());
             final int rawEntryCount = context.ensureActive()
                     .getRange(recordStore.indexSubspace(index).range()).asList().join().size();
             assertEquals(4, rawEntryCount, "no deferred write should be applied to the index before the drain");
@@ -1181,7 +1181,7 @@ class OnlineIndexerPendingWriteQueueTest extends OnlineIndexerTest {
 
         // Note: cannot use assertReadable(index) here, as it rebuilds the (MySimpleRecord) simple metadata.
         try (FDBRecordContext context = openContext()) {
-            assertTrue(recordStore.isIndexReadable(valueIndexName));
+            assertTrue(recordStore.getIndexState(valueIndexName).isReadable());
             context.commit();
         }
         assertEquals(Set.of(7L), indexRecNosForGroup(index, 1));
@@ -1251,7 +1251,7 @@ class OnlineIndexerPendingWriteQueueTest extends OnlineIndexerTest {
         try (FDBRecordContext context = fdb.openContext()) {
             final FDBRecordStore store = createStoreBuilder().setContext(context)
                     .createOrOpen(FDBRecordStoreBase.StoreExistenceCheck.NONE);
-            final boolean readable = store.isIndexReadable(index);
+            final boolean readable = store.getIndexState(index).isReadable();
             context.commit();
             return readable;
         }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerSimpleTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerSimpleTest.java
@@ -568,7 +568,7 @@ public class OnlineIndexerSimpleTest extends OnlineIndexerTest {
         openSimpleMetaData(hook);
         try (FDBRecordContext context = openContext()) {
             // Verify rangeSet is cleared when index is marked readable
-            assertTrue(recordStore.isIndexReadable(index));
+            assertTrue(recordStore.getIndexState(index).isReadable());
 
             final RangeSet rangeSet = new RangeSet(recordStore.indexRangeSubspace(index));
             Boolean isEmpty = rangeSet.isEmpty(context.ensureActive()).join();

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerTest.java
@@ -309,7 +309,7 @@ public abstract class OnlineIndexerTest {
         openSimpleMetaData(allIndexesHook(indexes));
         try (FDBRecordContext context = openContext()) {
             for (Index index : indexes) {
-                assertTrue(recordStore.isIndexReadable(index));
+                assertTrue(recordStore.getIndexState(index).isReadable());
             }
             context.commit();
         }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerUniqueIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerUniqueIndexTest.java
@@ -352,7 +352,7 @@ public class OnlineIndexerUniqueIndexTest extends OnlineIndexerTest {
         try (FDBRecordContext context = openContext()) {
             final IndexState indexState = recordStore.getIndexState(indexName);
             assertEquals(IndexState.READABLE_UNIQUE_PENDING, indexState);
-            assertTrue(recordStore.isIndexReadableUniquePending(indexName));
+            assertTrue(recordStore.getIndexState(indexName).isReadableUniquePending());
             context.commit();
         }
         scrubAndValidate(List.of(index));
@@ -451,7 +451,7 @@ public class OnlineIndexerUniqueIndexTest extends OnlineIndexerTest {
             // unique index with uniqueness violation:
             assertEquals(10, (int)recordStore.scanUniquenessViolations(indexes.get(0)).getCount().join());
             if (allowUniquePending) {
-                assertTrue(recordStore.isIndexReadableUniquePending(indexes.get(0)));
+                assertTrue(recordStore.getIndexState(indexes.get(0)).isReadableUniquePending());
                 final List<IndexEntry> scanned = recordStore.scanIndex(indexes.get(0), IndexScanType.BY_VALUE, TupleRange.ALL, null, ScanProperties.FORWARD_SCAN)
                         .asList().join();
                 assertEquals(scanned.size(), records.size());
@@ -460,15 +460,15 @@ public class OnlineIndexerUniqueIndexTest extends OnlineIndexerTest {
                 assertTrue(numValues.containsAll(scannedValues));
                 assertTrue(scannedValues.containsAll(numValues));
             } else {
-                assertTrue(recordStore.isIndexWriteOnly(indexes.get(0)));
+                assertTrue(recordStore.getIndexState(indexes.get(0)).isWriteOnly());
                 RecordCoreException e = assertThrows(ScanNonReadableIndexException.class,
                         () -> recordStore.scanIndex(indexes.get(0), IndexScanType.BY_VALUE, TupleRange.ALL, null, ScanProperties.FORWARD_SCAN));
                 assertTrue(e.getMessage().contains("Cannot scan non-readable index"));
             }
             // non-unique index:
-            assertTrue(recordStore.isIndexReadable(indexes.get(1)));
+            assertTrue(recordStore.getIndexState(indexes.get(1)).isReadable());
             // unique index of unique numbers:
-            assertTrue(recordStore.isIndexReadable(indexes.get(2)));
+            assertTrue(recordStore.getIndexState(indexes.get(2)).isReadable());
             context.commit();
         }
 
@@ -505,7 +505,7 @@ public class OnlineIndexerUniqueIndexTest extends OnlineIndexerTest {
         }
         scrubAndValidate(List.of(index));
         try (FDBRecordContext context = openContext()) {
-            assertTrue(recordStore.isIndexReadable(index.getName()));
+            assertTrue(recordStore.getIndexState(index.getName()).isReadable());
             assertEquals(0, (int)recordStore.scanUniquenessViolations(indexes.get(0)).getCount().join());
             context.commit();
         }
@@ -541,7 +541,7 @@ public class OnlineIndexerUniqueIndexTest extends OnlineIndexerTest {
         // verify that unique pending state is unchanged
         try (FDBRecordContext context = openContext()) {
             for (Index index: indexes) {
-                assertTrue(recordStore.isIndexReadableUniquePending(index));
+                assertTrue(recordStore.getIndexState(index).isReadableUniquePending());
                 boolean changed = recordStore.markIndexReadableOrUniquePending(index).join();
                 assertFalse(changed);
             }
@@ -573,7 +573,7 @@ public class OnlineIndexerUniqueIndexTest extends OnlineIndexerTest {
         // assert change after resolving
         try (FDBRecordContext context = openContext()) {
             for (Index index: indexes) {
-                assertTrue(recordStore.isIndexReadableUniquePending(index));
+                assertTrue(recordStore.getIndexState(index).isReadableUniquePending());
                 boolean changed = recordStore.markIndexReadableOrUniquePending(index).join();
                 assertTrue(changed);
             }
@@ -613,7 +613,7 @@ public class OnlineIndexerUniqueIndexTest extends OnlineIndexerTest {
         // verify that unique pending state is unchanged
         try (FDBRecordContext context = openContext()) {
             for (Index index: indexes) {
-                assertTrue(recordStore.isIndexReadableUniquePending(index));
+                assertTrue(recordStore.getIndexState(index).isReadableUniquePending());
                 boolean changed = recordStore.markIndexReadableOrUniquePending(index).join();
                 assertFalse(changed);
             }
@@ -633,7 +633,7 @@ public class OnlineIndexerUniqueIndexTest extends OnlineIndexerTest {
         // verify that unique pending state is unchanged
         try (FDBRecordContext context = openContext()) {
             for (Index index: indexes) {
-                assertTrue(recordStore.isIndexReadableUniquePending(index));
+                assertTrue(recordStore.getIndexState(index).isReadableUniquePending());
                 boolean changed = recordStore.markIndexReadableOrUniquePending(index).join();
                 assertFalse(changed);
                 assertEquals(20, (int)recordStore.scanUniquenessViolations(index).getCount().join());
@@ -663,7 +663,7 @@ public class OnlineIndexerUniqueIndexTest extends OnlineIndexerTest {
         scrubAndValidate(indexes);
         try (FDBRecordContext context = openContext()) {
             for (Index index: indexes) {
-                assertTrue(recordStore.isIndexReadable(index));
+                assertTrue(recordStore.getIndexState(index).isReadable());
                 assertEquals(0, (int)recordStore.scanUniquenessViolations(index).getCount().join());
             }
             context.commit();
@@ -710,7 +710,7 @@ public class OnlineIndexerUniqueIndexTest extends OnlineIndexerTest {
         // assert failure to mark readable or unique pending
         try (FDBRecordContext context = openContext()) {
             for (Index index: indexes) {
-                assertTrue(recordStore.isIndexWriteOnly(index));
+                assertTrue(recordStore.getIndexState(index).isWriteOnly());
                 assertThrows(Exception.class, () -> recordStore.markIndexReadableOrUniquePending(index).join());
                 assertThrows(Exception.class, () -> recordStore.markIndexReadable(index).join());
             }
@@ -750,7 +750,7 @@ public class OnlineIndexerUniqueIndexTest extends OnlineIndexerTest {
 
         // assert source index state is unique pending
         try (FDBRecordContext context = openContext()) {
-            assertTrue(recordStore.isIndexReadableUniquePending(srcIndex));
+            assertTrue(recordStore.getIndexState(srcIndex).isReadableUniquePending());
             context.commit();
         }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RecordTypeKeyTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/RecordTypeKeyTest.java
@@ -619,7 +619,7 @@ public class RecordTypeKeyTest extends FDBRecordStoreQueryTestBase {
 
             recordStore.checkVersion(null, FDBRecordStoreBase.StoreExistenceCheck.ERROR_IF_NOT_EXISTS).join();
 
-            assertTrue(recordStore.isIndexReadable("newIndex"));
+            assertTrue(recordStore.getIndexState("newIndex").isReadable());
 
             assertEquals(10, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_SCANNED));
             assertEquals(10, timer.getCount(FDBStoreTimer.Counts.ONLINE_INDEX_BUILDER_RECORDS_INDEXED));
@@ -658,7 +658,7 @@ public class RecordTypeKeyTest extends FDBRecordStoreQueryTestBase {
             uncheckedOpenSimpleRecordStore(context, hook);
             recordStore.checkVersion(null, FDBRecordStoreBase.StoreExistenceCheck.ERROR_IF_NOT_EXISTS).join();
 
-            assertTrue(recordStore.isIndexDisabled("newIndex"));
+            assertTrue(recordStore.getIndexState("newIndex").isDisabled());
 
             timer.reset();
 
@@ -681,7 +681,7 @@ public class RecordTypeKeyTest extends FDBRecordStoreQueryTestBase {
             uncheckedOpenSimpleRecordStore(context, hook);
             recordStore.checkVersion(null, FDBRecordStoreBase.StoreExistenceCheck.ERROR_IF_NOT_EXISTS).join();
 
-            assertTrue(recordStore.isIndexReadable("newIndex"));
+            assertTrue(recordStore.getIndexState("newIndex").isReadable());
 
             recordStore.clearAndMarkIndexWriteOnly("newIndex").join();
             context.commit();
@@ -735,9 +735,9 @@ public class RecordTypeKeyTest extends FDBRecordStoreQueryTestBase {
             uncheckedOpenSimpleRecordStore(context, hook);
             recordStore.checkVersion(null, FDBRecordStoreBase.StoreExistenceCheck.ERROR_IF_NOT_EXISTS).join();
 
-            assertTrue(recordStore.isIndexDisabled("newIndex"));
-            assertTrue(recordStore.isIndexDisabled("newSumIndex"));
-            assertTrue(recordStore.isIndexDisabled("newMaxIndex"));
+            assertTrue(recordStore.getIndexState("newIndex").isDisabled());
+            assertTrue(recordStore.getIndexState("newSumIndex").isDisabled());
+            assertTrue(recordStore.getIndexState("newMaxIndex").isDisabled());
 
             context.commit();
         }
@@ -765,9 +765,9 @@ public class RecordTypeKeyTest extends FDBRecordStoreQueryTestBase {
         try (FDBRecordContext context = openContext()) {
             uncheckedOpenSimpleRecordStore(context, hook);
 
-            assertTrue(recordStore.isIndexReadable("newIndex"));
-            assertTrue(recordStore.isIndexReadable("newSumIndex"));
-            assertTrue(recordStore.isIndexReadable("newMaxIndex"));
+            assertTrue(recordStore.getIndexState("newIndex").isReadable());
+            assertTrue(recordStore.getIndexState("newSumIndex").isReadable());
+            assertTrue(recordStore.getIndexState("newMaxIndex").isReadable());
 
             context.commit();
         }
@@ -810,7 +810,7 @@ public class RecordTypeKeyTest extends FDBRecordStoreQueryTestBase {
         try (FDBRecordContext context = openContext()) {
             uncheckedOpenSimpleRecordStore(context, addIndex);
             recordStore.checkVersion(null, FDBRecordStoreBase.StoreExistenceCheck.ERROR_IF_NOT_EXISTS).join();
-            assertTrue(recordStore.isIndexDisabled("newIndex"));
+            assertTrue(recordStore.getIndexState("newIndex").isDisabled());
             context.commit();
         }
 
@@ -824,7 +824,7 @@ public class RecordTypeKeyTest extends FDBRecordStoreQueryTestBase {
         try (FDBRecordContext context = openContext()) {
             uncheckedOpenSimpleRecordStore(context, addIndex);
             recordStore.checkVersion(null, FDBRecordStoreBase.StoreExistenceCheck.ERROR_IF_NOT_EXISTS).join();
-            assertTrue(recordStore.isIndexReadable("newIndex"));
+            assertTrue(recordStore.getIndexState("newIndex").isReadable());
             assertEquals(IntStream.range(0, numRecords).mapToObj(j -> Tuple.from(j, 0L, j)).collect(Collectors.toList()),
                     recordStore.scanIndex(recordStore.getRecordMetaData().getIndex("newIndex"),
                             IndexScanType.BY_VALUE, TupleRange.ALL, null, ScanProperties.FORWARD_SCAN)

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/HnswVectorIndexIndexingTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/HnswVectorIndexIndexingTest.java
@@ -199,7 +199,7 @@ class HnswVectorIndexIndexingTest extends VectorIndexTestBase {
 
             // Index should be in disabled state initially
             final Index index = recordStore.getRecordMetaData().getIndex(indexName);
-            assertThat(recordStore.isIndexReadable(index)).isFalse();
+            assertThat(recordStore.getIndexState(index).isReadable()).isFalse();
 
             commit(context);
         }
@@ -217,7 +217,7 @@ class HnswVectorIndexIndexingTest extends VectorIndexTestBase {
             index = recordStore.getRecordMetaData().getIndex(indexName);
             // Verify that the index will be only built here
             // (this is not a requirement, but only used for this module's tests)
-            assertThat(recordStore.isIndexReadable(index)).isFalse();
+            assertThat(recordStore.getIndexState(index).isReadable()).isFalse();
 
             try (OnlineIndexer indexer = OnlineIndexer.newBuilder()
                     .setRecordStore(recordStore)
@@ -231,7 +231,7 @@ class HnswVectorIndexIndexingTest extends VectorIndexTestBase {
         // Verify that the index is readable
         try (FDBRecordContext context = openContext()) {
             openRecordStore(context, indexHook);
-            assertThat(recordStore.isIndexReadable(index)).isTrue();
+            assertThat(recordStore.getIndexState(index).isReadable()).isTrue();
             commit(context);
         }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/SlidingWindowIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/SlidingWindowIndexTest.java
@@ -1118,7 +1118,7 @@ class SlidingWindowIndexTest extends FDBRecordStoreTestBase {
         try (FDBRecordContext context = openContext()) {
             openStore(context, 3, Direction.DESC, grouping);
             recordStore.markIndexWriteOnlyWithQueue(INDEX_NAME).join();
-            assertTrue(recordStore.isIndexWriteOnlyWithQueue(INDEX_NAME));
+            assertTrue(recordStore.getIndexState(INDEX_NAME).isWriteOnlyWithQueue());
 
             rec(5, "A", "c", 150, 0, sampleVector());   // queued ahead of the delete
             rec(6, "B", "c", 350, 0, sampleVector());   // queued ahead of the delete
@@ -1130,7 +1130,7 @@ class SlidingWindowIndexTest extends FDBRecordStoreTestBase {
         // Before the drain the queued writes are not applied yet: the window still reflects the readable build.
         try (FDBRecordContext context = openContext()) {
             openStore(context, 3, Direction.DESC, grouping);
-            assertTrue(recordStore.isIndexWriteOnlyWithQueue(INDEX_NAME));
+            assertTrue(recordStore.getIndexState(INDEX_NAME).isWriteOnlyWithQueue());
             assertThat(groupedSlidingWindow(Tuple.from("A"))).hasSizeOf(2).underlyingHnsw().containsInAnyOrder(1L, 2L);
             assertThat(groupedSlidingWindow(Tuple.from("B"))).hasSizeOf(2).underlyingHnsw().containsInAnyOrder(3L, 4L);
             commit(context);
@@ -1142,7 +1142,7 @@ class SlidingWindowIndexTest extends FDBRecordStoreTestBase {
         try (FDBRecordContext context = openContext()) {
             openStore(context, 3, Direction.DESC, grouping);
             final Index index = index();
-            assertTrue(recordStore.isIndexReadable(index));
+            assertTrue(recordStore.getIndexState(index).isReadable());
             assertThat(groupedSlidingWindow(Tuple.from("A"))).hasSizeOf(1).underlyingHnsw().containsInAnyOrder(7L);
             assertThat(groupedSlidingWindow(Tuple.from("B"))).hasSizeOf(3).underlyingHnsw().containsInAnyOrder(3L, 4L, 6L);
             assertNull(queueSize(context, index), "the queue data should have been erased once the index became readable");
@@ -1910,7 +1910,7 @@ class SlidingWindowIndexTest extends FDBRecordStoreTestBase {
         try (FDBRecordContext context = openContext()) {
             openStore(context, 5, Direction.DESC);
             recordStore.markIndexWriteOnlyWithQueue(INDEX_NAME).join();
-            assertTrue(recordStore.isIndexWriteOnlyWithQueue(INDEX_NAME));
+            assertTrue(recordStore.getIndexState(INDEX_NAME).isWriteOnlyWithQueue());
 
             rec(1, 100);
             rec(2, 200);
@@ -1951,7 +1951,7 @@ class SlidingWindowIndexTest extends FDBRecordStoreTestBase {
         try (FDBRecordContext context = openContext()) {
             openStore(context, 5, Direction.DESC);
             final Index index = recordStore.getRecordMetaData().getIndex(INDEX_NAME);
-            assertTrue(recordStore.isIndexReadable(index));
+            assertTrue(recordStore.getIndexState(index).isReadable());
             assertThat(slidingWindow())
                     .hasSizeOf(2)
                     .underlyingHnsw().containsInAnyOrder(1, 2);
@@ -1966,7 +1966,7 @@ class SlidingWindowIndexTest extends FDBRecordStoreTestBase {
         try (FDBRecordContext context = openContext()) {
             openStore(context, 2, Direction.DESC);
             recordStore.markIndexWriteOnlyWithQueue(INDEX_NAME).join();
-            assertTrue(recordStore.isIndexWriteOnlyWithQueue(INDEX_NAME));
+            assertTrue(recordStore.getIndexState(INDEX_NAME).isWriteOnlyWithQueue());
 
             // Descending relevance in primary-key order: recs 1 and 2 fill the window; recs 3 and 4 are below the
             // window boundary and must overflow (stay out of the window) once the queue is drained.
@@ -2014,7 +2014,7 @@ class SlidingWindowIndexTest extends FDBRecordStoreTestBase {
         try (FDBRecordContext context = openContext()) {
             openStore(context, 2, Direction.DESC);
             final Index index = recordStore.getRecordMetaData().getIndex(INDEX_NAME);
-            assertTrue(recordStore.isIndexReadable(index));
+            assertTrue(recordStore.getIndexState(index).isReadable());
             assertThat(slidingWindow())
                     .hasSizeOf(2)
                     .underlyingHnsw().containsInAnyOrder(1, 2);
@@ -2030,7 +2030,7 @@ class SlidingWindowIndexTest extends FDBRecordStoreTestBase {
         try (FDBRecordContext context = openContext()) {
             openStore(context, 2, Direction.DESC);
             recordStore.markIndexWriteOnlyWithQueue(INDEX_NAME).join();
-            assertTrue(recordStore.isIndexWriteOnlyWithQueue(INDEX_NAME));
+            assertTrue(recordStore.getIndexState(INDEX_NAME).isWriteOnlyWithQueue());
 
             rec(1, 100);
             rec(2, 200);
@@ -2044,7 +2044,7 @@ class SlidingWindowIndexTest extends FDBRecordStoreTestBase {
         try (FDBRecordContext context = openContext()) {
             openStore(context, 2, Direction.DESC);
             final Index index = index();
-            assertTrue(recordStore.isIndexReadable(index));
+            assertTrue(recordStore.getIndexState(index).isReadable());
             assertThat(slidingWindow())
                     .hasSizeOf(2)
                     .underlyingHnsw().containsInAnyOrder(3, 4);
@@ -2078,7 +2078,7 @@ class SlidingWindowIndexTest extends FDBRecordStoreTestBase {
         try (FDBRecordContext context = openContext()) {
             openStore(context, 3, Direction.DESC);
             final Index index = index();
-            assertTrue(recordStore.isIndexReadable(index));
+            assertTrue(recordStore.getIndexState(index).isReadable());
             assertThat(slidingWindow())
                     .hasSizeOf(2)
                     .underlyingHnsw().containsInAnyOrder(1, 3);
@@ -2171,7 +2171,7 @@ class SlidingWindowIndexTest extends FDBRecordStoreTestBase {
         try (FDBRecordContext context = openContext()) {
             openStore(context, 2, Direction.DESC, grouping);
             final Index index = index();
-            assertTrue(recordStore.isIndexReadable(index));
+            assertTrue(recordStore.getIndexState(index).isReadable());
             assertThat(groupedSlidingWindow(Tuple.from("A")))
                     .hasSizeOf(2)
                     .underlyingHnsw().containsInAnyOrder(1, 2);
@@ -2267,7 +2267,7 @@ class SlidingWindowIndexTest extends FDBRecordStoreTestBase {
         try (FDBRecordContext context = openContext()) {
             openStore(context, 2, Direction.DESC);
             final Index index = index();
-            assertTrue(recordStore.isIndexReadable(index));
+            assertTrue(recordStore.getIndexState(index).isReadable());
             // rec 1 has entered the window and evicted rec 3
             assertThat(slidingWindow())
                     .hasSizeOf(2)
@@ -2303,7 +2303,7 @@ class SlidingWindowIndexTest extends FDBRecordStoreTestBase {
         try (FDBRecordContext context = openContext()) {
             openStore(context, 2, Direction.DESC);
             final Index index = index();
-            assertTrue(recordStore.isIndexReadable(index));
+            assertTrue(recordStore.getIndexState(index).isReadable());
             // rec 1 has dropped out of the window and rec 3 has taken its place
             assertThat(slidingWindow())
                     .hasSizeOf(2)
@@ -2332,7 +2332,7 @@ class SlidingWindowIndexTest extends FDBRecordStoreTestBase {
         try (FDBRecordContext context = openContext()) {
             openStore(context, 2, Direction.DESC);
             final Index index = index();
-            assertTrue(recordStore.isIndexReadable(index));
+            assertTrue(recordStore.getIndexState(index).isReadable());
             assertThat(slidingWindow())
                     .hasSizeOf(2)
                     .underlyingHnsw().containsInAnyOrder(1, 2);
@@ -2360,7 +2360,7 @@ class SlidingWindowIndexTest extends FDBRecordStoreTestBase {
         try (FDBRecordContext context = openContext()) {
             openStore(context, 2, Direction.DESC);
             final Index index = index();
-            assertTrue(recordStore.isIndexReadable(index));
+            assertTrue(recordStore.getIndexState(index).isReadable());
             assertThat(slidingWindow())
                     .hasSizeOf(2)
                     .underlyingHnsw().containsInAnyOrder(2, 3);
@@ -2423,7 +2423,7 @@ class SlidingWindowIndexTest extends FDBRecordStoreTestBase {
         try (FDBRecordContext context = openContext()) {
             openStore(context, 3, Direction.DESC, ImmutableList.of(ImmutableList.of("zone")));
             recordStore.markIndexWriteOnlyWithQueue(INDEX_NAME).join();
-            assertTrue(recordStore.isIndexWriteOnlyWithQueue(INDEX_NAME));
+            assertTrue(recordStore.getIndexState(INDEX_NAME).isWriteOnlyWithQueue());
 
             final IndexMaintainer maintainer = maintainer();
             final QueryToKeyMatcher matcher =

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VectorIndexEngineTestSuite.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VectorIndexEngineTestSuite.java
@@ -718,7 +718,7 @@ abstract class VectorIndexEngineTestSuite extends VectorIndexTestBase {
 
         try (FDBRecordContext context = openContext()) {
             openRecordStore(context, hook);
-            assertThat(recordStore.isIndexReadable(recordStore.getRecordMetaData().getIndex(indexName))).isTrue();
+            assertThat(recordStore.getIndexState(recordStore.getRecordMetaData().getIndex(indexName)).isReadable()).isTrue();
             commit(context);
         }
     }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/storestate/DeleteStoreTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/storestate/DeleteStoreTest.java
@@ -169,13 +169,13 @@ public class DeleteStoreTest extends FDBRecordStoreTestBase {
         try (FDBRecordContext context = testContext.getCachedContext(fdb, storeBuilder, FDBRecordStoreBase.StoreExistenceCheck.ERROR_IF_NOT_EXISTS)) {
             openSimpleRecordStore(context);
             assertCacheHit(context.getTimer());
-            assertTrue(recordStore.isIndexDisabled(disabledIndex));
+            assertTrue(recordStore.getIndexState(disabledIndex).isDisabled());
             recordStore.deleteAllRecords();
 
             context.getTimer().reset();
             recordStore = recordStore.asBuilder().open();
             assertCacheHit(context.getTimer());
-            assertTrue(recordStore.isIndexDisabled(disabledIndex));
+            assertTrue(recordStore.getIndexState(disabledIndex).isDisabled());
             commit(context);
         }
     }
@@ -238,14 +238,14 @@ public class DeleteStoreTest extends FDBRecordStoreTestBase {
 
         try (FDBRecordContext context = testContext.getCachedContext(fdb, storeBuilder, FDBRecordStoreBase.StoreExistenceCheck.ERROR_IF_NOT_EXISTS)) {
             openSimpleRecordStore(context);
-            assertTrue(recordStore.isIndexDisabled(disabledIndex));
+            assertTrue(recordStore.getIndexState(disabledIndex).isDisabled());
             recordStore.deleteAllRecords();
             commit(context);
         }
 
         try (FDBRecordContext context = testContext.getCachedContext(fdb, storeBuilder, FDBRecordStoreBase.StoreExistenceCheck.ERROR_IF_NOT_EXISTS)) {
             openSimpleRecordStore(context);
-            assertTrue(recordStore.isIndexDisabled(disabledIndex));
+            assertTrue(recordStore.getIndexState(disabledIndex).isDisabled());
             commit(context);
         }
     }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/storestate/FDBRecordStoreStateCacheTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/storestate/FDBRecordStoreStateCacheTest.java
@@ -150,7 +150,7 @@ public class FDBRecordStoreStateCacheTest extends FDBRecordStoreTestBase {
             FDBRecordStoreStateCacheTestUtils.assertCacheHit(context.getTimer(), 1);
             recordStore.markIndexWriteOnly("MySimpleRecord$str_value_indexed").get();
             assertTrue(context.hasDirtyStoreState());
-            assertFalse(recordStore.isIndexReadable("MySimpleRecord$str_value_indexed"));
+            assertFalse(recordStore.getIndexState("MySimpleRecord$str_value_indexed").isReadable());
             FDBRecordStore initialRecordStore = recordStore;
 
             // Reopen the store with the same context and ensure the index is still not readable
@@ -158,7 +158,7 @@ public class FDBRecordStoreStateCacheTest extends FDBRecordStoreTestBase {
             FDBRecordStoreStateCacheTestUtils.assertCacheMiss(context.getTimer(), 1);
             assertNotSame(initialRecordStore, recordStore);
             assertNotSame(initialRecordStore.getRecordStoreState(), recordStore.getRecordStoreState());
-            assertFalse(recordStore.isIndexReadable("MySimpleRecord$str_value_indexed"));
+            assertFalse(recordStore.getIndexState("MySimpleRecord$str_value_indexed").isReadable());
 
             commit(context);
         }
@@ -169,7 +169,7 @@ public class FDBRecordStoreStateCacheTest extends FDBRecordStoreTestBase {
             context.setReadVersion(readVersion);
             openSimpleRecordStore(context);
             FDBRecordStoreStateCacheTestUtils.assertCacheHit(context.getTimer(), 1);
-            assertTrue(recordStore.isIndexReadable("MySimpleRecord$str_value_indexed"));
+            assertTrue(recordStore.getIndexState("MySimpleRecord$str_value_indexed").isReadable());
 
             // Add a random write-conflict range to ensure conflicts are actually checked
             context.ensureActive().addWriteConflictKey(recordStore.recordsSubspace().pack(UUID.randomUUID()));
@@ -186,7 +186,7 @@ public class FDBRecordStoreStateCacheTest extends FDBRecordStoreTestBase {
             long newReadVersion = context.getReadVersion();
             assertThat(newReadVersion, greaterThan(readVersion));
             readVersion = newReadVersion;
-            assertFalse(recordStore.isIndexReadable("MySimpleRecord$str_value_indexed"));
+            assertFalse(recordStore.getIndexState("MySimpleRecord$str_value_indexed").isReadable());
         }
 
         try (FDBRecordContext context = openContext()) {
@@ -194,7 +194,7 @@ public class FDBRecordStoreStateCacheTest extends FDBRecordStoreTestBase {
             context.setReadVersion(readVersion);
             openSimpleRecordStore(context);
             FDBRecordStoreStateCacheTestUtils.assertCacheHit(context.getTimer(), 1);
-            assertFalse(recordStore.isIndexReadable("MySimpleRecord$str_value_indexed"));
+            assertFalse(recordStore.getIndexState("MySimpleRecord$str_value_indexed").isReadable());
         }
     }
 
@@ -239,7 +239,7 @@ public class FDBRecordStoreStateCacheTest extends FDBRecordStoreTestBase {
             openSimpleRecordStore(context);
             FDBRecordStoreStateCacheTestUtils.assertCacheMiss(context.getTimer(), 1);
             assertArrayEquals(metaDataVersionStamp, context.getMetaDataVersionStamp(IsolationLevel.SNAPSHOT));
-            assertTrue(recordStore.isIndexWriteOnly("MySimpleRecord$str_value_indexed"));
+            assertTrue(recordStore.getIndexState("MySimpleRecord$str_value_indexed").isWriteOnly());
             commit(context);
         }
 
@@ -260,7 +260,7 @@ public class FDBRecordStoreStateCacheTest extends FDBRecordStoreTestBase {
             openSimpleRecordStore(context);
             assertArrayEquals(metaDataVersionStamp, context.getMetaDataVersionStamp(IsolationLevel.SNAPSHOT));
             FDBRecordStoreStateCacheTestUtils.assertCacheMiss(context.getTimer(), 1);
-            assertTrue(recordStore.isIndexWriteOnly("MySimpleRecord$str_value_indexed"));
+            assertTrue(recordStore.getIndexState("MySimpleRecord$str_value_indexed").isWriteOnly());
             // don't need to commit
         }
 
@@ -269,7 +269,7 @@ public class FDBRecordStoreStateCacheTest extends FDBRecordStoreTestBase {
             context.getTimer().reset();
             openSimpleRecordStore(context);
             FDBRecordStoreStateCacheTestUtils.assertCacheHit(context.getTimer(), 1);
-            assertTrue(recordStore.isIndexWriteOnly("MySimpleRecord$str_value_indexed"));
+            assertTrue(recordStore.getIndexState("MySimpleRecord$str_value_indexed").isWriteOnly());
             recordStore.markIndexReadable("MySimpleRecord$str_value_indexed").get();
             assertTrue(context.hasDirtyStoreState());
             assertNull(context.getMetaDataVersionStamp(IsolationLevel.SNAPSHOT));
@@ -281,7 +281,7 @@ public class FDBRecordStoreStateCacheTest extends FDBRecordStoreTestBase {
             context.getTimer().reset();
             openSimpleRecordStore(context);
             FDBRecordStoreStateCacheTestUtils.assertCacheMiss(context.getTimer(), 1);
-            assertTrue(recordStore.isIndexReadable("MySimpleRecord$str_value_indexed"));
+            assertTrue(recordStore.getIndexState("MySimpleRecord$str_value_indexed").isReadable());
             byte[] trMetaDataVersionStamp = context.getMetaDataVersionStamp(IsolationLevel.SNAPSHOT);
             assertNotNull(trMetaDataVersionStamp);
             assertThat(ByteArrayUtil.compareUnsigned(metaDataVersionStamp, trMetaDataVersionStamp), lessThan(0));
@@ -293,7 +293,7 @@ public class FDBRecordStoreStateCacheTest extends FDBRecordStoreTestBase {
             context.getTimer().reset();
             openSimpleRecordStore(context);
             FDBRecordStoreStateCacheTestUtils.assertCacheHit(context.getTimer(), 1);
-            assertTrue(recordStore.isIndexReadable("MySimpleRecord$str_value_indexed"));
+            assertTrue(recordStore.getIndexState("MySimpleRecord$str_value_indexed").isReadable());
             assertArrayEquals(metaDataVersionStamp, context.getMetaDataVersionStamp(IsolationLevel.SNAPSHOT));
         }
 
@@ -596,12 +596,12 @@ public class FDBRecordStoreStateCacheTest extends FDBRecordStoreTestBase {
         try (FDBRecordContext context = testContext.getCachedContext(fdb, storeBuilder1, FDBRecordStoreBase.StoreExistenceCheck.ERROR_IF_NOT_EXISTS)) {
             FDBRecordStore store1 = storeBuilder1.setContext(context).open();
             FDBRecordStoreStateCacheTestUtils.assertCacheHit(context.getTimer(), 1);
-            assertTrue(store1.isIndexWriteOnly("MySimpleRecord$str_value_indexed"));
-            assertTrue(store1.isIndexReadable("MySimpleRecord$num_value_3_indexed"));
+            assertTrue(store1.getIndexState("MySimpleRecord$str_value_indexed").isWriteOnly());
+            assertTrue(store1.getIndexState("MySimpleRecord$num_value_3_indexed").isReadable());
             FDBRecordStore store2 = storeBuilder2.setContext(context).open();
             FDBRecordStoreStateCacheTestUtils.assertCacheMiss(context.getTimer(), 1);
-            assertTrue(store2.isIndexReadable("MySimpleRecord$str_value_indexed"));
-            assertTrue(store2.isIndexDisabled("MySimpleRecord$num_value_3_indexed"));
+            assertTrue(store2.getIndexState("MySimpleRecord$str_value_indexed").isReadable());
+            assertTrue(store2.getIndexState("MySimpleRecord$num_value_3_indexed").isDisabled());
 
             readVersion = context.getReadVersion();
         }
@@ -612,12 +612,12 @@ public class FDBRecordStoreStateCacheTest extends FDBRecordStoreTestBase {
             context.setReadVersion(readVersion);
             FDBRecordStore store1 = storeBuilder1.setContext(context).open();
             FDBRecordStoreStateCacheTestUtils.assertCacheHit(context.getTimer(), 1);
-            assertTrue(store1.isIndexWriteOnly("MySimpleRecord$str_value_indexed"));
-            assertTrue(store1.isIndexReadable("MySimpleRecord$num_value_3_indexed"));
+            assertTrue(store1.getIndexState("MySimpleRecord$str_value_indexed").isWriteOnly());
+            assertTrue(store1.getIndexState("MySimpleRecord$num_value_3_indexed").isReadable());
             FDBRecordStore store2 = storeBuilder2.setContext(context).open();
             FDBRecordStoreStateCacheTestUtils.assertCacheHit(context.getTimer(), 2);
-            assertTrue(store2.isIndexReadable("MySimpleRecord$str_value_indexed"));
-            assertTrue(store2.isIndexDisabled("MySimpleRecord$num_value_3_indexed"));
+            assertTrue(store2.getIndexState("MySimpleRecord$str_value_indexed").isReadable());
+            assertTrue(store2.getIndexState("MySimpleRecord$num_value_3_indexed").isDisabled());
         }
     }
 
@@ -656,7 +656,7 @@ public class FDBRecordStoreStateCacheTest extends FDBRecordStoreTestBase {
             assertEquals(commitVersion, context.getReadVersion());
             openSimpleRecordStore(context);
             FDBRecordStoreStateCacheTestUtils.assertCacheMiss(timer, 1);
-            assertTrue(recordStore.isIndexDisabled("MySimpleRecord$str_value_indexed"));
+            assertTrue(recordStore.getIndexState("MySimpleRecord$str_value_indexed").isDisabled());
             commit(context); // should be read only-so won't change commit version
         }
 
@@ -666,7 +666,7 @@ public class FDBRecordStoreStateCacheTest extends FDBRecordStoreTestBase {
             assertEquals(commitVersion, context.getReadVersion());
             openSimpleRecordStore(context);
             FDBRecordStoreStateCacheTestUtils.assertCacheHit(timer, 1);
-            assertTrue(recordStore.isIndexDisabled("MySimpleRecord$str_value_indexed"));
+            assertTrue(recordStore.getIndexState("MySimpleRecord$str_value_indexed").isDisabled());
 
             // Add a dummy write to increase the DB version
             context.ensureActive().addWriteConflictKey(recordStore.recordsSubspace().pack(UUID.randomUUID()));
@@ -686,7 +686,7 @@ public class FDBRecordStoreStateCacheTest extends FDBRecordStoreTestBase {
             } else {
                 FDBRecordStoreStateCacheTestUtils.assertCacheHit(timer, 1);
             }
-            assertTrue(recordStore.isIndexDisabled("MySimpleRecord$str_value_indexed"));
+            assertTrue(recordStore.getIndexState("MySimpleRecord$str_value_indexed").isDisabled());
 
             // Add a dummy write to increase the DB version
             context.ensureActive().addWriteConflictKey(recordStore.recordsSubspace().pack(UUID.randomUUID()));
@@ -707,7 +707,7 @@ public class FDBRecordStoreStateCacheTest extends FDBRecordStoreTestBase {
             } else {
                 FDBRecordStoreStateCacheTestUtils.assertCacheHit(timer, 1);
             }
-            assertTrue(recordStore.isIndexDisabled("MySimpleRecord$str_value_indexed"));
+            assertTrue(recordStore.getIndexState("MySimpleRecord$str_value_indexed").isDisabled());
         }
 
         // Load the meta-data using the cached read version.
@@ -716,7 +716,7 @@ public class FDBRecordStoreStateCacheTest extends FDBRecordStoreTestBase {
             assertEquals(readVersion, context.getReadVersion());
             openSimpleRecordStore(context);
             FDBRecordStoreStateCacheTestUtils.assertCacheHit(timer, 1);
-            assertTrue(recordStore.isIndexDisabled("MySimpleRecord$str_value_indexed"));
+            assertTrue(recordStore.getIndexState("MySimpleRecord$str_value_indexed").isDisabled());
         }
     }
 

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
@@ -222,7 +222,7 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
 
     public int deleteDocumentBypassQueue(Tuple groupingKey, @Nullable Integer partitionId, Tuple primaryKey) throws IOException {
         return LuceneIndexMaintainerHelper.deleteDocument(state.context, directoryManager, state.index, groupingKey, partitionId, primaryKey,
-                state.store.isIndexWriteOnly(state.index));
+                state.store.getIndexState(state.index).isWriteOnly());
     }
 
     @Override
@@ -407,7 +407,7 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
      */
     private <M extends Message> CompletableFuture<Integer> tryDeleteInWriteOnlyMode(@Nonnull FDBIndexableRecord<M> record,
                                                                                     @Nonnull Tuple groupingKey) {
-        if (!state.store.isIndexWriteOnly(state.index)) {
+        if (!state.store.getIndexState(state.index).isWriteOnly()) {
             // no op
             return CompletableFuture.completedFuture(0);
         }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexScrubbingTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexScrubbingTest.java
@@ -108,7 +108,7 @@ class LuceneIndexScrubbingTest extends FDBLuceneTestBase {
             for (Map.Entry<Index, IndexState> entry : store.getAllIndexStates().entrySet()) {
                 Index index = entry.getKey();
                 IndexState indexState = entry.getValue();
-                if (index.getType().equalsIgnoreCase("lucene") && indexState.equals(IndexState.READABLE)) {
+                if (index.getType().equalsIgnoreCase("lucene") && indexState.isReadable()) {
                     atLeastOnce = true;
                     try (OnlineIndexScrubber indexScrubber = OnlineIndexScrubber.newBuilder()
                             .setRecordStore(store)
@@ -212,7 +212,7 @@ class LuceneIndexScrubbingTest extends FDBLuceneTestBase {
             for (Map.Entry<Index, IndexState> entry : store.getAllIndexStates().entrySet()) {
                 Index index = entry.getKey();
                 IndexState indexState = entry.getValue();
-                if (index.getType().equalsIgnoreCase("lucene") && indexState.equals(IndexState.READABLE)) {
+                if (index.getType().equalsIgnoreCase("lucene") && indexState.isReadable()) {
                     atLeastOnce = true;
                     try (OnlineIndexScrubber indexScrubber = OnlineIndexScrubber.newBuilder()
                             .setRecordStore(store)

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneOnlineIndexingTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneOnlineIndexingTest.java
@@ -158,13 +158,13 @@ class LuceneOnlineIndexingTest extends FDBRecordStoreTestBase {
                     .setRecordStore(recordStore)
                     .setIndex(index)
                     .build()) {
-                assertTrue(recordStore.isIndexDisabled(index));
+                assertTrue(recordStore.getIndexState(index).isDisabled());
                 indexBuilder.buildIndex(true);
             }
         }
         try (final FDBRecordContext context = openContext()) {
             rebuildIndexMetaData(context, SIMPLE_DOC, index);
-            assertTrue(recordStore.isIndexReadable(index));
+            assertTrue(recordStore.getIndexState(index).isReadable());
         }
         String[] allFiles = listFiles(index);
         assertTrue(allFiles.length < 12);
@@ -216,7 +216,7 @@ class LuceneOnlineIndexingTest extends FDBRecordStoreTestBase {
                         throw stopBuildException;
                     })
                     .build()) {
-                assertTrue(recordStore.isIndexDisabled(index));
+                assertTrue(recordStore.getIndexState(index).isDisabled());
                 final RuntimeException thrown = assertThrows(RuntimeException.class, () -> indexBuilder.buildIndex(true));
                 assertSame(stopBuildException, thrown);
             }
@@ -234,7 +234,7 @@ class LuceneOnlineIndexingTest extends FDBRecordStoreTestBase {
         // this will succeed
         try (final FDBRecordContext context = openContext(contextProps)) {
             rebuildIndexMetaData(context, COMPLEX_DOC, index);
-            assertTrue(recordStore.isIndexWriteOnly(index));
+            assertTrue(recordStore.getIndexState(index).isWriteOnly());
             recordStore.saveRecord(createComplexDocument(docId_1, ENGINEER_JOKE, 1, startTime));
             context.commit();
         }
@@ -250,7 +250,7 @@ class LuceneOnlineIndexingTest extends FDBRecordStoreTestBase {
         // this will also succeed
         try (final FDBRecordContext context = openContext(contextProps)) {
             rebuildIndexMetaData(context, COMPLEX_DOC, index);
-            assertTrue(recordStore.isIndexWriteOnly(index));
+            assertTrue(recordStore.getIndexState(index).isWriteOnly());
             recordStore.saveRecord(createComplexDocument(docId_2, ENGINEER_JOKE, 1, startTime + 1_000));
             // update record a second time
             recordStore.saveRecord(createComplexDocument(docId_1, ENGINEER_JOKE + " XANADU", 1, startTime));
@@ -271,7 +271,7 @@ class LuceneOnlineIndexingTest extends FDBRecordStoreTestBase {
                     .setRecordStore(recordStore)
                     .setIndex(index)
                     .build()) {
-                assertTrue(recordStore.isIndexWriteOnly(index));
+                assertTrue(recordStore.getIndexState(index).isWriteOnly());
                 indexBuilder.buildIndex(true);
             }
         }
@@ -407,7 +407,7 @@ class LuceneOnlineIndexingTest extends FDBRecordStoreTestBase {
         try (final FDBRecordContext context = openContext(contextProps)) {
             rebuildIndexMetaData(context, COMPLEX_DOC, index);
 
-            assertTrue(recordStore.isIndexReadable(index));
+            assertTrue(recordStore.getIndexState(index).isReadable());
 
             // search for docs with Math.pow(docCount, 2) - docCount < time < Math.pow(docCount, 2)
             // which should return all docs, if their updates completed successfully during index build
@@ -529,7 +529,7 @@ class LuceneOnlineIndexingTest extends FDBRecordStoreTestBase {
                             .setInitialMergesCountLimit(mergesLimit)
                             .build())
                     .build()) {
-                assertTrue(recordStore.isIndexDisabled(index));
+                assertTrue(recordStore.getIndexState(index).isDisabled());
                 indexBuilder.buildIndex(true);
             }
             context.commit();
@@ -537,7 +537,7 @@ class LuceneOnlineIndexingTest extends FDBRecordStoreTestBase {
         // .. and assert readable mode
         try (final FDBRecordContext context = openContext()) {
             rebuildIndexMetaData(context, document, index);
-            assertTrue(recordStore.isIndexReadable(index));
+            assertTrue(recordStore.getIndexState(index).isReadable());
         }
         // assert number of segments, the number below is based on previous runs of this test.
         // the key thing is to make sure that while it was building the index it actually did the merges.
@@ -617,7 +617,7 @@ class LuceneOnlineIndexingTest extends FDBRecordStoreTestBase {
                     .setLimit(transactionLimit)
                     .build()) {
                 for (Index index: indexes) {
-                    assertTrue(recordStore.isIndexDisabled(index));
+                    assertTrue(recordStore.getIndexState(index).isDisabled());
                 }
                 indexBuilder.buildIndex(true);
             }
@@ -626,7 +626,7 @@ class LuceneOnlineIndexingTest extends FDBRecordStoreTestBase {
         try (final FDBRecordContext context = openContext()) {
             recordStore = LuceneIndexTestUtils.openRecordStore(context, path, hook);
             for (Index index: indexes) {
-                assertTrue(recordStore.isIndexReadable(index));
+                assertTrue(recordStore.getIndexState(index).isReadable());
             }
         }
         // assert number of segments
@@ -712,14 +712,14 @@ class LuceneOnlineIndexingTest extends FDBRecordStoreTestBase {
                     .setRecordStore(recordStore)
                     .setIndex(index)
                     .build()) {
-                assertTrue(recordStore.isIndexDisabled(index));
+                assertTrue(recordStore.getIndexState(index).isDisabled());
                 indexBuilder.buildIndex(true);
             }
         }
         // .. and assert readable mode
         try (final FDBRecordContext context = openContext()) {
             openRecordStore(context, hook);
-            assertTrue(recordStore.isIndexReadable(index));
+            assertTrue(recordStore.getIndexState(index).isReadable());
         }
     }
 

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/highlight/LuceneScaleTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/highlight/LuceneScaleTest.java
@@ -533,7 +533,7 @@ public class LuceneScaleTest extends FDBRecordStoreTestBase {
                 maxDocId = LuceneConcurrency.asyncToSync(FDBStoreTimer.Waits.WAIT_LOAD_SYSTEM_KEY,
                         store.scanRecords(TupleRange.ALL, null, ScanProperties.FORWARD_SCAN).getCount(), context);
                 continuing = maxDocId > 0;
-                if (!store.isIndexReadable(INDEX.getName())) {
+                if (!store.getIndexState(INDEX.getName()).isReadable()) {
                     indexBuilder = OnlineIndexer.newBuilder()
                             .setRecordStore(store)
                             .addTargetIndex(INDEX.getName());


### PR DESCRIPTION
This is a technical change that makes `IndexState` the single source of truth for index-state and avoid using the FDBRecordStore's `isIndex*` as a way to query the index state. 

This PR should be followed up by deprecating the `FDBRecordStore.isIndex*` helpers before deletion. 
