### PR TITLE
Cleanups in `MetaDataProtoEditor`

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/MetaDataProtoEditor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/MetaDataProtoEditor.java
@@ -193,7 +193,8 @@ public class MetaDataProtoEditor {
     }
 
     /**
-     * Returns the declared {@code usage} of a message type, or {@code UNSET} if none is declared.
+     * Returns the declared {@code usage} of a message type. If the message type declares no {@code record} options,
+     * or no {@code usage} within them, returns {@code UNSET} (which is the Protobuf default for the field).
      */
     @Nonnull
     private static RecordTypeOptions.Usage getMessageTypeUsage(
@@ -261,20 +262,23 @@ public class MetaDataProtoEditor {
     }
 
     /**
-     * Returns the fully-qualified name of the message type referenced by {@code field}, resolved against
+     * Returns the fully-qualified name of the message or enum type referenced by {@code field}, resolved against
      * {@code messageDescriptor} by field number rather than name or position, since the number is the only
      * identifier guaranteed to tie a mutable builder field to its resolved descriptor counterpart. Returns
-     * {@code null} if the field does not reference a message type.
+     * {@code null} if the field is of a primitive type, and so references no named type at all.
      */
     @Nullable
-    private static String resolveFieldMessageTypeFullName(
+    private static String resolveFieldTypeFullName(
             @Nonnull Descriptors.Descriptor messageDescriptor,
             @Nonnull DescriptorProtos.FieldDescriptorProtoOrBuilder field) {
         final Descriptors.FieldDescriptor resolvedField = Objects.requireNonNull(
                 messageDescriptor.findFieldByNumber(field.getNumber()),
                 "Could not find field from protobuf in descriptor");
-        final Descriptors.Descriptor messageType = resolvedField.getMessageType();
-        return messageType == null ? null : "." + messageType.getFullName();
+        return switch (resolvedField.getJavaType()) {
+            case MESSAGE -> "." + resolvedField.getMessageType().getFullName();
+            case ENUM -> "." + resolvedField.getEnumType().getFullName();
+            default -> null;
+        };
     }
 
     /**
@@ -314,7 +318,7 @@ public class MetaDataProtoEditor {
         // we require that the actual Descriptor be passed in so that we can work on fully qualified type names, which
         // is much, much easier, and less likely to have a bug.
         if (field.hasTypeName() && !field.getTypeName().isEmpty()) {
-            final String fullyQualifiedName = resolveFieldMessageTypeFullName(messageDescriptor, field);
+            final String fullyQualifiedName = resolveFieldTypeFullName(messageDescriptor, field);
             if (fullyQualifiedName == null) {
                 return FieldTypeMatch.DOES_NOT_MATCH;
             } else if (fullyQualifiedName.equals(fullTypeName)) {
@@ -547,8 +551,9 @@ public class MetaDataProtoEditor {
             if (FieldTypeMatch.MATCHES.equals(fieldTypeMatch)) {
                 field.setTypeName(fullNewRecordTypeName);
             } else if (FieldTypeMatch.MATCHES_AS_NESTED.equals(fieldTypeMatch)) {
-                final String fullOldFieldTypeName = "." + descriptorForMessage.findFieldByNumber(field.getNumber())
-                        .getMessageType().getFullName();
+                final String fullOldFieldTypeName = Objects.requireNonNull(
+                        resolveFieldTypeFullName(descriptorForMessage, field),
+                        "A field matching as nested must reference a named type");
                 final String newFieldTypeName = fullNewRecordTypeName + fullOldFieldTypeName.substring(fullRecordTypeName.length());
                 field.setTypeName(newFieldTypeName);
             }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/MetaDataProtoEditor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/MetaDataProtoEditor.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ package com.apple.foundationdb.record.provider.foundationdb;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.RecordMetaDataBuilder;
 import com.apple.foundationdb.record.RecordMetaDataOptionsProto;
+import com.apple.foundationdb.record.RecordMetaDataOptionsProto.RecordTypeOptions;
 import com.apple.foundationdb.record.RecordMetaDataProto;
 import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.metadata.MetaDataException;
@@ -37,44 +38,39 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.stream.Collectors;
+
+import static com.apple.foundationdb.record.RecordMetaDataBuilder.DEFAULT_UNION_NAME;
 
 /**
- * A helper class for mutating the meta-data proto.
+ * A utility class for mutating the metadata proto.
  *
- * <p>
- * This class contains several helper methods for modifying a serialized meta-data, e.g., adding a new record type to the meta-data.
- * {@link FDBMetaDataStore#mutateMetaData(Consumer)} is one example of where these methods can be useful. That method
- * modifies the stored meta-data using a mutation callback and saves it back to the meta-data store.
- * </p>
- *
+ * <p>This class provides utility methods for modifying a serialized metadata; for example, adding a new record type to
+ * the metadata. One example of where these methods can be useful is {@link FDBMetaDataStore#mutateMetaData}. That
+ * method modifies the stored metadata using a mutation callback and saves it back to the metadata store.
  */
 @API(API.Status.EXPERIMENTAL)
 public class MetaDataProtoEditor {
     /**
-     * Add a new record type to the meta-data.
+     * Add a new record type to the metadata.
      *
-     * <p>
-     * Adding the record type involves three steps: the message type is added to the file descriptor's list of message types,
-     * a field of the given type is added to the union, and its primary key is set.
-     * Note that adding {@code UNION} record types is not allowed. To add {@code NESTED} record types, use {@link #addNestedRecordType}.
-     * </p>
+     * <p>Adding the record type involves three steps: the message type is added to the file descriptor's list of
+     * message types, a field of the given type is added to the union, and its primary key is set. Note that adding
+     * {@code UNION} record types is not allowed. To add {@code NESTED} record types, use {@link #addNestedRecordType}.
      *
-     * @param metaDataBuilder the meta-data builder
+     * @param metaDataBuilder the metadata builder
      * @param newRecordType the new record type
      * @param primaryKey the primary key of the new record type
      */
     public static void addRecordType(@Nonnull RecordMetaDataProto.MetaData.Builder metaDataBuilder,
                                      @Nonnull DescriptorProtos.DescriptorProto newRecordType,
                                      @Nonnull KeyExpression primaryKey) {
-        RecordMetaDataOptionsProto.RecordTypeOptions.Usage newRecordTypeUsage = getMessageTypeUsage(newRecordType);
-        if (RecordMetaDataBuilder.DEFAULT_UNION_NAME.equals(newRecordType.getName()) ||
-                newRecordTypeUsage == RecordMetaDataOptionsProto.RecordTypeOptions.Usage.UNION) {
+        RecordTypeOptions.Usage newRecordTypeUsage = getMessageTypeUsage(newRecordType);
+        if (DEFAULT_UNION_NAME.equals(newRecordType.getName()) ||
+                newRecordTypeUsage == RecordTypeOptions.Usage.UNION) {
             throw new MetaDataException("Adding UNION record type not allowed");
         }
-        if (newRecordTypeUsage == RecordMetaDataOptionsProto.RecordTypeOptions.Usage.NESTED) {
+        if (newRecordTypeUsage == RecordTypeOptions.Usage.NESTED) {
             throw new MetaDataException("Use addNestedRecordType for adding NESTED record types");
         }
         if (findMessageTypeByName(metaDataBuilder.getRecordsBuilder(), newRecordType.getName()) != null) {
@@ -91,6 +87,25 @@ public class MetaDataProtoEditor {
         addFieldToUnion(fetchUnionBuilder(recordsBuilder), recordsBuilder, newRecordType.getName());
     }
 
+    /**
+     * Returns the canonical union field name for a record type.
+     *
+     * @return {@code "_" + recordTypeName}
+     */
+    @Nonnull
+    private static String canonicalUnionFieldName(@Nonnull String recordTypeName) {
+        return "_" + recordTypeName;
+    }
+
+    /**
+     * Returns whether the name of a union field is the canonical {@code _recordTypeName} form.
+     */
+    private static boolean isCanonicalUnionFieldName(@Nonnull String unionFieldName, @Nonnull String recordTypeName) {
+        return unionFieldName.length() == recordTypeName.length() + 1
+                && unionFieldName.charAt(0) == '_'
+                && unionFieldName.regionMatches(1, recordTypeName, 0, recordTypeName.length());
+    }
+
     private static void addFieldToUnion(@Nonnull DescriptorProtos.DescriptorProto.Builder unionBuilder,
                                         @Nonnull DescriptorProtos.FileDescriptorProtoOrBuilder fileBuilder,
                                         @Nonnull String typeName) {
@@ -101,20 +116,48 @@ public class MetaDataProtoEditor {
                 .setLabel(DescriptorProtos.FieldDescriptorProto.Label.LABEL_OPTIONAL)
                 .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_MESSAGE)
                 .setTypeName(fullyQualifiedTypeName(fileBuilder, typeName))
-                .setName("_" + typeName)
+                .setName(canonicalUnionFieldName(typeName))
                 .setNumber(assignFieldNumber(unionBuilder));
         unionBuilder.addField(fieldBuilder);
     }
 
+    /**
+     * Returns the names of the top-level record types declared in the metadata.
+     */
     @Nonnull
     public static List<String> getRecordTypes(@Nonnull RecordMetaDataProto.MetaData.Builder metaDataBuilder) {
-        return metaDataBuilder.getRecordTypesBuilderList().stream()
-                .map(RecordMetaDataProto.RecordType.Builder::getName)
-                .collect(Collectors.toList());
+        return metaDataBuilder.getRecordTypesList().stream().map(RecordMetaDataProto.RecordType::getName).toList();
+    }
+
+    /**
+     * Returns the top-level message type descriptor with the given name, throwing if it is not found.
+     */
+    @Nonnull
+    private static Descriptors.Descriptor getMessageTypeByName(Descriptors.FileDescriptor fileDescriptor, String name) {
+        final Descriptors.Descriptor descriptor = fileDescriptor.findMessageTypeByName(name);
+        if (descriptor == null) {
+            throw new MetaDataException("Could not find descriptor")
+                    .addLogInfo(LogMessageKeys.NAME, name);
+        }
+        return descriptor;
+    }
+
+    /**
+     * Returns the builder for the top-level message type with the given name, or {@code null} if none is found.
+     */
+    @Nullable
+    private static DescriptorProtos.DescriptorProto.Builder findMessageTypeByName(
+            @Nonnull DescriptorProtos.FileDescriptorProto.Builder recordsBuilder,
+            @Nonnull String recordType) {
+        return recordsBuilder.getMessageTypeBuilderList().stream()
+                .filter(m -> m.getName().equals(recordType))
+                .findAny()
+                .orElse(null);
     }
 
     @Nonnull
-    private static DescriptorProtos.DescriptorProto.Builder fetchUnionBuilder(@Nonnull DescriptorProtos.FileDescriptorProto.Builder fileBuilder) {
+    private static DescriptorProtos.DescriptorProto.Builder fetchUnionBuilder(
+            @Nonnull DescriptorProtos.FileDescriptorProto.Builder fileBuilder) {
         for (DescriptorProtos.DescriptorProto.Builder messageTypeBuilder : fileBuilder.getMessageTypeBuilderList()) {
             if (isUnion(messageTypeBuilder)) {
                 return messageTypeBuilder;
@@ -124,10 +167,11 @@ public class MetaDataProtoEditor {
     }
 
     @Nullable
-    private static DescriptorProtos.FieldDescriptorProto.Builder fetchUnionFieldBuilder(@Nonnull DescriptorProtos.FileDescriptorProto.Builder recordsBuilder,
-                                                                                        @Nonnull DescriptorProtos.DescriptorProto.Builder unionBuilder,
-                                                                                        @Nonnull Descriptors.Descriptor unionDescriptor,
-                                                                                        @Nonnull String recordTypeName) {
+    private static DescriptorProtos.FieldDescriptorProto.Builder fetchUnionFieldBuilder(
+            @Nonnull DescriptorProtos.FileDescriptorProto.Builder recordsBuilder,
+            @Nonnull DescriptorProtos.DescriptorProto.Builder unionBuilder,
+            @Nonnull Descriptors.Descriptor unionDescriptor,
+            @Nonnull String recordTypeName) {
         DescriptorProtos.FieldDescriptorProto.Builder foundField = null;
         if (recordTypeName.contains(".")) {
             throw new MetaDataException("Record Type Name cannot contain '.'");
@@ -135,42 +179,55 @@ public class MetaDataProtoEditor {
         if (unionBuilder.getNestedTypeCount() > 0) {
             throw new MetaDataException("Nested types in union type not supported");
         }
-        for (DescriptorProtos.FieldDescriptorProto.Builder field : unionBuilder.getFieldBuilderList()) {
-            final FieldTypeMatch unionFieldMatch = fieldIsType(recordsBuilder, unionDescriptor, field, recordTypeName);
+        for (DescriptorProtos.FieldDescriptorProto.Builder unionField : unionBuilder.getFieldBuilderList()) {
+            final FieldTypeMatch unionFieldMatch = fieldIsType(recordsBuilder, unionDescriptor, unionField, recordTypeName);
             if (FieldTypeMatch.MATCHES.equals(unionFieldMatch)
-                    && (foundField == null || field.getName().equals("_" + recordTypeName) || field.getNumber() > foundField.getNumber())) {
+                    && (foundField == null
+                                || isCanonicalUnionFieldName(unionField.getName(), recordTypeName)
+                                || unionField.getNumber() > foundField.getNumber())) {
                 // Choose the matching field with either a matching name or the highest number.
-                foundField = field;
+                foundField = unionField;
             }
         }
         return foundField;
     }
 
+    /**
+     * Returns the declared {@code usage} of a message type, or {@code UNSET} if none is declared.
+     */
+    @Nonnull
+    private static RecordTypeOptions.Usage getMessageTypeUsage(
+            @Nonnull DescriptorProtos.DescriptorProtoOrBuilder messageType) {
+        return messageType.getOptions().getExtension(RecordMetaDataOptionsProto.record).getUsage();
+    }
+
+    /**
+     * Sets the usage of a message type, preserving any other options already set on the {@code record} extension.
+     */
+    private static void setMessageTypeUsage(@Nonnull DescriptorProtos.DescriptorProto.Builder messageTypeBuilder,
+                                            @Nonnull RecordTypeOptions.Usage usage) {
+        RecordTypeOptions.Builder recordOptionsBuilder =
+                messageTypeBuilder.getOptions().hasExtension(RecordMetaDataOptionsProto.record)
+                ? messageTypeBuilder.getOptionsBuilder().getExtension(RecordMetaDataOptionsProto.record).toBuilder()
+                : RecordTypeOptions.newBuilder();
+        recordOptionsBuilder.setUsage(usage);
+        messageTypeBuilder.getOptionsBuilder().setExtension(
+                RecordMetaDataOptionsProto.record,
+                recordOptionsBuilder.build());
+    }
+
     private static boolean isUnion(@Nonnull DescriptorProtos.DescriptorProtoOrBuilder messageType) {
-        if (RecordMetaDataBuilder.DEFAULT_UNION_NAME.equals(messageType.getName())) {
-            return true;
-        }
-        RecordMetaDataOptionsProto.RecordTypeOptions recordTypeOptions = messageType.getOptions()
-                .getExtension(RecordMetaDataOptionsProto.record);
-        return recordTypeOptions != null &&
-               recordTypeOptions.hasUsage() &&
-               recordTypeOptions.getUsage() == RecordMetaDataOptionsProto.RecordTypeOptions.Usage.UNION;
+        return DEFAULT_UNION_NAME.equals(messageType.getName())
+                || getMessageTypeUsage(messageType) == RecordTypeOptions.Usage.UNION;
     }
 
     private static boolean isUnion(@Nonnull Descriptors.Descriptor messageType) {
-        if (RecordMetaDataBuilder.DEFAULT_UNION_NAME.equals(messageType.getName())) {
-            return true;
-        }
-        RecordMetaDataOptionsProto.RecordTypeOptions recordTypeOptions = messageType.getOptions()
-                .getExtension(RecordMetaDataOptionsProto.record);
-        return recordTypeOptions != null &&
-               recordTypeOptions.hasUsage() &&
-               recordTypeOptions.getUsage() == RecordMetaDataOptionsProto.RecordTypeOptions.Usage.UNION;
+        return DEFAULT_UNION_NAME.equals(messageType.getName())
+                || getMessageTypeUsage(messageType.toProto()) == RecordTypeOptions.Usage.UNION;
     }
 
     @Nonnull
-    private static String fullyQualifiedTypeName(@Nonnull String namespace,
-                                                 @Nonnull String typeName) {
+    private static String fullyQualifiedTypeName(@Nonnull String namespace, @Nonnull String typeName) {
         if (typeName.startsWith(".")) {
             return typeName;
         } else if (!namespace.isEmpty()) {
@@ -197,10 +254,27 @@ public class MetaDataProtoEditor {
          */
         MATCHES,
         /**
-         * The field is definitely a nested type defined within the type requested.
-         * For example, the requested type might be an {@code OuterMessage} and the field an {@code OuterMessage.InnerMessage}.
+         * The field is definitely a nested type defined within the type requested. For example, the requested type
+         * might be an {@code OuterMessage} and the field an {@code OuterMessage.InnerMessage}.
          */
         MATCHES_AS_NESTED
+    }
+
+    /**
+     * Returns the fully-qualified name of the message type referenced by {@code field}, resolved against
+     * {@code messageDescriptor} by field number rather than name or position, since the number is the only
+     * identifier guaranteed to tie a mutable builder field to its resolved descriptor counterpart. Returns
+     * {@code null} if the field does not reference a message type.
+     */
+    @Nullable
+    private static String resolveFieldMessageTypeFullName(
+            @Nonnull Descriptors.Descriptor messageDescriptor,
+            @Nonnull DescriptorProtos.FieldDescriptorProtoOrBuilder field) {
+        final Descriptors.FieldDescriptor resolvedField = Objects.requireNonNull(
+                messageDescriptor.findFieldByNumber(field.getNumber()),
+                "Could not find field from protobuf in descriptor");
+        final Descriptors.Descriptor messageType = resolvedField.getMessageType();
+        return messageType == null ? null : "." + messageType.getFullName();
     }
 
     /**
@@ -214,24 +288,18 @@ public class MetaDataProtoEditor {
      * {@code .x.y.z.Foo}, or {@code .y.z.Foo}. Actually knowing which one is being referred to properly
      * requires knowing which types are actually defined and then traversing the namespace tree.
      *
-     * <p>
-     * This can get even worse with nested types. For example, within a record {@code Foo}, if it has
+     * <p>This can get even worse with nested types. For example, within a record {@code Foo}, if it has
      * a nested type {@code Bar}, a field with type {@code Foo} might be referring to either
      * the other {@code Foo} record or an additional type {@code Foo.Bar.Foo}.
-     * </p>
      *
-     * <p>
-     * Because getting that right is difficult and requires full knowledge of all defined types, this
+     * <p>Because getting that right is difficult and requires full knowledge of all defined types, this
      * instead takes a simpler approach where if it can be determined for sure that the type is the
      * same, it returns that the type {@link FieldTypeMatch#MATCHES}. If it can be determined that the
      * type is definitely different, then this returns that it {@link FieldTypeMatch#DOES_NOT_MATCH}.
-     * </p>
      *
-     * <p>
-     * It is also possible that the field matches (or might match) a nested type defined within the
+     * <p>It is also possible that the field matches (or might match) a nested type defined within the
      * given type. In that case, this can return that it matches (or might match) as a nested type.
      * This is useful for determining whether the type needs to be renamed, for example.
-     * </p>
      *
      * @param field the field descriptor to check the type of
      * @param fullTypeName the fully-qualified type name
@@ -246,14 +314,10 @@ public class MetaDataProtoEditor {
         // we require that the actual Descriptor be passed in so that we can work on fully qualified type names, which
         // is much, much easier, and less likely to have a bug.
         if (field.hasTypeName() && !field.getTypeName().isEmpty()) {
-            // search by fieldNumber instead of name because we may have renamed the field in the builder
-            // but we can't change the number (without corrupting things)
-            final String fullyQualifiedName = "." + Objects.requireNonNull(
-                            messageDescriptor.findFieldByNumber(field.getNumber()),
-                            "Could not find field from protobuf in descriptor")
-                    .getMessageType()
-                    .getFullName();
-            if (fullyQualifiedName.equals(fullTypeName)) {
+            final String fullyQualifiedName = resolveFieldMessageTypeFullName(messageDescriptor, field);
+            if (fullyQualifiedName == null) {
+                return FieldTypeMatch.DOES_NOT_MATCH;
+            } else if (fullyQualifiedName.equals(fullTypeName)) {
                 return FieldTypeMatch.MATCHES;
             } else if (fullyQualifiedName.startsWith(fullTypeName) && fullyQualifiedName.charAt(fullTypeName.length()) == '.') {
                 return FieldTypeMatch.MATCHES_AS_NESTED;
@@ -278,20 +342,26 @@ public class MetaDataProtoEditor {
         if (messageType.getFieldCount() == 0) {
             return 1;
         }
-        return messageType.getFieldList().stream().mapToInt(DescriptorProtos.FieldDescriptorProto::getNumber).max().getAsInt() + 1;
+        return messageType.getFieldList().stream()
+                .mapToInt(DescriptorProtos.FieldDescriptorProto::getNumber)
+                .max()
+                .orElseThrow()
+                + 1;
     }
 
     /**
-     * Add a new {@code NESTED} record type to the meta-data. This can be used to define fields in other record types,
+     * Add a new {@code NESTED} record type to the metadata. This can be used to define fields in other record types,
      * but it does not add the new record type to the union.
      *
-     * @param metaDataBuilder the meta-data builder
+     * @param metaDataBuilder the metadata builder
      * @param newRecordType the new record type
      */
-    public static void addNestedRecordType(@Nonnull RecordMetaDataProto.MetaData.Builder metaDataBuilder, @Nonnull DescriptorProtos.DescriptorProto newRecordType) {
-        RecordMetaDataOptionsProto.RecordTypeOptions.Usage newRecordTypeUsage = getMessageTypeUsage(newRecordType);
-        if (newRecordTypeUsage != RecordMetaDataOptionsProto.RecordTypeOptions.Usage.NESTED &&
-                newRecordTypeUsage != RecordMetaDataOptionsProto.RecordTypeOptions.Usage.UNSET) {
+    public static void addNestedRecordType(
+            @Nonnull RecordMetaDataProto.MetaData.Builder metaDataBuilder,
+            @Nonnull DescriptorProtos.DescriptorProto newRecordType) {
+        RecordTypeOptions.Usage newRecordTypeUsage = getMessageTypeUsage(newRecordType);
+        if (newRecordTypeUsage != RecordTypeOptions.Usage.NESTED &&
+                newRecordTypeUsage != RecordTypeOptions.Usage.UNSET) {
             throw new MetaDataException("Record type is not NESTED");
         }
         if (findMessageTypeByName(metaDataBuilder.getRecordsBuilder(), newRecordType.getName()) != null) {
@@ -300,28 +370,13 @@ public class MetaDataProtoEditor {
         metaDataBuilder.getRecordsBuilder().addMessageType(newRecordType);
     }
 
-    @Nonnull
-    private static RecordMetaDataOptionsProto.RecordTypeOptions.Usage getMessageTypeUsage(@Nonnull DescriptorProtos.DescriptorProtoOrBuilder messageType) {
-        RecordMetaDataOptionsProto.RecordTypeOptions recordTypeOptions = messageType.getOptions()
-                .getExtension(RecordMetaDataOptionsProto.record);
-        if (recordTypeOptions != null && recordTypeOptions.hasUsage()) {
-            return recordTypeOptions.getUsage();
-        }
-        return RecordMetaDataOptionsProto.RecordTypeOptions.Usage.UNSET;
-    }
-
-    @Nullable
-    private static DescriptorProtos.DescriptorProto.Builder findMessageTypeByName(@Nonnull DescriptorProtos.FileDescriptorProto.Builder recordsBuilder, @Nonnull String recordType) {
-        return recordsBuilder.getMessageTypeBuilderList().stream().filter(m -> m.getName().equals(recordType)).findAny().orElse(null);
-    }
-
     /**
-     * Deprecate a record type from the meta-data. The record is still defined in the record definition, but any
+     * Deprecate a record type from the metadata. The record is still defined in the record definition, but any
      * occurrences
      * of the field in the union descriptor are deprecated. If there are any top-level record types that are defined
      * as nested messages within the deprecated record type, those fields in the union will also be deprecated.
      *
-     * @param metaDataBuilder the meta-data builder
+     * @param metaDataBuilder the metadata builder
      * @param recordType the record type to be deprecated
      */
     public static void deprecateRecordType(@Nonnull RecordMetaDataProto.MetaData.Builder metaDataBuilder,
@@ -359,22 +414,31 @@ public class MetaDataProtoEditor {
     }
 
     /**
-     * Rename a record type. This can be used to update any top-level record type defined within the
-     * meta-data's records descriptor, including {@code NESTED} records or the union descriptor. However,
-     * it cannot be used to rename nested messages (i.e., messages defined within other messages) or
-     * records defined in imported files. In addition to updating the file descriptor, if the record type
-     * is not {@code NESTED} or the union descriptor, update any other references to the record type
-     * within the meta-data (such as within index definitions).
+     * Renames a record type. This can be used to update any top-level record type defined within the metadata’s
+     * records descriptor, including {@code NESTED} records or the union descriptor. However, it cannot be used to
+     * rename nested messages (i.e., messages defined within other messages) or records defined in imported files.
      *
-     * @param metaDataBuilder the meta-data builder
+     * <ul>
+     * <li>Message names are rewritten.
+     * <li>Field types ({@code typeName}) that reference a renamed type are rewritten, whether the reference is direct
+     *     or to a nested type of a renamed type.
+     * <li>The union usage option is set when the union is renamed.
+     * <li>The canonical {@code _typeName} union field is renamed when possible.
+     * <li>If the record type has {@code RECORD} usage, the record type list, indexes, and joined record types are
+     *     updated.
+     * <li>Unnested record type constituents are updated.
+     * </ul>
+     *
+     * @param metaDataBuilder the metadata builder
      * @param recordTypeName the name of the existing top-level record type
      * @param newRecordTypeName the new name to give to the record type
      */
     public static void renameRecordType(@Nonnull RecordMetaDataProto.MetaData.Builder metaDataBuilder,
-                                        @Nonnull String recordTypeName, @Nonnull String newRecordTypeName,
+                                        @Nonnull String recordTypeName,
+                                        @Nonnull String newRecordTypeName,
                                         @Nonnull Descriptors.FileDescriptor[] dependencies) {
-        // Create a copy of the records builder (rather than calling metaDataBuilder.getRecordsBuilder()) to avoid
-        // corrupting the records builder in metaDataBuilder before all validation has been done.
+        // Validate the rename. Rather than calling `metaDataBuilder.getRecordsBuilder()`, create a copy of the records
+        // builder to avoid corrupting the one in `metaDataBuilder` before all validation has been done.
         final DescriptorProtos.FileDescriptorProto records = metaDataBuilder.getRecords();
         boolean found = false;
         for (DescriptorProtos.DescriptorProto messageType : records.getMessageTypeList()) {
@@ -387,31 +451,32 @@ public class MetaDataProtoEditor {
         if (!found) {
             throw new MetaDataException("No record type found with name " + recordTypeName);
         }
+
+        // Identity transformation requires no work. From here on, we can assume `recordTypeName != newRecordTypeName`,
+        // which simplifies things.
         if (recordTypeName.equals(newRecordTypeName)) {
-            // Identity transformation requires no work.
-            // From here on in, we can assume that recordTypeName != newRecordTypeName, which simplifies things.
             return;
         }
         final Descriptors.FileDescriptor fileDescriptor = RecordMetaDataBuilder.buildFileDescriptor(records, dependencies);
         final DescriptorProtos.FileDescriptorProto.Builder recordsBuilder = records.toBuilder();
 
         // Determine the usage of the original record type by looking through the union builder.
-        // If we find a field that matches, also update its name to be in the canonical form (i.e., "_" + recordTypeName)
+        // If we find a union field that matches, also update its name to be in the canonical form.
         DescriptorProtos.DescriptorProto.Builder unionBuilder = fetchUnionBuilder(recordsBuilder);
-        RecordMetaDataOptionsProto.RecordTypeOptions.Usage usage;
+        RecordTypeOptions.Usage usage;
         if (unionBuilder.getName().equals(recordTypeName)) {
-            usage = RecordMetaDataOptionsProto.RecordTypeOptions.Usage.UNION;
+            usage = RecordTypeOptions.Usage.UNION;
         } else {
-            final Descriptors.Descriptor unionDescriptor = getDescriptor(fileDescriptor, unionBuilder.getName());
+            final Descriptors.Descriptor unionDescriptor = getMessageTypeByName(fileDescriptor, unionBuilder.getName());
             DescriptorProtos.FieldDescriptorProto.Builder unionFieldBuilder = fetchUnionFieldBuilder(recordsBuilder,
                     unionBuilder, unionDescriptor, recordTypeName);
             if (unionFieldBuilder == null) {
-                usage = RecordMetaDataOptionsProto.RecordTypeOptions.Usage.NESTED;
+                usage = RecordTypeOptions.Usage.NESTED;
             } else {
-                usage = RecordMetaDataOptionsProto.RecordTypeOptions.Usage.RECORD;
+                usage = RecordTypeOptions.Usage.RECORD;
                 // Change the name to the "canonical" form unless that would cause a field name conflict
-                if (unionFieldBuilder.getName().equals("_" + recordTypeName)) {
-                    String newFieldName = "_" + newRecordTypeName;
+                if (isCanonicalUnionFieldName(unionFieldBuilder.getName(), recordTypeName)) {
+                    String newFieldName = canonicalUnionFieldName(newRecordTypeName);
                     if (unionBuilder.getFieldBuilderList().stream()
                             .noneMatch(otherUnionField -> otherUnionField != unionFieldBuilder
                                     && otherUnionField.getName().equals(newFieldName))) {
@@ -420,106 +485,106 @@ public class MetaDataProtoEditor {
                 }
             }
         }
-        // Do not allow renaming to the default union name unless the record type is already the union
-        if (RecordMetaDataBuilder.DEFAULT_UNION_NAME.equals(newRecordTypeName) &&
-                !RecordMetaDataOptionsProto.RecordTypeOptions.Usage.UNION.equals(usage)) {
+
+        // Do not allow renaming to the default union name unless the record type is already the union.
+        if (DEFAULT_UNION_NAME.equals(newRecordTypeName) && !RecordTypeOptions.Usage.UNION.equals(usage)) {
             throw new MetaDataException("Cannot rename record type to the default union name", LogMessageKeys.RECORD_TYPE, recordTypeName);
         }
-        // Rename the record type within the file
+
+        // Rename the record type within the file.
         renameRecordTypeUsages(recordsBuilder, recordTypeName, newRecordTypeName, fileDescriptor);
 
-        // If the record type is a top level record type, change its usage elsewhere in the meta-data
-        if (RecordMetaDataOptionsProto.RecordTypeOptions.Usage.RECORD.equals(usage)) {
+        // If the record type is a top-level record type, change its usage elsewhere in the metadata.
+        if (RecordTypeOptions.Usage.RECORD.equals(usage)) {
             renameTopLevelRecordType(metaDataBuilder, recordTypeName, newRecordTypeName);
         }
-        renameRecordTypeUsagesInUnnested(metaDataBuilder, fileDescriptor, recordTypeName, newRecordTypeName,
-                getDescriptor(fileDescriptor, recordTypeName));
 
-        // Update the file descriptor
+        // Update unnested types (even if the record type is not a top-level type).
+        renameRecordTypeUsagesInUnnested(metaDataBuilder, fileDescriptor, recordTypeName, newRecordTypeName,
+                getMessageTypeByName(fileDescriptor, recordTypeName));
+
+        // Update the file descriptor.
         metaDataBuilder.setRecords(recordsBuilder);
     }
 
-    private static Descriptors.Descriptor getDescriptor(final Descriptors.FileDescriptor fileDescriptor, String name) {
-        final Descriptors.Descriptor descriptor = fileDescriptor.findMessageTypeByName(name);
-        if (descriptor == null) {
-            throw new MetaDataException("Could not find descriptor")
-                    .addLogInfo(LogMessageKeys.NAME,  name);
-        }
-        return descriptor;
-    }
-
+    /**
+     * Renames a record type within the records file. To this end, updates references to it in the fields of every
+     * message type (recursively, including nested types). If it is the union type, also update its usage option.
+     */
     private static void renameRecordTypeUsages(@Nonnull DescriptorProtos.FileDescriptorProto.Builder recordsBuilder,
-                                               @Nonnull String oldRecordTypeName, @Nonnull String newRecordTypeName,
+                                               @Nonnull String recordTypeName, @Nonnull String newRecordTypeName,
                                                @Nonnull Descriptors.FileDescriptor fileDescriptor) {
         final String namespace = recordsBuilder.getPackage();
-        final String fullOldRecordTypeName = fullyQualifiedTypeName(namespace, oldRecordTypeName);
+        final String fullRecordTypeName = fullyQualifiedTypeName(namespace, recordTypeName);
         final String fullNewRecordTypeName = fullyQualifiedTypeName(namespace, newRecordTypeName);
 
-        // Rename the record type within the file
+        // Rename the record type within the file.
         for (DescriptorProtos.DescriptorProto.Builder messageTypeBuilder : recordsBuilder.getMessageTypeBuilderList()) {
-            final Descriptors.Descriptor descriptor = getDescriptor(fileDescriptor, messageTypeBuilder.getName());
-            // Change any fields referencing the old type so that they now reference the new type
-            renameRecordTypeUsages(namespace, messageTypeBuilder, fullOldRecordTypeName,
-                    fullNewRecordTypeName, descriptor);
-            if (messageTypeBuilder.getName().equals(oldRecordTypeName)) {
+            final Descriptors.Descriptor descriptor = getMessageTypeByName(fileDescriptor, messageTypeBuilder.getName());
+            // Change any fields referencing the old type so that they now reference the new type.
+            renameRecordTypeUsages(namespace, messageTypeBuilder, fullRecordTypeName, fullNewRecordTypeName, descriptor);
+            if (messageTypeBuilder.getName().equals(recordTypeName)) {
                 // If renaming the union type, be sure that the record.usage option is set to UNION.
-                if (isUnion(messageTypeBuilder)) {
-                    RecordMetaDataOptionsProto.RecordTypeOptions recordOptions = null;
-                    if (messageTypeBuilder.getOptions().hasExtension(RecordMetaDataOptionsProto.record)) {
-                        recordOptions = messageTypeBuilder.getOptionsBuilder().getExtension(RecordMetaDataOptionsProto.record);
-                    }
-                    if (recordOptions == null || !recordOptions.hasUsage() ||
-                            !recordOptions.getUsage().equals(RecordMetaDataOptionsProto.RecordTypeOptions.Usage.UNION)) {
-                        RecordMetaDataOptionsProto.RecordTypeOptions.Builder recordOptionsBuilder = recordOptions == null
-                                                                                                    ? RecordMetaDataOptionsProto.RecordTypeOptions.newBuilder()
-                                                                                                    : recordOptions.toBuilder();
-                        recordOptionsBuilder.setUsage(RecordMetaDataOptionsProto.RecordTypeOptions.Usage.UNION);
-                        messageTypeBuilder.getOptionsBuilder().setExtension(RecordMetaDataOptionsProto.record, recordOptionsBuilder.build());
-                    }
+                if (isUnion(messageTypeBuilder) && getMessageTypeUsage(messageTypeBuilder) != RecordTypeOptions.Usage.UNION) {
+                    setMessageTypeUsage(messageTypeBuilder, RecordTypeOptions.Usage.UNION);
                 }
                 messageTypeBuilder.setName(newRecordTypeName);
             }
         }
     }
 
+    /**
+     * Renames references to a record type among the fields of a single message type, recursing into its nested types.
+     */
     private static void renameRecordTypeUsages(@Nonnull String namespace,
                                                @Nonnull DescriptorProtos.DescriptorProto.Builder messageTypeBuilder,
-                                               @Nonnull String fullOldRecordTypeName,
+                                               @Nonnull String fullRecordTypeName,
                                                @Nonnull String fullNewRecordTypeName,
                                                final Descriptors.Descriptor descriptorForMessage) {
-        // Rename any fields within the record type to the new type name
+        // Rename any fields within the record type to the new type name.
         for (DescriptorProtos.FieldDescriptorProto.Builder field : messageTypeBuilder.getFieldBuilderList()) {
-            final FieldTypeMatch fieldTypeMatch = fieldIsType(descriptorForMessage, field, fullOldRecordTypeName);
+            final FieldTypeMatch fieldTypeMatch = fieldIsType(descriptorForMessage, field, fullRecordTypeName);
             if (FieldTypeMatch.MATCHES.equals(fieldTypeMatch)) {
                 field.setTypeName(fullNewRecordTypeName);
             } else if (FieldTypeMatch.MATCHES_AS_NESTED.equals(fieldTypeMatch)) {
                 final String fullOldFieldTypeName = "." + descriptorForMessage.findFieldByNumber(field.getNumber())
                         .getMessageType().getFullName();
-                final String newFieldTypeName = fullNewRecordTypeName + fullOldFieldTypeName.substring(fullOldRecordTypeName.length());
+                final String newFieldTypeName = fullNewRecordTypeName + fullOldFieldTypeName.substring(fullRecordTypeName.length());
                 field.setTypeName(newFieldTypeName);
             }
         }
-        // Rename the record type if used within any nested message types
+
+        // Rename the record type if used within any nested message types.
         if (messageTypeBuilder.getNestedTypeCount() > 0) {
-            final String nestedNamespace = namespace.isEmpty() ? messageTypeBuilder.getName() : (namespace + "." + messageTypeBuilder.getName());
+            final String nestedNamespace =
+                    namespace.isEmpty()
+                    ? messageTypeBuilder.getName()
+                    : (namespace + "." + messageTypeBuilder.getName());
             for (DescriptorProtos.DescriptorProto.Builder nestedTypeBuilder : messageTypeBuilder.getNestedTypeBuilderList()) {
                 final Descriptors.Descriptor nestedDescriptor = Objects.requireNonNull(
                         descriptorForMessage.findNestedTypeByName(nestedTypeBuilder.getName()),
                         "FileDescriptor does not have nested type that exists in protobuf");
-                renameRecordTypeUsages(nestedNamespace, nestedTypeBuilder,
-                        fullOldRecordTypeName, fullNewRecordTypeName, nestedDescriptor);
+                renameRecordTypeUsages(nestedNamespace, nestedTypeBuilder, fullRecordTypeName, fullNewRecordTypeName,
+                        nestedDescriptor);
             }
         }
     }
 
+    /**
+     * Updates the top-level record type list, any index definitions, and any joined record types that reference a
+     * renamed record type. Throws if the metadata has {@code UserDefinedFunctions}, since renaming is not supported
+     * in that case.
+     */
     private static void renameTopLevelRecordType(@Nonnull RecordMetaDataProto.MetaData.Builder metaDataBuilder,
-                                                 @Nonnull String recordTypeName, @Nonnull String newRecordTypeName) {
-        List<RecordMetaDataProto.RecordType> recordTypes;
+                                                 @Nonnull String recordTypeName,
+                                                 @Nonnull String newRecordTypeName) {
+        List<RecordMetaDataProto.RecordType> recordTypes =
+                new ArrayList<>(metaDataBuilder.getRecordTypesBuilderList().size());
         boolean foundRecordType = false;
-        recordTypes = new ArrayList<>(metaDataBuilder.getRecordTypesBuilderList().size());
         for (RecordMetaDataProto.RecordType recordType : metaDataBuilder.getRecordTypesList()) {
             if (recordType.getName().equals(newRecordTypeName)) {
-                // Despite the earlier check in this method, this can still be triggered if there is an imported record with the given name
+                // Note: Despite the earlier check in this method, this can still be triggered if there is an imported
+                // record with the given name.
                 throw new MetaDataException("Cannot rename record type to " + newRecordTypeName + " as an imported record type of that name already exists");
             } else if (recordType.getName().equals(recordTypeName)) {
                 recordTypes.add(recordType.toBuilder().setName(newRecordTypeName).build());
@@ -529,44 +594,64 @@ public class MetaDataProtoEditor {
             }
         }
         if (!foundRecordType) {
-            // This shouldn't happen, but if somehow the record type was in the union but not the record type list, throw an error
+            // This shouldn't happen, but if somehow the record type was in the union but not the record type list,
+            // throw an error.
             throw new MetaDataException("Missing " + recordTypeName + " in record type list");
         }
-        // Rename the record type within any indexes
+
+        // Rename the record type within any indexes.
         List<RecordMetaDataProto.Index> indexes = new ArrayList<>(metaDataBuilder.getIndexesList());
         indexes.replaceAll(index -> {
-            if (index.getRecordTypeList().contains(recordTypeName)) {
-                List<String> indexRecordTypes = new ArrayList<>(index.getRecordTypeList());
-                indexRecordTypes.replaceAll(indexRecordType -> indexRecordType.equals(recordTypeName) ? newRecordTypeName : indexRecordType);
-                return index.toBuilder().clearRecordType().addAllRecordType(indexRecordTypes).build();
-            } else {
+            if (!index.getRecordTypeList().contains(recordTypeName)) {
                 return index;
             }
+            List<String> indexRecordTypes = new ArrayList<>(index.getRecordTypeList());
+            indexRecordTypes.replaceAll(name -> name.equals(recordTypeName) ? newRecordTypeName : name);
+            return index.toBuilder().clearRecordType().addAllRecordType(indexRecordTypes).build();
         });
-        // Update the metaDataBuilder with all of the renamed things
+
+        // Update the `metaDataBuilder` with all the renamed things.
         metaDataBuilder.clearRecordTypes();
         metaDataBuilder.addAllRecordTypes(recordTypes);
         metaDataBuilder.clearIndexes();
         metaDataBuilder.addAllIndexes(indexes);
-        // unnested types have to be updated even if it's not a top-level type, so they have their own method
+        // Unnested types have to be updated even if it’s not a top-level type, so they have their own method.
         updateJoinedRecordTypes(metaDataBuilder, recordTypeName, newRecordTypeName);
+
         if (metaDataBuilder.getUserDefinedFunctionsCount() > 0) {
-            // UserDefinedFunctions may be a string that needs parsing to figure out the types it references
+            // UserDefinedFunctions may be a string that needs parsing to figure out the types it references.
             throw new MetaDataException("Renaming record types with UserDefinedFunctions is not supported");
         }
     }
 
+    /**
+     * Updates joined record types' constituents that reference a renamed record type.
+     */
+    private static void updateJoinedRecordTypes(@Nonnull RecordMetaDataProto.MetaData.Builder metaDataBuilder,
+                                                @Nonnull String recordTypeName,
+                                                @Nonnull String newRecordTypeName) {
+        for (var joined : metaDataBuilder.getJoinedRecordTypesBuilderList()) {
+            for (var constituent : joined.getJoinConstituentsBuilderList()) {
+                if (constituent.getRecordType().equals(recordTypeName)) {
+                    constituent.setRecordType(newRecordTypeName);
+                }
+            }
+        }
+    }
 
+    /**
+     * Updates unnested record types' constituents that reference a renamed record type as their (non-nested) parent.
+     */
     private static void renameRecordTypeUsagesInUnnested(@Nonnull RecordMetaDataProto.MetaData.Builder metaDataBuilder,
                                                          @Nonnull Descriptors.FileDescriptor fileDescriptor,
-                                                         @Nonnull String oldRecordTypeName,
+                                                         @Nonnull String recordTypeName,
                                                          @Nonnull String newRecordTypeName,
                                                          @Nonnull Descriptors.Descriptor oldTypeDescriptor) {
         for (var unnested : metaDataBuilder.getUnnestedRecordTypesBuilderList()) {
             for (var constituent : unnested.getNestedConstituentsBuilderList()) {
                 // The nested constituents would most likely be nested types, not record types, and thus would not be
-                // renamed
-                if (constituent.getParent().isEmpty() && constituent.getTypeName().equals(oldRecordTypeName)) {
+                // renamed.
+                if (constituent.getParent().isEmpty() && constituent.getTypeName().equals(recordTypeName)) {
                     constituent.setTypeName(newRecordTypeName);
                 } else {
                     final Descriptors.Descriptor constituentTypeDescriptor = UnnestedRecordTypeBuilder.findDescriptorByName(fileDescriptor,
@@ -586,6 +671,7 @@ public class MetaDataProtoEditor {
 
     /**
      * Whether the {@code targetDescriptor} is equal to or nested within {@code typeDescriptor}.
+     *
      * @param typeDescriptor a type
      * @param targetDescriptor a type that may or may not be nested in {@code typeDescriptor}
      * @return {@code true} if the {@code targetDescriptor} is the same as {@code typeDescriptor} or a nested type of it
@@ -601,27 +687,18 @@ public class MetaDataProtoEditor {
         }
     }
 
-    private static void updateJoinedRecordTypes(@Nonnull RecordMetaDataProto.MetaData.Builder metaDataBuilder,
-                                                @Nonnull String oldRecordTypeName,
-                                                @Nonnull String newRecordTypeName) {
-        for (var joined : metaDataBuilder.getJoinedRecordTypesBuilderList()) {
-            for (var constituent : joined.getJoinConstituentsBuilderList()) {
-                if (constituent.getRecordType().equals(oldRecordTypeName)) {
-                    constituent.setRecordType(newRecordTypeName);
-                }
-            }
-        }
-    }
-
     /**
      * Add a field to a record type.
      *
-     * @param metaDataBuilder the meta-data builder
+     * @param metaDataBuilder the metadata builder
      * @param recordType the record type to add the field to
      * @param field the field to be added
      */
-    public static void addField(@Nonnull RecordMetaDataProto.MetaData.Builder metaDataBuilder, @Nonnull String recordType, @Nonnull DescriptorProtos.FieldDescriptorProto field) {
-        DescriptorProtos.DescriptorProto.Builder messageType = findMessageTypeByName(metaDataBuilder.getRecordsBuilder(), recordType);
+    public static void addField(@Nonnull RecordMetaDataProto.MetaData.Builder metaDataBuilder,
+                                @Nonnull String recordType,
+                                @Nonnull DescriptorProtos.FieldDescriptorProto field) {
+        DescriptorProtos.DescriptorProto.Builder messageType =
+                findMessageTypeByName(metaDataBuilder.getRecordsBuilder(), recordType);
         if (messageType == null) {
             throw new MetaDataException("Record type " + recordType + " does not exist");
         }
@@ -635,18 +712,18 @@ public class MetaDataProtoEditor {
     /**
      * Deprecate a field from a record type.
      *
-     * @param metaDataBuilder the meta-data builder
+     * @param metaDataBuilder the metadata builder
      * @param recordType the record type to deprecate the field from
      * @param fieldName the name of the field to be deprecated
      */
-    public static void deprecateField(@Nonnull RecordMetaDataProto.MetaData.Builder metaDataBuilder, @Nonnull String recordType, @Nonnull String fieldName) {
-        // Find the record type
-        DescriptorProtos.DescriptorProto.Builder messageType = findMessageTypeByName(metaDataBuilder.getRecordsBuilder(), recordType);
+    public static void deprecateField(@Nonnull RecordMetaDataProto.MetaData.Builder metaDataBuilder,
+                                      @Nonnull String recordType,
+                                      @Nonnull String fieldName) {
+        DescriptorProtos.DescriptorProto.Builder messageType =
+                findMessageTypeByName(metaDataBuilder.getRecordsBuilder(), recordType);
         if (messageType == null) {
             throw new MetaDataException("Record type " + recordType + " does not exist");
         }
-
-        // Deprecate the field
         DescriptorProtos.FieldDescriptorProto.Builder fieldBuilder = findFieldByName(messageType, fieldName);
         if (fieldBuilder == null) {
             throw new MetaDataException("Field " + fieldName + " not found in record type " + recordType);
@@ -663,20 +740,23 @@ public class MetaDataProtoEditor {
     }
 
     @Nullable
-    private static DescriptorProtos.FieldDescriptorProto.Builder findFieldByName(@Nonnull DescriptorProtos.DescriptorProto.Builder messageType, @Nonnull String fieldName) {
-        return messageType.getFieldBuilderList().stream().filter(m -> m.getName().equals(fieldName)).findAny().orElse(null);
+    private static DescriptorProtos.FieldDescriptorProto.Builder findFieldByName(
+            @Nonnull DescriptorProtos.DescriptorProto.Builder messageType,
+            @Nonnull String fieldName) {
+        return messageType.getFieldBuilderList().stream()
+                .filter(m -> m.getName().equals(fieldName))
+                .findAny()
+                .orElse(null);
     }
 
     /**
      * Add a default union to the given records descriptor if missing.
      *
-     * <p>
-     * This method is a no-op if the union is present. Otherwise, the method will add a union to the records
-     * descriptor. The union descriptor will be filled in with all of the record types defined in the file except
+     * <p>This method is a no-op if the union is present. Otherwise, the method will add a union to the records
+     * descriptor. The union descriptor will be filled in with all the record types defined in the file except
      * {@code NESTED} record types.
-     * </p>
      *
-     * @param fileDescriptor the records descriptor of the record meta-data
+     * @param fileDescriptor the records descriptor of the record metadata
      * @return the resulting records descriptor
      */
     @Nonnull
@@ -688,7 +768,8 @@ public class MetaDataProtoEditor {
         DescriptorProtos.FileDescriptorProto.Builder fileBuilder = fileDescriptorProto.toBuilder();
         fileBuilder.addMessageType(createDefaultUnion(fileBuilder));
         try {
-            return Descriptors.FileDescriptor.buildFrom(fileBuilder.build(), fileDescriptor.getDependencies().toArray(new Descriptors.FileDescriptor[0]));
+            return Descriptors.FileDescriptor.buildFrom(
+                    fileBuilder.build(), fileDescriptor.getDependencies().toArray(new Descriptors.FileDescriptor[0]));
         } catch (Descriptors.DescriptorValidationException e) {
             throw new MetaDataException("Failed to add a default union", e);
         }
@@ -697,13 +778,11 @@ public class MetaDataProtoEditor {
     /**
      * Creates a default union descriptor for the given file descriptor if missing.
      *
-     * <p>
-     * If the given file descriptor is missing a union message, this method will add one before updating the meta-data.
-     * The generated union descriptor is constructed by adding any non-{@code NESTED} types in the file descriptor to the
-     * union descriptor from the currently stored meta-data. A new field is not added if a field of the given type already
-     * exists, and the order of any existing fields is preserved. Note that types are identified by name, so renaming
-     * top-level message types may result in validation errors when trying to update the record descriptor.
-     * </p>
+     * <p>If the given file descriptor is missing a union message, this method will add one before updating the metadata.
+     * The generated union descriptor is constructed by adding any non-{@code NESTED} types in the file descriptor to
+     * the union descriptor from the currently stored metadata. A new field is not added if a field of the given type
+     * already exists, and the order of any existing fields is preserved. Note that types are identified by name, so
+     * renaming top-level message types may result in validation errors when trying to update the record descriptor.
      *
      * @param fileDescriptor the file descriptor to create a union for
      * @param baseUnionDescriptor the base union descriptor
@@ -727,7 +806,7 @@ public class MetaDataProtoEditor {
             final Descriptors.Descriptor unionDescriptor = fileDescriptor.findMessageTypeByName(unionDescriptorBuilder.getName());
             for (final Descriptors.Descriptor messageType : fileDescriptor.getMessageTypes()) {
                 if (!Objects.equals(unionDescriptor, messageType)
-                        && getMessageTypeUsage(messageType.toProto()) != RecordMetaDataOptionsProto.RecordTypeOptions.Usage.NESTED) {
+                        && getMessageTypeUsage(messageType.toProto()) != RecordTypeOptions.Usage.NESTED) {
                     if (unionDescriptor.getFields().stream().noneMatch(field -> field.getMessageType() == messageType)) {
                         addFieldToUnion(unionDescriptorBuilder, fileBuilder, messageType.getName());
                     }
@@ -744,10 +823,10 @@ public class MetaDataProtoEditor {
     @Nonnull
     private static DescriptorProtos.DescriptorProto.Builder createDefaultUnion(@Nonnull DescriptorProtos.FileDescriptorProtoOrBuilder recordsDescriptor) {
         DescriptorProtos.DescriptorProto.Builder unionMessageType = DescriptorProtos.DescriptorProto.newBuilder();
-        unionMessageType.setName(RecordMetaDataBuilder.DEFAULT_UNION_NAME);
+        unionMessageType.setName(DEFAULT_UNION_NAME);
         for (DescriptorProtos.DescriptorProtoOrBuilder messageType : recordsDescriptor.getMessageTypeOrBuilderList()) {
-            RecordMetaDataOptionsProto.RecordTypeOptions.Usage messageTypeUsage = getMessageTypeUsage(messageType);
-            if (messageTypeUsage != RecordMetaDataOptionsProto.RecordTypeOptions.Usage.NESTED) {
+            RecordTypeOptions.Usage messageTypeUsage = getMessageTypeUsage(messageType);
+            if (messageTypeUsage != RecordTypeOptions.Usage.NESTED) {
                 addFieldToUnion(unionMessageType, recordsDescriptor, messageType.getName());
             }
         }
@@ -755,8 +834,9 @@ public class MetaDataProtoEditor {
     }
 
     /**
-     * Creates a default union descriptor for the given file descriptor and a base union descriptor. It adds all of the
+     * Creates a default union descriptor for the given file descriptor and a base union descriptor. It adds all the
      * non-{@code NESTED} message types that exist in the base union to the synthetic union.
+     *
      * @param fileDescriptor the file descriptor to create a union for
      * @param baseUnionDescriptor the base union descriptor
      * @return the builder for the union
@@ -766,7 +846,7 @@ public class MetaDataProtoEditor {
     public static DescriptorProtos.DescriptorProto.Builder createSyntheticUnion(@Nonnull Descriptors.FileDescriptor fileDescriptor,
                                                                                 @Nonnull Descriptors.Descriptor baseUnionDescriptor) {
         DescriptorProtos.DescriptorProto.Builder unionMessageType = DescriptorProtos.DescriptorProto.newBuilder();
-        unionMessageType.setName(RecordMetaDataBuilder.DEFAULT_UNION_NAME);
+        unionMessageType.setName(DEFAULT_UNION_NAME);
         if (!baseUnionDescriptor.getOneofs().isEmpty()) {
             throw new MetaDataException("Adding record type to oneof is not allowed");
         }
@@ -775,8 +855,8 @@ public class MetaDataProtoEditor {
             if (messageType == null) {
                 throw new MetaDataException("Record type " + field.getMessageType().getName() + " removed");
             }
-            RecordMetaDataOptionsProto.RecordTypeOptions.Usage messageTypeUsage = getMessageTypeUsage(messageType.toProto());
-            if (messageTypeUsage != RecordMetaDataOptionsProto.RecordTypeOptions.Usage.NESTED) {
+            RecordTypeOptions.Usage messageTypeUsage = getMessageTypeUsage(messageType.toProto());
+            if (messageTypeUsage != RecordTypeOptions.Usage.NESTED) {
                 unionMessageType.addField(field.toProto().toBuilder()
                         .setTypeName(fullyQualifiedTypeName(messageType.getFile().getPackage(), messageType.getName())));
             }
@@ -786,6 +866,7 @@ public class MetaDataProtoEditor {
 
     /**
      * Checks if the file descriptor has a union.
+     *
      * @param fileDescriptor the file descriptor
      * @return true if the file descriptor has a union
      */

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/MetaDataProtoEditorUnitTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/MetaDataProtoEditorUnitTest.java
@@ -25,6 +25,7 @@ import com.apple.foundationdb.record.RecordMetaDataBuilder;
 import com.apple.foundationdb.record.RecordMetaDataProto;
 import com.apple.foundationdb.record.TestRecords1Proto;
 import com.apple.foundationdb.record.TestRecordsDoubleNestedProto;
+import com.apple.foundationdb.record.TestRecordsEnumProto;
 import com.apple.foundationdb.record.metadata.MetaDataException;
 import com.apple.foundationdb.record.metadata.RecordType;
 import com.apple.foundationdb.record.provider.foundationdb.MetaDataProtoEditor.FieldTypeMatch;
@@ -112,6 +113,25 @@ public class MetaDataProtoEditorUnitTest {
                 fieldIsType(file, RecordMetaDataBuilder.DEFAULT_UNION_NAME, "_MySimpleRecord", ".com.apple.foundationdb.record.test2.MySimpleRecord"));
         assertEquals(FieldTypeMatch.DOES_NOT_MATCH,
                 fieldIsType(file, RecordMetaDataBuilder.DEFAULT_UNION_NAME, "_MySimpleRecord", "MyOtherRecord"));
+    }
+
+    /**
+     * An enum-typed field references its enum type, so it matches as nested within the message declaring that enum.
+     */
+    @Test
+    public void fieldIsTypeEnum() throws Descriptors.DescriptorValidationException {
+        final DescriptorProtos.FileDescriptorProto file = TestRecordsEnumProto.getDescriptor().toProto();
+        assertEquals(FieldTypeMatch.MATCHES_AS_NESTED,
+                fieldIsType(file, "MyShapeRecord", "size", "MyShapeRecord"));
+        assertEquals(FieldTypeMatch.MATCHES,
+                fieldIsType(file, "MyShapeRecord", "size", "MyShapeRecord.Size"));
+        assertEquals(FieldTypeMatch.MATCHES,
+                fieldIsType(file, "MyShapeRecord", "size", ".com.apple.foundationdb.record.testenum.MyShapeRecord.Size"));
+        assertEquals(FieldTypeMatch.DOES_NOT_MATCH,
+                fieldIsType(file, "MyShapeRecord", "size", "MyShapeRecord.Color"));
+        // A primitive field references no named type at all.
+        assertEquals(FieldTypeMatch.DOES_NOT_MATCH,
+                fieldIsType(file, "MyShapeRecord", "rec_name", "MyShapeRecord"));
     }
 
     @Test
@@ -522,6 +542,31 @@ public class MetaDataProtoEditorUnitTest {
                             return builder.build();
                         })
                         .collect(Collectors.toList()));
+    }
+
+    /**
+     * Renaming a record type that has enum-typed fields, whose type names have to follow the renamed enclosing type.
+     */
+    @Test
+    void withEnumFields() {
+        final RecordMetaDataProto.MetaData original = RecordMetaData.newBuilder()
+                .setRecords(TestRecordsEnumProto.getDescriptor())
+                .build().toProto();
+
+        final RecordMetaData renamed = runRename(original,
+                MetaDataProtoEditorUnitTest::simpleRename,
+                MetaDataProtoEditorUnitTest::simpleRenameUndo);
+
+        // The enum fields still resolve to their nested enum types, which are unchanged but for their enclosing type.
+        final Descriptors.Descriptor shapeRecord = getMessage(renamed, simpleRename("MyShapeRecord"));
+        for (final String fieldName : List.of("size", "color", "shape")) {
+            final Descriptors.EnumDescriptor originalEnum =
+                    TestRecordsEnumProto.MyShapeRecord.getDescriptor().findFieldByName(fieldName).getEnumType();
+            final Descriptors.EnumDescriptor renamedEnum = shapeRecord.findFieldByName(fieldName).getEnumType();
+            assertEquals(originalEnum.toProto(), renamedEnum.toProto());
+            assertEquals(simpleRename(originalEnum.getContainingType().getName()),
+                    renamedEnum.getContainingType().getName());
+        }
     }
 
     @Nonnull


### PR DESCRIPTION
These are small cleanups and pre-refactorings in preparation for an upcoming change to `renameRecordTypes()`.

* Extract various helpers to reduce the complexity in some methods.
* Extract `resolveFieldMessageTypeFullName()` out of `fieldIsType()`, for reuse by the upcoming change.
* This also fixes a latent bug: Enum field type names are now resolved and renamed along with their enclosing message, where `fieldIsType()` previously threw an `UnsupportedOperationException` for a field whose declared type is an enum.
* Simplify `getRecordTypes()` to use the non-builder record type list.
* Simplify `isUnion()` and `getMessageTypeUsage()` by relying on the invariant that a proto extension getter never returns null.
* Plus assorted reformattings, comments tweaks, static imports, and small code tweaks to reduce noise and verbosity.