### PR TITLE
Generate empty code coverage when no tests are run

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -222,6 +222,17 @@ jobs:
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
           name: other-coverage-data
+      # If this run tested no subprojects there are no jars or execution data to merge, so
+      # codeCoverageReport would be skipped and no coverage-report artifact would be produced.
+      # Build all jars and seed empty execution data so codeCoverageReport still emits a
+      # full-codebase 0% report. This must be a separate Gradle invocation from the report below:
+      # codeCoverageReport only mustRunAfter (not dependsOn) the jar tasks and evaluates which
+      # jars exist at configuration time, so the jars must already be on disk when it configures.
+      - name: Build jars and seed empty coverage data
+        if: needs.plan.outputs.run_all != 'true' && needs.plan.outputs.matrix == '[]' && needs.plan.outputs.run_other_tests != 'true'
+        uses: ./actions/run-gradle
+        with:
+          gradle_command: jar createEmptyCoverageData
       - name: Run JaCoCo Report
         uses: ./actions/run-gradle
         with:

--- a/gradle/root.gradle
+++ b/gradle/root.gradle
@@ -178,3 +178,33 @@ tasks.register('codeCoverageReport', JacocoReport) {
         html.required = true
     }
 }
+
+// Seed empty jacoco execution data files at the paths codeCoverageReport reads, so that a
+// coverage report can still be generated when no tests actually ran (e.g. a pull_request build
+// whose diff affected no coverage subproject). codeCoverageReport has a built-in onlyIf that
+// skips it unless at least one execution data file exists; an empty (zero-byte) .exec loads as
+// an empty execution-data store, which yields a full-codebase 0% report when combined with the
+// subproject jars. This task only creates files that don't already exist, so it never clobbers
+// real coverage data and is a no-op on normal test/coverage runs.
+tasks.register('createEmptyCoverageData') {
+    def coverageSubprojects = subprojects.findAll { sp ->
+        sp.name != 'examples' &&
+            sp.name != 'fdb-record-layer-core-shaded' &&
+            sp.name != 'fdb-record-layer-jmh'
+    }
+    // Resolve the destination files to plain File objects at configuration time (mirroring how
+    // codeCoverageReport builds its executionData) so the doLast action captures only a
+    // serializable List<File> and stays compatible with the configuration cache.
+    def execFiles = coverageSubprojects.collectMany { sp -> sp.tasks.withType(Test) }.collect { testTask ->
+        def dest = testTask.jacoco.destinationFile
+        (dest instanceof Provider) ? dest.get().asFile : dest as File
+    }
+    doLast {
+        execFiles.each { execFile ->
+            if (!execFile.exists()) {
+                execFile.parentFile.mkdirs()
+                execFile.createNewFile()
+            }
+        }
+    }
+}


### PR DESCRIPTION
This generates an empty code coverage when the plans says not to run any test. I validated locally that the combination of runnig
1. `./gradlew jar createEmptyCoverageData`
2. `./gradlew codeCoverageReport`

Generates a coverage report with our code, and everything having no coverage.