### PR TITLE
Carry the physical index kind on plans so it survives serialization

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/PhysicalIndexKind.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/PhysicalIndexKind.java
@@ -1,0 +1,191 @@
+/*
+ * PhysicalIndexKind.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.planprotos.PPhysicalIndexKind;
+import com.apple.foundationdb.record.query.plan.serialization.PlanSerialization;
+import com.google.common.collect.BiMap;
+
+import javax.annotation.Nonnull;
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * The kind of physical structure backing an index, as opposed to the logical
+ * {@link com.apple.foundationdb.record.metadata.IndexTypes index type} it is declared as. Several index types share a
+ * structure — every aggregate index is ultimately ordered key-value pairs, just like a value index — while a single index
+ * type can be backed by more than one structure, as a {@code vector} index is by either HNSW or Guardiann.
+ * <p>
+ * This is what lets planning and costing reason about an access by what it will actually do at runtime. Two plans that
+ * are indistinguishable to the cost model may sit on structures with very different access characteristics, and a cost
+ * criterion, or an explicitly stated preference, may want to tell them apart.
+ * <p>
+ * The values that are not a structure at all, {@link #NONE} and {@link #MIXED}, exist because a plan is asked for its
+ * kind as a whole, not just an individual access: a plan may reach no index, or several of differing kinds. See
+ * {@link #combine(Iterable)}.
+ */
+@API(API.Status.EXPERIMENTAL)
+public enum PhysicalIndexKind {
+    //
+    // UNKNOWN is deliberately first so that it stays at ordinal zero however many kinds are added later: it is the
+    // value a consumer should fall back to, and the one a serialized form defaults to when it carries nothing.
+    //
+    /**
+     * A structure that is not known here, because whoever supplies the kind did not declare one. A consumer keyed on a
+     * specific structure should treat this as "not the one I am looking for" rather than as any particular kind.
+     */
+    UNKNOWN,
+    /**
+     * The primary keyspace, reached directly rather than through an index — a full record scan, or an operator that does
+     * not read records at all. Physically this is ordered key-value pairs just as {@link #BTREE} is; it is called out
+     * separately because no index is involved, which is usually the distinction a consumer cares about.
+     */
+    PRIMARY,
+    /**
+     * Ordered key-value pairs, which is to say FoundationDB's keyspace used directly. Backs
+     * {@link com.apple.foundationdb.record.metadata.IndexTypes#VALUE value} and
+     * {@link com.apple.foundationdb.record.metadata.IndexTypes#VERSION version} indexes, every atomic-mutation
+     * aggregate ({@code count}, {@code sum}, {@code min_ever}, {@code max_ever} and friends), the permuted
+     * {@code min}/{@code max} indexes, and {@code bitmap_value}, whose bitmaps are values in exactly such a keyspace.
+     */
+    BTREE,
+    /**
+     * A probabilistic skip list over the keyspace, giving ordinal rank and select in addition to ordered access. Backs
+     * {@link com.apple.foundationdb.record.metadata.IndexTypes#RANK rank} and
+     * {@link com.apple.foundationdb.record.metadata.IndexTypes#TIME_WINDOW_LEADERBOARD time_window_leaderboard}.
+     */
+    RANKED_SET,
+    /**
+     * A postings structure mapping tokens to the records containing them. Backs
+     * {@link com.apple.foundationdb.record.metadata.IndexTypes#TEXT text}.
+     */
+    INVERTED,
+    /**
+     * An R-tree over the keyspace, for overlap and containment on multi-dimensional data. Backs
+     * {@link com.apple.foundationdb.record.metadata.IndexTypes#MULTIDIMENSIONAL multidimensional}.
+     */
+    R_TREE,
+    /**
+     * A space-filling curve linearizing multi-dimensional data into the ordered keyspace. Backs the
+     * {@code spatial_geophile} index type of the spatial module.
+     */
+    SPACE_FILLING_CURVE,
+    /**
+     * A hierarchical navigable small world graph, for approximate nearest-neighbor search. Backs a
+     * {@link com.apple.foundationdb.record.metadata.IndexTypes#VECTOR vector} index whose engine is HNSW.
+     */
+    HNSW,
+    /**
+     * A clustered vector structure, for approximate nearest-neighbor search. Backs a
+     * {@link com.apple.foundationdb.record.metadata.IndexTypes#VECTOR vector} index whose engine is Guardiann.
+     */
+    GUARDIANN,
+    /**
+     * A Lucene index, held in a directory of its own rather than as plain key-value pairs. Backs the {@code lucene}
+     * index type of the Lucene module.
+     */
+    LUCENE,
+    /**
+     * An in-memory structure rather than anything persistent, as a temporary table is. Combining this with another kind
+     * yields that other kind rather than {@link #MIXED}: it is not a persistent structure a plan relies on, so it says
+     * nothing about which one the plan is built around. See {@link #combine(Iterable)}.
+     */
+    IN_MEMORY,
+    /**
+     * More than one kind, i.e. a plan whose accesses do not agree on a structure. Deliberately not a set of the kinds
+     * involved: a consumer that needs that detail should look at the individual accesses rather than at the plan.
+     */
+    MIXED;
+
+    @Nonnull
+    private static final BiMap<PhysicalIndexKind, PPhysicalIndexKind> TO_PROTO =
+            PlanSerialization.protoEnumBiMap(PhysicalIndexKind.class, PPhysicalIndexKind.class);
+
+    /**
+     * Combines the kinds of several accesses, or of the children of a plan, into the kind of the whole. An empty
+     * argument yields {@link #UNKNOWN}, kinds that all agree yield that kind, and anything else yields {@link #MIXED}.
+     * <p>
+     * {@link #IN_MEMORY} is the one identity: it drops out of the combination, so {@code BTREE} combined with it is
+     * still {@code BTREE}, and only a combination of nothing but {@code IN_MEMORY} stays {@code IN_MEMORY}. A temporary
+     * table alongside an index scan does not make a plan ambiguous about which persistent structure it is built around.
+     * <p>
+     * {@link #PRIMARY}, by contrast, is <em>not</em> an identity: combining it with another kind yields {@link #MIXED}.
+     * A union of a full scan and an index scan genuinely is a plan of two minds about how it reaches records, and
+     * reporting it as though it were purely the one kind would overstate what is known about it.
+     *
+     * @param kinds the kinds to combine
+     * @return the kind of the whole
+     */
+    @Nonnull
+    public static PhysicalIndexKind combine(@Nonnull final Iterable<PhysicalIndexKind> kinds) {
+        PhysicalIndexKind combined = null;
+        boolean sawInMemory = false;
+        for (final PhysicalIndexKind kind : kinds) {
+            if (kind == IN_MEMORY) {
+                sawInMemory = true;
+                continue;
+            }
+            if (combined == null) {
+                combined = kind;
+            } else if (combined != kind) {
+                return MIXED;
+            }
+        }
+        if (combined != null) {
+            return combined;
+        }
+        return sawInMemory ? IN_MEMORY : UNKNOWN;
+    }
+
+    /**
+     * Combines the kinds of several accesses, or of the children of a plan, into the kind of the whole.
+     *
+     * @param kinds the kinds to combine
+     * @return the kind of the whole
+     * @see #combine(Iterable)
+     */
+    @Nonnull
+    public static PhysicalIndexKind combine(@Nonnull final PhysicalIndexKind... kinds) {
+        return combine(Arrays.asList(kinds));
+    }
+
+    /**
+     * Converts this kind to its protobuf equivalent, so that a plan can carry it.
+     *
+     * @return the protobuf equivalent of this kind
+     */
+    @Nonnull
+    public PPhysicalIndexKind toProto() {
+        return Objects.requireNonNull(TO_PROTO.get(this));
+    }
+
+    /**
+     * Converts a kind back from its protobuf equivalent.
+     *
+     * @param physicalIndexKindProto the protobuf kind
+     * @return the kind
+     */
+    @Nonnull
+    public static PhysicalIndexKind fromProto(@Nonnull final PPhysicalIndexKind physicalIndexKindProto) {
+        return Objects.requireNonNull(TO_PROTO.inverse().get(physicalIndexKindProto));
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/bitmap/ComposedBitmapIndexQueryPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/bitmap/ComposedBitmapIndexQueryPlan.java
@@ -48,6 +48,7 @@ import com.apple.foundationdb.record.query.plan.plans.QueryResult;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryCoveringIndexPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlanWithNoChildren;
+import com.apple.foundationdb.record.query.plan.PhysicalIndexKind;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Message;
@@ -604,4 +605,18 @@ public class ComposedBitmapIndexQueryPlan extends AbstractRelationalExpressionWi
         }
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * A composed bitmap query traverses each of the index plans it composes, so its kind is their combination.
+     *
+     * @return the combined kind of the composed index plans
+     */
+    @Nonnull
+    @Override
+    public PhysicalIndexKind getPhysicalIndexKind() {
+        return PhysicalIndexKind.combine(indexPlans.stream()
+                .map(RecordQueryCoveringIndexPlan::getPhysicalIndexKind)
+                .collect(ImmutableList.toImmutableList()));
+    }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/AggregateIndexMatchCandidate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/AggregateIndexMatchCandidate.java
@@ -52,6 +52,7 @@ import com.apple.foundationdb.record.query.plan.plans.RecordQueryFetchFromPartia
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryIndexPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryStreamingAggregationPlan;
+import com.apple.foundationdb.record.query.plan.PhysicalIndexKind;
 import com.apple.foundationdb.record.util.pair.NonnullPair;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
@@ -639,5 +640,18 @@ public class AggregateIndexMatchCandidate implements MatchCandidate, WithBaseQua
     @Override
     public Type.Record getBaseType() {
         return baseType;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * An aggregate index access traverses the ordered keyspace holding the grouped aggregates.
+     *
+     * @return {@code BTREE}
+     */
+    @Nonnull
+    @Override
+    public PhysicalIndexKind getPhysicalIndexKind() {
+        return PhysicalIndexKind.BTREE;
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchCandidate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchCandidate.java
@@ -34,6 +34,7 @@ import com.apple.foundationdb.record.query.plan.cascades.values.Value;
 import com.apple.foundationdb.record.query.plan.cascades.values.simplification.OrderingValueComputationRuleSet;
 import com.apple.foundationdb.record.query.plan.cascades.values.translation.PullUp;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
+import com.apple.foundationdb.record.query.plan.PhysicalIndexKind;
 import com.apple.foundationdb.record.util.pair.NonnullPair;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
@@ -69,6 +70,19 @@ public interface MatchCandidate {
      */
     @Nonnull
     String getName();
+
+    /**
+     * Returns the {@link PhysicalIndexKind kind of physical structure} an access along this candidate traverses. This is
+     * a property of the candidate rather than of the index: one index can offer several candidates that reach it in
+     * different ways, and a {@link com.apple.foundationdb.record.metadata.IndexTypes#RANK rank} index is the standing
+     * example — it offers a windowed candidate that traverses the ranked set, and a plain value candidate that traverses
+     * the ordered keyspace underneath it. The kind is what the resulting plan records, so that costing can reason about
+     * what an access will actually do at runtime.
+     *
+     * @return the kind of physical structure an access along this candidate traverses
+     */
+    @Nonnull
+    PhysicalIndexKind getPhysicalIndexKind();
 
     /**
      * Returns the traversal object for this candidate. The traversal object can either be computed up-front when

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PrimaryScanMatchCandidate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/PrimaryScanMatchCandidate.java
@@ -29,6 +29,7 @@ import com.apple.foundationdb.record.query.plan.cascades.values.Value;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryScanPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryTypeFilterPlan;
+import com.apple.foundationdb.record.query.plan.PhysicalIndexKind;
 import com.google.common.base.Suppliers;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
@@ -243,5 +244,18 @@ public class PrimaryScanMatchCandidate implements MatchCandidate, ValueIndexLike
             builder.addComparisonRange(comparisonRange);
         }
         return builder.build();
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * A primary scan reaches records through the primary keyspace rather than through an index.
+     *
+     * @return {@code PRIMARY}
+     */
+    @Nonnull
+    @Override
+    public PhysicalIndexKind getPhysicalIndexKind() {
+        return PhysicalIndexKind.PRIMARY;
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ValueIndexScanMatchCandidate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ValueIndexScanMatchCandidate.java
@@ -35,6 +35,7 @@ import com.apple.foundationdb.record.query.plan.plans.RecordQueryCoveringIndexPl
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryFetchFromPartialRecordPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryIndexPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
+import com.apple.foundationdb.record.query.plan.PhysicalIndexKind;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
@@ -311,4 +312,18 @@ public class ValueIndexScanMatchCandidate implements ScanWithFetchMatchCandidate
         }
         return builder.build();
     }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * A value index access traverses the ordered keyspace.
+     *
+     * @return {@code BTREE}
+     */
+    @Nonnull
+    @Override
+    public PhysicalIndexKind getPhysicalIndexKind() {
+        return PhysicalIndexKind.BTREE;
+    }
+
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/VectorIndexScanMatchCandidate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/VectorIndexScanMatchCandidate.java
@@ -22,6 +22,7 @@ package com.apple.foundationdb.record.query.plan.cascades;
 
 import com.apple.foundationdb.record.EvaluationContext;
 import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.metadata.IndexOptions;
 import com.apple.foundationdb.record.metadata.RecordType;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.provider.foundationdb.VectorIndexScanComparisons;
@@ -33,6 +34,7 @@ import com.apple.foundationdb.record.query.plan.cascades.values.simplification.O
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryFetchFromPartialRecordPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryIndexPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
+import com.apple.foundationdb.record.query.plan.PhysicalIndexKind;
 import com.google.common.base.Suppliers;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
@@ -48,6 +50,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
+import java.util.Locale;
 
 /**
  * A specialized match candidate for vector similarity search queries backed by vector similarity indexes
@@ -439,4 +442,31 @@ public class VectorIndexScanMatchCandidate implements WithPrimaryKeyMatchCandida
         }
         return builder.build();
     }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * A vector index access traverses whichever structure the index's engine maintains.
+     *
+     * @return {@code HNSW} or {@code GUARDIANN}, according to the index's engine
+     */
+    @Nonnull
+    @Override
+    public PhysicalIndexKind getPhysicalIndexKind() {
+        // An unset engine option means HNSW, matching what the maintainer does, so that vector indexes created before
+        // the engine became selectable keep reporting the structure they are actually backed by.
+        final String vectorEngine = index.getOption(IndexOptions.VECTOR_ENGINE);
+        if (vectorEngine == null) {
+            return PhysicalIndexKind.HNSW;
+        }
+        switch (vectorEngine.toUpperCase(Locale.ROOT)) {
+            case "HNSW":
+                return PhysicalIndexKind.HNSW;
+            case "GUARDIANN":
+                return PhysicalIndexKind.GUARDIANN;
+            default:
+                return PhysicalIndexKind.UNKNOWN;
+        }
+    }
+
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/WindowedIndexScanMatchCandidate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/WindowedIndexScanMatchCandidate.java
@@ -42,6 +42,7 @@ import com.apple.foundationdb.record.query.plan.plans.RecordQueryCoveringIndexPl
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryFetchFromPartialRecordPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryIndexPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
+import com.apple.foundationdb.record.query.plan.PhysicalIndexKind;
 import com.google.common.base.Suppliers;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
@@ -479,5 +480,19 @@ public class WindowedIndexScanMatchCandidate implements ScanWithFetchMatchCandid
                                                               @Nonnull final CorrelationIdentifier scoreAlias,
                                                               @Nonnull final List<CorrelationIdentifier> primaryKeyAliases) {
         return ImmutableList.<CorrelationIdentifier>builder().addAll(groupingAliases).add(scoreAlias).addAll(primaryKeyAliases).build();
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * A windowed access traverses the ranked set. Note that the same index also offers a plain value candidate, which
+     * traverses the ordered keyspace underneath and therefore reports {@code BTREE}.
+     *
+     * @return {@code RANKED_SET}
+     */
+    @Nonnull
+    @Override
+    public PhysicalIndexKind getPhysicalIndexKind() {
+        return PhysicalIndexKind.RANKED_SET;
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryAggregateIndexPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryAggregateIndexPlan.java
@@ -55,6 +55,7 @@ import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalE
 import com.apple.foundationdb.record.query.plan.cascades.typing.TypeRepository;
 import com.apple.foundationdb.record.query.plan.cascades.values.Value;
 import com.apple.foundationdb.record.query.plan.cascades.values.translation.TranslationMap;
+import com.apple.foundationdb.record.query.plan.PhysicalIndexKind;
 import com.google.auto.service.AutoService;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
@@ -423,4 +424,16 @@ public class RecordQueryAggregateIndexPlan extends AbstractRelationalExpressionW
             return RecordQueryAggregateIndexPlan.fromProto(serializationContext, recordQueryAggregateIndexPlanProto);
         }
     }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return the wrapped index plan's kind
+     */
+    @Nonnull
+    @Override
+    public PhysicalIndexKind getPhysicalIndexKind() {
+        return indexPlan.getPhysicalIndexKind();
+    }
+
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryCoveringIndexPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryCoveringIndexPlan.java
@@ -53,6 +53,7 @@ import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalE
 import com.apple.foundationdb.record.query.plan.cascades.values.IndexedValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.Value;
 import com.apple.foundationdb.record.query.plan.cascades.values.translation.TranslationMap;
+import com.apple.foundationdb.record.query.plan.PhysicalIndexKind;
 import com.google.auto.service.AutoService;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
@@ -374,4 +375,18 @@ public class RecordQueryCoveringIndexPlan extends AbstractRelationalExpressionWi
             return RecordQueryCoveringIndexPlan.fromProto(serializationContext, recordQueryCoveringIndexPlanProto);
         }
     }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * A covering scan traverses whatever the index plan it wraps traverses; avoiding the fetch does not change that.
+     *
+     * @return the wrapped index plan's kind
+     */
+    @Nonnull
+    @Override
+    public PhysicalIndexKind getPhysicalIndexKind() {
+        return indexPlan.getPhysicalIndexKind();
+    }
+
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryExplodePlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryExplodePlan.java
@@ -50,6 +50,7 @@ import com.apple.foundationdb.record.query.plan.cascades.values.QueriedValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.RecordConstructorValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.Value;
 import com.apple.foundationdb.record.query.plan.cascades.values.translation.TranslationMap;
+import com.apple.foundationdb.record.query.plan.PhysicalIndexKind;
 import com.google.auto.service.AutoService;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
@@ -378,5 +379,16 @@ public class RecordQueryExplodePlan extends AbstractRelationalExpressionWithoutC
                                                 @Nonnull final PRecordQueryExplodePlan proto) {
             return RecordQueryExplodePlan.fromProto(serializationContext, proto);
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return {@code PRIMARY}, as no index is involved
+     */
+    @Nonnull
+    @Override
+    public PhysicalIndexKind getPhysicalIndexKind() {
+        return PhysicalIndexKind.IN_MEMORY;
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryIndexPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryIndexPlan.java
@@ -83,6 +83,7 @@ import com.apple.foundationdb.record.query.plan.cascades.values.QueriedValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.Value;
 import com.apple.foundationdb.record.query.plan.cascades.values.translation.TranslationMap;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryFetchFromPartialRecordPlan.FetchIndexRecords;
+import com.apple.foundationdb.record.query.plan.PhysicalIndexKind;
 import com.apple.foundationdb.tuple.ByteArrayUtil;
 import com.apple.foundationdb.tuple.ByteArrayUtil2;
 import com.google.auto.service.AutoService;
@@ -157,6 +158,12 @@ public class RecordQueryIndexPlan extends AbstractRelationalExpressionWithoutChi
     protected final boolean strictlySorted;
     @Nonnull
     private final Optional<? extends MatchCandidate> matchCandidateOptional;
+    /**
+     * The kind of physical structure this scan traverses. Captured from the match candidate when the plan is created,
+     * because the candidate itself does not survive serialization while this does.
+     */
+    @Nonnull
+    private final PhysicalIndexKind physicalIndexKind;
     @Nonnull
     private final Type resultType;
     @Nonnull
@@ -206,7 +213,12 @@ public class RecordQueryIndexPlan extends AbstractRelationalExpressionWithoutChi
                 recordQueryIndexPlanProto.getStrictlySorted(),
                 Optional.empty(),
                 Type.fromTypeProto(serializationContext, Objects.requireNonNull(recordQueryIndexPlanProto.getResultType())),
-                QueryPlanConstraint.fromProto(serializationContext, Objects.requireNonNull(recordQueryIndexPlanProto.getConstraint())));
+                QueryPlanConstraint.fromProto(serializationContext, Objects.requireNonNull(recordQueryIndexPlanProto.getConstraint())),
+                KeyValueCursorBase.SerializationMode.TO_NEW,
+                // A plan written before the kind was carried says nothing about it, which is exactly UNKNOWN.
+                recordQueryIndexPlanProto.hasPhysicalIndexKind()
+                ? PhysicalIndexKind.fromProto(recordQueryIndexPlanProto.getPhysicalIndexKind())
+                : PhysicalIndexKind.UNKNOWN);
     }
 
     @VisibleForTesting
@@ -236,6 +248,24 @@ public class RecordQueryIndexPlan extends AbstractRelationalExpressionWithoutChi
                                 @Nonnull final Type resultType,
                                 @Nonnull final QueryPlanConstraint constraint,
                                 @Nonnull final KeyValueCursorBase.SerializationMode serializationMode) {
+        this(indexName, commonPrimaryKey, scanParameters, indexFetchMethod, fetchIndexRecords, reverse, strictlySorted,
+                matchCandidateOptional, resultType, constraint, serializationMode,
+                matchCandidateOptional.map(MatchCandidate::getPhysicalIndexKind).orElse(PhysicalIndexKind.UNKNOWN));
+    }
+
+    @SuppressWarnings("this-escape")
+    private RecordQueryIndexPlan(@Nonnull final String indexName,
+                                 @Nullable final KeyExpression commonPrimaryKey,
+                                 @Nonnull final IndexScanParameters scanParameters,
+                                 @Nonnull final IndexFetchMethod indexFetchMethod,
+                                 @Nonnull final FetchIndexRecords fetchIndexRecords,
+                                 final boolean reverse,
+                                 final boolean strictlySorted,
+                                 @Nonnull final Optional<? extends MatchCandidate> matchCandidateOptional,
+                                 @Nonnull final Type resultType,
+                                 @Nonnull final QueryPlanConstraint constraint,
+                                 @Nonnull final KeyValueCursorBase.SerializationMode serializationMode,
+                                 @Nonnull final PhysicalIndexKind physicalIndexKind) {
         this.indexName = indexName;
         this.commonPrimaryKey = commonPrimaryKey;
         this.scanParameters = scanParameters;
@@ -244,6 +274,7 @@ public class RecordQueryIndexPlan extends AbstractRelationalExpressionWithoutChi
         this.reverse = reverse;
         this.strictlySorted = strictlySorted;
         this.matchCandidateOptional = matchCandidateOptional;
+        this.physicalIndexKind = physicalIndexKind;
         this.resultType = resultType;
         if (indexFetchMethod != IndexFetchMethod.SCAN_AND_FETCH) {
             if (!scanParameters.getScanType().equals(IndexScanType.BY_VALUE)) {
@@ -579,7 +610,15 @@ public class RecordQueryIndexPlan extends AbstractRelationalExpressionWithoutChi
                 } else {
                     planHash = PlanHashable.objectsPlanHash(mode, BASE_HASH, indexName, scanParameters, reverse, strictlySorted);
                 }
-                return planHash;
+                if (mode == PlanHashMode.VC0) {
+                    return planHash;
+                }
+                //
+                // From VC1 on, the physical structure the scan traverses is part of the plan's identity: it is carried on
+                // the plan rather than derived, so two plans that differ only in it are genuinely different plans. Older
+                // modes must not account for it, or every existing hash would change.
+                //
+                return PlanHashable.objectsPlanHash(mode, planHash, physicalIndexKind);
             default:
                 throw new UnsupportedOperationException("Hash kind " + mode.name() + " is not supported");
         }
@@ -752,6 +791,7 @@ public class RecordQueryIndexPlan extends AbstractRelationalExpressionWithoutChi
         builder.setStrictlySorted(strictlySorted);
         builder.setResultType(resultType.toTypeProto(serializationContext));
         builder.setConstraint(constraint.toProto(serializationContext));
+        builder.setPhysicalIndexKind(physicalIndexKind.toProto());
         return builder.build();
     }
 
@@ -899,5 +939,19 @@ public class RecordQueryIndexPlan extends AbstractRelationalExpressionWithoutChi
                                               @Nonnull final PRecordQueryIndexPlan recordQueryIndexPlanProto) {
             return RecordQueryIndexPlan.fromProto(serializationContext, recordQueryIndexPlanProto);
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Answered from the kind captured when this plan was created, not from the match candidate, so that it is still
+     * available on a plan that has been through serialization.
+     *
+     * @return the kind of physical structure this scan traverses
+     */
+    @Nonnull
+    @Override
+    public PhysicalIndexKind getPhysicalIndexKind() {
+        return physicalIndexKind;
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryLoadByKeysPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryLoadByKeysPlan.java
@@ -48,6 +48,7 @@ import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalE
 import com.apple.foundationdb.record.query.plan.cascades.values.QueriedValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.Value;
 import com.apple.foundationdb.record.query.plan.cascades.values.translation.TranslationMap;
+import com.apple.foundationdb.record.query.plan.PhysicalIndexKind;
 import com.apple.foundationdb.tuple.Tuple;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -370,4 +371,16 @@ public class RecordQueryLoadByKeysPlan extends AbstractRelationalExpressionWitho
             }
         }
     }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return {@code PRIMARY}, as no index is involved
+     */
+    @Nonnull
+    @Override
+    public PhysicalIndexKind getPhysicalIndexKind() {
+        return PhysicalIndexKind.PRIMARY;
+    }
+
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryPlan.java
@@ -44,6 +44,7 @@ import com.apple.foundationdb.record.query.plan.cascades.explain.PlannerGraphRew
 import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpression;
 import com.apple.foundationdb.record.query.plan.serialization.PlanSerialization;
 import com.apple.foundationdb.record.query.plan.visitor.RecordQueryPlannerSubstitutionVisitor;
+import com.apple.foundationdb.record.query.plan.PhysicalIndexKind;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
@@ -385,4 +386,14 @@ public interface RecordQueryPlan extends QueryPlan<FDBQueriedRecord<Message>>, P
                                                     @Nonnull final PRecordQueryPlan recordQueryPlanProto) {
         return (RecordQueryPlan)PlanSerialization.dispatchFromProtoContainer(serializationContext, recordQueryPlanProto);
     }
+
+    /**
+     * Returns the {@link PhysicalIndexKind kind of physical structure} this plan traverses to reach records. A leaf
+     * answers for itself, a plan with a single child answers with its child's kind, and a plan with several children
+     * answers with {@link PhysicalIndexKind#combine(Iterable) their combination}.
+     *
+     * @return the kind of physical structure this plan traverses
+     */
+    @Nonnull
+    PhysicalIndexKind getPhysicalIndexKind();
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryPlanWithChild.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryPlanWithChild.java
@@ -30,6 +30,7 @@ import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import com.apple.foundationdb.record.query.plan.PhysicalIndexKind;
 
 /**
  * A query plan with a single child plan.
@@ -98,4 +99,18 @@ public interface RecordQueryPlanWithChild extends RecordQueryPlanWithChildren {
 
     @Nonnull
     RecordQueryPlanWithChild withChild(@Nonnull Reference childRef);
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * A plan with a single child traverses whatever its child traverses.
+     *
+     * @return the child's kind
+     */
+    @Nonnull
+    @Override
+    default PhysicalIndexKind getPhysicalIndexKind() {
+        return getChild().getPhysicalIndexKind();
+    }
+
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryPlanWithChildren.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryPlanWithChildren.java
@@ -26,6 +26,8 @@ import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalE
 import javax.annotation.Nonnull;
 import java.util.HashSet;
 import java.util.Set;
+import com.apple.foundationdb.record.query.plan.PhysicalIndexKind;
+import com.google.common.collect.ImmutableList;
 
 /**
  * A query plan with child plans.
@@ -60,5 +62,21 @@ public interface RecordQueryPlanWithChildren extends RecordQueryPlan, Relational
     @Override
     default boolean hasLoadBykeys() {
         return getChildren().stream().anyMatch(RecordQueryPlan::hasLoadBykeys);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * A plan with several children traverses the combination of what its children traverse, which is
+     * {@link PhysicalIndexKind#MIXED} unless they all agree.
+     *
+     * @return the combined kind of the children
+     */
+    @Nonnull
+    @Override
+    default PhysicalIndexKind getPhysicalIndexKind() {
+        return PhysicalIndexKind.combine(getChildren().stream()
+                .map(RecordQueryPlan::getPhysicalIndexKind)
+                .collect(ImmutableList.toImmutableList()));
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryRangePlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryRangePlan.java
@@ -48,6 +48,7 @@ import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
 import com.apple.foundationdb.record.query.plan.cascades.values.QueriedValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.Value;
 import com.apple.foundationdb.record.query.plan.cascades.values.translation.TranslationMap;
+import com.apple.foundationdb.record.query.plan.PhysicalIndexKind;
 import com.google.auto.service.AutoService;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
@@ -285,4 +286,16 @@ public class RecordQueryRangePlan extends AbstractRelationalExpressionWithoutChi
             return RecordQueryRangePlan.fromProto(serializationContext, recordQueryRangePlanProto);
         }
     }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return {@code PRIMARY}, as no index is involved
+     */
+    @Nonnull
+    @Override
+    public PhysicalIndexKind getPhysicalIndexKind() {
+        return PhysicalIndexKind.IN_MEMORY;
+    }
+
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryScanPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryScanPlan.java
@@ -58,6 +58,7 @@ import com.apple.foundationdb.record.query.plan.cascades.values.Value;
 import com.apple.foundationdb.record.query.plan.cascades.values.translation.TranslationMap;
 import com.apple.foundationdb.record.query.plan.explain.ExplainTokens;
 import com.apple.foundationdb.record.query.plan.explain.WithIndentationsExplainFormatter;
+import com.apple.foundationdb.record.query.plan.PhysicalIndexKind;
 import com.google.auto.service.AutoService;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Suppliers;
@@ -592,5 +593,16 @@ public class RecordQueryScanPlan extends AbstractRelationalExpressionWithoutChil
                                              @Nonnull final PRecordQueryScanPlan recordQueryScanPlanProto) {
             return RecordQueryScanPlan.fromProto(serializationContext, recordQueryScanPlanProto);
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return {@code PRIMARY}, as no index is involved
+     */
+    @Nonnull
+    @Override
+    public PhysicalIndexKind getPhysicalIndexKind() {
+        return PhysicalIndexKind.PRIMARY;
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryTableFunctionPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryTableFunctionPlan.java
@@ -50,6 +50,7 @@ import com.apple.foundationdb.record.query.plan.cascades.values.QueriedValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.StreamingValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.Value;
 import com.apple.foundationdb.record.query.plan.cascades.values.translation.TranslationMap;
+import com.apple.foundationdb.record.query.plan.PhysicalIndexKind;
 import com.google.auto.service.AutoService;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
@@ -73,7 +74,7 @@ public class RecordQueryTableFunctionPlan extends AbstractRelationalExpressionWi
     @Nonnull
     private final StreamingValue value;
 
-    public RecordQueryTableFunctionPlan(@Nonnull final StreamingValue collectionValue) {
+    public  RecordQueryTableFunctionPlan(@Nonnull final StreamingValue collectionValue) {
         this.value = collectionValue;
     }
 
@@ -280,6 +281,17 @@ public class RecordQueryTableFunctionPlan extends AbstractRelationalExpressionWi
                                                       @Nonnull final PRecordQueryTableFunctionPlan message) {
             return RecordQueryTableFunctionPlan.fromProto(serializationContext, message);
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return {@code PRIMARY}, as no index is involved
+     */
+    @Nonnull
+    @Override
+    public PhysicalIndexKind getPhysicalIndexKind() {
+        return PhysicalIndexKind.IN_MEMORY;
     }
 }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryTextIndexPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryTextIndexPlan.java
@@ -49,6 +49,7 @@ import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalE
 import com.apple.foundationdb.record.query.plan.cascades.values.QueriedValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.Value;
 import com.apple.foundationdb.record.query.plan.cascades.values.translation.TranslationMap;
+import com.apple.foundationdb.record.query.plan.PhysicalIndexKind;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -304,5 +305,16 @@ public class RecordQueryTextIndexPlan extends AbstractRelationalExpressionWithou
     @Override
     public PRecordQueryPlan toRecordQueryPlanProto(@Nonnull final PlanSerializationContext serializationContext) {
         throw new RecordCoreException("serialization of this plan is not supported");
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return {@code INVERTED}, the postings structure a text index is backed by
+     */
+    @Nonnull
+    @Override
+    public PhysicalIndexKind getPhysicalIndexKind() {
+        return PhysicalIndexKind.INVERTED;
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/TempTableScanPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/TempTableScanPlan.java
@@ -48,6 +48,7 @@ import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
 import com.apple.foundationdb.record.query.plan.cascades.values.QueriedValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.Value;
 import com.apple.foundationdb.record.query.plan.cascades.values.translation.TranslationMap;
+import com.apple.foundationdb.record.query.plan.PhysicalIndexKind;
 import com.google.auto.service.AutoService;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
@@ -266,5 +267,16 @@ public class TempTableScanPlan extends AbstractRelationalExpressionWithoutChildr
                                            @Nonnull final PTempTableScanPlan tempTableScanPlanProto) {
             return TempTableScanPlan.fromProto(serializationContext, tempTableScanPlanProto);
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return {@code IN_MEMORY}, as a temporary table is not a persistent structure
+     */
+    @Nonnull
+    @Override
+    public PhysicalIndexKind getPhysicalIndexKind() {
+        return PhysicalIndexKind.IN_MEMORY;
     }
 }

--- a/fdb-record-layer-core/src/main/proto/record_query_plan.proto
+++ b/fdb-record-layer-core/src/main/proto/record_query_plan.proto
@@ -1919,6 +1919,7 @@ message PRecordQueryIndexPlan {
   optional bool strictly_sorted = 7;
   optional PType result_type = 8;
   optional PQueryPlanConstraint constraint = 9;
+  optional PPhysicalIndexKind physical_index_kind = 10;
 }
 
 //
@@ -1983,6 +1984,21 @@ message PVectorIndexScanOptions {
     optional com.apple.foundationdb.record.expressions.Value value = 2;
   }
   repeated POptionEntry optionEntries = 1;
+}
+
+enum PPhysicalIndexKind {
+  UNKNOWN = 1;
+  PRIMARY = 2;
+  BTREE = 3;
+  RANKED_SET = 4;
+  INVERTED = 5;
+  R_TREE = 6;
+  SPACE_FILLING_CURVE = 7;
+  HNSW = 8;
+  GUARDIANN = 9;
+  LUCENE = 10;
+  IN_MEMORY = 11;
+  MIXED = 12;
 }
 
 enum PIndexFetchMethod {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/PhysicalIndexKindTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/PhysicalIndexKindTest.java
@@ -1,0 +1,132 @@
+/*
+ * PhysicalIndexKindTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import javax.annotation.Nonnull;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests of {@link PhysicalIndexKind#combine}, which decides the kind of a plan from the kinds of its parts.
+ */
+class PhysicalIndexKindTest {
+    @Test
+    void nothingToCombineIsUnknown() {
+        assertEquals(PhysicalIndexKind.UNKNOWN, PhysicalIndexKind.combine());
+        assertEquals(PhysicalIndexKind.UNKNOWN, PhysicalIndexKind.combine(ImmutableList.of()));
+    }
+
+    /**
+     * {@link PhysicalIndexKind#UNKNOWN} is first so that it stays at ordinal zero as kinds are added.
+     */
+    @Test
+    void unknownIsTheFirstKind() {
+        assertEquals(0, PhysicalIndexKind.UNKNOWN.ordinal());
+    }
+
+    @ParameterizedTest
+    @EnumSource(PhysicalIndexKind.class)
+    void oneKindCombinesToItself(@Nonnull final PhysicalIndexKind kind) {
+        assertEquals(kind, PhysicalIndexKind.combine(kind));
+    }
+
+    @ParameterizedTest
+    @EnumSource(PhysicalIndexKind.class)
+    void severalOfTheSameKindCombineToThatKind(@Nonnull final PhysicalIndexKind kind) {
+        assertEquals(kind, PhysicalIndexKind.combine(kind, kind, kind));
+    }
+
+    @Test
+    void differingKindsCombineToMixed() {
+        assertEquals(PhysicalIndexKind.MIXED,
+                PhysicalIndexKind.combine(PhysicalIndexKind.HNSW, PhysicalIndexKind.GUARDIANN));
+        assertEquals(PhysicalIndexKind.MIXED,
+                PhysicalIndexKind.combine(PhysicalIndexKind.BTREE, PhysicalIndexKind.BTREE, PhysicalIndexKind.LUCENE));
+    }
+
+    /**
+     * {@link PhysicalIndexKind#PRIMARY} is not an identity: a plan that reaches an index in one branch and not in the
+     * other is of two minds about how it reaches records, and saying it is purely the one kind would overstate what is
+     * known.
+     */
+    @Test
+    void primaryIsNotAnIdentity() {
+        assertEquals(PhysicalIndexKind.MIXED,
+                PhysicalIndexKind.combine(PhysicalIndexKind.PRIMARY, PhysicalIndexKind.BTREE));
+        assertEquals(PhysicalIndexKind.MIXED,
+                PhysicalIndexKind.combine(PhysicalIndexKind.BTREE, PhysicalIndexKind.PRIMARY));
+    }
+
+    /**
+     * {@link PhysicalIndexKind#IN_MEMORY} is the one identity: a temporary table alongside an index scan does not make a
+     * plan ambiguous about which persistent structure it is built around, so it drops out of the combination.
+     */
+    @Test
+    void inMemoryDropsOutOfTheCombination() {
+        assertEquals(PhysicalIndexKind.BTREE,
+                PhysicalIndexKind.combine(PhysicalIndexKind.BTREE, PhysicalIndexKind.IN_MEMORY));
+        assertEquals(PhysicalIndexKind.BTREE,
+                PhysicalIndexKind.combine(PhysicalIndexKind.IN_MEMORY, PhysicalIndexKind.BTREE));
+        assertEquals(PhysicalIndexKind.HNSW,
+                PhysicalIndexKind.combine(PhysicalIndexKind.IN_MEMORY, PhysicalIndexKind.HNSW,
+                        PhysicalIndexKind.IN_MEMORY));
+    }
+
+    /**
+     * Dropping out is not the same as making everything agree: kinds that disagree are still mixed, whether or not an
+     * in-memory structure is along for the ride.
+     */
+    @Test
+    void inMemoryDoesNotRescueDisagreeingKinds() {
+        assertEquals(PhysicalIndexKind.MIXED,
+                PhysicalIndexKind.combine(PhysicalIndexKind.GUARDIANN, PhysicalIndexKind.HNSW,
+                        PhysicalIndexKind.BTREE));
+        assertEquals(PhysicalIndexKind.MIXED,
+                PhysicalIndexKind.combine(PhysicalIndexKind.GUARDIANN, PhysicalIndexKind.HNSW,
+                        PhysicalIndexKind.BTREE, PhysicalIndexKind.IN_MEMORY));
+    }
+
+    @Test
+    void onlyInMemoryStaysInMemory() {
+        assertEquals(PhysicalIndexKind.IN_MEMORY,
+                PhysicalIndexKind.combine(PhysicalIndexKind.IN_MEMORY, PhysicalIndexKind.IN_MEMORY));
+        assertEquals(PhysicalIndexKind.IN_MEMORY,
+                PhysicalIndexKind.combine(PhysicalIndexKind.IN_MEMORY));
+    }
+
+    /**
+     * Combining is not a set union: once mixed, always mixed, whatever it is mixed with.
+     */
+    @Test
+    void mixedStaysMixed() {
+        assertEquals(PhysicalIndexKind.MIXED,
+                PhysicalIndexKind.combine(PhysicalIndexKind.MIXED, PhysicalIndexKind.MIXED));
+        assertEquals(PhysicalIndexKind.MIXED,
+                PhysicalIndexKind.combine(PhysicalIndexKind.MIXED, PhysicalIndexKind.BTREE));
+        assertEquals(PhysicalIndexKind.MIXED,
+                PhysicalIndexKind.combine(PhysicalIndexKind.HNSW, PhysicalIndexKind.MIXED));
+    }
+}

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/explain/ExplainPlanVisitorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/explain/ExplainPlanVisitorTest.java
@@ -90,6 +90,7 @@ import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedUnionP
 import com.apple.foundationdb.record.query.plan.plans.TranslateValueFunction;
 import com.apple.foundationdb.record.query.plan.sorting.RecordQuerySortKey;
 import com.apple.foundationdb.record.query.plan.sorting.RecordQuerySortPlan;
+import com.apple.foundationdb.record.query.plan.PhysicalIndexKind;
 import com.apple.foundationdb.record.util.pair.NonnullPair;
 import com.apple.foundationdb.record.util.pair.Pair;
 import com.apple.foundationdb.tuple.Tuple;
@@ -672,6 +673,12 @@ public class ExplainPlanVisitorTest {
      * of a plan if the size limit has already been hit.
      */
     private static class UnstringableQueryPlan implements RecordQueryPlan {
+        @Nonnull
+        @Override
+        public PhysicalIndexKind getPhysicalIndexKind() {
+            return PhysicalIndexKind.UNKNOWN;
+        }
+
         private final boolean reverse;
 
         public UnstringableQueryPlan() {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryIndexPlanPhysicalIndexKindTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryIndexPlanPhysicalIndexKindTest.java
@@ -1,0 +1,182 @@
+/*
+ * RecordQueryIndexPlanPhysicalIndexKindTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.plans;
+
+import com.apple.foundationdb.record.IndexFetchMethod;
+import com.apple.foundationdb.record.IndexScanType;
+import com.apple.foundationdb.record.PlanHashable;
+import com.apple.foundationdb.record.PlanSerializationContext;
+import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.metadata.IndexTypes;
+import com.apple.foundationdb.record.metadata.RecordType;
+import com.apple.foundationdb.record.provider.foundationdb.IndexScanComparisons;
+import com.apple.foundationdb.record.query.plan.PhysicalIndexKind;
+import com.apple.foundationdb.record.query.plan.QueryPlanConstraint;
+import com.apple.foundationdb.record.query.plan.ScanComparisons;
+import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
+import com.apple.foundationdb.record.query.plan.cascades.Reference;
+import com.apple.foundationdb.record.query.plan.cascades.Traversal;
+import com.apple.foundationdb.record.query.plan.cascades.ValueIndexScanMatchCandidate;
+import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.util.Collections;
+import java.util.Optional;
+
+import static com.apple.foundationdb.record.metadata.Key.Expressions.field;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * Tests that a {@link RecordQueryIndexPlan} carries the {@link PhysicalIndexKind} of the access it was created for, that
+ * it still carries it after a round trip through serialization — which is the point of holding it on the plan rather than
+ * reading it off the match candidate — and that only {@code VC1} accounts for it in the plan hash.
+ */
+class RecordQueryIndexPlanPhysicalIndexKindTest {
+    @Nonnull
+    private static Type.Record baseType() {
+        return Type.Record.fromFields(ImmutableList.of(
+                Type.Record.Field.of(Type.primitiveType(Type.TypeCode.LONG), Optional.of("aField"))));
+    }
+
+    @Nonnull
+    private static RecordQueryIndexPlan valueIndexPlan(@Nonnull final String indexName) {
+        final Index index = new Index(indexName, field("aField"), IndexTypes.VALUE);
+        final Type.Record baseType = baseType();
+        final ValueIndexScanMatchCandidate matchCandidate =
+                new ValueIndexScanMatchCandidate(index,
+                        Collections.<RecordType>emptyList(),
+                        Traversal.withRoot(Reference.empty()),
+                        ImmutableList.<CorrelationIdentifier>of(),
+                        baseType,
+                        CorrelationIdentifier.of("base"),
+                        ImmutableList.of(),
+                        ImmutableList.of(),
+                        field("aField"),
+                        null);
+        return new RecordQueryIndexPlan(index.getName(),
+                null,
+                new IndexScanComparisons(IndexScanType.BY_VALUE, ScanComparisons.EMPTY),
+                IndexFetchMethod.SCAN_AND_FETCH,
+                RecordQueryFetchFromPartialRecordPlan.FetchIndexRecords.PRIMARY_KEY,
+                false,
+                false,
+                matchCandidate,
+                baseType,
+                QueryPlanConstraint.noConstraint());
+    }
+
+
+    /**
+     * The same plan with its carried kind stripped, as a plan written before the kind existed reads back.
+     *
+     * @param plan the plan to strip
+     * @return the same plan, carrying no kind
+     */
+    @Nonnull
+    private static RecordQueryIndexPlan withoutKind(@Nonnull final RecordQueryIndexPlan plan) {
+        return RecordQueryIndexPlan.fromProto(PlanSerializationContext.newForCurrentMode(),
+                plan.toRecordQueryIndexPlanProto(PlanSerializationContext.newForCurrentMode())
+                        .toBuilder()
+                        .clearPhysicalIndexKind()
+                        .build());
+    }
+
+    @Test
+    void kindIsTakenFromTheMatchCandidate() {
+        assertEquals(PhysicalIndexKind.BTREE, valueIndexPlan("anIndex").getPhysicalIndexKind());
+    }
+
+    /**
+     * The whole reason the kind sits on the plan: a match candidate is not serialized, so a plan that read its kind from
+     * the candidate would lose it here.
+     */
+    @Test
+    void kindSurvivesSerialization() {
+        final RecordQueryIndexPlan plan = valueIndexPlan("anIndex");
+        final var serializationContext = PlanSerializationContext.newForCurrentMode();
+        final RecordQueryIndexPlan deserialized =
+                RecordQueryIndexPlan.fromProto(serializationContext,
+                        plan.toRecordQueryIndexPlanProto(serializationContext));
+
+        assertEquals(PhysicalIndexKind.BTREE, deserialized.getPhysicalIndexKind(),
+                "the kind should survive a round trip even though the match candidate does not");
+        assertEquals(Optional.empty(), deserialized.getMatchCandidateMaybe(),
+                "sanity: the match candidate itself is still not serialized");
+    }
+
+    /**
+     * Accounting for the kind changes a plan's hash, so it may only be done from {@code VC1} on. {@code VC0} is
+     * {@link PlanHashable#CURRENT_FOR_CONTINUATION} and its hashes are load-bearing for continuations.
+     */
+    @Test
+    void onlyVc1AccountsForTheKind() {
+        final RecordQueryIndexPlan plan = valueIndexPlan("anIndex");
+        final RecordQueryIndexPlan sameButUnknownKind = withoutKind(plan);
+
+        assertEquals(PhysicalIndexKind.UNKNOWN, sameButUnknownKind.getPhysicalIndexKind(),
+                "a plan carrying no kind should read back as UNKNOWN");
+        assertEquals(plan.planHash(PlanHashable.PlanHashMode.VC0),
+                sameButUnknownKind.planHash(PlanHashable.PlanHashMode.VC0),
+                "VC0 must not account for the kind");
+        assertNotEquals(plan.planHash(PlanHashable.PlanHashMode.VC1),
+                sameButUnknownKind.planHash(PlanHashable.PlanHashMode.VC1),
+                "VC1 must account for the kind");
+    }
+
+    /**
+     * A plan with several children reports the combination of their kinds, so a union of two value index scans is still
+     * {@code BTREE} while a union with something unclassified is {@code MIXED}.
+     */
+    @Test
+    void unionCombinesItsChildrenKinds() {
+        assertEquals(PhysicalIndexKind.BTREE,
+                union(valueIndexPlan("oneIndex"), valueIndexPlan("anotherIndex")).getPhysicalIndexKind());
+        assertEquals(PhysicalIndexKind.MIXED,
+                union(valueIndexPlan("oneIndex"), withoutKind(valueIndexPlan("anotherIndex"))).getPhysicalIndexKind());
+    }
+
+    /**
+     * Only the index scan itself folds the kind into its hash; a plan above it picks that up through its children's
+     * hashes, so the {@code VC0}/{@code VC1} split holds for a whole plan tree and not just for the scan.
+     */
+    @Test
+    void theKindReachesAParentPlansVc1Hash() {
+        final RecordQueryIndexPlan child = valueIndexPlan("anIndex");
+        final RecordQueryPlan withKind = union(child, valueIndexPlan("anotherIndex"));
+        final RecordQueryPlan withoutChildKind = union(withoutKind(child), valueIndexPlan("anotherIndex"));
+
+        assertEquals(withKind.planHash(PlanHashable.PlanHashMode.VC0),
+                withoutChildKind.planHash(PlanHashable.PlanHashMode.VC0),
+                "VC0 must not account for a child's kind either");
+        assertNotEquals(withKind.planHash(PlanHashable.PlanHashMode.VC1),
+                withoutChildKind.planHash(PlanHashable.PlanHashMode.VC1),
+                "VC1 should account for a child's kind through the child's own hash");
+    }
+
+    @Nonnull
+    private static RecordQueryPlan union(@Nonnull final RecordQueryPlan left, @Nonnull final RecordQueryPlan right) {
+        return RecordQueryUnionPlan.from(left, right, field("aField"), false);
+    }
+
+}

--- a/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileSpatialObjectQueryPlan.java
+++ b/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileSpatialObjectQueryPlan.java
@@ -40,6 +40,7 @@ import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalE
 import com.apple.foundationdb.record.query.plan.cascades.values.translation.TranslationMap;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlanWithIndex;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlanWithNoChildren;
+import com.apple.foundationdb.record.query.plan.PhysicalIndexKind;
 import com.apple.foundationdb.tuple.Tuple;
 import com.geophile.z.SpatialIndex;
 import com.geophile.z.SpatialJoin;
@@ -240,4 +241,15 @@ public abstract class GeophileSpatialObjectQueryPlan extends AbstractRelationalE
     public int computeHashCodeWithoutChildren() {
         return Objects.hash(indexName, prefixComparisons);
     }
+    /**
+     * {@inheritDoc}
+     *
+     * @return {@code SPACE_FILLING_CURVE}, the structure a geophile spatial index is backed by
+     */
+    @Nonnull
+    @Override
+    public PhysicalIndexKind getPhysicalIndexKind() {
+        return PhysicalIndexKind.SPACE_FILLING_CURVE;
+    }
+
 }


### PR DESCRIPTION
The only route from a plan to the index kind behind an access is its `MatchCandidate`, which isn't serialized: `RecordQueryIndexPlan` keeps it in a field absent from `PRecordQueryIndexPlan`, so a deserialized plan knows nothing about the kind of index it scans. This adds `PhysicalIndexKind`, the structure backing an access, as opposed to the logical `IndexTypes` it is declared as, since the two don't line up one-to-one in either direction. Each `MatchCandidate` declares the kind an access along it traverses, `RecordQueryPlan` exposes it for any plan, and `RecordQueryIndexPlan` carries it in the proto so it survives a round trip.

Nothing consumes the kind yet; it's a channel for anything that would like to tell two accesses apart by what they physically do, which costing in particular could benefit from. Compatibility holds in both directions: the proto field is optional and an older plan deserializes to `UNKNOWN`, and the kind enters the plan hash only from `VC1` on, so existing hashes are untouched.

This fixes #4428.