### PR TITLE
add additional vector options prematurely

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/IndexOptions.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/metadata/IndexOptions.java
@@ -461,6 +461,13 @@ public class IndexOptions {
     /** Guardiann-only: maximum number of primary vectors in a cluster before a split is triggered. */
     public static final String GUARDIANN_PRIMARY_CLUSTER_MAX = "guardiannPrimaryClusterMax";
 
+    /**
+     * Guardiann-only: hard cap on primary vectors in a cluster, above {@code guardiannPrimaryClusterMax}. When deferred
+     * maintenance tasks are not run in the writing transaction, an insert that would take a cluster above this cap is
+     * rejected with a back-pressure exception, so writers slow down while the background merge drains the split backlog.
+     */
+    public static final String GUARDIANN_PRIMARY_CLUSTER_HARD_MAX = "guardiannPrimaryClusterHardMax";
+
     /** Guardiann-only: maximum number of under-replicated primary vectors before a reassign is triggered. */
     public static final String GUARDIANN_UNDERREPLICATED_PRIMARY_CLUSTER_MAX = "guardiannUnderreplicatedPrimaryClusterMax";
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VectorIndexEngine.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VectorIndexEngine.java
@@ -23,7 +23,6 @@ package com.apple.foundationdb.record.provider.foundationdb.indexes;
 import com.apple.foundationdb.async.common.ResultEntry;
 import com.apple.foundationdb.linear.Metric;
 import com.apple.foundationdb.linear.RealVector;
-import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.IndexOptions;
 import com.apple.foundationdb.record.metadata.MetaDataException;
@@ -35,7 +34,6 @@ import com.apple.foundationdb.tuple.Tuple;
 
 import javax.annotation.Nonnull;
 import java.util.List;
-import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
@@ -110,42 +108,14 @@ sealed interface VectorIndexEngine permits HnswVectorIndexEngine, GuardiannVecto
                                    @Nonnull RealVector vector);
 
     /**
-     * The kinds of vector engine, as selectable through the {@link IndexOptions#VECTOR_ENGINE} index option.
-     */
-    enum Kind {
-        HNSW,
-        GUARDIANN;
-
-        /**
-         * Resolves an engine kind from its option string, accepting any letter case. When {@code value} is
-         * {@code null} (the option was not set) the engine defaults to {@link #HNSW}, so vector indexes created before
-         * the engine option existed continue to use HNSW.
-         *
-         * @param value the raw option value, or {@code null} if unset
-         * @return the resolved engine kind
-         */
-        @Nonnull
-        static Kind fromOptionValue(final String value) {
-            if (value == null) {
-                return HNSW;
-            }
-            return switch (value.toUpperCase(Locale.ROOT)) {
-                case "HNSW" -> HNSW;
-                case "GUARDIANN" -> GUARDIANN;
-                default -> throw new MetaDataException("unknown vector index engine", LogMessageKeys.VALUE, value);
-            };
-        }
-    }
-
-    /**
      * Determines the engine kind an index is configured to use.
      *
      * @param index the index definition
      * @return the engine kind
      */
     @Nonnull
-    static Kind kindFromIndex(@Nonnull final Index index) {
-        return Kind.fromOptionValue(index.getOption(IndexOptions.VECTOR_ENGINE));
+    static VectorIndexEngineKind kindFromIndex(@Nonnull final Index index) {
+        return VectorIndexEngineKind.fromOptionValue(index.getOption(IndexOptions.VECTOR_ENGINE));
     }
 
     /**
@@ -193,7 +163,7 @@ sealed interface VectorIndexEngine permits HnswVectorIndexEngine, GuardiannVecto
     static void validateChangedOptions(@Nonnull final Index oldIndex, @Nonnull final Index newIndex,
                                        @Nonnull final Set<String> changedOptions) {
         // The engine backing an index can never change; that would reinterpret the on-disk layout.
-        final Kind newIndexKind = kindFromIndex(newIndex);
+        final VectorIndexEngineKind newIndexKind = kindFromIndex(newIndex);
         VectorIndexOptionsHelper.disallowChange(changedOptions, IndexOptions.VECTOR_ENGINE,
                 kindFromIndex(oldIndex), newIndexKind, newIndex.getName());
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VectorIndexEngineKind.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VectorIndexEngineKind.java
@@ -1,0 +1,60 @@
+/*
+ * VectorIndexEngineKind.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb.indexes;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.logging.LogMessageKeys;
+import com.apple.foundationdb.record.metadata.IndexOptions;
+import com.apple.foundationdb.record.metadata.MetaDataException;
+
+import javax.annotation.Nonnull;
+import java.util.Locale;
+
+/**
+ * The kinds of vector engine, as selectable through the {@link IndexOptions#VECTOR_ENGINE} index option. Public so
+ * consumers of the record layer can name the engine an index is (or should be) built with; the {@link VectorIndexEngine}
+ * implementations themselves remain internal.
+ */
+@API(API.Status.EXPERIMENTAL)
+public enum VectorIndexEngineKind {
+    HNSW,
+    GUARDIANN;
+
+    /**
+     * Resolves an engine kind from its option string, accepting any letter case. When {@code value} is
+     * {@code null} (the option was not set) the engine defaults to {@link #HNSW}, so vector indexes created before
+     * the engine option existed continue to use HNSW.
+     *
+     * @param value the raw option value, or {@code null} if unset
+     * @return the resolved engine kind
+     */
+    @Nonnull
+    public static VectorIndexEngineKind fromOptionValue(final String value) {
+        if (value == null) {
+            return HNSW;
+        }
+        return switch (value.toUpperCase(Locale.ROOT)) {
+            case "HNSW" -> HNSW;
+            case "GUARDIANN" -> GUARDIANN;
+            default -> throw new MetaDataException("unknown vector index engine", LogMessageKeys.VALUE, value);
+        };
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VectorIndexOptionKeys.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VectorIndexOptionKeys.java
@@ -42,6 +42,13 @@ import java.util.List;
 @API(API.Status.EXPERIMENTAL)
 public final class VectorIndexOptionKeys {
     //
+    // The engine selector: which vector engine backs the index. Engine-neutral and brand-new, so a single canonical
+    // {@code vector*} name with no legacy alias.
+    //
+    public static final VectorOptionKey<VectorIndexEngineKind> ENGINE =
+            VectorOptionKey.ofEngine(IndexOptions.VECTOR_ENGINE);
+
+    //
     // Shared concepts: one option key per concept both engines share.
     //
     // TEMPORARY (rolling-upgrade wire compatibility): the canonical name is deliberately the legacy {@code hnsw*} name,
@@ -99,6 +106,8 @@ public final class VectorIndexOptionKeys {
             VectorOptionKey.ofInteger(IndexOptions.GUARDIANN_PRIMARY_CLUSTER_MIN);
     public static final VectorOptionKey<Integer> GUARDIANN_PRIMARY_CLUSTER_MAX =
             VectorOptionKey.ofInteger(IndexOptions.GUARDIANN_PRIMARY_CLUSTER_MAX);
+    public static final VectorOptionKey<Integer> GUARDIANN_PRIMARY_CLUSTER_HARD_MAX =
+            VectorOptionKey.ofInteger(IndexOptions.GUARDIANN_PRIMARY_CLUSTER_HARD_MAX);
     public static final VectorOptionKey<Integer> GUARDIANN_UNDERREPLICATED_PRIMARY_CLUSTER_MAX =
             VectorOptionKey.ofInteger(IndexOptions.GUARDIANN_UNDERREPLICATED_PRIMARY_CLUSTER_MAX);
     public static final VectorOptionKey<Integer> GUARDIANN_REPLICATED_CLUSTER_MAX_WRITES =
@@ -154,12 +163,14 @@ public final class VectorIndexOptionKeys {
      * {@code VectorIndexOptionKeysTest.allContainsEveryDeclaredKey}.
      */
     static final List<VectorOptionKey<?>> ALL = ImmutableList.of(
+            ENGINE,
             METRIC, NUM_DIMENSIONS, SAMPLE_VECTOR_STATS_PROBABILITY, MAINTAIN_STATS_PROBABILITY, STATS_THRESHOLD,
             USE_RABITQ, RABITQ_NUM_EX_BITS,
             HNSW_USE_INLINING, HNSW_M, HNSW_M_MAX, HNSW_M_MAX_0, HNSW_EF_CONSTRUCTION, HNSW_EF_REPAIR,
             HNSW_EXTEND_CANDIDATES, HNSW_KEEP_PRUNED_CONNECTIONS, HNSW_MAX_NUM_CONCURRENT_DELETE_FROM_LAYER,
             HNSW_MAX_NUM_CONCURRENT_NODE_FETCHES, HNSW_MAX_NUM_CONCURRENT_NEIGHBORHOOD_FETCHES,
-            GUARDIANN_PRIMARY_CLUSTER_MIN, GUARDIANN_PRIMARY_CLUSTER_MAX, GUARDIANN_UNDERREPLICATED_PRIMARY_CLUSTER_MAX,
+            GUARDIANN_PRIMARY_CLUSTER_MIN, GUARDIANN_PRIMARY_CLUSTER_MAX, GUARDIANN_PRIMARY_CLUSTER_HARD_MAX,
+            GUARDIANN_UNDERREPLICATED_PRIMARY_CLUSTER_MAX,
             GUARDIANN_REPLICATED_CLUSTER_MAX_WRITES, GUARDIANN_REPLICATED_CLUSTER_TARGET,
             GUARDIANN_REPLICATION_PRIORITY_MIN, GUARDIANN_REPLICATION_DISTANCE_RATIO_WEIGHT,
             GUARDIANN_REPLICATION_Z_SCORE_WEIGHT, GUARDIANN_REPLICATION_STATS_MIN_SAMPLE_SIZE,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VectorOptionKey.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VectorOptionKey.java
@@ -57,8 +57,8 @@ import java.util.function.Supplier;
  * key deserialized from a legacy wire name identical to the freshly declared canonical key (so options maps, equality,
  * and plan hashes are stable across the alias). The key is {@link PlanHashable}, contributing only its canonical name,
  * so a scan-options map keyed by these keys hashes deterministically. Instances are created through the typed factories
- * ({@link #ofInteger}, {@link #ofDouble}, {@link #ofBoolean}, {@link #ofMetric}) and are intended to be declared once as
- * {@code static final} catalog entries.
+ * ({@link #ofInteger}, {@link #ofDouble}, {@link #ofBoolean}, {@link #ofMetric}, {@link #ofEngine}) and are intended to
+ * be declared once as {@code static final} catalog entries.
  *
  * @param <T> the parsed/stored value type of the option
  */
@@ -235,5 +235,14 @@ public final class VectorOptionKey<T> implements PlanHashable {
         // Metric::valueOf, so the serializer must be Metric::name to round-trip.
         return new VectorOptionKey<>(canonicalName, ImmutableList.copyOf(aliases), Metric.class, Metric::valueOf,
                 Metric::name);
+    }
+
+    @Nonnull
+    public static VectorOptionKey<VectorIndexEngineKind> ofEngine(@Nonnull final String canonicalName,
+                                                                   @Nonnull final String... aliases) {
+        // Kind.fromOptionValue accepts any letter case (and rejects unknown values); the serializer is Kind::name so the
+        // stored form round-trips back through the parser.
+        return new VectorOptionKey<>(canonicalName, ImmutableList.copyOf(aliases), VectorIndexEngineKind.class,
+                VectorIndexEngineKind::fromOptionValue, VectorIndexEngineKind::name);
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/GuardiannVectorIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/GuardiannVectorIndexTest.java
@@ -47,7 +47,7 @@ class GuardiannVectorIndexTest extends VectorIndexEngineTestSuite {
     @Override
     protected Map<String, String> indexOptions() {
         return ImmutableMap.<String, String>builder()
-                .put(IndexOptions.VECTOR_ENGINE, VectorIndexEngine.Kind.GUARDIANN.name())
+                .put(IndexOptions.VECTOR_ENGINE, VectorIndexEngineKind.GUARDIANN.name())
                 .put(IndexOptions.VECTOR_METRIC, Metric.EUCLIDEAN_METRIC.name())
                 .put(IndexOptions.VECTOR_NUM_DIMENSIONS, "128")
                 .put(IndexOptions.GUARDIANN_PRIMARY_CLUSTER_MAX, "200")
@@ -69,7 +69,7 @@ class GuardiannVectorIndexTest extends VectorIndexEngineTestSuite {
             validateOptionsEvolution(metaData, index,
                     ImmutableMap.<String, String>builder()
                             // immutable — must be re-specified at the same value
-                            .put(IndexOptions.VECTOR_ENGINE, VectorIndexEngine.Kind.GUARDIANN.name())
+                            .put(IndexOptions.VECTOR_ENGINE, VectorIndexEngineKind.GUARDIANN.name())
                             .put(IndexOptions.VECTOR_METRIC, Metric.EUCLIDEAN_METRIC.name())
                             .put(IndexOptions.VECTOR_NUM_DIMENSIONS, "128")
                             .put(IndexOptions.GUARDIANN_PRIMARY_CLUSTER_MAX, "200")
@@ -88,7 +88,7 @@ class GuardiannVectorIndexTest extends VectorIndexEngineTestSuite {
 
             // switching the engine is never allowed
             assertInvalidOptionsEvolution(metaData, index,
-                    optionsWith(IndexOptions.VECTOR_ENGINE, VectorIndexEngine.Kind.HNSW.name()));
+                    optionsWith(IndexOptions.VECTOR_ENGINE, VectorIndexEngineKind.HNSW.name()));
 
             // changing an immutable encoding option is not allowed
             assertInvalidOptionsEvolution(metaData, index,

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/HnswVectorIndexIndexingTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/HnswVectorIndexIndexingTest.java
@@ -58,7 +58,7 @@ class HnswVectorIndexIndexingTest extends VectorIndexTestBase {
     @Nonnull
     @Override
     protected Map<String, String> indexOptions() {
-        return ImmutableMap.of(IndexOptions.VECTOR_ENGINE, VectorIndexEngine.Kind.HNSW.name(),
+        return ImmutableMap.of(IndexOptions.VECTOR_ENGINE, VectorIndexEngineKind.HNSW.name(),
                 IndexOptions.VECTOR_METRIC, Metric.EUCLIDEAN_METRIC.name(),
                 IndexOptions.VECTOR_NUM_DIMENSIONS, "128");
     }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/HnswVectorIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/HnswVectorIndexTest.java
@@ -41,7 +41,7 @@ class HnswVectorIndexTest extends VectorIndexEngineTestSuite {
     @Nonnull
     @Override
     protected Map<String, String> indexOptions() {
-        return ImmutableMap.of(IndexOptions.VECTOR_ENGINE, VectorIndexEngine.Kind.HNSW.name(),
+        return ImmutableMap.of(IndexOptions.VECTOR_ENGINE, VectorIndexEngineKind.HNSW.name(),
                 IndexOptions.VECTOR_METRIC, Metric.EUCLIDEAN_METRIC.name(),
                 IndexOptions.VECTOR_NUM_DIMENSIONS, "128");
     }
@@ -57,7 +57,7 @@ class HnswVectorIndexTest extends VectorIndexEngineTestSuite {
             // validate the allowed changes all at once
             validateOptionsEvolution(metaData, index,
                     ImmutableMap.<String, String>builder()
-                            .put(IndexOptions.VECTOR_ENGINE, VectorIndexEngine.Kind.HNSW.name())
+                            .put(IndexOptions.VECTOR_ENGINE, VectorIndexEngineKind.HNSW.name())
                             // cannot change those per se but must accept same value
                             .put(IndexOptions.VECTOR_METRIC, Metric.EUCLIDEAN_METRIC.name())
                             .put(IndexOptions.VECTOR_NUM_DIMENSIONS, "128")
@@ -90,7 +90,7 @@ class HnswVectorIndexTest extends VectorIndexEngineTestSuite {
             // switching the engine is never allowed
             assertInvalidOptionsEvolution(metaData, index,
                     ImmutableMap.of(IndexOptions.VECTOR_NUM_DIMENSIONS, "128",
-                            IndexOptions.VECTOR_ENGINE, VectorIndexEngine.Kind.GUARDIANN.name()));
+                            IndexOptions.VECTOR_ENGINE, VectorIndexEngineKind.GUARDIANN.name()));
 
             assertInvalidOptionsEvolution(metaData, index,
                     ImmutableMap.of(IndexOptions.VECTOR_NUM_DIMENSIONS, "128",

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DdlVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DdlVisitor.java
@@ -22,8 +22,8 @@ package com.apple.foundationdb.relational.recordlayer.query.visitors;
 
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.linear.Metric;
-import com.apple.foundationdb.record.metadata.IndexOptions;
 import com.apple.foundationdb.record.metadata.IndexTypes;
+import com.apple.foundationdb.record.provider.foundationdb.indexes.VectorIndexEngineKind;
 import com.apple.foundationdb.record.provider.foundationdb.indexes.VectorIndexOptionKeys;
 import com.apple.foundationdb.record.provider.foundationdb.indexes.VectorOptionKey;
 import com.apple.foundationdb.record.query.plan.cascades.RawSqlFunction;
@@ -80,13 +80,11 @@ import java.util.stream.Collectors;
 
 @API(API.Status.EXPERIMENTAL)
 public final class DdlVisitor extends DelegatingVisitor<BaseVisitor> {
-    // Engine names as stored in the IndexOptions.VECTOR_ENGINE option (mirrors VectorIndexEngine.Kind, which is not
-    // visible from this module). HNSW is the engine used when the option is absent.
-    private static final String HNSW_ENGINE = "HNSW";
-    private static final String GUARDIANN_ENGINE = "GUARDIANN";
-    private static final Set<String> ANY_ENGINE = ImmutableSet.of(HNSW_ENGINE, GUARDIANN_ENGINE);
-    private static final Set<String> HNSW_ONLY = ImmutableSet.of(HNSW_ENGINE);
-    private static final Set<String> GUARDIANN_ONLY = ImmutableSet.of(GUARDIANN_ENGINE);
+    // The vector engines an option may apply to. HNSW is the engine used when the VECTOR_ENGINE option is absent.
+    private static final Set<VectorIndexEngineKind> ANY_ENGINE =
+            ImmutableSet.of(VectorIndexEngineKind.HNSW, VectorIndexEngineKind.GUARDIANN);
+    private static final Set<VectorIndexEngineKind> HNSW_ONLY = ImmutableSet.of(VectorIndexEngineKind.HNSW);
+    private static final Set<VectorIndexEngineKind> GUARDIANN_ONLY = ImmutableSet.of(VectorIndexEngineKind.GUARDIANN);
 
     // The curated set of vector index options exposed through SQL DDL, keyed by their (lower-cased) SQL option name.
     // Adding or removing an option, or changing which engine it applies to, is a one-line change here and needs no
@@ -370,7 +368,7 @@ public final class DdlVisitor extends DelegatingVisitor<BaseVisitor> {
      * @param <T> the option's value type
      */
     private record VectorSqlOption<T>(@Nonnull VectorOptionKey<T> key,
-                                      @Nonnull Set<String> engines,
+                                      @Nonnull Set<VectorIndexEngineKind> engines,
                                       @Nonnull Function<RelationalParser.VectorIndexOptionValueContext, T> coerce) {
         void writeTo(@Nonnull final BiConsumer<String, String> sink,
                      @Nonnull final RelationalParser.VectorIndexOptionValueContext value) {
@@ -379,8 +377,8 @@ public final class DdlVisitor extends DelegatingVisitor<BaseVisitor> {
     }
 
     @Nonnull
-    private static String parseVectorEngine(@Nonnull final RelationalParser.VectorEngineContext engineContext) {
-        return engineContext.GUARDIANN() != null ? GUARDIANN_ENGINE : HNSW_ENGINE;
+    private static VectorIndexEngineKind parseVectorEngine(@Nonnull final RelationalParser.VectorEngineContext engineContext) {
+        return engineContext.GUARDIANN() != null ? VectorIndexEngineKind.GUARDIANN : VectorIndexEngineKind.HNSW;
     }
 
     private static int parseOptionInt(@Nonnull final RelationalParser.VectorIndexOptionValueContext value) {
@@ -396,13 +394,13 @@ public final class DdlVisitor extends DelegatingVisitor<BaseVisitor> {
     }
 
     @Nonnull
-    private Map<String, String> parseVectorOptions(@Nonnull final String engine,
+    private Map<String, String> parseVectorOptions(@Nonnull final VectorIndexEngineKind engine,
                                                    @Nullable final RelationalParser.VectorIndexOptionsContext indexOptionsContext) {
         final var indexOptionsBuilder = ImmutableMap.<String, String>builder();
         // Guardiann must be recorded explicitly; HNSW is the default when the engine option is absent, so leave it
         // implicit (keeps HNSW index metadata unchanged and readable by nodes that predate the engine option).
-        if (GUARDIANN_ENGINE.equals(engine)) {
-            indexOptionsBuilder.put(IndexOptions.VECTOR_ENGINE, engine);
+        if (engine == VectorIndexEngineKind.GUARDIANN) {
+            VectorIndexOptionKeys.ENGINE.put(indexOptionsBuilder::put, engine);
         }
         if (indexOptionsContext == null) {
             return indexOptionsBuilder.build();
@@ -416,7 +414,7 @@ public final class DdlVisitor extends DelegatingVisitor<BaseVisitor> {
                         "unsupported vector index option '" + name + "'");
             }
             Assert.thatUnchecked(spec.engines().contains(engine), ErrorCode.UNSUPPORTED_OPERATION,
-                    () -> "vector index option '" + name + "' is not valid for the " + engine + " vector engine");
+                    () -> "vector index option '" + name + "' is not valid for the " + engine.name() + " vector engine");
             Assert.thatUnchecked(seen.add(name), ErrorCode.SYNTAX_ERROR,
                     () -> "duplicate vector index option '" + name + "'");
             try {


### PR DESCRIPTION
  # Pre-add vector index option keys (hard cap + engine) for downstream consumers

  ## Summary
  Adds two vector index option keys to the public catalog so a downstream consumer of this
  repo can start writing them **before** the corresponding behavior is implemented
  here. The keys are insert on `main` today — they are declared and accepted, but nothing reads
  them yet, so an index carrying them behaves exactly as it does without them.

  To give the engine option a proper typed key (parallel to `METRIC`/`ofMetric`), this also
  promotes the vector-engine enum to a public top-level type and rewires the SQL DDL layer to
  use it instead of local string constants.

  ## What changed
  **New option keys**
  - `IndexOptions.GUARDIANN_PRIMARY_CLUSTER_HARD_MAX` (`"guardiannPrimaryClusterHardMax"`) — the
    string constant only; the hard-cap back-pressure behavior itself is not implemented on this
    branch.
  - `VectorIndexOptionKeys.GUARDIANN_PRIMARY_CLUSTER_HARD_MAX` — the typed `VectorOptionKey<Integer>`
    for it.
  - `VectorIndexOptionKeys.ENGINE` — a typed key for the existing `IndexOptions.VECTOR_ENGINE`
    option, backed by a new `VectorOptionKey.ofEngine(...)` factory (mirrors `ofMetric`).
  - Both keys are registered in `VectorIndexOptionKeys.ALL` (kept in sync with the declared fields,
    as enforced by `VectorIndexOptionKeysTest.allContainsEveryDeclaredKey`).

  **Engine enum promotion**
  - Extracted `VectorIndexEngine.Kind` into a new public top-level enum
    `VectorIndexEngineKind` (the `VectorIndexEngine` implementations remain package-private). This
    is what lets `ofEngine` be typed to a publicly-nameable enum, so external consumers can pass a
    typed engine value — the same way `ofMetric` uses the public `Metric`.
  - Repointed all references (`VectorIndexEngine`, `VectorOptionKey`, and the vector tests) to the
    new enum.

  **SQL DDL rewire**
  - `DdlVisitor` now uses `VectorIndexEngineKind` instead of its private `"HNSW"`/`"GUARDIANN"`
    string constants, and writes the engine option through `VectorIndexOptionKeys.ENGINE`.

  ## Why
  This gives the ability to the adopter to reference these keys now so its code can roll out ahead of the 
  actual implementation. Declaring the keys here (and making the engine enum public) lets it depend on the
  stable, typed catalog rather than hardcoding wire strings.

  ## Compatibility / behavior
  - **No behavior change.** Nothing on `main` reads `GUARDIANN_PRIMARY_CLUSTER_HARD_MAX`. Vector
    index validation (`VectorIndexHelper.validate`) only rejects an option specified under more than
    one of its own alias names and parses each engine's known config; an unread, single-named option
    is accepted and ignored. Record-layer index options are arbitrary strings, so nothing rejects the
    new key.
  - **Stored metadata is byte-identical.** The DDL layer still writes `("vectorEngine", "GUARDIANN")`
    (the `ENGINE` key's canonical name is `VECTOR_ENGINE` and its serializer is
    `VectorIndexEngineKind::name`).
