### PR TITLE
Bump version to 4.12.17.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@
 #
 
 rootProject.name=fdb-record-layer
-version=4.12.16.0
+version=4.12.17.0
 releaseBuild=false
 
 # this should be false for release branches (i.e. if there is no -SNAPSHOT on the above version)


### PR DESCRIPTION
Issues with the build messed up 4.12.17.0. Bumping the current version to it to try producing a clean 4.12.18.0