### PR TITLE
Add a conditional rule `decorrelateThenSimplification` to `RewritingRuleSet`

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/RewritingRuleSet.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/RewritingRuleSet.java
@@ -36,6 +36,7 @@ import com.google.common.collect.Streams;
 
 import javax.annotation.Nonnull;
 import java.util.Set;
+import java.util.stream.Stream;
 
 /**
  * A set of rules for use by a planner that supports quickly finding rules that could match a given planner expression.
@@ -43,30 +44,32 @@ import java.util.Set;
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("java:S1452")
 public class RewritingRuleSet extends CascadesRuleSet {
-    private static final ConditionalExplorationCascadesRule<SelectExpression>
-            decorrelateThenSimplification =
-            new ConditionalExplorationCascadesRule<>(new DecorrelateValuesRule(),
+    // Note: The order of the rules does not affect the search space. Decorrelation comes first because it can be an
+    // “enabler” for the other rule, and putting simplification first would increase overhead by adding unnecessary
+    // simplification attempts.
+    private static final ConditionalExplorationCascadesRule<SelectExpression> decorrelateThenSimplification =
+            new ConditionalExplorationCascadesRule<>(
+                    new DecorrelateValuesRule(),
                     new QueryPredicateSimplificationRule());
 
     private static final Set<ExplorationCascadesRule<? extends RelationalExpression>> EXPLORATION_RULES =
-            ImmutableSet.of(decorrelateThenSimplification, new RewriteOuterJoinRule());
+            ImmutableSet.of(
+                    decorrelateThenSimplification,
+                    new RewriteOuterJoinRule());
 
-    private static final Set<AbstractCascadesRule<? extends RelationalExpression>> PREORDER_RULES = ImmutableSet.of();
+    private static final Set<AbstractCascadesRule<? extends RelationalExpression>> PREORDER_RULES =
+            ImmutableSet.of();
 
     private static final ConditionalCascadesRule.ConditionalImplementationCascadesRule<SelectExpression>
             selectMergeThenPushDown =
-            new ConditionalCascadesRule.ConditionalImplementationCascadesRule<>(new SelectMergeRule(),
+            new ConditionalCascadesRule.ConditionalImplementationCascadesRule<>(
+                    new SelectMergeRule(),
                     new PredicatePushDownRule());
 
-    private static final Set<ImplementationCascadesRule<? extends RelationalExpression>> IMPLEMENTATION_RULES = ImmutableSet.of(
-            selectMergeThenPushDown,
-            new FinalizeExpressionsRule()
-    );
-
-    private static final Set<ConditionalCascadesRule<? extends RelationalExpression, ?>> CONDITIONAL_RULES =
+    private static final Set<ImplementationCascadesRule<? extends RelationalExpression>> IMPLEMENTATION_RULES =
             ImmutableSet.of(
-                    decorrelateThenSimplification,
-                    selectMergeThenPushDown);
+                    selectMergeThenPushDown,
+                    new FinalizeExpressionsRule());
 
     @Nonnull
     private static final Set<CascadesRule<? extends RelationalExpression>> ALL_EXPRESSION_RULES =
@@ -78,15 +81,30 @@ public class RewritingRuleSet extends CascadesRuleSet {
 
     @Nonnull
     public static final Set<CascadesRule<? extends RelationalExpression>> OPTIONAL_RULES =
-            Streams.concat(PREORDER_RULES.stream(), EXPLORATION_RULES.stream(), IMPLEMENTATION_RULES.stream(),
-                            CONDITIONAL_RULES.stream()
-                                    .flatMap(conditionalCascadesRule -> conditionalCascadesRule.getRules().stream()))
-                    .filter(rule -> !(rule instanceof FinalizeExpressionsRule) &&
-                            !(rule instanceof ConditionalCascadesRule))
+            Streams.<CascadesRule<? extends RelationalExpression>>concat(
+                            PREORDER_RULES.stream(),
+                            EXPLORATION_RULES.stream(),
+                            IMPLEMENTATION_RULES.stream())
+                    .flatMap(RewritingRuleSet::expandConditionalRules)
+                    .filter(rule -> !(rule instanceof FinalizeExpressionsRule))
                     .collect(ImmutableSet.toImmutableSet());
 
     @Nonnull
     public static final RewritingRuleSet DEFAULT = new RewritingRuleSet();
+
+    /**
+     * Expands a rule into the rules that can be individually enabled or disabled through the planner configuration.
+     * For a {@link ConditionalCascadesRule}, those are its inner rules, as the wrapping rule is never applied on its
+     * own; for any other rule, it is the rule itself.
+     */
+    @Nonnull
+    private static Stream<? extends CascadesRule<? extends RelationalExpression>> expandConditionalRules(
+            @Nonnull final CascadesRule<? extends RelationalExpression> rule) {
+        if (rule instanceof ConditionalCascadesRule<?, ?> conditionalRule) {
+            return conditionalRule.getRules().stream();
+        }
+        return Stream.of(rule);
+    }
 
     @VisibleForTesting
     RewritingRuleSet() {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/RewritingRuleSet.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/RewritingRuleSet.java
@@ -64,7 +64,9 @@ public class RewritingRuleSet extends CascadesRuleSet {
     );
 
     private static final Set<ConditionalCascadesRule<? extends RelationalExpression, ?>> CONDITIONAL_RULES =
-            ImmutableSet.of(decorrelateThenSimplification);
+            ImmutableSet.of(
+                    decorrelateThenSimplification,
+                    selectMergeThenPushDown);
 
     @Nonnull
     private static final Set<CascadesRule<? extends RelationalExpression>> ALL_EXPRESSION_RULES =

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/RewritingRuleSet.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/RewritingRuleSet.java
@@ -21,7 +21,9 @@
 package com.apple.foundationdb.record.query.plan.cascades;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.query.plan.cascades.ConditionalCascadesRule.ConditionalExplorationCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpression;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.SelectExpression;
 import com.apple.foundationdb.record.query.plan.cascades.rules.DecorrelateValuesRule;
 import com.apple.foundationdb.record.query.plan.cascades.rules.FinalizeExpressionsRule;
 import com.apple.foundationdb.record.query.plan.cascades.rules.PredicatePushDownRule;
@@ -30,6 +32,7 @@ import com.apple.foundationdb.record.query.plan.cascades.rules.RewriteOuterJoinR
 import com.apple.foundationdb.record.query.plan.cascades.rules.SelectMergeRule;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Streams;
 
 import javax.annotation.Nonnull;
 import java.util.Set;
@@ -40,11 +43,14 @@ import java.util.Set;
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("java:S1452")
 public class RewritingRuleSet extends CascadesRuleSet {
-    private static final Set<ExplorationCascadesRule<? extends RelationalExpression>> EXPLORATION_RULES = ImmutableSet.of(
-            new QueryPredicateSimplificationRule(),
-            new DecorrelateValuesRule(),
-            new RewriteOuterJoinRule()
-    );
+    private static final ConditionalExplorationCascadesRule<SelectExpression>
+            decorrelateThenSimplification =
+            new ConditionalExplorationCascadesRule<>(new DecorrelateValuesRule(),
+                    new QueryPredicateSimplificationRule());
+
+    private static final Set<ExplorationCascadesRule<? extends RelationalExpression>> EXPLORATION_RULES =
+            ImmutableSet.of(decorrelateThenSimplification, new RewriteOuterJoinRule());
+
     private static final Set<AbstractCascadesRule<? extends RelationalExpression>> PREORDER_RULES = ImmutableSet.of();
 
     private static final Set<ImplementationCascadesRule<? extends RelationalExpression>> IMPLEMENTATION_RULES = ImmutableSet.of(
@@ -52,6 +58,9 @@ public class RewritingRuleSet extends CascadesRuleSet {
             new PredicatePushDownRule(),
             new FinalizeExpressionsRule()
     );
+
+    private static final Set<ConditionalCascadesRule<? extends RelationalExpression, ?>> CONDITIONAL_RULES =
+            ImmutableSet.of(decorrelateThenSimplification);
 
     @Nonnull
     private static final Set<CascadesRule<? extends RelationalExpression>> ALL_EXPRESSION_RULES =
@@ -63,8 +72,11 @@ public class RewritingRuleSet extends CascadesRuleSet {
 
     @Nonnull
     public static final Set<CascadesRule<? extends RelationalExpression>> OPTIONAL_RULES =
-            ALL_EXPRESSION_RULES.stream()
-                    .filter(rule -> !(rule instanceof FinalizeExpressionsRule))
+            Streams.concat(PREORDER_RULES.stream(), EXPLORATION_RULES.stream(), IMPLEMENTATION_RULES.stream(),
+                            CONDITIONAL_RULES.stream()
+                                    .flatMap(conditionalCascadesRule -> conditionalCascadesRule.getRules().stream()))
+                    .filter(rule -> !(rule instanceof FinalizeExpressionsRule) &&
+                            !(rule instanceof ConditionalCascadesRule))
                     .collect(ImmutableSet.toImmutableSet());
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/RewritingRuleSet.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/RewritingRuleSet.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.query.plan.cascades.ConditionalCascadesRule.ConditionalExplorationCascadesRule;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpression;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.SelectExpression;
 import com.apple.foundationdb.record.query.plan.cascades.rules.DecorrelateValuesRule;
@@ -31,6 +32,7 @@ import com.apple.foundationdb.record.query.plan.cascades.rules.RewriteOuterJoinR
 import com.apple.foundationdb.record.query.plan.cascades.rules.SelectMergeRule;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Streams;
 
 import javax.annotation.Nonnull;
 import java.util.Set;
@@ -41,11 +43,14 @@ import java.util.Set;
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("java:S1452")
 public class RewritingRuleSet extends CascadesRuleSet {
-    private static final Set<ExplorationCascadesRule<? extends RelationalExpression>> EXPLORATION_RULES = ImmutableSet.of(
-            new QueryPredicateSimplificationRule(),
-            new DecorrelateValuesRule(),
-            new RewriteOuterJoinRule()
-    );
+    private static final ConditionalExplorationCascadesRule<SelectExpression>
+            decorrelateThenSimplification =
+            new ConditionalExplorationCascadesRule<>(new DecorrelateValuesRule(),
+                    new QueryPredicateSimplificationRule());
+
+    private static final Set<ExplorationCascadesRule<? extends RelationalExpression>> EXPLORATION_RULES =
+            ImmutableSet.of(decorrelateThenSimplification, new RewriteOuterJoinRule());
+
     private static final Set<AbstractCascadesRule<? extends RelationalExpression>> PREORDER_RULES = ImmutableSet.of();
 
     private static final ConditionalCascadesRule.ConditionalImplementationCascadesRule<SelectExpression>
@@ -58,6 +63,9 @@ public class RewritingRuleSet extends CascadesRuleSet {
             new FinalizeExpressionsRule()
     );
 
+    private static final Set<ConditionalCascadesRule<? extends RelationalExpression, ?>> CONDITIONAL_RULES =
+            ImmutableSet.of(decorrelateThenSimplification);
+
     @Nonnull
     private static final Set<CascadesRule<? extends RelationalExpression>> ALL_EXPRESSION_RULES =
             ImmutableSet.<CascadesRule<? extends RelationalExpression>>builder()
@@ -68,8 +76,11 @@ public class RewritingRuleSet extends CascadesRuleSet {
 
     @Nonnull
     public static final Set<CascadesRule<? extends RelationalExpression>> OPTIONAL_RULES =
-            ALL_EXPRESSION_RULES.stream()
-                    .filter(rule -> !(rule instanceof FinalizeExpressionsRule))
+            Streams.concat(PREORDER_RULES.stream(), EXPLORATION_RULES.stream(), IMPLEMENTATION_RULES.stream(),
+                            CONDITIONAL_RULES.stream()
+                                    .flatMap(conditionalCascadesRule -> conditionalCascadesRule.getRules().stream()))
+                    .filter(rule -> !(rule instanceof FinalizeExpressionsRule) &&
+                            !(rule instanceof ConditionalCascadesRule))
                     .collect(ImmutableSet.toImmutableSet());
 
     @Nonnull

--- a/yaml-tests/src/test/resources/join-with-order-by-tests.metrics.binpb
+++ b/yaml-tests/src/test/resources/join-with-order-by-tests.metrics.binpb
@@ -171,8 +171,8 @@ v
 }ö#
 }
 joins-with-order-by-tests`EXPLAIN select (x.*), (y.*) from t1_f(1) as x, t2_f(1) as y where x.a3 = y.b3 order by x.a2 descô"
-™
-™Á÷]Ø îšô'(z0ö‹8©@”ISCAN(t1$a1_a2 [EQUALS promote(@c15 AS LONG)] REVERSE) | FLATMAP q0 -> { COVERING(t2$b1_b3 [EQUALS promote(@c15 AS LONG)] -> [b1: KEY:[0], b3: KEY:[1], id: KEY:[2]]) | FILTER q0.a3 EQUALS _.b3 | FETCH AS q1 RETURN ((q0.__ROW_VERSION AS __ROW_VERSION, q0.id AS id, q0.a1 AS a1, q0.a2 AS a2, q0.a3 AS a3) AS x, (q1.__ROW_VERSION AS __ROW_VERSION, q1.id AS id, q1.b1 AS b1, q1.b2 AS b2, q1.b3 AS b3) AS y) }¼digraph G {
+•
+¤¶ÛCÖ ÍÓ€(z0¯»Ž8©@”ISCAN(t1$a1_a2 [EQUALS promote(@c15 AS LONG)] REVERSE) | FLATMAP q0 -> { COVERING(t2$b1_b3 [EQUALS promote(@c15 AS LONG)] -> [b1: KEY:[0], b3: KEY:[1], id: KEY:[2]]) | FILTER q0.a3 EQUALS _.b3 | FETCH AS q1 RETURN ((q0.__ROW_VERSION AS __ROW_VERSION, q0.id AS id, q0.a1 AS a1, q0.a2 AS a2, q0.a3 AS a3) AS x, (q1.__ROW_VERSION AS __ROW_VERSION, q1.id AS id, q1.b1 AS b1, q1.b2 AS b2, q1.b3 AS b3) AS y) }¼digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -200,8 +200,8 @@ v
 }¢&
 v
 joins-with-order-by-testsYEXPLAIN select (y.*) from t1_f(1) as x, t2_f(1) as y where x.a3 = y.b3 order by x.a2 desc§%
-Ù
-¼«‘\è ’¼(|0ðæÞ8­@ÒISCAN(t1$a1_a2 [EQUALS promote(@c9 AS LONG)] REVERSE) | FLATMAP q0 -> { COVERING(t2$b1_b3 [EQUALS promote(@c9 AS LONG)] -> [b1: KEY:[0], b3: KEY:[1], id: KEY:[2]]) | FILTER q0.a3 EQUALS _.b3 | FETCH AS q1 RETURN ((q1.__ROW_VERSION AS __ROW_VERSION, q1.id AS id, q1.b1 AS b1, q1.b2 AS b2, q1.b3 AS b3) AS y, q0.a2 AS a2) } | MAP (_.y AS y)±"digraph G {
+Õ
+´¸”Cæ œ§(|0ã¿•8­@ÒISCAN(t1$a1_a2 [EQUALS promote(@c9 AS LONG)] REVERSE) | FLATMAP q0 -> { COVERING(t2$b1_b3 [EQUALS promote(@c9 AS LONG)] -> [b1: KEY:[0], b3: KEY:[1], id: KEY:[2]]) | FILTER q0.a3 EQUALS _.b3 | FETCH AS q1 RETURN ((q1.__ROW_VERSION AS __ROW_VERSION, q1.id AS id, q1.b1 AS b1, q1.b2 AS b2, q1.b3 AS b3) AS y, q0.a2 AS a2) } | MAP (_.y AS y)±"digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -231,8 +231,8 @@ v
 }á$
 
 joins-with-order-by-testsdEXPLAIN select (x.*), (y.*) from t1_g(1) as x, t2_g(1) as y where x.a3 = y.b3 order by x.the_a2 descÚ#
-™
-´¶¹eØ £ ¬)(z0²õÛ8©@¶ISCAN(t1$a1_a2 [EQUALS promote(@c15 AS LONG)] REVERSE) | FLATMAP q0 -> { COVERING(t2$b1_b3 [EQUALS promote(@c15 AS LONG)] -> [b1: KEY:[0], b3: KEY:[1], id: KEY:[2]]) | FILTER q0.a3 EQUALS _.b3 | FETCH AS q1 RETURN ((q0.__ROW_VERSION AS __ROW_VERSION, q0.id AS id, q0.a1 AS a1, q0.a2 AS a2, q0.a3 AS a3, q0.a2 AS the_a2) AS x, (q1.__ROW_VERSION AS __ROW_VERSION, q1.id AS id, q1.b1 AS b1, q1.b2 AS b2, q1.b3 AS b3, q1.b2 AS the_b2) AS y) }€ digraph G {
+•
+ˆ€ÑEÖ •õŒ(z0üº8©@¶ISCAN(t1$a1_a2 [EQUALS promote(@c15 AS LONG)] REVERSE) | FLATMAP q0 -> { COVERING(t2$b1_b3 [EQUALS promote(@c15 AS LONG)] -> [b1: KEY:[0], b3: KEY:[1], id: KEY:[2]]) | FILTER q0.a3 EQUALS _.b3 | FETCH AS q1 RETURN ((q0.__ROW_VERSION AS __ROW_VERSION, q0.id AS id, q0.a1 AS a1, q0.a2 AS a2, q0.a3 AS a3, q0.a2 AS the_a2) AS x, (q1.__ROW_VERSION AS __ROW_VERSION, q1.id AS id, q1.b1 AS b1, q1.b2 AS b2, q1.b3 AS b3, q1.b2 AS the_b2) AS y) }€ digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -257,11 +257,11 @@ v
     rankDir=LR;
     2 -> 4 [ color="red" style="invis" ];
   }
-}õ&
+}ô&
 z
-joins-with-order-by-tests]EXPLAIN select (y.*) from t1_g(1) as x, t2_g(1) as y where x.a3 = y.b3 order by x.the_a2 descö%
-Ù
-Á‚«Uè Ž„ü (|0øÎê8­@çISCAN(t1$a1_a2 [EQUALS promote(@c9 AS LONG)] REVERSE) | FLATMAP q0 -> { COVERING(t2$b1_b3 [EQUALS promote(@c9 AS LONG)] -> [b1: KEY:[0], b3: KEY:[1], id: KEY:[2]]) | FILTER q0.a3 EQUALS _.b3 | FETCH AS q1 RETURN ((q1.__ROW_VERSION AS __ROW_VERSION, q1.id AS id, q1.b1 AS b1, q1.b2 AS b2, q1.b3 AS b3, q1.b2 AS the_b2) AS y, q0.a2 AS the_a2) } | MAP (_.y AS y)ë"digraph G {
+joins-with-order-by-tests]EXPLAIN select (y.*) from t1_g(1) as x, t2_g(1) as y where x.a3 = y.b3 order by x.the_a2 descõ%
+Õ
+ê±ç:æ ¸Ñ(|0ð‘}8­@çISCAN(t1$a1_a2 [EQUALS promote(@c9 AS LONG)] REVERSE) | FLATMAP q0 -> { COVERING(t2$b1_b3 [EQUALS promote(@c9 AS LONG)] -> [b1: KEY:[0], b3: KEY:[1], id: KEY:[2]]) | FILTER q0.a3 EQUALS _.b3 | FETCH AS q1 RETURN ((q1.__ROW_VERSION AS __ROW_VERSION, q1.id AS id, q1.b1 AS b1, q1.b2 AS b2, q1.b3 AS b3, q1.b2 AS the_b2) AS y, q0.a2 AS the_a2) } | MAP (_.y AS y)ë"digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -291,33 +291,33 @@ z
 }‹&
 ‹
 joins-with-order-by-testsnEXPLAIN select x.a2, x.a3, y.b2, y.b3 from t1_g(1) as x, t2_g(1) as y where x.a3 = y.b3 order by x.the_a2 descú$
-Ù
-ãý…[è åÈÃ'(|0©žØ8­@ÔISCAN(t1$a1_a2 [EQUALS promote(@c19 AS LONG)] REVERSE) | FLATMAP q0 -> { COVERING(t2$b1_b3 [EQUALS promote(@c19 AS LONG)] -> [b1: KEY:[0], b3: KEY:[1], id: KEY:[2]]) | FILTER q0.a3 EQUALS _.b3 | FETCH AS q1 RETURN (q0.a2 AS a2, q0.a3 AS a3, q1.b2 AS b2, q1.b3 AS b3, q0.a2 AS the_a2) } | MAP (_.a2 AS a2, _.a3 AS a3, _.b2 AS b2, _.b3 AS b3)‚"digraph G {
+Õ
+¤Ç±?æ ‡±—(|0ýÀ‘8­@ÔISCAN(t1$a1_a2 [EQUALS promote(@c19 AS LONG)] REVERSE) | FLATMAP q0 -> { COVERING(t2$b1_b3 [EQUALS promote(@c19 AS LONG)] -> [b1: KEY:[0], b3: KEY:[1], id: KEY:[2]]) | FILTER q0.a3 EQUALS _.b3 | FETCH AS q1 RETURN (q0.a2 AS a2, q0.a3 AS a3, q1.b2 AS b2, q1.b3 AS b3, q0.a2 AS the_a2) } | MAP (_.a2 AS a2, _.a3 AS a3, _.b2 AS b2, _.b3 AS b3)‚"digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
   1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q44.a2 AS a2, q44.a3 AS a3, q44.b2 AS b2, q44.b3 AS b3)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS a2, STRING AS a3, LONG AS b2, STRING AS b3)" ];
   2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Nested Loop Join</td></tr><tr><td align="left">FLATMAP (q12.a2 AS a2, q12.a3 AS a3, q33.b2 AS b2, q33.b3 AS b3, q12.a2 AS the_a2)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS a2, STRING AS a3, LONG AS b2, STRING AS b3, LONG AS the_a2)" ];
-  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">comparisons: [EQUALS promote(@c19 AS LONG)]</td></tr><tr><td align="left">direction: reversed</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS id, LONG AS a1, LONG AS a2, STRING AS a3, VERSION AS __ROW_VERSION)" ];
-  4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Fetch Records</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="12" tooltip="RELATION(LONG AS id, LONG AS b1, LONG AS b2, STRING AS b3, VERSION AS __ROW_VERSION)" ];
-  5 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">t1$a1_a2</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS id, LONG AS a1, LONG AS a2, STRING AS a3, VERSION AS __ROW_VERSION)" ];
-  6 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE q12.a3 EQUALS q215.b3</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS id, LONG AS b1, LONG AS b2, STRING AS b3, VERSION AS __ROW_VERSION)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Fetch Records</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="12" tooltip="RELATION(LONG AS id, LONG AS b1, LONG AS b2, STRING AS b3, VERSION AS __ROW_VERSION)" ];
+  4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">comparisons: [EQUALS promote(@c19 AS LONG)]</td></tr><tr><td align="left">direction: reversed</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS id, LONG AS a1, LONG AS a2, STRING AS a3, VERSION AS __ROW_VERSION)" ];
+  5 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE q12.a3 EQUALS q215.b3</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS id, LONG AS b1, LONG AS b2, STRING AS b3, VERSION AS __ROW_VERSION)" ];
+  6 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">t1$a1_a2</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS id, LONG AS a1, LONG AS a2, STRING AS a3, VERSION AS __ROW_VERSION)" ];
   7 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Covering Index Scan</td></tr><tr><td align="left">comparisons: [EQUALS promote(@c19 AS LONG)]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS id, LONG AS b1, LONG AS b2, STRING AS b3, VERSION AS __ROW_VERSION)" ];
   8 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">t2$b1_b3</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS id, LONG AS b1, LONG AS b2, STRING AS b3, VERSION AS __ROW_VERSION)" ];
-  3 -> 2 [ label=<&nbsp;q12> label="q12" color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  4 -> 2 [ label=<&nbsp;q33> label="q33" color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  5 -> 3 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  6 -> 4 [ label=<&nbsp;q217> label="q217" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  7 -> 6 [ label=<&nbsp;q215> label="q215" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  3 -> 2 [ label=<&nbsp;q33> label="q33" color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  4 -> 2 [ label=<&nbsp;q12> label="q12" color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  5 -> 3 [ label=<&nbsp;q217> label="q217" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  6 -> 4 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  7 -> 5 [ label=<&nbsp;q215> label="q215" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   8 -> 7 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q44> label="q44" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   {
-    6 -> 2 [ color="blue" style="dotted" arrowhead="none" tailport="nw" headport="s" constraint="false" ];
+    5 -> 2 [ color="blue" style="dotted" arrowhead="none" tailport="nw" headport="s" constraint="false" ];
   }
   {
     rank=same;
     rankDir=LR;
-    3 -> 4 [ color="red" style="invis" ];
+    4 -> 3 [ color="red" style="invis" ];
   }
 }”
 •
@@ -1293,7 +1293,7 @@ j
 }
 j
 joins-with-order-by-testsMEXPLAIN select (a.*), (b.*) from t1_f(1) as a, t2_f(1) as b where a.a3 = b.b3’
-²Ò®–¯ã Æðƒ?(ž0¢Úð8´@ÐISCAN(t2$b1 [EQUALS promote(@c15 AS LONG)]) | FLATMAP q0 -> { ISCAN(t1$a1 [EQUALS promote(@c15 AS LONG)]) | FILTER _.a3 EQUALS q0.b3 AS q1 RETURN ((q1.__ROW_VERSION AS __ROW_VERSION, q1.id AS id, q1.a1 AS a1, q1.a2 AS a2, q1.a3 AS a3) AS a, (q0.__ROW_VERSION AS __ROW_VERSION, q0.id AS id, q0.b1 AS b1, q0.b2 AS b2, q0.b3 AS b3) AS b) }œdigraph G {
+®áú±á …§´0(ž0‰ˆˆ8´@ÐISCAN(t2$b1 [EQUALS promote(@c15 AS LONG)]) | FLATMAP q0 -> { ISCAN(t1$a1 [EQUALS promote(@c15 AS LONG)]) | FILTER _.a3 EQUALS q0.b3 AS q1 RETURN ((q1.__ROW_VERSION AS __ROW_VERSION, q1.id AS id, q1.a1 AS a1, q1.a2 AS a2, q1.a3 AS a3) AS a, (q0.__ROW_VERSION AS __ROW_VERSION, q0.id AS id, q0.b1 AS b1, q0.b2 AS b2, q0.b3 AS b3) AS b) }œdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -1316,11 +1316,11 @@ j
     rankDir=LR;
     2 -> 4 [ color="red" style="invis" ];
   }
-}·#
+}¶#
 x
-joins-with-order-by-tests[EXPLAIN select (a.*), (b.*) from t1_f(1) as a, t2_f(1) as b where a.a3 = b.b3 order by a.a2º"
-™
-Òã¹WØ ü·Õ"(z0Ï¸Ñ8©@ŒISCAN(t1$a1_a2 [EQUALS promote(@c15 AS LONG)]) | FLATMAP q0 -> { COVERING(t2$b1_b3 [EQUALS promote(@c15 AS LONG)] -> [b1: KEY:[0], b3: KEY:[1], id: KEY:[2]]) | FILTER q0.a3 EQUALS _.b3 | FETCH AS q1 RETURN ((q0.__ROW_VERSION AS __ROW_VERSION, q0.id AS id, q0.a1 AS a1, q0.a2 AS a2, q0.a3 AS a3) AS a, (q1.__ROW_VERSION AS __ROW_VERSION, q1.id AS id, q1.b1 AS b1, q1.b2 AS b2, q1.b3 AS b3) AS b) }Šdigraph G {
+joins-with-order-by-tests[EXPLAIN select (a.*), (b.*) from t1_f(1) as a, t2_f(1) as b where a.a3 = b.b3 order by a.a2¹"
+•
+Ùäœ>Ö ýÊÐ(z0Ïò|8©@ŒISCAN(t1$a1_a2 [EQUALS promote(@c15 AS LONG)]) | FLATMAP q0 -> { COVERING(t2$b1_b3 [EQUALS promote(@c15 AS LONG)] -> [b1: KEY:[0], b3: KEY:[1], id: KEY:[2]]) | FILTER q0.a3 EQUALS _.b3 | FETCH AS q1 RETURN ((q0.__ROW_VERSION AS __ROW_VERSION, q0.id AS id, q0.a1 AS a1, q0.a2 AS a2, q0.a3 AS a3) AS a, (q1.__ROW_VERSION AS __ROW_VERSION, q1.id AS id, q1.b1 AS b1, q1.b2 AS b2, q1.b3 AS b3) AS b) }Šdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -1348,8 +1348,8 @@ x
 }“
 x
 joins-with-order-by-tests[EXPLAIN select (a.*), (b.*) from t1_f(1) as a, t2_f(1) as b where a.a3 = b.b3 order by b.b3–
-Š
-Á¨ü\Ú â¬ˆ((z0²åÍ8¦@ÓISCAN(t2$b1_b3 [EQUALS promote(@c15 AS LONG)]) | FLATMAP q0 -> { ISCAN(t1$a1 [EQUALS promote(@c15 AS LONG)]) | FILTER _.a3 EQUALS q0.b3 AS q1 RETURN ((q1.__ROW_VERSION AS __ROW_VERSION, q1.id AS id, q1.a1 AS a1, q1.a2 AS a2, q1.a3 AS a3) AS a, (q0.__ROW_VERSION AS __ROW_VERSION, q0.id AS id, q0.b1 AS b1, q0.b2 AS b2, q0.b3 AS b3) AS b) }Ÿdigraph G {
+†
+¶­Á?Ø ãð(z0î½8¦@ÓISCAN(t2$b1_b3 [EQUALS promote(@c15 AS LONG)]) | FLATMAP q0 -> { ISCAN(t1$a1 [EQUALS promote(@c15 AS LONG)]) | FILTER _.a3 EQUALS q0.b3 AS q1 RETURN ((q1.__ROW_VERSION AS __ROW_VERSION, q1.id AS id, q1.a1 AS a1, q1.a2 AS a2, q1.a3 AS a3) AS a, (q0.__ROW_VERSION AS __ROW_VERSION, q0.id AS id, q0.b1 AS b1, q0.b2 AS b2, q0.b3 AS b3) AS b) }Ÿdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;

--- a/yaml-tests/src/test/resources/join-with-order-by-tests.metrics.binpb
+++ b/yaml-tests/src/test/resources/join-with-order-by-tests.metrics.binpb
@@ -171,8 +171,8 @@ v
 }ö#
 }
 joins-with-order-by-tests`EXPLAIN select (x.*), (y.*) from t1_f(1) as x, t2_f(1) as y where x.a3 = y.b3 order by x.a2 descô"
- 
-£ûñYß œú¹$(z0òÀê8©@”ISCAN(t1$a1_a2 [EQUALS promote(@c15 AS LONG)] REVERSE) | FLATMAP q0 -> { COVERING(t2$b1_b3 [EQUALS promote(@c15 AS LONG)] -> [b1: KEY:[0], b3: KEY:[1], id: KEY:[2]]) | FILTER q0.a3 EQUALS _.b3 | FETCH AS q1 RETURN ((q0.__ROW_VERSION AS __ROW_VERSION, q0.id AS id, q0.a1 AS a1, q0.a2 AS a2, q0.a3 AS a3) AS x, (q1.__ROW_VERSION AS __ROW_VERSION, q1.id AS id, q1.b1 AS b1, q1.b2 AS b2, q1.b3 AS b3) AS y) }¼digraph G {
+œ
+©Ú‚=Ý ‡Íö(z0ÞÌ‚8©@”ISCAN(t1$a1_a2 [EQUALS promote(@c15 AS LONG)] REVERSE) | FLATMAP q0 -> { COVERING(t2$b1_b3 [EQUALS promote(@c15 AS LONG)] -> [b1: KEY:[0], b3: KEY:[1], id: KEY:[2]]) | FILTER q0.a3 EQUALS _.b3 | FETCH AS q1 RETURN ((q0.__ROW_VERSION AS __ROW_VERSION, q0.id AS id, q0.a1 AS a1, q0.a2 AS a2, q0.a3 AS a3) AS x, (q1.__ROW_VERSION AS __ROW_VERSION, q1.id AS id, q1.b1 AS b1, q1.b2 AS b2, q1.b3 AS b3) AS y) }¼digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -200,8 +200,8 @@ v
 }¢&
 v
 joins-with-order-by-testsYEXPLAIN select (y.*) from t1_f(1) as x, t2_f(1) as y where x.a3 = y.b3 order by x.a2 desc§%
-à
-ÙÎòrï Œãˆ"(|0Ê—þ8­@ÒISCAN(t1$a1_a2 [EQUALS promote(@c9 AS LONG)] REVERSE) | FLATMAP q0 -> { COVERING(t2$b1_b3 [EQUALS promote(@c9 AS LONG)] -> [b1: KEY:[0], b3: KEY:[1], id: KEY:[2]]) | FILTER q0.a3 EQUALS _.b3 | FETCH AS q1 RETURN ((q1.__ROW_VERSION AS __ROW_VERSION, q1.id AS id, q1.b1 AS b1, q1.b2 AS b2, q1.b3 AS b3) AS y, q0.a2 AS a2) } | MAP (_.y AS y)±"digraph G {
+Ü
+²ù±<í ˆ´Ï(|0üæ…8­@ÒISCAN(t1$a1_a2 [EQUALS promote(@c9 AS LONG)] REVERSE) | FLATMAP q0 -> { COVERING(t2$b1_b3 [EQUALS promote(@c9 AS LONG)] -> [b1: KEY:[0], b3: KEY:[1], id: KEY:[2]]) | FILTER q0.a3 EQUALS _.b3 | FETCH AS q1 RETURN ((q1.__ROW_VERSION AS __ROW_VERSION, q1.id AS id, q1.b1 AS b1, q1.b2 AS b2, q1.b3 AS b3) AS y, q0.a2 AS a2) } | MAP (_.y AS y)±"digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -231,8 +231,8 @@ v
 }á$
 
 joins-with-order-by-testsdEXPLAIN select (x.*), (y.*) from t1_g(1) as x, t2_g(1) as y where x.a3 = y.b3 order by x.the_a2 descÚ#
- 
-ûÚÉoß ¥ä§3(z0œä…8©@¶ISCAN(t1$a1_a2 [EQUALS promote(@c15 AS LONG)] REVERSE) | FLATMAP q0 -> { COVERING(t2$b1_b3 [EQUALS promote(@c15 AS LONG)] -> [b1: KEY:[0], b3: KEY:[1], id: KEY:[2]]) | FILTER q0.a3 EQUALS _.b3 | FETCH AS q1 RETURN ((q0.__ROW_VERSION AS __ROW_VERSION, q0.id AS id, q0.a1 AS a1, q0.a2 AS a2, q0.a3 AS a3, q0.a2 AS the_a2) AS x, (q1.__ROW_VERSION AS __ROW_VERSION, q1.id AS id, q1.b1 AS b1, q1.b2 AS b2, q1.b3 AS b3, q1.b2 AS the_b2) AS y) }€ digraph G {
+œ
+Ñ©ø>Ý ·íù(z0¿×‚8©@¶ISCAN(t1$a1_a2 [EQUALS promote(@c15 AS LONG)] REVERSE) | FLATMAP q0 -> { COVERING(t2$b1_b3 [EQUALS promote(@c15 AS LONG)] -> [b1: KEY:[0], b3: KEY:[1], id: KEY:[2]]) | FILTER q0.a3 EQUALS _.b3 | FETCH AS q1 RETURN ((q0.__ROW_VERSION AS __ROW_VERSION, q0.id AS id, q0.a1 AS a1, q0.a2 AS a2, q0.a3 AS a3, q0.a2 AS the_a2) AS x, (q1.__ROW_VERSION AS __ROW_VERSION, q1.id AS id, q1.b1 AS b1, q1.b2 AS b2, q1.b3 AS b3, q1.b2 AS the_b2) AS y) }€ digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -260,39 +260,39 @@ v
 }õ&
 z
 joins-with-order-by-tests]EXPLAIN select (y.*) from t1_g(1) as x, t2_g(1) as y where x.a3 = y.b3 order by x.the_a2 descö%
-à
-Ý¹ÙSï Æ¿Ý#(|0Þ­Ü8­@çISCAN(t1$a1_a2 [EQUALS promote(@c9 AS LONG)] REVERSE) | FLATMAP q0 -> { COVERING(t2$b1_b3 [EQUALS promote(@c9 AS LONG)] -> [b1: KEY:[0], b3: KEY:[1], id: KEY:[2]]) | FILTER q0.a3 EQUALS _.b3 | FETCH AS q1 RETURN ((q1.__ROW_VERSION AS __ROW_VERSION, q1.id AS id, q1.b1 AS b1, q1.b2 AS b2, q1.b3 AS b3, q1.b2 AS the_b2) AS y, q0.a2 AS the_a2) } | MAP (_.y AS y)ë"digraph G {
+Ü
+Ÿ¼š@í õéÙ(|0ÑÌˆ8­@çISCAN(t1$a1_a2 [EQUALS promote(@c9 AS LONG)] REVERSE) | FLATMAP q0 -> { COVERING(t2$b1_b3 [EQUALS promote(@c9 AS LONG)] -> [b1: KEY:[0], b3: KEY:[1], id: KEY:[2]]) | FILTER q0.a3 EQUALS _.b3 | FETCH AS q1 RETURN ((q1.__ROW_VERSION AS __ROW_VERSION, q1.id AS id, q1.b1 AS b1, q1.b2 AS b2, q1.b3 AS b3, q1.b2 AS the_b2) AS y, q0.a2 AS the_a2) } | MAP (_.y AS y)ë"digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
   1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q44.y AS y)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(VERSION AS __ROW_VERSION, LONG AS id, LONG AS b1, LONG AS b2, STRING AS b3, LONG AS the_b2 AS y)" ];
   2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Nested Loop Join</td></tr><tr><td align="left">FLATMAP ((q33.__ROW_VERSION AS __ROW_VERSION, q33.id AS id, q33.b1 AS b1, q33.b2 AS b2, q33.b3 AS b3, q33.b2 AS the_b2) AS y, q12.a2 AS the_a2)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(VERSION AS __ROW_VERSION, LONG AS id, LONG AS b1, LONG AS b2, STRING AS b3, LONG AS the_b2 AS y, LONG AS the_a2)" ];
-  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Fetch Records</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="12" tooltip="RELATION(LONG AS id, LONG AS b1, LONG AS b2, STRING AS b3, VERSION AS __ROW_VERSION)" ];
-  4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">comparisons: [EQUALS promote(@c9 AS LONG)]</td></tr><tr><td align="left">direction: reversed</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS id, LONG AS a1, LONG AS a2, STRING AS a3, VERSION AS __ROW_VERSION)" ];
-  5 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE q12.a3 EQUALS q215.b3</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS id, LONG AS b1, LONG AS b2, STRING AS b3, VERSION AS __ROW_VERSION)" ];
-  6 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">t1$a1_a2</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS id, LONG AS a1, LONG AS a2, STRING AS a3, VERSION AS __ROW_VERSION)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">comparisons: [EQUALS promote(@c9 AS LONG)]</td></tr><tr><td align="left">direction: reversed</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS id, LONG AS a1, LONG AS a2, STRING AS a3, VERSION AS __ROW_VERSION)" ];
+  4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Fetch Records</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="12" tooltip="RELATION(LONG AS id, LONG AS b1, LONG AS b2, STRING AS b3, VERSION AS __ROW_VERSION)" ];
+  5 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">t1$a1_a2</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS id, LONG AS a1, LONG AS a2, STRING AS a3, VERSION AS __ROW_VERSION)" ];
+  6 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE q12.a3 EQUALS q215.b3</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS id, LONG AS b1, LONG AS b2, STRING AS b3, VERSION AS __ROW_VERSION)" ];
   7 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Covering Index Scan</td></tr><tr><td align="left">comparisons: [EQUALS promote(@c9 AS LONG)]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS id, LONG AS b1, LONG AS b2, STRING AS b3, VERSION AS __ROW_VERSION)" ];
   8 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">t2$b1_b3</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS id, LONG AS b1, LONG AS b2, STRING AS b3, VERSION AS __ROW_VERSION)" ];
-  3 -> 2 [ label=<&nbsp;q33> label="q33" color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  4 -> 2 [ label=<&nbsp;q12> label="q12" color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  5 -> 3 [ label=<&nbsp;q217> label="q217" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  6 -> 4 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  7 -> 5 [ label=<&nbsp;q215> label="q215" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  3 -> 2 [ label=<&nbsp;q12> label="q12" color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  4 -> 2 [ label=<&nbsp;q33> label="q33" color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  5 -> 3 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  6 -> 4 [ label=<&nbsp;q217> label="q217" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  7 -> 6 [ label=<&nbsp;q215> label="q215" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   8 -> 7 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q44> label="q44" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   {
-    5 -> 2 [ color="blue" style="dotted" arrowhead="none" tailport="nw" headport="s" constraint="false" ];
+    6 -> 2 [ color="blue" style="dotted" arrowhead="none" tailport="nw" headport="s" constraint="false" ];
   }
   {
     rank=same;
     rankDir=LR;
-    4 -> 3 [ color="red" style="invis" ];
+    3 -> 4 [ color="red" style="invis" ];
   }
 }‹&
 ‹
 joins-with-order-by-testsnEXPLAIN select x.a2, x.a3, y.b2, y.b3 from t1_g(1) as x, t2_g(1) as y where x.a3 = y.b3 order by x.the_a2 descú$
-à
-—ËHï «”ï(|0Ç§›8­@ÔISCAN(t1$a1_a2 [EQUALS promote(@c19 AS LONG)] REVERSE) | FLATMAP q0 -> { COVERING(t2$b1_b3 [EQUALS promote(@c19 AS LONG)] -> [b1: KEY:[0], b3: KEY:[1], id: KEY:[2]]) | FILTER q0.a3 EQUALS _.b3 | FETCH AS q1 RETURN (q0.a2 AS a2, q0.a3 AS a3, q1.b2 AS b2, q1.b3 AS b3, q0.a2 AS the_a2) } | MAP (_.a2 AS a2, _.a3 AS a3, _.b2 AS b2, _.b3 AS b3)‚"digraph G {
+Ü
+–¹©:í ž´–(|0™ú„8­@ÔISCAN(t1$a1_a2 [EQUALS promote(@c19 AS LONG)] REVERSE) | FLATMAP q0 -> { COVERING(t2$b1_b3 [EQUALS promote(@c19 AS LONG)] -> [b1: KEY:[0], b3: KEY:[1], id: KEY:[2]]) | FILTER q0.a3 EQUALS _.b3 | FETCH AS q1 RETURN (q0.a2 AS a2, q0.a3 AS a3, q1.b2 AS b2, q1.b3 AS b3, q0.a2 AS the_a2) } | MAP (_.a2 AS a2, _.a3 AS a3, _.b2 AS b2, _.b3 AS b3)‚"digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -1291,10 +1291,10 @@ j
     rankDir=LR;
     5 -> 6 [ color="red" style="invis" ];
   }
-}
+}€
 j
-joins-with-order-by-testsMEXPLAIN select (a.*), (b.*) from t1_f(1) as a, t2_f(1) as b where a.a3 = b.b3’
-¹ ·ØÑê á¯™N(ž0ªà8´@ÐISCAN(t2$b1 [EQUALS promote(@c15 AS LONG)]) | FLATMAP q0 -> { ISCAN(t1$a1 [EQUALS promote(@c15 AS LONG)]) | FILTER _.a3 EQUALS q0.b3 AS q1 RETURN ((q1.__ROW_VERSION AS __ROW_VERSION, q1.id AS id, q1.a1 AS a1, q1.a2 AS a2, q1.a3 AS a3) AS a, (q0.__ROW_VERSION AS __ROW_VERSION, q0.id AS id, q0.b1 AS b1, q0.b2 AS b2, q0.b3 AS b3) AS b) }œdigraph G {
+joins-with-order-by-testsMEXPLAIN select (a.*), (b.*) from t1_f(1) as a, t2_f(1) as b where a.a3 = b.b3‘
+µÎ¸Ëgè öç‰&(ž0óÑ8´@ÐISCAN(t2$b1 [EQUALS promote(@c15 AS LONG)]) | FLATMAP q0 -> { ISCAN(t1$a1 [EQUALS promote(@c15 AS LONG)]) | FILTER _.a3 EQUALS q0.b3 AS q1 RETURN ((q1.__ROW_VERSION AS __ROW_VERSION, q1.id AS id, q1.a1 AS a1, q1.a2 AS a2, q1.a3 AS a3) AS a, (q0.__ROW_VERSION AS __ROW_VERSION, q0.id AS id, q0.b1 AS b1, q0.b2 AS b2, q0.b3 AS b3) AS b) }œdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -1320,8 +1320,8 @@ j
 }·#
 x
 joins-with-order-by-tests[EXPLAIN select (a.*), (b.*) from t1_f(1) as a, t2_f(1) as b where a.a3 = b.b3 order by a.a2º"
- 
-ˆà½Wß È¶×"(z0€ç8©@ŒISCAN(t1$a1_a2 [EQUALS promote(@c15 AS LONG)]) | FLATMAP q0 -> { COVERING(t2$b1_b3 [EQUALS promote(@c15 AS LONG)] -> [b1: KEY:[0], b3: KEY:[1], id: KEY:[2]]) | FILTER q0.a3 EQUALS _.b3 | FETCH AS q1 RETURN ((q0.__ROW_VERSION AS __ROW_VERSION, q0.id AS id, q0.a1 AS a1, q0.a2 AS a2, q0.a3 AS a3) AS a, (q1.__ROW_VERSION AS __ROW_VERSION, q1.id AS id, q1.b1 AS b1, q1.b2 AS b2, q1.b3 AS b3) AS b) }Šdigraph G {
+œ
+ª´åBÝ ‰î¼(z0ÞÇ‰8©@ŒISCAN(t1$a1_a2 [EQUALS promote(@c15 AS LONG)]) | FLATMAP q0 -> { COVERING(t2$b1_b3 [EQUALS promote(@c15 AS LONG)] -> [b1: KEY:[0], b3: KEY:[1], id: KEY:[2]]) | FILTER q0.a3 EQUALS _.b3 | FETCH AS q1 RETURN ((q0.__ROW_VERSION AS __ROW_VERSION, q0.id AS id, q0.a1 AS a1, q0.a2 AS a2, q0.a3 AS a3) AS a, (q1.__ROW_VERSION AS __ROW_VERSION, q1.id AS id, q1.b1 AS b1, q1.b2 AS b2, q1.b3 AS b3) AS b) }Šdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -1346,11 +1346,11 @@ x
     rankDir=LR;
     2 -> 4 [ color="red" style="invis" ];
   }
-}“
+}’
 x
-joins-with-order-by-tests[EXPLAIN select (a.*), (b.*) from t1_f(1) as a, t2_f(1) as b where a.a3 = b.b3 order by b.b3–
-‘
-þ²³ á »Èô(z0¼¦¡8¦@ÓISCAN(t2$b1_b3 [EQUALS promote(@c15 AS LONG)]) | FLATMAP q0 -> { ISCAN(t1$a1 [EQUALS promote(@c15 AS LONG)]) | FILTER _.a3 EQUALS q0.b3 AS q1 RETURN ((q1.__ROW_VERSION AS __ROW_VERSION, q1.id AS id, q1.a1 AS a1, q1.a2 AS a2, q1.a3 AS a3) AS a, (q0.__ROW_VERSION AS __ROW_VERSION, q0.id AS id, q0.b1 AS b1, q0.b2 AS b2, q0.b3 AS b3) AS b) }Ÿdigraph G {
+joins-with-order-by-tests[EXPLAIN select (a.*), (b.*) from t1_f(1) as a, t2_f(1) as b where a.a3 = b.b3 order by b.b3•
+
+ËÄ¹?ß Å½(z0Þ„{8¦@ÓISCAN(t2$b1_b3 [EQUALS promote(@c15 AS LONG)]) | FLATMAP q0 -> { ISCAN(t1$a1 [EQUALS promote(@c15 AS LONG)]) | FILTER _.a3 EQUALS q0.b3 AS q1 RETURN ((q1.__ROW_VERSION AS __ROW_VERSION, q1.id AS id, q1.a1 AS a1, q1.a2 AS a2, q1.a3 AS a3) AS a, (q0.__ROW_VERSION AS __ROW_VERSION, q0.id AS id, q0.b1 AS b1, q0.b2 AS b2, q0.b3 AS b3) AS b) }Ÿdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;

--- a/yaml-tests/src/test/resources/join-with-order-by-tests.metrics.yaml
+++ b/yaml-tests/src/test/resources/join-with-order-by-tests.metrics.yaml
@@ -102,12 +102,12 @@ joins-with-order-by-tests:
         AS __ROW_VERSION, q0.id AS id, q0.a1 AS a1, q0.a2 AS a2, q0.a3 AS a3) AS x,
         (q1.__ROW_VERSION AS __ROW_VERSION, q1.id AS id, q1.b1 AS b1, q1.b2 AS b2,
         q1.b3 AS b3) AS y) }'
-    task_count: 1312
-    task_total_time_ms: 188
-    transform_count: 351
-    transform_time_ms: 76
+    task_count: 1308
+    task_total_time_ms: 127
+    transform_count: 349
+    transform_time_ms: 50
     transform_yield_count: 122
-    insert_time_ms: 3
+    insert_time_ms: 2
     insert_new_count: 169
     insert_reused_count: 8
 -   query: EXPLAIN select (y.*) from t1_f(1) as x, t2_f(1) as y where x.a3 = y.b3
@@ -118,12 +118,12 @@ joins-with-order-by-tests:
         id: KEY:[2]]) | FILTER q0.a3 EQUALS _.b3 | FETCH AS q1 RETURN ((q1.__ROW_VERSION
         AS __ROW_VERSION, q1.id AS id, q1.b1 AS b1, q1.b2 AS b2, q1.b3 AS b3) AS y,
         q0.a2 AS a2) } | MAP (_.y AS y)'
-    task_count: 1376
-    task_total_time_ms: 240
-    transform_count: 367
-    transform_time_ms: 71
+    task_count: 1372
+    task_total_time_ms: 126
+    transform_count: 365
+    transform_time_ms: 43
     transform_yield_count: 124
-    insert_time_ms: 12
+    insert_time_ms: 2
     insert_new_count: 173
     insert_reused_count: 8
 -   query: EXPLAIN select (x.*), (y.*) from t1_g(1) as x, t2_g(1) as y where x.a3
@@ -135,12 +135,12 @@ joins-with-order-by-tests:
         AS __ROW_VERSION, q0.id AS id, q0.a1 AS a1, q0.a2 AS a2, q0.a3 AS a3, q0.a2
         AS the_a2) AS x, (q1.__ROW_VERSION AS __ROW_VERSION, q1.id AS id, q1.b1 AS
         b1, q1.b2 AS b2, q1.b3 AS b3, q1.b2 AS the_b2) AS y) }'
-    task_count: 1312
-    task_total_time_ms: 233
-    transform_count: 351
-    transform_time_ms: 107
+    task_count: 1308
+    task_total_time_ms: 131
+    transform_count: 349
+    transform_time_ms: 56
     transform_yield_count: 122
-    insert_time_ms: 4
+    insert_time_ms: 2
     insert_new_count: 169
     insert_reused_count: 8
 -   query: EXPLAIN select (y.*) from t1_g(1) as x, t2_g(1) as y where x.a3 = y.b3
@@ -151,12 +151,12 @@ joins-with-order-by-tests:
         id: KEY:[2]]) | FILTER q0.a3 EQUALS _.b3 | FETCH AS q1 RETURN ((q1.__ROW_VERSION
         AS __ROW_VERSION, q1.id AS id, q1.b1 AS b1, q1.b2 AS b2, q1.b3 AS b3, q1.b2
         AS the_b2) AS y, q0.a2 AS the_a2) } | MAP (_.y AS y)'
-    task_count: 1376
-    task_total_time_ms: 175
-    transform_count: 367
-    transform_time_ms: 74
+    task_count: 1372
+    task_total_time_ms: 134
+    transform_count: 365
+    transform_time_ms: 51
     transform_yield_count: 124
-    insert_time_ms: 3
+    insert_time_ms: 2
     insert_new_count: 173
     insert_reused_count: 8
 -   query: EXPLAIN select x.a2, x.a3, y.b2, y.b3 from t1_g(1) as x, t2_g(1) as y where
@@ -167,10 +167,10 @@ joins-with-order-by-tests:
         KEY:[1], id: KEY:[2]]) | FILTER q0.a3 EQUALS _.b3 | FETCH AS q1 RETURN (q0.a2
         AS a2, q0.a3 AS a3, q1.b2 AS b2, q1.b3 AS b3, q0.a2 AS the_a2) } | MAP (_.a2
         AS a2, _.a3 AS a3, _.b2 AS b2, _.b3 AS b3)'
-    task_count: 1376
-    task_total_time_ms: 151
-    transform_count: 367
-    transform_time_ms: 52
+    task_count: 1372
+    task_total_time_ms: 122
+    transform_count: 365
+    transform_time_ms: 48
     transform_yield_count: 124
     insert_time_ms: 2
     insert_new_count: 173
@@ -655,12 +655,12 @@ joins-with-order-by-tests:
         AS __ROW_VERSION, q1.id AS id, q1.a1 AS a1, q1.a2 AS a2, q1.a3 AS a3) AS a,
         (q0.__ROW_VERSION AS __ROW_VERSION, q0.id AS id, q0.b1 AS b1, q0.b2 AS b2,
         q0.b3 AS b3) AS b) }
-    task_count: 2105
-    task_total_time_ms: 439
-    transform_count: 490
-    transform_time_ms: 163
+    task_count: 2101
+    task_total_time_ms: 217
+    transform_count: 488
+    transform_time_ms: 79
     transform_yield_count: 158
-    insert_time_ms: 24
+    insert_time_ms: 3
     insert_new_count: 308
     insert_reused_count: 13
 -   query: EXPLAIN select (a.*), (b.*) from t1_f(1) as a, t2_f(1) as b where a.a3
@@ -672,12 +672,12 @@ joins-with-order-by-tests:
         q0.id AS id, q0.a1 AS a1, q0.a2 AS a2, q0.a3 AS a3) AS a, (q1.__ROW_VERSION
         AS __ROW_VERSION, q1.id AS id, q1.b1 AS b1, q1.b2 AS b2, q1.b3 AS b3) AS b)
         }'
-    task_count: 1312
-    task_total_time_ms: 183
-    transform_count: 351
-    transform_time_ms: 72
+    task_count: 1308
+    task_total_time_ms: 140
+    transform_count: 349
+    transform_time_ms: 59
     transform_yield_count: 122
-    insert_time_ms: 10
+    insert_time_ms: 2
     insert_new_count: 169
     insert_reused_count: 8
 -   query: EXPLAIN select (a.*), (b.*) from t1_f(1) as a, t2_f(1) as b where a.a3
@@ -688,10 +688,10 @@ joins-with-order-by-tests:
         AS __ROW_VERSION, q1.id AS id, q1.a1 AS a1, q1.a2 AS a2, q1.a3 AS a3) AS a,
         (q0.__ROW_VERSION AS __ROW_VERSION, q0.id AS id, q0.b1 AS b1, q0.b2 AS b2,
         q0.b3 AS b3) AS b) }
-    task_count: 1297
-    task_total_time_ms: 67
-    transform_count: 353
-    transform_time_ms: 29
+    task_count: 1293
+    task_total_time_ms: 133
+    transform_count: 351
+    transform_time_ms: 53
     transform_yield_count: 122
     insert_time_ms: 2
     insert_new_count: 166

--- a/yaml-tests/src/test/resources/join-with-order-by-tests.metrics.yaml
+++ b/yaml-tests/src/test/resources/join-with-order-by-tests.metrics.yaml
@@ -102,12 +102,12 @@ joins-with-order-by-tests:
         AS __ROW_VERSION, q0.id AS id, q0.a1 AS a1, q0.a2 AS a2, q0.a3 AS a3) AS x,
         (q1.__ROW_VERSION AS __ROW_VERSION, q1.id AS id, q1.b1 AS b1, q1.b2 AS b2,
         q1.b3 AS b3) AS y) }'
-    task_count: 1305
-    task_total_time_ms: 196
-    transform_count: 344
-    transform_time_ms: 83
+    task_count: 1301
+    task_total_time_ms: 142
+    transform_count: 342
+    transform_time_ms: 58
     transform_yield_count: 122
-    insert_time_ms: 4
+    insert_time_ms: 2
     insert_new_count: 169
     insert_reused_count: 8
 -   query: EXPLAIN select (y.*) from t1_f(1) as x, t2_f(1) as y where x.a3 = y.b3
@@ -118,12 +118,12 @@ joins-with-order-by-tests:
         id: KEY:[2]]) | FILTER q0.a3 EQUALS _.b3 | FETCH AS q1 RETURN ((q1.__ROW_VERSION
         AS __ROW_VERSION, q1.id AS id, q1.b1 AS b1, q1.b2 AS b2, q1.b3 AS b3) AS y,
         q0.a2 AS a2) } | MAP (_.y AS y)'
-    task_count: 1369
-    task_total_time_ms: 193
-    transform_count: 360
-    transform_time_ms: 65
+    task_count: 1365
+    task_total_time_ms: 140
+    transform_count: 358
+    transform_time_ms: 50
     transform_yield_count: 124
-    insert_time_ms: 3
+    insert_time_ms: 2
     insert_new_count: 173
     insert_reused_count: 8
 -   query: EXPLAIN select (x.*), (y.*) from t1_g(1) as x, t2_g(1) as y where x.a3
@@ -135,12 +135,12 @@ joins-with-order-by-tests:
         AS __ROW_VERSION, q0.id AS id, q0.a1 AS a1, q0.a2 AS a2, q0.a3 AS a3, q0.a2
         AS the_a2) AS x, (q1.__ROW_VERSION AS __ROW_VERSION, q1.id AS id, q1.b1 AS
         b1, q1.b2 AS b2, q1.b3 AS b3, q1.b2 AS the_b2) AS y) }'
-    task_count: 1305
-    task_total_time_ms: 212
-    transform_count: 344
-    transform_time_ms: 86
+    task_count: 1301
+    task_total_time_ms: 146
+    transform_count: 342
+    transform_time_ms: 63
     transform_yield_count: 122
-    insert_time_ms: 3
+    insert_time_ms: 2
     insert_new_count: 169
     insert_reused_count: 8
 -   query: EXPLAIN select (y.*) from t1_g(1) as x, t2_g(1) as y where x.a3 = y.b3
@@ -151,12 +151,12 @@ joins-with-order-by-tests:
         id: KEY:[2]]) | FILTER q0.a3 EQUALS _.b3 | FETCH AS q1 RETURN ((q1.__ROW_VERSION
         AS __ROW_VERSION, q1.id AS id, q1.b1 AS b1, q1.b2 AS b2, q1.b3 AS b3, q1.b2
         AS the_b2) AS y, q0.a2 AS the_a2) } | MAP (_.y AS y)'
-    task_count: 1369
-    task_total_time_ms: 178
-    transform_count: 360
-    transform_time_ms: 69
+    task_count: 1365
+    task_total_time_ms: 123
+    transform_count: 358
+    transform_time_ms: 47
     transform_yield_count: 124
-    insert_time_ms: 3
+    insert_time_ms: 2
     insert_new_count: 173
     insert_reused_count: 8
 -   query: EXPLAIN select x.a2, x.a3, y.b2, y.b3 from t1_g(1) as x, t2_g(1) as y where
@@ -167,12 +167,12 @@ joins-with-order-by-tests:
         KEY:[1], id: KEY:[2]]) | FILTER q0.a3 EQUALS _.b3 | FETCH AS q1 RETURN (q0.a2
         AS a2, q0.a3 AS a3, q1.b2 AS b2, q1.b3 AS b3, q0.a2 AS the_a2) } | MAP (_.a2
         AS a2, _.a3 AS a3, _.b2 AS b2, _.b3 AS b3)'
-    task_count: 1369
-    task_total_time_ms: 190
-    transform_count: 360
-    transform_time_ms: 82
+    task_count: 1365
+    task_total_time_ms: 132
+    transform_count: 358
+    transform_time_ms: 50
     transform_yield_count: 124
-    insert_time_ms: 3
+    insert_time_ms: 2
     insert_new_count: 173
     insert_reused_count: 8
 -   query: EXPLAIN select (t1.*), (t2.*) from t1, t2 where t1.a1 = 1 and t2.b1 = 1
@@ -655,12 +655,12 @@ joins-with-order-by-tests:
         AS __ROW_VERSION, q1.id AS id, q1.a1 AS a1, q1.a2 AS a2, q1.a3 AS a3) AS a,
         (q0.__ROW_VERSION AS __ROW_VERSION, q0.id AS id, q0.b1 AS b1, q0.b2 AS b2,
         q0.b3 AS b3) AS b) }
-    task_count: 2098
-    task_total_time_ms: 367
-    transform_count: 483
-    transform_time_ms: 132
+    task_count: 2094
+    task_total_time_ms: 271
+    transform_count: 481
+    transform_time_ms: 101
     transform_yield_count: 158
-    insert_time_ms: 6
+    insert_time_ms: 4
     insert_new_count: 308
     insert_reused_count: 13
 -   query: EXPLAIN select (a.*), (b.*) from t1_f(1) as a, t2_f(1) as b where a.a3
@@ -672,12 +672,12 @@ joins-with-order-by-tests:
         q0.id AS id, q0.a1 AS a1, q0.a2 AS a2, q0.a3 AS a3) AS a, (q1.__ROW_VERSION
         AS __ROW_VERSION, q1.id AS id, q1.b1 AS b1, q1.b2 AS b2, q1.b3 AS b3) AS b)
         }'
-    task_count: 1305
-    task_total_time_ms: 183
-    transform_count: 344
-    transform_time_ms: 72
+    task_count: 1301
+    task_total_time_ms: 130
+    transform_count: 342
+    transform_time_ms: 51
     transform_yield_count: 122
-    insert_time_ms: 3
+    insert_time_ms: 2
     insert_new_count: 169
     insert_reused_count: 8
 -   query: EXPLAIN select (a.*), (b.*) from t1_f(1) as a, t2_f(1) as b where a.a3
@@ -688,11 +688,11 @@ joins-with-order-by-tests:
         AS __ROW_VERSION, q1.id AS id, q1.a1 AS a1, q1.a2 AS a2, q1.a3 AS a3) AS a,
         (q0.__ROW_VERSION AS __ROW_VERSION, q0.id AS id, q0.b1 AS b1, q0.b2 AS b2,
         q0.b3 AS b3) AS b) }
-    task_count: 1290
-    task_total_time_ms: 194
-    transform_count: 346
-    transform_time_ms: 84
+    task_count: 1286
+    task_total_time_ms: 133
+    transform_count: 344
+    transform_time_ms: 52
     transform_yield_count: 122
-    insert_time_ms: 3
+    insert_time_ms: 2
     insert_new_count: 166
     insert_reused_count: 5

--- a/yaml-tests/src/test/resources/null-extraction-tests.metrics.binpb
+++ b/yaml-tests/src/test/resources/null-extraction-tests.metrics.binpb
@@ -8,10 +8,10 @@ Y
   1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">comparisons: [EQUALS promote(@c8 AS LONG), EQUALS @c12]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS B1, STRING AS B2, LONG AS B3)" ];
   2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">I1</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS B1, STRING AS B2, LONG AS B3)" ];
   2 -> 1 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}‹
+}Š
 e
-agg-index-tests-countLEXPLAIN select * from B where b3 = 4 and b2 = 'b' and (? is null or b1 < 20)¡
-Žù–¨F¤ ƒÔ… (^0øÞÆ8Ë@ºCOVERING(I1 [EQUALS promote(@c7 AS LONG), EQUALS promote(@c11 AS STRING)] -> [B1: KEY:[3], B2: KEY:[1], B3: KEY:[0]]) | FILTER @c14 IS_NULL OR _.B1 LESS_THAN promote(@c20 AS INT) | FETCHÃdigraph G {
+agg-index-tests-countLEXPLAIN select * from B where b3 = 4 and b2 = 'b' and (? is null or b1 < 20) 
+’ÃÈ÷	¦ þØÏ(^0¬–98Ë@ºCOVERING(I1 [EQUALS promote(@c7 AS LONG), EQUALS promote(@c11 AS STRING)] -> [B1: KEY:[3], B2: KEY:[1], B3: KEY:[0]]) | FILTER @c14 IS_NULL OR _.B1 LESS_THAN promote(@c20 AS INT) | FETCHÃdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;

--- a/yaml-tests/src/test/resources/null-extraction-tests.metrics.binpb
+++ b/yaml-tests/src/test/resources/null-extraction-tests.metrics.binpb
@@ -8,10 +8,10 @@ Y
   1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">comparisons: [EQUALS promote(@c8 AS LONG), EQUALS @c12]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(INT AS B1, STRING AS B2, LONG AS B3)" ];
   2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">I1</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(INT AS B1, STRING AS B2, LONG AS B3)" ];
   2 -> 1 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}Š
+}‹
 e
-agg-index-tests-countLEXPLAIN select * from B where b3 = 4 and b2 = 'b' and (? is null or b1 < 20) 
-’ÃÈ÷	¦ þØÏ(^0¬–98Ë@ºCOVERING(I1 [EQUALS promote(@c7 AS LONG), EQUALS promote(@c11 AS STRING)] -> [B1: KEY:[3], B2: KEY:[1], B3: KEY:[0]]) | FILTER @c14 IS_NULL OR _.B1 LESS_THAN promote(@c20 AS INT) | FETCHÃdigraph G {
+agg-index-tests-countLEXPLAIN select * from B where b3 = 4 and b2 = 'b' and (? is null or b1 < 20)¡
+ŽŽÈÚ*¤ º®¨(^0ˆÔ®8Ë@ºCOVERING(I1 [EQUALS promote(@c7 AS LONG), EQUALS promote(@c11 AS STRING)] -> [B1: KEY:[3], B2: KEY:[1], B3: KEY:[0]]) | FILTER @c14 IS_NULL OR _.B1 LESS_THAN promote(@c20 AS INT) | FETCHÃdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;

--- a/yaml-tests/src/test/resources/null-extraction-tests.metrics.yaml
+++ b/yaml-tests/src/test/resources/null-extraction-tests.metrics.yaml
@@ -18,11 +18,11 @@ agg-index-tests-count:
     explain: 'COVERING(I1 [EQUALS promote(@c7 AS LONG), EQUALS promote(@c11 AS STRING)]
         -> [B1: KEY:[3], B2: KEY:[1], B3: KEY:[0]]) | FILTER @c14 IS_NULL OR _.B1
         LESS_THAN promote(@c20 AS INT) | FETCH'
-    task_count: 1682
-    task_total_time_ms: 20
-    transform_count: 294
-    transform_time_ms: 5
+    task_count: 1678
+    task_total_time_ms: 89
+    transform_count: 292
+    transform_time_ms: 32
     transform_yield_count: 94
-    insert_time_ms: 0
+    insert_time_ms: 7
     insert_new_count: 203
     insert_reused_count: 19

--- a/yaml-tests/src/test/resources/null-extraction-tests.metrics.yaml
+++ b/yaml-tests/src/test/resources/null-extraction-tests.metrics.yaml
@@ -18,11 +18,11 @@ agg-index-tests-count:
     explain: 'COVERING(I1 [EQUALS promote(@c7 AS LONG), EQUALS promote(@c11 AS STRING)]
         -> [B1: KEY:[3], B2: KEY:[1], B3: KEY:[0]]) | FILTER @c14 IS_NULL OR _.B1
         LESS_THAN promote(@c20 AS INT) | FETCH'
-    task_count: 1678
-    task_total_time_ms: 147
-    transform_count: 292
-    transform_time_ms: 67
+    task_count: 1682
+    task_total_time_ms: 20
+    transform_count: 294
+    transform_time_ms: 5
     transform_yield_count: 94
-    insert_time_ms: 7
+    insert_time_ms: 0
     insert_new_count: 203
     insert_reused_count: 19

--- a/yaml-tests/src/test/resources/sql-functions.metrics.binpb
+++ b/yaml-tests/src/test/resources/sql-functions.metrics.binpb
@@ -1,8 +1,7 @@
 ç
 R
 basic-sql-function-tests6EXPLAIN select col1, col2 from f1(a => 103, b => 'b');∂
-Ñ	ëÕÿ'Ü ËØ‰
-(`0å’˘8é@	ôCOVERING(T1_IDX1 [EQUALS @c13, [LESS_THAN promote(@c9 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)˘
+Ç	òıÃ'Ö …⁄Ú(`0¸‡î8é@	ôCOVERING(T1_IDX1 [EQUALS @c13, [LESS_THAN promote(@c9 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)˘
 digraph G {
   fontname=courier;
   rankdir=BT;
@@ -15,7 +14,7 @@ digraph G {
 }ç
 R
 basic-sql-function-tests6EXPLAIN select col1, col2 from f1(b => 'b', a => 103);∂
-Ñ	˙‚ÿIÜ Ìœ·(`0££¿8é@	ôCOVERING(T1_IDX1 [EQUALS @c9, [LESS_THAN promote(@c13 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)˘
+Ç	µÙŸ*Ö ã£¬	(`0©®ï8é@	ôCOVERING(T1_IDX1 [EQUALS @c9, [LESS_THAN promote(@c13 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)˘
 digraph G {
   fontname=courier;
   rankdir=BT;
@@ -28,7 +27,8 @@ digraph G {
 }Å
 H
 basic-sql-function-tests,EXPLAIN select col1, col2 from f1(103, 'b');¥
-Ñ	∏Ó˜,Ü ˜ªô(`0óıí8é@	òCOVERING(T1_IDX1 [EQUALS @c9, [LESS_THAN promote(@c7 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)¯
+Ç	¡˛±+Ö ‘õî
+(`0ß‹†8é@	òCOVERING(T1_IDX1 [EQUALS @c9, [LESS_THAN promote(@c7 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)¯
 digraph G {
   fontname=courier;
   rankdir=BT;
@@ -38,11 +38,10 @@ digraph G {
   3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">T1_IDX1</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS COL1, STRING AS COL2, INT AS COL3)" ];
   3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q178> label="q178" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}À
+} 
 M
-basic-sql-function-tests1EXPLAIN select col1 + 10, col2 from f1(103, 'b');˘
-Ïˇ¶(ı ë˙Ô
-(V0¡ùº8z@iISCAN(T1_IDX1 [EQUALS @c11, [LESS_THAN promote(@c9 AS LONG)]]) | MAP (_.COL1 + @c3 AS _0, _.COL2 AS COL2)Ó
+basic-sql-function-tests1EXPLAIN select col1 + 10, col2 from f1(103, 'b');¯
+Íƒ†#Ù Áƒ›	(V0ÿˆg8z@iISCAN(T1_IDX1 [EQUALS @c11, [LESS_THAN promote(@c9 AS LONG)]]) | MAP (_.COL1 + @c3 AS _0, _.COL2 AS COL2)Ó
 digraph G {
   fontname=courier;
   rankdir=BT;
@@ -55,7 +54,7 @@ digraph G {
 }¯
 ?
 basic-sql-function-tests#EXPLAIN select * from f1(103, 'b');¥
-Ñ	ø–Í%Ü ó‰–	(`0ÙÚπ8é@	òCOVERING(T1_IDX1 [EQUALS @c7, [LESS_THAN promote(@c5 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)¯
+Ç	Üì¯*Ö ’∏ø	(`0¿ô§8é@	òCOVERING(T1_IDX1 [EQUALS @c7, [LESS_THAN promote(@c5 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)¯
 digraph G {
   fontname=courier;
   rankdir=BT;
@@ -68,7 +67,8 @@ digraph G {
 }π
 O
 basic-sql-function-tests3EXPLAIN select * from f1(103, 'b') where col1 = 101Â
-À	¸”√]ï é⁄ú(c0Çåª8ô@√COVERING(T1_IDX4 [EQUALS promote(@c12 AS LONG), EQUALS @c7] -> [COL1: KEY:[0], COL2: KEY:[1], COL3: KEY:[2]]) | FILTER _.COL1 LESS_THAN promote(@c5 AS LONG) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)˛digraph G {
+…	≈´∂3î Û¿˝
+(c0á÷∏8ô@√COVERING(T1_IDX4 [EQUALS promote(@c12 AS LONG), EQUALS @c7] -> [COL1: KEY:[0], COL2: KEY:[1], COL3: KEY:[2]]) | FILTER _.COL1 LESS_THAN promote(@c5 AS LONG) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)˛digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -82,7 +82,8 @@ O
 }π
 O
 basic-sql-function-tests3EXPLAIN select * from f1(103, 'c') where col1 = 104Â
-À	¸”√]ï é⁄ú(c0Çåª8ô@√COVERING(T1_IDX4 [EQUALS promote(@c12 AS LONG), EQUALS @c7] -> [COL1: KEY:[0], COL2: KEY:[1], COL3: KEY:[2]]) | FILTER _.COL1 LESS_THAN promote(@c5 AS LONG) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)˛digraph G {
+…	≈´∂3î Û¿˝
+(c0á÷∏8ô@√COVERING(T1_IDX4 [EQUALS promote(@c12 AS LONG), EQUALS @c7] -> [COL1: KEY:[0], COL2: KEY:[1], COL3: KEY:[2]]) | FILTER _.COL1 LESS_THAN promote(@c5 AS LONG) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)˛digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -96,7 +97,7 @@ O
 }á
 B
 basic-sql-function-tests&EXPLAIN select * from f1(103 + 1, 'b')¿
-Ñ	å¬û'Ü ÂÈô(`0âÔ∏8é@	ûCOVERING(T1_IDX1 [EQUALS @c9, [LESS_THAN promote(@c5 + @c7 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)˛
+Ç	˘†¨,Ö •ø…	(`0Ëˇï8é@	ûCOVERING(T1_IDX1 [EQUALS @c9, [LESS_THAN promote(@c5 + @c7 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)˛
 digraph G {
   fontname=courier;
   rankdir=BT;
@@ -109,7 +110,7 @@ digraph G {
 }ˇ
 h
 basic-sql-function-testsLEXPLAIN select * from (select * from f1(103 + 1, 'b')) as x where col1 < 105í
-±	û„˚2ë ™‡í(c0Î„â8ï@
+Ø	Äêß)ê ¯–ñ	(c0∞öù8ï@
 √COVERING(T1_IDX1 [EQUALS @c13, [LESS_THAN promote(@c21 AS LONG) && LESS_THAN promote(@c9 + @c11 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)´digraph G {
   fontname=courier;
   rankdir=BT;
@@ -119,10 +120,10 @@ h
   3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">T1_IDX1</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS COL1, STRING AS COL2, INT AS COL3)" ];
   3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q182> label="q182" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}·
+}‡
 ó
-basic-sql-function-tests{EXPLAIN select A.col1 AS W, A.col2 AS X, B.col1 AS Y, B.col2 AS Z from f1(103, 'b') A, f1(103, 'b') B where A.col1 = B.col1ƒ
-ã∂˘ºÇÚ è›Ûi(‡0∆Üó8ü@≤ISCAN(T1_IDX1 [EQUALS @c29, [LESS_THAN promote(@c27 AS LONG)]]) | FLATMAP q0 -> { COVERING(T1_IDX1 [EQUALS @c29, EQUALS q0.COL1] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | FILTER _.COL1 LESS_THAN promote(@c27 AS LONG) | FETCH AS q1 RETURN (q1.COL1 AS W, q1.COL2 AS X, q0.COL1 AS Y, q0.COL2 AS Z) }Ïdigraph G {
+basic-sql-function-tests{EXPLAIN select A.col1 AS W, A.col2 AS X, B.col1 AS Y, B.col2 AS Z from f1(103, 'b') A, f1(103, 'b') B where A.col1 = B.col1√
+á„˙à{ ƒ’Å+(‡0¨•Ÿ8ü@≤ISCAN(T1_IDX1 [EQUALS @c29, [LESS_THAN promote(@c27 AS LONG)]]) | FLATMAP q0 -> { COVERING(T1_IDX1 [EQUALS @c29, EQUALS q0.COL1] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | FILTER _.COL1 LESS_THAN promote(@c27 AS LONG) | FETCH AS q1 RETURN (q1.COL1 AS W, q1.COL2 AS X, q0.COL1 AS Y, q0.COL2 AS Z) }Ïdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -147,10 +148,10 @@ h
     rankDir=LR;
     2 -> 4 [ color="red" style="invis" ];
   }
-}ˆ
+}ı
 ¨
-basic-sql-function-testsèEXPLAIN select A.col1 AS W, A.col2 AS X, B.col1 AS Y, B.col2 AS Z from f1(a => 103, b => 'b') A, f1(a => 103, b => 'b') B where A.col1 = B.col1ƒ
-ã‚ïÎ†Ú ˝Ω—1(‡0Øﬁ·8ü@≤ISCAN(T1_IDX1 [EQUALS @c33, [LESS_THAN promote(@c29 AS LONG)]]) | FLATMAP q0 -> { COVERING(T1_IDX1 [EQUALS @c33, EQUALS q0.COL1] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | FILTER _.COL1 LESS_THAN promote(@c29 AS LONG) | FETCH AS q1 RETURN (q1.COL1 AS W, q1.COL2 AS X, q0.COL1 AS Y, q0.COL2 AS Z) }Ïdigraph G {
+basic-sql-function-testsèEXPLAIN select A.col1 AS W, A.col2 AS X, B.col1 AS Y, B.col2 AS Z from f1(a => 103, b => 'b') A, f1(a => 103, b => 'b') B where A.col1 = B.col1√
+á«∑≠ ﬁ≈Ù+(‡0¨å“8ü@≤ISCAN(T1_IDX1 [EQUALS @c33, [LESS_THAN promote(@c29 AS LONG)]]) | FLATMAP q0 -> { COVERING(T1_IDX1 [EQUALS @c33, EQUALS q0.COL1] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | FILTER _.COL1 LESS_THAN promote(@c29 AS LONG) | FETCH AS q1 RETURN (q1.COL1 AS W, q1.COL2 AS X, q0.COL1 AS Y, q0.COL2 AS Z) }Ïdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -178,7 +179,8 @@ h
 }ï
 j
 basic-sql-function-testsNEXPLAIN with x(y, z) as (select * from f1(b => 'b', a => 103)) select * from x¶
-û	—á∫Rå ©Ï°(b0–µ∑8í@	îCOVERING(T1_IDX1 [EQUALS @c16, [LESS_THAN promote(@c20 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS Y, _.COL2 AS Z)Ó
+ú	∂ƒˆ)ã —Âè
+(b0óÌõ8í@	îCOVERING(T1_IDX1 [EQUALS @c16, [LESS_THAN promote(@c20 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS Y, _.COL2 AS Z)Ó
 digraph G {
   fontname=courier;
   rankdir=BT;
@@ -191,7 +193,7 @@ digraph G {
 }ã
 `
 basic-sql-function-testsDEXPLAIN with x(y, z) as (select * from f1(103, 'b')) select * from x¶
-û	êŸ◊/å îâû(b0ÇˆÅ8í@	îCOVERING(T1_IDX1 [EQUALS @c16, [LESS_THAN promote(@c14 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS Y, _.COL2 AS Z)Ó
+ú	€Ûò-ã ¥¸≈	(b0ˆ‚û8í@	îCOVERING(T1_IDX1 [EQUALS @c16, [LESS_THAN promote(@c14 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS Y, _.COL2 AS Z)Ó
 digraph G {
   fontname=courier;
   rankdir=BT;
@@ -201,10 +203,10 @@ digraph G {
   3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">T1_IDX1</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS COL1, STRING AS COL2, INT AS COL3)" ];
   3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q183> label="q183" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}Û!
+}Ú!
 Z
-basic-sql-function-tests>EXPLAIN select * from t2 where exists (select * from f2(t2.z))î!
-ó’„®6ë µŸü(r0È§8ê@ôISCAN(T2_IDX1 <,>) | FLATMAP q0 -> { ISCAN(T1_IDX1 <,>) | FILTER promote(_.COL3 AS LONG) EQUALS q0.Z | DEFAULT NULL | FILTER _ NOT_NULL AS q1 RETURN q0 }◊digraph G {
+basic-sql-function-tests>EXPLAIN select * from t2 where exists (select * from f2(t2.z))ì!
+ï∑°%ê íÑ®(r0•á[8ê@ôISCAN(T2_IDX1 <,>) | FLATMAP q0 -> { ISCAN(T1_IDX1 <,>) | FILTER promote(_.COL3 AS LONG) EQUALS q0.Z | DEFAULT NULL | FILTER _ NOT_NULL AS q1 RETURN q0 }◊digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -234,10 +236,10 @@ Z
     rankDir=LR;
     2 -> 4 [ color="red" style="invis" ];
   }
-}¯!
+}˜!
 _
-basic-sql-function-testsCEXPLAIN select * from t2 where exists (select * from f2(k => t2.z))î!
-óú¨èJë íòä"(r0çÈ∂8ê@ôISCAN(T2_IDX1 <,>) | FLATMAP q0 -> { ISCAN(T1_IDX1 <,>) | FILTER promote(_.COL3 AS LONG) EQUALS q0.Z | DEFAULT NULL | FILTER _ NOT_NULL AS q1 RETURN q0 }◊digraph G {
+basic-sql-function-testsCEXPLAIN select * from t2 where exists (select * from f2(k => t2.z))ì!
+ïÇ◊œ$ê ˇ„‚(r0ê–a8ê@ôISCAN(T2_IDX1 <,>) | FLATMAP q0 -> { ISCAN(T1_IDX1 <,>) | FILTER promote(_.COL3 AS LONG) EQUALS q0.Z | DEFAULT NULL | FILTER _ NOT_NULL AS q1 RETURN q0 }◊digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -270,7 +272,7 @@ _
 }‡
 A
 basic-sql-function-tests%EXPLAIN select * from f3(103, 'b', 4)ö
-Ù’îíø∂ ‘ïå9(⁄0ô™Æ8≈@‚ISCAN(T1_IDX1 <,>) | FILTER promote(_.COL3 AS LONG) EQUALS promote(@c9 AS LONG) | FLATMAP q0 -> { ISCAN(T1_IDX1 [EQUALS @c7, [LESS_THAN promote(@c5 AS LONG)]]) AS q1 RETURN (q1.COL1 AS COL1, q1.COL2 AS COL2, q0.COL3 AS COL3) }ídigraph G {
+‚–ó âØ „Ú«'(⁄0£êé8≈@‚ISCAN(T1_IDX1 <,>) | FILTER promote(_.COL3 AS LONG) EQUALS promote(@c9 AS LONG) | FLATMAP q0 -> { ISCAN(T1_IDX1 [EQUALS @c7, [LESS_THAN promote(@c5 AS LONG)]]) AS q1 RETURN (q1.COL1 AS COL1, q1.COL2 AS COL2, q0.COL3 AS COL3) }ídigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -296,7 +298,7 @@ A
 }ë
 D
 basic-sql-function-tests(EXPLAIN select * from f4(103, 'b', 2, 2)»
-»#‘˚ΩÓÛ ˚”Ì>(É0¡˜º8ﬁ@g˘ISCAN(T1_IDX1 <,>) | FILTER promote(_.COL3 AS LONG) EQUALS promote(@c9 AS LONG) + promote(@c9 AS LONG) | FLATMAP q0 -> { ISCAN(T1_IDX1 [EQUALS @c7, [LESS_THAN promote(@c5 AS LONG)]]) AS q1 RETURN (q1.COL1 AS COL1, q1.COL2 AS COL2, q0.COL3 AS COL3) }©digraph G {
+ã#…ÓÒæﬁ éÂ¡((É0⁄…8ﬁ@g˘ISCAN(T1_IDX1 <,>) | FILTER promote(_.COL3 AS LONG) EQUALS promote(@c9 AS LONG) + promote(@c9 AS LONG) | FLATMAP q0 -> { ISCAN(T1_IDX1 [EQUALS @c7, [LESS_THAN promote(@c5 AS LONG)]]) AS q1 RETURN (q1.COL1 AS COL1, q1.COL2 AS COL2, q0.COL3 AS COL3) }©digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -322,7 +324,8 @@ D
 }´
 X
 basic-sql-function-tests<EXPLAIN select * from f4(a => 103, b => 'b', c => 2, d => 2)Œ
-»#˚Ïˆ«Û £‰©X(É0æ‡≠8ﬁ@g¸ISCAN(T1_IDX1 <,>) | FILTER promote(_.COL3 AS LONG) EQUALS promote(@c15 AS LONG) + promote(@c15 AS LONG) | FLATMAP q0 -> { ISCAN(T1_IDX1 [EQUALS @c11, [LESS_THAN promote(@c7 AS LONG)]]) AS q1 RETURN (q1.COL1 AS COL1, q1.COL2 AS COL2, q0.COL3 AS COL3) }¨digraph G {
+ã#≈Æ·àﬁ Û‹…9(É0ìÓ§
+8ﬁ@g¸ISCAN(T1_IDX1 <,>) | FILTER promote(_.COL3 AS LONG) EQUALS promote(@c15 AS LONG) + promote(@c15 AS LONG) | FLATMAP q0 -> { ISCAN(T1_IDX1 [EQUALS @c11, [LESS_THAN promote(@c7 AS LONG)]]) AS q1 RETURN (q1.COL1 AS COL1, q1.COL2 AS COL2, q0.COL3 AS COL3) }¨digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -348,7 +351,7 @@ X
 }û
 7
 basic-sql-function-testsEXPLAIN select * from f5();‚
-î	©ﬁ—Yã ˛ŸÜ(b0‡Œ®8í@	´COVERING(T1_IDX1 [EQUALS promote('b' AS STRING), [LESS_THAN promote(103 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)ìdigraph G {
+í	Ù Æ*ä Ÿø»	(b0´±ë8í@	´COVERING(T1_IDX1 [EQUALS promote('b' AS STRING), [LESS_THAN promote(103 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)ìdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -360,7 +363,7 @@ X
 }°
 :
 basic-sql-function-testsEXPLAIN select * from f5(103);‚
-î	∂â 1ã æü∆(b0†£∆8í@	´COVERING(T1_IDX1 [EQUALS promote('b' AS STRING), [LESS_THAN promote(@c5 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)ìdigraph G {
+í	îÿª*ä º€Å	(b0»«û8í@	´COVERING(T1_IDX1 [EQUALS promote('b' AS STRING), [LESS_THAN promote(@c5 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)ìdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -372,7 +375,7 @@ X
 }¯
 ?
 basic-sql-function-tests#EXPLAIN select * from f5(b => 'b');¥
-Ñ	â†À#Ü ÿﬂÊ(`0æÃ8é@	òCOVERING(T1_IDX1 [EQUALS @c7, [LESS_THAN promote(103 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)¯
+Ç	˘®…*Ö â†…	(`0Œˇô8é@	òCOVERING(T1_IDX1 [EQUALS @c7, [LESS_THAN promote(103 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)¯
 digraph G {
   fontname=courier;
   rankdir=BT;
@@ -385,7 +388,7 @@ digraph G {
 }Ñ
 I
 basic-sql-function-tests-EXPLAIN select * from f5(b => 'b', a => 103);∂
-Ñ	ÛÒ•ZÜ ŒË¬(`0◊√⁄8é@	ôCOVERING(T1_IDX1 [EQUALS @c7, [LESS_THAN promote(@c11 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)˘
+Ç	ˆÕ‚'Ö ”òﬁ(`0≠¬î8é@	ôCOVERING(T1_IDX1 [EQUALS @c7, [LESS_THAN promote(@c11 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)˘
 digraph G {
   fontname=courier;
   rankdir=BT;
@@ -398,7 +401,7 @@ digraph G {
 }Ñ
 I
 basic-sql-function-tests-EXPLAIN select * from f5(b => 'b', a => 102);∂
-Ñ	ÛÒ•ZÜ ŒË¬(`0◊√⁄8é@	ôCOVERING(T1_IDX1 [EQUALS @c7, [LESS_THAN promote(@c11 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)˘
+Ç	ˆÕ‚'Ö ”òﬁ(`0≠¬î8é@	ôCOVERING(T1_IDX1 [EQUALS @c7, [LESS_THAN promote(@c11 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)˘
 digraph G {
   fontname=courier;
   rankdir=BT;
@@ -411,7 +414,7 @@ digraph G {
 }Ñ
 I
 basic-sql-function-tests-EXPLAIN select * from f5(b => 'a', a => 102);∂
-Ñ	ÛÒ•ZÜ ŒË¬(`0◊√⁄8é@	ôCOVERING(T1_IDX1 [EQUALS @c7, [LESS_THAN promote(@c11 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)˘
+Ç	ˆÕ‚'Ö ”òﬁ(`0≠¬î8é@	ôCOVERING(T1_IDX1 [EQUALS @c7, [LESS_THAN promote(@c11 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)˘
 digraph G {
   fontname=courier;
   rankdir=BT;
@@ -424,7 +427,8 @@ digraph G {
 }Ñ
 I
 basic-sql-function-tests-EXPLAIN select * from f5(a => 102, b => 'a');∂
-Ñ	…Ôë)Ü ‰îˇ	(`0µ≠8é@	ôCOVERING(T1_IDX1 [EQUALS @c11, [LESS_THAN promote(@c7 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)˘
+Ç	°√Ô,Ö ç–ß
+(`0Õòö8é@	ôCOVERING(T1_IDX1 [EQUALS @c11, [LESS_THAN promote(@c7 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)˘
 digraph G {
   fontname=courier;
   rankdir=BT;
@@ -437,7 +441,7 @@ digraph G {
 }°
 :
 basic-sql-function-testsEXPLAIN select * from f5(102);‚
-î	∂â 1ã æü∆(b0†£∆8í@	´COVERING(T1_IDX1 [EQUALS promote('b' AS STRING), [LESS_THAN promote(@c5 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)ìdigraph G {
+í	îÿª*ä º€Å	(b0»«û8í@	´COVERING(T1_IDX1 [EQUALS promote('b' AS STRING), [LESS_THAN promote(@c5 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)ìdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -449,7 +453,7 @@ digraph G {
 }¯
 ?
 basic-sql-function-tests#EXPLAIN select * from f5(102, 'a');¥
-Ñ	æ≈¿Ü À∑˝(`0◊òû8é@	òCOVERING(T1_IDX1 [EQUALS @c7, [LESS_THAN promote(@c5 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)¯
+Ç	≤õÕ*Ö ìπ«	(`0¢üî8é@	òCOVERING(T1_IDX1 [EQUALS @c7, [LESS_THAN promote(@c5 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)¯
 digraph G {
   fontname=courier;
   rankdir=BT;

--- a/yaml-tests/src/test/resources/sql-functions.metrics.binpb
+++ b/yaml-tests/src/test/resources/sql-functions.metrics.binpb
@@ -1,7 +1,7 @@
 ç
 R
 basic-sql-function-tests6EXPLAIN select col1, col2 from f1(a => 103, b => 'b');∂
-Ä	 øﬁ>Ç Å‹„(`0∑áÄ8é@	ôCOVERING(T1_IDX1 [EQUALS @c13, [LESS_THAN promote(@c9 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)˘
+˛ª‹∫.Å ‚∞ˇ	(`0˛–û8é@	ôCOVERING(T1_IDX1 [EQUALS @c13, [LESS_THAN promote(@c9 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)˘
 digraph G {
   fontname=courier;
   rankdir=BT;
@@ -14,7 +14,8 @@ digraph G {
 }ç
 R
 basic-sql-function-tests6EXPLAIN select col1, col2 from f1(b => 'b', a => 103);∂
-Ä	‚±Ñ9Ç ôÀº(`0˚ØÔ8é@	ôCOVERING(T1_IDX1 [EQUALS @c9, [LESS_THAN promote(@c13 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)˘
+˛—Ω—/Å —à‘
+(`0¸Î£8é@	ôCOVERING(T1_IDX1 [EQUALS @c9, [LESS_THAN promote(@c13 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)˘
 digraph G {
   fontname=courier;
   rankdir=BT;
@@ -27,7 +28,7 @@ digraph G {
 }Å
 H
 basic-sql-function-tests,EXPLAIN select col1, col2 from f1(103, 'b');¥
-Ä	çÂƒ3Ç ·Èˇ(`0Ÿ°Œ8é@	òCOVERING(T1_IDX1 [EQUALS @c9, [LESS_THAN promote(@c7 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)¯
+˛⁄»¸/Å °∆Ä(`0√ª£8é@	òCOVERING(T1_IDX1 [EQUALS @c9, [LESS_THAN promote(@c7 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)¯
 digraph G {
   fontname=courier;
   rankdir=BT;
@@ -37,10 +38,10 @@ digraph G {
   3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">T1_IDX1</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS COL1, STRING AS COL2, INT AS COL3)" ];
   3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q178> label="q178" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}À
+} 
 M
-basic-sql-function-tests1EXPLAIN select col1 + 10, col2 from f1(103, 'b');˘
-Ë˛Ëé9Ò ¯Õ¿(V0≠ˆ®8z@iISCAN(T1_IDX1 [EQUALS @c11, [LESS_THAN promote(@c9 AS LONG)]]) | MAP (_.COL1 + @c3 AS _0, _.COL2 AS COL2)Ó
+basic-sql-function-tests1EXPLAIN select col1 + 10, col2 from f1(103, 'b');¯
+Ê©Ã±& ü∂µ	(V0Óßr8z@iISCAN(T1_IDX1 [EQUALS @c11, [LESS_THAN promote(@c9 AS LONG)]]) | MAP (_.COL1 + @c3 AS _0, _.COL2 AS COL2)Ó
 digraph G {
   fontname=courier;
   rankdir=BT;
@@ -53,7 +54,8 @@ digraph G {
 }¯
 ?
 basic-sql-function-tests#EXPLAIN select * from f1(103, 'b');¥
-Ä	Ï∑¿.Ç ¶Øï(`0ª‡∆8é@	òCOVERING(T1_IDX1 [EQUALS @c7, [LESS_THAN promote(@c5 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)¯
+˛¶∏-Å €Ωâ
+(`0¶˛ù8é@	òCOVERING(T1_IDX1 [EQUALS @c7, [LESS_THAN promote(@c5 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)¯
 digraph G {
   fontname=courier;
   rankdir=BT;
@@ -66,7 +68,7 @@ digraph G {
 }π
 O
 basic-sql-function-tests3EXPLAIN select * from f1(103, 'b') where col1 = 101Â
-¥	êàıGç ¢¡Î(b0§„˙8ñ@
+≤	ﬂ¯å4å ã˘ú(b0ÿå«8ñ@
 √COVERING(T1_IDX4 [EQUALS promote(@c12 AS LONG), EQUALS @c7] -> [COL1: KEY:[0], COL2: KEY:[1], COL3: KEY:[2]]) | FILTER _.COL1 LESS_THAN promote(@c5 AS LONG) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)˛digraph G {
   fontname=courier;
   rankdir=BT;
@@ -81,7 +83,7 @@ O
 }π
 O
 basic-sql-function-tests3EXPLAIN select * from f1(103, 'c') where col1 = 104Â
-¥	êàıGç ¢¡Î(b0§„˙8ñ@
+≤	ﬂ¯å4å ã˘ú(b0ÿå«8ñ@
 √COVERING(T1_IDX4 [EQUALS promote(@c12 AS LONG), EQUALS @c7] -> [COL1: KEY:[0], COL2: KEY:[1], COL3: KEY:[2]]) | FILTER _.COL1 LESS_THAN promote(@c5 AS LONG) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)˛digraph G {
   fontname=courier;
   rankdir=BT;
@@ -96,7 +98,8 @@ O
 }á
 B
 basic-sql-function-tests&EXPLAIN select * from f1(103 + 1, 'b')¿
-Ä	¯”ß>Ç Ôÿ’(`0¢Ö‚8é@	ûCOVERING(T1_IDX1 [EQUALS @c9, [LESS_THAN promote(@c5 + @c7 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)˛
+˛¿º∏.Å ô˛—
+(`0Œ˝®8é@	ûCOVERING(T1_IDX1 [EQUALS @c9, [LESS_THAN promote(@c5 + @c7 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)˛
 digraph G {
   fontname=courier;
   rankdir=BT;
@@ -109,7 +112,7 @@ digraph G {
 }ˇ
 h
 basic-sql-function-testsLEXPLAIN select * from (select * from f1(103 + 1, 'b')) as x where col1 < 105í
-ô	⁄Û¸<à ¸†∆(b0¿ºç8í@	√COVERING(T1_IDX1 [EQUALS @c13, [LESS_THAN promote(@c21 AS LONG) && LESS_THAN promote(@c9 + @c11 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)´digraph G {
+ó	πáﬁ/á ò€¿(b0„ëª8í@	√COVERING(T1_IDX1 [EQUALS @c13, [LESS_THAN promote(@c21 AS LONG) && LESS_THAN promote(@c9 + @c11 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)´digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -121,7 +124,7 @@ h
 }·
 ó
 basic-sql-function-tests{EXPLAIN select A.col1 AS W, A.col2 AS X, B.col1 AS Y, B.col2 AS Z from f1(103, 'b') A, f1(103, 'b') B where A.col1 = B.col1ƒ
-Ññ¶±¬Î Ü¯∞E(‡0‚ò–8ü@≤ISCAN(T1_IDX1 [EQUALS @c29, [LESS_THAN promote(@c27 AS LONG)]]) | FLATMAP q0 -> { COVERING(T1_IDX1 [EQUALS @c29, EQUALS q0.COL1] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | FILTER _.COL1 LESS_THAN promote(@c27 AS LONG) | FETCH AS q1 RETURN (q1.COL1 AS W, q1.COL2 AS X, q0.COL1 AS Y, q0.COL2 AS Z) }Ïdigraph G {
+ÄÌıΩÉÈ ◊≈∏.(‡0‰¸„8ü@≤ISCAN(T1_IDX1 [EQUALS @c29, [LESS_THAN promote(@c27 AS LONG)]]) | FLATMAP q0 -> { COVERING(T1_IDX1 [EQUALS @c29, EQUALS q0.COL1] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | FILTER _.COL1 LESS_THAN promote(@c27 AS LONG) | FETCH AS q1 RETURN (q1.COL1 AS W, q1.COL2 AS X, q0.COL1 AS Y, q0.COL2 AS Z) }Ïdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -149,7 +152,7 @@ h
 }ˆ
 ¨
 basic-sql-function-testsèEXPLAIN select A.col1 AS W, A.col2 AS X, B.col1 AS Y, B.col2 AS Z from f1(a => 103, b => 'b') A, f1(a => 103, b => 'b') B where A.col1 = B.col1ƒ
-Ñƒ®úÕÎ À±çN(‡0ñ£Á8ü@≤ISCAN(T1_IDX1 [EQUALS @c33, [LESS_THAN promote(@c29 AS LONG)]]) | FLATMAP q0 -> { COVERING(T1_IDX1 [EQUALS @c33, EQUALS q0.COL1] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | FILTER _.COL1 LESS_THAN promote(@c29 AS LONG) | FETCH AS q1 RETURN (q1.COL1 AS W, q1.COL2 AS X, q0.COL1 AS Y, q0.COL2 AS Z) }Ïdigraph G {
+Ä⁄Ì¢ÄÈ ˆÑ√,(‡0é∆Á8ü@≤ISCAN(T1_IDX1 [EQUALS @c33, [LESS_THAN promote(@c29 AS LONG)]]) | FLATMAP q0 -> { COVERING(T1_IDX1 [EQUALS @c33, EQUALS q0.COL1] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | FILTER _.COL1 LESS_THAN promote(@c29 AS LONG) | FETCH AS q1 RETURN (q1.COL1 AS W, q1.COL2 AS X, q0.COL1 AS Y, q0.COL2 AS Z) }Ïdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -177,7 +180,7 @@ h
 }ï
 j
 basic-sql-function-testsNEXPLAIN with x(y, z) as (select * from f1(b => 'b', a => 103)) select * from x¶
-ô	ñó‰Dá ª€Ã(b0…ÜÙ8í@	îCOVERING(T1_IDX1 [EQUALS @c16, [LESS_THAN promote(@c20 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS Y, _.COL2 AS Z)Ó
+ó	Ê◊í(Ü ˇÍã	(b0¬»å8í@	îCOVERING(T1_IDX1 [EQUALS @c16, [LESS_THAN promote(@c20 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS Y, _.COL2 AS Z)Ó
 digraph G {
   fontname=courier;
   rankdir=BT;
@@ -190,7 +193,7 @@ digraph G {
 }ã
 `
 basic-sql-function-testsDEXPLAIN with x(y, z) as (select * from f1(103, 'b')) select * from x¶
-ô	´çåEá ¶Ùü(b0Ë€Ò8í@	îCOVERING(T1_IDX1 [EQUALS @c16, [LESS_THAN promote(@c14 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS Y, _.COL2 AS Z)Ó
+ó	ö·Æ3Ü ˜ß˚(b0£—¨8í@	îCOVERING(T1_IDX1 [EQUALS @c16, [LESS_THAN promote(@c14 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS Y, _.COL2 AS Z)Ó
 digraph G {
   fontname=courier;
   rankdir=BT;
@@ -200,10 +203,10 @@ digraph G {
   3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">T1_IDX1</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS COL1, STRING AS COL2, INT AS COL3)" ];
   3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q183> label="q183" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}Û!
+}Ú!
 Z
-basic-sql-function-tests>EXPLAIN select * from t2 where exists (select * from f2(t2.z))î!
-ìÄıÙ1ç »“ê(r0ﬁ„≥8ê@ôISCAN(T2_IDX1 <,>) | FLATMAP q0 -> { ISCAN(T1_IDX1 <,>) | FILTER promote(_.COL3 AS LONG) EQUALS q0.Z | DEFAULT NULL | FILTER _ NOT_NULL AS q1 RETURN q0 }◊digraph G {
+basic-sql-function-tests>EXPLAIN select * from t2 where exists (select * from f2(t2.z))ì!
+ë·˘Ë+å ó¥Â(r0öÛo8ê@ôISCAN(T2_IDX1 <,>) | FLATMAP q0 -> { ISCAN(T1_IDX1 <,>) | FILTER promote(_.COL3 AS LONG) EQUALS q0.Z | DEFAULT NULL | FILTER _ NOT_NULL AS q1 RETURN q0 }◊digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -233,10 +236,10 @@ Z
     rankDir=LR;
     2 -> 4 [ color="red" style="invis" ];
   }
-}¯!
+}˜!
 _
-basic-sql-function-testsCEXPLAIN select * from t2 where exists (select * from f2(k => t2.z))î!
-ì÷≤¬Aç åÕƒ(r0˚œª8ê@ôISCAN(T2_IDX1 <,>) | FLATMAP q0 -> { ISCAN(T1_IDX1 <,>) | FILTER promote(_.COL3 AS LONG) EQUALS q0.Z | DEFAULT NULL | FILTER _ NOT_NULL AS q1 RETURN q0 }◊digraph G {
+basic-sql-function-testsCEXPLAIN select * from t2 where exists (select * from f2(k => t2.z))ì!
+ëÔòÒ+å âû€(r0†ï|8ê@ôISCAN(T2_IDX1 <,>) | FLATMAP q0 -> { ISCAN(T1_IDX1 <,>) | FILTER promote(_.COL3 AS LONG) EQUALS q0.Z | DEFAULT NULL | FILTER _ NOT_NULL AS q1 RETURN q0 }◊digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -269,7 +272,7 @@ _
 }‡
 A
 basic-sql-function-tests%EXPLAIN select * from f3(103, 'b', 4)ö
-€¢∏ó–ù Áå‘=(⁄0Âºÿ8≈@‚ISCAN(T1_IDX1 <,>) | FILTER promote(_.COL3 AS LONG) EQUALS promote(@c9 AS LONG) | FLATMAP q0 -> { ISCAN(T1_IDX1 [EQUALS @c7, [LESS_THAN promote(@c5 AS LONG)]]) AS q1 RETURN (q1.COL1 AS COL1, q1.COL2 AS COL2, q0.COL3 AS COL3) }ídigraph G {
+…¨úúôñ ∏˛◊)(⁄0≠∆≈8≈@‚ISCAN(T1_IDX1 <,>) | FILTER promote(_.COL3 AS LONG) EQUALS promote(@c9 AS LONG) | FLATMAP q0 -> { ISCAN(T1_IDX1 [EQUALS @c7, [LESS_THAN promote(@c5 AS LONG)]]) AS q1 RETURN (q1.COL1 AS COL1, q1.COL2 AS COL2, q0.COL3 AS COL3) }ídigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -295,7 +298,7 @@ A
 }ë
 D
 basic-sql-function-tests(EXPLAIN select * from f4(103, 'b', 2, 2)»
-Ö#≈·ã∫∞ ê™§i(É0∂Ç›8ﬁ@g˘ISCAN(T1_IDX1 <,>) | FILTER promote(_.COL3 AS LONG) EQUALS promote(@c9 AS LONG) + promote(@c9 AS LONG) | FLATMAP q0 -> { ISCAN(T1_IDX1 [EQUALS @c7, [LESS_THAN promote(@c5 AS LONG)]]) AS q1 RETURN (q1.COL1 AS COL1, q1.COL2 AS COL2, q0.COL3 AS COL3) }©digraph G {
+»"âÛ⁄∑õ Ò¡µD(É0ø§Î8ﬁ@g˘ISCAN(T1_IDX1 <,>) | FILTER promote(_.COL3 AS LONG) EQUALS promote(@c9 AS LONG) + promote(@c9 AS LONG) | FLATMAP q0 -> { ISCAN(T1_IDX1 [EQUALS @c7, [LESS_THAN promote(@c5 AS LONG)]]) AS q1 RETURN (q1.COL1 AS COL1, q1.COL2 AS COL2, q0.COL3 AS COL3) }©digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -321,7 +324,7 @@ D
 }´
 X
 basic-sql-function-tests<EXPLAIN select * from f4(a => 103, b => 'b', c => 2, d => 2)Œ
-Ö#ëÚí«∞ íÙ˘I(É0Ù“Ó8ﬁ@g¸ISCAN(T1_IDX1 <,>) | FILTER promote(_.COL3 AS LONG) EQUALS promote(@c15 AS LONG) + promote(@c15 AS LONG) | FLATMAP q0 -> { ISCAN(T1_IDX1 [EQUALS @c11, [LESS_THAN promote(@c7 AS LONG)]]) AS q1 RETURN (q1.COL1 AS COL1, q1.COL2 AS COL2, q0.COL3 AS COL3) }¨digraph G {
+»"íÎ∞êõ ÷ÕÔ7(É0∞Ãá8ﬁ@g¸ISCAN(T1_IDX1 <,>) | FILTER promote(_.COL3 AS LONG) EQUALS promote(@c15 AS LONG) + promote(@c15 AS LONG) | FLATMAP q0 -> { ISCAN(T1_IDX1 [EQUALS @c11, [LESS_THAN promote(@c7 AS LONG)]]) AS q1 RETURN (q1.COL1 AS COL1, q1.COL2 AS COL2, q0.COL3 AS COL3) }¨digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -347,7 +350,7 @@ X
 }û
 7
 basic-sql-function-testsEXPLAIN select * from f5();‚
-ê	ıˆ∫3á ±Ç≥(b0ë∏¸8í@	´COVERING(T1_IDX1 [EQUALS promote('b' AS STRING), [LESS_THAN promote(103 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)ìdigraph G {
+é	ÄÒõ3Ü ß …(b0Ëú§8í@	´COVERING(T1_IDX1 [EQUALS promote('b' AS STRING), [LESS_THAN promote(103 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)ìdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -359,7 +362,8 @@ X
 }°
 :
 basic-sql-function-testsEXPLAIN select * from f5(103);‚
-ê	ÓÔÚ8á ÇœÓ(b0üñ·8í@	´COVERING(T1_IDX1 [EQUALS promote('b' AS STRING), [LESS_THAN promote(@c5 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)ìdigraph G {
+é	†Ñø0Ü Ê™π
+(b0ˆπ¢8í@	´COVERING(T1_IDX1 [EQUALS promote('b' AS STRING), [LESS_THAN promote(@c5 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)ìdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -371,7 +375,8 @@ X
 }¯
 ?
 basic-sql-function-tests#EXPLAIN select * from f5(b => 'b');¥
-Ä	∆¨≥;Ç ùå√(`0πÒ‹8é@	òCOVERING(T1_IDX1 [EQUALS @c7, [LESS_THAN promote(103 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)¯
+˛‰ùâ1Å ¬õõ
+(`0 Óª8é@	òCOVERING(T1_IDX1 [EQUALS @c7, [LESS_THAN promote(103 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)¯
 digraph G {
   fontname=courier;
   rankdir=BT;
@@ -384,7 +389,8 @@ digraph G {
 }Ñ
 I
 basic-sql-function-tests-EXPLAIN select * from f5(b => 'b', a => 103);∂
-Ä	ä¶›AÇ äÆ◊(`0íÆ˜8é@	ôCOVERING(T1_IDX1 [EQUALS @c7, [LESS_THAN promote(@c11 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)˘
+˛∫úæ/Å øÓ∆
+(`0üÓ®8é@	ôCOVERING(T1_IDX1 [EQUALS @c7, [LESS_THAN promote(@c11 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)˘
 digraph G {
   fontname=courier;
   rankdir=BT;
@@ -397,7 +403,8 @@ digraph G {
 }Ñ
 I
 basic-sql-function-tests-EXPLAIN select * from f5(b => 'b', a => 102);∂
-Ä	ä¶›AÇ äÆ◊(`0íÆ˜8é@	ôCOVERING(T1_IDX1 [EQUALS @c7, [LESS_THAN promote(@c11 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)˘
+˛∫úæ/Å øÓ∆
+(`0üÓ®8é@	ôCOVERING(T1_IDX1 [EQUALS @c7, [LESS_THAN promote(@c11 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)˘
 digraph G {
   fontname=courier;
   rankdir=BT;
@@ -410,7 +417,8 @@ digraph G {
 }Ñ
 I
 basic-sql-function-tests-EXPLAIN select * from f5(b => 'a', a => 102);∂
-Ä	ä¶›AÇ äÆ◊(`0íÆ˜8é@	ôCOVERING(T1_IDX1 [EQUALS @c7, [LESS_THAN promote(@c11 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)˘
+˛∫úæ/Å øÓ∆
+(`0üÓ®8é@	ôCOVERING(T1_IDX1 [EQUALS @c7, [LESS_THAN promote(@c11 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)˘
 digraph G {
   fontname=courier;
   rankdir=BT;
@@ -423,7 +431,8 @@ digraph G {
 }Ñ
 I
 basic-sql-function-tests-EXPLAIN select * from f5(a => 102, b => 'a');∂
-Ä	Å”òCÇ Â¢¸(`0Ë Ë8é@	ôCOVERING(T1_IDX1 [EQUALS @c11, [LESS_THAN promote(@c7 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)˘
+˛õπï-Å üôÄ
+(`0≈úí8é@	ôCOVERING(T1_IDX1 [EQUALS @c11, [LESS_THAN promote(@c7 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)˘
 digraph G {
   fontname=courier;
   rankdir=BT;
@@ -436,7 +445,8 @@ digraph G {
 }°
 :
 basic-sql-function-testsEXPLAIN select * from f5(102);‚
-ê	ÓÔÚ8á ÇœÓ(b0üñ·8í@	´COVERING(T1_IDX1 [EQUALS promote('b' AS STRING), [LESS_THAN promote(@c5 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)ìdigraph G {
+é	†Ñø0Ü Ê™π
+(b0ˆπ¢8í@	´COVERING(T1_IDX1 [EQUALS promote('b' AS STRING), [LESS_THAN promote(@c5 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)ìdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -448,7 +458,7 @@ digraph G {
 }¯
 ?
 basic-sql-function-tests#EXPLAIN select * from f5(102, 'a');¥
-Ä	˛§ïEÇ òãè(`0÷˝ë8é@	òCOVERING(T1_IDX1 [EQUALS @c7, [LESS_THAN promote(@c5 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)¯
+˛œÇï/Å ¸´ª(`0—Å¢8é@	òCOVERING(T1_IDX1 [EQUALS @c7, [LESS_THAN promote(@c5 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)¯
 digraph G {
   fontname=courier;
   rankdir=BT;

--- a/yaml-tests/src/test/resources/sql-functions.metrics.yaml
+++ b/yaml-tests/src/test/resources/sql-functions.metrics.yaml
@@ -4,12 +4,12 @@ basic-sql-function-tests:
     explain: 'COVERING(T1_IDX1 [EQUALS @c13, [LESS_THAN promote(@c9 AS LONG)]] ->
         [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2
         AS COL2)'
-    task_count: 1152
-    task_total_time_ms: 131
-    transform_count: 258
-    transform_time_ms: 33
+    task_count: 1150
+    task_total_time_ms: 97
+    transform_count: 257
+    transform_time_ms: 20
     transform_yield_count: 96
-    insert_time_ms: 4
+    insert_time_ms: 2
     insert_new_count: 142
     insert_reused_count: 9
 -   query: EXPLAIN select col1, col2 from f1(b => 'b', a => 103);
@@ -17,48 +17,48 @@ basic-sql-function-tests:
     explain: 'COVERING(T1_IDX1 [EQUALS @c9, [LESS_THAN promote(@c13 AS LONG)]] ->
         [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2
         AS COL2)'
-    task_count: 1152
-    task_total_time_ms: 119
-    transform_count: 258
-    transform_time_ms: 32
+    task_count: 1150
+    task_total_time_ms: 99
+    transform_count: 257
+    transform_time_ms: 22
     transform_yield_count: 96
-    insert_time_ms: 3
+    insert_time_ms: 2
     insert_new_count: 142
     insert_reused_count: 9
 -   query: EXPLAIN select col1, col2 from f1(103, 'b');
     ref: sql-functions.yamsql:71
     explain: 'COVERING(T1_IDX1 [EQUALS @c9, [LESS_THAN promote(@c7 AS LONG)]] -> [COL1:
         KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)'
-    task_count: 1152
-    task_total_time_ms: 108
-    transform_count: 258
-    transform_time_ms: 29
+    task_count: 1150
+    task_total_time_ms: 100
+    transform_count: 257
+    transform_time_ms: 23
     transform_yield_count: 96
-    insert_time_ms: 3
+    insert_time_ms: 2
     insert_new_count: 142
     insert_reused_count: 9
 -   query: EXPLAIN select col1 + 10, col2 from f1(103, 'b');
     ref: sql-functions.yamsql:75
     explain: ISCAN(T1_IDX1 [EQUALS @c11, [LESS_THAN promote(@c9 AS LONG)]]) | MAP
         (_.COL1 + @c3 AS _0, _.COL2 AS COL2)
-    task_count: 1000
-    task_total_time_ms: 119
-    transform_count: 241
-    transform_time_ms: 32
+    task_count: 998
+    task_total_time_ms: 80
+    transform_count: 240
+    transform_time_ms: 19
     transform_yield_count: 86
-    insert_time_ms: 2
+    insert_time_ms: 1
     insert_new_count: 122
     insert_reused_count: 4
 -   query: EXPLAIN select * from f1(103, 'b');
     ref: sql-functions.yamsql:79
     explain: 'COVERING(T1_IDX1 [EQUALS @c7, [LESS_THAN promote(@c5 AS LONG)]] -> [COL1:
         KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)'
-    task_count: 1152
-    task_total_time_ms: 97
-    transform_count: 258
-    transform_time_ms: 23
+    task_count: 1150
+    task_total_time_ms: 95
+    transform_count: 257
+    transform_time_ms: 21
     transform_yield_count: 96
-    insert_time_ms: 3
+    insert_time_ms: 2
     insert_new_count: 142
     insert_reused_count: 9
 -   query: EXPLAIN select * from f1(103, 'b') where col1 = 101
@@ -66,12 +66,12 @@ basic-sql-function-tests:
     explain: 'COVERING(T1_IDX4 [EQUALS promote(@c12 AS LONG), EQUALS @c7] -> [COL1:
         KEY:[0], COL2: KEY:[1], COL3: KEY:[2]]) | FILTER _.COL1 LESS_THAN promote(@c5
         AS LONG) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)'
-    task_count: 1204
-    task_total_time_ms: 150
-    transform_count: 269
-    transform_time_ms: 33
+    task_count: 1202
+    task_total_time_ms: 109
+    transform_count: 268
+    transform_time_ms: 23
     transform_yield_count: 98
-    insert_time_ms: 4
+    insert_time_ms: 3
     insert_new_count: 150
     insert_reused_count: 10
 -   query: EXPLAIN select * from f1(103, 'c') where col1 = 104
@@ -79,12 +79,12 @@ basic-sql-function-tests:
     explain: 'COVERING(T1_IDX4 [EQUALS promote(@c12 AS LONG), EQUALS @c7] -> [COL1:
         KEY:[0], COL2: KEY:[1], COL3: KEY:[2]]) | FILTER _.COL1 LESS_THAN promote(@c5
         AS LONG) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)'
-    task_count: 1204
-    task_total_time_ms: 150
-    transform_count: 269
-    transform_time_ms: 33
+    task_count: 1202
+    task_total_time_ms: 109
+    transform_count: 268
+    transform_time_ms: 23
     transform_yield_count: 98
-    insert_time_ms: 4
+    insert_time_ms: 3
     insert_new_count: 150
     insert_reused_count: 10
 -   query: EXPLAIN select * from f1(103 + 1, 'b')
@@ -92,12 +92,12 @@ basic-sql-function-tests:
     explain: 'COVERING(T1_IDX1 [EQUALS @c9, [LESS_THAN promote(@c5 + @c7 AS LONG)]]
         -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2
         AS COL2)'
-    task_count: 1152
-    task_total_time_ms: 130
-    transform_count: 258
-    transform_time_ms: 32
+    task_count: 1150
+    task_total_time_ms: 97
+    transform_count: 257
+    transform_time_ms: 22
     transform_yield_count: 96
-    insert_time_ms: 3
+    insert_time_ms: 2
     insert_new_count: 142
     insert_reused_count: 9
 -   query: EXPLAIN select * from (select * from f1(103 + 1, 'b')) as x where col1
@@ -106,12 +106,12 @@ basic-sql-function-tests:
     explain: 'COVERING(T1_IDX1 [EQUALS @c13, [LESS_THAN promote(@c21 AS LONG) && LESS_THAN
         promote(@c9 + @c11 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]])
         | MAP (_.COL1 AS COL1, _.COL2 AS COL2)'
-    task_count: 1177
-    task_total_time_ms: 127
-    transform_count: 264
-    transform_time_ms: 32
+    task_count: 1175
+    task_total_time_ms: 100
+    transform_count: 263
+    transform_time_ms: 24
     transform_yield_count: 98
-    insert_time_ms: 4
+    insert_time_ms: 3
     insert_new_count: 146
     insert_reused_count: 9
 -   query: EXPLAIN select A.col1 AS W, A.col2 AS X, B.col1 AS Y, B.col2 AS Z from
@@ -122,12 +122,12 @@ basic-sql-function-tests:
         COL2: KEY:[0], COL3: KEY:[2]]) | FILTER _.COL1 LESS_THAN promote(@c27 AS LONG)
         | FETCH AS q1 RETURN (q1.COL1 AS W, q1.COL2 AS X, q0.COL1 AS Y, q0.COL2 AS
         Z) }'
-    task_count: 2692
-    task_total_time_ms: 407
-    transform_count: 619
-    transform_time_ms: 145
+    task_count: 2688
+    task_total_time_ms: 275
+    transform_count: 617
+    transform_time_ms: 97
     transform_yield_count: 224
-    insert_time_ms: 9
+    insert_time_ms: 5
     insert_new_count: 415
     insert_reused_count: 14
 -   query: EXPLAIN select A.col1 AS W, A.col2 AS X, B.col1 AS Y, B.col2 AS Z from
@@ -138,12 +138,12 @@ basic-sql-function-tests:
         COL2: KEY:[0], COL3: KEY:[2]]) | FILTER _.COL1 LESS_THAN promote(@c29 AS LONG)
         | FETCH AS q1 RETURN (q1.COL1 AS W, q1.COL2 AS X, q0.COL1 AS Y, q0.COL2 AS
         Z) }'
-    task_count: 2692
-    task_total_time_ms: 430
-    transform_count: 619
-    transform_time_ms: 163
+    task_count: 2688
+    task_total_time_ms: 269
+    transform_count: 617
+    transform_time_ms: 93
     transform_yield_count: 224
-    insert_time_ms: 10
+    insert_time_ms: 5
     insert_new_count: 415
     insert_reused_count: 14
 -   query: EXPLAIN with x(y, z) as (select * from f1(b => 'b', a => 103)) select *
@@ -152,12 +152,12 @@ basic-sql-function-tests:
     explain: 'COVERING(T1_IDX1 [EQUALS @c16, [LESS_THAN promote(@c20 AS LONG)]] ->
         [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS Y, _.COL2
         AS Z)'
-    task_count: 1177
-    task_total_time_ms: 144
-    transform_count: 263
-    transform_time_ms: 30
+    task_count: 1175
+    task_total_time_ms: 84
+    transform_count: 262
+    transform_time_ms: 19
     transform_yield_count: 98
-    insert_time_ms: 3
+    insert_time_ms: 2
     insert_new_count: 146
     insert_reused_count: 9
 -   query: EXPLAIN with x(y, z) as (select * from f1(103, 'b')) select * from x
@@ -165,36 +165,36 @@ basic-sql-function-tests:
     explain: 'COVERING(T1_IDX1 [EQUALS @c16, [LESS_THAN promote(@c14 AS LONG)]] ->
         [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS Y, _.COL2
         AS Z)'
-    task_count: 1177
-    task_total_time_ms: 144
-    transform_count: 263
-    transform_time_ms: 29
+    task_count: 1175
+    task_total_time_ms: 107
+    transform_count: 262
+    transform_time_ms: 25
     transform_yield_count: 98
-    insert_time_ms: 3
+    insert_time_ms: 2
     insert_new_count: 146
     insert_reused_count: 9
 -   query: EXPLAIN select * from t2 where exists (select * from f2(t2.z))
     ref: sql-functions.yamsql:122
     explain: ISCAN(T2_IDX1 <,>) | FLATMAP q0 -> { ISCAN(T1_IDX1 <,>) | FILTER promote(_.COL3
         AS LONG) EQUALS q0.Z | DEFAULT NULL | FILTER _ NOT_NULL AS q1 RETURN q0 }
-    task_count: 1043
-    task_total_time_ms: 104
-    transform_count: 269
-    transform_time_ms: 38
+    task_count: 1041
+    task_total_time_ms: 91
+    transform_count: 268
+    transform_time_ms: 31
     transform_yield_count: 114
-    insert_time_ms: 2
+    insert_time_ms: 1
     insert_new_count: 144
     insert_reused_count: 5
 -   query: EXPLAIN select * from t2 where exists (select * from f2(k => t2.z))
     ref: sql-functions.yamsql:126
     explain: ISCAN(T2_IDX1 <,>) | FLATMAP q0 -> { ISCAN(T1_IDX1 <,>) | FILTER promote(_.COL3
         AS LONG) EQUALS q0.Z | DEFAULT NULL | FILTER _ NOT_NULL AS q1 RETURN q0 }
-    task_count: 1043
-    task_total_time_ms: 137
-    transform_count: 269
-    transform_time_ms: 57
+    task_count: 1041
+    task_total_time_ms: 92
+    transform_count: 268
+    transform_time_ms: 32
     transform_yield_count: 114
-    insert_time_ms: 3
+    insert_time_ms: 2
     insert_new_count: 144
     insert_reused_count: 5
 -   query: EXPLAIN select * from f3(103, 'b', 4)
@@ -203,12 +203,12 @@ basic-sql-function-tests:
         AS LONG) | FLATMAP q0 -> { ISCAN(T1_IDX1 [EQUALS @c7, [LESS_THAN promote(@c5
         AS LONG)]]) AS q1 RETURN (q1.COL1 AS COL1, q1.COL2 AS COL2, q0.COL3 AS COL3)
         }
-    task_count: 2395
-    task_total_time_ms: 436
-    transform_count: 541
-    transform_time_ms: 129
+    task_count: 2377
+    task_total_time_ms: 321
+    transform_count: 534
+    transform_time_ms: 87
     transform_yield_count: 218
-    insert_time_ms: 11
+    insert_time_ms: 7
     insert_new_count: 453
     insert_reused_count: 24
 -   query: EXPLAIN select * from f3(103, 'b', 4)
@@ -217,12 +217,12 @@ basic-sql-function-tests:
         AS LONG) | FLATMAP q0 -> { ISCAN(T1_IDX1 [EQUALS @c7, [LESS_THAN promote(@c5
         AS LONG)]]) AS q1 RETURN (q1.COL1 AS COL1, q1.COL2 AS COL2, q0.COL3 AS COL3)
         }
-    task_count: 2395
-    task_total_time_ms: 436
-    transform_count: 541
-    transform_time_ms: 129
+    task_count: 2377
+    task_total_time_ms: 321
+    transform_count: 534
+    transform_time_ms: 87
     transform_yield_count: 218
-    insert_time_ms: 11
+    insert_time_ms: 7
     insert_new_count: 453
     insert_reused_count: 24
 -   query: EXPLAIN select * from f4(103, 'b', 2, 2)
@@ -231,12 +231,12 @@ basic-sql-function-tests:
         AS LONG) + promote(@c9 AS LONG) | FLATMAP q0 -> { ISCAN(T1_IDX1 [EQUALS @c7,
         [LESS_THAN promote(@c5 AS LONG)]]) AS q1 RETURN (q1.COL1 AS COL1, q1.COL2
         AS COL2, q0.COL3 AS COL3) }
-    task_count: 4485
-    task_total_time_ms: 927
-    transform_count: 944
-    transform_time_ms: 220
+    task_count: 4424
+    task_total_time_ms: 653
+    transform_count: 923
+    transform_time_ms: 143
     transform_yield_count: 387
-    insert_time_ms: 37
+    insert_time_ms: 24
     insert_new_count: 1118
     insert_reused_count: 103
 -   query: EXPLAIN select * from f4(a => 103, b => 'b', c => 2, d => 2)
@@ -245,12 +245,12 @@ basic-sql-function-tests:
         AS LONG) + promote(@c15 AS LONG) | FLATMAP q0 -> { ISCAN(T1_IDX1 [EQUALS @c11,
         [LESS_THAN promote(@c7 AS LONG)]]) AS q1 RETURN (q1.COL1 AS COL1, q1.COL2
         AS COL2, q0.COL3 AS COL3) }
-    task_count: 4485
-    task_total_time_ms: 686
-    transform_count: 944
-    transform_time_ms: 155
+    task_count: 4424
+    task_total_time_ms: 571
+    transform_count: 923
+    transform_time_ms: 117
     transform_yield_count: 387
-    insert_time_ms: 29
+    insert_time_ms: 23
     insert_new_count: 1118
     insert_reused_count: 103
 -   query: EXPLAIN select * from f5();
@@ -258,12 +258,12 @@ basic-sql-function-tests:
     explain: 'COVERING(T1_IDX1 [EQUALS promote(''b'' AS STRING), [LESS_THAN promote(103
         AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1
         AS COL1, _.COL2 AS COL2)'
-    task_count: 1168
+    task_count: 1166
     task_total_time_ms: 107
-    transform_count: 263
-    transform_time_ms: 26
+    transform_count: 262
+    transform_time_ms: 24
     transform_yield_count: 98
-    insert_time_ms: 4
+    insert_time_ms: 2
     insert_new_count: 146
     insert_reused_count: 9
 -   query: EXPLAIN select * from f5(103);
@@ -271,22 +271,22 @@ basic-sql-function-tests:
     explain: 'COVERING(T1_IDX1 [EQUALS promote(''b'' AS STRING), [LESS_THAN promote(@c5
         AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1
         AS COL1, _.COL2 AS COL2)'
-    task_count: 1168
-    task_total_time_ms: 119
-    transform_count: 263
-    transform_time_ms: 29
+    task_count: 1166
+    task_total_time_ms: 101
+    transform_count: 262
+    transform_time_ms: 21
     transform_yield_count: 98
-    insert_time_ms: 3
+    insert_time_ms: 2
     insert_new_count: 146
     insert_reused_count: 9
 -   query: EXPLAIN select * from f5(b => 'b');
     ref: sql-functions.yamsql:154
     explain: 'COVERING(T1_IDX1 [EQUALS @c7, [LESS_THAN promote(103 AS LONG)]] -> [COL1:
         KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)'
-    task_count: 1152
-    task_total_time_ms: 124
-    transform_count: 258
-    transform_time_ms: 30
+    task_count: 1150
+    task_total_time_ms: 102
+    transform_count: 257
+    transform_time_ms: 21
     transform_yield_count: 96
     insert_time_ms: 3
     insert_new_count: 142
@@ -296,12 +296,12 @@ basic-sql-function-tests:
     explain: 'COVERING(T1_IDX1 [EQUALS @c7, [LESS_THAN promote(@c11 AS LONG)]] ->
         [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2
         AS COL2)'
-    task_count: 1152
-    task_total_time_ms: 137
-    transform_count: 258
-    transform_time_ms: 32
+    task_count: 1150
+    task_total_time_ms: 99
+    transform_count: 257
+    transform_time_ms: 22
     transform_yield_count: 96
-    insert_time_ms: 4
+    insert_time_ms: 2
     insert_new_count: 142
     insert_reused_count: 9
 -   query: EXPLAIN select * from f5(b => 'b', a => 102);
@@ -309,12 +309,12 @@ basic-sql-function-tests:
     explain: 'COVERING(T1_IDX1 [EQUALS @c7, [LESS_THAN promote(@c11 AS LONG)]] ->
         [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2
         AS COL2)'
-    task_count: 1152
-    task_total_time_ms: 137
-    transform_count: 258
-    transform_time_ms: 32
+    task_count: 1150
+    task_total_time_ms: 99
+    transform_count: 257
+    transform_time_ms: 22
     transform_yield_count: 96
-    insert_time_ms: 4
+    insert_time_ms: 2
     insert_new_count: 142
     insert_reused_count: 9
 -   query: EXPLAIN select * from f5(b => 'a', a => 102);
@@ -322,12 +322,12 @@ basic-sql-function-tests:
     explain: 'COVERING(T1_IDX1 [EQUALS @c7, [LESS_THAN promote(@c11 AS LONG)]] ->
         [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2
         AS COL2)'
-    task_count: 1152
-    task_total_time_ms: 137
-    transform_count: 258
-    transform_time_ms: 32
+    task_count: 1150
+    task_total_time_ms: 99
+    transform_count: 257
+    transform_time_ms: 22
     transform_yield_count: 96
-    insert_time_ms: 4
+    insert_time_ms: 2
     insert_new_count: 142
     insert_reused_count: 9
 -   query: EXPLAIN select * from f5(a => 102, b => 'a');
@@ -335,12 +335,12 @@ basic-sql-function-tests:
     explain: 'COVERING(T1_IDX1 [EQUALS @c11, [LESS_THAN promote(@c7 AS LONG)]] ->
         [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2
         AS COL2)'
-    task_count: 1152
-    task_total_time_ms: 140
-    transform_count: 258
-    transform_time_ms: 29
+    task_count: 1150
+    task_total_time_ms: 94
+    transform_count: 257
+    transform_time_ms: 20
     transform_yield_count: 96
-    insert_time_ms: 3
+    insert_time_ms: 2
     insert_new_count: 142
     insert_reused_count: 9
 -   query: EXPLAIN select * from f5(102);
@@ -348,23 +348,23 @@ basic-sql-function-tests:
     explain: 'COVERING(T1_IDX1 [EQUALS promote(''b'' AS STRING), [LESS_THAN promote(@c5
         AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1
         AS COL1, _.COL2 AS COL2)'
-    task_count: 1168
-    task_total_time_ms: 119
-    transform_count: 263
-    transform_time_ms: 29
+    task_count: 1166
+    task_total_time_ms: 101
+    transform_count: 262
+    transform_time_ms: 21
     transform_yield_count: 98
-    insert_time_ms: 3
+    insert_time_ms: 2
     insert_new_count: 146
     insert_reused_count: 9
 -   query: EXPLAIN select * from f5(102, 'a');
     ref: sql-functions.yamsql:178
     explain: 'COVERING(T1_IDX1 [EQUALS @c7, [LESS_THAN promote(@c5 AS LONG)]] -> [COL1:
         KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)'
-    task_count: 1152
-    task_total_time_ms: 145
-    transform_count: 258
-    transform_time_ms: 29
+    task_count: 1150
+    task_total_time_ms: 98
+    transform_count: 257
+    transform_time_ms: 24
     transform_yield_count: 96
-    insert_time_ms: 4
+    insert_time_ms: 2
     insert_new_count: 142
     insert_reused_count: 9

--- a/yaml-tests/src/test/resources/sql-functions.metrics.yaml
+++ b/yaml-tests/src/test/resources/sql-functions.metrics.yaml
@@ -4,12 +4,12 @@ basic-sql-function-tests:
     explain: 'COVERING(T1_IDX1 [EQUALS @c13, [LESS_THAN promote(@c9 AS LONG)]] ->
         [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2
         AS COL2)'
-    task_count: 1156
+    task_count: 1154
     task_total_time_ms: 83
-    transform_count: 262
-    transform_time_ms: 22
+    transform_count: 261
+    transform_time_ms: 18
     transform_yield_count: 96
-    insert_time_ms: 4
+    insert_time_ms: 2
     insert_new_count: 142
     insert_reused_count: 9
 -   query: EXPLAIN select col1, col2 from f1(b => 'b', a => 103);
@@ -17,48 +17,48 @@ basic-sql-function-tests:
     explain: 'COVERING(T1_IDX1 [EQUALS @c9, [LESS_THAN promote(@c13 AS LONG)]] ->
         [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2
         AS COL2)'
-    task_count: 1156
-    task_total_time_ms: 154
-    transform_count: 262
-    transform_time_ms: 33
+    task_count: 1154
+    task_total_time_ms: 89
+    transform_count: 261
+    transform_time_ms: 19
     transform_yield_count: 96
-    insert_time_ms: 7
+    insert_time_ms: 2
     insert_new_count: 142
     insert_reused_count: 9
 -   query: EXPLAIN select col1, col2 from f1(103, 'b');
     ref: sql-functions.yamsql:71
     explain: 'COVERING(T1_IDX1 [EQUALS @c9, [LESS_THAN promote(@c7 AS LONG)]] -> [COL1:
         KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)'
-    task_count: 1156
-    task_total_time_ms: 94
-    transform_count: 262
-    transform_time_ms: 27
+    task_count: 1154
+    task_total_time_ms: 90
+    transform_count: 261
+    transform_time_ms: 21
     transform_yield_count: 96
-    insert_time_ms: 4
+    insert_time_ms: 2
     insert_new_count: 142
     insert_reused_count: 9
 -   query: EXPLAIN select col1 + 10, col2 from f1(103, 'b');
     ref: sql-functions.yamsql:75
     explain: ISCAN(T1_IDX1 [EQUALS @c11, [LESS_THAN promote(@c9 AS LONG)]]) | MAP
         (_.COL1 + @c3 AS _0, _.COL2 AS COL2)
-    task_count: 1004
-    task_total_time_ms: 84
-    transform_count: 245
-    transform_time_ms: 22
+    task_count: 1002
+    task_total_time_ms: 73
+    transform_count: 244
+    transform_time_ms: 20
     transform_yield_count: 86
-    insert_time_ms: 9
+    insert_time_ms: 1
     insert_new_count: 122
     insert_reused_count: 4
 -   query: EXPLAIN select * from f1(103, 'b');
     ref: sql-functions.yamsql:79
     explain: 'COVERING(T1_IDX1 [EQUALS @c7, [LESS_THAN promote(@c5 AS LONG)]] -> [COL1:
         KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)'
-    task_count: 1156
-    task_total_time_ms: 79
-    transform_count: 262
-    transform_time_ms: 20
+    task_count: 1154
+    task_total_time_ms: 90
+    transform_count: 261
+    transform_time_ms: 19
     transform_yield_count: 96
-    insert_time_ms: 3
+    insert_time_ms: 2
     insert_new_count: 142
     insert_reused_count: 9
 -   query: EXPLAIN select * from f1(103, 'b') where col1 = 101
@@ -66,12 +66,12 @@ basic-sql-function-tests:
     explain: 'COVERING(T1_IDX4 [EQUALS promote(@c12 AS LONG), EQUALS @c7] -> [COL1:
         KEY:[0], COL2: KEY:[1], COL3: KEY:[2]]) | FILTER _.COL1 LESS_THAN promote(@c5
         AS LONG) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)'
-    task_count: 1227
-    task_total_time_ms: 196
-    transform_count: 277
-    transform_time_ms: 59
+    task_count: 1225
+    task_total_time_ms: 107
+    transform_count: 276
+    transform_time_ms: 23
     transform_yield_count: 99
-    insert_time_ms: 5
+    insert_time_ms: 3
     insert_new_count: 153
     insert_reused_count: 11
 -   query: EXPLAIN select * from f1(103, 'c') where col1 = 104
@@ -79,12 +79,12 @@ basic-sql-function-tests:
     explain: 'COVERING(T1_IDX4 [EQUALS promote(@c12 AS LONG), EQUALS @c7] -> [COL1:
         KEY:[0], COL2: KEY:[1], COL3: KEY:[2]]) | FILTER _.COL1 LESS_THAN promote(@c5
         AS LONG) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)'
-    task_count: 1227
-    task_total_time_ms: 196
-    transform_count: 277
-    transform_time_ms: 59
+    task_count: 1225
+    task_total_time_ms: 107
+    transform_count: 276
+    transform_time_ms: 23
     transform_yield_count: 99
-    insert_time_ms: 5
+    insert_time_ms: 3
     insert_new_count: 153
     insert_reused_count: 11
 -   query: EXPLAIN select * from f1(103 + 1, 'b')
@@ -92,12 +92,12 @@ basic-sql-function-tests:
     explain: 'COVERING(T1_IDX1 [EQUALS @c9, [LESS_THAN promote(@c5 + @c7 AS LONG)]]
         -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2
         AS COL2)'
-    task_count: 1156
-    task_total_time_ms: 82
-    transform_count: 262
-    transform_time_ms: 25
+    task_count: 1154
+    task_total_time_ms: 92
+    transform_count: 261
+    transform_time_ms: 20
     transform_yield_count: 96
-    insert_time_ms: 3
+    insert_time_ms: 2
     insert_new_count: 142
     insert_reused_count: 9
 -   query: EXPLAIN select * from (select * from f1(103 + 1, 'b')) as x where col1
@@ -106,12 +106,12 @@ basic-sql-function-tests:
     explain: 'COVERING(T1_IDX1 [EQUALS @c13, [LESS_THAN promote(@c21 AS LONG) && LESS_THAN
         promote(@c9 + @c11 AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]])
         | MAP (_.COL1 AS COL1, _.COL2 AS COL2)'
-    task_count: 1201
-    task_total_time_ms: 106
-    transform_count: 273
-    transform_time_ms: 29
+    task_count: 1199
+    task_total_time_ms: 86
+    transform_count: 272
+    transform_time_ms: 19
     transform_yield_count: 99
-    insert_time_ms: 4
+    insert_time_ms: 2
     insert_new_count: 149
     insert_reused_count: 10
 -   query: EXPLAIN select A.col1 AS W, A.col2 AS X, B.col1 AS Y, B.col2 AS Z from
@@ -122,12 +122,12 @@ basic-sql-function-tests:
         COL2: KEY:[0], COL3: KEY:[2]]) | FILTER _.COL1 LESS_THAN promote(@c27 AS LONG)
         | FETCH AS q1 RETURN (q1.COL1 AS W, q1.COL2 AS X, q0.COL1 AS Y, q0.COL2 AS
         Z) }'
-    task_count: 2699
-    task_total_time_ms: 542
-    transform_count: 626
-    transform_time_ms: 222
+    task_count: 2695
+    task_total_time_ms: 258
+    transform_count: 624
+    transform_time_ms: 90
     transform_yield_count: 224
-    insert_time_ms: 17
+    insert_time_ms: 5
     insert_new_count: 415
     insert_reused_count: 14
 -   query: EXPLAIN select A.col1 AS W, A.col2 AS X, B.col1 AS Y, B.col2 AS Z from
@@ -138,12 +138,12 @@ basic-sql-function-tests:
         COL2: KEY:[0], COL3: KEY:[2]]) | FILTER _.COL1 LESS_THAN promote(@c29 AS LONG)
         | FETCH AS q1 RETURN (q1.COL1 AS W, q1.COL2 AS X, q0.COL1 AS Y, q0.COL2 AS
         Z) }'
-    task_count: 2699
-    task_total_time_ms: 337
-    transform_count: 626
-    transform_time_ms: 104
+    task_count: 2695
+    task_total_time_ms: 267
+    transform_count: 624
+    transform_time_ms: 92
     transform_yield_count: 224
-    insert_time_ms: 12
+    insert_time_ms: 5
     insert_new_count: 415
     insert_reused_count: 14
 -   query: EXPLAIN with x(y, z) as (select * from f1(b => 'b', a => 103)) select *
@@ -152,12 +152,12 @@ basic-sql-function-tests:
     explain: 'COVERING(T1_IDX1 [EQUALS @c16, [LESS_THAN promote(@c20 AS LONG)]] ->
         [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS Y, _.COL2
         AS Z)'
-    task_count: 1182
-    task_total_time_ms: 172
-    transform_count: 268
-    transform_time_ms: 42
+    task_count: 1180
+    task_total_time_ms: 87
+    transform_count: 267
+    transform_time_ms: 21
     transform_yield_count: 98
-    insert_time_ms: 15
+    insert_time_ms: 2
     insert_new_count: 146
     insert_reused_count: 9
 -   query: EXPLAIN with x(y, z) as (select * from f1(103, 'b')) select * from x
@@ -165,36 +165,36 @@ basic-sql-function-tests:
     explain: 'COVERING(T1_IDX1 [EQUALS @c16, [LESS_THAN promote(@c14 AS LONG)]] ->
         [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS Y, _.COL2
         AS Z)'
-    task_count: 1182
-    task_total_time_ms: 100
-    transform_count: 268
-    transform_time_ms: 27
+    task_count: 1180
+    task_total_time_ms: 94
+    transform_count: 267
+    transform_time_ms: 20
     transform_yield_count: 98
-    insert_time_ms: 4
+    insert_time_ms: 2
     insert_new_count: 146
     insert_reused_count: 9
 -   query: EXPLAIN select * from t2 where exists (select * from f2(t2.z))
     ref: sql-functions.yamsql:122
     explain: ISCAN(T2_IDX1 <,>) | FLATMAP q0 -> { ISCAN(T1_IDX1 <,>) | FILTER promote(_.COL3
         AS LONG) EQUALS q0.Z | DEFAULT NULL | FILTER _ NOT_NULL AS q1 RETURN q0 }
-    task_count: 1047
-    task_total_time_ms: 113
-    transform_count: 273
-    transform_time_ms: 31
+    task_count: 1045
+    task_total_time_ms: 78
+    transform_count: 272
+    transform_time_ms: 25
     transform_yield_count: 114
-    insert_time_ms: 2
+    insert_time_ms: 1
     insert_new_count: 144
     insert_reused_count: 5
 -   query: EXPLAIN select * from t2 where exists (select * from f2(k => t2.z))
     ref: sql-functions.yamsql:126
     explain: ISCAN(T2_IDX1 <,>) | FLATMAP q0 -> { ISCAN(T1_IDX1 <,>) | FILTER promote(_.COL3
         AS LONG) EQUALS q0.Z | DEFAULT NULL | FILTER _ NOT_NULL AS q1 RETURN q0 }
-    task_count: 1047
-    task_total_time_ms: 155
-    transform_count: 273
-    transform_time_ms: 71
+    task_count: 1045
+    task_total_time_ms: 76
+    transform_count: 272
+    transform_time_ms: 26
     transform_yield_count: 114
-    insert_time_ms: 5
+    insert_time_ms: 1
     insert_new_count: 144
     insert_reused_count: 5
 -   query: EXPLAIN select * from f3(103, 'b', 4)
@@ -203,12 +203,12 @@ basic-sql-function-tests:
         AS LONG) | FLATMAP q0 -> { ISCAN(T1_IDX1 [EQUALS @c7, [LESS_THAN promote(@c5
         AS LONG)]]) AS q1 RETURN (q1.COL1 AS COL1, q1.COL2 AS COL2, q0.COL3 AS COL3)
         }
-    task_count: 2420
-    task_total_time_ms: 400
-    transform_count: 566
-    transform_time_ms: 119
+    task_count: 2402
+    task_total_time_ms: 288
+    transform_count: 559
+    transform_time_ms: 82
     transform_yield_count: 218
-    insert_time_ms: 15
+    insert_time_ms: 6
     insert_new_count: 453
     insert_reused_count: 24
 -   query: EXPLAIN select * from f3(103, 'b', 4)
@@ -217,12 +217,12 @@ basic-sql-function-tests:
         AS LONG) | FLATMAP q0 -> { ISCAN(T1_IDX1 [EQUALS @c7, [LESS_THAN promote(@c5
         AS LONG)]]) AS q1 RETURN (q1.COL1 AS COL1, q1.COL2 AS COL2, q0.COL3 AS COL3)
         }
-    task_count: 2420
-    task_total_time_ms: 400
-    transform_count: 566
-    transform_time_ms: 119
+    task_count: 2402
+    task_total_time_ms: 288
+    transform_count: 559
+    transform_time_ms: 82
     transform_yield_count: 218
-    insert_time_ms: 15
+    insert_time_ms: 6
     insert_new_count: 453
     insert_reused_count: 24
 -   query: EXPLAIN select * from f4(103, 'b', 2, 2)
@@ -231,12 +231,12 @@ basic-sql-function-tests:
         AS LONG) + promote(@c9 AS LONG) | FLATMAP q0 -> { ISCAN(T1_IDX1 [EQUALS @c7,
         [LESS_THAN promote(@c5 AS LONG)]]) AS q1 RETURN (q1.COL1 AS COL1, q1.COL2
         AS COL2, q0.COL3 AS COL3) }
-    task_count: 4552
-    task_total_time_ms: 500
-    transform_count: 1011
-    transform_time_ms: 131
+    task_count: 4491
+    task_total_time_ms: 400
+    transform_count: 990
+    transform_time_ms: 84
     transform_yield_count: 387
-    insert_time_ms: 34
+    insert_time_ms: 17
     insert_new_count: 1118
     insert_reused_count: 103
 -   query: EXPLAIN select * from f4(a => 103, b => 'b', c => 2, d => 2)
@@ -245,12 +245,12 @@ basic-sql-function-tests:
         AS LONG) + promote(@c15 AS LONG) | FLATMAP q0 -> { ISCAN(T1_IDX1 [EQUALS @c11,
         [LESS_THAN promote(@c7 AS LONG)]]) AS q1 RETURN (q1.COL1 AS COL1, q1.COL2
         AS COL2, q0.COL3 AS COL3) }
-    task_count: 4552
-    task_total_time_ms: 687
-    transform_count: 1011
-    transform_time_ms: 185
+    task_count: 4491
+    task_total_time_ms: 555
+    transform_count: 990
+    transform_time_ms: 120
     transform_yield_count: 387
-    insert_time_ms: 36
+    insert_time_ms: 21
     insert_new_count: 1118
     insert_reused_count: 103
 -   query: EXPLAIN select * from f5();
@@ -258,12 +258,12 @@ basic-sql-function-tests:
     explain: 'COVERING(T1_IDX1 [EQUALS promote(''b'' AS STRING), [LESS_THAN promote(103
         AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1
         AS COL1, _.COL2 AS COL2)'
-    task_count: 1172
-    task_total_time_ms: 187
-    transform_count: 267
-    transform_time_ms: 56
+    task_count: 1170
+    task_total_time_ms: 88
+    transform_count: 266
+    transform_time_ms: 20
     transform_yield_count: 98
-    insert_time_ms: 4
+    insert_time_ms: 2
     insert_new_count: 146
     insert_reused_count: 9
 -   query: EXPLAIN select * from f5(103);
@@ -271,24 +271,24 @@ basic-sql-function-tests:
     explain: 'COVERING(T1_IDX1 [EQUALS promote(''b'' AS STRING), [LESS_THAN promote(@c5
         AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1
         AS COL1, _.COL2 AS COL2)'
-    task_count: 1172
-    task_total_time_ms: 103
-    transform_count: 267
-    transform_time_ms: 24
+    task_count: 1170
+    task_total_time_ms: 89
+    transform_count: 266
+    transform_time_ms: 18
     transform_yield_count: 98
-    insert_time_ms: 3
+    insert_time_ms: 2
     insert_new_count: 146
     insert_reused_count: 9
 -   query: EXPLAIN select * from f5(b => 'b');
     ref: sql-functions.yamsql:154
     explain: 'COVERING(T1_IDX1 [EQUALS @c7, [LESS_THAN promote(103 AS LONG)]] -> [COL1:
         KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)'
-    task_count: 1156
-    task_total_time_ms: 74
-    transform_count: 262
-    transform_time_ms: 24
+    task_count: 1154
+    task_total_time_ms: 89
+    transform_count: 261
+    transform_time_ms: 20
     transform_yield_count: 96
-    insert_time_ms: 5
+    insert_time_ms: 2
     insert_new_count: 142
     insert_reused_count: 9
 -   query: EXPLAIN select * from f5(b => 'b', a => 103);
@@ -296,12 +296,12 @@ basic-sql-function-tests:
     explain: 'COVERING(T1_IDX1 [EQUALS @c7, [LESS_THAN promote(@c11 AS LONG)]] ->
         [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2
         AS COL2)'
-    task_count: 1156
-    task_total_time_ms: 189
-    transform_count: 262
-    transform_time_ms: 36
+    task_count: 1154
+    task_total_time_ms: 83
+    transform_count: 261
+    transform_time_ms: 18
     transform_yield_count: 96
-    insert_time_ms: 14
+    insert_time_ms: 2
     insert_new_count: 142
     insert_reused_count: 9
 -   query: EXPLAIN select * from f5(b => 'b', a => 102);
@@ -309,12 +309,12 @@ basic-sql-function-tests:
     explain: 'COVERING(T1_IDX1 [EQUALS @c7, [LESS_THAN promote(@c11 AS LONG)]] ->
         [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2
         AS COL2)'
-    task_count: 1156
-    task_total_time_ms: 189
-    transform_count: 262
-    transform_time_ms: 36
+    task_count: 1154
+    task_total_time_ms: 83
+    transform_count: 261
+    transform_time_ms: 18
     transform_yield_count: 96
-    insert_time_ms: 14
+    insert_time_ms: 2
     insert_new_count: 142
     insert_reused_count: 9
 -   query: EXPLAIN select * from f5(b => 'a', a => 102);
@@ -322,12 +322,12 @@ basic-sql-function-tests:
     explain: 'COVERING(T1_IDX1 [EQUALS @c7, [LESS_THAN promote(@c11 AS LONG)]] ->
         [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2
         AS COL2)'
-    task_count: 1156
-    task_total_time_ms: 189
-    transform_count: 262
-    transform_time_ms: 36
+    task_count: 1154
+    task_total_time_ms: 83
+    transform_count: 261
+    transform_time_ms: 18
     transform_yield_count: 96
-    insert_time_ms: 14
+    insert_time_ms: 2
     insert_new_count: 142
     insert_reused_count: 9
 -   query: EXPLAIN select * from f5(a => 102, b => 'a');
@@ -335,10 +335,10 @@ basic-sql-function-tests:
     explain: 'COVERING(T1_IDX1 [EQUALS @c11, [LESS_THAN promote(@c7 AS LONG)]] ->
         [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2
         AS COL2)'
-    task_count: 1156
-    task_total_time_ms: 86
-    transform_count: 262
-    transform_time_ms: 20
+    task_count: 1154
+    task_total_time_ms: 94
+    transform_count: 261
+    transform_time_ms: 21
     transform_yield_count: 96
     insert_time_ms: 2
     insert_new_count: 142
@@ -348,22 +348,22 @@ basic-sql-function-tests:
     explain: 'COVERING(T1_IDX1 [EQUALS promote(''b'' AS STRING), [LESS_THAN promote(@c5
         AS LONG)]] -> [COL1: KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1
         AS COL1, _.COL2 AS COL2)'
-    task_count: 1172
-    task_total_time_ms: 103
-    transform_count: 267
-    transform_time_ms: 24
+    task_count: 1170
+    task_total_time_ms: 89
+    transform_count: 266
+    transform_time_ms: 18
     transform_yield_count: 98
-    insert_time_ms: 3
+    insert_time_ms: 2
     insert_new_count: 146
     insert_reused_count: 9
 -   query: EXPLAIN select * from f5(102, 'a');
     ref: sql-functions.yamsql:178
     explain: 'COVERING(T1_IDX1 [EQUALS @c7, [LESS_THAN promote(@c5 AS LONG)]] -> [COL1:
         KEY:[1], COL2: KEY:[0], COL3: KEY:[2]]) | MAP (_.COL1 AS COL1, _.COL2 AS COL2)'
-    task_count: 1156
-    task_total_time_ms: 61
-    transform_count: 262
-    transform_time_ms: 16
+    task_count: 1154
+    task_total_time_ms: 89
+    transform_count: 261
+    transform_time_ms: 20
     transform_yield_count: 96
     insert_time_ms: 2
     insert_new_count: 142

--- a/yaml-tests/src/test/resources/user-defined-macro-function-tests.metrics.binpb
+++ b/yaml-tests/src/test/resources/user-defined-macro-function-tests.metrics.binpb
@@ -82,10 +82,10 @@ t
   3 -> 2 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   4 -> 3 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}Ä
+}ˇ
 J
-"user-defined-scalar-function-tests$EXPLAIN select * from table_func1(3)±
-ÛÛÇ¯Ä Ú†ª()0õˆN8A@zISCAN(I2 <,>) | FILTER _.ID LESS_THAN_OR_EQUALS promote(@c5 AS LONG) | MAP (_.ID AS ID, _.ID AS ID_COPY, _.R.V.Z AS Z_VAL)ñdigraph G {
+"user-defined-scalar-function-tests$EXPLAIN select * from table_func1(3)∞
+ÒÍúù æË’()0„ﬁ8A@zISCAN(I2 <,>) | FILTER _.ID LESS_THAN_OR_EQUALS promote(@c5 AS LONG) | MAP (_.ID AS ID, _.ID AS ID_COPY, _.R.V.Z AS Z_VAL)ñdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -99,7 +99,7 @@ J
 }æ
 L
 "user-defined-scalar-function-tests&EXPLAIN select * from table_func2(140)Ì
-êÂ÷ñÑ ú‡“(+0øá<8C@hISCAN(I2 [[GREATER_THAN_OR_EQUALS promote(@c5 AS LONG)]]) | MAP (_.ID AS PROCESSED_ID, _.R.V.Z AS Z_VAL)‰digraph G {
+éˆÿÉ ø€˝(+0ˆÌ48C@hISCAN(I2 [[GREATER_THAN_OR_EQUALS promote(@c5 AS LONG)]]) | MAP (_.ID AS PROCESSED_ID, _.R.V.Z AS Z_VAL)‰digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -111,7 +111,7 @@ L
 }Ì
 O
 "user-defined-scalar-function-tests)EXPLAIN select * from table_func3(20, 40)ô
-‚ÇáçX ≥¸¡(0£à18.@ñSCAN([IS SIMPLE_TABLE, [GREATER_THAN_OR_EQUALS promote(@c5 AS LONG) && LESS_THAN_OR_EQUALS promote(@c7 AS LONG)]]) | MAP (_.A AS A_VAL, _.A AS A_COPY)‚digraph G {
+‡óÈåW åÚŸ(0≠· 8.@ñSCAN([IS SIMPLE_TABLE, [GREATER_THAN_OR_EQUALS promote(@c5 AS LONG) && LESS_THAN_OR_EQUALS promote(@c7 AS LONG)]]) | MAP (_.A AS A_VAL, _.A AS A_COPY)‚digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -120,10 +120,10 @@ O
   3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Primary Storage</td></tr><tr><td align="left">record types: [SIMPLE_TABLE, NESTED, ORDER_T, PRICE_LIST, DEEP_NESTED_T]</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS A, STRING AS B, INT AS C)" ];
   3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q12> label="q12" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}§
+}£
 ™
-"user-defined-scalar-function-testsÉEXPLAIN select t1.id_copy as A, t2.processed_id as B from table_func1(2) t1, table_func2(100) t2 where t1.id_copy = t2.processed_idÙ
-Æ	ÙÍƒ+≤ Œ˛„(`0öñ¡8Ø@	–ISCAN(I2 [[GREATER_THAN_OR_EQUALS promote(@c21 AS LONG)]]) | FLATMAP q0 -> { ISCAN(I2 <,>) | FILTER _.ID EQUALS q0.ID AND _.ID LESS_THAN_OR_EQUALS promote(@c15 AS LONG) AS q1 RETURN (q1.ID AS A, q0.ID AS B) }Ädigraph G {
+"user-defined-scalar-function-testsÉEXPLAIN select t1.id_copy as A, t2.processed_id as B from table_func1(2) t1, table_func2(100) t2 where t1.id_copy = t2.processed_idÛ
+™	ÍÈÊ.∞ £ÚÅ(`0ò•v8Ø@	–ISCAN(I2 [[GREATER_THAN_OR_EQUALS promote(@c21 AS LONG)]]) | FLATMAP q0 -> { ISCAN(I2 <,>) | FILTER _.ID EQUALS q0.ID AND _.ID LESS_THAN_OR_EQUALS promote(@c15 AS LONG) AS q1 RETURN (q1.ID AS A, q0.ID AS B) }Ädigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -146,10 +146,10 @@ O
     rankDir=LR;
     2 -> 4 [ color="red" style="invis" ];
   }
-}€
+}⁄
 g
-"user-defined-scalar-function-testsAEXPLAIN select self(id_copy) as A, z_val as B from table_func1(4)Ô
-Û’⁄‰Ä çÑ¬()0™ÚI8A@eISCAN(I2 <,>) | FILTER _.ID LESS_THAN_OR_EQUALS promote(@c14 AS LONG) | MAP (_.ID AS A, _.R.V.Z AS B)Èdigraph G {
+"user-defined-scalar-function-testsAEXPLAIN select self(id_copy) as A, z_val as B from table_func1(4)Ó
+ÒÑ“¸ ˝Ôã()0≤„68A@eISCAN(I2 <,>) | FILTER _.ID LESS_THAN_OR_EQUALS promote(@c14 AS LONG) | MAP (_.ID AS A, _.R.V.Z AS B)Èdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -163,7 +163,7 @@ g
 }˛
 w
 "user-defined-scalar-function-testsQEXPLAIN select self(self(a_val)) as A, self(a_copy) as B from table_func3(10, 30)Ç
-‚ÈÃÿX µ÷®(0©‰$8.@èSCAN([IS SIMPLE_TABLE, [GREATER_THAN_OR_EQUALS promote(@c20 AS LONG) && LESS_THAN_OR_EQUALS promote(@c22 AS LONG)]]) | MAP (_.A AS A, _.A AS B)“digraph G {
+‡‹ŒÖW ‡ﬁ˚(0Ω…"8.@èSCAN([IS SIMPLE_TABLE, [GREATER_THAN_OR_EQUALS promote(@c20 AS LONG) && LESS_THAN_OR_EQUALS promote(@c22 AS LONG)]]) | MAP (_.A AS A, _.A AS B)“digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -175,7 +175,7 @@ w
 }Û
 b
 "user-defined-scalar-function-tests<EXPLAIN select * from table_func1(6) where self(id_copy) > 3å
-ÛÆˇ«Å ∑ß∞()0¸ËV8A@¶ISCAN(I2 <,>) | FILTER _.ID LESS_THAN_OR_EQUALS promote(@c5 AS LONG) AND _.ID GREATER_THAN promote(@c13 AS LONG) | MAP (_.ID AS ID, _.ID AS ID_COPY, _.R.V.Z AS Z_VAL)ƒdigraph G {
+Ò≥Ã≠Ä ¡Øë()0Öˇ68A@¶ISCAN(I2 <,>) | FILTER _.ID LESS_THAN_OR_EQUALS promote(@c5 AS LONG) AND _.ID GREATER_THAN promote(@c13 AS LONG) | MAP (_.ID AS ID, _.ID AS ID_COPY, _.R.V.Z AS Z_VAL)ƒdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;

--- a/yaml-tests/src/test/resources/user-defined-macro-function-tests.metrics.binpb
+++ b/yaml-tests/src/test/resources/user-defined-macro-function-tests.metrics.binpb
@@ -85,7 +85,7 @@ t
 }Ä
 J
 "user-defined-scalar-function-tests$EXPLAIN select * from table_func1(3)±
-˜‡˝ƒÑ Äù†()0÷Óo8A@zISCAN(I2 <,>) | FILTER _.ID LESS_THAN_OR_EQUALS promote(@c5 AS LONG) | MAP (_.ID AS ID, _.ID AS ID_COPY, _.R.V.Z AS Z_VAL)ñdigraph G {
+ı€¶Å	É £åØ()0€…8A@zISCAN(I2 <,>) | FILTER _.ID LESS_THAN_OR_EQUALS promote(@c5 AS LONG) | MAP (_.ID AS ID, _.ID AS ID_COPY, _.R.V.Z AS Z_VAL)ñdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -99,7 +99,7 @@ J
 }æ
 L
 "user-defined-scalar-function-tests&EXPLAIN select * from table_func2(140)Ì
-îﬂÌ®à ¿≤°(+0¨„R8C@hISCAN(I2 [[GREATER_THAN_OR_EQUALS promote(@c5 AS LONG)]]) | MAP (_.ID AS PROCESSED_ID, _.R.V.Z AS Z_VAL)‰digraph G {
+íÃÄÒá áÍ÷(+0ë£38C@hISCAN(I2 [[GREATER_THAN_OR_EQUALS promote(@c5 AS LONG)]]) | MAP (_.ID AS PROCESSED_ID, _.R.V.Z AS Z_VAL)‰digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -111,7 +111,7 @@ L
 }Ì
 O
 "user-defined-scalar-function-tests)EXPLAIN select * from table_func3(20, 40)ô
-ÊÎ˝ã\ Õ »(0Õ¶08.@ñSCAN([IS SIMPLE_TABLE, [GREATER_THAN_OR_EQUALS promote(@c5 AS LONG) && LESS_THAN_OR_EQUALS promote(@c7 AS LONG)]]) | MAP (_.A AS A_VAL, _.A AS A_COPY)‚digraph G {
+‰∑îû	[ ŸÁ¯(0çı8.@ñSCAN([IS SIMPLE_TABLE, [GREATER_THAN_OR_EQUALS promote(@c5 AS LONG) && LESS_THAN_OR_EQUALS promote(@c7 AS LONG)]]) | MAP (_.A AS A_VAL, _.A AS A_COPY)‚digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -120,10 +120,10 @@ O
   3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Primary Storage</td></tr><tr><td align="left">record types: [SIMPLE_TABLE, NESTED, ORDER_T, PRICE_LIST, DEEP_NESTED_T]</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS A, STRING AS B, INT AS C)" ];
   3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q12> label="q12" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}§
+}£
 ™
-"user-defined-scalar-function-testsÉEXPLAIN select t1.id_copy as A, t2.processed_id as B from table_func1(2) t1, table_func2(100) t2 where t1.id_copy = t2.processed_idÙ
-µ	„¿Öπ ‚Òì(`0Ü©û8Ø@	–ISCAN(I2 [[GREATER_THAN_OR_EQUALS promote(@c21 AS LONG)]]) | FLATMAP q0 -> { ISCAN(I2 <,>) | FILTER _.ID EQUALS q0.ID AND _.ID LESS_THAN_OR_EQUALS promote(@c15 AS LONG) AS q1 RETURN (q1.ID AS A, q0.ID AS B) }Ädigraph G {
+"user-defined-scalar-function-testsÉEXPLAIN select t1.id_copy as A, t2.processed_id as B from table_func1(2) t1, table_func2(100) t2 where t1.id_copy = t2.processed_idÛ
+±	´ﬁ©∑ Òß¿(`0≈ö>8Ø@	–ISCAN(I2 [[GREATER_THAN_OR_EQUALS promote(@c21 AS LONG)]]) | FLATMAP q0 -> { ISCAN(I2 <,>) | FILTER _.ID EQUALS q0.ID AND _.ID LESS_THAN_OR_EQUALS promote(@c15 AS LONG) AS q1 RETURN (q1.ID AS A, q0.ID AS B) }Ädigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -149,8 +149,7 @@ O
 }€
 g
 "user-defined-scalar-function-testsAEXPLAIN select self(id_copy) as A, z_val as B from table_func1(4)Ô
-˜‚‘œ
-Ñ ‰Î†()0±˛D8A@eISCAN(I2 <,>) | FILTER _.ID LESS_THAN_OR_EQUALS promote(@c14 AS LONG) | MAP (_.ID AS A, _.R.V.Z AS B)Èdigraph G {
+ı≈¢≠É ô´í()0Êï38A@eISCAN(I2 <,>) | FILTER _.ID LESS_THAN_OR_EQUALS promote(@c14 AS LONG) | MAP (_.ID AS A, _.R.V.Z AS B)Èdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -164,7 +163,7 @@ g
 }˛
 w
 "user-defined-scalar-function-testsQEXPLAIN select self(self(a_val)) as A, self(a_copy) as B from table_func3(10, 30)Ç
-ÊÕÂ£\ ÑÈí(0¶Û 8.@èSCAN([IS SIMPLE_TABLE, [GREATER_THAN_OR_EQUALS promote(@c20 AS LONG) && LESS_THAN_OR_EQUALS promote(@c22 AS LONG)]]) | MAP (_.A AS A, _.A AS B)“digraph G {
+‰”®¸[ ˜ÓÁ(0 ∂"8.@èSCAN([IS SIMPLE_TABLE, [GREATER_THAN_OR_EQUALS promote(@c20 AS LONG) && LESS_THAN_OR_EQUALS promote(@c22 AS LONG)]]) | MAP (_.A AS A, _.A AS B)“digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -176,7 +175,7 @@ w
 }Û
 b
 "user-defined-scalar-function-tests<EXPLAIN select * from table_func1(6) where self(id_copy) > 3å
-ä…¡˛â ç›ä(*0ÕŸ@8D@¶ISCAN(I2 <,>) | FILTER _.ID LESS_THAN_OR_EQUALS promote(@c5 AS LONG) AND _.ID GREATER_THAN promote(@c13 AS LONG) | MAP (_.ID AS ID, _.ID AS ID_COPY, _.R.V.Z AS Z_VAL)ƒdigraph G {
+àÙ©ûà ≥é°(*0—∆38D@¶ISCAN(I2 <,>) | FILTER _.ID LESS_THAN_OR_EQUALS promote(@c5 AS LONG) AND _.ID GREATER_THAN promote(@c13 AS LONG) | MAP (_.ID AS ID, _.ID AS ID_COPY, _.R.V.Z AS Z_VAL)ƒdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;

--- a/yaml-tests/src/test/resources/user-defined-macro-function-tests.metrics.yaml
+++ b/yaml-tests/src/test/resources/user-defined-macro-function-tests.metrics.yaml
@@ -77,22 +77,22 @@ user-defined-scalar-function-tests:
     ref: user-defined-macro-function-tests.yamsql:108
     explain: ISCAN(I2 <,>) | FILTER _.ID LESS_THAN_OR_EQUALS promote(@c5 AS LONG)
         | MAP (_.ID AS ID, _.ID AS ID_COPY, _.R.V.Z AS Z_VAL)
-    task_count: 499
-    task_total_time_ms: 41
-    transform_count: 128
-    transform_time_ms: 11
+    task_count: 497
+    task_total_time_ms: 10
+    transform_count: 127
+    transform_time_ms: 3
     transform_yield_count: 41
-    insert_time_ms: 1
+    insert_time_ms: 0
     insert_new_count: 65
     insert_reused_count: 4
 -   query: EXPLAIN select * from table_func2(140)
     ref: user-defined-macro-function-tests.yamsql:113
     explain: ISCAN(I2 [[GREATER_THAN_OR_EQUALS promote(@c5 AS LONG)]]) | MAP (_.ID
         AS PROCESSED_ID, _.R.V.Z AS Z_VAL)
-    task_count: 528
-    task_total_time_ms: 44
-    transform_count: 132
-    transform_time_ms: 9
+    task_count: 526
+    task_total_time_ms: 39
+    transform_count: 131
+    transform_time_ms: 8
     transform_yield_count: 43
     insert_time_ms: 0
     insert_new_count: 67
@@ -101,10 +101,10 @@ user-defined-scalar-function-tests:
     ref: user-defined-macro-function-tests.yamsql:118
     explain: SCAN([IS SIMPLE_TABLE, [GREATER_THAN_OR_EQUALS promote(@c5 AS LONG) &&
         LESS_THAN_OR_EQUALS promote(@c7 AS LONG)]]) | MAP (_.A AS A_VAL, _.A AS A_COPY)
-    task_count: 354
-    task_total_time_ms: 31
-    transform_count: 88
-    transform_time_ms: 7
+    task_count: 352
+    task_total_time_ms: 29
+    transform_count: 87
+    transform_time_ms: 5
     transform_yield_count: 29
     insert_time_ms: 0
     insert_new_count: 46
@@ -115,24 +115,24 @@ user-defined-scalar-function-tests:
     explain: ISCAN(I2 [[GREATER_THAN_OR_EQUALS promote(@c21 AS LONG)]]) | FLATMAP
         q0 -> { ISCAN(I2 <,>) | FILTER _.ID EQUALS q0.ID AND _.ID LESS_THAN_OR_EQUALS
         promote(@c15 AS LONG) AS q1 RETURN (q1.ID AS A, q0.ID AS B) }
-    task_count: 1198
-    task_total_time_ms: 91
-    transform_count: 306
-    transform_time_ms: 33
+    task_count: 1194
+    task_total_time_ms: 98
+    transform_count: 304
+    transform_time_ms: 29
     transform_yield_count: 96
-    insert_time_ms: 3
+    insert_time_ms: 1
     insert_new_count: 175
     insert_reused_count: 9
 -   query: EXPLAIN select self(id_copy) as A, z_val as B from table_func1(4)
     ref: user-defined-macro-function-tests.yamsql:128
     explain: ISCAN(I2 <,>) | FILTER _.ID LESS_THAN_OR_EQUALS promote(@c14 AS LONG)
         | MAP (_.ID AS A, _.R.V.Z AS B)
-    task_count: 499
-    task_total_time_ms: 45
-    transform_count: 128
-    transform_time_ms: 11
+    task_count: 497
+    task_total_time_ms: 37
+    transform_count: 127
+    transform_time_ms: 8
     transform_yield_count: 41
-    insert_time_ms: 1
+    insert_time_ms: 0
     insert_new_count: 65
     insert_reused_count: 4
 -   query: EXPLAIN select self(self(a_val)) as A, self(a_copy) as B from table_func3(10,
@@ -140,9 +140,9 @@ user-defined-scalar-function-tests:
     ref: user-defined-macro-function-tests.yamsql:133
     explain: SCAN([IS SIMPLE_TABLE, [GREATER_THAN_OR_EQUALS promote(@c20 AS LONG)
         && LESS_THAN_OR_EQUALS promote(@c22 AS LONG)]]) | MAP (_.A AS A, _.A AS B)
-    task_count: 354
-    task_total_time_ms: 30
-    transform_count: 88
+    task_count: 352
+    task_total_time_ms: 29
+    transform_count: 87
     transform_time_ms: 6
     transform_yield_count: 29
     insert_time_ms: 0
@@ -153,12 +153,12 @@ user-defined-scalar-function-tests:
     explain: ISCAN(I2 <,>) | FILTER _.ID LESS_THAN_OR_EQUALS promote(@c5 AS LONG)
         AND _.ID GREATER_THAN promote(@c13 AS LONG) | MAP (_.ID AS ID, _.ID AS ID_COPY,
         _.R.V.Z AS Z_VAL)
-    task_count: 499
-    task_total_time_ms: 47
-    transform_count: 129
-    transform_time_ms: 15
+    task_count: 497
+    task_total_time_ms: 38
+    transform_count: 128
+    transform_time_ms: 8
     transform_yield_count: 41
-    insert_time_ms: 1
+    insert_time_ms: 0
     insert_new_count: 65
     insert_reused_count: 4
 -   query: EXPLAIN select id, abcd(a) as d_val from deep_nested_t

--- a/yaml-tests/src/test/resources/user-defined-macro-function-tests.metrics.yaml
+++ b/yaml-tests/src/test/resources/user-defined-macro-function-tests.metrics.yaml
@@ -77,34 +77,34 @@ user-defined-scalar-function-tests:
     ref: user-defined-macro-function-tests.yamsql:108
     explain: ISCAN(I2 <,>) | FILTER _.ID LESS_THAN_OR_EQUALS promote(@c5 AS LONG)
         | MAP (_.ID AS ID, _.ID AS ID_COPY, _.R.V.Z AS Z_VAL)
-    task_count: 503
-    task_total_time_ms: 45
-    transform_count: 132
-    transform_time_ms: 11
+    task_count: 501
+    task_total_time_ms: 18
+    transform_count: 131
+    transform_time_ms: 4
     transform_yield_count: 41
-    insert_time_ms: 1
+    insert_time_ms: 0
     insert_new_count: 65
     insert_reused_count: 4
 -   query: EXPLAIN select * from table_func2(140)
     ref: user-defined-macro-function-tests.yamsql:113
     explain: ISCAN(I2 [[GREATER_THAN_OR_EQUALS promote(@c5 AS LONG)]]) | MAP (_.ID
         AS PROCESSED_ID, _.R.V.Z AS Z_VAL)
-    task_count: 532
-    task_total_time_ms: 34
-    transform_count: 136
-    transform_time_ms: 8
+    task_count: 530
+    task_total_time_ms: 37
+    transform_count: 135
+    transform_time_ms: 9
     transform_yield_count: 43
-    insert_time_ms: 1
+    insert_time_ms: 0
     insert_new_count: 67
     insert_reused_count: 3
 -   query: EXPLAIN select * from table_func3(20, 40)
     ref: user-defined-macro-function-tests.yamsql:118
     explain: SCAN([IS SIMPLE_TABLE, [GREATER_THAN_OR_EQUALS promote(@c5 AS LONG) &&
         LESS_THAN_OR_EQUALS promote(@c7 AS LONG)]]) | MAP (_.A AS A_VAL, _.A AS A_COPY)
-    task_count: 358
-    task_total_time_ms: 16
-    transform_count: 92
-    transform_time_ms: 5
+    task_count: 356
+    task_total_time_ms: 19
+    transform_count: 91
+    transform_time_ms: 4
     transform_yield_count: 29
     insert_time_ms: 0
     insert_new_count: 46
@@ -115,24 +115,24 @@ user-defined-scalar-function-tests:
     explain: ISCAN(I2 [[GREATER_THAN_OR_EQUALS promote(@c21 AS LONG)]]) | FLATMAP
         q0 -> { ISCAN(I2 <,>) | FILTER _.ID EQUALS q0.ID AND _.ID LESS_THAN_OR_EQUALS
         promote(@c15 AS LONG) AS q1 RETURN (q1.ID AS A, q0.ID AS B) }
-    task_count: 1205
-    task_total_time_ms: 60
-    transform_count: 313
-    transform_time_ms: 23
+    task_count: 1201
+    task_total_time_ms: 34
+    transform_count: 311
+    transform_time_ms: 11
     transform_yield_count: 96
-    insert_time_ms: 2
+    insert_time_ms: 1
     insert_new_count: 175
     insert_reused_count: 9
 -   query: EXPLAIN select self(id_copy) as A, z_val as B from table_func1(4)
     ref: user-defined-macro-function-tests.yamsql:128
     explain: ISCAN(I2 <,>) | FILTER _.ID LESS_THAN_OR_EQUALS promote(@c14 AS LONG)
         | MAP (_.ID AS A, _.R.V.Z AS B)
-    task_count: 503
-    task_total_time_ms: 22
-    transform_count: 132
-    transform_time_ms: 6
+    task_count: 501
+    task_total_time_ms: 38
+    transform_count: 131
+    transform_time_ms: 8
     transform_yield_count: 41
-    insert_time_ms: 1
+    insert_time_ms: 0
     insert_new_count: 65
     insert_reused_count: 4
 -   query: EXPLAIN select self(self(a_val)) as A, self(a_copy) as B from table_func3(10,
@@ -140,10 +140,10 @@ user-defined-scalar-function-tests:
     ref: user-defined-macro-function-tests.yamsql:133
     explain: SCAN([IS SIMPLE_TABLE, [GREATER_THAN_OR_EQUALS promote(@c20 AS LONG)
         && LESS_THAN_OR_EQUALS promote(@c22 AS LONG)]]) | MAP (_.A AS A, _.A AS B)
-    task_count: 358
-    task_total_time_ms: 17
-    transform_count: 92
-    transform_time_ms: 4
+    task_count: 356
+    task_total_time_ms: 29
+    transform_count: 91
+    transform_time_ms: 7
     transform_yield_count: 29
     insert_time_ms: 0
     insert_new_count: 46
@@ -153,12 +153,12 @@ user-defined-scalar-function-tests:
     explain: ISCAN(I2 <,>) | FILTER _.ID LESS_THAN_OR_EQUALS promote(@c5 AS LONG)
         AND _.ID GREATER_THAN promote(@c13 AS LONG) | MAP (_.ID AS ID, _.ID AS ID_COPY,
         _.R.V.Z AS Z_VAL)
-    task_count: 522
-    task_total_time_ms: 25
-    transform_count: 137
+    task_count: 520
+    task_total_time_ms: 31
+    transform_count: 136
     transform_time_ms: 8
     transform_yield_count: 42
-    insert_time_ms: 1
+    insert_time_ms: 0
     insert_new_count: 68
     insert_reused_count: 5
 -   query: EXPLAIN select id, abcd(a) as d_val from deep_nested_t

--- a/yaml-tests/src/test/resources/valid-identifiers.metrics.binpb
+++ b/yaml-tests/src/test/resources/valid-identifiers.metrics.binpb
@@ -301,7 +301,7 @@ D
 }²
 8
 	all-tests+EXPLAIN select * from "__$func3"(10, 1, 1);õ
-—ÏĞûi¾ ”‹Ÿ(u0Ï¯ì8—@˜SCAN([IS my__1adjacency__1list, EQUALS promote(@c7 AS LONG)]) | FLATMAP q0 -> { SCAN([IS my__1adjacency__1list, [LESS_THAN promote(@c5 AS LONG)]]) | FILTER _.my__parent EQUALS promote(@c7 AS LONG) AS q1 RETURN (q1.me AS _0, q1.my__parent AS _1, q0.me AS _2, q0.my__parent AS _3) }¹digraph G {
+‡ÖÌ‘C¸ Õúê(u0ƒÛà8—@˜SCAN([IS my__1adjacency__1list, EQUALS promote(@c7 AS LONG)]) | FLATMAP q0 -> { SCAN([IS my__1adjacency__1list, [LESS_THAN promote(@c5 AS LONG)]]) | FILTER _.my__parent EQUALS promote(@c7 AS LONG) AS q1 RETURN (q1.me AS _0, q1.my__parent AS _1, q0.me AS _2, q0.my__parent AS _3) }¹digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -327,7 +327,7 @@ D
 }ñ
 -
 	all-tests EXPLAIN select * from "$yay"(5);¿
-âÑÚı	Z ¬™œ(0æÑ(8/@qSCAN([IS foo__2tableE]) | FILTER _.foo.tableE.E3.S1 EQUALS promote(@c5 AS LONG) | MAP (_.foo.tableE.E1 AS _$x.id)®digraph G {
+àÇ×ÉY õªÍ(0äã8/@qSCAN([IS foo__2tableE]) | FILTER _.foo.tableE.E3.S1 EQUALS promote(@c5 AS LONG) | MAP (_.foo.tableE.E1 AS _$x.id)®digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -341,7 +341,7 @@ D
 }ó
 /
 	all-tests"EXPLAIN select * from "__2yay"(6);¿
-âİû¤Z î¢é(0³§.8/@qSCAN([IS foo__2tableE]) | FILTER _.foo.tableE.E3.S1 EQUALS promote(@c5 AS LONG) | MAP (_.foo.tableE.E1 AS _$y.id)®digraph G {
+àÃ¤Y Ñ’‹(0í²)8/@qSCAN([IS foo__2tableE]) | FILTER _.foo.tableE.E3.S1 EQUALS promote(@c5 AS LONG) | MAP (_.foo.tableE.E1 AS _$y.id)®digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -355,7 +355,7 @@ D
 }ü
 8
 	all-tests+EXPLAIN select * from "à¤¨à¤®à¤¸à¥à¤¤"(4);¿
-âÚè‘Z ¸°Ã(0µ:8/@qSCAN([IS foo__2tableE]) | FILTER _.foo.tableE.E3.S1 EQUALS promote(@c5 AS LONG) | MAP (_.foo.tableE.E1 AS _$z.id)®digraph G {
+àÌ»±Y ÅµŠ(0 ô%8/@qSCAN([IS foo__2tableE]) | FILTER _.foo.tableE.E3.S1 EQUALS promote(@c5 AS LONG) | MAP (_.foo.tableE.E1 AS _$z.id)®digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -748,7 +748,7 @@ unnamed-12=EXPLAIN SELECT "__T3$COL2" FROM "__T3" WHERE "__T3$COL2" > 13Ê
 9
 
 unnamed-12+EXPLAIN SELECT * FROM "__func__T3$col2"(13)
-âöÈÿZ ıœÕ(0õ¢$8/@oSCAN([IS __T3]) | FILTER _.__T3$COL2 EQUALS promote(@c5 AS LONG) | MAP (_.__T3$COL1 AS c.1, _.__T3$COL3 AS c.2)şdigraph G {
+àƒ‘ö	Y ¤ë(0ÑÕ8/@oSCAN([IS __T3]) | FILTER _.__T3$COL2 EQUALS promote(@c5 AS LONG) | MAP (_.__T3$COL1 AS c.1, _.__T3$COL3 AS c.2)şdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;

--- a/yaml-tests/src/test/resources/valid-identifiers.metrics.binpb
+++ b/yaml-tests/src/test/resources/valid-identifiers.metrics.binpb
@@ -301,7 +301,7 @@ D
 }≤
 8
 	all-tests+EXPLAIN select * from "__$func3"(10, 1, 1);ı
-ØÿçîP÷ ÁÓÚ(u0˝Àâ8ó@òSCAN([IS my__1adjacency__1list, EQUALS promote(@c7 AS LONG)]) | FLATMAP q0 -> { SCAN([IS my__1adjacency__1list, [LESS_THAN promote(@c5 AS LONG)]]) | FILTER _.my__parent EQUALS promote(@c7 AS LONG) AS q1 RETURN (q1.me AS _0, q1.my__parent AS _1, q0.me AS _2, q0.my__parent AS _3) }πdigraph G {
+ü»˛Õ/– À—π(u0πõ¸8ó@òSCAN([IS my__1adjacency__1list, EQUALS promote(@c7 AS LONG)]) | FLATMAP q0 -> { SCAN([IS my__1adjacency__1list, [LESS_THAN promote(@c5 AS LONG)]]) | FILTER _.my__parent EQUALS promote(@c7 AS LONG) AS q1 RETURN (q1.me AS _0, q1.my__parent AS _1, q0.me AS _2, q0.my__parent AS _3) }πdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -327,8 +327,7 @@ D
 }Ò
 -
 	all-tests EXPLAIN select * from "$yay"(5);ø
-Êâ°Ê
-^ Æ∫Ã(0ÂÕ*8/@qSCAN([IS foo__2tableE]) | FILTER _.foo.tableE.E3.S1 EQUALS promote(@c5 AS LONG) | MAP (_.foo.tableE.E1 AS _$x.id)Ædigraph G {
+‰¿·ä] √Âñ(0ú¥#8/@qSCAN([IS foo__2tableE]) | FILTER _.foo.tableE.E3.S1 EQUALS promote(@c5 AS LONG) | MAP (_.foo.tableE.E1 AS _$x.id)Ædigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -342,7 +341,7 @@ D
 }Û
 /
 	all-tests"EXPLAIN select * from "__2yay"(6);ø
-Ê»ˇ‘^ œ¿π(0ÛÜ-8/@qSCAN([IS foo__2tableE]) | FILTER _.foo.tableE.E3.S1 EQUALS promote(@c5 AS LONG) | MAP (_.foo.tableE.E1 AS _$y.id)Ædigraph G {
+‰óã˜] ß¬ä(0ˆ•'8/@qSCAN([IS foo__2tableE]) | FILTER _.foo.tableE.E3.S1 EQUALS promote(@c5 AS LONG) | MAP (_.foo.tableE.E1 AS _$y.id)Ædigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -356,7 +355,7 @@ D
 }¸
 8
 	all-tests+EXPLAIN select * from "‡§®‡§Æ‡§∏‡•ç‡§§"(4);ø
-Ê≈Éﬂ	^ ó°ˆ(0‡ã.8/@qSCAN([IS foo__2tableE]) | FILTER _.foo.tableE.E3.S1 EQUALS promote(@c5 AS LONG) | MAP (_.foo.tableE.E1 AS _$z.id)Ædigraph G {
+‰á—Ô] ñÊÑ(0çñ%8/@qSCAN([IS foo__2tableE]) | FILTER _.foo.tableE.E3.S1 EQUALS promote(@c5 AS LONG) | MAP (_.foo.tableE.E1 AS _$z.id)Ædigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -745,12 +744,11 @@ unnamed-12=EXPLAIN SELECT "__T3$COL2" FROM "__T3" WHERE "__T3$COL2" > 13 
   3 -> 2 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   4 -> 3 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q22> label="q22" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}À
+} 
 9
 
-unnamed-12+EXPLAIN SELECT * FROM "__func__T3$col2"(13)ç
-Ê…“ë
-^ ˛»∫(0£•'8/@oSCAN([IS __T3]) | FILTER _.__T3$COL2 EQUALS promote(@c5 AS LONG) | MAP (_.__T3$COL1 AS c.1, _.__T3$COL3 AS c.2)˛digraph G {
+unnamed-12+EXPLAIN SELECT * FROM "__func__T3$col2"(13)å
+‰–¥Ò] ˜’x(0ß˜8/@oSCAN([IS __T3]) | FILTER _.__T3$COL2 EQUALS promote(@c5 AS LONG) | MAP (_.__T3$COL1 AS c.1, _.__T3$COL3 AS c.2)˛digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;

--- a/yaml-tests/src/test/resources/valid-identifiers.metrics.yaml
+++ b/yaml-tests/src/test/resources/valid-identifiers.metrics.yaml
@@ -275,22 +275,22 @@ all-tests:
         q0 -> { SCAN([IS my__1adjacency__1list, [LESS_THAN promote(@c5 AS LONG)]])
         | FILTER _.my__parent EQUALS promote(@c7 AS LONG) AS q1 RETURN (q1.me AS _0,
         q1.my__parent AS _1, q0.me AS _2, q0.my__parent AS _3) }
-    task_count: 1455
-    task_total_time_ms: 168
-    transform_count: 342
-    transform_time_ms: 41
+    task_count: 1439
+    task_total_time_ms: 99
+    transform_count: 336
+    transform_time_ms: 24
     transform_yield_count: 117
-    insert_time_ms: 8
+    insert_time_ms: 4
     insert_new_count: 279
     insert_reused_count: 17
 -   query: EXPLAIN select * from "$yay"(5);
     ref: valid-identifiers.yamsql:360
     explain: SCAN([IS foo__2tableE]) | FILTER _.foo.tableE.E3.S1 EQUALS promote(@c5
         AS LONG) | MAP (_.foo.tableE.E1 AS _$x.id)
-    task_count: 358
-    task_total_time_ms: 22
-    transform_count: 94
-    transform_time_ms: 5
+    task_count: 356
+    task_total_time_ms: 23
+    transform_count: 93
+    transform_time_ms: 4
     transform_yield_count: 28
     insert_time_ms: 0
     insert_new_count: 47
@@ -299,10 +299,10 @@ all-tests:
     ref: valid-identifiers.yamsql:364
     explain: SCAN([IS foo__2tableE]) | FILTER _.foo.tableE.E3.S1 EQUALS promote(@c5
         AS LONG) | MAP (_.foo.tableE.E1 AS _$y.id)
-    task_count: 358
-    task_total_time_ms: 26
-    transform_count: 94
-    transform_time_ms: 5
+    task_count: 356
+    task_total_time_ms: 27
+    transform_count: 93
+    transform_time_ms: 4
     transform_yield_count: 28
     insert_time_ms: 0
     insert_new_count: 47
@@ -311,10 +311,10 @@ all-tests:
     ref: valid-identifiers.yamsql:368
     explain: SCAN([IS foo__2tableE]) | FILTER _.foo.tableE.E3.S1 EQUALS promote(@c5
         AS LONG) | MAP (_.foo.tableE.E1 AS _$z.id)
-    task_count: 358
-    task_total_time_ms: 20
-    transform_count: 94
-    transform_time_ms: 6
+    task_count: 356
+    task_total_time_ms: 26
+    transform_count: 93
+    transform_time_ms: 4
     transform_yield_count: 28
     insert_time_ms: 0
     insert_new_count: 47
@@ -648,10 +648,10 @@ unnamed-12:
     ref: valid-identifiers.yamsql:702
     explain: SCAN([IS __T3]) | FILTER _.__T3$COL2 EQUALS promote(@c5 AS LONG) | MAP
         (_.__T3$COL1 AS c.1, _.__T3$COL3 AS c.2)
-    task_count: 358
-    task_total_time_ms: 21
-    transform_count: 94
-    transform_time_ms: 5
+    task_count: 356
+    task_total_time_ms: 8
+    transform_count: 93
+    transform_time_ms: 1
     transform_yield_count: 28
     insert_time_ms: 0
     insert_new_count: 47

--- a/yaml-tests/src/test/resources/valid-identifiers.metrics.yaml
+++ b/yaml-tests/src/test/resources/valid-identifiers.metrics.yaml
@@ -275,22 +275,22 @@ all-tests:
         q0 -> { SCAN([IS my__1adjacency__1list, [LESS_THAN promote(@c5 AS LONG)]])
         | FILTER _.my__parent EQUALS promote(@c7 AS LONG) AS q1 RETURN (q1.me AS _0,
         q1.my__parent AS _1, q0.me AS _2, q0.my__parent AS _3) }
-    task_count: 1431
-    task_total_time_ms: 222
-    transform_count: 318
-    transform_time_ms: 52
+    task_count: 1415
+    task_total_time_ms: 140
+    transform_count: 312
+    transform_time_ms: 31
     transform_yield_count: 117
-    insert_time_ms: 10
+    insert_time_ms: 3
     insert_new_count: 279
     insert_reused_count: 17
 -   query: EXPLAIN select * from "$yay"(5);
     ref: valid-identifiers.yamsql:360
     explain: SCAN([IS foo__2tableE]) | FILTER _.foo.tableE.E3.S1 EQUALS promote(@c5
         AS LONG) | MAP (_.foo.tableE.E1 AS _$x.id)
-    task_count: 354
-    task_total_time_ms: 20
-    transform_count: 90
-    transform_time_ms: 4
+    task_count: 352
+    task_total_time_ms: 17
+    transform_count: 89
+    transform_time_ms: 3
     transform_yield_count: 28
     insert_time_ms: 0
     insert_new_count: 47
@@ -299,10 +299,10 @@ all-tests:
     ref: valid-identifiers.yamsql:364
     explain: SCAN([IS foo__2tableE]) | FILTER _.foo.tableE.E3.S1 EQUALS promote(@c5
         AS LONG) | MAP (_.foo.tableE.E1 AS _$y.id)
-    task_count: 354
-    task_total_time_ms: 27
-    transform_count: 90
-    transform_time_ms: 5
+    task_count: 352
+    task_total_time_ms: 25
+    transform_count: 89
+    transform_time_ms: 4
     transform_yield_count: 28
     insert_time_ms: 0
     insert_new_count: 47
@@ -311,10 +311,10 @@ all-tests:
     ref: valid-identifiers.yamsql:368
     explain: SCAN([IS foo__2tableE]) | FILTER _.foo.tableE.E3.S1 EQUALS promote(@c5
         AS LONG) | MAP (_.foo.tableE.E1 AS _$z.id)
-    task_count: 354
-    task_total_time_ms: 38
-    transform_count: 90
-    transform_time_ms: 9
+    task_count: 352
+    task_total_time_ms: 23
+    transform_count: 89
+    transform_time_ms: 4
     transform_yield_count: 28
     insert_time_ms: 0
     insert_new_count: 47
@@ -648,9 +648,9 @@ unnamed-12:
     ref: valid-identifiers.yamsql:702
     explain: SCAN([IS __T3]) | FILTER _.__T3$COL2 EQUALS promote(@c5 AS LONG) | MAP
         (_.__T3$COL1 AS c.1, _.__T3$COL3 AS c.2)
-    task_count: 354
-    task_total_time_ms: 16
-    transform_count: 90
+    task_count: 352
+    task_total_time_ms: 20
+    transform_count: 89
     transform_time_ms: 3
     transform_yield_count: 28
     insert_time_ms: 0

--- a/yaml-tests/src/test/resources/versions-tests.metrics.binpb
+++ b/yaml-tests/src/test/resources/versions-tests.metrics.binpb
@@ -164,10 +164,10 @@ H
   3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">I1</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS COL1, LONG AS COL2, VERSION AS __ROW_VERSION)" ];
   3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}¥
+}≥
 8
-versions-queries$EXPLAIN select t1_v.* from t1_v(10);˜
-œÕ¬Ì0“ ı÷ì(G0¯≈£8i@|ISCAN(I1 [EQUALS promote(@c7 AS LONG)]) | MAP (_.__ROW_VERSION AS __ROW_VERSION, _.ID AS ID, _.COL1 AS COL1, _.COL2 AS COL2)Ÿdigraph G {
+versions-queries$EXPLAIN select t1_v.* from t1_v(10);ˆ
+ÕÌ≥√ — éçœ(G0≥≠h8i@|ISCAN(I1 [EQUALS promote(@c7 AS LONG)]) | MAP (_.__ROW_VERSION AS __ROW_VERSION, _.ID AS ID, _.COL1 AS COL1, _.COL2 AS COL2)Ÿdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -201,11 +201,10 @@ H
   3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">I1</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS COL1, LONG AS COL2, VERSION AS __ROW_VERSION)" ];
   3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}õ
+}ö
 Ñ
-versions-queriespEXPLAIN select s.version, s.col2 from (select "__ROW_VERSION" as version, t1_v.col2 as col2 from t1_v(10)) AS s;ë
-ËÊ¿Ø(◊ ıæŸ
-(I0√˜ù8m@[ISCAN(I1 [EQUALS promote(@c23 AS LONG)]) | MAP (_.__ROW_VERSION AS VERSION, _.COL2 AS COL2)îdigraph G {
+versions-queriespEXPLAIN select s.version, s.col2 from (select "__ROW_VERSION" as version, t1_v.col2 as col2 from t1_v(10)) AS s;ê
+Êñ÷û÷ ƒ¨œ(I0–¢d8m@[ISCAN(I1 [EQUALS promote(@c23 AS LONG)]) | MAP (_.__ROW_VERSION AS VERSION, _.COL2 AS COL2)îdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -336,7 +335,7 @@ r
 }Ø
 l
 versions-queriesXEXPLAIN select t1_v."__ROW_VERSION", t1_v.id from t1_v(20) order by "__ROW_VERSION" ASC;æ
-Û¸¯—Ñ öèÇ	(40ù∫O8>@pISCAN(GROUPED_VERSION_INDEX [EQUALS promote(@c11 AS LONG)]) | MAP (_.__ROW_VERSION AS __ROW_VERSION, _.ID AS ID)≠digraph G {
+ÒÇ˚•É ≥¬‡(40«“08>@pISCAN(GROUPED_VERSION_INDEX [EQUALS promote(@c11 AS LONG)]) | MAP (_.__ROW_VERSION AS __ROW_VERSION, _.ID AS ID)≠digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -522,7 +521,7 @@ b
 }Á
 `
 versions-queriesLEXPLAIN select * from unindexed_t_v(30) where col2 = 'odd' or col2 = 'even';Ç
-˙¬°îb Øàç(0À¢R88@ÏSCAN([IS UNINDEXED_T]) | FILTER (_.COL2 EQUALS promote(@c10 AS STRING) OR _.COL2 EQUALS promote(@c14 AS STRING)) AND _.COL1 EQUALS promote(@c5 AS LONG) | MAP (_.__ROW_VERSION AS __ROW_VERSION, _.ID AS ID, _.COL1 AS COL1, _.COL2 AS COL2)ıdigraph G {
+¯√áâa ˆ”ú(0œ⁄188@ÏSCAN([IS UNINDEXED_T]) | FILTER (_.COL2 EQUALS promote(@c10 AS STRING) OR _.COL2 EQUALS promote(@c14 AS STRING)) AND _.COL1 EQUALS promote(@c5 AS LONG) | MAP (_.__ROW_VERSION AS __ROW_VERSION, _.ID AS ID, _.COL1 AS COL1, _.COL2 AS COL2)ıdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -662,7 +661,7 @@ y
 }ª(
 ÿ
 versions-queries√EXPLAIN select a.version AS version3, a.r.id AS id3, b.version AS version4, b.r.id AS id4, a.r.col2, b.r.col4 from t3_by_col1('b') a, t4_by_col1('b') b where 2 in b.r.col4 and b.r.col2 = a.r.col2›&
-Øô‘–ßò ï›çr(‚0…¬Ÿ8˙@*‰COVERING(T3_VERSION_WITH_COL1 <,> -> [COL1: VALUE:[0], ID: KEY:[2]]) | FILTER _.COL1 EQUALS @c43 | FETCH | FLATMAP q0 -> { ISCAN(T4_COL2 [EQUALS q0.COL2]) | FILTER _.COL1 EQUALS @c43 AND promote(@c53 AS LONG) IN _.COL4 AS q1 RETURN (q0.__ROW_VERSION AS VERSION3, q0.ID AS ID3, q1.__ROW_VERSION AS VERSION4, q1.ID AS ID4, q0.COL2 AS COL2, q1.COL4 AS COL4) }”#digraph G {
+´ﬂÆ˛Õñ ùãπM(‚0‹Ñû8˙@*‰COVERING(T3_VERSION_WITH_COL1 <,> -> [COL1: VALUE:[0], ID: KEY:[2]]) | FILTER _.COL1 EQUALS @c43 | FETCH | FLATMAP q0 -> { ISCAN(T4_COL2 [EQUALS q0.COL2]) | FILTER _.COL1 EQUALS @c43 AND promote(@c53 AS LONG) IN _.COL4 AS q1 RETURN (q0.__ROW_VERSION AS VERSION3, q0.ID AS ID3, q1.__ROW_VERSION AS VERSION4, q1.ID AS ID4, q0.COL2 AS COL2, q1.COL4 AS COL4) }”#digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -812,8 +811,8 @@ c
 }Ÿ$
 e
 versions-queriesQEXPLAIN select (A.*), (B.*) from t2_v(2) as A, t3_v(2) as B where A.col2 = B.col1Ô#
-º
-∆≥Øx‚ Æ≤ª'(n0¸°á8ƒ@	ÌISCAN(T3_VERSION_WITH_COL1 <,>) | FILTER _.COL2 EQUALS promote(@c15 AS LONG) | FLATMAP q0 -> { ISCAN(T2_COL2 [EQUALS q0.COL1]) | FILTER _.COL1 EQUALS promote(@c15 AS LONG) AS q1 RETURN ((q1.__ROW_VERSION AS __ROW_VERSION, q1.ID AS ID, q1.COL1 AS COL1, q1.COL2 AS COL2) AS A, (q0.__ROW_VERSION AS __ROW_VERSION, q0.ID AS ID, q0.COL1 AS COL1, q0.COL2 AS COL2) AS B) }ﬁ digraph G {
+∏
+“∞ÜS‡ €ó¡(n0îóß8ƒ@	ÌISCAN(T3_VERSION_WITH_COL1 <,>) | FILTER _.COL2 EQUALS promote(@c15 AS LONG) | FLATMAP q0 -> { ISCAN(T2_COL2 [EQUALS q0.COL1]) | FILTER _.COL1 EQUALS promote(@c15 AS LONG) AS q1 RETURN ((q1.__ROW_VERSION AS __ROW_VERSION, q1.ID AS ID, q1.COL1 AS COL1, q1.COL2 AS COL2) AS A, (q0.__ROW_VERSION AS __ROW_VERSION, q0.ID AS ID, q0.COL1 AS COL1, q0.COL2 AS COL2) AS B) }ﬁ digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -844,11 +843,11 @@ e
     rankDir=LR;
     2 -> 5 [ color="red" style="invis" ];
   }
-}≠<
+}¨<
 û
-versions-queriesâEXPLAIN select (A.*) as A, (B.*) as B, (C.*) as C from t2_v(2) as A, t3_v(2) as B, t4_v(2) as C where A.col2 = B.col1 AND B.col1 = C.col1â;
-É Æ§®«¡
- ò˚ó(Ç0√¥ß	8Ú@A˚ISCAN(T3_VERSION_WITH_COL1 <,>) | FILTER _.COL2 EQUALS promote(@c27 AS LONG) | FLATMAP q0 -> { ISCAN(T3_VERSION_WITH_COL1 <,>) | FILTER _.COL2 EQUALS promote(@c27 AS LONG) AND q0.COL1 EQUALS _.COL1 | FLATMAP q1 -> { ISCAN(T2_COL2 [EQUALS q0.COL1]) | FILTER _.COL1 EQUALS promote(@c27 AS LONG) AS q2 RETURN (q2 AS _0, q1 AS _1) } AS q3 RETURN ((q3._0.__ROW_VERSION AS __ROW_VERSION, q3._0.ID AS ID, q3._0.COL1 AS COL1, q3._0.COL2 AS COL2) AS A, (q0.__ROW_VERSION AS __ROW_VERSION, q0.ID AS ID, q0.COL1 AS COL1, q0.COL2 AS COL2) AS B, (q3._1.__ROW_VERSION AS __ROW_VERSION, q3._1.ID AS ID, q3._1.COL1 AS COL1, q3._1.COL2 AS COL2) AS C) }Ë5digraph G {
+versions-queriesâEXPLAIN select (A.*) as A, (B.*) as B, (C.*) as C from t2_v(2) as A, t3_v(2) as B, t4_v(2) as C where A.col2 = B.col1 AND B.col1 = C.col1à;
+˝‚Ò≤iæ
+ ã∆€,(Ç0‰∆ê8Ú@A˚ISCAN(T3_VERSION_WITH_COL1 <,>) | FILTER _.COL2 EQUALS promote(@c27 AS LONG) | FLATMAP q0 -> { ISCAN(T3_VERSION_WITH_COL1 <,>) | FILTER _.COL2 EQUALS promote(@c27 AS LONG) AND q0.COL1 EQUALS _.COL1 | FLATMAP q1 -> { ISCAN(T2_COL2 [EQUALS q0.COL1]) | FILTER _.COL1 EQUALS promote(@c27 AS LONG) AS q2 RETURN (q2 AS _0, q1 AS _1) } AS q3 RETURN ((q3._0.__ROW_VERSION AS __ROW_VERSION, q3._0.ID AS ID, q3._0.COL1 AS COL1, q3._0.COL2 AS COL2) AS A, (q0.__ROW_VERSION AS __ROW_VERSION, q0.ID AS ID, q0.COL1 AS COL1, q0.COL2 AS COL2) AS B, (q3._1.__ROW_VERSION AS __ROW_VERSION, q3._1.ID AS ID, q3._1.COL1 AS COL1, q3._1.COL2 AS COL2) AS C) }Ë5digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;

--- a/yaml-tests/src/test/resources/versions-tests.metrics.binpb
+++ b/yaml-tests/src/test/resources/versions-tests.metrics.binpb
@@ -167,7 +167,7 @@ H
 }≥
 8
 versions-queries$EXPLAIN select t1_v.* from t1_v(10);ˆ
-”ÒêÈ"÷ É¸Í(G0è∆r8i@|ISCAN(I1 [EQUALS promote(@c7 AS LONG)]) | MAP (_.__ROW_VERSION AS __ROW_VERSION, _.ID AS ID, _.COL1 AS COL1, _.COL2 AS COL2)Ÿdigraph G {
+—ê§Û’ ûÍ€(G0∆ÔU8i@|ISCAN(I1 [EQUALS promote(@c7 AS LONG)]) | MAP (_.__ROW_VERSION AS __ROW_VERSION, _.ID AS ID, _.COL1 AS COL1, _.COL2 AS COL2)Ÿdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -203,7 +203,7 @@ H
 }ö
 Ñ
 versions-queriespEXPLAIN select s.version, s.col2 from (select "__ROW_VERSION" as version, t1_v.col2 as col2 from t1_v(10)) AS s;ê
-Ìøºå#‹ ØÔÍ	(I0˚¢n8m@[ISCAN(I1 [EQUALS promote(@c23 AS LONG)]) | MAP (_.__ROW_VERSION AS VERSION, _.COL2 AS COL2)îdigraph G {
+ÎƒŸù€ ‡¿ƒ(I0‹ºZ8m@[ISCAN(I1 [EQUALS promote(@c23 AS LONG)]) | MAP (_.__ROW_VERSION AS VERSION, _.COL2 AS COL2)îdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -334,7 +334,7 @@ r
 }Ø
 l
 versions-queriesXEXPLAIN select t1_v."__ROW_VERSION", t1_v.id from t1_v(20) order by "__ROW_VERSION" ASC;æ
-˜Î≠à √ç∏(40∑õM8>@pISCAN(GROUPED_VERSION_INDEX [EQUALS promote(@c11 AS LONG)]) | MAP (_.__ROW_VERSION AS __ROW_VERSION, _.ID AS ID)≠digraph G {
+ıÓÌ¢á –ÑÑ(40˛÷.8>@pISCAN(GROUPED_VERSION_INDEX [EQUALS promote(@c11 AS LONG)]) | MAP (_.__ROW_VERSION AS __ROW_VERSION, _.ID AS ID)≠digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -520,7 +520,7 @@ b
 }Á
 `
 versions-queriesLEXPLAIN select * from unindexed_t_v(30) where col2 = 'odd' or col2 = 'even';Ç
-•∂±„o ‰πË(!0Âõ[8>@ÏSCAN([IS UNINDEXED_T]) | FILTER (_.COL2 EQUALS promote(@c10 AS STRING) OR _.COL2 EQUALS promote(@c14 AS STRING)) AND _.COL1 EQUALS promote(@c5 AS LONG) | MAP (_.__ROW_VERSION AS __ROW_VERSION, _.ID AS ID, _.COL1 AS COL1, _.COL2 AS COL2)ıdigraph G {
+£÷É∂n ØÙß(!0ô¿;8>@ÏSCAN([IS UNINDEXED_T]) | FILTER (_.COL2 EQUALS promote(@c10 AS STRING) OR _.COL2 EQUALS promote(@c14 AS STRING)) AND _.COL1 EQUALS promote(@c5 AS LONG) | MAP (_.__ROW_VERSION AS __ROW_VERSION, _.ID AS ID, _.COL1 AS COL1, _.COL2 AS COL2)ıdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -657,10 +657,10 @@ y
     rankDir=LR;
     2 -> 6 [ color="red" style="invis" ];
   }
-}∫(
+}ª(
 ÿ
-versions-queries√EXPLAIN select a.version AS version3, a.r.id AS id3, b.version AS version4, b.r.id AS id4, a.r.col2, b.r.col4 from t3_by_col1('b') a, t4_by_col1('b') b where 2 in b.r.col4 and b.r.col2 = a.r.col2‹&
-Ààååk£ ºπœ0(„0ŸŒÚ8Å@+‰COVERING(T3_VERSION_WITH_COL1 <,> -> [COL1: VALUE:[0], ID: KEY:[2]]) | FILTER _.COL1 EQUALS @c43 | FETCH | FLATMAP q0 -> { ISCAN(T4_COL2 [EQUALS q0.COL2]) | FILTER _.COL1 EQUALS @c43 AND promote(@c53 AS LONG) IN _.COL4 AS q1 RETURN (q0.__ROW_VERSION AS VERSION3, q0.ID AS ID3, q1.__ROW_VERSION AS VERSION4, q1.ID AS ID4, q0.COL2 AS COL2, q1.COL4 AS COL4) }”#digraph G {
+versions-queries√EXPLAIN select a.version AS version3, a.r.id AS id3, b.version AS version4, b.r.id AS id4, a.r.col2, b.r.col4 from t3_by_col1('b') a, t4_by_col1('b') b where 2 in b.r.col4 and b.r.col2 = a.r.col2›&
+«†ÊÓ≈° ©“ˆG(„0›œü8Å@+‰COVERING(T3_VERSION_WITH_COL1 <,> -> [COL1: VALUE:[0], ID: KEY:[2]]) | FILTER _.COL1 EQUALS @c43 | FETCH | FLATMAP q0 -> { ISCAN(T4_COL2 [EQUALS q0.COL2]) | FILTER _.COL1 EQUALS @c43 AND promote(@c53 AS LONG) IN _.COL4 AS q1 RETURN (q0.__ROW_VERSION AS VERSION3, q0.ID AS ID3, q1.__ROW_VERSION AS VERSION4, q1.ID AS ID4, q0.COL2 AS COL2, q1.COL4 AS COL4) }”#digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -810,8 +810,8 @@ c
 }Ÿ$
 e
 versions-queriesQEXPLAIN select (A.*), (B.*) from t2_v(2) as A, t3_v(2) as B where A.col2 = B.col1Ô#
-√
-¬ß©[È î·¢!(n0™áƒ8ƒ@	ÌISCAN(T3_VERSION_WITH_COL1 <,>) | FILTER _.COL2 EQUALS promote(@c15 AS LONG) | FLATMAP q0 -> { ISCAN(T2_COL2 [EQUALS q0.COL1]) | FILTER _.COL1 EQUALS promote(@c15 AS LONG) AS q1 RETURN ((q1.__ROW_VERSION AS __ROW_VERSION, q1.ID AS ID, q1.COL1 AS COL1, q1.COL2 AS COL2) AS A, (q0.__ROW_VERSION AS __ROW_VERSION, q0.ID AS ID, q0.COL1 AS COL1, q0.COL2 AS COL2) AS B) }ﬁ digraph G {
+ø
+¨À—RÁ áÛ£(n0êÏî8ƒ@	ÌISCAN(T3_VERSION_WITH_COL1 <,>) | FILTER _.COL2 EQUALS promote(@c15 AS LONG) | FLATMAP q0 -> { ISCAN(T2_COL2 [EQUALS q0.COL1]) | FILTER _.COL1 EQUALS promote(@c15 AS LONG) AS q1 RETURN ((q1.__ROW_VERSION AS __ROW_VERSION, q1.ID AS ID, q1.COL1 AS COL1, q1.COL2 AS COL2) AS A, (q0.__ROW_VERSION AS __ROW_VERSION, q0.ID AS ID, q0.COL1 AS COL1, q0.COL2 AS COL2) AS B) }ﬁ digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -829,24 +829,24 @@ e
   7 -> 6 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   5 -> 1 [ label=<&nbsp;q12> label="q12" color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   {
+    2 -> 1 [ color="blue" style="dotted" arrowhead="none" tailport="nw" headport="s" constraint="false" ];
+  }
+  {
     6 -> 1 [ color="blue" style="dotted" arrowhead="none" tailport="nw" headport="s" constraint="false" ];
   }
   {
     5 -> 1 [ color="blue" style="dotted" arrowhead="none" tailport="nw" headport="s" constraint="false" ];
   }
   {
-    2 -> 1 [ color="blue" style="dotted" arrowhead="none" tailport="nw" headport="s" constraint="false" ];
-  }
-  {
     rank=same;
     rankDir=LR;
     2 -> 5 [ color="red" style="invis" ];
   }
-}Æ<
+}≠<
 û
-versions-queriesâEXPLAIN select (A.*) as A, (B.*) as B, (C.*) as C from t2_v(2) as A, t3_v(2) as B, t4_v(2) as C where A.col2 = B.col1 AND B.col1 = C.col1ä;
-ç ÿèÀõÀ
- ˙†Ñç(Ç0„ìñ8Ú@A˚ISCAN(T3_VERSION_WITH_COL1 <,>) | FILTER _.COL2 EQUALS promote(@c27 AS LONG) | FLATMAP q0 -> { ISCAN(T3_VERSION_WITH_COL1 <,>) | FILTER _.COL2 EQUALS promote(@c27 AS LONG) AND q0.COL1 EQUALS _.COL1 | FLATMAP q1 -> { ISCAN(T2_COL2 [EQUALS q0.COL1]) | FILTER _.COL1 EQUALS promote(@c27 AS LONG) AS q2 RETURN (q2 AS _0, q1 AS _1) } AS q3 RETURN ((q3._0.__ROW_VERSION AS __ROW_VERSION, q3._0.ID AS ID, q3._0.COL1 AS COL1, q3._0.COL2 AS COL2) AS A, (q0.__ROW_VERSION AS __ROW_VERSION, q0.ID AS ID, q0.COL1 AS COL1, q0.COL2 AS COL2) AS B, (q3._1.__ROW_VERSION AS __ROW_VERSION, q3._1.ID AS ID, q3._1.COL1 AS COL1, q3._1.COL2 AS COL2) AS C) }Ë5digraph G {
+versions-queriesâEXPLAIN select (A.*) as A, (B.*) as B, (C.*) as C from t2_v(2) as A, t3_v(2) as B, t4_v(2) as C where A.col2 = B.col1 AND B.col1 = C.col1â;
+á ñÓ∑ »
+ Ñ¡¢y(Ç0å¶˝8Ú@A˚ISCAN(T3_VERSION_WITH_COL1 <,>) | FILTER _.COL2 EQUALS promote(@c27 AS LONG) | FLATMAP q0 -> { ISCAN(T3_VERSION_WITH_COL1 <,>) | FILTER _.COL2 EQUALS promote(@c27 AS LONG) AND q0.COL1 EQUALS _.COL1 | FLATMAP q1 -> { ISCAN(T2_COL2 [EQUALS q0.COL1]) | FILTER _.COL1 EQUALS promote(@c27 AS LONG) AS q2 RETURN (q2 AS _0, q1 AS _1) } AS q3 RETURN ((q3._0.__ROW_VERSION AS __ROW_VERSION, q3._0.ID AS ID, q3._0.COL1 AS COL1, q3._0.COL2 AS COL2) AS A, (q0.__ROW_VERSION AS __ROW_VERSION, q0.ID AS ID, q0.COL1 AS COL1, q0.COL2 AS COL2) AS B, (q3._1.__ROW_VERSION AS __ROW_VERSION, q3._1.ID AS ID, q3._1.COL1 AS COL1, q3._1.COL2 AS COL2) AS C) }Ë5digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -855,30 +855,30 @@ e
   3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS COL1, LONG AS COL2, VERSION AS __ROW_VERSION)" ];
   4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">T3_VERSION_WITH_COL1</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS COL1, LONG AS COL2, VERSION AS __ROW_VERSION)" ];
   5 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Nested Loop Join</td></tr><tr><td align="left">FLATMAP (q12 AS _0, q54 AS _1)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS COL1, STRING AS COL2, VERSION AS __ROW_VERSION AS _0, LONG AS ID, STRING AS COL1, LONG AS COL2, VERSION AS __ROW_VERSION AS _1)" ];
-  6 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE q12.COL1 EQUALS promote(@c27 AS LONG)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS COL1, STRING AS COL2, VERSION AS __ROW_VERSION)" ];
-  7 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE q54.COL2 EQUALS promote(@c27 AS LONG) AND q33.COL1 EQUALS q54.COL1</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS COL1, LONG AS COL2, VERSION AS __ROW_VERSION)" ];
-  8 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">comparisons: [EQUALS q33.COL1]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS COL1, STRING AS COL2, VERSION AS __ROW_VERSION)" ];
-  9 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS COL1, LONG AS COL2, VERSION AS __ROW_VERSION)" ];
-  10 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">T2_COL2</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS COL1, STRING AS COL2, VERSION AS __ROW_VERSION)" ];
-  11 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">T3_VERSION_WITH_COL1</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS COL1, LONG AS COL2, VERSION AS __ROW_VERSION)" ];
+  6 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE q54.COL2 EQUALS promote(@c27 AS LONG) AND q33.COL1 EQUALS q54.COL1</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS COL1, LONG AS COL2, VERSION AS __ROW_VERSION)" ];
+  7 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE q12.COL1 EQUALS promote(@c27 AS LONG)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS COL1, STRING AS COL2, VERSION AS __ROW_VERSION)" ];
+  8 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS COL1, LONG AS COL2, VERSION AS __ROW_VERSION)" ];
+  9 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">comparisons: [EQUALS q33.COL1]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS COL1, STRING AS COL2, VERSION AS __ROW_VERSION)" ];
+  10 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">T3_VERSION_WITH_COL1</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS COL1, LONG AS COL2, VERSION AS __ROW_VERSION)" ];
+  11 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">T2_COL2</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS COL1, STRING AS COL2, VERSION AS __ROW_VERSION)" ];
   3 -> 2 [ label=<&nbsp;q33> label="q33" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   4 -> 3 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q33> label="q33" color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  6 -> 5 [ label=<&nbsp;q12> label="q12" color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  7 -> 5 [ label=<&nbsp;q54> label="q54" color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  8 -> 6 [ label=<&nbsp;q12> label="q12" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  9 -> 7 [ label=<&nbsp;q54> label="q54" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  6 -> 5 [ label=<&nbsp;q54> label="q54" color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  7 -> 5 [ label=<&nbsp;q12> label="q12" color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  8 -> 6 [ label=<&nbsp;q54> label="q54" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  9 -> 7 [ label=<&nbsp;q12> label="q12" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   10 -> 8 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   11 -> 9 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   5 -> 1 [ label=<&nbsp;q154> label="q154" color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   {
-    8 -> 1 [ color="blue" style="dotted" arrowhead="none" tailport="nw" headport="s" constraint="false" ];
-  }
-  {
-    7 -> 1 [ color="blue" style="dotted" arrowhead="none" tailport="nw" headport="s" constraint="false" ];
-  }
-  {
     2 -> 1 [ color="blue" style="dotted" arrowhead="none" tailport="nw" headport="s" constraint="false" ];
+  }
+  {
+    6 -> 1 [ color="blue" style="dotted" arrowhead="none" tailport="nw" headport="s" constraint="false" ];
+  }
+  {
+    9 -> 1 [ color="blue" style="dotted" arrowhead="none" tailport="nw" headport="s" constraint="false" ];
   }
   {
     rank=same;
@@ -894,6 +894,6 @@ e
   {
     rank=same;
     rankDir=LR;
-    7 -> 6 [ color="red" style="invis" ];
+    6 -> 7 [ color="red" style="invis" ];
   }
 }

--- a/yaml-tests/src/test/resources/versions-tests.metrics.yaml
+++ b/yaml-tests/src/test/resources/versions-tests.metrics.yaml
@@ -155,10 +155,10 @@ versions-queries:
     ref: versions-tests.yamsql:272
     explain: ISCAN(I1 [EQUALS promote(@c7 AS LONG)]) | MAP (_.__ROW_VERSION AS __ROW_VERSION,
         _.ID AS ID, _.COL1 AS COL1, _.COL2 AS COL2)
-    task_count: 851
-    task_total_time_ms: 73
-    transform_count: 214
-    transform_time_ms: 24
+    task_count: 849
+    task_total_time_ms: 60
+    transform_count: 213
+    transform_time_ms: 14
     transform_yield_count: 71
     insert_time_ms: 1
     insert_new_count: 105
@@ -194,10 +194,10 @@ versions-queries:
     ref: versions-tests.yamsql:287
     explain: ISCAN(I1 [EQUALS promote(@c23 AS LONG)]) | MAP (_.__ROW_VERSION AS VERSION,
         _.COL2 AS COL2)
-    task_count: 877
-    task_total_time_ms: 73
-    transform_count: 220
-    transform_time_ms: 20
+    task_count: 875
+    task_total_time_ms: 61
+    transform_count: 219
+    transform_time_ms: 15
     transform_yield_count: 73
     insert_time_ms: 1
     insert_new_count: 109
@@ -330,12 +330,12 @@ versions-queries:
     ref: versions-tests.yamsql:362
     explain: ISCAN(GROUPED_VERSION_INDEX [EQUALS promote(@c11 AS LONG)]) | MAP (_.__ROW_VERSION
         AS __ROW_VERSION, _.ID AS ID)
-    task_count: 503
-    task_total_time_ms: 55
-    transform_count: 136
-    transform_time_ms: 15
+    task_count: 501
+    task_total_time_ms: 40
+    transform_count: 135
+    transform_time_ms: 12
     transform_yield_count: 52
-    insert_time_ms: 1
+    insert_time_ms: 0
     insert_new_count: 62
     insert_reused_count: 2
 -   query: EXPLAIN select "__ROW_VERSION", t1.id from t1 where col1 = 20 order by
@@ -513,12 +513,12 @@ versions-queries:
         OR _.COL2 EQUALS promote(@c14 AS STRING)) AND _.COL1 EQUALS promote(@c5 AS
         LONG) | MAP (_.__ROW_VERSION AS __ROW_VERSION, _.ID AS ID, _.COL1 AS COL1,
         _.COL2 AS COL2)
-    task_count: 421
-    task_total_time_ms: 37
-    transform_count: 111
-    transform_time_ms: 14
+    task_count: 419
+    task_total_time_ms: 42
+    transform_count: 110
+    transform_time_ms: 11
     transform_yield_count: 33
-    insert_time_ms: 1
+    insert_time_ms: 0
     insert_new_count: 62
     insert_reused_count: 4
 -   query: EXPLAIN select "__ROW_VERSION", (a.*), (b.*) from t1 as a, (select * from
@@ -597,12 +597,12 @@ versions-queries:
         q0.COL2]) | FILTER _.COL1 EQUALS @c43 AND promote(@c53 AS LONG) IN _.COL4
         AS q1 RETURN (q0.__ROW_VERSION AS VERSION3, q0.ID AS ID3, q1.__ROW_VERSION
         AS VERSION4, q1.ID AS ID4, q0.COL2 AS COL2, q1.COL4 AS COL4) }'
-    task_count: 3275
-    task_total_time_ms: 224
-    transform_count: 1059
-    transform_time_ms: 101
+    task_count: 3271
+    task_total_time_ms: 414
+    transform_count: 1057
+    transform_time_ms: 150
     transform_yield_count: 227
-    insert_time_ms: 12
+    insert_time_ms: 11
     insert_new_count: 513
     insert_reused_count: 43
 -   query: EXPLAIN select "__ROW_VERSION", id, col1, col3 from t4 where col3 in (1,
@@ -685,12 +685,12 @@ versions-queries:
         promote(@c15 AS LONG) AS q1 RETURN ((q1.__ROW_VERSION AS __ROW_VERSION, q1.ID
         AS ID, q1.COL1 AS COL1, q1.COL2 AS COL2) AS A, (q0.__ROW_VERSION AS __ROW_VERSION,
         q0.ID AS ID, q0.COL1 AS COL1, q0.COL2 AS COL2) AS B) }
-    task_count: 1347
-    task_total_time_ms: 191
-    transform_count: 361
-    transform_time_ms: 69
+    task_count: 1343
+    task_total_time_ms: 173
+    transform_count: 359
+    transform_time_ms: 57
     transform_yield_count: 110
-    insert_time_ms: 3
+    insert_time_ms: 2
     insert_new_count: 196
     insert_reused_count: 9
 -   query: EXPLAIN select (A.*) as A, (B.*) as B, (C.*) as C from t2_v(2) as A, t3_v(2)
@@ -705,11 +705,11 @@ versions-queries:
         AS __ROW_VERSION, q0.ID AS ID, q0.COL1 AS COL1, q0.COL2 AS COL2) AS B, (q3._1.__ROW_VERSION
         AS __ROW_VERSION, q3._1.ID AS ID, q3._1.COL1 AS COL1, q3._1.COL2 AS COL2)
         AS C) }
-    task_count: 4109
-    task_total_time_ms: 863
-    transform_count: 1355
-    transform_time_ms: 295
+    task_count: 4103
+    task_total_time_ms: 692
+    transform_count: 1352
+    transform_time_ms: 254
     transform_yield_count: 258
-    insert_time_ms: 25
+    insert_time_ms: 14
     insert_new_count: 626
     insert_reused_count: 65

--- a/yaml-tests/src/test/resources/versions-tests.metrics.yaml
+++ b/yaml-tests/src/test/resources/versions-tests.metrics.yaml
@@ -155,12 +155,12 @@ versions-queries:
     ref: versions-tests.yamsql:272
     explain: ISCAN(I1 [EQUALS promote(@c7 AS LONG)]) | MAP (_.__ROW_VERSION AS __ROW_VERSION,
         _.ID AS ID, _.COL1 AS COL1, _.COL2 AS COL2)
-    task_count: 847
-    task_total_time_ms: 102
-    transform_count: 210
-    transform_time_ms: 25
+    task_count: 845
+    task_total_time_ms: 68
+    transform_count: 209
+    transform_time_ms: 15
     transform_yield_count: 71
-    insert_time_ms: 2
+    insert_time_ms: 1
     insert_new_count: 105
     insert_reused_count: 6
 -   query: EXPLAIN select s.version, s.col2 from (select "__ROW_VERSION" as version,
@@ -194,12 +194,12 @@ versions-queries:
     ref: versions-tests.yamsql:287
     explain: ISCAN(I1 [EQUALS promote(@c23 AS LONG)]) | MAP (_.__ROW_VERSION AS VERSION,
         _.COL2 AS COL2)
-    task_count: 872
-    task_total_time_ms: 84
-    transform_count: 215
-    transform_time_ms: 22
+    task_count: 870
+    task_total_time_ms: 65
+    transform_count: 214
+    transform_time_ms: 18
     transform_yield_count: 73
-    insert_time_ms: 2
+    insert_time_ms: 1
     insert_new_count: 109
     insert_reused_count: 6
 -   query: EXPLAIN select "__ROW_VERSION" as version, t1.* from t1 where col1 = 20;
@@ -330,12 +330,12 @@ versions-queries:
     ref: versions-tests.yamsql:362
     explain: ISCAN(GROUPED_VERSION_INDEX [EQUALS promote(@c11 AS LONG)]) | MAP (_.__ROW_VERSION
         AS __ROW_VERSION, _.ID AS ID)
-    task_count: 499
-    task_total_time_ms: 62
-    transform_count: 132
-    transform_time_ms: 18
+    task_count: 497
+    task_total_time_ms: 42
+    transform_count: 131
+    transform_time_ms: 12
     transform_yield_count: 52
-    insert_time_ms: 1
+    insert_time_ms: 0
     insert_new_count: 62
     insert_reused_count: 2
 -   query: EXPLAIN select "__ROW_VERSION", t1.id from t1 where col1 = 20 order by
@@ -513,12 +513,12 @@ versions-queries:
         OR _.COL2 EQUALS promote(@c14 AS STRING)) AND _.COL1 EQUALS promote(@c5 AS
         LONG) | MAP (_.__ROW_VERSION AS __ROW_VERSION, _.ID AS ID, _.COL1 AS COL1,
         _.COL2 AS COL2)
-    task_count: 378
-    task_total_time_ms: 50
-    transform_count: 98
-    transform_time_ms: 14
+    task_count: 376
+    task_total_time_ms: 35
+    transform_count: 97
+    transform_time_ms: 10
     transform_yield_count: 31
-    insert_time_ms: 1
+    insert_time_ms: 0
     insert_new_count: 56
     insert_reused_count: 2
 -   query: EXPLAIN select "__ROW_VERSION", (a.*), (b.*) from t1 as a, (select * from
@@ -597,12 +597,12 @@ versions-queries:
         q0.COL2]) | FILTER _.COL1 EQUALS @c43 AND promote(@c53 AS LONG) IN _.COL4
         AS q1 RETURN (q0.__ROW_VERSION AS VERSION3, q0.ID AS ID3, q1.__ROW_VERSION
         AS VERSION4, q1.ID AS ID4, q0.COL2 AS COL2, q1.COL4 AS COL4) }'
-    task_count: 3247
-    task_total_time_ms: 619
-    transform_count: 1048
-    transform_time_ms: 239
+    task_count: 3243
+    task_total_time_ms: 431
+    transform_count: 1046
+    transform_time_ms: 162
     transform_yield_count: 226
-    insert_time_ms: 18
+    insert_time_ms: 10
     insert_new_count: 506
     insert_reused_count: 42
 -   query: EXPLAIN select "__ROW_VERSION", id, col1, col3 from t4 where col3 in (1,
@@ -685,12 +685,12 @@ versions-queries:
         promote(@c15 AS LONG) AS q1 RETURN ((q1.__ROW_VERSION AS __ROW_VERSION, q1.ID
         AS ID, q1.COL1 AS COL1, q1.COL2 AS COL2) AS A, (q0.__ROW_VERSION AS __ROW_VERSION,
         q0.ID AS ID, q0.COL1 AS COL1, q0.COL2 AS COL2) AS B) }
-    task_count: 1340
-    task_total_time_ms: 252
-    transform_count: 354
-    transform_time_ms: 82
+    task_count: 1336
+    task_total_time_ms: 174
+    transform_count: 352
+    transform_time_ms: 59
     transform_yield_count: 110
-    insert_time_ms: 4
+    insert_time_ms: 2
     insert_new_count: 196
     insert_reused_count: 9
 -   query: EXPLAIN select (A.*) as A, (B.*) as B, (C.*) as C from t2_v(2) as A, t3_v(2)
@@ -705,11 +705,11 @@ versions-queries:
         AS __ROW_VERSION, q0.ID AS ID, q0.COL1 AS COL1, q0.COL2 AS COL2) AS B, (q3._1.__ROW_VERSION
         AS __ROW_VERSION, q3._1.ID AS ID, q3._1.COL1 AS COL1, q3._1.COL2 AS COL2)
         AS C) }
-    task_count: 4099
-    task_total_time_ms: 686
-    transform_count: 1345
-    transform_time_ms: 266
+    task_count: 4093
+    task_total_time_ms: 221
+    transform_count: 1342
+    transform_time_ms: 93
     transform_yield_count: 258
-    insert_time_ms: 19
+    insert_time_ms: 6
     insert_new_count: 626
     insert_reused_count: 65

--- a/yaml-tests/src/test/resources/versions-with-single-type-tests.metrics.binpb
+++ b/yaml-tests/src/test/resources/versions-with-single-type-tests.metrics.binpb
@@ -34,10 +34,10 @@ Z
   3 -> 2 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   4 -> 3 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q22> label="q22" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}‰
+}„
 >
-single-type-versions-queriesEXPLAIN select * from t1_v(10)°
-‚´ÅúZ ¯ô€(0ŒË8/@éSCAN([IS T1]) | FILTER _.COL1 EQUALS promote(@c5 AS LONG) | MAP (_.__ROW_VERSION AS __ROW_VERSION, _.ID AS ID, _.COL1 AS COL1, _.COL2 AS COL2)Údigraph G {
+single-type-versions-queriesEXPLAIN select * from t1_v(10)†
+‡Ì≈¶Y ‚∑W(0•Ö8/@éSCAN([IS T1]) | FILTER _.COL1 EQUALS promote(@c5 AS LONG) | MAP (_.__ROW_VERSION AS __ROW_VERSION, _.ID AS ID, _.COL1 AS COL1, _.COL2 AS COL2)Údigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;

--- a/yaml-tests/src/test/resources/versions-with-single-type-tests.metrics.binpb
+++ b/yaml-tests/src/test/resources/versions-with-single-type-tests.metrics.binpb
@@ -34,10 +34,10 @@ Z
   3 -> 2 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   4 -> 3 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q22> label="q22" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}δ
+}γ
 >
-single-type-versions-queriesEXPLAIN select * from t1_v(10)΅
-ζΚÒ^ Τ“Ψ(0Έ8/@SCAN([IS T1]) | FILTER _.COL1 EQUALS promote(@c5 AS LONG) | MAP (_.__ROW_VERSION AS __ROW_VERSION, _.ID AS ID, _.COL1 AS COL1, _.COL2 AS COL2)ςdigraph G {
+single-type-versions-queriesEXPLAIN select * from t1_v(10) 
+δτίν] ‡J(0ÒΏ8/@SCAN([IS T1]) | FILTER _.COL1 EQUALS promote(@c5 AS LONG) | MAP (_.__ROW_VERSION AS __ROW_VERSION, _.ID AS ID, _.COL1 AS COL1, _.COL2 AS COL2)ςdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;

--- a/yaml-tests/src/test/resources/versions-with-single-type-tests.metrics.yaml
+++ b/yaml-tests/src/test/resources/versions-with-single-type-tests.metrics.yaml
@@ -37,10 +37,10 @@ single-type-versions-queries:
     ref: versions-with-single-type-tests.yamsql:105
     explain: SCAN([IS T1]) | FILTER _.COL1 EQUALS promote(@c5 AS LONG) | MAP (_.__ROW_VERSION
         AS __ROW_VERSION, _.ID AS ID, _.COL1 AS COL1, _.COL2 AS COL2)
-    task_count: 358
-    task_total_time_ms: 9
-    transform_count: 94
-    transform_time_ms: 3
+    task_count: 356
+    task_total_time_ms: 3
+    transform_count: 93
+    transform_time_ms: 1
     transform_yield_count: 28
     insert_time_ms: 0
     insert_new_count: 47

--- a/yaml-tests/src/test/resources/versions-with-single-type-tests.metrics.yaml
+++ b/yaml-tests/src/test/resources/versions-with-single-type-tests.metrics.yaml
@@ -37,10 +37,10 @@ single-type-versions-queries:
     ref: versions-with-single-type-tests.yamsql:105
     explain: SCAN([IS T1]) | FILTER _.COL1 EQUALS promote(@c5 AS LONG) | MAP (_.__ROW_VERSION
         AS __ROW_VERSION, _.ID AS ID, _.COL1 AS COL1, _.COL2 AS COL2)
-    task_count: 354
-    task_total_time_ms: 13
-    transform_count: 90
-    transform_time_ms: 3
+    task_count: 352
+    task_total_time_ms: 4
+    transform_count: 89
+    transform_time_ms: 1
     transform_yield_count: 28
     insert_time_ms: 0
     insert_new_count: 47


### PR DESCRIPTION
This change adds a conditional rule, `decorrelateThenPushDownThenSimplification`, which chains `DecorrelateValuesRule` › `QueryPredicateSimplificationRule` so that the next rewrite is only attempted when the previous one made progress.

### Rationale

Regarding which of the two rules should come first, note that the order does _not_ affect the search space (in terms of `transform_yield_count`/`insert_new_count`), since the suppressed rule still gets a chance to match on the yielded expression. However, it does affect how much wasted work is done.

The reason why we place `DecorrelateValuesRule` _before_ `QueryPredicateSimplificationRule` is that the former can be an enabler for the latter; in other words, decorrelation can unlock simplification opportunities. This is because, currently, the constant-folding rules can only act on literals (or on parameters they can dereference to literals), whereas a reference to a values box, such as `p.x`, is a `FieldValue` over a quantifier and hence opaque to constant folding. Decorrelation may be able to push a values box down and substitute its result value for such references, turning `a = p.x` into, say, `a = 42` and thereby giving simplification something to constant-fold in the first place. If simplification came first, a potentially unproductive simplification attempt would happen on every level of a nested chain of values boxes.

**Empirically,** swapping the order to `QueryPredicateSimplificationRule` › `DecorrelateValuesRule` changes the yaml-test planner metrics as follows (across 99 tests, 638 queries with metrics, confirmed to be deterministic):

| Metric                  | Decorrelate-first | Simplify-first | Delta |
|-------------------------|-------------------|----------------|-------|
| `task_count`            | 477,358           | 477,507        | +149  |
| `transform_count`       | 144,456           | 144,439        | −17   |
| `transform_yield_count` | 39,518            | 39,518         | 0     |
| `insert_new_count`      | 59,717            | 59,717         | 0     |
| `insert_reused_count`   | 4,956             | 4,956          | 0     |
| `explain` plan changes  | —                 | —              | 0     |

Note that yields and memo inserts are identical and there are no plan changes, which confirms that the only difference is in wasted attempts. The totals are roughly on par. However, the distribution underneath is somewhat lopsided: 127 queries improve under simplify-first, yet only ever by 1–3 tasks, while 48 regress. The regressions are concentrated on the function-inlining workload that these rules are designed for: `sql-functions.yamsql` shows +207 tasks and +79 transforms, with the worst single query at +61 tasks and +21 transforms. The gains are flat and bounded, whereas the regressions are expected to grow with nesting depth. This experiment therefore supports keeping decorrelation first.