### PR TITLE
Optimize serialization for WriteOnly with PendingWritesQueue

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/ContextSessionKey.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/ContextSessionKey.java
@@ -48,7 +48,7 @@ public final class ContextSessionKey<T> {
      * Value type: {@code Set<String>}. Returns {@code null} if no write-only-with-queue index was updated.
      * Useful for diagnosing conflicts that may happen when an index is updated by the indexer.
      */
-    public static final ContextSessionKey<Set<String>> WRITE_ONLY_WITH_QUEUE_INDEXES_UPDATED = new ContextSessionKey<>("writeOnlyIndexesUpdated");
+    public static final ContextSessionKey<Set<String>> WRITE_ONLY_WITH_QUEUE_INDEXES_UPDATED = new ContextSessionKey<>("writeOnlyWithQueueIndexesUpdated");
     /**
      * Session key for the set of readable index names updated in this transaction.
      * Note that this captures both {@link com.apple.foundationdb.record.IndexState#READABLE} and

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -781,12 +781,19 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
                     // Push the old/new record to a write pending queue instead of updating the index directly. The
                     // ongoing online indexer will drain the queue and perform the actual index update. A maintainer that
                     // does not support the queue will throw from serializePendingWriteQueue below.
-                    future = IndexingPendingWriteQueue.enqueuePendingIndexUpdate(this, index,
-                            IndexBuildProto.PendingWritesQueueEntry.newBuilder()
-                                    .setOperation(IndexBuildProto.PendingWritesQueueEntry.Operation.UPDATE)
-                                    .setData(maintainer.serializePendingWriteQueue(oldRecord, newRecord))
-                                    .build());
-                    context.addToSessionSet(ContextSessionKey.WRITE_ONLY_WITH_QUEUE_INDEXES_UPDATED, index.getName());
+                    final Any pendingWriteData = maintainer.serializePendingWriteQueue(oldRecord, newRecord);
+                    if (pendingWriteData == null) {
+                        // The maintainer reported that this update requires no index change (e.g. the record is
+                        // filtered out of the index), so there is nothing to defer onto the queue.
+                        future = AsyncUtil.DONE;
+                    } else {
+                        future = IndexingPendingWriteQueue.enqueuePendingIndexUpdate(this, index,
+                                IndexBuildProto.PendingWritesQueueEntry.newBuilder()
+                                        .setOperation(IndexBuildProto.PendingWritesQueueEntry.Operation.UPDATE)
+                                        .setData(pendingWriteData)
+                                        .build());
+                        context.addToSessionSet(ContextSessionKey.WRITE_ONLY_WITH_QUEUE_INDEXES_UPDATED, index.getName());
+                    }
                     break;
 
                 case WRITE_ONLY:

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -783,8 +783,7 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
                     // does not support the queue will throw from serializePendingWriteQueue below.
                     final Any pendingWriteData = maintainer.serializePendingWriteQueue(oldRecord, newRecord);
                     if (pendingWriteData == null) {
-                        // The maintainer reported that this update requires no index change (e.g. the record is
-                        // filtered out of the index), so there is nothing to defer onto the queue.
+                        // Nothing to defer onto the queue.
                         future = AsyncUtil.DONE;
                     } else {
                         future = IndexingPendingWriteQueue.enqueuePendingIndexUpdate(this, index,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexMaintainer.java
@@ -164,8 +164,7 @@ public abstract class IndexMaintainer {
      * @param oldRecord the previous stored record or <code>null</code> if a new record is being created
      * @param newRecord the new record or <code>null</code> if an old record is being deleted
      * @param <M> type of message
-     * @return a packed message to save in the pending write queue, or <code>null</code> if this update requires no
-     *     change to the index and so nothing needs to be deferred onto the queue
+     * @return a packed message to save in the pending write queue. Null is returned if no update is needed.
      */
     @Nullable
     @API(API.Status.EXPERIMENTAL)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexMaintainer.java
@@ -164,9 +164,10 @@ public abstract class IndexMaintainer {
      * @param oldRecord the previous stored record or <code>null</code> if a new record is being created
      * @param newRecord the new record or <code>null</code> if an old record is being deleted
      * @param <M> type of message
-     * @return a packed message to save in the pending write queue
+     * @return a packed message to save in the pending write queue, or <code>null</code> if this update requires no
+     *     change to the index and so nothing needs to be deferred onto the queue
      */
-    @Nonnull
+    @Nullable
     @API(API.Status.EXPERIMENTAL)
     public <M extends Message> Any serializePendingWriteQueue(@Nullable FDBIndexableRecord<M> oldRecord,
                                                               @Nullable FDBIndexableRecord<M> newRecord) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/SlidingWindowIndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/SlidingWindowIndexMaintainer.java
@@ -450,20 +450,20 @@ public class SlidingWindowIndexMaintainer extends IndexMaintainer {
                 IndexBuildProto.SlidingWindowQueueEntry.newBuilder();
         boolean anyChange = false;
         if (shouldMaintain(oldRecord)) {
+            builder.setOldEntryKey(entryKeyOf(oldRecord).pack());
             final Any delegatedDelete = delegate.serializePendingWriteQueue(oldRecord, null);
             if (delegatedDelete != null) {
-                builder.setOldEntryKey(entryKeyOf(oldRecord).pack());
                 builder.setDelegatedDelete(delegatedDelete);
-                anyChange = true;
             }
+            anyChange = true;
         }
         if (shouldMaintain(newRecord)) {
+            builder.setNewEntryKey(entryKeyOf(newRecord).pack());
             final Any delegatedInsert = delegate.serializePendingWriteQueue(null, newRecord);
             if (delegatedInsert != null) {
-                builder.setNewEntryKey(entryKeyOf(newRecord).pack());
                 builder.setDelegatedInsert(delegatedInsert);
-                anyChange = true;
             }
+            anyChange = true;
         }
         // If nothing was maintained for either records, return null to indicate that no change is needed
         return anyChange ? Any.pack(builder.build()) : null;
@@ -496,11 +496,11 @@ public class SlidingWindowIndexMaintainer extends IndexMaintainer {
         final Any delegateDelete = entry.hasDelegatedDelete() ? entry.getDelegatedDelete() : null;
         final Any delegateInsert = entry.hasDelegatedInsert() ? entry.getDelegatedInsert() : null;
         // The maintenance filter was already applied when the update was first deferred, so it is not re-evaluated here.
-        validateOrThrowEx(oldKey == null || delegateDelete != null, "old record key without delegate delete");
-        validateOrThrowEx(newKey == null || delegateInsert != null, "new record key without delegate insert");
+        validateOrThrowEx(delegateDelete == null || oldKey != null, "delegate delete without old record key");
+        validateOrThrowEx(delegateInsert == null || newKey != null, "delegate insert without new record key");
         return updateWindowWhileWriteOnly(oldKey, newKey,
-                () -> delegate.updateFromQueue(delegateDelete),
-                () -> delegate.updateFromQueue(delegateInsert));
+                () -> delegateDelete == null ? AsyncUtil.DONE : delegate.updateFromQueue(delegateDelete),
+                () -> delegateInsert == null ? AsyncUtil.DONE : delegate.updateFromQueue(delegateInsert));
     }
 
     private void validateOrThrowEx(boolean isValid, @Nonnull String msg) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/SlidingWindowIndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/SlidingWindowIndexMaintainer.java
@@ -441,22 +441,34 @@ public class SlidingWindowIndexMaintainer extends IndexMaintainer {
         });
     }
 
-    @Nonnull
+    @Nullable
     @Override
     public <M extends Message> Any serializePendingWriteQueue(@Nullable final FDBIndexableRecord<M> oldRecord, @Nullable final FDBIndexableRecord<M> newRecord) {
         // The maintenance filter is applied here, at enqueue time, so a record filtered out of this index is never
         // deferred onto the queue and updateFromQueue does not need the record to re-check it.
         final IndexBuildProto.SlidingWindowQueueEntry.Builder builder =
                 IndexBuildProto.SlidingWindowQueueEntry.newBuilder();
+        boolean anyChange = false;
         if (shouldMaintain(oldRecord)) {
-            builder.setOldEntryKey(entryKeyOf(oldRecord).pack());
-            builder.setDelegatedDelete(delegate.serializePendingWriteQueue(oldRecord, null));
+            // The delegate governs whether this half is a real change; if it defers nothing then the entry key is
+            // omitted too, keeping the oldEntryKey/delegatedDelete pairing that updateFromQueue validates.
+            final Any delegatedDelete = delegate.serializePendingWriteQueue(oldRecord, null);
+            if (delegatedDelete != null) {
+                builder.setOldEntryKey(entryKeyOf(oldRecord).pack());
+                builder.setDelegatedDelete(delegatedDelete);
+                anyChange = true;
+            }
         }
         if (shouldMaintain(newRecord)) {
-            builder.setNewEntryKey(entryKeyOf(newRecord).pack());
-            builder.setDelegatedInsert(delegate.serializePendingWriteQueue(null, newRecord));
+            final Any delegatedInsert = delegate.serializePendingWriteQueue(null, newRecord);
+            if (delegatedInsert != null) {
+                builder.setNewEntryKey(entryKeyOf(newRecord).pack());
+                builder.setDelegatedInsert(delegatedInsert);
+                anyChange = true;
+            }
         }
-        return Any.pack(builder.build());
+        // Nothing was maintained for either record: no change is needed, so defer nothing onto the queue.
+        return anyChange ? Any.pack(builder.build()) : null;
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/SlidingWindowIndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/SlidingWindowIndexMaintainer.java
@@ -450,8 +450,6 @@ public class SlidingWindowIndexMaintainer extends IndexMaintainer {
                 IndexBuildProto.SlidingWindowQueueEntry.newBuilder();
         boolean anyChange = false;
         if (shouldMaintain(oldRecord)) {
-            // The delegate governs whether this half is a real change; if it defers nothing then the entry key is
-            // omitted too, keeping the oldEntryKey/delegatedDelete pairing that updateFromQueue validates.
             final Any delegatedDelete = delegate.serializePendingWriteQueue(oldRecord, null);
             if (delegatedDelete != null) {
                 builder.setOldEntryKey(entryKeyOf(oldRecord).pack());
@@ -467,7 +465,7 @@ public class SlidingWindowIndexMaintainer extends IndexMaintainer {
                 anyChange = true;
             }
         }
-        // Nothing was maintained for either record: no change is needed, so defer nothing onto the queue.
+        // If nothing was maintained for either records, return null to indicate that no change is needed
         return anyChange ? Any.pack(builder.build()) : null;
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/StandardIndexMaintainerWithQueue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/StandardIndexMaintainerWithQueue.java
@@ -64,7 +64,7 @@ public abstract class StandardIndexMaintainerWithQueue extends StandardIndexMain
     }
 
     @Override
-    @Nonnull
+    @Nullable
     public <M extends Message> Any serializePendingWriteQueue(@Nullable final FDBIndexableRecord<M> oldRecord,
                                                               @Nullable final FDBIndexableRecord<M> newRecord) {
         return serializePendingWrites(state, oldRecord, newRecord);
@@ -86,12 +86,15 @@ public abstract class StandardIndexMaintainerWithQueue extends StandardIndexMain
      * @param oldRecord the previous stored record, or {@code null} for an insert
      * @param newRecord the new record, or {@code null} for a delete
      * @param <M> type of message
-     * @return the packed payload to enqueue
+     * @return the packed payload to enqueue, or {@code null} if there is nothing to defer (both records {@code null})
      */
-    @Nonnull
+    @Nullable
     static <M extends Message> Any serializePendingWrites(@Nonnull final IndexMaintainerState state,
                                                           @Nullable final FDBIndexableRecord<M> oldRecord,
                                                           @Nullable final FDBIndexableRecord<M> newRecord) {
+        if (oldRecord == null && newRecord == null) {
+            return null;
+        }
         final IndexBuildProto.OldAndNewRecords.Builder builder = IndexBuildProto.OldAndNewRecords.newBuilder();
         if (oldRecord != null) {
             builder.setOldRecords(serializePendingRecord(state, oldRecord));

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/StandardIndexMaintainerWithQueue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/StandardIndexMaintainerWithQueue.java
@@ -65,9 +65,16 @@ public abstract class StandardIndexMaintainerWithQueue extends StandardIndexMain
 
     @Override
     @Nullable
-    public <M extends Message> Any serializePendingWriteQueue(@Nullable final FDBIndexableRecord<M> oldRecord,
-                                                              @Nullable final FDBIndexableRecord<M> newRecord) {
-        return serializePendingWrites(state, oldRecord, newRecord);
+    public <M extends Message> Any serializePendingWriteQueue(@Nullable FDBIndexableRecord<M> oldRecord,
+                                                              @Nullable FDBIndexableRecord<M> newRecord) {
+        final IndexBuildProto.OldAndNewRecords.Builder builder = IndexBuildProto.OldAndNewRecords.newBuilder();
+        if (oldRecord != null) {
+            builder.setOldRecords(serializePendingRecord(state, oldRecord));
+        }
+        if (newRecord != null) {
+            builder.setNewRecord(serializePendingRecord(state, newRecord));
+        }
+        return Any.pack(builder.build());
     }
 
     @Override
@@ -81,29 +88,8 @@ public abstract class StandardIndexMaintainerWithQueue extends StandardIndexMain
     }
 
     /**
-     * Serialize an old/new record pair into the {@link Any}-packed payload deferred onto the pending write queue.
-     * @param state the maintainer state whose store serializer is used
-     * @param oldRecord the previous stored record, or {@code null} for an insert
-     * @param newRecord the new record, or {@code null} for a delete
-     * @param <M> type of message
-     * @return the packed payload to enqueue
-     */
-    private static <M extends Message> Any serializePendingWrites(@Nonnull final IndexMaintainerState state,
-                                                                  @Nullable final FDBIndexableRecord<M> oldRecord,
-                                                          @Nullable final FDBIndexableRecord<M> newRecord) {
-        final IndexBuildProto.OldAndNewRecords.Builder builder = IndexBuildProto.OldAndNewRecords.newBuilder();
-        if (oldRecord != null) {
-            builder.setOldRecords(serializePendingRecord(state, oldRecord));
-        }
-        if (newRecord != null) {
-            builder.setNewRecord(serializePendingRecord(state, newRecord));
-        }
-        return Any.pack(builder.build());
-    }
-
-    /**
      * Unpack the {@link IndexBuildProto.OldAndNewRecords} payload from a queue entry's data.
-     * @param data the {@link Any}-packed payload produced by {@link #serializePendingWrites}
+     * @param data the {@link Any}-packed payload produced by {@link #serializePendingWriteQueue(FDBIndexableRecord, FDBIndexableRecord)}
      * @return the unpacked old/new records
      */
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/StandardIndexMaintainerWithQueue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/StandardIndexMaintainerWithQueue.java
@@ -86,15 +86,11 @@ public abstract class StandardIndexMaintainerWithQueue extends StandardIndexMain
      * @param oldRecord the previous stored record, or {@code null} for an insert
      * @param newRecord the new record, or {@code null} for a delete
      * @param <M> type of message
-     * @return the packed payload to enqueue, or {@code null} if there is nothing to defer (both records {@code null})
+     * @return the packed payload to enqueue
      */
-    @Nullable
-    static <M extends Message> Any serializePendingWrites(@Nonnull final IndexMaintainerState state,
-                                                          @Nullable final FDBIndexableRecord<M> oldRecord,
+    private static <M extends Message> Any serializePendingWrites(@Nonnull final IndexMaintainerState state,
+                                                                  @Nullable final FDBIndexableRecord<M> oldRecord,
                                                           @Nullable final FDBIndexableRecord<M> newRecord) {
-        if (oldRecord == null && newRecord == null) {
-            return null;
-        }
         final IndexBuildProto.OldAndNewRecords.Builder builder = IndexBuildProto.OldAndNewRecords.newBuilder();
         if (oldRecord != null) {
             builder.setOldRecords(serializePendingRecord(state, oldRecord));

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VectorIndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VectorIndexMaintainer.java
@@ -69,6 +69,7 @@ import com.google.protobuf.Message;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -392,12 +393,28 @@ public class VectorIndexMaintainer extends StandardIndexMaintainer {
         } catch (InvalidProtocolBufferException ex) {
             throw new RecordCoreException("failed to parse vector index pending write queue entry data", ex);
         }
-        CompletableFuture<Void> future = AsyncUtil.DONE;
-        for (final IndexBuildProto.IndexEntry entry : entries.getOldEntriesList()) {
-            future = future.thenCompose(ignore -> updateIndexEntry(fromProto(entry), true));
+        List<IndexEntry> oldIndexEntries = fromProto(entries.getOldEntriesList());
+        List<IndexEntry> newIndexEntries = fromProto(entries.getNewEntriesList());
+        if (oldIndexEntries != null && newIndexEntries != null && skipUpdateForUnchangedKeys()) {
+            // Remove unchanged keys from the lists of keys to update, mirroring StandardIndexMaintainer.update.
+            final List<IndexEntry> commonKeys = commonKeys(oldIndexEntries, newIndexEntries);
+            if (!commonKeys.isEmpty()) {
+                oldIndexEntries = makeMutable(oldIndexEntries);
+                oldIndexEntries.removeAll(commonKeys);
+                newIndexEntries = makeMutable(newIndexEntries);
+                newIndexEntries.removeAll(commonKeys);
+            }
         }
-        for (final IndexBuildProto.IndexEntry entry : entries.getNewEntriesList()) {
-            future = future.thenCompose(ignore -> updateIndexEntry(fromProto(entry), false));
+        CompletableFuture<Void> future = AsyncUtil.DONE;
+        if (oldIndexEntries != null) {
+            for (final IndexEntry entry : oldIndexEntries) {
+                future = future.thenCompose(ignore -> updateIndexEntry(entry, true));
+            }
+        }
+        if (newIndexEntries != null) {
+            for (final IndexEntry entry : newIndexEntries) {
+                future = future.thenCompose(ignore -> updateIndexEntry(entry, false));
+            }
         }
         return future;
     }
@@ -417,6 +434,18 @@ public class VectorIndexMaintainer extends StandardIndexMaintainer {
                 Tuple.fromBytes(entry.getKey().toByteArray()),
                 Tuple.fromBytes(entry.getValue().toByteArray()),
                 Tuple.fromBytes(entry.getPrimaryKey().toByteArray()));
+    }
+
+    @Nullable
+    private List<IndexEntry> fromProto(@Nonnull final List<IndexBuildProto.IndexEntry> protoEntries) {
+        if (protoEntries.isEmpty()) {
+            return null;
+        }
+        final List<IndexEntry> indexEntries = new ArrayList<>(protoEntries.size());
+        for (final IndexBuildProto.IndexEntry entry : protoEntries) {
+            indexEntries.add(fromProto(entry));
+        }
+        return indexEntries;
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VectorIndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VectorIndexMaintainer.java
@@ -359,7 +359,7 @@ public class VectorIndexMaintainer extends StandardIndexMaintainer {
     }
 
     @Override
-    @Nonnull
+    @Nullable
     public <M extends Message> Any serializePendingWriteQueue(@Nullable final FDBIndexableRecord<M> oldRecord,
                                                               @Nullable final FDBIndexableRecord<M> newRecord) {
         // Serialize the computed index entries rather than the whole record.
@@ -375,6 +375,10 @@ public class VectorIndexMaintainer extends StandardIndexMaintainer {
         if (newEntries != null) {
             Verify.verify(newEntries.size() == 1);
             builder.addNewEntries(toProto(newEntries.get(0), newRecord.getPrimaryKey()));
+        }
+        if (oldEntries == null && newEntries == null) {
+            // Both records were filtered out of this index; there is nothing to defer onto the queue.
+            return null;
         }
         return Any.pack(builder.build());
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VectorIndexMaintainer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VectorIndexMaintainer.java
@@ -69,7 +69,6 @@ import com.google.protobuf.Message;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -395,7 +394,7 @@ public class VectorIndexMaintainer extends StandardIndexMaintainer {
         }
         List<IndexEntry> oldIndexEntries = fromProto(entries.getOldEntriesList());
         List<IndexEntry> newIndexEntries = fromProto(entries.getNewEntriesList());
-        if (oldIndexEntries != null && newIndexEntries != null && skipUpdateForUnchangedKeys()) {
+        if (skipUpdateForUnchangedKeys()) {
             // Remove unchanged keys from the lists of keys to update, mirroring StandardIndexMaintainer.update.
             final List<IndexEntry> commonKeys = commonKeys(oldIndexEntries, newIndexEntries);
             if (!commonKeys.isEmpty()) {
@@ -406,15 +405,11 @@ public class VectorIndexMaintainer extends StandardIndexMaintainer {
             }
         }
         CompletableFuture<Void> future = AsyncUtil.DONE;
-        if (oldIndexEntries != null) {
-            for (final IndexEntry entry : oldIndexEntries) {
-                future = future.thenCompose(ignore -> updateIndexEntry(entry, true));
-            }
+        for (final IndexEntry entry : oldIndexEntries) {
+            future = future.thenCompose(ignore -> updateIndexEntry(entry, true));
         }
-        if (newIndexEntries != null) {
-            for (final IndexEntry entry : newIndexEntries) {
-                future = future.thenCompose(ignore -> updateIndexEntry(entry, false));
-            }
+        for (final IndexEntry entry : newIndexEntries) {
+            future = future.thenCompose(ignore -> updateIndexEntry(entry, false));
         }
         return future;
     }
@@ -436,16 +431,9 @@ public class VectorIndexMaintainer extends StandardIndexMaintainer {
                 Tuple.fromBytes(entry.getPrimaryKey().toByteArray()));
     }
 
-    @Nullable
+    @Nonnull
     private List<IndexEntry> fromProto(@Nonnull final List<IndexBuildProto.IndexEntry> protoEntries) {
-        if (protoEntries.isEmpty()) {
-            return null;
-        }
-        final List<IndexEntry> indexEntries = new ArrayList<>(protoEntries.size());
-        for (final IndexBuildProto.IndexEntry entry : protoEntries) {
-            indexEntries.add(fromProto(entry));
-        }
-        return indexEntries;
+        return protoEntries.stream().map(this::fromProto).toList();
     }
 
     @Override

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/SlidingWindowIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/SlidingWindowIndexTest.java
@@ -2153,6 +2153,50 @@ class SlidingWindowIndexTest extends FDBRecordStoreTestBase {
     }
 
     @Test
+    void writeOnlyWithQueueUpdateOfWindowValueOnlyRefilesEntry() throws Exception {
+        // Test the case of record change that affects the window, but not the delegate
+        try (FDBRecordContext context = openContext()) {
+            openStore(context, 3, Direction.DESC);
+            rec(1, 100);   // the boundary: the worst of three entries in a window of 3
+            rec(2, 200);
+            rec(3, 300);
+            assertThat(slidingWindow()).hasSizeOf(3).underlyingHnsw().containsInAnyOrder(1, 2, 3);
+            commit(context);
+        }
+
+        try (FDBRecordContext context = openContext()) {
+            openStore(context, 3, Direction.DESC);
+            recordStore.markIndexWriteOnlyWithQueue(INDEX_NAME).join();
+            rec(1, 250);  // update: 100 -> 250, same vector, deferred to the queue
+            commit(context);
+        }
+
+        drainQueue(3, Direction.DESC);
+
+        try (FDBRecordContext context = openContext()) {
+            openStore(context, 3, Direction.DESC);
+            assertThat(slidingWindow())
+                    .hasSizeOf(3)
+                    .underlyingHnsw().containsInAnyOrder(1, 2, 3);
+            commit(context);
+        }
+
+        // The count and the delegate look identical whether the entry was re-filed, so probe the boundary
+        // instead: rec 2 at 200 is now the worst entry in the window, so a new record at 220 has to evict it. Had
+        // rec 1's entry been left behind at 100, rec 1 would still be the boundary and would have been evicted.
+        try (FDBRecordContext context = openContext()) {
+            openStore(context, 3, Direction.DESC);
+            assertTrue(recordStore.isIndexReadable(index()));
+            rec(4, 220);
+            assertThat(slidingWindow())
+                    .as("the boundary must have moved to rec 2 when rec 1 was re-filed at its higher window value")
+                    .hasSizeOf(3)
+                    .underlyingHnsw().containsInAnyOrder(1, 3, 4);
+            commit(context);
+        }
+    }
+
+    @Test
     void writeOnlyWithQueueGroupedRoutesPerGroup() throws Exception {
         // Each partition maintains its own window when writes are deferred and later drained.
         final List<List<String>> grouping = ImmutableList.of(ImmutableList.of("zone"));

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VectorIndexEngineTestSuite.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VectorIndexEngineTestSuite.java
@@ -873,8 +873,8 @@ abstract class VectorIndexEngineTestSuite extends VectorIndexTestBase {
      */
     @Nonnull
     private VectorIndexMaintainer maintainerExcludingRecordsWithoutVector(@Nonnull final Index index) {
-        final IndexMaintenanceFilter filter = (ignored, record) ->
-                record instanceof VectorRecord && ((VectorRecord)record).hasVectorData()
+        final IndexMaintenanceFilter filter = (ignored, rec) ->
+                rec instanceof VectorRecord && ((VectorRecord)rec).hasVectorData()
                 ? IndexMaintenanceFilter.IndexValues.ALL
                 : IndexMaintenanceFilter.IndexValues.NONE;
         return new VectorIndexMaintainer(new IndexMaintainerState(recordStore, index, filter));

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VectorIndexEngineTestSuite.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VectorIndexEngineTestSuite.java
@@ -26,6 +26,7 @@ import com.apple.foundationdb.record.Bindings;
 import com.apple.foundationdb.record.EvaluationContext;
 import com.apple.foundationdb.record.ExecuteProperties;
 import com.apple.foundationdb.record.ExecuteState;
+import com.apple.foundationdb.record.IndexBuildProto;
 import com.apple.foundationdb.record.IndexEntry;
 import com.apple.foundationdb.record.IndexScanType;
 import com.apple.foundationdb.record.IsolationLevel;
@@ -45,6 +46,8 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoredRecord;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainer;
+import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerState;
+import com.apple.foundationdb.record.provider.foundationdb.IndexMaintenanceFilter;
 import com.apple.foundationdb.record.provider.foundationdb.OnlineIndexer;
 import com.apple.foundationdb.record.provider.foundationdb.VectorIndexScanComparisons;
 import com.apple.foundationdb.record.provider.foundationdb.VectorIndexScanOptions;
@@ -71,6 +74,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -717,6 +721,124 @@ abstract class VectorIndexEngineTestSuite extends VectorIndexTestBase {
         checkResultsGrouped(createIndexPlan(queryVector, k, "GroupedVectorIndex"), Integer.MAX_VALUE, expectedResults);
     }
 
+    @Test
+    void pendingWriteQueueSkipsRecordExcludedByFilter() throws Exception {
+        final HalfRealVector query = constantHalfVector(0.1f, 128);
+        try (FDBRecordContext context = openContext()) {
+            openRecordStore(context, this::addUngroupedVectorIndex);
+            final Index index = recordStore.getRecordMetaData().getIndex("UngroupedVectorIndex");
+            final VectorIndexMaintainer maintainer = maintainerExcludingRecordsWithoutVector(index);
+
+            final FDBStoredRecord<Message> witness = saveVectorRecord(2L, constantHalfVector(0.5f, 128));
+            final FDBStoredRecord<Message> excluded = unsavedVectorRecord(witness, 1L, null);
+
+            assertThat(maintainer.serializePendingWriteQueue(null, excluded))
+                    .as("adding a record the filter excludes must not be deferred onto the queue")
+                    .isNull();
+            assertThat(maintainer.serializePendingWriteQueue(excluded, excluded))
+                    .as("changing a record that is excluded before and after must not be deferred either")
+                    .isNull();
+            assertThat(maintainer.serializePendingWriteQueue(excluded, null))
+                    .as("removing a record the filter excludes must not be deferred either")
+                    .isNull();
+
+            assertThat(nearestRecNos(index, query, 10))
+                    .as("only the witness was ever indexed")
+                    .containsExactly(2L);
+            commit(context);
+        }
+    }
+
+    @Test
+    void pendingWriteQueueDefersInsertWhenRecordBecomesIncluded() throws Exception {
+        final HalfRealVector query = constantHalfVector(0.1f, 128);
+        try (FDBRecordContext context = openContext()) {
+            openRecordStore(context, this::addUngroupedVectorIndex);
+            final Index index = recordStore.getRecordMetaData().getIndex("UngroupedVectorIndex");
+            final VectorIndexMaintainer maintainer = maintainerExcludingRecordsWithoutVector(index);
+
+            final FDBStoredRecord<Message> witness = saveVectorRecord(2L, constantHalfVector(0.5f, 128));
+            final FDBStoredRecord<Message> excluded = unsavedVectorRecord(witness, 1L, null);
+            final FDBStoredRecord<Message> included = unsavedVectorRecord(witness, 1L, constantHalfVector(0.11f, 128));
+
+            final Any entry = maintainer.serializePendingWriteQueue(excluded, included);
+            assertThat(entry).as("the included half still has to be deferred").isNotNull();
+            final IndexBuildProto.OldAndNewIndexEntries deferred =
+                    entry.unpack(IndexBuildProto.OldAndNewIndexEntries.class);
+            assertThat(deferred.getOldEntriesCount())
+                    .as("the excluded old half must not be deferred: there is nothing in the index to remove")
+                    .isZero();
+            assertThat(deferred.getNewEntriesCount()).isOne();
+
+            maintainer.updateFromQueue(entry).join();
+            assertThat(nearestRecNos(index, query, 10))
+                    .as("draining the insert-only payload must add the newly included record")
+                    .containsExactly(1L, 2L);
+            commit(context);
+        }
+    }
+
+    @Test
+    void pendingWriteQueueDefersDeleteWhenRecordBecomesExcluded() throws Exception {
+        final HalfRealVector query = constantHalfVector(0.1f, 128);
+        try (FDBRecordContext context = openContext()) {
+            openRecordStore(context, this::addUngroupedVectorIndex);
+            final Index index = recordStore.getRecordMetaData().getIndex("UngroupedVectorIndex");
+            final VectorIndexMaintainer maintainer = maintainerExcludingRecordsWithoutVector(index);
+
+            saveVectorRecord(2L, constantHalfVector(0.5f, 128)); // witness that must survive
+            final FDBStoredRecord<Message> included = saveVectorRecord(1L, constantHalfVector(0.11f, 128));
+            assertThat(nearestRecNos(index, query, 10)).containsExactly(1L, 2L);
+
+            final FDBStoredRecord<Message> excluded = unsavedVectorRecord(included, 1L, null);
+            final Any entry = maintainer.serializePendingWriteQueue(included, excluded);
+            assertThat(entry).as("the removal still has to be deferred").isNotNull();
+            final IndexBuildProto.OldAndNewIndexEntries deferred =
+                    entry.unpack(IndexBuildProto.OldAndNewIndexEntries.class);
+            assertThat(deferred.getOldEntriesCount()).isOne();
+            assertThat(deferred.getNewEntriesCount())
+                    .as("the excluded new half must not be deferred: it does not belong in the index")
+                    .isZero();
+
+            maintainer.updateFromQueue(entry).join();
+            assertThat(nearestRecNos(index, query, 10))
+                    .as("draining the delete-only payload must take the newly excluded record out of the index")
+                    .containsExactly(2L);
+            commit(context);
+        }
+    }
+
+    @Test
+    void pendingWriteQueueRoundTripsIncludedRecordWhenFilterPresent() throws Exception {
+        final HalfRealVector query = constantHalfVector(0.1f, 128);
+        try (FDBRecordContext context = openContext()) {
+            openRecordStore(context, this::addUngroupedVectorIndex);
+            final Index index = recordStore.getRecordMetaData().getIndex("UngroupedVectorIndex");
+            final VectorIndexMaintainer maintainer = maintainerExcludingRecordsWithoutVector(index);
+
+            final FDBStoredRecord<Message> witness = saveVectorRecord(2L, constantHalfVector(0.5f, 128));
+            final FDBStoredRecord<Message> added = unsavedVectorRecord(witness, 1L, constantHalfVector(0.11f, 128));
+
+            maintainer.updateFromQueue(Objects.requireNonNull(maintainer.serializePendingWriteQueue(null, added))).join();
+            assertThat(nearestRecNos(index, query, 10))
+                    .as("an included record is added even though a filter is in force")
+                    .containsExactly(1L, 2L);
+
+            // Move it past the witness: uniform vectors make the resulting order unambiguous.
+            final FDBStoredRecord<Message> changed = unsavedVectorRecord(witness, 1L, constantHalfVector(0.9f, 128));
+            maintainer.updateFromQueue(Objects.requireNonNull(maintainer.serializePendingWriteQueue(added, changed))).join();
+            assertThat(nearestRecNos(index, query, 10))
+                    .as("an included record is updated in place, and repositioned by its new vector")
+                    .containsExactly(2L, 1L);
+
+            maintainer.updateFromQueue(Objects.requireNonNull(maintainer.serializePendingWriteQueue(changed, null))).join();
+            assertThat(nearestRecNos(index, query, 10))
+                    .as("an included record is removed, leaving the witness untouched")
+                    .containsExactly(2L);
+            commit(context);
+        }
+    }
+
     @Nonnull
     private FDBStoredRecord<Message> saveVectorRecord(final long recNo, @Nonnull final HalfRealVector vector) {
         final Message rec = VectorRecord.newBuilder()
@@ -740,6 +862,41 @@ abstract class VectorIndexEngineTestSuite extends VectorIndexTestBase {
         return FDBStoredRecord.newBuilder(rec)
                 .setPrimaryKey(primaryKey)
                 .setRecordType(stored.getRecordType())
+                .build();
+    }
+
+    /**
+     * A maintainer over the given index whose maintenance filter excludes records that have no vector yet — the shape
+     * of a record whose embedding has not been computed. Vector presence is the only property of a
+     * {@code VectorRecord} that can change without changing its primary key, so it is what lets a record cross the
+     * filter in place.
+     */
+    @Nonnull
+    private VectorIndexMaintainer maintainerExcludingRecordsWithoutVector(@Nonnull final Index index) {
+        final IndexMaintenanceFilter filter = (ignored, record) ->
+                record instanceof VectorRecord && ((VectorRecord)record).hasVectorData()
+                ? IndexMaintenanceFilter.IndexValues.ALL
+                : IndexMaintenanceFilter.IndexValues.NONE;
+        return new VectorIndexMaintainer(new IndexMaintainerState(recordStore, index, filter));
+    }
+
+    /**
+     * Builds, without saving it, a record in group 0 (the group {@link #saveVectorRecord} uses) with the given rec-no,
+     * carrying the given vector or no vector at all when {@code vector} is {@code null}. The record type is taken from
+     * {@code template}.
+     */
+    @Nonnull
+    private FDBStoredRecord<Message> unsavedVectorRecord(@Nonnull final FDBStoredRecord<Message> template,
+                                                         final long recNo,
+                                                         @Nullable final HalfRealVector vector) {
+        final VectorRecord.Builder rec = VectorRecord.newBuilder().setGroupId(0).setRecNo(recNo);
+        if (vector != null) {
+            rec.setVectorData(ByteString.copyFrom(vector.getRawData()));
+        }
+        final Message message = rec.build();
+        return FDBStoredRecord.newBuilder(message)
+                .setPrimaryKey(Tuple.from(0L, recNo))
+                .setRecordType(template.getRecordType())
                 .build();
     }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VectorIndexEngineTestSuite.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VectorIndexEngineTestSuite.java
@@ -42,6 +42,7 @@ import com.apple.foundationdb.record.metadata.MetaDataEvolutionValidator;
 import com.apple.foundationdb.record.metadata.MetaDataException;
 import com.apple.foundationdb.record.provider.foundationdb.FDBQueriedRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
+import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoredRecord;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainer;
 import com.apple.foundationdb.record.provider.foundationdb.OnlineIndexer;
@@ -568,6 +569,47 @@ abstract class VectorIndexEngineTestSuite extends VectorIndexTestBase {
     }
 
     @Test
+    void pendingWriteQueueSkipsUnchangedVector() throws Exception {
+        // Test record rewriting without its vector changing
+        final HalfRealVector query = constantHalfVector(0.1f, 128);
+        final HalfRealVector witnessVector = constantHalfVector(0.5f, 128);
+        final HalfRealVector vector = constantHalfVector(0.11f, 128);
+        try (FDBRecordContext context = openContext()) {
+            openRecordStore(context, this::addUngroupedVectorIndex);
+            final Index index = recordStore.getRecordMetaData().getIndex("UngroupedVectorIndex");
+            final IndexMaintainer maintainer = recordStore.getIndexMaintainer(index);
+
+            saveVectorRecord(2L, witnessVector); // witness that must not move
+            final FDBStoredRecord<Message> stored = saveVectorRecord(1L, vector);
+            assertThat(nearestRecNos(index, query, 10)).containsExactly(1L, 2L);
+
+            final Any unchanged = maintainer.serializePendingWriteQueue(stored, rewriteWithVector(stored, vector));
+            assertThat(unchanged)
+                    .as("an unchanged vector is still deferred onto the queue; the skip happens on the way out")
+                    .isNotNull();
+
+            timer.reset();
+            maintainer.updateFromQueue(unchanged).join();
+            final long writesWhenUnchanged = timer.getCount(FDBStoreTimer.Counts.SAVE_INDEX_KEY);
+            final long readsWhenUnchanged = timer.getCount(FDBStoreTimer.Counts.LOAD_INDEX_KEY);
+
+            assertThat(writesWhenUnchanged).isZero();
+            assertThat(readsWhenUnchanged).isZero();
+            assertThat(nearestRecNos(index, query, 10)).containsExactly(1L, 2L);
+
+            final Any changed = maintainer.serializePendingWriteQueue(stored,
+                    rewriteWithVector(stored, constantHalfVector(0.9f, 128)));
+            timer.reset();
+            assertThat(changed).isNotNull();
+            maintainer.updateFromQueue(changed).join();
+            assertThat(timer.getCount(FDBStoreTimer.Counts.SAVE_INDEX_KEY))
+                    .as("a changed vector must still be applied")
+                    .isPositive();
+            commit(context);
+        }
+    }
+
+    @Test
     void updateFromQueueDeleteIsIdempotent() throws Exception {
         // Re-draining a delete entry (e.g. a retried indexer) must be a harmless no-op the second time: HNSW.delete
         // completes without error when the node is already gone.
@@ -683,6 +725,22 @@ abstract class VectorIndexEngineTestSuite extends VectorIndexTestBase {
                 .setVectorData(ByteString.copyFrom(vector.getRawData()))
                 .build();
         return recordStore.saveRecord(rec);
+    }
+
+    @Nonnull
+    private FDBStoredRecord<Message> rewriteWithVector(@Nonnull final FDBStoredRecord<Message> stored,
+                                                       @Nonnull final HalfRealVector vector) {
+        // The primary key is (group_id, rec_no), so both fields come back out of the record being rewritten.
+        final Tuple primaryKey = stored.getPrimaryKey();
+        final Message rec = VectorRecord.newBuilder()
+                .setGroupId(Ints.checkedCast(primaryKey.getLong(0)))
+                .setRecNo(primaryKey.getLong(1))
+                .setVectorData(ByteString.copyFrom(vector.getRawData()))
+                .build();
+        return FDBStoredRecord.newBuilder(rec)
+                .setPrimaryKey(primaryKey)
+                .setRecordType(stored.getRecordType())
+                .build();
     }
 
     /**


### PR DESCRIPTION
This PR is a followup of https://github.com/FoundationDB/fdb-record-layer/pull/4370. 

If an update is not needed (i.e both new and old records were filtered out), skip pushing a pending write queue item as the operation is a no-op. 
Vector index, when updating from queue, will remove common entries (i.e. replacing an entry with an exact copy) similar to what `IndexStandardMaintainer` does during regular update.