### PR TITLE
Optimize `MetaDataProtoEditor.renameRecordTypes()`

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/MetaDataProtoEditor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/MetaDataProtoEditor.java
@@ -36,9 +36,15 @@ import com.google.protobuf.Descriptors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
-import java.util.function.Function;
+import java.util.Set;
+import java.util.function.UnaryOperator;
 
 import static com.apple.foundationdb.record.RecordMetaDataBuilder.DEFAULT_UNION_NAME;
 
@@ -408,13 +414,189 @@ public class MetaDataProtoEditor {
         }
     }
 
-    public static void renameRecordTypes(@Nonnull RecordMetaDataProto.MetaData.Builder metaDataBuilder,
-                                         @Nonnull Function<String, String> renamer,
-                                         @Nonnull Descriptors.FileDescriptor[] dependencies) {
-        for (final String recordType : MetaDataProtoEditor.getRecordTypes(metaDataBuilder)) {
-            MetaDataProtoEditor.renameRecordType(metaDataBuilder,
-                    recordType, renamer.apply(recordType), dependencies);
+    /**
+     * Internal representation of a record type to be renamed by {@link #renameRecordTypes}.
+     */
+    private static final class RecordTypeRename {
+        /** The current name. */
+        @Nonnull
+        private final String name;
+        /** The new name. */
+        @Nonnull
+        private final String newName;
+        /** The fully qualified current name. */
+        @Nonnull
+        private final String fullName;
+        /** The fully qualified new name. */
+        @Nonnull
+        private final String fullNewName;
+        /**
+         * The usage, as determined by looking at the union type. (Initially {@code UNSET}, to be filled in by
+         * {@link #determineRecordTypeUnionFieldsAndUsages}).
+         */
+        @Nonnull
+        private RecordTypeOptions.Usage usage = RecordTypeOptions.Usage.UNSET;
+        /**
+         * Builder of the referencing union field, if any. (Initially null, to be filled in by
+         * {@link #determineRecordTypeUnionFieldsAndUsages}).
+         */
+        @Nullable
+        private DescriptorProtos.FieldDescriptorProto.Builder unionField;
+
+        RecordTypeRename(@Nonnull String namespace, @Nonnull String name, @Nonnull String newName) {
+            this.name = name;
+            this.newName = newName;
+            this.fullName = fullyQualifiedTypeName(namespace, name);
+            this.fullNewName = fullyQualifiedTypeName(namespace, newName);
         }
+    }
+
+    /**
+     * A map of {@link RecordTypeRename}s, keyed by the record type's current (simple) name, as built by
+     * {@link #analyzeRecordTypeRenames}. Also provides a lookup by fully qualified name, built lazily on first use.
+     */
+    private static final class RecordTypeRenames {
+        @Nonnull
+        private final Map<String, RecordTypeRename> byName;
+        @Nullable
+        private Map<String, RecordTypeRename> byFullName;
+
+        RecordTypeRenames(@Nonnull Map<String, RecordTypeRename> byName) {
+            this.byName = byName;
+        }
+
+        boolean isEmpty() {
+            return byName.isEmpty();
+        }
+
+        @Nonnull
+        Collection<RecordTypeRename> values() {
+            return byName.values();
+        }
+
+        @Nullable
+        RecordTypeRename get(@Nonnull String name) {
+            return byName.get(name);
+        }
+
+        /**
+         * Returns the new name for {@code name}, if there is a rename of {@code name} with the given {@code usage};
+         * otherwise, returns {@code null}.
+         */
+        @Nullable
+        String get(@Nonnull String name, @Nonnull RecordTypeOptions.Usage usage) {
+            final RecordTypeRename rename = byName.get(name);
+            return rename != null && rename.usage == usage ? rename.newName : null;
+        }
+
+        /**
+         * Returns the rename whose (original) fully qualified name is {@code fullName}, if any.
+         */
+        @Nullable
+        RecordTypeRename getByFullName(@Nonnull String fullName) {
+            if (byFullName == null) {
+                byFullName = new HashMap<>();
+                for (final RecordTypeRename rename : byName.values()) {
+                    byFullName.put(rename.fullName, rename);
+                }
+            }
+            return byFullName.get(fullName);
+        }
+    }
+
+    /**
+     * Renames the record types in the metadata, according to the name mapping defined by {@code renamer}. For each
+     * renamed record type (where {@code renamer} yields a name that is not equal to the current one), this method
+     * applies the same transformations that {@link #renameRecordType} would, but it operates in an efficient, batched
+     * manner. The entire mapping is applied in a single walk over the given {@code metadata}, and the records
+     * {@link Descriptors.FileDescriptor} is compiled exactly once.
+     *
+     * <p>For a collision-free mapping of a single {@code RECORD}-usage type, this is exactly equivalent to the
+     * corresponding {@link #renameRecordType} call. For anything broader, the two diverge in a few respects, each
+     * noted below: which types the mapping is applied to, how imported types are treated, and which mappings are
+     * accepted rather than rejected. Where they differ, it is generally because applying the whole batch at once
+     * admits mappings that no single ordering of one-by-one renames could express.
+     *
+     * <p>Unlike {@link #renameRecordType}, {@code renamer} is only ever applied to (and can therefore only rename)
+     * {@code RECORD}-usage top-level types, i.e., those in {@code MetaData.record_types}; it cannot rename
+     * {@code NESTED} types or the union type itself.
+     *
+     * <p>Imported record types, i.e., those registered in {@code MetaData.record_types} whose message type is defined
+     * in a dependency file rather than in {@code MetaData.records}, cannot be renamed by this metadata, so
+     * {@code renamer} is never applied to them. (Note that {@link #renameRecordType}, by contrast, rejects such a
+     * rename outright, with a “No record type found” {@link MetaDataException}.) An imported record type can still be
+     * the cause of a collision, as described below.
+     *
+     * <p><b>Precondition:</b> The {@code renamer} must define a consistent, collision-free mapping. That is, no two
+     * distinct existing top-level record types may map to the same new name, and no record type may be renamed to a
+     * name that collides with another (renamed or unchanged) top-level type or an imported record type. If a collision
+     * is detected, no rename is performed, and a {@link MetaDataException} is thrown.
+     *
+     * <p>Validating the mapping as a whole means a batch may be accepted where the equivalent one-by-one renames
+     * would fail, and rejected where they would quietly succeed. A batch that permutes existing names, for instance
+     * swapping {@code Foo} and {@code Bar}, is collision-free and therefore accepted, whereas renaming those types
+     * one at a time would collide on whichever is renamed first. Conversely, a mapping that would make two union
+     * fields share a name is rejected here, while {@link #renameRecordType} leaves the second field under its old
+     * name instead of reporting the conflict.
+     *
+     * <p>The following is an example of a simple, collision-free renaming. It prepends a fixed string to every name:
+     * <pre>
+     * MetaDataProtoEditor.renameRecordTypes(builder, name -> "prefix_" + name, dependencies);
+     * </pre>
+     *
+     * @param metadata the metadata builder
+     * @param renamer a function mapping each existing top-level record type name to its new name
+     * @param dependencies the dependencies of the records file descriptor
+     * @see #renameRecordType
+     */
+    public static void renameRecordTypes(@Nonnull RecordMetaDataProto.MetaData.Builder metadata,
+                                         @Nonnull UnaryOperator<String> renamer,
+                                         @Nonnull Descriptors.FileDescriptor[] dependencies) {
+        // Collect the renames into a map, skipping identity renames. This method will throw `MetaDataException` if
+        // there is any conflict.
+        final RecordTypeRenames renames = analyzeRecordTypeRenames(metadata, renamer);
+        if (renames.isEmpty()) {
+            return;
+        }
+
+        validateNoUserDefinedFunctions(metadata);
+
+        // Build the file descriptor exactly once, from the original `MetaData.records` proto. Every descriptor
+        // lookup below is done by original name, so we can use this single descriptor for every rename in the
+        // mapping.
+        final DescriptorProtos.FileDescriptorProto records = metadata.getRecords();
+        final Descriptors.FileDescriptor fileDesc = RecordMetaDataBuilder.buildFileDescriptor(records, dependencies);
+
+        // Validate the `MetaData.unnested_record_types` constituents before making any changes.
+        validateRecordTypeUsagesInUnnestedRecordTypes(metadata.getUnnestedRecordTypesBuilderList(), fileDesc, renames);
+
+        // Determine the usage of each renamed type by looking at the union message type within `MetaData.records`.
+        final DescriptorProtos.DescriptorProto.Builder union = fetchUnionBuilder(metadata.getRecordsBuilder());
+        if (union.getNestedTypeCount() > 0) {
+            throw new MetaDataException("Nested types in union type not supported");
+        }
+        determineRecordTypeUnionFieldsAndUsages(renames, fileDesc, union);
+
+        // Validate that renaming the canonical union fields would not cause a collision.
+        validateUnionFieldRenames(union, renames);
+
+        // Rename the canonical union field, if present, for each renamed type.
+        renameUnionFields(renames);
+
+        // Rename every message type in `MetaData.records`, and all field type references.
+        renameRecordTypeUsagesInMessageTypes(metadata.getRecordsBuilder().getMessageTypeBuilderList(), renames, fileDesc);
+
+        // Update `MetaData.record_types` for every top-level RECORD type.
+        renameRecordTypeUsagesInRecordTypes(metadata.getRecordTypesBuilderList(), renames);
+
+        // Update `MetaData.indexes` for every top-level RECORD type.
+        renameRecordTypeUsagesInIndexes(metadata.getIndexesBuilderList(), renames);
+
+        // Update `MetaData.joined_record_types` constituents for every renamed type.
+        renameRecordTypeUsagesInJoinedRecordTypes(metadata.getJoinedRecordTypesBuilderList(), renames);
+
+        // Rename `MetaData.unnested_record_types` constituents for every renamed type.
+        renameRecordTypeUsagesInUnnestedRecordTypes(metadata.getUnnestedRecordTypesBuilderList(), renames);
     }
 
     /**
@@ -689,6 +871,379 @@ public class MetaDataProtoEditor {
             return false;
         } else {
             return isNested(typeDescriptor.getContainingType(), targetDescriptor);
+        }
+    }
+
+    /**
+     * A helper for {@link #renameRecordTypes} that converts the record-type name mapping defined by {@code renamer}
+     * into the internal, ordered, old-to-new map. Also validates the mapping against the full set of top-level
+     * message types, and raises {@link MetaDataException} if it is invalid.
+     */
+    @Nonnull
+    private static RecordTypeRenames analyzeRecordTypeRenames(
+            @Nonnull RecordMetaDataProto.MetaData.Builder metaDataBuilder,
+            @Nonnull UnaryOperator<String> renamer) {
+        // Apply `renamer` to each record type name and build the map representing the renamings.
+        final String namespace = metaDataBuilder.getRecords().getPackage();
+        // Don’t apply the renamer to imported record types. They are registered in `record_types` but defined in a
+        // dependency file, so this metadata cannot rename them.
+        final Set<String> localMessageTypes = new HashSet<>();
+        for (final DescriptorProtos.DescriptorProto messageType : metaDataBuilder.getRecords().getMessageTypeList()) {
+            localMessageTypes.add(messageType.getName());
+        }
+        final Map<String, RecordTypeRename> renames = new LinkedHashMap<>();
+        for (final String recordType : getRecordTypes(metaDataBuilder)) {
+            if (!localMessageTypes.contains(recordType)) {
+                continue;
+            }
+            final String newName = renamer.apply(recordType);
+            // Skip identity renames, as they require no work.
+            if (recordType.equals(newName)) {
+                continue;
+            }
+            renames.put(recordType, new RecordTypeRename(namespace, recordType, newName));
+        }
+
+        if (renames.isEmpty()) {
+            return new RecordTypeRenames(renames);
+        }
+
+        // Build the inverse new-to-old mapping and use it to perform basic validation:
+        // * No two distinct existing record types may map to the same new name.
+        // * No record type may be renamed to a name that collides with another (renamed or unchanged) top-level type.
+        final Map<String, String> inverse = new HashMap<>();
+        for (final RecordTypeRename rename : renames.values()) {
+            final String previous = inverse.put(rename.newName, rename.name);
+            if (previous != null) {
+                throw new MetaDataException("Cannot rename record types `" + previous + "` and `" + rename.name
+                        + "` to the same name `" + rename.newName + "`");
+            }
+        }
+
+        // If a message type is not itself being renamed, then it must not be the target of a rename either.
+        for (final DescriptorProtos.DescriptorProto messageType : metaDataBuilder.getRecords().getMessageTypeList()) {
+            final String name = messageType.getName();
+            if (!renames.containsKey(name) && inverse.containsKey(name)) {
+                throw new MetaDataException("Cannot rename record type to " + name + " as it already exists");
+            }
+        }
+
+        // Likewise for the metadata's full record type registry, which (unlike `getMessageTypeList()` above) also
+        // includes record types imported from a dependency file.
+        for (final String name : getRecordTypes(metaDataBuilder)) {
+            if (!renames.containsKey(name) && inverse.containsKey(name)) {
+                throw new MetaDataException("Cannot rename record type to " + name + " as an imported record type of that name already exists");
+            }
+        }
+
+        return new RecordTypeRenames(renames);
+    }
+
+    /**
+     * A helper for {@link #renameRecordTypes} that determines the {@link RecordTypeOptions.Usage Usage} of each
+     * renamed type by looking at the union. Fills in the {@code usage} and {@code unionField} of the entries
+     * in {@code renames}. Does not mutate {@code fileDescriptor} and {@code unionBuilder}.
+     */
+    private static void determineRecordTypeUnionFieldsAndUsages(
+            @Nonnull RecordTypeRenames renames,
+            @Nonnull Descriptors.FileDescriptor fileDescriptor,
+            @Nonnull DescriptorProtos.DescriptorProto.Builder unionBuilder) {
+        final String unionName = unionBuilder.getName();
+        final Descriptors.Descriptor unionDescriptor = getMessageTypeByName(fileDescriptor, unionName);
+
+        // Find, for each renamed record type, the union field that references it (if any), in a single pass over the
+        // union's fields.
+        for (final DescriptorProtos.FieldDescriptorProto.Builder unionField : unionBuilder.getFieldBuilderList()) {
+            if (!unionField.hasTypeName() || unionField.getTypeName().isEmpty()) {
+                continue;
+            }
+
+            final String fullReferencedName = resolveFieldTypeFullName(unionDescriptor, unionField);
+            if (fullReferencedName == null) {
+                continue;
+            }
+
+            final RecordTypeRename rename = renames.getByFullName(fullReferencedName);
+            if (rename == null) {
+                continue;
+            }
+
+            // If multiple fields reference this record type, prefer the canonically-named one; otherwise, keep the
+            // one with the highest field number.
+            if (rename.unionField == null
+                    || isCanonicalUnionFieldName(unionField.getName(), rename.name)
+                    || unionField.getNumber() > rename.unionField.getNumber()) {
+                rename.unionField = unionField;
+            }
+        }
+
+        for (final RecordTypeRename rename : renames.values()) {
+            // Determine the usage of each renamed record type, based on the union field found above, if any.
+            // * If the type name equals the union name, the usage is UNION.
+            // * Otherwise, if the type has a corresponding union field, it is a top-level record type, i.e., RECORD.
+            // * Otherwise, it can only ever be used as an embedded message type, i.e., NESTED.
+            if (rename.name.equals(unionName)) {
+                rename.unionField = null;
+                rename.usage = RecordTypeOptions.Usage.UNION;
+            } else {
+                rename.usage = rename.unionField == null
+                               ? RecordTypeOptions.Usage.NESTED
+                               : RecordTypeOptions.Usage.RECORD;
+            }
+
+            // Prevent renaming a non-UNION type to the default union name.
+            if (!rename.usage.equals(RecordTypeOptions.Usage.UNION) && rename.newName.equals(DEFAULT_UNION_NAME)) {
+                throw new MetaDataException(
+                        "Cannot rename record type to the default union name",
+                        LogMessageKeys.RECORD_TYPE, rename.name);
+            }
+        }
+    }
+
+    /**
+     * Validates that renaming each rename's canonical union field (if any) to its new canonical name would not
+     * collide with any other field of the union message type within {@code MetaData.records}, once every rename in
+     * {@code renames} has been applied. Performs no mutation, so that this can be called before any other edits are
+     * made.
+     */
+    private static void validateUnionFieldRenames(@Nonnull DescriptorProtos.DescriptorProto.Builder unionBuilder,
+                                                   @Nonnull RecordTypeRenames renames) {
+        // Fields that are themselves about to be renamed to their new canonical form never count as a collision
+        // target below, since they won't keep their current name once this batch of renames is applied. (Without
+        // this exclusion, a batch that e.g. swaps two type names — Foo -> Baz and Bar -> Foo — could spuriously be
+        // rejected: Bar's rename to "_Foo" would appear to collide with Foo's own, still-pristine "_Foo" field.)
+        final Set<DescriptorProtos.FieldDescriptorProto.Builder> beingRenamed = new HashSet<>();
+        for (final RecordTypeRename rename : renames.values()) {
+            if (rename.unionField != null && isCanonicalUnionFieldName(rename.unionField.getName(), rename.name)) {
+                beingRenamed.add(rename.unionField);
+            }
+        }
+        for (final RecordTypeRename rename : renames.values()) {
+            if (!beingRenamed.contains(rename.unionField)) {
+                continue;
+            }
+            final String newName = canonicalUnionFieldName(rename.newName);
+            final boolean hasCollision = unionBuilder.getFieldBuilderList().stream()
+                    .anyMatch(fb -> fb != rename.unionField && fb.getName().equals(newName) && !beingRenamed.contains(fb));
+            if (hasCollision) {
+                throw new MetaDataException("Cannot rename union field to " + newName + " as a field of that name already exists",
+                        LogMessageKeys.RECORD_TYPE, rename.name);
+            }
+        }
+    }
+
+    /**
+     * Renames the canonical union field, if present, for each rename in {@code renames}. The union field is a field
+     * of the union message type within {@code MetaData.records}. Callers must have already validated the renames
+     * via {@link #validateUnionFieldRenames}.
+     */
+    private static void renameUnionFields(@Nonnull RecordTypeRenames renames) {
+        for (final RecordTypeRename rename : renames.values()) {
+            if (rename.unionField != null && isCanonicalUnionFieldName(rename.unionField.getName(), rename.name)) {
+                rename.unionField.setName(canonicalUnionFieldName(rename.newName));
+            }
+        }
+    }
+
+    /**
+     * A helper for {@link #renameRecordTypes} that applies the name mapping in a single walk over the message types
+     * in {@code MetaData.records}, using the given compiled file descriptor for type resolution. Field type
+     * references are resolved (via the original descriptor) to the original type they point at; if that original
+     * type is, or is nested within, any renamed type, the reference is rewritten to point at the renamed type.
+     */
+    private static void renameRecordTypeUsagesInMessageTypes(@Nonnull List<DescriptorProtos.DescriptorProto.Builder> messageTypes,
+                                               @Nonnull RecordTypeRenames renames,
+                                               @Nonnull Descriptors.FileDescriptor fileDescriptor) {
+        // Walk every message type, rewriting references to renamed types and renaming the type itself.
+        for (final DescriptorProtos.DescriptorProto.Builder mtb : messageTypes) {
+            final String name = mtb.getName();
+
+            // Rewrite `typeName` field references within the message type.
+            final Descriptors.Descriptor descriptor = getMessageTypeByName(fileDescriptor, name);
+            renameRecordTypeUsagesInMessageType(mtb, renames, descriptor);
+
+            final RecordTypeRename rename = renames.get(name);
+            if (rename == null) {
+                continue;
+            }
+
+            // If renaming the union type, be sure that the `record.usage` option is set to UNION.
+            if (name.equals(DEFAULT_UNION_NAME) && getMessageTypeUsage(mtb) != RecordTypeOptions.Usage.UNION) {
+                setMessageTypeUsage(mtb, RecordTypeOptions.Usage.UNION);
+            }
+
+            // Rename the message type itself.
+            mtb.setName(rename.newName);
+        }
+    }
+
+    /**
+     * Recursively rewrites {@code typeName} field references within a message type and its nested types. For each
+     * message or enum field, it resolves the original referenced type to its fully-qualified name and, if that type is
+     * or is nested within any renamed type, rewrites the field's {@code typeName} accordingly.
+     */
+    private static void renameRecordTypeUsagesInMessageType(@Nonnull DescriptorProtos.DescriptorProto.Builder messageTypeBuilder,
+                                               @Nonnull RecordTypeRenames renames,
+                                               @Nonnull Descriptors.Descriptor descriptorForMessage) {
+        for (final DescriptorProtos.FieldDescriptorProto.Builder field : messageTypeBuilder.getFieldBuilderList()) {
+            if (!field.hasTypeName() || field.getTypeName().isEmpty()) {
+                continue;
+            }
+            final String fullReferencedName = resolveFieldTypeFullName(descriptorForMessage, field);
+            if (fullReferencedName == null) {
+                continue;
+            }
+
+            // Check the referenced type, then each of its containing types in turn, against the renamed types:
+            // truncate `candidateName` at the last '.' to walk from the referenced type up to its outermost
+            // containing type, which is equivalent to (but cheaper than) repeatedly calling `getContainingType()`.
+            // For example, if `fullReferencedName` is ".pkg.Outer.Inner" and "Outer" is being renamed to "NewOuter",
+            // `candidateName` first tries ".pkg.Outer.Inner" (no match), then ".pkg.Outer" (matches), yielding the
+            // rewritten type name ".pkg.NewOuter" + ".Inner" = ".pkg.NewOuter.Inner".
+            String candidateName = fullReferencedName;
+            while (true) {
+                // If `candidateName` is a renamed type, substitute its new name for the matched prefix, leaving any
+                // trailing nested-type suffix (e.g. ".InnerRecord") untouched.
+                final RecordTypeRename rename = renames.getByFullName(candidateName);
+                if (rename != null) {
+                    field.setTypeName(rename.fullNewName + fullReferencedName.substring(candidateName.length()));
+                    break;
+                }
+                // Strip the last name segment to move up to the containing type; stop once there is no more
+                // package/type prefix left (the leading '.' is always at index 0).
+                final int lastDot = candidateName.lastIndexOf('.');
+                if (lastDot <= 0) {
+                    break;
+                }
+                candidateName = candidateName.substring(0, lastDot);
+            }
+        }
+
+        // Recurse into nested types, since a field elsewhere in the file may reference one of them.
+        for (final DescriptorProtos.DescriptorProto.Builder nestedTypeBuilder : messageTypeBuilder.getNestedTypeBuilderList()) {
+            final Descriptors.Descriptor nestedDescriptor = Objects.requireNonNull(
+                    descriptorForMessage.findNestedTypeByName(nestedTypeBuilder.getName()),
+                    "FileDescriptor does not have nested type that exists in protobuf");
+            // Recursively rewrite field type references within the nested type.
+            renameRecordTypeUsagesInMessageType(nestedTypeBuilder, renames, nestedDescriptor);
+        }
+    }
+
+    /**
+     * Validates that {@code MetaData.user_defined_functions} is empty, since a user-defined function may be a
+     * string that needs parsing to figure out the record types it references, which renaming does not support.
+     * Performs no mutation, so that this can be called before any other edits are made.
+     */
+    private static void validateNoUserDefinedFunctions(@Nonnull RecordMetaDataProto.MetaData.Builder metaDataBuilder) {
+        if (metaDataBuilder.getUserDefinedFunctionsCount() > 0) {
+            throw new MetaDataException("Renaming record types with UserDefinedFunctions is not supported");
+        }
+    }
+
+    /**
+     * Rewrites {@code MetaData.record_types} for every {@code RECORD}-usage rename in {@code renames}. Any collision
+     * with an unrenamed type has already been ruled out upfront, by the caller.
+     */
+    private static void renameRecordTypeUsagesInRecordTypes(
+            @Nonnull List<RecordMetaDataProto.RecordType.Builder> recordTypes,
+            @Nonnull RecordTypeRenames renames) {
+        for (final var recordType : recordTypes) {
+            final String newName = renames.get(recordType.getName(), RecordTypeOptions.Usage.RECORD);
+            if (newName != null) {
+                recordType.setName(newName);
+            }
+        }
+    }
+
+    /**
+     * Rewrites the record types referenced by any {@code MetaData.indexes} entry, for every {@code RECORD}-usage
+     * rename in {@code renames}.
+     */
+    private static void renameRecordTypeUsagesInIndexes(@Nonnull List<RecordMetaDataProto.Index.Builder> indexes,
+                                                        @Nonnull RecordTypeRenames renames) {
+        for (final var index : indexes) {
+            for (int i = 0; i < index.getRecordTypeCount(); i++) {
+                final String newName = renames.get(index.getRecordType(i), RecordTypeOptions.Usage.RECORD);
+                if (newName != null) {
+                    index.setRecordType(i, newName);
+                }
+            }
+        }
+    }
+
+    /**
+     * Updates the join constituents in {@code MetaData.joined_record_types} that reference any {@code RECORD}-usage
+     * rename in {@code renames}; renames of any other usage are ignored.
+     */
+    private static void renameRecordTypeUsagesInJoinedRecordTypes(
+            @Nonnull List<RecordMetaDataProto.JoinedRecordType.Builder> joinedRecordTypes,
+            @Nonnull RecordTypeRenames renames) {
+        for (final var joined : joinedRecordTypes) {
+            for (final var constituent : joined.getJoinConstituentsBuilderList()) {
+                final RecordTypeRename rename = renames.get(constituent.getRecordType());
+                if (rename != null && rename.usage == RecordTypeOptions.Usage.RECORD) {
+                    constituent.setRecordType(rename.newName);
+                }
+            }
+        }
+    }
+
+    /**
+     * Validates the nested constituents of {@code MetaData.unnested_record_types} affected by any renamed type: any
+     * constituent whose type is nested within a renamed type, other than as that type's own (non-nested)
+     * constituent, causes a {@link MetaDataException}, since renaming a type used by a non-parent unnested
+     * constituent is not supported. Performs no mutation, so that this can be called before any other edits are
+     * made.
+     */
+    private static void validateRecordTypeUsagesInUnnestedRecordTypes(
+            @Nonnull List<RecordMetaDataProto.UnnestedRecordType.Builder> unnestedRecordTypes,
+            @Nonnull Descriptors.FileDescriptor fileDescriptor,
+            @Nonnull RecordTypeRenames renames) {
+        for (var unnested : unnestedRecordTypes) {
+            for (var constituent : unnested.getNestedConstituentsBuilderList()) {
+                // The nested constituents would most likely be nested types, not record types, and thus would not be
+                // renamed.
+                if (constituent.getParent().isEmpty()) {
+                    continue;
+                }
+                final String name = constituent.getTypeName();
+                final Descriptors.Descriptor constituentTypeDescriptor
+                        = UnnestedRecordTypeBuilder.findDescriptorByName(fileDescriptor, name);
+                if (constituentTypeDescriptor == null) {
+                    throw new MetaDataException("missing descriptor for nested constituent")
+                            .addLogInfo(LogMessageKeys.EXPECTED, name)
+                            .addLogInfo(LogMessageKeys.CONSTITUENT, constituent.getName());
+                }
+                // Walk up the containing-type chain: if the constituent's type, or any type it is nested within, is
+                // being renamed, this non-parent reference to it can't be safely updated.
+                for (Descriptors.Descriptor typeDescriptor = constituentTypeDescriptor;
+                        typeDescriptor != null;
+                        typeDescriptor = typeDescriptor.getContainingType()) {
+                    if (renames.getByFullName("." + typeDescriptor.getFullName()) != null) {
+                        throw new MetaDataException("Renaming types used by non-parent unnested constituents is not supported");
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Renames the nested constituents of {@code MetaData.unnested_record_types} that directly name (as their own,
+     * non-nested type) any rename in {@code renames}. Callers must have already validated the rename via
+     * {@link #validateRecordTypeUsagesInUnnestedRecordTypes}.
+     */
+    private static void renameRecordTypeUsagesInUnnestedRecordTypes(
+            @Nonnull List<RecordMetaDataProto.UnnestedRecordType.Builder> unnestedRecordTypes,
+            @Nonnull RecordTypeRenames renames) {
+        for (var unnested : unnestedRecordTypes) {
+            for (var constituent : unnested.getNestedConstituentsBuilderList()) {
+                if (constituent.getParent().isEmpty()) {
+                    final RecordTypeRename rename = renames.get(constituent.getTypeName());
+                    if (rename != null) {
+                        constituent.setTypeName(rename.newName);
+                    }
+                }
+            }
         }
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/MetaDataProtoEditor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/MetaDataProtoEditor.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ package com.apple.foundationdb.record.provider.foundationdb;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.RecordMetaDataBuilder;
 import com.apple.foundationdb.record.RecordMetaDataOptionsProto;
+import com.apple.foundationdb.record.RecordMetaDataOptionsProto.RecordTypeOptions;
 import com.apple.foundationdb.record.RecordMetaDataProto;
 import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.metadata.MetaDataException;
@@ -37,44 +38,39 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.stream.Collectors;
+
+import static com.apple.foundationdb.record.RecordMetaDataBuilder.DEFAULT_UNION_NAME;
 
 /**
- * A helper class for mutating the meta-data proto.
+ * A utility class for mutating the metadata proto.
  *
- * <p>
- * This class contains several helper methods for modifying a serialized meta-data, e.g., adding a new record type to the meta-data.
- * {@link FDBMetaDataStore#mutateMetaData(Consumer)} is one example of where these methods can be useful. That method
- * modifies the stored meta-data using a mutation callback and saves it back to the meta-data store.
- * </p>
- *
+ * <p>This class provides utility methods for modifying a serialized metadata; for example, adding a new record type to
+ * the metadata. One example of where these methods can be useful is {@link FDBMetaDataStore#mutateMetaData}. That
+ * method modifies the stored metadata using a mutation callback and saves it back to the metadata store.
  */
 @API(API.Status.EXPERIMENTAL)
 public class MetaDataProtoEditor {
     /**
-     * Add a new record type to the meta-data.
+     * Add a new record type to the metadata.
      *
-     * <p>
-     * Adding the record type involves three steps: the message type is added to the file descriptor's list of message types,
-     * a field of the given type is added to the union, and its primary key is set.
-     * Note that adding {@code UNION} record types is not allowed. To add {@code NESTED} record types, use {@link #addNestedRecordType}.
-     * </p>
+     * <p>Adding the record type involves three steps: the message type is added to the file descriptor's list of
+     * message types, a field of the given type is added to the union, and its primary key is set. Note that adding
+     * {@code UNION} record types is not allowed. To add {@code NESTED} record types, use {@link #addNestedRecordType}.
      *
-     * @param metaDataBuilder the meta-data builder
+     * @param metaDataBuilder the metadata builder
      * @param newRecordType the new record type
      * @param primaryKey the primary key of the new record type
      */
     public static void addRecordType(@Nonnull RecordMetaDataProto.MetaData.Builder metaDataBuilder,
                                      @Nonnull DescriptorProtos.DescriptorProto newRecordType,
                                      @Nonnull KeyExpression primaryKey) {
-        RecordMetaDataOptionsProto.RecordTypeOptions.Usage newRecordTypeUsage = getMessageTypeUsage(newRecordType);
-        if (RecordMetaDataBuilder.DEFAULT_UNION_NAME.equals(newRecordType.getName()) ||
-                newRecordTypeUsage == RecordMetaDataOptionsProto.RecordTypeOptions.Usage.UNION) {
+        RecordTypeOptions.Usage newRecordTypeUsage = getMessageTypeUsage(newRecordType);
+        if (DEFAULT_UNION_NAME.equals(newRecordType.getName()) ||
+                newRecordTypeUsage == RecordTypeOptions.Usage.UNION) {
             throw new MetaDataException("Adding UNION record type not allowed");
         }
-        if (newRecordTypeUsage == RecordMetaDataOptionsProto.RecordTypeOptions.Usage.NESTED) {
+        if (newRecordTypeUsage == RecordTypeOptions.Usage.NESTED) {
             throw new MetaDataException("Use addNestedRecordType for adding NESTED record types");
         }
         if (findMessageTypeByName(metaDataBuilder.getRecordsBuilder(), newRecordType.getName()) != null) {
@@ -91,6 +87,25 @@ public class MetaDataProtoEditor {
         addFieldToUnion(fetchUnionBuilder(recordsBuilder), recordsBuilder, newRecordType.getName());
     }
 
+    /**
+     * Returns the canonical union field name for a record type.
+     *
+     * @return {@code "_" + recordTypeName}
+     */
+    @Nonnull
+    private static String canonicalUnionFieldName(@Nonnull String recordTypeName) {
+        return "_" + recordTypeName;
+    }
+
+    /**
+     * Returns whether the name of a union field is the canonical {@code _recordTypeName} form.
+     */
+    private static boolean isCanonicalUnionFieldName(@Nonnull String unionFieldName, @Nonnull String recordTypeName) {
+        return unionFieldName.length() == recordTypeName.length() + 1
+                && unionFieldName.charAt(0) == '_'
+                && unionFieldName.regionMatches(1, recordTypeName, 0, recordTypeName.length());
+    }
+
     private static void addFieldToUnion(@Nonnull DescriptorProtos.DescriptorProto.Builder unionBuilder,
                                         @Nonnull DescriptorProtos.FileDescriptorProtoOrBuilder fileBuilder,
                                         @Nonnull String typeName) {
@@ -101,20 +116,48 @@ public class MetaDataProtoEditor {
                 .setLabel(DescriptorProtos.FieldDescriptorProto.Label.LABEL_OPTIONAL)
                 .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_MESSAGE)
                 .setTypeName(fullyQualifiedTypeName(fileBuilder, typeName))
-                .setName("_" + typeName)
+                .setName(canonicalUnionFieldName(typeName))
                 .setNumber(assignFieldNumber(unionBuilder));
         unionBuilder.addField(fieldBuilder);
     }
 
+    /**
+     * Returns the names of the top-level record types declared in the metadata.
+     */
     @Nonnull
     public static List<String> getRecordTypes(@Nonnull RecordMetaDataProto.MetaData.Builder metaDataBuilder) {
-        return metaDataBuilder.getRecordTypesBuilderList().stream()
-                .map(RecordMetaDataProto.RecordType.Builder::getName)
-                .collect(Collectors.toList());
+        return metaDataBuilder.getRecordTypesList().stream().map(RecordMetaDataProto.RecordType::getName).toList();
+    }
+
+    /**
+     * Returns the top-level message type descriptor with the given name, throwing if it is not found.
+     */
+    @Nonnull
+    private static Descriptors.Descriptor getMessageTypeByName(Descriptors.FileDescriptor fileDescriptor, String name) {
+        final Descriptors.Descriptor descriptor = fileDescriptor.findMessageTypeByName(name);
+        if (descriptor == null) {
+            throw new MetaDataException("Could not find descriptor")
+                    .addLogInfo(LogMessageKeys.NAME, name);
+        }
+        return descriptor;
+    }
+
+    /**
+     * Returns the builder for the top-level message type with the given name, or {@code null} if none is found.
+     */
+    @Nullable
+    private static DescriptorProtos.DescriptorProto.Builder findMessageTypeByName(
+            @Nonnull DescriptorProtos.FileDescriptorProto.Builder recordsBuilder,
+            @Nonnull String recordType) {
+        return recordsBuilder.getMessageTypeBuilderList().stream()
+                .filter(m -> m.getName().equals(recordType))
+                .findAny()
+                .orElse(null);
     }
 
     @Nonnull
-    private static DescriptorProtos.DescriptorProto.Builder fetchUnionBuilder(@Nonnull DescriptorProtos.FileDescriptorProto.Builder fileBuilder) {
+    private static DescriptorProtos.DescriptorProto.Builder fetchUnionBuilder(
+            @Nonnull DescriptorProtos.FileDescriptorProto.Builder fileBuilder) {
         for (DescriptorProtos.DescriptorProto.Builder messageTypeBuilder : fileBuilder.getMessageTypeBuilderList()) {
             if (isUnion(messageTypeBuilder)) {
                 return messageTypeBuilder;
@@ -124,10 +167,11 @@ public class MetaDataProtoEditor {
     }
 
     @Nullable
-    private static DescriptorProtos.FieldDescriptorProto.Builder fetchUnionFieldBuilder(@Nonnull DescriptorProtos.FileDescriptorProto.Builder recordsBuilder,
-                                                                                        @Nonnull DescriptorProtos.DescriptorProto.Builder unionBuilder,
-                                                                                        @Nonnull Descriptors.Descriptor unionDescriptor,
-                                                                                        @Nonnull String recordTypeName) {
+    private static DescriptorProtos.FieldDescriptorProto.Builder fetchUnionFieldBuilder(
+            @Nonnull DescriptorProtos.FileDescriptorProto.Builder recordsBuilder,
+            @Nonnull DescriptorProtos.DescriptorProto.Builder unionBuilder,
+            @Nonnull Descriptors.Descriptor unionDescriptor,
+            @Nonnull String recordTypeName) {
         DescriptorProtos.FieldDescriptorProto.Builder foundField = null;
         if (recordTypeName.contains(".")) {
             throw new MetaDataException("Record Type Name cannot contain '.'");
@@ -135,42 +179,55 @@ public class MetaDataProtoEditor {
         if (unionBuilder.getNestedTypeCount() > 0) {
             throw new MetaDataException("Nested types in union type not supported");
         }
-        for (DescriptorProtos.FieldDescriptorProto.Builder field : unionBuilder.getFieldBuilderList()) {
-            final FieldTypeMatch unionFieldMatch = fieldIsType(recordsBuilder, unionDescriptor, field, recordTypeName);
+        for (DescriptorProtos.FieldDescriptorProto.Builder unionField : unionBuilder.getFieldBuilderList()) {
+            final FieldTypeMatch unionFieldMatch = fieldIsType(recordsBuilder, unionDescriptor, unionField, recordTypeName);
             if (FieldTypeMatch.MATCHES.equals(unionFieldMatch)
-                    && (foundField == null || field.getName().equals("_" + recordTypeName) || field.getNumber() > foundField.getNumber())) {
+                    && (foundField == null
+                                || isCanonicalUnionFieldName(unionField.getName(), recordTypeName)
+                                || unionField.getNumber() > foundField.getNumber())) {
                 // Choose the matching field with either a matching name or the highest number.
-                foundField = field;
+                foundField = unionField;
             }
         }
         return foundField;
     }
 
+    /**
+     * Returns the declared {@code usage} of a message type, or {@code UNSET} if none is declared.
+     */
+    @Nonnull
+    private static RecordTypeOptions.Usage getMessageTypeUsage(
+            @Nonnull DescriptorProtos.DescriptorProtoOrBuilder messageType) {
+        return messageType.getOptions().getExtension(RecordMetaDataOptionsProto.record).getUsage();
+    }
+
+    /**
+     * Sets the usage of a message type, preserving any other options already set on the {@code record} extension.
+     */
+    private static void setMessageTypeUsage(@Nonnull DescriptorProtos.DescriptorProto.Builder messageTypeBuilder,
+                                            @Nonnull RecordTypeOptions.Usage usage) {
+        RecordTypeOptions.Builder recordOptionsBuilder =
+                messageTypeBuilder.getOptions().hasExtension(RecordMetaDataOptionsProto.record)
+                ? messageTypeBuilder.getOptionsBuilder().getExtension(RecordMetaDataOptionsProto.record).toBuilder()
+                : RecordTypeOptions.newBuilder();
+        recordOptionsBuilder.setUsage(usage);
+        messageTypeBuilder.getOptionsBuilder().setExtension(
+                RecordMetaDataOptionsProto.record,
+                recordOptionsBuilder.build());
+    }
+
     private static boolean isUnion(@Nonnull DescriptorProtos.DescriptorProtoOrBuilder messageType) {
-        if (RecordMetaDataBuilder.DEFAULT_UNION_NAME.equals(messageType.getName())) {
-            return true;
-        }
-        RecordMetaDataOptionsProto.RecordTypeOptions recordTypeOptions = messageType.getOptions()
-                .getExtension(RecordMetaDataOptionsProto.record);
-        return recordTypeOptions != null &&
-               recordTypeOptions.hasUsage() &&
-               recordTypeOptions.getUsage() == RecordMetaDataOptionsProto.RecordTypeOptions.Usage.UNION;
+        return DEFAULT_UNION_NAME.equals(messageType.getName())
+                || getMessageTypeUsage(messageType) == RecordTypeOptions.Usage.UNION;
     }
 
     private static boolean isUnion(@Nonnull Descriptors.Descriptor messageType) {
-        if (RecordMetaDataBuilder.DEFAULT_UNION_NAME.equals(messageType.getName())) {
-            return true;
-        }
-        RecordMetaDataOptionsProto.RecordTypeOptions recordTypeOptions = messageType.getOptions()
-                .getExtension(RecordMetaDataOptionsProto.record);
-        return recordTypeOptions != null &&
-               recordTypeOptions.hasUsage() &&
-               recordTypeOptions.getUsage() == RecordMetaDataOptionsProto.RecordTypeOptions.Usage.UNION;
+        return DEFAULT_UNION_NAME.equals(messageType.getName())
+                || getMessageTypeUsage(messageType.toProto()) == RecordTypeOptions.Usage.UNION;
     }
 
     @Nonnull
-    private static String fullyQualifiedTypeName(@Nonnull String namespace,
-                                                 @Nonnull String typeName) {
+    private static String fullyQualifiedTypeName(@Nonnull String namespace, @Nonnull String typeName) {
         if (typeName.startsWith(".")) {
             return typeName;
         } else if (!namespace.isEmpty()) {
@@ -197,10 +254,27 @@ public class MetaDataProtoEditor {
          */
         MATCHES,
         /**
-         * The field is definitely a nested type defined within the type requested.
-         * For example, the requested type might be an {@code OuterMessage} and the field an {@code OuterMessage.InnerMessage}.
+         * The field is definitely a nested type defined within the type requested. For example, the requested type
+         * might be an {@code OuterMessage} and the field an {@code OuterMessage.InnerMessage}.
          */
         MATCHES_AS_NESTED
+    }
+
+    /**
+     * Returns the fully-qualified name of the message type referenced by {@code field}, resolved against
+     * {@code messageDescriptor} by field number rather than name or position, since the number is the only
+     * identifier guaranteed to tie a mutable builder field to its resolved descriptor counterpart. Returns
+     * {@code null} if the field does not reference a message type.
+     */
+    @Nullable
+    private static String resolveFieldMessageTypeFullName(
+            @Nonnull Descriptors.Descriptor messageDescriptor,
+            @Nonnull DescriptorProtos.FieldDescriptorProtoOrBuilder field) {
+        final Descriptors.FieldDescriptor resolvedField = Objects.requireNonNull(
+                messageDescriptor.findFieldByNumber(field.getNumber()),
+                "Could not find field from protobuf in descriptor");
+        final Descriptors.Descriptor messageType = resolvedField.getMessageType();
+        return messageType == null ? null : "." + messageType.getFullName();
     }
 
     /**
@@ -214,24 +288,18 @@ public class MetaDataProtoEditor {
      * {@code .x.y.z.Foo}, or {@code .y.z.Foo}. Actually knowing which one is being referred to properly
      * requires knowing which types are actually defined and then traversing the namespace tree.
      *
-     * <p>
-     * This can get even worse with nested types. For example, within a record {@code Foo}, if it has
+     * <p>This can get even worse with nested types. For example, within a record {@code Foo}, if it has
      * a nested type {@code Bar}, a field with type {@code Foo} might be referring to either
      * the other {@code Foo} record or an additional type {@code Foo.Bar.Foo}.
-     * </p>
      *
-     * <p>
-     * Because getting that right is difficult and requires full knowledge of all defined types, this
+     * <p>Because getting that right is difficult and requires full knowledge of all defined types, this
      * instead takes a simpler approach where if it can be determined for sure that the type is the
      * same, it returns that the type {@link FieldTypeMatch#MATCHES}. If it can be determined that the
      * type is definitely different, then this returns that it {@link FieldTypeMatch#DOES_NOT_MATCH}.
-     * </p>
      *
-     * <p>
-     * It is also possible that the field matches (or might match) a nested type defined within the
+     * <p>It is also possible that the field matches (or might match) a nested type defined within the
      * given type. In that case, this can return that it matches (or might match) as a nested type.
      * This is useful for determining whether the type needs to be renamed, for example.
-     * </p>
      *
      * @param field the field descriptor to check the type of
      * @param fullTypeName the fully-qualified type name
@@ -246,14 +314,10 @@ public class MetaDataProtoEditor {
         // we require that the actual Descriptor be passed in so that we can work on fully qualified type names, which
         // is much, much easier, and less likely to have a bug.
         if (field.hasTypeName() && !field.getTypeName().isEmpty()) {
-            // search by fieldNumber instead of name because we may have renamed the field in the builder
-            // but we can't change the number (without corrupting things)
-            final String fullyQualifiedName = "." + Objects.requireNonNull(
-                            messageDescriptor.findFieldByNumber(field.getNumber()),
-                            "Could not find field from protobuf in descriptor")
-                    .getMessageType()
-                    .getFullName();
-            if (fullyQualifiedName.equals(fullTypeName)) {
+            final String fullyQualifiedName = resolveFieldMessageTypeFullName(messageDescriptor, field);
+            if (fullyQualifiedName == null) {
+                return FieldTypeMatch.DOES_NOT_MATCH;
+            } else if (fullyQualifiedName.equals(fullTypeName)) {
                 return FieldTypeMatch.MATCHES;
             } else if (fullyQualifiedName.startsWith(fullTypeName) && fullyQualifiedName.charAt(fullTypeName.length()) == '.') {
                 return FieldTypeMatch.MATCHES_AS_NESTED;
@@ -278,20 +342,26 @@ public class MetaDataProtoEditor {
         if (messageType.getFieldCount() == 0) {
             return 1;
         }
-        return messageType.getFieldList().stream().mapToInt(DescriptorProtos.FieldDescriptorProto::getNumber).max().getAsInt() + 1;
+        return messageType.getFieldList().stream()
+                .mapToInt(DescriptorProtos.FieldDescriptorProto::getNumber)
+                .max()
+                .orElseThrow()
+                + 1;
     }
 
     /**
-     * Add a new {@code NESTED} record type to the meta-data. This can be used to define fields in other record types,
+     * Add a new {@code NESTED} record type to the metadata. This can be used to define fields in other record types,
      * but it does not add the new record type to the union.
      *
-     * @param metaDataBuilder the meta-data builder
+     * @param metaDataBuilder the metadata builder
      * @param newRecordType the new record type
      */
-    public static void addNestedRecordType(@Nonnull RecordMetaDataProto.MetaData.Builder metaDataBuilder, @Nonnull DescriptorProtos.DescriptorProto newRecordType) {
-        RecordMetaDataOptionsProto.RecordTypeOptions.Usage newRecordTypeUsage = getMessageTypeUsage(newRecordType);
-        if (newRecordTypeUsage != RecordMetaDataOptionsProto.RecordTypeOptions.Usage.NESTED &&
-                newRecordTypeUsage != RecordMetaDataOptionsProto.RecordTypeOptions.Usage.UNSET) {
+    public static void addNestedRecordType(
+            @Nonnull RecordMetaDataProto.MetaData.Builder metaDataBuilder,
+            @Nonnull DescriptorProtos.DescriptorProto newRecordType) {
+        RecordTypeOptions.Usage newRecordTypeUsage = getMessageTypeUsage(newRecordType);
+        if (newRecordTypeUsage != RecordTypeOptions.Usage.NESTED &&
+                newRecordTypeUsage != RecordTypeOptions.Usage.UNSET) {
             throw new MetaDataException("Record type is not NESTED");
         }
         if (findMessageTypeByName(metaDataBuilder.getRecordsBuilder(), newRecordType.getName()) != null) {
@@ -300,28 +370,13 @@ public class MetaDataProtoEditor {
         metaDataBuilder.getRecordsBuilder().addMessageType(newRecordType);
     }
 
-    @Nonnull
-    private static RecordMetaDataOptionsProto.RecordTypeOptions.Usage getMessageTypeUsage(@Nonnull DescriptorProtos.DescriptorProtoOrBuilder messageType) {
-        RecordMetaDataOptionsProto.RecordTypeOptions recordTypeOptions = messageType.getOptions()
-                .getExtension(RecordMetaDataOptionsProto.record);
-        if (recordTypeOptions != null && recordTypeOptions.hasUsage()) {
-            return recordTypeOptions.getUsage();
-        }
-        return RecordMetaDataOptionsProto.RecordTypeOptions.Usage.UNSET;
-    }
-
-    @Nullable
-    private static DescriptorProtos.DescriptorProto.Builder findMessageTypeByName(@Nonnull DescriptorProtos.FileDescriptorProto.Builder recordsBuilder, @Nonnull String recordType) {
-        return recordsBuilder.getMessageTypeBuilderList().stream().filter(m -> m.getName().equals(recordType)).findAny().orElse(null);
-    }
-
     /**
-     * Deprecate a record type from the meta-data. The record is still defined in the record definition, but any
+     * Deprecate a record type from the metadata. The record is still defined in the record definition, but any
      * occurrences
      * of the field in the union descriptor are deprecated. If there are any top-level record types that are defined
      * as nested messages within the deprecated record type, those fields in the union will also be deprecated.
      *
-     * @param metaDataBuilder the meta-data builder
+     * @param metaDataBuilder the metadata builder
      * @param recordType the record type to be deprecated
      */
     public static void deprecateRecordType(@Nonnull RecordMetaDataProto.MetaData.Builder metaDataBuilder,
@@ -359,22 +414,31 @@ public class MetaDataProtoEditor {
     }
 
     /**
-     * Rename a record type. This can be used to update any top-level record type defined within the
-     * meta-data's records descriptor, including {@code NESTED} records or the union descriptor. However,
-     * it cannot be used to rename nested messages (i.e., messages defined within other messages) or
-     * records defined in imported files. In addition to updating the file descriptor, if the record type
-     * is not {@code NESTED} or the union descriptor, update any other references to the record type
-     * within the meta-data (such as within index definitions).
+     * Renames a record type. This can be used to update any top-level record type defined within the metadata’s
+     * records descriptor, including {@code NESTED} records or the union descriptor. However, it cannot be used to
+     * rename nested messages (i.e., messages defined within other messages) or records defined in imported files.
      *
-     * @param metaDataBuilder the meta-data builder
+     * <ul>
+     * <li>Message names are rewritten.
+     * <li>Field types ({@code typeName}) that reference a renamed type are rewritten, whether the reference is direct
+     *     or to a nested type of a renamed type.
+     * <li>The union usage option is set when the union is renamed.
+     * <li>The canonical {@code _typeName} union field is renamed when possible.
+     * <li>If the record type has {@code RECORD} usage, the record type list, indexes, and joined record types are
+     *     updated.
+     * <li>Unnested record type constituents are updated.
+     * </ul>
+     *
+     * @param metaDataBuilder the metadata builder
      * @param recordTypeName the name of the existing top-level record type
      * @param newRecordTypeName the new name to give to the record type
      */
     public static void renameRecordType(@Nonnull RecordMetaDataProto.MetaData.Builder metaDataBuilder,
-                                        @Nonnull String recordTypeName, @Nonnull String newRecordTypeName,
+                                        @Nonnull String recordTypeName,
+                                        @Nonnull String newRecordTypeName,
                                         @Nonnull Descriptors.FileDescriptor[] dependencies) {
-        // Create a copy of the records builder (rather than calling metaDataBuilder.getRecordsBuilder()) to avoid
-        // corrupting the records builder in metaDataBuilder before all validation has been done.
+        // Validate the rename. Rather than calling `metaDataBuilder.getRecordsBuilder()`, create a copy of the records
+        // builder to avoid corrupting the one in `metaDataBuilder` before all validation has been done.
         final DescriptorProtos.FileDescriptorProto records = metaDataBuilder.getRecords();
         boolean found = false;
         for (DescriptorProtos.DescriptorProto messageType : records.getMessageTypeList()) {
@@ -387,31 +451,32 @@ public class MetaDataProtoEditor {
         if (!found) {
             throw new MetaDataException("No record type found with name " + recordTypeName);
         }
+
+        // Identity transformation requires no work. From here on, we can assume `recordTypeName != newRecordTypeName`,
+        // which simplifies things.
         if (recordTypeName.equals(newRecordTypeName)) {
-            // Identity transformation requires no work.
-            // From here on in, we can assume that recordTypeName != newRecordTypeName, which simplifies things.
             return;
         }
         final Descriptors.FileDescriptor fileDescriptor = RecordMetaDataBuilder.buildFileDescriptor(records, dependencies);
         final DescriptorProtos.FileDescriptorProto.Builder recordsBuilder = records.toBuilder();
 
         // Determine the usage of the original record type by looking through the union builder.
-        // If we find a field that matches, also update its name to be in the canonical form (i.e., "_" + recordTypeName)
+        // If we find a union field that matches, also update its name to be in the canonical form.
         DescriptorProtos.DescriptorProto.Builder unionBuilder = fetchUnionBuilder(recordsBuilder);
-        RecordMetaDataOptionsProto.RecordTypeOptions.Usage usage;
+        RecordTypeOptions.Usage usage;
         if (unionBuilder.getName().equals(recordTypeName)) {
-            usage = RecordMetaDataOptionsProto.RecordTypeOptions.Usage.UNION;
+            usage = RecordTypeOptions.Usage.UNION;
         } else {
-            final Descriptors.Descriptor unionDescriptor = getDescriptor(fileDescriptor, unionBuilder.getName());
+            final Descriptors.Descriptor unionDescriptor = getMessageTypeByName(fileDescriptor, unionBuilder.getName());
             DescriptorProtos.FieldDescriptorProto.Builder unionFieldBuilder = fetchUnionFieldBuilder(recordsBuilder,
                     unionBuilder, unionDescriptor, recordTypeName);
             if (unionFieldBuilder == null) {
-                usage = RecordMetaDataOptionsProto.RecordTypeOptions.Usage.NESTED;
+                usage = RecordTypeOptions.Usage.NESTED;
             } else {
-                usage = RecordMetaDataOptionsProto.RecordTypeOptions.Usage.RECORD;
+                usage = RecordTypeOptions.Usage.RECORD;
                 // Change the name to the "canonical" form unless that would cause a field name conflict
-                if (unionFieldBuilder.getName().equals("_" + recordTypeName)) {
-                    String newFieldName = "_" + newRecordTypeName;
+                if (isCanonicalUnionFieldName(unionFieldBuilder.getName(), recordTypeName)) {
+                    String newFieldName = canonicalUnionFieldName(newRecordTypeName);
                     if (unionBuilder.getFieldBuilderList().stream()
                             .noneMatch(otherUnionField -> otherUnionField != unionFieldBuilder
                                     && otherUnionField.getName().equals(newFieldName))) {
@@ -420,106 +485,106 @@ public class MetaDataProtoEditor {
                 }
             }
         }
-        // Do not allow renaming to the default union name unless the record type is already the union
-        if (RecordMetaDataBuilder.DEFAULT_UNION_NAME.equals(newRecordTypeName) &&
-                !RecordMetaDataOptionsProto.RecordTypeOptions.Usage.UNION.equals(usage)) {
+
+        // Do not allow renaming to the default union name unless the record type is already the union.
+        if (DEFAULT_UNION_NAME.equals(newRecordTypeName) && !RecordTypeOptions.Usage.UNION.equals(usage)) {
             throw new MetaDataException("Cannot rename record type to the default union name", LogMessageKeys.RECORD_TYPE, recordTypeName);
         }
-        // Rename the record type within the file
+
+        // Rename the record type within the file.
         renameRecordTypeUsages(recordsBuilder, recordTypeName, newRecordTypeName, fileDescriptor);
 
-        // If the record type is a top level record type, change its usage elsewhere in the meta-data
-        if (RecordMetaDataOptionsProto.RecordTypeOptions.Usage.RECORD.equals(usage)) {
+        // If the record type is a top-level record type, change its usage elsewhere in the metadata.
+        if (RecordTypeOptions.Usage.RECORD.equals(usage)) {
             renameTopLevelRecordType(metaDataBuilder, recordTypeName, newRecordTypeName);
         }
-        renameRecordTypeUsagesInUnnested(metaDataBuilder, fileDescriptor, recordTypeName, newRecordTypeName,
-                getDescriptor(fileDescriptor, recordTypeName));
 
-        // Update the file descriptor
+        // Update unnested types (even if the record type is not a top-level type).
+        renameRecordTypeUsagesInUnnested(metaDataBuilder, fileDescriptor, recordTypeName, newRecordTypeName,
+                getMessageTypeByName(fileDescriptor, recordTypeName));
+
+        // Update the file descriptor.
         metaDataBuilder.setRecords(recordsBuilder);
     }
 
-    private static Descriptors.Descriptor getDescriptor(final Descriptors.FileDescriptor fileDescriptor, String name) {
-        final Descriptors.Descriptor descriptor = fileDescriptor.findMessageTypeByName(name);
-        if (descriptor == null) {
-            throw new MetaDataException("Could not find descriptor")
-                    .addLogInfo(LogMessageKeys.NAME,  name);
-        }
-        return descriptor;
-    }
-
+    /**
+     * Renames a record type within the records file. To this end, updates references to it in the fields of every
+     * message type (recursively, including nested types). If it is the union type, also update its usage option.
+     */
     private static void renameRecordTypeUsages(@Nonnull DescriptorProtos.FileDescriptorProto.Builder recordsBuilder,
-                                               @Nonnull String oldRecordTypeName, @Nonnull String newRecordTypeName,
+                                               @Nonnull String recordTypeName, @Nonnull String newRecordTypeName,
                                                @Nonnull Descriptors.FileDescriptor fileDescriptor) {
         final String namespace = recordsBuilder.getPackage();
-        final String fullOldRecordTypeName = fullyQualifiedTypeName(namespace, oldRecordTypeName);
+        final String fullRecordTypeName = fullyQualifiedTypeName(namespace, recordTypeName);
         final String fullNewRecordTypeName = fullyQualifiedTypeName(namespace, newRecordTypeName);
 
-        // Rename the record type within the file
+        // Rename the record type within the file.
         for (DescriptorProtos.DescriptorProto.Builder messageTypeBuilder : recordsBuilder.getMessageTypeBuilderList()) {
-            final Descriptors.Descriptor descriptor = getDescriptor(fileDescriptor, messageTypeBuilder.getName());
-            // Change any fields referencing the old type so that they now reference the new type
-            renameRecordTypeUsages(namespace, messageTypeBuilder, fullOldRecordTypeName,
-                    fullNewRecordTypeName, descriptor);
-            if (messageTypeBuilder.getName().equals(oldRecordTypeName)) {
+            final Descriptors.Descriptor descriptor = getMessageTypeByName(fileDescriptor, messageTypeBuilder.getName());
+            // Change any fields referencing the old type so that they now reference the new type.
+            renameRecordTypeUsages(namespace, messageTypeBuilder, fullRecordTypeName, fullNewRecordTypeName, descriptor);
+            if (messageTypeBuilder.getName().equals(recordTypeName)) {
                 // If renaming the union type, be sure that the record.usage option is set to UNION.
-                if (isUnion(messageTypeBuilder)) {
-                    RecordMetaDataOptionsProto.RecordTypeOptions recordOptions = null;
-                    if (messageTypeBuilder.getOptions().hasExtension(RecordMetaDataOptionsProto.record)) {
-                        recordOptions = messageTypeBuilder.getOptionsBuilder().getExtension(RecordMetaDataOptionsProto.record);
-                    }
-                    if (recordOptions == null || !recordOptions.hasUsage() ||
-                            !recordOptions.getUsage().equals(RecordMetaDataOptionsProto.RecordTypeOptions.Usage.UNION)) {
-                        RecordMetaDataOptionsProto.RecordTypeOptions.Builder recordOptionsBuilder = recordOptions == null
-                                                                                                    ? RecordMetaDataOptionsProto.RecordTypeOptions.newBuilder()
-                                                                                                    : recordOptions.toBuilder();
-                        recordOptionsBuilder.setUsage(RecordMetaDataOptionsProto.RecordTypeOptions.Usage.UNION);
-                        messageTypeBuilder.getOptionsBuilder().setExtension(RecordMetaDataOptionsProto.record, recordOptionsBuilder.build());
-                    }
+                if (isUnion(messageTypeBuilder) && getMessageTypeUsage(messageTypeBuilder) != RecordTypeOptions.Usage.UNION) {
+                    setMessageTypeUsage(messageTypeBuilder, RecordTypeOptions.Usage.UNION);
                 }
                 messageTypeBuilder.setName(newRecordTypeName);
             }
         }
     }
 
+    /**
+     * Renames references to a record type among the fields of a single message type, recursing into its nested types.
+     */
     private static void renameRecordTypeUsages(@Nonnull String namespace,
                                                @Nonnull DescriptorProtos.DescriptorProto.Builder messageTypeBuilder,
-                                               @Nonnull String fullOldRecordTypeName,
+                                               @Nonnull String fullRecordTypeName,
                                                @Nonnull String fullNewRecordTypeName,
                                                final Descriptors.Descriptor descriptorForMessage) {
-        // Rename any fields within the record type to the new type name
+        // Rename any fields within the record type to the new type name.
         for (DescriptorProtos.FieldDescriptorProto.Builder field : messageTypeBuilder.getFieldBuilderList()) {
-            final FieldTypeMatch fieldTypeMatch = fieldIsType(descriptorForMessage, field, fullOldRecordTypeName);
+            final FieldTypeMatch fieldTypeMatch = fieldIsType(descriptorForMessage, field, fullRecordTypeName);
             if (FieldTypeMatch.MATCHES.equals(fieldTypeMatch)) {
                 field.setTypeName(fullNewRecordTypeName);
             } else if (FieldTypeMatch.MATCHES_AS_NESTED.equals(fieldTypeMatch)) {
                 final String fullOldFieldTypeName = "." + descriptorForMessage.findFieldByNumber(field.getNumber())
                         .getMessageType().getFullName();
-                final String newFieldTypeName = fullNewRecordTypeName + fullOldFieldTypeName.substring(fullOldRecordTypeName.length());
+                final String newFieldTypeName = fullNewRecordTypeName + fullOldFieldTypeName.substring(fullRecordTypeName.length());
                 field.setTypeName(newFieldTypeName);
             }
         }
-        // Rename the record type if used within any nested message types
+
+        // Rename the record type if used within any nested message types.
         if (messageTypeBuilder.getNestedTypeCount() > 0) {
-            final String nestedNamespace = namespace.isEmpty() ? messageTypeBuilder.getName() : (namespace + "." + messageTypeBuilder.getName());
+            final String nestedNamespace =
+                    namespace.isEmpty()
+                    ? messageTypeBuilder.getName()
+                    : (namespace + "." + messageTypeBuilder.getName());
             for (DescriptorProtos.DescriptorProto.Builder nestedTypeBuilder : messageTypeBuilder.getNestedTypeBuilderList()) {
                 final Descriptors.Descriptor nestedDescriptor = Objects.requireNonNull(
                         descriptorForMessage.findNestedTypeByName(nestedTypeBuilder.getName()),
                         "FileDescriptor does not have nested type that exists in protobuf");
-                renameRecordTypeUsages(nestedNamespace, nestedTypeBuilder,
-                        fullOldRecordTypeName, fullNewRecordTypeName, nestedDescriptor);
+                renameRecordTypeUsages(nestedNamespace, nestedTypeBuilder, fullRecordTypeName, fullNewRecordTypeName,
+                        nestedDescriptor);
             }
         }
     }
 
+    /**
+     * Updates the top-level record type list, any index definitions, and any joined record types that reference a
+     * renamed record type. Throws if the metadata has {@code UserDefinedFunctions}, since renaming is not supported
+     * in that case.
+     */
     private static void renameTopLevelRecordType(@Nonnull RecordMetaDataProto.MetaData.Builder metaDataBuilder,
-                                                 @Nonnull String recordTypeName, @Nonnull String newRecordTypeName) {
-        List<RecordMetaDataProto.RecordType> recordTypes;
+                                                 @Nonnull String recordTypeName,
+                                                 @Nonnull String newRecordTypeName) {
+        List<RecordMetaDataProto.RecordType> recordTypes =
+                new ArrayList<>(metaDataBuilder.getRecordTypesBuilderList().size());
         boolean foundRecordType = false;
-        recordTypes = new ArrayList<>(metaDataBuilder.getRecordTypesBuilderList().size());
         for (RecordMetaDataProto.RecordType recordType : metaDataBuilder.getRecordTypesList()) {
             if (recordType.getName().equals(newRecordTypeName)) {
-                // Despite the earlier check in this method, this can still be triggered if there is an imported record with the given name
+                // Note: Despite the earlier check in this method, this can still be triggered if there is an imported
+                // record with the given name.
                 throw new MetaDataException("Cannot rename record type to " + newRecordTypeName + " as an imported record type of that name already exists");
             } else if (recordType.getName().equals(recordTypeName)) {
                 recordTypes.add(recordType.toBuilder().setName(newRecordTypeName).build());
@@ -529,44 +594,64 @@ public class MetaDataProtoEditor {
             }
         }
         if (!foundRecordType) {
-            // This shouldn't happen, but if somehow the record type was in the union but not the record type list, throw an error
+            // This shouldn't happen, but if somehow the record type was in the union but not the record type list,
+            // throw an error.
             throw new MetaDataException("Missing " + recordTypeName + " in record type list");
         }
-        // Rename the record type within any indexes
+
+        // Rename the record type within any indexes.
         List<RecordMetaDataProto.Index> indexes = new ArrayList<>(metaDataBuilder.getIndexesList());
         indexes.replaceAll(index -> {
-            if (index.getRecordTypeList().contains(recordTypeName)) {
-                List<String> indexRecordTypes = new ArrayList<>(index.getRecordTypeList());
-                indexRecordTypes.replaceAll(indexRecordType -> indexRecordType.equals(recordTypeName) ? newRecordTypeName : indexRecordType);
-                return index.toBuilder().clearRecordType().addAllRecordType(indexRecordTypes).build();
-            } else {
+            if (!index.getRecordTypeList().contains(recordTypeName)) {
                 return index;
             }
+            List<String> indexRecordTypes = new ArrayList<>(index.getRecordTypeList());
+            indexRecordTypes.replaceAll(name -> name.equals(recordTypeName) ? newRecordTypeName : name);
+            return index.toBuilder().clearRecordType().addAllRecordType(indexRecordTypes).build();
         });
-        // Update the metaDataBuilder with all of the renamed things
+
+        // Update the `metaDataBuilder` with all the renamed things.
         metaDataBuilder.clearRecordTypes();
         metaDataBuilder.addAllRecordTypes(recordTypes);
         metaDataBuilder.clearIndexes();
         metaDataBuilder.addAllIndexes(indexes);
-        // unnested types have to be updated even if it's not a top-level type, so they have their own method
+        // Unnested types have to be updated even if it’s not a top-level type, so they have their own method.
         updateJoinedRecordTypes(metaDataBuilder, recordTypeName, newRecordTypeName);
+
         if (metaDataBuilder.getUserDefinedFunctionsCount() > 0) {
-            // UserDefinedFunctions may be a string that needs parsing to figure out the types it references
+            // UserDefinedFunctions may be a string that needs parsing to figure out the types it references.
             throw new MetaDataException("Renaming record types with UserDefinedFunctions is not supported");
         }
     }
 
+    /**
+     * Updates joined record types' constituents that reference a renamed record type.
+     */
+    private static void updateJoinedRecordTypes(@Nonnull RecordMetaDataProto.MetaData.Builder metaDataBuilder,
+                                                @Nonnull String recordTypeName,
+                                                @Nonnull String newRecordTypeName) {
+        for (var joined : metaDataBuilder.getJoinedRecordTypesBuilderList()) {
+            for (var constituent : joined.getJoinConstituentsBuilderList()) {
+                if (constituent.getRecordType().equals(recordTypeName)) {
+                    constituent.setRecordType(newRecordTypeName);
+                }
+            }
+        }
+    }
 
+    /**
+     * Updates unnested record types' constituents that reference a renamed record type as their (non-nested) parent.
+     */
     private static void renameRecordTypeUsagesInUnnested(@Nonnull RecordMetaDataProto.MetaData.Builder metaDataBuilder,
                                                          @Nonnull Descriptors.FileDescriptor fileDescriptor,
-                                                         @Nonnull String oldRecordTypeName,
+                                                         @Nonnull String recordTypeName,
                                                          @Nonnull String newRecordTypeName,
                                                          @Nonnull Descriptors.Descriptor oldTypeDescriptor) {
         for (var unnested : metaDataBuilder.getUnnestedRecordTypesBuilderList()) {
             for (var constituent : unnested.getNestedConstituentsBuilderList()) {
                 // The nested constituents would most likely be nested types, not record types, and thus would not be
-                // renamed
-                if (constituent.getParent().isEmpty() && constituent.getTypeName().equals(oldRecordTypeName)) {
+                // renamed.
+                if (constituent.getParent().isEmpty() && constituent.getTypeName().equals(recordTypeName)) {
                     constituent.setTypeName(newRecordTypeName);
                 } else {
                     final Descriptors.Descriptor constituentTypeDescriptor = UnnestedRecordTypeBuilder.findDescriptorByName(fileDescriptor,
@@ -586,6 +671,7 @@ public class MetaDataProtoEditor {
 
     /**
      * Whether the {@code targetDescriptor} is equal to or nested within {@code typeDescriptor}.
+     *
      * @param typeDescriptor a type
      * @param targetDescriptor a type that may or may not be nested in {@code typeDescriptor}
      * @return {@code true} if the {@code targetDescriptor} is the same as {@code typeDescriptor} or a nested type of it
@@ -601,27 +687,18 @@ public class MetaDataProtoEditor {
         }
     }
 
-    private static void updateJoinedRecordTypes(@Nonnull RecordMetaDataProto.MetaData.Builder metaDataBuilder,
-                                                @Nonnull String oldRecordTypeName,
-                                                @Nonnull String newRecordTypeName) {
-        for (var joined : metaDataBuilder.getJoinedRecordTypesBuilderList()) {
-            for (var constituent : joined.getJoinConstituentsBuilderList()) {
-                if (constituent.getRecordType().equals(oldRecordTypeName)) {
-                    constituent.setRecordType(newRecordTypeName);
-                }
-            }
-        }
-    }
-
     /**
      * Add a field to a record type.
      *
-     * @param metaDataBuilder the meta-data builder
+     * @param metaDataBuilder the metadata builder
      * @param recordType the record type to add the field to
      * @param field the field to be added
      */
-    public static void addField(@Nonnull RecordMetaDataProto.MetaData.Builder metaDataBuilder, @Nonnull String recordType, @Nonnull DescriptorProtos.FieldDescriptorProto field) {
-        DescriptorProtos.DescriptorProto.Builder messageType = findMessageTypeByName(metaDataBuilder.getRecordsBuilder(), recordType);
+    public static void addField(@Nonnull RecordMetaDataProto.MetaData.Builder metaDataBuilder,
+                                @Nonnull String recordType,
+                                @Nonnull DescriptorProtos.FieldDescriptorProto field) {
+        DescriptorProtos.DescriptorProto.Builder messageType =
+                findMessageTypeByName(metaDataBuilder.getRecordsBuilder(), recordType);
         if (messageType == null) {
             throw new MetaDataException("Record type " + recordType + " does not exist");
         }
@@ -635,18 +712,18 @@ public class MetaDataProtoEditor {
     /**
      * Deprecate a field from a record type.
      *
-     * @param metaDataBuilder the meta-data builder
+     * @param metaDataBuilder the metadata builder
      * @param recordType the record type to deprecate the field from
      * @param fieldName the name of the field to be deprecated
      */
-    public static void deprecateField(@Nonnull RecordMetaDataProto.MetaData.Builder metaDataBuilder, @Nonnull String recordType, @Nonnull String fieldName) {
-        // Find the record type
-        DescriptorProtos.DescriptorProto.Builder messageType = findMessageTypeByName(metaDataBuilder.getRecordsBuilder(), recordType);
+    public static void deprecateField(@Nonnull RecordMetaDataProto.MetaData.Builder metaDataBuilder,
+                                      @Nonnull String recordType,
+                                      @Nonnull String fieldName) {
+        DescriptorProtos.DescriptorProto.Builder messageType =
+                findMessageTypeByName(metaDataBuilder.getRecordsBuilder(), recordType);
         if (messageType == null) {
             throw new MetaDataException("Record type " + recordType + " does not exist");
         }
-
-        // Deprecate the field
         DescriptorProtos.FieldDescriptorProto.Builder fieldBuilder = findFieldByName(messageType, fieldName);
         if (fieldBuilder == null) {
             throw new MetaDataException("Field " + fieldName + " not found in record type " + recordType);
@@ -663,20 +740,23 @@ public class MetaDataProtoEditor {
     }
 
     @Nullable
-    private static DescriptorProtos.FieldDescriptorProto.Builder findFieldByName(@Nonnull DescriptorProtos.DescriptorProto.Builder messageType, @Nonnull String fieldName) {
-        return messageType.getFieldBuilderList().stream().filter(m -> m.getName().equals(fieldName)).findAny().orElse(null);
+    private static DescriptorProtos.FieldDescriptorProto.Builder findFieldByName(
+            @Nonnull DescriptorProtos.DescriptorProto.Builder messageType,
+            @Nonnull String fieldName) {
+        return messageType.getFieldBuilderList().stream()
+                .filter(m -> m.getName().equals(fieldName))
+                .findAny()
+                .orElse(null);
     }
 
     /**
      * Add a default union to the given records descriptor if missing.
      *
-     * <p>
-     * This method is a no-op if the union is present. Otherwise, the method will add a union to the records
-     * descriptor. The union descriptor will be filled in with all of the record types defined in the file except
+     * <p>This method is a no-op if the union is present. Otherwise, the method will add a union to the records
+     * descriptor. The union descriptor will be filled in with all the record types defined in the file except
      * {@code NESTED} record types.
-     * </p>
      *
-     * @param fileDescriptor the records descriptor of the record meta-data
+     * @param fileDescriptor the records descriptor of the record metadata
      * @return the resulting records descriptor
      */
     @Nonnull
@@ -688,7 +768,8 @@ public class MetaDataProtoEditor {
         DescriptorProtos.FileDescriptorProto.Builder fileBuilder = fileDescriptorProto.toBuilder();
         fileBuilder.addMessageType(createDefaultUnion(fileBuilder));
         try {
-            return Descriptors.FileDescriptor.buildFrom(fileBuilder.build(), fileDescriptor.getDependencies().toArray(new Descriptors.FileDescriptor[0]));
+            return Descriptors.FileDescriptor.buildFrom(
+                    fileBuilder.build(), fileDescriptor.getDependencies().toArray(new Descriptors.FileDescriptor[0]));
         } catch (Descriptors.DescriptorValidationException e) {
             throw new MetaDataException("Failed to add a default union", e);
         }
@@ -697,13 +778,11 @@ public class MetaDataProtoEditor {
     /**
      * Creates a default union descriptor for the given file descriptor if missing.
      *
-     * <p>
-     * If the given file descriptor is missing a union message, this method will add one before updating the meta-data.
-     * The generated union descriptor is constructed by adding any non-{@code NESTED} types in the file descriptor to the
-     * union descriptor from the currently stored meta-data. A new field is not added if a field of the given type already
-     * exists, and the order of any existing fields is preserved. Note that types are identified by name, so renaming
-     * top-level message types may result in validation errors when trying to update the record descriptor.
-     * </p>
+     * <p>If the given file descriptor is missing a union message, this method will add one before updating the metadata.
+     * The generated union descriptor is constructed by adding any non-{@code NESTED} types in the file descriptor to
+     * the union descriptor from the currently stored metadata. A new field is not added if a field of the given type
+     * already exists, and the order of any existing fields is preserved. Note that types are identified by name, so
+     * renaming top-level message types may result in validation errors when trying to update the record descriptor.
      *
      * @param fileDescriptor the file descriptor to create a union for
      * @param baseUnionDescriptor the base union descriptor
@@ -727,7 +806,7 @@ public class MetaDataProtoEditor {
             final Descriptors.Descriptor unionDescriptor = fileDescriptor.findMessageTypeByName(unionDescriptorBuilder.getName());
             for (final Descriptors.Descriptor messageType : fileDescriptor.getMessageTypes()) {
                 if (!Objects.equals(unionDescriptor, messageType)
-                        && getMessageTypeUsage(messageType.toProto()) != RecordMetaDataOptionsProto.RecordTypeOptions.Usage.NESTED) {
+                        && getMessageTypeUsage(messageType.toProto()) != RecordTypeOptions.Usage.NESTED) {
                     if (unionDescriptor.getFields().stream().noneMatch(field -> field.getMessageType() == messageType)) {
                         addFieldToUnion(unionDescriptorBuilder, fileBuilder, messageType.getName());
                     }
@@ -744,10 +823,10 @@ public class MetaDataProtoEditor {
     @Nonnull
     private static DescriptorProtos.DescriptorProto.Builder createDefaultUnion(@Nonnull DescriptorProtos.FileDescriptorProtoOrBuilder recordsDescriptor) {
         DescriptorProtos.DescriptorProto.Builder unionMessageType = DescriptorProtos.DescriptorProto.newBuilder();
-        unionMessageType.setName(RecordMetaDataBuilder.DEFAULT_UNION_NAME);
+        unionMessageType.setName(DEFAULT_UNION_NAME);
         for (DescriptorProtos.DescriptorProtoOrBuilder messageType : recordsDescriptor.getMessageTypeOrBuilderList()) {
-            RecordMetaDataOptionsProto.RecordTypeOptions.Usage messageTypeUsage = getMessageTypeUsage(messageType);
-            if (messageTypeUsage != RecordMetaDataOptionsProto.RecordTypeOptions.Usage.NESTED) {
+            RecordTypeOptions.Usage messageTypeUsage = getMessageTypeUsage(messageType);
+            if (messageTypeUsage != RecordTypeOptions.Usage.NESTED) {
                 addFieldToUnion(unionMessageType, recordsDescriptor, messageType.getName());
             }
         }
@@ -755,8 +834,9 @@ public class MetaDataProtoEditor {
     }
 
     /**
-     * Creates a default union descriptor for the given file descriptor and a base union descriptor. It adds all of the
+     * Creates a default union descriptor for the given file descriptor and a base union descriptor. It adds all the
      * non-{@code NESTED} message types that exist in the base union to the synthetic union.
+     *
      * @param fileDescriptor the file descriptor to create a union for
      * @param baseUnionDescriptor the base union descriptor
      * @return the builder for the union
@@ -766,7 +846,7 @@ public class MetaDataProtoEditor {
     public static DescriptorProtos.DescriptorProto.Builder createSyntheticUnion(@Nonnull Descriptors.FileDescriptor fileDescriptor,
                                                                                 @Nonnull Descriptors.Descriptor baseUnionDescriptor) {
         DescriptorProtos.DescriptorProto.Builder unionMessageType = DescriptorProtos.DescriptorProto.newBuilder();
-        unionMessageType.setName(RecordMetaDataBuilder.DEFAULT_UNION_NAME);
+        unionMessageType.setName(DEFAULT_UNION_NAME);
         if (!baseUnionDescriptor.getOneofs().isEmpty()) {
             throw new MetaDataException("Adding record type to oneof is not allowed");
         }
@@ -775,8 +855,8 @@ public class MetaDataProtoEditor {
             if (messageType == null) {
                 throw new MetaDataException("Record type " + field.getMessageType().getName() + " removed");
             }
-            RecordMetaDataOptionsProto.RecordTypeOptions.Usage messageTypeUsage = getMessageTypeUsage(messageType.toProto());
-            if (messageTypeUsage != RecordMetaDataOptionsProto.RecordTypeOptions.Usage.NESTED) {
+            RecordTypeOptions.Usage messageTypeUsage = getMessageTypeUsage(messageType.toProto());
+            if (messageTypeUsage != RecordTypeOptions.Usage.NESTED) {
                 unionMessageType.addField(field.toProto().toBuilder()
                         .setTypeName(fullyQualifiedTypeName(messageType.getFile().getPackage(), messageType.getName())));
             }
@@ -786,6 +866,7 @@ public class MetaDataProtoEditor {
 
     /**
      * Checks if the file descriptor has a union.
+     *
      * @param fileDescriptor the file descriptor
      * @return true if the file descriptor has a union
      */

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/MetaDataProtoEditor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/MetaDataProtoEditor.java
@@ -36,9 +36,15 @@ import com.google.protobuf.Descriptors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
-import java.util.function.Function;
+import java.util.Set;
+import java.util.function.UnaryOperator;
 
 import static com.apple.foundationdb.record.RecordMetaDataBuilder.DEFAULT_UNION_NAME;
 
@@ -404,13 +410,166 @@ public class MetaDataProtoEditor {
         }
     }
 
-    public static void renameRecordTypes(@Nonnull RecordMetaDataProto.MetaData.Builder metaDataBuilder,
-                                         @Nonnull Function<String, String> renamer,
-                                         @Nonnull Descriptors.FileDescriptor[] dependencies) {
-        for (final String recordType : MetaDataProtoEditor.getRecordTypes(metaDataBuilder)) {
-            MetaDataProtoEditor.renameRecordType(metaDataBuilder,
-                    recordType, renamer.apply(recordType), dependencies);
+    /**
+     * Internal representation of a record type to be renamed by {@link #renameRecordTypes}.
+     */
+    private static final class RecordTypeRename {
+        /// The current name.
+        @Nonnull
+        private final String name;
+        /// The new name.
+        @Nonnull
+        private final String newName;
+        /// The fully qualified current name.
+        @Nonnull
+        private final String fullName;
+        /// The fully qualified new name.
+        @Nonnull
+        private final String fullNewName;
+        /// The usage, as determined by looking at the union type. (Initially {@code UNSET}, to be filled in by
+        /// {@link #determineRecordTypeUnionFieldsAndUsages}).
+        @Nonnull
+        private RecordTypeOptions.Usage usage = RecordTypeOptions.Usage.UNSET;
+        /// Builder of the referencing union field, if any. (Initially null, to be filled in by
+        /// {@link #determineRecordTypeUnionFieldsAndUsages}).
+        @Nullable
+        private DescriptorProtos.FieldDescriptorProto.Builder unionField;
+
+        RecordTypeRename(@Nonnull String namespace, @Nonnull String name, @Nonnull String newName) {
+            this.name = name;
+            this.newName = newName;
+            this.fullName = fullyQualifiedTypeName(namespace, name);
+            this.fullNewName = fullyQualifiedTypeName(namespace, newName);
         }
+    }
+
+    /**
+     * A map of {@link RecordTypeRename}s, keyed by the record type's current (simple) name, as built by
+     * {@link #analyzeRecordTypeRenames}. Also provides a lookup by fully qualified name, built lazily on first use.
+     */
+    private static final class RecordTypeRenames {
+        @Nonnull
+        private final Map<String, RecordTypeRename> byName;
+        @Nullable
+        private Map<String, RecordTypeRename> byFullName;
+
+        RecordTypeRenames(@Nonnull Map<String, RecordTypeRename> byName) {
+            this.byName = byName;
+        }
+
+        boolean isEmpty() {
+            return byName.isEmpty();
+        }
+
+        @Nonnull
+        Collection<RecordTypeRename> values() {
+            return byName.values();
+        }
+
+        @Nullable
+        RecordTypeRename get(@Nonnull String name) {
+            return byName.get(name);
+        }
+
+        /**
+         * Returns the new name for {@code name}, if there is a rename of {@code name} with the given {@code usage};
+         * otherwise, returns {@code null}.
+         */
+        @Nullable
+        String get(@Nonnull String name, @Nonnull RecordTypeOptions.Usage usage) {
+            final RecordTypeRename rename = byName.get(name);
+            return rename != null && rename.usage == usage ? rename.newName : null;
+        }
+
+        /**
+         * Returns the rename whose (original) fully qualified name is {@code fullName}, if any.
+         */
+        @Nullable
+        RecordTypeRename getByFullName(@Nonnull String fullName) {
+            if (byFullName == null) {
+                byFullName = new HashMap<>();
+                for (final RecordTypeRename rename : byName.values()) {
+                    byFullName.put(rename.fullName, rename);
+                }
+            }
+            return byFullName.get(fullName);
+        }
+    }
+
+    /**
+     * Renames the record types in the metadata, according to the name mapping defined by {@code renamer}. For each
+     * renamed record type (where {@code renamer} yields a name that is not equal to the current one), this method
+     * applies the same transformations that {@link #renameRecordType} would, but it operates in an efficient, batched
+     * manner. The entire mapping is applied in a single walk over the given {@code metadata}, and the records
+     * {@link Descriptors.FileDescriptor} is compiled exactly once.
+     *
+     * <p>Unlike {@link #renameRecordType}, {@code renamer} is only ever applied to (and can therefore only rename)
+     * {@code RECORD}-usage top-level types, i.e., those in {@code MetaData.record_types}; it cannot rename
+     * {@code NESTED} types or the union type itself.
+     *
+     * <p><b>Precondition:</b> The {@code renamer} must define a consistent, collision-free mapping. That is, no two
+     * distinct existing top-level record types may map to the same new name, and no record type may be renamed to a
+     * name that collides with another (renamed or unchanged) top-level type or an imported record type. If a collision
+     * is detected, no rename is performed, and a {@link MetaDataException} is thrown.
+     *
+     * <p>The following is an example of a simple, collision-free renaming. It prepends a fixed string to every name:
+     * <pre>
+     * MetaDataProtoEditor.renameRecordTypes(builder, name -> "prefix_" + name, dependencies);
+     * </pre>
+     *
+     * @param metadata the metadata builder
+     * @param renamer a function mapping each existing top-level record type name to its new name
+     * @param dependencies the dependencies of the records file descriptor
+     * @see #renameRecordType
+     */
+    public static void renameRecordTypes(@Nonnull RecordMetaDataProto.MetaData.Builder metadata,
+                                         @Nonnull UnaryOperator<String> renamer,
+                                         @Nonnull Descriptors.FileDescriptor[] dependencies) {
+        // Collect the renames into a map, skipping identity renames. This method will throw `MetaDataException` if
+        // there is any conflict.
+        final RecordTypeRenames renames = analyzeRecordTypeRenames(metadata, renamer);
+        if (renames.isEmpty()) {
+            return;
+        }
+
+        validateNoUserDefinedFunctions(metadata);
+
+        // Build the file descriptor exactly once, from the original `MetaData.records` proto. Every descriptor
+        // lookup below is done by original name, so we can use this single descriptor for every rename in the
+        // mapping.
+        final DescriptorProtos.FileDescriptorProto records = metadata.getRecords();
+        final Descriptors.FileDescriptor fileDesc = RecordMetaDataBuilder.buildFileDescriptor(records, dependencies);
+
+        // Validate the `MetaData.unnested_record_types` constituents before making any changes.
+        validateRecordTypeUsagesInUnnestedRecordTypes(metadata.getUnnestedRecordTypesBuilderList(), fileDesc, renames);
+
+        // Determine the usage of each renamed type by looking at the union message type within `MetaData.records`.
+        final DescriptorProtos.DescriptorProto.Builder union = fetchUnionBuilder(metadata.getRecordsBuilder());
+        if (union.getNestedTypeCount() > 0) {
+            throw new MetaDataException("Nested types in union type not supported");
+        }
+        determineRecordTypeUnionFieldsAndUsages(renames, fileDesc, union);
+
+        // Validate that renaming the canonical union fields would not cause a collision.
+        validateUnionFieldRenames(union, renames);
+
+        // Rename the canonical union field, if present, for each renamed type.
+        renameUnionFields(renames);
+
+        // Rename every message type in `MetaData.records`, and all field type references.
+        renameRecordTypeUsagesInMessageTypes(metadata.getRecordsBuilder().getMessageTypeBuilderList(), renames, fileDesc);
+
+        // Update `MetaData.record_types` for every top-level RECORD type.
+        renameRecordTypeUsagesInRecordTypes(metadata.getRecordTypesBuilderList(), renames);
+
+        // Update `MetaData.indexes` for every top-level RECORD type.
+        renameRecordTypeUsagesInIndexes(metadata.getIndexesBuilderList(), renames);
+
+        // Update `MetaData.joined_record_types` constituents for every renamed type.
+        renameRecordTypeUsagesInJoinedRecordTypes(metadata.getJoinedRecordTypesBuilderList(), renames);
+
+        // Rename `MetaData.unnested_record_types` constituents for every renamed type.
+        renameRecordTypeUsagesInUnnestedRecordTypes(metadata.getUnnestedRecordTypesBuilderList(), renames);
     }
 
     /**
@@ -684,6 +843,373 @@ public class MetaDataProtoEditor {
             return false;
         } else {
             return isNested(typeDescriptor.getContainingType(), targetDescriptor);
+        }
+    }
+
+    /**
+     * A helper for {@link #renameRecordTypes} that converts the record-type name mapping defined by {@code renamer}
+     * into the internal, ordered, old-to-new map. Also validates the mapping against the full set of top-level
+     * message types, and raises {@link MetaDataException} if it is invalid.
+     */
+    @Nonnull
+    private static RecordTypeRenames analyzeRecordTypeRenames(
+            @Nonnull RecordMetaDataProto.MetaData.Builder metaDataBuilder,
+            @Nonnull UnaryOperator<String> renamer) {
+        // Apply `renamer` to each record type name and build the map representing the renamings.
+        final String namespace = metaDataBuilder.getRecords().getPackage();
+        final Map<String, RecordTypeRename> renames = new LinkedHashMap<>();
+        for (final String recordType : getRecordTypes(metaDataBuilder)) {
+            final String newName = renamer.apply(recordType);
+            // Skip identity renames, as they require no work.
+            if (recordType.equals(newName)) {
+                continue;
+            }
+            if (recordType.contains(".")) {
+                throw new MetaDataException("Record Type Name cannot contain '.'");
+            }
+            renames.put(recordType, new RecordTypeRename(namespace, recordType, newName));
+        }
+
+        if (renames.isEmpty()) {
+            return new RecordTypeRenames(renames);
+        }
+
+        // Build the inverse new-to-old mapping and use it to perform basic validation:
+        // * No two distinct existing record types may map to the same new name.
+        // * No record type may be renamed to a name that collides with another (renamed or unchanged) top-level type.
+        final Map<String, String> inverse = new HashMap<>();
+        for (final RecordTypeRename rename : renames.values()) {
+            final String previous = inverse.put(rename.newName, rename.name);
+            if (previous != null) {
+                throw new MetaDataException("Cannot rename record types `" + previous + "` and `" + rename.name
+                        + "` to the same name `" + rename.newName + "`");
+            }
+        }
+
+        // If a message type is not itself being renamed, then it must not be the target of a rename either.
+        for (final DescriptorProtos.DescriptorProto messageType : metaDataBuilder.getRecords().getMessageTypeList()) {
+            final String name = messageType.getName();
+            if (!renames.containsKey(name) && inverse.containsKey(name)) {
+                throw new MetaDataException("Cannot rename record type to " + name + " as it already exists");
+            }
+        }
+
+        // Likewise for the metadata's full record type registry, which (unlike `getMessageTypeList()` above) also
+        // includes record types imported from a dependency file.
+        for (final String name : getRecordTypes(metaDataBuilder)) {
+            if (!renames.containsKey(name) && inverse.containsKey(name)) {
+                throw new MetaDataException("Cannot rename record type to " + name + " as an imported record type of that name already exists");
+            }
+        }
+
+        return new RecordTypeRenames(renames);
+    }
+
+    /**
+     * A helper for {@link #renameRecordTypes} that determines the {@link RecordTypeOptions.Usage Usage} of each
+     * renamed type by looking at the union. Fills in the {@code usage} and {@code unionField} of the entries
+     * in {@code renames}. Does not mutate {@code fileDescriptor} and {@code unionBuilder}.
+     */
+    private static void determineRecordTypeUnionFieldsAndUsages(
+            @Nonnull RecordTypeRenames renames,
+            @Nonnull Descriptors.FileDescriptor fileDescriptor,
+            @Nonnull DescriptorProtos.DescriptorProto.Builder unionBuilder) {
+        final String unionName = unionBuilder.getName();
+        final Descriptors.Descriptor unionDescriptor = getMessageTypeByName(fileDescriptor, unionName);
+
+        // Find, for each renamed record type, the union field that references it (if any), in a single pass over the
+        // union's fields.
+        for (final DescriptorProtos.FieldDescriptorProto.Builder unionField : unionBuilder.getFieldBuilderList()) {
+            if (!unionField.hasTypeName() || unionField.getTypeName().isEmpty()) {
+                continue;
+            }
+
+            final String fullReferencedName = resolveFieldMessageTypeFullName(unionDescriptor, unionField);
+            if (fullReferencedName == null) {
+                continue;
+            }
+
+            final RecordTypeRename rename = renames.getByFullName(fullReferencedName);
+            if (rename == null) {
+                continue;
+            }
+
+            // If multiple fields reference this record type, prefer the canonically-named one; otherwise, keep the
+            // one with the highest field number.
+            if (rename.unionField == null
+                    || isCanonicalUnionFieldName(unionField.getName(), rename.name)
+                    || unionField.getNumber() > rename.unionField.getNumber()) {
+                rename.unionField = unionField;
+            }
+        }
+
+        for (final RecordTypeRename rename : renames.values()) {
+            // Determine the usage of each renamed record type, based on the union field found above, if any.
+            // * If the type name equals the union name, the usage is UNION.
+            // * Otherwise, if the type has a corresponding union field, it is a top-level record type, i.e., RECORD.
+            // * Otherwise, it can only ever be used as an embedded message type, i.e., NESTED.
+            if (rename.name.equals(unionName)) {
+                rename.unionField = null;
+                rename.usage = RecordTypeOptions.Usage.UNION;
+            } else {
+                rename.usage = rename.unionField == null
+                               ? RecordTypeOptions.Usage.NESTED
+                               : RecordTypeOptions.Usage.RECORD;
+            }
+
+            // Prevent renaming a non-UNION type to the default union name.
+            if (!rename.usage.equals(RecordTypeOptions.Usage.UNION) && rename.newName.equals(DEFAULT_UNION_NAME)) {
+                throw new MetaDataException(
+                        "Cannot rename record type to the default union name",
+                        LogMessageKeys.RECORD_TYPE, rename.name);
+            }
+        }
+    }
+
+    /**
+     * Validates that renaming each rename's canonical union field (if any) to its new canonical name would not
+     * collide with any other field of the union message type within {@code MetaData.records}, once every rename in
+     * {@code renames} has been applied. Performs no mutation, so that this can be called before any other edits are
+     * made.
+     */
+    private static void validateUnionFieldRenames(@Nonnull DescriptorProtos.DescriptorProto.Builder unionBuilder,
+                                                   @Nonnull RecordTypeRenames renames) {
+        // Fields that are themselves about to be renamed to their new canonical form never count as a collision
+        // target below, since they won't keep their current name once this batch of renames is applied. (Without
+        // this exclusion, a batch that e.g. swaps two type names — Foo -> Baz and Bar -> Foo — could spuriously be
+        // rejected: Bar's rename to "_Foo" would appear to collide with Foo's own, still-pristine "_Foo" field.)
+        final Set<DescriptorProtos.FieldDescriptorProto.Builder> beingRenamed = new HashSet<>();
+        for (final RecordTypeRename rename : renames.values()) {
+            if (rename.unionField != null && isCanonicalUnionFieldName(rename.unionField.getName(), rename.name)) {
+                beingRenamed.add(rename.unionField);
+            }
+        }
+        for (final RecordTypeRename rename : renames.values()) {
+            if (!beingRenamed.contains(rename.unionField)) {
+                continue;
+            }
+            final String newName = canonicalUnionFieldName(rename.newName);
+            final boolean hasCollision = unionBuilder.getFieldBuilderList().stream()
+                    .anyMatch(fb -> fb != rename.unionField && fb.getName().equals(newName) && !beingRenamed.contains(fb));
+            if (hasCollision) {
+                throw new MetaDataException("Cannot rename union field to " + newName + " as a field of that name already exists",
+                        LogMessageKeys.RECORD_TYPE, rename.name);
+            }
+        }
+    }
+
+    /**
+     * Renames the canonical union field, if present, for each rename in {@code renames}. The union field is a field
+     * of the union message type within {@code MetaData.records}. Callers must have already validated the renames
+     * via {@link #validateUnionFieldRenames}.
+     */
+    private static void renameUnionFields(@Nonnull RecordTypeRenames renames) {
+        for (final RecordTypeRename rename : renames.values()) {
+            if (rename.unionField != null && isCanonicalUnionFieldName(rename.unionField.getName(), rename.name)) {
+                rename.unionField.setName(canonicalUnionFieldName(rename.newName));
+            }
+        }
+    }
+
+    /**
+     * A helper for {@link #renameRecordTypes} that applies the name mapping in a single walk over the message types
+     * in {@code MetaData.records}, using the given compiled file descriptor for type resolution. Field type
+     * references are resolved (via the original descriptor) to the original type they point at; if that original
+     * type is, or is nested within, any renamed type, the reference is rewritten to point at the renamed type.
+     */
+    private static void renameRecordTypeUsagesInMessageTypes(@Nonnull List<DescriptorProtos.DescriptorProto.Builder> messageTypes,
+                                               @Nonnull RecordTypeRenames renames,
+                                               @Nonnull Descriptors.FileDescriptor fileDescriptor) {
+        // Walk every message type, rewriting references to renamed types and renaming the type itself.
+        for (final DescriptorProtos.DescriptorProto.Builder mtb : messageTypes) {
+            final String name = mtb.getName();
+
+            // Rewrite `typeName` field references within the message type.
+            final Descriptors.Descriptor descriptor = getMessageTypeByName(fileDescriptor, name);
+            renameRecordTypeUsagesInMessageType(mtb, renames, descriptor);
+
+            final RecordTypeRename rename = renames.get(name);
+            if (rename == null) {
+                continue;
+            }
+
+            // If renaming the union type, be sure that the `record.usage` option is set to UNION.
+            if (name.equals(DEFAULT_UNION_NAME) && getMessageTypeUsage(mtb) != RecordTypeOptions.Usage.UNION) {
+                setMessageTypeUsage(mtb, RecordTypeOptions.Usage.UNION);
+            }
+
+            // Rename the message type itself.
+            mtb.setName(rename.newName);
+        }
+    }
+
+    /**
+     * Recursively rewrites {@code typeName} field references within a message type and its nested types. For each
+     * message field, it resolves the original referenced type to its fully-qualified name and, if that type is
+     * or is nested within any renamed type, rewrites the field's {@code typeName} accordingly.
+     */
+    private static void renameRecordTypeUsagesInMessageType(@Nonnull DescriptorProtos.DescriptorProto.Builder messageTypeBuilder,
+                                               @Nonnull RecordTypeRenames renames,
+                                               @Nonnull Descriptors.Descriptor descriptorForMessage) {
+        for (final DescriptorProtos.FieldDescriptorProto.Builder field : messageTypeBuilder.getFieldBuilderList()) {
+            if (!field.hasTypeName() || field.getTypeName().isEmpty()) {
+                continue;
+            }
+            final String fullReferencedName = resolveFieldMessageTypeFullName(descriptorForMessage, field);
+            if (fullReferencedName == null) {
+                continue;
+            }
+
+            // Check the referenced type, then each of its containing types in turn, against the renamed types:
+            // truncate `candidateName` at the last '.' to walk from the referenced type up to its outermost
+            // containing type, which is equivalent to (but cheaper than) repeatedly calling `getContainingType()`.
+            // For example, if `fullReferencedName` is ".pkg.Outer.Inner" and "Outer" is being renamed to "NewOuter",
+            // `candidateName` first tries ".pkg.Outer.Inner" (no match), then ".pkg.Outer" (matches), yielding the
+            // rewritten type name ".pkg.NewOuter" + ".Inner" = ".pkg.NewOuter.Inner".
+            String candidateName = fullReferencedName;
+            while (true) {
+                // If `candidateName` is a renamed type, substitute its new name for the matched prefix, leaving any
+                // trailing nested-type suffix (e.g. ".InnerRecord") untouched.
+                final RecordTypeRename rename = renames.getByFullName(candidateName);
+                if (rename != null) {
+                    field.setTypeName(rename.fullNewName + fullReferencedName.substring(candidateName.length()));
+                    break;
+                }
+                // Strip the last name segment to move up to the containing type; stop once there is no more
+                // package/type prefix left (the leading '.' is always at index 0).
+                final int lastDot = candidateName.lastIndexOf('.');
+                if (lastDot <= 0) {
+                    break;
+                }
+                candidateName = candidateName.substring(0, lastDot);
+            }
+        }
+
+        // Recurse into nested types, since a field elsewhere in the file may reference one of them.
+        for (final DescriptorProtos.DescriptorProto.Builder nestedTypeBuilder : messageTypeBuilder.getNestedTypeBuilderList()) {
+            final Descriptors.Descriptor nestedDescriptor = Objects.requireNonNull(
+                    descriptorForMessage.findNestedTypeByName(nestedTypeBuilder.getName()),
+                    "FileDescriptor does not have nested type that exists in protobuf");
+            // Recursively rewrite field type references within the nested type.
+            renameRecordTypeUsagesInMessageType(nestedTypeBuilder, renames, nestedDescriptor);
+        }
+    }
+
+    /**
+     * Validates that {@code MetaData.user_defined_functions} is empty, since a user-defined function may be a
+     * string that needs parsing to figure out the record types it references, which renaming does not support.
+     * Performs no mutation, so that this can be called before any other edits are made.
+     */
+    private static void validateNoUserDefinedFunctions(@Nonnull RecordMetaDataProto.MetaData.Builder metaDataBuilder) {
+        if (metaDataBuilder.getUserDefinedFunctionsCount() > 0) {
+            throw new MetaDataException("Renaming record types with UserDefinedFunctions is not supported");
+        }
+    }
+
+    /**
+     * Rewrites {@code MetaData.record_types} for every {@code RECORD}-usage rename in {@code renames}. Any collision
+     * with an unrenamed type has already been ruled out upfront, by the caller.
+     */
+    private static void renameRecordTypeUsagesInRecordTypes(
+            @Nonnull List<RecordMetaDataProto.RecordType.Builder> recordTypes,
+            @Nonnull RecordTypeRenames renames) {
+        for (final var recordType : recordTypes) {
+            final String newName = renames.get(recordType.getName(), RecordTypeOptions.Usage.RECORD);
+            if (newName != null) {
+                recordType.setName(newName);
+            }
+        }
+    }
+
+    /**
+     * Rewrites the record types referenced by any {@code MetaData.indexes} entry, for every {@code RECORD}-usage
+     * rename in {@code renames}.
+     */
+    private static void renameRecordTypeUsagesInIndexes(@Nonnull List<RecordMetaDataProto.Index.Builder> indexes,
+                                                        @Nonnull RecordTypeRenames renames) {
+        for (final var index : indexes) {
+            for (int i = 0; i < index.getRecordTypeCount(); i++) {
+                final String newName = renames.get(index.getRecordType(i), RecordTypeOptions.Usage.RECORD);
+                if (newName != null) {
+                    index.setRecordType(i, newName);
+                }
+            }
+        }
+    }
+
+    /**
+     * Updates the join constituents in {@code MetaData.joined_record_types} that reference any {@code RECORD}-usage
+     * rename in {@code renames}; renames of any other usage are ignored.
+     */
+    private static void renameRecordTypeUsagesInJoinedRecordTypes(
+            @Nonnull List<RecordMetaDataProto.JoinedRecordType.Builder> joinedRecordTypes,
+            @Nonnull RecordTypeRenames renames) {
+        for (final var joined : joinedRecordTypes) {
+            for (final var constituent : joined.getJoinConstituentsBuilderList()) {
+                final RecordTypeRename rename = renames.get(constituent.getRecordType());
+                if (rename != null && rename.usage == RecordTypeOptions.Usage.RECORD) {
+                    constituent.setRecordType(rename.newName);
+                }
+            }
+        }
+    }
+
+    /**
+     * Validates the nested constituents of {@code MetaData.unnested_record_types} affected by any renamed type: any
+     * constituent whose type is nested within a renamed type, other than as that type's own (non-nested)
+     * constituent, causes a {@link MetaDataException}, since renaming a type used by a non-parent unnested
+     * constituent is not supported. Performs no mutation, so that this can be called before any other edits are
+     * made.
+     */
+    private static void validateRecordTypeUsagesInUnnestedRecordTypes(
+            @Nonnull List<RecordMetaDataProto.UnnestedRecordType.Builder> unnestedRecordTypes,
+            @Nonnull Descriptors.FileDescriptor fileDescriptor,
+            @Nonnull RecordTypeRenames renames) {
+        for (var unnested : unnestedRecordTypes) {
+            for (var constituent : unnested.getNestedConstituentsBuilderList()) {
+                // The nested constituents would most likely be nested types, not record types, and thus would not be
+                // renamed.
+                if (constituent.getParent().isEmpty()) {
+                    continue;
+                }
+                final String name = constituent.getTypeName();
+                final Descriptors.Descriptor constituentTypeDescriptor
+                        = UnnestedRecordTypeBuilder.findDescriptorByName(fileDescriptor, name);
+                if (constituentTypeDescriptor == null) {
+                    throw new MetaDataException("missing descriptor for nested constituent")
+                            .addLogInfo(LogMessageKeys.EXPECTED, name)
+                            .addLogInfo(LogMessageKeys.CONSTITUENT, constituent.getName());
+                }
+                // Walk up the containing-type chain: if the constituent's type, or any type it is nested within, is
+                // being renamed, this non-parent reference to it can't be safely updated.
+                for (Descriptors.Descriptor typeDescriptor = constituentTypeDescriptor;
+                        typeDescriptor != null;
+                        typeDescriptor = typeDescriptor.getContainingType()) {
+                    if (renames.get(typeDescriptor.getName()) != null) {
+                        throw new MetaDataException("Renaming types used by non-parent unnested constituents is not supported");
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Renames the nested constituents of {@code MetaData.unnested_record_types} that directly name (as their own,
+     * non-nested type) any rename in {@code renames}. Callers must have already validated the rename via
+     * {@link #validateRecordTypeUsagesInUnnestedRecordTypes}.
+     */
+    private static void renameRecordTypeUsagesInUnnestedRecordTypes(
+            @Nonnull List<RecordMetaDataProto.UnnestedRecordType.Builder> unnestedRecordTypes,
+            @Nonnull RecordTypeRenames renames) {
+        for (var unnested : unnestedRecordTypes) {
+            for (var constituent : unnested.getNestedConstituentsBuilderList()) {
+                if (constituent.getParent().isEmpty()) {
+                    final RecordTypeRename rename = renames.get(constituent.getTypeName());
+                    if (rename != null) {
+                        constituent.setTypeName(rename.newName);
+                    }
+                }
+            }
         }
     }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/MetaDataProtoEditorUnitTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/MetaDataProtoEditorUnitTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,19 +25,25 @@ import com.apple.foundationdb.record.RecordMetaDataBuilder;
 import com.apple.foundationdb.record.RecordMetaDataProto;
 import com.apple.foundationdb.record.TestRecords1Proto;
 import com.apple.foundationdb.record.TestRecordsDoubleNestedProto;
+import com.apple.foundationdb.record.metadata.Key;
 import com.apple.foundationdb.record.metadata.MetaDataException;
 import com.apple.foundationdb.record.metadata.RecordType;
+import com.apple.foundationdb.record.metadata.SyntheticRecordType;
 import com.apple.foundationdb.record.provider.foundationdb.MetaDataProtoEditor.FieldTypeMatch;
 import com.apple.test.BooleanSource;
+import com.apple.test.Tags;
 import com.google.protobuf.DescriptorProtos;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.util.JsonFormat;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -50,6 +56,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -61,12 +68,15 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
- * Tests for the meta-data proto editor. There are more tests for this class (in action) in the {@link FDBMetaDataStoreTest}
- * class. Those tests are more end-to-end, and they are for doing things like testing that when the meta-data
- * are read from the database, edited, and written back, everything works. These tests focus on just the editor
- * itself.
+ * Unit tests for the metadata proto editor. These tests focus on just the editor itself.
+ *
+ * <p>There are more tests for this class (in action) in {@link FDBMetaDataStoreTest}. Those tests are more end-to-end,
+ * and they are for doing things like testing that when the metadata are read from the database, edited, and written
+ * back, everything works.
  */
 public class MetaDataProtoEditorUnitTest {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MetaDataProtoEditorUnitTest.class);
+
 
     @Nonnull
     private FieldTypeMatch fieldIsType(@Nonnull DescriptorProtos.FileDescriptorProto.Builder file,
@@ -280,6 +290,15 @@ public class MetaDataProtoEditorUnitTest {
         assertEquals(Set.of("MiddleRecord"), getNestedTypeNames(renamedDescriptor.findMessageTypeByName("OtterRecord")));
         assertEquals(Set.of("InnerRecord"), getNestedTypeNames(renamedDescriptor.findMessageTypeByName("OtterRecord")
                 .findNestedTypeByName("MiddleRecord")));
+
+        // Cross-check: Renaming the same single type via the batched `renameRecordTypes()` method should produce
+        // a byte-for-byte identical result.
+        final RecordMetaDataProto.MetaData.Builder batchedBuilder = metaData.toProto().toBuilder();
+        MetaDataProtoEditor.renameRecordTypes(
+                batchedBuilder,
+                name -> name.equals("OuterRecord") ? "OtterRecord" : name,
+                getDependencies(metaData));
+        assertEquals(metaDataProtoBuilder.build(), batchedBuilder.build());
     }
 
     @Nonnull
@@ -293,6 +312,57 @@ public class MetaDataProtoEditorUnitTest {
     @Nonnull
     private static Descriptors.FileDescriptor[] getDependencies(final RecordMetaData metaData) {
         return metaData.getRecordsDescriptor().getDependencies().toArray(new Descriptors.FileDescriptor[0]);
+    }
+
+    /**
+     * A naive implementation of {@link MetaDataProtoEditor#renameRecordTypes} for testing purposes. Applies
+     * {@code renamer} to every top-level record type in {@code originalProto}, one type at a time via
+     * {@link MetaDataProtoEditor#renameRecordType}.
+     */
+    @Nonnull
+    private static RecordMetaDataProto.MetaData renameRecordTypesOneByOne(
+            @Nonnull RecordMetaDataProto.MetaData originalProto,
+            @Nonnull UnaryOperator<String> renamer,
+            @Nonnull Descriptors.FileDescriptor[] dependencies) {
+        final RecordMetaDataProto.MetaData.Builder builder = originalProto.toBuilder();
+        for (final String recordType : MetaDataProtoEditor.getRecordTypes(builder)) {
+            MetaDataProtoEditor.renameRecordType(builder, recordType, renamer.apply(recordType), dependencies);
+        }
+        return builder.build();
+    }
+
+    /**
+     * Asserts that applying {@code renamer} via the batched {@link MetaDataProtoEditor#renameRecordTypes} method
+     * produces byte-for-byte the same metadata as applying it one type at a time via {@link #renameRecordTypesOneByOne}.
+     * Note though that this cross-check is only applicable to renamings whose validity depends on iteration order
+     * (see {@link #conflictingName}).
+     */
+    private static void crossCheckRenamedMetaData(
+            @Nonnull RecordMetaDataProto.MetaData originalProto,
+            @Nonnull UnaryOperator<String> renamer,
+            @Nonnull Descriptors.FileDescriptor[] dependencies,
+            @Nonnull RecordMetaDataProto.MetaData batchedResult) {
+        final RecordMetaDataProto.MetaData oneByOne = renameRecordTypesOneByOne(originalProto, renamer, dependencies);
+        // Compare via `RecordMetaData.build().toProto()` rather than the raw protos directly, since building a
+        // `RecordMetaData` normalizes some fields (e.g., filling in `nullInterpretation`) that may otherwise differ
+        // in representation, though not in meaning, depending on which path produced the raw proto.
+        final RecordMetaData batchedRecordMetaData = RecordMetaData.build(batchedResult);
+        final RecordMetaData oneByOneRecordMetaData = RecordMetaData.build(oneByOne);
+        assertEquals(batchedRecordMetaData.toProto(), oneByOneRecordMetaData.toProto());
+    }
+
+    /**
+     * Asserts that {@code renamer} is rejected by both the batched {@link MetaDataProtoEditor#renameRecordTypes} and
+     * an equivalent one-by-one sequence of {@link MetaDataProtoEditor#renameRecordType} calls.
+     */
+    private static void crossRenameRecordTypesIsRejected(
+            @Nonnull RecordMetaDataProto.MetaData originalProto,
+            @Nonnull UnaryOperator<String> renamer,
+            @Nonnull Descriptors.FileDescriptor[] dependencies) {
+        assertThrows(MetaDataException.class,
+                () -> MetaDataProtoEditor.renameRecordTypes(originalProto.toBuilder(), renamer, dependencies));
+        assertThrows(MetaDataException.class,
+                () -> renameRecordTypesOneByOne(originalProto, renamer, dependencies));
     }
 
     private void renameFieldTypes(@Nonnull DescriptorProtos.DescriptorProto.Builder messageTypeBuilder, @Nonnull String oldTypeName, @Nonnull String newTypeName) {
@@ -348,6 +418,12 @@ public class MetaDataProtoEditorUnitTest {
         assertSame(renamedOuterOuterInner, renamedOuterOuter.findFieldByName("inner").getMessageType());
         assertSame(renamedOuter, renamedOuterOuterInner.findFieldByName("outer").getMessageType());
 
+        // Cross-check: Renaming the same single type via the batched `renameRecordTypes()` should produce a
+        // byte-for-byte identical result.
+        final RecordMetaDataProto.MetaData.Builder batchedBuilder = metaData.toProto().toBuilder();
+        MetaDataProtoEditor.renameRecordTypes(batchedBuilder,
+                name -> name.equals("OuterRecord") ? "OtterRecord" : name, getDependencies(metaData));
+        assertEquals(metaDataProtoBuilder.build(), batchedBuilder.build());
     }
 
     public static RecordMetaDataProto.MetaData.Builder loadMetaData(@Nonnull String name) throws IOException {
@@ -370,12 +446,32 @@ public class MetaDataProtoEditorUnitTest {
                         "DuplicateUnionFields.json",
                         "OneTypeWithIndexes.json",
                         "MultiTypeIndex.json",
-                        "UniversalIndex.json",
-                        "UnnestedExternalType.json",
-                        "UnnestedInternal.json",
-                        "Joined.json"
+                        "UniversalIndex.json"
                 ).map(filename -> Arguments.of(filename, (Consumer<RecordMetaData>) renamed -> { })),
                 Stream.of(
+                        Arguments.of("UnnestedExternalType.json",
+                                (Consumer<RecordMetaData>) renamed -> {
+                                    // "parent" (T1) is a top-level RECORD type and gets renamed; "child" names the
+                                    // dependency-defined UUID type, which is not a top-level record type and so is
+                                    // left untouched.
+                                    assertEquals(Map.of("parent", simpleRename("T1"), "child", "UUID"),
+                                            constituentTypeNames(renamed));
+                                }),
+                        Arguments.of("UnnestedInternal.json",
+                                (Consumer<RecordMetaData>) renamed -> {
+                                    // "parent" (T2) is a top-level RECORD type and gets renamed; "child" names T1,
+                                    // which has NESTED usage and so is left untouched.
+                                    assertEquals(Map.of("parent", simpleRename("T2"), "child", "T1"),
+                                            constituentTypeNames(renamed));
+                                }),
+                        Arguments.of("Joined.json",
+                                (Consumer<RecordMetaData>) renamed -> {
+                                    final SyntheticRecordType<?> join = renamed.getSyntheticRecordType("JOIN");
+                                    assertEquals(Set.of(simpleRename("T1"), simpleRename("T2")),
+                                            join.getConstituents().stream()
+                                                    .map(constituent -> constituent.getRecordType().getName())
+                                                    .collect(Collectors.toSet()));
+                                }),
                         Arguments.of("AlsoInDependency.json",
                                 (Consumer<RecordMetaData>) renamed -> {
                                     final Descriptors.Descriptor uuidType = getMessage(renamed, simpleRename("UUID"));
@@ -416,6 +512,17 @@ public class MetaDataProtoEditorUnitTest {
                 .findFirst().orElseThrow().getMessageType();
     }
 
+    /**
+     * Maps each constituent's own name (e.g. "parent", "child") to the name of the record type it names, for the
+     * unnested synthetic record type named {@code "__3_syntheticType_1"} in the fixtures that use it.
+     */
+    @Nonnull
+    private static Map<String, String> constituentTypeNames(final RecordMetaData renamed) {
+        return renamed.getSyntheticRecordType("__3_syntheticType_1").getConstituents().stream()
+                .collect(Collectors.toMap(SyntheticRecordType.Constituent::getName,
+                        constituent -> constituent.getRecordType().getName()));
+    }
+
     @ParameterizedTest(name = "{0}")
     @MethodSource("renamableFiles")
     void simplePrefix(String name, Consumer<RecordMetaData> extraAssertions) throws IOException {
@@ -423,18 +530,201 @@ public class MetaDataProtoEditorUnitTest {
         extraAssertions.accept(renamed);
     }
 
+    /**
+     * The rename must reject a renamer that maps two distinct record types to the same new name.
+     */
+    @Test
+    void batchedRejectsCollidingRenames() throws IOException {
+        final RecordMetaDataProto.MetaData originalProto = loadMetaData("TwoBoringTypes.json").build();
+        crossRenameRecordTypesIsRejected(
+                originalProto,
+                name -> "Collision",
+                RecordMetaDataBuilder.getDependencies(originalProto, Map.of()));
+    }
+
+    /**
+     * A batch that swaps two record types' names must succeed, since neither rename target collides with an
+     * "unrenamed" type — both are moving. This exercises the {@code beingRenamed} exclusion in
+     * {@code validateUnionFieldRenames()} (and the analogous exclusion in {@code analyzeRecordTypeRenames()}),
+     * without which this scenario would be spuriously rejected. Unlike the other rename tests here, this one is
+     * batched-only: like {@link #conflictingName}, a swap is order-dependent for the one-by-one path (renaming
+     * "UUID" to "T2" first would collide with the not-yet-renamed "T2").
+     */
+    @Test
+    void batchedAllowsSwappingTwoNames() throws IOException {
+        final RecordMetaDataProto.MetaData originalProto = loadMetaData("AlsoInDependency.json").build();
+        final RecordMetaDataProto.MetaData.Builder builder = originalProto.toBuilder();
+        MetaDataProtoEditor.renameRecordTypes(builder,
+                name -> name.equals("UUID") ? "T2" : name.equals("T2") ? "UUID" : name,
+                RecordMetaDataBuilder.getDependencies(originalProto, Map.of()));
+        final RecordMetaData renamed = RecordMetaData.build(builder.build());
+        assertEquals(Set.of("UUID", "T2"), renamed.getRecordTypes().keySet());
+        // Content moves with the name: UUID's original single-field shape is now under "T2", and vice versa.
+        assertEquals(1, renamed.getRecordType("T2").getDescriptor().getFields().size());
+        assertEquals(3, renamed.getRecordType("UUID").getDescriptor().getFields().size());
+    }
+
+    /**
+     * The rename must reject the schemas that rename a type used by a non-parent unnested constituent.
+     */
     @ParameterizedTest
     @ValueSource(strings = {
             "UnnestedRenamed.json",
             "UnnestedRenamedNested.json",
     })
     void unsupported(String name) throws IOException {
-        final RecordMetaDataProto.MetaData.Builder builder = loadMetaData(name);
-        final RecordMetaDataProto.MetaData originalProto = builder.build();
+        final RecordMetaDataProto.MetaData originalProto = loadMetaData(name).build();
         RecordMetaData.build(originalProto); // ensure original metadata is valid
-        assertThrows(MetaDataException.class, () -> MetaDataProtoEditor.renameRecordTypes(builder,
+        crossRenameRecordTypesIsRejected(
+                originalProto,
                 MetaDataProtoEditorUnitTest::simpleRename,
-                RecordMetaDataBuilder.getDependencies(builder.build(), Map.of())));
+                RecordMetaDataBuilder.getDependencies(originalProto, Map.of()));
+    }
+
+    /**
+     * The rename must reject a renamer that maps a record type to the name of a distinct, un-renamed existing type.
+     */
+    @Test
+    void batchedRejectsRenameToExistingType() throws IOException {
+        final RecordMetaDataProto.MetaData originalProto = loadMetaData("TwoBoringTypes.json").build();
+        crossRenameRecordTypesIsRejected(
+                originalProto,
+                name -> name.equals("T1") ? "T2" : name,
+                RecordMetaDataBuilder.getDependencies(originalProto, Map.of()));
+    }
+
+    /**
+     * The rename must reject a renamer that maps a record type to the name of an existing record type that is
+     * registered in {@code MetaData.record_types} but has no corresponding message type in {@code MetaData.records}
+     * (as would be the case for a record type whose message is defined in a dependency file, i.e., "imported").
+     */
+    @Test
+    void batchedRejectsRenameToImportedType() throws IOException {
+        final RecordMetaDataProto.MetaData.Builder builder = loadMetaData("TwoBoringTypes.json");
+        builder.addRecordTypes(RecordMetaDataProto.RecordType.newBuilder().setName("Imported").build());
+        final RecordMetaDataProto.MetaData originalProto = builder.build();
+        crossRenameRecordTypesIsRejected(
+                originalProto,
+                name -> name.equals("T1") ? "Imported" : name,
+                RecordMetaDataBuilder.getDependencies(originalProto, Map.of()));
+    }
+
+    /**
+     * The rename must reject a renamer whose canonical union field name would collide with an existing,
+     * non-canonically-named union field of another (un-renamed) type. Unlike the other exception tests here, this
+     * one is batched-only: renaming one type at a time via {@link MetaDataProtoEditor#renameRecordType} silently
+     * leaves the colliding field under its old name instead of throwing (see {@link #conflictingName}).
+     */
+    @Test
+    void batchedRejectsUnionFieldCollision() throws IOException {
+        final RecordMetaDataProto.MetaData originalProto = loadMetaData("DuplicateUnionFields.json").build();
+        final MetaDataException exception = assertThrows(MetaDataException.class,
+                () -> MetaDataProtoEditor.renameRecordTypes(
+                        originalProto.toBuilder(),
+                        name -> name.equals("T2") ? "T1_1" : name,
+                        RecordMetaDataBuilder.getDependencies(originalProto, Map.of())));
+        Assertions.assertThat(exception.getMessage())
+                .startsWith("Cannot rename union field to ")
+                .endsWith("as a field of that name already exists");
+    }
+
+    /**
+     * The rename must reject any renaming when the metadata has {@code user_defined_functions}, since a
+     * user-defined function may be a string that references record types by name in ways that renaming cannot
+     * safely account for.
+     */
+    @Test
+    void batchedRejectsUserDefinedFunctions() throws IOException {
+        final RecordMetaDataProto.MetaData.Builder builder = loadMetaData("TwoBoringTypes.json");
+        builder.addUserDefinedFunctions(RecordMetaDataProto.PUserDefinedFunction.newBuilder().build());
+        final RecordMetaDataProto.MetaData originalProto = builder.build();
+        crossRenameRecordTypesIsRejected(
+                originalProto,
+                MetaDataProtoEditorUnitTest::simpleRename,
+                RecordMetaDataBuilder.getDependencies(originalProto, Map.of()));
+    }
+
+    /**
+     * The rename must reject a renamer that maps a non-union record type to the default union name.
+     */
+    @Test
+    void batchedRejectsRenameToDefaultUnionName() throws IOException {
+        final RecordMetaDataProto.MetaData originalProto = loadMetaData("TwoBoringTypes.json").build();
+        crossRenameRecordTypesIsRejected(
+                originalProto,
+                name -> name.equals("T1") ? RecordMetaDataBuilder.DEFAULT_UNION_NAME : name,
+                RecordMetaDataBuilder.getDependencies(originalProto, Map.of()));
+    }
+
+    /**
+     * The rename must reject any renaming when the union message type itself declares a nested type.
+     */
+    @Test
+    void batchedRejectsNestedTypeInUnion() throws IOException {
+        final RecordMetaDataProto.MetaData.Builder builder = loadMetaData("TwoBoringTypes.json");
+        for (final DescriptorProtos.DescriptorProto.Builder messageType : builder.getRecordsBuilder().getMessageTypeBuilderList()) {
+            if (messageType.getName().equals(RecordMetaDataBuilder.DEFAULT_UNION_NAME)) {
+                messageType.addNestedType(DescriptorProtos.DescriptorProto.newBuilder().setName("Nested"));
+            }
+        }
+        final RecordMetaDataProto.MetaData originalProto = builder.build();
+        crossRenameRecordTypesIsRejected(
+                originalProto,
+                MetaDataProtoEditorUnitTest::simpleRename,
+                RecordMetaDataBuilder.getDependencies(originalProto, Map.of()));
+    }
+
+    /**
+     * The rename must reject a renamer applied to a (contrived) record type whose name contains a {@code '.'}. This
+     * check runs before any descriptor validation, so it is only reachable via a hand-crafted {@code MetaData}
+     * whose {@code record_types} entry does not correspond to any actual message type.
+     */
+    @Test
+    void batchedRejectsDottedRecordTypeName() throws IOException {
+        final RecordMetaDataProto.MetaData.Builder builder = loadMetaData("TwoBoringTypes.json");
+        builder.addRecordTypes(RecordMetaDataProto.RecordType.newBuilder().setName("a.b").build());
+        final RecordMetaDataProto.MetaData originalProto = builder.build();
+        final Descriptors.FileDescriptor[] dependencies = RecordMetaDataBuilder.getDependencies(originalProto, Map.of());
+        final MetaDataException exception = assertThrows(MetaDataException.class,
+                () -> MetaDataProtoEditor.renameRecordTypes(
+                        originalProto.toBuilder(),
+                        name -> name.equals("a.b") ? "c" : name,
+                        dependencies));
+        assertEquals("Record Type Name cannot contain '.'", exception.getMessage());
+    }
+
+    /**
+     * The rename must reject any renaming when {@code MetaData.records} has no union message type at all.
+     */
+    @Test
+    void batchedRejectsMissingUnion() throws IOException {
+        final RecordMetaDataProto.MetaData.Builder builder = loadMetaData("TwoBoringTypes.json");
+        final DescriptorProtos.FileDescriptorProto.Builder recordsBuilder = builder.getRecordsBuilder();
+        final List<DescriptorProtos.DescriptorProto> withoutUnion = recordsBuilder.getMessageTypeList().stream()
+                .filter(messageType -> !messageType.getName().equals(RecordMetaDataBuilder.DEFAULT_UNION_NAME))
+                .collect(Collectors.toList());
+        recordsBuilder.clearMessageType().addAllMessageType(withoutUnion);
+        final RecordMetaDataProto.MetaData originalProto = builder.build();
+        crossRenameRecordTypesIsRejected(
+                originalProto,
+                MetaDataProtoEditorUnitTest::simpleRename,
+                RecordMetaDataBuilder.getDependencies(originalProto, Map.of()));
+    }
+
+    /**
+     * The rename must reject any renaming when an unnested record type's non-parent constituent names a type that
+     * cannot be resolved in the file descriptor.
+     */
+    @Test
+    void batchedRejectsMissingNestedConstituentDescriptor() throws IOException {
+        final RecordMetaDataProto.MetaData.Builder builder = loadMetaData("UnnestedInternal.json");
+        RecordMetaData.build(builder.build()); // ensure original metadata is valid
+        builder.getUnnestedRecordTypesBuilder(0).getNestedConstituentsBuilder(1).setTypeName("DoesNotExist");
+        final RecordMetaDataProto.MetaData originalProto = builder.build();
+        crossRenameRecordTypesIsRejected(
+                originalProto,
+                MetaDataProtoEditorUnitTest::simpleRename,
+                RecordMetaDataBuilder.getDependencies(originalProto, Map.of()));
     }
 
     @ParameterizedTest(name = "{0}")
@@ -443,27 +733,37 @@ public class MetaDataProtoEditorUnitTest {
         final RecordMetaDataProto.MetaData.Builder builder = loadMetaData(name);
         final RecordMetaDataProto.MetaData originalProto = builder.build();
         final RecordMetaData originalMetaData = RecordMetaData.build(originalProto);
-        MetaDataProtoEditor.renameRecordTypes(builder, MetaDataProtoEditorUnitTest::simpleRename,
-                RecordMetaDataBuilder.getDependencies(originalProto, Map.of()));
+        final Descriptors.FileDescriptor[] dependencies = RecordMetaDataBuilder.getDependencies(originalProto, Map.of());
+        MetaDataProtoEditor.renameRecordTypes(builder, MetaDataProtoEditorUnitTest::simpleRename, dependencies);
 
         final RecordMetaDataProto.MetaData firstRename = builder.build();
+        crossCheckRenamedMetaData(
+                originalProto,
+                MetaDataProtoEditorUnitTest::simpleRename,
+                dependencies,
+                firstRename);
         basicRenameAsserts(firstRename, originalMetaData,
                 MetaDataProtoEditorUnitTest::simpleRename,
                 MetaDataProtoEditorUnitTest::simpleRenameUndo);
 
         // again
-        MetaDataProtoEditor.renameRecordTypes(builder, MetaDataProtoEditorUnitTest::simpleRename,
-                RecordMetaDataBuilder.getDependencies(originalProto, Map.of()));
+        MetaDataProtoEditor.renameRecordTypes(builder, MetaDataProtoEditorUnitTest::simpleRename, dependencies);
 
         final RecordMetaDataProto.MetaData secondRename = builder.build();
+        crossCheckRenamedMetaData(
+                firstRename,
+                MetaDataProtoEditorUnitTest::simpleRename,
+                dependencies,
+                secondRename);
         basicRenameAsserts(secondRename, RecordMetaData.build(firstRename),
                 MetaDataProtoEditorUnitTest::simpleRename,
                 MetaDataProtoEditorUnitTest::simpleRenameUndo);
 
         final RecordMetaDataProto.MetaData.Builder restartBuilder = originalProto.toBuilder();
-        MetaDataProtoEditor.renameRecordTypes(restartBuilder,
+        MetaDataProtoEditor.renameRecordTypes(
+                restartBuilder,
                 oldName -> simpleRename(simpleRename(oldName)),
-                RecordMetaDataBuilder.getDependencies(originalProto, Map.of()));
+                dependencies);
         assertEquals(builder.build(), secondRename);
 
     }
@@ -473,8 +773,10 @@ public class MetaDataProtoEditorUnitTest {
     void conflictingName(boolean t1Conflicts) throws IOException {
         // In the future we may want to make this work, but for now, I just want to assert that it either succeeds
         // and produces a valid metadata, or fails with a clear exception. Currently, it is order dependent.
+        // Note also that this is exactly the kind of scenario where one-by-one renaming is *not* expected to match
+        // the batched renaming; so we use `runRenameBatchedOnly()` here rather than `runRename()`.
         final String prefix = "__Q_";
-        final RecordMetaData withConflict = runRename(loadMetaData("TwoBoringTypes.json").build(),
+        final RecordMetaData withConflict = runRenameBatchedOnly(loadMetaData("TwoBoringTypes.json").build(),
                 oldName -> {
                     if (t1Conflicts) {
                         return !oldName.equals("T1") ? prefix + "T1" : oldName;
@@ -489,14 +791,62 @@ public class MetaDataProtoEditorUnitTest {
             assertEquals(Set.of("T2", prefix + "T2"), withConflict.getRecordTypes().keySet());
         }
         try {
-            runRename(withConflict.toProto(),
+            runRenameBatchedOnly(withConflict.toProto(),
                     oldName -> prefix + oldName,
                     newName -> newName.substring(prefix.length()));
         } catch (MetaDataException e) {
-            Assertions.assertThat(e)
-                    .hasMessageStartingWith("Cannot rename record type to ")
-                    .hasMessageEndingWith("as it already exists");
+            Assertions.assertThat(e.getMessage())
+                    .satisfiesAnyOf(
+                            message -> Assertions.assertThat(message).startsWith("Cannot rename record type to ").endsWith("as it already exists"),
+                            message -> Assertions.assertThat(message).startsWith("Cannot rename union field to ").endsWith("as a field of that name already exists"));
         }
+    }
+
+    /**
+     * A renamer that returns every type's own name unchanged must be a true no-op: the metadata must come out
+     * byte-for-byte identical to how it went in, confirming that the early-return path for an empty rename set
+     * never mutates anything.
+     */
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("renamableFiles")
+    void identityRenameIsNoOp(String name) throws IOException {
+        final RecordMetaDataProto.MetaData originalProto = loadMetaData(name).build();
+        final RecordMetaDataProto.MetaData.Builder builder = originalProto.toBuilder();
+        MetaDataProtoEditor.renameRecordTypes(builder, UnaryOperator.identity(),
+                RecordMetaDataBuilder.getDependencies(originalProto, Map.of()));
+        assertEquals(originalProto, builder.build());
+    }
+
+    /**
+     * Exercises {@link MetaDataProtoEditor#renameRecordTypes} with a large number of record types, to get a rough
+     * sense of how it scales. Not a strict benchmark: there is no assertion on timing, only a log line. Run via the
+     * {@code performanceTest} Gradle task.
+     */
+    @Test
+    @Tag(Tags.Performance)
+    void renameManyRecordTypes() {
+        final int typeCount = 200;
+        final RecordMetaDataProto.MetaData.Builder builder = RecordMetaDataProto.MetaData.newBuilder();
+        builder.setRecords(DescriptorProtos.FileDescriptorProto.newBuilder()
+                .addMessageType(DescriptorProtos.DescriptorProto.newBuilder().setName(RecordMetaDataBuilder.DEFAULT_UNION_NAME)));
+        for (int i = 0; i < typeCount; i++) {
+            MetaDataProtoEditor.addRecordType(builder,
+                    DescriptorProtos.DescriptorProto.newBuilder()
+                            .setName("T" + i)
+                            .addField(DescriptorProtos.FieldDescriptorProto.newBuilder()
+                                    .setName("ID")
+                                    .setNumber(1)
+                                    .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_INT64))
+                            .build(),
+                    Key.Expressions.field("ID"));
+        }
+
+        final long startNanos = System.nanoTime();
+        MetaDataProtoEditor.renameRecordTypes(builder, MetaDataProtoEditorUnitTest::simpleRename, new Descriptors.FileDescriptor[0]);
+        final long elapsedNanos = System.nanoTime() - startNanos;
+        LOGGER.info("Renamed {} record types in {} ms", typeCount, elapsedNanos / 1e6);
+
+        assertEquals(typeCount, RecordMetaData.build(builder.build()).getRecordTypes().size());
     }
 
     @Test
@@ -541,19 +891,40 @@ public class MetaDataProtoEditorUnitTest {
         return runRename(originalProto, MetaDataProtoEditorUnitTest::simpleRename, MetaDataProtoEditorUnitTest::simpleRenameUndo);
     }
 
+    /**
+     * Performs the rename via the batched {@link MetaDataProtoEditor#renameRecordTypes} method, then cross-checks that
+     * an equivalent one-by-one sequence of {@link MetaDataProtoEditor#renameRecordType} calls produces byte-for-byte
+     * the same metadata.
+     *
+     * @see #runRenameBatchedOnly
+     */
     @Nonnull
     private RecordMetaData runRename(final RecordMetaDataProto.MetaData originalProto,
-                                     final Function<String, String> rename,
+                                     final UnaryOperator<String> rename,
                                      final Function<String, String> undoRename) {
+        final RecordMetaData renamed = runRenameBatchedOnly(originalProto, rename, undoRename);
+        final Descriptors.FileDescriptor[] dependencies = RecordMetaDataBuilder.getDependencies(originalProto, Map.of());
+        crossCheckRenamedMetaData(originalProto, rename, dependencies, renamed.toProto());
+        return renamed;
+    }
+
+    /**
+     * Perform the rename using (only) the batched {@link MetaDataProtoEditor#renameRecordTypes} method, without any
+     * cross-checking. Use this for renamings whose validity is sensitive to iteration order (see
+     * {@link #conflictingName}), since the one-by-one path is not expected to match those.
+     * 
+     * @see #runRename(RecordMetaDataProto.MetaData, UnaryOperator, Function)
+     */
+    @Nonnull
+    private RecordMetaData runRenameBatchedOnly(final RecordMetaDataProto.MetaData originalProto,
+                                                final UnaryOperator<String> rename,
+                                                final Function<String, String> undoRename) {
         final RecordMetaDataProto.MetaData.Builder builder = originalProto.toBuilder();
         final RecordMetaData originalMetaData = RecordMetaData.build(originalProto);
-        MetaDataProtoEditor.renameRecordTypes(builder, rename,
-                RecordMetaDataBuilder.getDependencies(originalProto, Map.of()));
-
+        final Descriptors.FileDescriptor[] dependencies = RecordMetaDataBuilder.getDependencies(originalProto, Map.of());
+        MetaDataProtoEditor.renameRecordTypes(builder, rename, dependencies);
         final RecordMetaDataProto.MetaData build = builder.build();
-        return basicRenameAsserts(build, originalMetaData,
-                rename,
-                undoRename);
+        return basicRenameAsserts(build, originalMetaData, rename, undoRename);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/MetaDataProtoEditorUnitTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/MetaDataProtoEditorUnitTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,31 +26,39 @@ import com.apple.foundationdb.record.RecordMetaDataProto;
 import com.apple.foundationdb.record.TestRecords1Proto;
 import com.apple.foundationdb.record.TestRecordsDoubleNestedProto;
 import com.apple.foundationdb.record.TestRecordsEnumProto;
+import com.apple.foundationdb.record.metadata.Key;
 import com.apple.foundationdb.record.metadata.MetaDataException;
 import com.apple.foundationdb.record.metadata.RecordType;
+import com.apple.foundationdb.record.metadata.SyntheticRecordType;
 import com.apple.foundationdb.record.provider.foundationdb.MetaDataProtoEditor.FieldTypeMatch;
 import com.apple.test.BooleanSource;
+import com.apple.test.Tags;
 import com.google.protobuf.DescriptorProtos;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.util.JsonFormat;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -62,12 +70,14 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
- * Tests for the meta-data proto editor. There are more tests for this class (in action) in the {@link FDBMetaDataStoreTest}
- * class. Those tests are more end-to-end, and they are for doing things like testing that when the meta-data
- * are read from the database, edited, and written back, everything works. These tests focus on just the editor
- * itself.
+ * Unit tests for the metadata proto editor. These tests focus on just the editor itself.
+ *
+ * <p>There are more tests for this class (in action) in {@link FDBMetaDataStoreTest}. Those tests are more end-to-end,
+ * and they are for doing things like testing that when the metadata are read from the database, edited, and written
+ * back, everything works.
  */
 public class MetaDataProtoEditorUnitTest {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MetaDataProtoEditorUnitTest.class);
 
     @Nonnull
     private FieldTypeMatch fieldIsType(@Nonnull DescriptorProtos.FileDescriptorProto.Builder file,
@@ -300,6 +310,15 @@ public class MetaDataProtoEditorUnitTest {
         assertEquals(Set.of("MiddleRecord"), getNestedTypeNames(renamedDescriptor.findMessageTypeByName("OtterRecord")));
         assertEquals(Set.of("InnerRecord"), getNestedTypeNames(renamedDescriptor.findMessageTypeByName("OtterRecord")
                 .findNestedTypeByName("MiddleRecord")));
+
+        // Cross-check: Renaming the same single type via the batched `renameRecordTypes()` method should produce
+        // a byte-for-byte identical result.
+        final RecordMetaDataProto.MetaData.Builder batchedBuilder = metaData.toProto().toBuilder();
+        MetaDataProtoEditor.renameRecordTypes(
+                batchedBuilder,
+                name -> name.equals("OuterRecord") ? "OtterRecord" : name,
+                getDependencies(metaData));
+        assertEquals(metaDataProtoBuilder.build(), batchedBuilder.build());
     }
 
     @Nonnull
@@ -313,6 +332,57 @@ public class MetaDataProtoEditorUnitTest {
     @Nonnull
     private static Descriptors.FileDescriptor[] getDependencies(final RecordMetaData metaData) {
         return metaData.getRecordsDescriptor().getDependencies().toArray(new Descriptors.FileDescriptor[0]);
+    }
+
+    /**
+     * A naive implementation of {@link MetaDataProtoEditor#renameRecordTypes} for testing purposes. Applies
+     * {@code renamer} to every top-level record type in {@code originalProto}, one type at a time via
+     * {@link MetaDataProtoEditor#renameRecordType}.
+     */
+    @Nonnull
+    private static RecordMetaDataProto.MetaData renameRecordTypesOneByOne(
+            @Nonnull RecordMetaDataProto.MetaData originalProto,
+            @Nonnull UnaryOperator<String> renamer,
+            @Nonnull Descriptors.FileDescriptor[] dependencies) {
+        final RecordMetaDataProto.MetaData.Builder builder = originalProto.toBuilder();
+        for (final String recordType : MetaDataProtoEditor.getRecordTypes(builder)) {
+            MetaDataProtoEditor.renameRecordType(builder, recordType, renamer.apply(recordType), dependencies);
+        }
+        return builder.build();
+    }
+
+    /**
+     * Asserts that applying {@code renamer} via the batched {@link MetaDataProtoEditor#renameRecordTypes} method
+     * produces byte-for-byte the same metadata as applying it one type at a time via {@link #renameRecordTypesOneByOne}.
+     * Note though that this cross-check is only applicable to renamings whose validity depends on iteration order
+     * (see {@link #conflictingName}).
+     */
+    private static void crossCheckRenamedMetaData(
+            @Nonnull RecordMetaDataProto.MetaData originalProto,
+            @Nonnull UnaryOperator<String> renamer,
+            @Nonnull Descriptors.FileDescriptor[] dependencies,
+            @Nonnull RecordMetaDataProto.MetaData batchedResult) {
+        final RecordMetaDataProto.MetaData oneByOne = renameRecordTypesOneByOne(originalProto, renamer, dependencies);
+        // Compare via `RecordMetaData.build().toProto()` rather than the raw protos directly, since building a
+        // `RecordMetaData` normalizes some fields (e.g., filling in `nullInterpretation`) that may otherwise differ
+        // in representation, though not in meaning, depending on which path produced the raw proto.
+        final RecordMetaData batchedRecordMetaData = RecordMetaData.build(batchedResult);
+        final RecordMetaData oneByOneRecordMetaData = RecordMetaData.build(oneByOne);
+        assertEquals(batchedRecordMetaData.toProto(), oneByOneRecordMetaData.toProto());
+    }
+
+    /**
+     * Asserts that {@code renamer} is rejected by both the batched {@link MetaDataProtoEditor#renameRecordTypes} and
+     * an equivalent one-by-one sequence of {@link MetaDataProtoEditor#renameRecordType} calls.
+     */
+    private static void crossRenameRecordTypesIsRejected(
+            @Nonnull RecordMetaDataProto.MetaData originalProto,
+            @Nonnull UnaryOperator<String> renamer,
+            @Nonnull Descriptors.FileDescriptor[] dependencies) {
+        assertThrows(MetaDataException.class,
+                () -> MetaDataProtoEditor.renameRecordTypes(originalProto.toBuilder(), renamer, dependencies));
+        assertThrows(MetaDataException.class,
+                () -> renameRecordTypesOneByOne(originalProto, renamer, dependencies));
     }
 
     private void renameFieldTypes(@Nonnull DescriptorProtos.DescriptorProto.Builder messageTypeBuilder, @Nonnull String oldTypeName, @Nonnull String newTypeName) {
@@ -368,6 +438,12 @@ public class MetaDataProtoEditorUnitTest {
         assertSame(renamedOuterOuterInner, renamedOuterOuter.findFieldByName("inner").getMessageType());
         assertSame(renamedOuter, renamedOuterOuterInner.findFieldByName("outer").getMessageType());
 
+        // Cross-check: Renaming the same single type via the batched `renameRecordTypes()` should produce a
+        // byte-for-byte identical result.
+        final RecordMetaDataProto.MetaData.Builder batchedBuilder = metaData.toProto().toBuilder();
+        MetaDataProtoEditor.renameRecordTypes(batchedBuilder,
+                name -> name.equals("OuterRecord") ? "OtterRecord" : name, getDependencies(metaData));
+        assertEquals(metaDataProtoBuilder.build(), batchedBuilder.build());
     }
 
     public static RecordMetaDataProto.MetaData.Builder loadMetaData(@Nonnull String name) throws IOException {
@@ -390,12 +466,32 @@ public class MetaDataProtoEditorUnitTest {
                         "DuplicateUnionFields.json",
                         "OneTypeWithIndexes.json",
                         "MultiTypeIndex.json",
-                        "UniversalIndex.json",
-                        "UnnestedExternalType.json",
-                        "UnnestedInternal.json",
-                        "Joined.json"
+                        "UniversalIndex.json"
                 ).map(filename -> Arguments.of(filename, (Consumer<RecordMetaData>) renamed -> { })),
                 Stream.of(
+                        Arguments.of("UnnestedExternalType.json",
+                                (Consumer<RecordMetaData>) renamed -> {
+                                    // "parent" (T1) is a top-level RECORD type and gets renamed; "child" names the
+                                    // dependency-defined UUID type, which is not a top-level record type and so is
+                                    // left untouched.
+                                    assertEquals(Map.of("parent", simpleRename("T1"), "child", "UUID"),
+                                            constituentTypeNames(renamed));
+                                }),
+                        Arguments.of("UnnestedInternal.json",
+                                (Consumer<RecordMetaData>) renamed -> {
+                                    // "parent" (T2) is a top-level RECORD type and gets renamed; "child" names T1,
+                                    // which has NESTED usage and so is left untouched.
+                                    assertEquals(Map.of("parent", simpleRename("T2"), "child", "T1"),
+                                            constituentTypeNames(renamed));
+                                }),
+                        Arguments.of("Joined.json",
+                                (Consumer<RecordMetaData>) renamed -> {
+                                    final SyntheticRecordType<?> join = renamed.getSyntheticRecordType("JOIN");
+                                    assertEquals(Set.of(simpleRename("T1"), simpleRename("T2")),
+                                            join.getConstituents().stream()
+                                                    .map(constituent -> constituent.getRecordType().getName())
+                                                    .collect(Collectors.toSet()));
+                                }),
                         Arguments.of("AlsoInDependency.json",
                                 (Consumer<RecordMetaData>) renamed -> {
                                     final Descriptors.Descriptor uuidType = getMessage(renamed, simpleRename("UUID"));
@@ -436,6 +532,17 @@ public class MetaDataProtoEditorUnitTest {
                 .findFirst().orElseThrow().getMessageType();
     }
 
+    /**
+     * Maps each constituent's own name (e.g. "parent", "child") to the name of the record type it names, for the
+     * unnested synthetic record type named {@code "__3_syntheticType_1"} in the fixtures that use it.
+     */
+    @Nonnull
+    private static Map<String, String> constituentTypeNames(final RecordMetaData renamed) {
+        return renamed.getSyntheticRecordType("__3_syntheticType_1").getConstituents().stream()
+                .collect(Collectors.toMap(SyntheticRecordType.Constituent::getName,
+                        constituent -> constituent.getRecordType().getName()));
+    }
+
     @ParameterizedTest(name = "{0}")
     @MethodSource("renamableFiles")
     void simplePrefix(String name, Consumer<RecordMetaData> extraAssertions) throws IOException {
@@ -443,18 +550,253 @@ public class MetaDataProtoEditorUnitTest {
         extraAssertions.accept(renamed);
     }
 
+    /**
+     * The rename must reject a renamer that maps two distinct record types to the same new name.
+     */
+    @Test
+    void batchedRejectsCollidingRenames() throws IOException {
+        final RecordMetaDataProto.MetaData originalProto = loadMetaData("TwoBoringTypes.json").build();
+        crossRenameRecordTypesIsRejected(
+                originalProto,
+                name -> "Collision",
+                RecordMetaDataBuilder.getDependencies(originalProto, Map.of()));
+    }
+
+    /**
+     * A batch that swaps two record types' names must succeed, since neither rename target collides with an
+     * "unrenamed" type — both are moving. This exercises the {@code beingRenamed} exclusion in
+     * {@code validateUnionFieldRenames()} (and the analogous exclusion in {@code analyzeRecordTypeRenames()}),
+     * without which this scenario would be spuriously rejected. Unlike the other rename tests here, this one is
+     * batched-only: like {@link #conflictingName}, a swap is order-dependent for the one-by-one path (renaming
+     * "UUID" to "T2" first would collide with the not-yet-renamed "T2").
+     */
+    @Test
+    void batchedAllowsSwappingTwoNames() throws IOException {
+        final RecordMetaDataProto.MetaData originalProto = loadMetaData("AlsoInDependency.json").build();
+        final RecordMetaDataProto.MetaData.Builder builder = originalProto.toBuilder();
+        MetaDataProtoEditor.renameRecordTypes(builder,
+                name -> name.equals("UUID") ? "T2" : name.equals("T2") ? "UUID" : name,
+                RecordMetaDataBuilder.getDependencies(originalProto, Map.of()));
+        final RecordMetaData renamed = RecordMetaData.build(builder.build());
+        assertEquals(Set.of("UUID", "T2"), renamed.getRecordTypes().keySet());
+        // Content moves with the name: UUID's original single-field shape is now under "T2", and vice versa.
+        assertEquals(1, renamed.getRecordType("T2").getDescriptor().getFields().size());
+        assertEquals(3, renamed.getRecordType("UUID").getDescriptor().getFields().size());
+    }
+
+    /**
+     * The rename must reject the schemas that rename a type used by a non-parent unnested constituent.
+     */
     @ParameterizedTest
     @ValueSource(strings = {
             "UnnestedRenamed.json",
             "UnnestedRenamedNested.json",
     })
     void unsupported(String name) throws IOException {
-        final RecordMetaDataProto.MetaData.Builder builder = loadMetaData(name);
-        final RecordMetaDataProto.MetaData originalProto = builder.build();
+        final RecordMetaDataProto.MetaData originalProto = loadMetaData(name).build();
         RecordMetaData.build(originalProto); // ensure original metadata is valid
-        assertThrows(MetaDataException.class, () -> MetaDataProtoEditor.renameRecordTypes(builder,
+        crossRenameRecordTypesIsRejected(
+                originalProto,
                 MetaDataProtoEditorUnitTest::simpleRename,
-                RecordMetaDataBuilder.getDependencies(builder.build(), Map.of())));
+                RecordMetaDataBuilder.getDependencies(originalProto, Map.of()));
+    }
+
+    /**
+     * The rename must reject a renamer that maps a record type to the name of a distinct, un-renamed existing type.
+     */
+    @Test
+    void batchedRejectsRenameToExistingType() throws IOException {
+        final RecordMetaDataProto.MetaData originalProto = loadMetaData("TwoBoringTypes.json").build();
+        crossRenameRecordTypesIsRejected(
+                originalProto,
+                name -> name.equals("T1") ? "T2" : name,
+                RecordMetaDataBuilder.getDependencies(originalProto, Map.of()));
+    }
+
+    /**
+     * The rename must reject a renamer that maps a record type to the name of an existing record type that is
+     * registered in {@code MetaData.record_types} but has no corresponding message type in {@code MetaData.records}
+     * (as would be the case for a record type whose message is defined in a dependency file, i.e., "imported").
+     */
+    @Test
+    void batchedRejectsRenameToImportedType() throws IOException {
+        final RecordMetaDataProto.MetaData.Builder builder = loadMetaData("TwoBoringTypes.json");
+        builder.addRecordTypes(RecordMetaDataProto.RecordType.newBuilder().setName("Imported").build());
+        final RecordMetaDataProto.MetaData originalProto = builder.build();
+        crossRenameRecordTypesIsRejected(
+                originalProto,
+                name -> name.equals("T1") ? "Imported" : name,
+                RecordMetaDataBuilder.getDependencies(originalProto, Map.of()));
+    }
+
+    /**
+     * An imported record type, i.e., one registered in {@code MetaData.record_types} whose message type lives in a
+     * dependency file rather than in {@code MetaData.records}, must be left untouched by the rename, and the renamer
+     * must not even be applied to it. This is a documented divergence from
+     * {@link MetaDataProtoEditor#renameRecordType}, which rejects the same rename outright, so it is asserted
+     * separately for each path.
+     */
+    @Test
+    void batchedSkipsImportedType() throws IOException {
+        final RecordMetaDataProto.MetaData.Builder builder = loadMetaData("TwoBoringTypes.json");
+        builder.addRecordTypes(RecordMetaDataProto.RecordType.newBuilder().setName("Imported").build());
+        final RecordMetaDataProto.MetaData originalProto = builder.build();
+        final Descriptors.FileDescriptor[] dependencies =
+                RecordMetaDataBuilder.getDependencies(originalProto, Map.of());
+
+        // The batched path renames the real top-level types, and never consults the renamer for the imported one.
+        final Set<String> renamerSawNames = new LinkedHashSet<>();
+        final RecordMetaDataProto.MetaData.Builder batchedBuilder = originalProto.toBuilder();
+        MetaDataProtoEditor.renameRecordTypes(batchedBuilder, name -> {
+            renamerSawNames.add(name);
+            return simpleRename(name);
+        }, dependencies);
+        assertEquals(Set.of("T1", "T2"), renamerSawNames);
+        assertEquals(List.of(simpleRename("T1"), simpleRename("T2"), "Imported"),
+                MetaDataProtoEditor.getRecordTypes(batchedBuilder));
+
+        // The one-by-one path, by contrast, rejects the very same rename.
+        final MetaDataException exception = assertThrows(MetaDataException.class,
+                () -> MetaDataProtoEditor.renameRecordType(originalProto.toBuilder(), "Imported",
+                        simpleRename("Imported"), dependencies));
+        assertEquals("No record type found with name Imported", exception.getMessage());
+    }
+
+    /**
+     * Renaming a top-level record type must not be blocked by an unrelated nested type that merely shares its simple
+     * name. In the fixture, the top-level {@code T1} is renamed while an unnested constituent references {@code T2}'s
+     * own nested type, also named {@code T1}; only a fully-qualified comparison tells the two apart.
+     */
+    @Test
+    void shadowedNestedTypeNameDoesNotBlockRename() throws IOException {
+        final RecordMetaDataProto.MetaData originalProto = loadMetaData("UnnestedShadowedName.json").build();
+        RecordMetaData.build(originalProto); // ensure original metadata is valid
+        final RecordMetaData renamed = runRename(originalProto,
+                name -> name.equals("T1") ? simpleRename("T1") : name,
+                name -> name.equals(simpleRename("T1")) ? "T1" : name);
+        assertEquals(Set.of(simpleRename("T1"), "T2"), renamed.getRecordTypes().keySet());
+        // The shadowing nested type keeps its own name, and the constituent still points at it rather than at the
+        // renamed top-level type. (Constituent type names are reported as simple names, so "T1" here is T2's nested
+        // type; the descriptor's full name below distinguishes it from the renamed top-level one.)
+        assertEquals(Map.of("parent", "T2", "child", "T1"), constituentTypeNames(renamed));
+        assertEquals("T2.T1", renamed.getSyntheticRecordType("__3_syntheticType_1").getConstituents().stream()
+                .filter(constituent -> constituent.getName().equals("child"))
+                .findFirst().orElseThrow().getRecordType().getDescriptor().getFullName());
+    }
+
+    /**
+     * The rename must reject a renamer whose canonical union field name would collide with an existing,
+     * non-canonically-named union field of another (un-renamed) type. Unlike the other exception tests here, this
+     * one is batched-only: renaming one type at a time via {@link MetaDataProtoEditor#renameRecordType} silently
+     * leaves the colliding field under its old name instead of throwing (see {@link #conflictingName}).
+     */
+    @Test
+    void batchedRejectsUnionFieldCollision() throws IOException {
+        final RecordMetaDataProto.MetaData originalProto = loadMetaData("DuplicateUnionFields.json").build();
+        final MetaDataException exception = assertThrows(MetaDataException.class,
+                () -> MetaDataProtoEditor.renameRecordTypes(
+                        originalProto.toBuilder(),
+                        name -> name.equals("T2") ? "T1_1" : name,
+                        RecordMetaDataBuilder.getDependencies(originalProto, Map.of())));
+        Assertions.assertThat(exception.getMessage())
+                .startsWith("Cannot rename union field to ")
+                .endsWith("as a field of that name already exists");
+    }
+
+    /**
+     * The rename must reject any renaming when the metadata has {@code user_defined_functions}, since a
+     * user-defined function may be a string that references record types by name in ways that renaming cannot
+     * safely account for.
+     */
+    @Test
+    void batchedRejectsUserDefinedFunctions() throws IOException {
+        final RecordMetaDataProto.MetaData.Builder builder = loadMetaData("TwoBoringTypes.json");
+        builder.addUserDefinedFunctions(RecordMetaDataProto.PUserDefinedFunction.newBuilder().build());
+        final RecordMetaDataProto.MetaData originalProto = builder.build();
+        crossRenameRecordTypesIsRejected(
+                originalProto,
+                MetaDataProtoEditorUnitTest::simpleRename,
+                RecordMetaDataBuilder.getDependencies(originalProto, Map.of()));
+    }
+
+    /**
+     * The rename must reject a renamer that maps a non-union record type to the default union name.
+     */
+    @Test
+    void batchedRejectsRenameToDefaultUnionName() throws IOException {
+        final RecordMetaDataProto.MetaData originalProto = loadMetaData("TwoBoringTypes.json").build();
+        crossRenameRecordTypesIsRejected(
+                originalProto,
+                name -> name.equals("T1") ? RecordMetaDataBuilder.DEFAULT_UNION_NAME : name,
+                RecordMetaDataBuilder.getDependencies(originalProto, Map.of()));
+    }
+
+    /**
+     * The rename must reject any renaming when the union message type itself declares a nested type.
+     */
+    @Test
+    void batchedRejectsNestedTypeInUnion() throws IOException {
+        final RecordMetaDataProto.MetaData.Builder builder = loadMetaData("TwoBoringTypes.json");
+        for (final DescriptorProtos.DescriptorProto.Builder messageType : builder.getRecordsBuilder().getMessageTypeBuilderList()) {
+            if (messageType.getName().equals(RecordMetaDataBuilder.DEFAULT_UNION_NAME)) {
+                messageType.addNestedType(DescriptorProtos.DescriptorProto.newBuilder().setName("Nested"));
+            }
+        }
+        final RecordMetaDataProto.MetaData originalProto = builder.build();
+        crossRenameRecordTypesIsRejected(
+                originalProto,
+                MetaDataProtoEditorUnitTest::simpleRename,
+                RecordMetaDataBuilder.getDependencies(originalProto, Map.of()));
+    }
+
+    /**
+     * A record type whose name contains a {@code '.'} cannot correspond to any message type in
+     * {@code MetaData.records}, since message type names are always simple identifiers. It is therefore treated as
+     * imported and skipped, rather than rejected.
+     */
+    @Test
+    void batchedSkipsDottedRecordTypeName() throws IOException {
+        final RecordMetaDataProto.MetaData.Builder builder = loadMetaData("TwoBoringTypes.json");
+        builder.addRecordTypes(RecordMetaDataProto.RecordType.newBuilder().setName("a.b").build());
+        final RecordMetaDataProto.MetaData originalProto = builder.build();
+        final Descriptors.FileDescriptor[] dependencies = RecordMetaDataBuilder.getDependencies(originalProto, Map.of());
+        final RecordMetaDataProto.MetaData.Builder renamed = originalProto.toBuilder();
+        MetaDataProtoEditor.renameRecordTypes(renamed, name -> name.equals("a.b") ? "c" : name, dependencies);
+        assertEquals(List.of("T1", "T2", "a.b"), MetaDataProtoEditor.getRecordTypes(renamed));
+    }
+
+    /**
+     * The rename must reject any renaming when {@code MetaData.records} has no union message type at all.
+     */
+    @Test
+    void batchedRejectsMissingUnion() throws IOException {
+        final RecordMetaDataProto.MetaData.Builder builder = loadMetaData("TwoBoringTypes.json");
+        final DescriptorProtos.FileDescriptorProto.Builder recordsBuilder = builder.getRecordsBuilder();
+        final List<DescriptorProtos.DescriptorProto> withoutUnion = recordsBuilder.getMessageTypeList().stream()
+                .filter(messageType -> !messageType.getName().equals(RecordMetaDataBuilder.DEFAULT_UNION_NAME))
+                .collect(Collectors.toList());
+        recordsBuilder.clearMessageType().addAllMessageType(withoutUnion);
+        final RecordMetaDataProto.MetaData originalProto = builder.build();
+        crossRenameRecordTypesIsRejected(
+                originalProto,
+                MetaDataProtoEditorUnitTest::simpleRename,
+                RecordMetaDataBuilder.getDependencies(originalProto, Map.of()));
+    }
+
+    /**
+     * The rename must reject any renaming when an unnested record type's non-parent constituent names a type that
+     * cannot be resolved in the file descriptor.
+     */
+    @Test
+    void batchedRejectsMissingNestedConstituentDescriptor() throws IOException {
+        final RecordMetaDataProto.MetaData.Builder builder = loadMetaData("UnnestedInternal.json");
+        RecordMetaData.build(builder.build()); // ensure original metadata is valid
+        builder.getUnnestedRecordTypesBuilder(0).getNestedConstituentsBuilder(1).setTypeName("DoesNotExist");
+        final RecordMetaDataProto.MetaData originalProto = builder.build();
+        crossRenameRecordTypesIsRejected(
+                originalProto,
+                MetaDataProtoEditorUnitTest::simpleRename,
+                RecordMetaDataBuilder.getDependencies(originalProto, Map.of()));
     }
 
     @ParameterizedTest(name = "{0}")
@@ -463,27 +805,37 @@ public class MetaDataProtoEditorUnitTest {
         final RecordMetaDataProto.MetaData.Builder builder = loadMetaData(name);
         final RecordMetaDataProto.MetaData originalProto = builder.build();
         final RecordMetaData originalMetaData = RecordMetaData.build(originalProto);
-        MetaDataProtoEditor.renameRecordTypes(builder, MetaDataProtoEditorUnitTest::simpleRename,
-                RecordMetaDataBuilder.getDependencies(originalProto, Map.of()));
+        final Descriptors.FileDescriptor[] dependencies = RecordMetaDataBuilder.getDependencies(originalProto, Map.of());
+        MetaDataProtoEditor.renameRecordTypes(builder, MetaDataProtoEditorUnitTest::simpleRename, dependencies);
 
         final RecordMetaDataProto.MetaData firstRename = builder.build();
+        crossCheckRenamedMetaData(
+                originalProto,
+                MetaDataProtoEditorUnitTest::simpleRename,
+                dependencies,
+                firstRename);
         basicRenameAsserts(firstRename, originalMetaData,
                 MetaDataProtoEditorUnitTest::simpleRename,
                 MetaDataProtoEditorUnitTest::simpleRenameUndo);
 
         // again
-        MetaDataProtoEditor.renameRecordTypes(builder, MetaDataProtoEditorUnitTest::simpleRename,
-                RecordMetaDataBuilder.getDependencies(originalProto, Map.of()));
+        MetaDataProtoEditor.renameRecordTypes(builder, MetaDataProtoEditorUnitTest::simpleRename, dependencies);
 
         final RecordMetaDataProto.MetaData secondRename = builder.build();
+        crossCheckRenamedMetaData(
+                firstRename,
+                MetaDataProtoEditorUnitTest::simpleRename,
+                dependencies,
+                secondRename);
         basicRenameAsserts(secondRename, RecordMetaData.build(firstRename),
                 MetaDataProtoEditorUnitTest::simpleRename,
                 MetaDataProtoEditorUnitTest::simpleRenameUndo);
 
         final RecordMetaDataProto.MetaData.Builder restartBuilder = originalProto.toBuilder();
-        MetaDataProtoEditor.renameRecordTypes(restartBuilder,
+        MetaDataProtoEditor.renameRecordTypes(
+                restartBuilder,
                 oldName -> simpleRename(simpleRename(oldName)),
-                RecordMetaDataBuilder.getDependencies(originalProto, Map.of()));
+                dependencies);
         assertEquals(builder.build(), secondRename);
 
     }
@@ -493,8 +845,10 @@ public class MetaDataProtoEditorUnitTest {
     void conflictingName(boolean t1Conflicts) throws IOException {
         // In the future we may want to make this work, but for now, I just want to assert that it either succeeds
         // and produces a valid metadata, or fails with a clear exception. Currently, it is order dependent.
+        // Note also that this is exactly the kind of scenario where one-by-one renaming is *not* expected to match
+        // the batched renaming; so we use `runRenameBatchedOnly()` here rather than `runRename()`.
         final String prefix = "__Q_";
-        final RecordMetaData withConflict = runRename(loadMetaData("TwoBoringTypes.json").build(),
+        final RecordMetaData withConflict = runRenameBatchedOnly(loadMetaData("TwoBoringTypes.json").build(),
                 oldName -> {
                     if (t1Conflicts) {
                         return !oldName.equals("T1") ? prefix + "T1" : oldName;
@@ -509,14 +863,62 @@ public class MetaDataProtoEditorUnitTest {
             assertEquals(Set.of("T2", prefix + "T2"), withConflict.getRecordTypes().keySet());
         }
         try {
-            runRename(withConflict.toProto(),
+            runRenameBatchedOnly(withConflict.toProto(),
                     oldName -> prefix + oldName,
                     newName -> newName.substring(prefix.length()));
         } catch (MetaDataException e) {
-            Assertions.assertThat(e)
-                    .hasMessageStartingWith("Cannot rename record type to ")
-                    .hasMessageEndingWith("as it already exists");
+            Assertions.assertThat(e.getMessage())
+                    .satisfiesAnyOf(
+                            message -> Assertions.assertThat(message).startsWith("Cannot rename record type to ").endsWith("as it already exists"),
+                            message -> Assertions.assertThat(message).startsWith("Cannot rename union field to ").endsWith("as a field of that name already exists"));
         }
+    }
+
+    /**
+     * A renamer that returns every type's own name unchanged must be a true no-op: the metadata must come out
+     * byte-for-byte identical to how it went in, confirming that the early-return path for an empty rename set
+     * never mutates anything.
+     */
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("renamableFiles")
+    void identityRenameIsNoOp(String name) throws IOException {
+        final RecordMetaDataProto.MetaData originalProto = loadMetaData(name).build();
+        final RecordMetaDataProto.MetaData.Builder builder = originalProto.toBuilder();
+        MetaDataProtoEditor.renameRecordTypes(builder, UnaryOperator.identity(),
+                RecordMetaDataBuilder.getDependencies(originalProto, Map.of()));
+        assertEquals(originalProto, builder.build());
+    }
+
+    /**
+     * Exercises {@link MetaDataProtoEditor#renameRecordTypes} with a large number of record types, to get a rough
+     * sense of how it scales. Not a strict benchmark: there is no assertion on timing, only a log line. Run via the
+     * {@code performanceTest} Gradle task.
+     */
+    @Test
+    @Tag(Tags.Performance)
+    void renameManyRecordTypes() {
+        final int typeCount = 200;
+        final RecordMetaDataProto.MetaData.Builder builder = RecordMetaDataProto.MetaData.newBuilder();
+        builder.setRecords(DescriptorProtos.FileDescriptorProto.newBuilder()
+                .addMessageType(DescriptorProtos.DescriptorProto.newBuilder().setName(RecordMetaDataBuilder.DEFAULT_UNION_NAME)));
+        for (int i = 0; i < typeCount; i++) {
+            MetaDataProtoEditor.addRecordType(builder,
+                    DescriptorProtos.DescriptorProto.newBuilder()
+                            .setName("T" + i)
+                            .addField(DescriptorProtos.FieldDescriptorProto.newBuilder()
+                                    .setName("ID")
+                                    .setNumber(1)
+                                    .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_INT64))
+                            .build(),
+                    Key.Expressions.field("ID"));
+        }
+
+        final long startNanos = System.nanoTime();
+        MetaDataProtoEditor.renameRecordTypes(builder, MetaDataProtoEditorUnitTest::simpleRename, new Descriptors.FileDescriptor[0]);
+        final long elapsedNanos = System.nanoTime() - startNanos;
+        LOGGER.info("Renamed {} record types in {} ms", typeCount, elapsedNanos / 1e6);
+
+        assertEquals(typeCount, RecordMetaData.build(builder.build()).getRecordTypes().size());
     }
 
     @Test
@@ -586,19 +988,40 @@ public class MetaDataProtoEditorUnitTest {
         return runRename(originalProto, MetaDataProtoEditorUnitTest::simpleRename, MetaDataProtoEditorUnitTest::simpleRenameUndo);
     }
 
+    /**
+     * Performs the rename via the batched {@link MetaDataProtoEditor#renameRecordTypes} method, then cross-checks that
+     * an equivalent one-by-one sequence of {@link MetaDataProtoEditor#renameRecordType} calls produces byte-for-byte
+     * the same metadata.
+     *
+     * @see #runRenameBatchedOnly
+     */
     @Nonnull
     private RecordMetaData runRename(final RecordMetaDataProto.MetaData originalProto,
-                                     final Function<String, String> rename,
+                                     final UnaryOperator<String> rename,
                                      final Function<String, String> undoRename) {
+        final RecordMetaData renamed = runRenameBatchedOnly(originalProto, rename, undoRename);
+        final Descriptors.FileDescriptor[] dependencies = RecordMetaDataBuilder.getDependencies(originalProto, Map.of());
+        crossCheckRenamedMetaData(originalProto, rename, dependencies, renamed.toProto());
+        return renamed;
+    }
+
+    /**
+     * Perform the rename using (only) the batched {@link MetaDataProtoEditor#renameRecordTypes} method, without any
+     * cross-checking. Use this for renamings whose validity is sensitive to iteration order (see
+     * {@link #conflictingName}), since the one-by-one path is not expected to match those.
+     *
+     * @see #runRename(RecordMetaDataProto.MetaData, UnaryOperator, Function)
+     */
+    @Nonnull
+    private RecordMetaData runRenameBatchedOnly(final RecordMetaDataProto.MetaData originalProto,
+                                                final UnaryOperator<String> rename,
+                                                final Function<String, String> undoRename) {
         final RecordMetaDataProto.MetaData.Builder builder = originalProto.toBuilder();
         final RecordMetaData originalMetaData = RecordMetaData.build(originalProto);
-        MetaDataProtoEditor.renameRecordTypes(builder, rename,
-                RecordMetaDataBuilder.getDependencies(originalProto, Map.of()));
-
+        final Descriptors.FileDescriptor[] dependencies = RecordMetaDataBuilder.getDependencies(originalProto, Map.of());
+        MetaDataProtoEditor.renameRecordTypes(builder, rename, dependencies);
         final RecordMetaDataProto.MetaData build = builder.build();
-        return basicRenameAsserts(build, originalMetaData,
-                rename,
-                undoRename);
+        return basicRenameAsserts(build, originalMetaData, rename, undoRename);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/test/resources/Joined.json
+++ b/fdb-record-layer-core/src/test/resources/Joined.json
@@ -84,7 +84,7 @@
               "fan_type": "SCALAR"
             }
           },
-          "right": "textSearch",
+          "right": "T2",
           "right_expression": {
             "field": {
               "field_name": "ID",

--- a/fdb-record-layer-core/src/test/resources/UnnestedShadowedName.json
+++ b/fdb-record-layer-core/src/test/resources/UnnestedShadowedName.json
@@ -28,16 +28,6 @@
             "name": "ID",
             "number": 1,
             "type": "TYPE_INT64"
-          },
-          {
-            "name": "T2",
-            "number": 2,
-            "type": "TYPE_INT64"
-          },
-          {
-            "name": "A",
-            "number": 3,
-            "type": "TYPE_INT64"
           }
         ]
       },
@@ -50,51 +40,28 @@
             "type": "TYPE_INT64"
           },
           {
-            "name": "B",
+            "name": "sub",
             "number": 2,
-            "type": "TYPE_INT64"
+            "label": "LABEL_REPEATED",
+            "type": "TYPE_MESSAGE",
+            "type_name": "T2.T1"
+          }
+        ],
+        "nested_type": [
+          {
+            "name": "T1",
+            "field": [
+              {
+                "name": "V",
+                "number": 1,
+                "type": "TYPE_STRING"
+              }
+            ]
           }
         ]
       }
     ]
   },
-
-  "joined_record_types": [
-    {
-      "name": "JOIN",
-      "record_type_key": {
-        "long_value": -1
-      },
-      "join_constituents": [
-        {
-          "name": "T1",
-          "record_type": "T1"
-        },
-        {
-          "name": "T2",
-          "record_type": "T2"
-        }
-      ],
-      "joins": [
-        {
-          "left": "T1",
-          "left_expression": {
-            "field": {
-              "field_name": "T2",
-              "fan_type": "SCALAR"
-            }
-          },
-          "right": "T2",
-          "right_expression": {
-            "field": {
-              "field_name": "ID",
-              "fan_type": "SCALAR"
-            }
-          }
-        }
-      ]
-    }
-  ],
   "record_types": [
     {
       "name": "T1",
@@ -113,6 +80,31 @@
           "fan_type": "SCALAR"
         }
       }
+    }
+  ],
+  "unnested_record_types": [
+    {
+      "name": "__3_syntheticType_1",
+      "record_type_key": {
+        "long_value": -1
+      },
+      "nested_constituents": [
+        {
+          "name": "parent",
+          "type_name": "T2"
+        },
+        {
+          "name": "child",
+          "parent": "parent",
+          "type_name": "T2.T1",
+          "nesting_expression": {
+            "field": {
+              "field_name": "sub",
+              "fan_type": "FAN_OUT"
+            }
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
* Replace the naive O(N²) implementation of `renameRecordTypes()`, which renames the types one by one via `renameRecordType()`, with an efficient batched version that applies all renames in one go.
* Cleanly split the per-rename validation from the actual mutation throughout, so that the whole batch gets validated _before_ anything is mutated.
* Add a `RecordTypeRenames` data structure that indexes renames by fully qualified name to avoid having to scan all renames per item. This brings what would otherwise still be an O(N²) algorithm down to O(N).
* Leave `renameRecordType()` itself untouched for the time being. It will be simplified in a subsequent change by “rebasing” it on the utility methods introduced here.

The batched implementation performs the costly compilation of the `FileDescriptor` exactly _once_ (via `Descriptors.FileDescriptor.buildFrom()`, from the original proto) and applies the name mapping in a single walk of the builder. The trivial implementation, by contrast, performs a recompilation of the entire records `FileDescriptor` plus a full `records.toBuilder()` deep-copy _in each iteration_ of the loop over the record types. In the common use case where _all_ top-level record types are to be renamed, that means O(N) descriptor compilations for N record types.

Applying multiple renames in the batched manner is equivalent to applying them one-by-one, _provided that_ the name mapping defined by the given `renamer` is collision-free. The batched implementation validates the mapping upfront. This allows it to provide a stronger exception safety guarantee. If the mapping is invalid, an exception will be thrown before _any_ of the renames is performed. The one-by-one implementation, by contrast, may raise an exception halfway through; and that may depend on the order in which the renames are applied.

### Testing

* Cross-check `renameRecordType()` and `renameRecordTypes()` against each other throughout the existing test suite.
* Add dedicated tests for every `MetaDataException` reachable from `renameRecordTypes()`, plus a couple of previously unexercised edge cases.
* Fix an unrelated, pre-existing bug in the `Joined.json` test fixture (a join referenced a nonexistent constituent), uncovered along the way.
* Add a performance test that renames a large number of record types. In a local ad-hoc experiment, the batched implementation measured about 21× faster than an equivalent one-by-one sequence of `renameRecordType()` calls for 100 record types (0.26 ms versus 5.7 ms), and about 36× faster for 200 (0.53 ms versus 19 ms). The widening gap with the number of record types is consistent with the O(N) vs. O(N²) difference between the two.