### PR TITLE
Refine syntax checks in `ExpressionVisitor#visitAggregateWindowedFunction()`

### DIFF
--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/ExpressionVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/ExpressionVisitor.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2021-2025 Apple Inc. and the FoundationDB project authors
+ * Copyright 2021-2026 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,6 +65,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Streams;
 import com.google.protobuf.ZeroCopyByteString;
 import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.Token;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -352,8 +353,13 @@ public final class ExpressionVisitor extends DelegatingVisitor<BaseVisitor> {
     @Nonnull
     @Override
     public Expression visitAggregateWindowedFunction(@Nonnull RelationalParser.AggregateWindowedFunctionContext functionContext) {
-        Assert.thatUnchecked(functionContext.aggregator == null || functionContext.aggregator.getText().equals(functionContext.ALL().getText()),
-                ErrorCode.UNSUPPORTED_QUERY, () -> String.format(Locale.ROOT, "Unsupported aggregator %s", functionContext.aggregator.getText()));
+        // Handle the aggregator (aka. set quantifier). Existing aggregates support only ALL (the default).
+        final Token aggregator = functionContext.aggregator;
+        Assert.thatUnchecked(
+                aggregator == null || aggregator.getType() == RelationalParser.ALL,
+                ErrorCode.UNSUPPORTED_QUERY,
+                () -> String.format(Locale.ROOT, "aggregator %s is not supported",
+                        Assert.notNullUnchecked(aggregator).getText()));
         final var functionName = functionContext.functionName.getText();
         Optional<Expression> argumentMaybe = Optional.empty();
         if (functionContext.starArg != null) {

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/ExpressionVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/ExpressionVisitor.java
@@ -353,6 +353,8 @@ public final class ExpressionVisitor extends DelegatingVisitor<BaseVisitor> {
     @Nonnull
     @Override
     public Expression visitAggregateWindowedFunction(@Nonnull RelationalParser.AggregateWindowedFunctionContext functionContext) {
+        final var functionName = functionContext.functionName.getText();
+
         // Handle the aggregator (aka. set quantifier). Existing aggregates support only ALL (the default).
         final Token aggregator = functionContext.aggregator;
         Assert.thatUnchecked(
@@ -360,7 +362,14 @@ public final class ExpressionVisitor extends DelegatingVisitor<BaseVisitor> {
                 ErrorCode.UNSUPPORTED_QUERY,
                 () -> String.format(Locale.ROOT, "aggregator %s is not supported",
                         Assert.notNullUnchecked(aggregator).getText()));
-        final var functionName = functionContext.functionName.getText();
+
+        // Handle the OVER clause. The grammar admits it for most aggregates, but using an aggregate as a window
+        // function is not implemented.
+        Assert.isNullUnchecked(
+                functionContext.overClause(),
+                ErrorCode.UNSUPPORTED_QUERY,
+                String.format(Locale.ROOT, "an OVER clause is not supported for %s()", functionName));
+
         Optional<Expression> argumentMaybe = Optional.empty();
         if (functionContext.starArg != null) {
             argumentMaybe = Optional.of(Expression.ofUnnamed(RecordConstructorValue.ofColumns(List.of())));

--- a/yaml-tests/src/test/resources/groupby-tests.yamsql
+++ b/yaml-tests/src/test/resources/groupby-tests.yamsql
@@ -213,6 +213,15 @@ test_block:
       - query: SELECT COUNT(DISTINCT col1) FROM T1
       - supported_version: !current_version
       - error: UNSUPPORTED_QUERY
+    -
+      # An OVER clause is grammatically accepted, but using an aggregate as a window function is not implemented.
+      - query: SELECT SUM(col2) OVER (PARTITION BY col1) FROM T1
+      - supported_version: !current_version
+      - error: UNSUPPORTED_QUERY
+    -
+      - query: SELECT MAX(col2) OVER () FROM T1
+      - supported_version: !current_version
+      - error: UNSUPPORTED_QUERY
 ---
 test_block:
   name: group-by-tests-with-continuations

--- a/yaml-tests/src/test/resources/groupby-tests.yamsql
+++ b/yaml-tests/src/test/resources/groupby-tests.yamsql
@@ -204,6 +204,15 @@ test_block:
       - supported_version: 4.12.1.0
       - explain: "ISCAN(I1 <,>) | FILTER _.COL1 EQUALS promote(@c10 AS LONG) OR _.COL2 EQUALS promote(@c14 AS LONG) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
       - result: [{!l 8}]
+    -
+      # DISTINCT is not yet supported for any aggregate.
+      - query: SELECT SUM(DISTINCT col1) FROM T1
+      - supported_version: !current_version
+      - error: UNSUPPORTED_QUERY
+    -
+      - query: SELECT COUNT(DISTINCT col1) FROM T1
+      - supported_version: !current_version
+      - error: UNSUPPORTED_QUERY
 ---
 test_block:
   name: group-by-tests-with-continuations


### PR DESCRIPTION
**Fix `NullPointerException` for aggregates with `DISTINCT`**

In `ExpressionVisitor#visitAggregateWindowedFunction()`, use the token type instead of `ALL().getText()` to inspect the aggregator. Aggregates with `DISTINCT`, such as `COUNT(DISTINCT «expr»)`, are not supported and should raise an `UNSUPPORTED_QUERY` error. However, the `ALL().getText()` access in the old version would raise a `NullPointerException` instead, since `ALL()` is null precisely in that case. The `NullPointerException` would surface as an internal error instead of the desired `UNSUPPORTED_QUERY` SQLSTATE.

**Reject an `OVER` clause on an aggregate function**

The grammar admits an `overClause` on most of the aggregate alternatives. However, using an aggregate as a window function is not implemented, and `visitAggregateWindowedFunction()` never looks at the `OVER` clause. Instead, it gets dropped silently, which effectively turns something like `SUM(col2) OVER (PARTITION BY col1)` into a plain aggregate. With this change we now properly reject the `OVER` clause instead.