### PR TITLE
Yamlsql CHECK_EXPLAIN also updates explain in metrics file

### DIFF
--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/MetricsDiffAnalyzer.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/MetricsDiffAnalyzer.java
@@ -513,7 +513,7 @@ public final class MetricsDiffAnalyzer {
         }
 
         private void appendStatisticalSummary(@Nonnull final StringBuilder report, @Nonnull final MetricsStatistics stats) {
-            for (final var fieldName : YamlExecutionContext.TRACKED_METRIC_FIELDS) {
+            for (final var fieldName : YamlMetricsMaintainer.TRACKED_METRIC_FIELDS) {
                 final var fieldStats = stats.getFieldStatistics(fieldName);
                 final var regressionFieldStats = stats.getRegressionStatistics(fieldName);
                 if (fieldStats.hasChanges() || regressionFieldStats.hasChanges()) {
@@ -608,7 +608,7 @@ public final class MetricsDiffAnalyzer {
                     final var newMetrics = change.newInfo.getCountersAndTimers();
                     final var descriptor = oldMetrics.getDescriptorForType();
 
-                    for (final var fieldName : YamlExecutionContext.TRACKED_METRIC_FIELDS) {
+                    for (final var fieldName : YamlMetricsMaintainer.TRACKED_METRIC_FIELDS) {
                         final var field = descriptor.findFieldByName(fieldName);
                         final var oldValue = (long)oldMetrics.getField(field);
                         final var newValue = (long)newMetrics.getField(field);
@@ -663,7 +663,7 @@ public final class MetricsDiffAnalyzer {
             final var newMetrics = change.newInfo.getCountersAndTimers();
             final var descriptor = oldMetrics.getDescriptorForType();
 
-            for (final var fieldName : YamlExecutionContext.TRACKED_METRIC_FIELDS) {
+            for (final var fieldName : YamlMetricsMaintainer.TRACKED_METRIC_FIELDS) {
                 final var field = descriptor.findFieldByName(fieldName);
                 final var oldValue = (long)oldMetrics.getField(field);
                 final var newValue = (long)newMetrics.getField(field);
@@ -698,7 +698,7 @@ public final class MetricsDiffAnalyzer {
 
             final var descriptor = oldMetrics.getDescriptorForType();
 
-            for (final var fieldName : YamlExecutionContext.TRACKED_METRIC_FIELDS) {
+            for (final var fieldName : YamlMetricsMaintainer.TRACKED_METRIC_FIELDS) {
                 final Descriptors.FieldDescriptor field = descriptor.findFieldByName(fieldName);
                 final long oldValue = (long)oldMetrics.getField(field);
                 final long newValue = (long)newMetrics.getField(field);

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/MetricsInfo.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/MetricsInfo.java
@@ -97,7 +97,7 @@ public final class MetricsInfo {
                                               @Nonnull final MetricsInfo actual) {
         final var metricsDescriptor = PlannerMetricsProto.CountersAndTimers.getDescriptor();
 
-        return YamlExecutionContext.TRACKED_METRIC_FIELDS.stream()
+        return YamlMetricsMaintainer.TRACKED_METRIC_FIELDS.stream()
                 .map(metricsDescriptor::findFieldByName)
                 .anyMatch(field -> isMetricDifferent(expected, actual, field));
     }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlCorrection.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlCorrection.java
@@ -32,8 +32,8 @@ import java.util.List;
  * <p>
  *     Known implementations:
  *     <ul>
- *         <li>{@link YamlExecutionContext.ExplainCorrection} – replaces a single {@code explain:} line.</li>
- *         <li>{@link YamlExecutionContext.MetadataCorrection} – replaces a {@code resultMetadata:} block.</li>
+ *         <li>{@link YamlFilesMaintainer.ExplainCorrection} – replaces a single {@code explain:} line.</li>
+ *         <li>{@link YamlFilesMaintainer.MetadataCorrection} – replaces a {@code resultMetadata:} block.</li>
  *     </ul>
  * </p>
  */

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlExecutionContext.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlExecutionContext.java
@@ -123,6 +123,7 @@ public final class YamlExecutionContext {
     }
 
     public void registerResource(@Nonnull final YamlReference.YamlResource resource) throws RelationalException {
+        // topLevelResource is already registered in the constructor
         if (resource == topLevelResource) {
             return;
         }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlExecutionContext.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlExecutionContext.java
@@ -103,6 +103,9 @@ public final class YamlExecutionContext {
     }
 
     YamlExecutionContext(@Nonnull YamlReference.YamlResource topLevelResource, @Nonnull YamlConnectionFactory factory, @Nonnull final ContextOptions additionalOptions) throws RelationalException {
+        this.connectionFactory = factory;
+        this.topLevelResource = topLevelResource;
+        this.additionalOptions = additionalOptions;
         if (isInCI() && (shouldCorrectExplains() || shouldCorrectMetrics() || shouldCorrectResultMetadata() || shouldAddResultMetadata() || shouldAddExplains())) {
             logger.error("‼️ Yamsql files cannot be modified during CI runs.");
             Assertions.fail("‼️ Yamsql files cannot be modified during CI runs. " +
@@ -113,9 +116,6 @@ public final class YamlExecutionContext {
             logger.info("ℹ️ Number of threads to be used for parallel execution " + getNumThreads());
             getNightlyRepetition().ifPresent(rep -> logger.info("ℹ️ Running with high repetition value set to " + rep));
         }
-        this.connectionFactory = factory;
-        this.topLevelResource = topLevelResource;
-        this.additionalOptions = additionalOptions;
         this.metricsMaintainer = new YamlMetricsMaintainer(topLevelResource);
         this.filesMaintainer = new YamlFilesMaintainer();
         loadResourceForEditIfNeeded(topLevelResource);

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlExecutionContext.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlExecutionContext.java
@@ -26,69 +26,42 @@ import com.apple.foundationdb.relational.api.exceptions.ErrorCode;
 import com.apple.foundationdb.relational.api.exceptions.RelationalException;
 import com.apple.foundationdb.relational.util.Assert;
 import com.apple.foundationdb.relational.yamltests.block.IncludeBlock;
-import com.apple.foundationdb.relational.yamltests.command.queryconfigs.CheckResultMetadataConfig;
 import com.apple.foundationdb.relational.yamltests.generated.stats.PlannerMetricsProto;
-import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.Streams;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
 import org.opentest4j.TestAbortedException;
-import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.BufferedInputStream;
-import java.io.BufferedReader;
 import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.FileWriter;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.PrintWriter;
+import java.io.Serial;
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 @SuppressWarnings({"PMD.GuardLogStatement"}) // It already is, but PMD is confused and reporting error in unrelated locations.
 public final class YamlExecutionContext {
-    private static final Logger logger = LogManager.getLogger(YamlRunner.class);
-
-    /**
-     * List of metrics field names that are tracked for planner comparison.
-     * These are the core metrics that should be consistent between runs, excluding timing
-     * information which can vary.
-     */
-    public static final List<String> TRACKED_METRIC_FIELDS = List.of(
-            "task_count",
-            "transform_count",
-            "transform_yield_count",
-            "insert_new_count",
-            "insert_reused_count"
-    );
+    private static final Logger logger = LogManager.getLogger(YamlExecutionContext.class);
 
     public static final ContextOption<Boolean> OPTION_FORCE_CONTINUATIONS = new ContextOption<>("optionForceContinuation");
     public static final ContextOption<Boolean> OPTION_CORRECT_EXPLAIN = new ContextOption<>("optionCorrectExplain");
@@ -103,26 +76,17 @@ public final class YamlExecutionContext {
     @Nonnull final YamlReference.YamlResource topLevelResource;
     @Nonnull
     private final Set<YamlReference.YamlResource> registeredResources = new HashSet<>();
+
     @Nonnull
-    private final Map<YamlReference.YamlResource, List<String>> editedFileStream = new HashMap<>();
+    private final YamlMetricsMaintainer metricsMaintainer;
     @Nonnull
-    private final Map<YamlReference.YamlResource, Boolean> isDirty = new HashMap<>();
-    /**
-     * Pending corrections (explain and result-metadata), buffered so they can be applied in descending
-     * line-number order to avoid stale-offset corruption when multiple corrections target the same file.
-     */
-    @Nonnull
-    private final Map<YamlReference.YamlResource, List<YamlCorrection>> pendingCorrections = new HashMap<>();
-    @Nullable
-    private ImmutableMap<PlannerMetricsProto.Identifier, PlannerMetricsProto.Info> expectedMetricsMap;
-    @Nonnull
-    private Map<QueryAndLocation, PlannerMetricsProto.Info> actualMetricsMap = new HashMap<>();
-    private volatile boolean isDirtyMetrics = false;
+    private final YamlFilesMaintainer filesMaintainer;
     @Nonnull
     private final YamlConnectionFactory connectionFactory;
     @SuppressWarnings("AbbreviationAsWordInName")
     private final Map<YamlReference.YamlResource, List<String>> connectionURIs = new HashMap<>();
     // Additional options that can be set by the runners to impact test execution
+    @Nonnull
     private final ContextOptions additionalOptions;
     private final Map<String, String> transactionSetups = new HashMap<>();
     @Nonnull
@@ -130,6 +94,7 @@ public final class YamlExecutionContext {
 
     public static class YamlExecutionError extends RuntimeException {
 
+        @Serial
         private static final long serialVersionUID = 10L;
 
         YamlExecutionError(String msg, Throwable throwable) {
@@ -137,10 +102,7 @@ public final class YamlExecutionContext {
         }
     }
 
-    YamlExecutionContext(@Nonnull YamlReference.YamlResource topLevelResource, @Nonnull YamlConnectionFactory factory, @Nonnull final ContextOptions additionalOptions) {
-        this.connectionFactory = factory;
-        this.topLevelResource = topLevelResource;
-        this.additionalOptions = additionalOptions;
+    YamlExecutionContext(@Nonnull YamlReference.YamlResource topLevelResource, @Nonnull YamlConnectionFactory factory, @Nonnull final ContextOptions additionalOptions) throws RelationalException {
         if (isInCI() && (shouldCorrectExplains() || shouldCorrectMetrics() || shouldCorrectResultMetadata() || shouldAddResultMetadata() || shouldAddExplains())) {
             logger.error("‼️ Yamsql files cannot be modified during CI runs.");
             Assertions.fail("‼️ Yamsql files cannot be modified during CI runs. " +
@@ -151,22 +113,30 @@ public final class YamlExecutionContext {
             logger.info("ℹ️ Number of threads to be used for parallel execution " + getNumThreads());
             getNightlyRepetition().ifPresent(rep -> logger.info("ℹ️ Running with high repetition value set to " + rep));
         }
+        this.connectionFactory = factory;
+        this.topLevelResource = topLevelResource;
+        this.additionalOptions = additionalOptions;
+        this.metricsMaintainer = new YamlMetricsMaintainer(topLevelResource);
+        this.filesMaintainer = new YamlFilesMaintainer();
+        loadResourceForEditIfNeeded(topLevelResource);
+        registeredResources.add(topLevelResource);
     }
 
     public void registerResource(@Nonnull final YamlReference.YamlResource resource) throws RelationalException {
+        if (resource == topLevelResource) {
+            return;
+        }
         if (registeredResources.contains(resource)) {
             throw new RuntimeException("The resource " + resource + " is already registered.");
         }
-        if (shouldCorrectExplains() || shouldCorrectResultMetadata() || shouldAddResultMetadata() || shouldAddExplains()) {
-            this.editedFileStream.put(resource, loadYamlResource(resource));
-        }
-        if (this.expectedMetricsMap == null) {
-            this.expectedMetricsMap = loadMetricsResource(resource);
-            this.actualMetricsMap = new TreeMap<>(Comparator.comparing(QueryAndLocation::getReference)
-                    .thenComparing(QueryAndLocation::getBlockName)
-                    .thenComparing(QueryAndLocation::getQuery));
-        }
+        loadResourceForEditIfNeeded(resource);
         registeredResources.add(resource);
+    }
+
+    private void loadResourceForEditIfNeeded(@Nonnull YamlReference.YamlResource resource) throws RelationalException {
+        if (shouldCorrectExplains() || shouldCorrectResultMetadata() || shouldAddResultMetadata() || shouldAddExplains()) {
+            filesMaintainer.loadFile(resource);
+        }
     }
 
     public void setConnectionOptions(@Nonnull final Options connectionOptions) {
@@ -202,355 +172,14 @@ public final class YamlExecutionContext {
         return additionalOptions.getOrDefault(OPTION_ADD_EXPLAIN, false);
     }
 
-    public boolean correctResultMetadata(@Nonnull final YamlReference reference,
-                                         @Nonnull final List<CheckResultMetadataConfig.ColumnDescriptor> actualColumns) {
-        if (!shouldCorrectResultMetadata()) {
-            return false;
-        }
-        if (editedFileStream.get(reference.getResource()) == null) {
-            return false;
-        }
-        synchronized (this) {
-            pendingCorrections
-                    .computeIfAbsent(reference.getResource(), k -> new ArrayList<>())
-                    .add(new MetadataCorrection(reference, new ArrayList<>(actualColumns)));
-            isDirty.put(reference.getResource(), true);
-        }
-        return true;
+    @Nonnull
+    public YamlMetricsMaintainer getMetricsMaintainer() {
+        return metricsMaintainer;
     }
 
-    public boolean addResultMetadata(@Nonnull final YamlReference queryReference,
-                                     @Nonnull final List<CheckResultMetadataConfig.ColumnDescriptor> actualColumns) {
-        if (!shouldAddResultMetadata()) {
-            return false;
-        }
-        if (editedFileStream.get(queryReference.getResource()) == null) {
-            return false;
-        }
-        synchronized (this) {
-            final List<YamlCorrection> corrections = pendingCorrections
-                    .computeIfAbsent(queryReference.getResource(), k -> new ArrayList<>());
-            // Deduplicate: if a correction for this query line is already pending, skip.
-            // The query could run multiple times depending on repetition, and each of the run calls addResultMetadata independently.
-            // Since the YAML file is parsed only once at the start, all runs see the same parsed config with no resultMetadata yet,
-            // and all queue a correction. The deduplication check prevents all but the first correct from being added.
-            final int lineNumber = queryReference.getLineNumber();
-            final boolean alreadyPending = corrections.stream()
-                    .anyMatch(c -> c instanceof AddMetadataCorrection && c.getLineNumber() == lineNumber);
-            if (!alreadyPending) {
-                corrections.add(new AddMetadataCorrection(queryReference, new ArrayList<>(actualColumns)));
-                isDirty.put(queryReference.getResource(), true);
-            }
-        }
-        return true;
-    }
-
-    public boolean correctExplain(@Nonnull final YamlReference reference, @Nonnull String actual) {
-        if (!shouldCorrectExplains() && !shouldAddExplains()) {
-            return false;
-        }
-        if (editedFileStream.get(reference.getResource()) == null) {
-            return false;
-        }
-        synchronized (this) {
-            pendingCorrections
-                    .computeIfAbsent(reference.getResource(), k -> new ArrayList<>())
-                    .add(new ExplainCorrection(reference, actual));
-            isDirty.put(reference.getResource(), true);
-        }
-        return true;
-    }
-
-    private void applyPendingCorrections(@Nonnull final YamlReference.YamlResource resource) {
-        final List<YamlCorrection> corrections = pendingCorrections.get(resource);
-        if (corrections == null || corrections.isEmpty()) {
-            return;
-        }
-        final List<String> lines = editedFileStream.get(resource);
-        if (lines == null) {
-            return;
-        }
-        // Sort descending by line number so each edit only shifts lines that have already been processed.
-        corrections.sort(Comparator.comparingInt(c -> -c.getLineNumber()));
-        for (final YamlCorrection correction : corrections) {
-            correction.apply(lines);
-        }
-    }
-
-    /**
-     * Replaces a single {@code explain:} line in the YAMSQL source file.
-     */
-    public static final class ExplainCorrection implements YamlCorrection {
-        @Nonnull
-        private final YamlReference reference;
-        @Nonnull
-        private final String actual;
-
-        ExplainCorrection(@Nonnull final YamlReference reference, @Nonnull final String actual) {
-            this.reference = reference;
-            this.actual = actual;
-        }
-
-        @Override
-        public int getLineNumber() {
-            return reference.getLineNumber();
-        }
-
-        @Override
-        public void apply(@Nonnull final List<String> lines) {
-            final int idx = reference.getLineNumber() - 1;
-            if (idx >= 0 && idx < lines.size()) {
-                final String itemPrefix = " ".repeat(indentOf(lines.get(idx)));
-                lines.set(idx, itemPrefix + "- explain: \"" + actual + "\"");
-            }
-        }
-    }
-
-    /**
-     * Replaces a {@code resultMetadata:} block in the YAMSQL source file with the actual column descriptors.
-     */
-    public static final class MetadataCorrection implements YamlCorrection {
-        @Nonnull
-        private final YamlReference reference;
-        @Nonnull
-        private final List<CheckResultMetadataConfig.ColumnDescriptor> actualColumns;
-
-        MetadataCorrection(@Nonnull final YamlReference reference,
-                           @Nonnull final List<CheckResultMetadataConfig.ColumnDescriptor> actualColumns) {
-            this.reference = reference;
-            this.actualColumns = actualColumns;
-        }
-
-        @Override
-        public int getLineNumber() {
-            return reference.getLineNumber();
-        }
-
-        @Override
-        public void apply(@Nonnull final List<String> lines) {
-            final int startIdx = reference.getLineNumber() - 1; // 1-based → 0-based
-            if (startIdx < 0 || startIdx >= lines.size()) {
-                return;
-            }
-            final String startLine = lines.get(startIdx);
-            final int indent = indentOf(startLine);
-
-            // Build replacement lines
-            final List<String> newLines = new ArrayList<>();
-            final String itemPrefix = " ".repeat(indent);
-            final String cols = actualColumns.stream().map(YamlExecutionContext::buildInlineDescriptor)
-                    .collect(Collectors.joining(", "));
-            newLines.add(itemPrefix + "- resultMetadata: [" + cols + "]");
-
-            // Find the end of the existing resultMetadata block
-            int endIdx = startIdx + 1;
-            while (endIdx < lines.size()) {
-                final String line = lines.get(endIdx);
-                if (line.isBlank()) {
-                    endIdx++;
-                    continue;
-                }
-                if (indentOf(line) > indent) {
-                    endIdx++;
-                } else {
-                    break;
-                }
-            }
-
-            lines.subList(startIdx, endIdx).clear();
-            lines.addAll(startIdx, newLines);
-        }
-    }
-
-    /**
-     * Builds a single-line inline YAML representation for a {@link CheckResultMetadataConfig.ColumnDescriptor}.
-     * <ul>
-     *   <li>Scalar column: {@code {NAME: TYPE}}</li>
-     *   <li>Struct column (no type name): {@code {NAME: [{FIELD: TYPE}, ...]}}</li>
-     *   <li>Struct column (with type name): {@code {NAME: [structTypeName, {FIELD: TYPE}, ...]}}</li>
-     *   <li>Array-of-scalar column: {@code {NAME: {array: TYPE}}}</li>
-     *   <li>Array-of-array column: {@code {NAME: {array: {array: TYPE}}}}</li>
-     *   <li>Array-of-struct column (no type name): {@code {NAME: {array: [{FIELD: TYPE}, ...]}}}</li>
-     *   <li>Array-of-struct column (with type name): {@code {NAME: {array: [structTypeName, {FIELD: TYPE}, ...]}}}</li>
-     * </ul>
-     */
-    static String buildInlineDescriptor(@Nonnull final CheckResultMetadataConfig.ColumnDescriptor col) {
-        if (col.isArray && col.fields != null) {
-            final String typePrefix = col.structTypeName != null ? col.structTypeName + ", " : "";
-            final String fields = col.fields.stream().map(YamlExecutionContext::buildInlineDescriptor)
-                    .collect(Collectors.joining(", "));
-            return "{" + col.name + ": {array: [" + typePrefix + fields + "]}}";
-        } else if (col.fields != null) {
-            final String typePrefix = col.structTypeName != null ? col.structTypeName + ", " : "";
-            final String fields = col.fields.stream().map(YamlExecutionContext::buildInlineDescriptor)
-                    .collect(Collectors.joining(", "));
-            return "{" + col.name + ": [" + typePrefix + fields + "]}";
-        } else {
-            return "{" + col.name + ": " + typeNameToInlineValue(col.typeName) + "}";
-        }
-    }
-
-    /**
-     * Converts an SQL array type name (e.g., {@code "ARRAY(INTEGER)"}) to its {@code {array: ...}} inline YAML
-     * representation. Non-array type names are returned unchanged.
-     * <ul>
-     *   <li>{@code "ARRAY(INTEGER)"} → {@code "{array: INTEGER}"}</li>
-     *   <li>{@code "ARRAY(ARRAY(INTEGER))"} → {@code "{array: {array: INTEGER}}"}</li>
-     *   <li>{@code "BIGINT"} → {@code "BIGINT"}</li>
-     * </ul>
-     */
-    static String typeNameToInlineValue(@Nonnull final String typeName) {
-        if (typeName.startsWith("ARRAY(") && typeName.endsWith(")")) {
-            final String inner = typeName.substring(6, typeName.length() - 1);
-            return "{array: " + typeNameToInlineValue(inner) + "}";
-        }
-        return typeName;
-    }
-
-    static int indentOf(@Nonnull final String line) {
-        int indent = 0;
-        while (indent < line.length() && line.charAt(indent) == ' ') {
-            indent++;
-        }
-        return indent;
-    }
-
-    static int findInsertionPoint(@Nonnull final List<String> lines, final int startIdx,
-                                  @Nonnull final String itemPrefix,
-                                  @Nonnull final Predicate<String> stopAt) {
-        for (int i = startIdx; i < lines.size(); i++) {
-            final String line = lines.get(i);
-            if (stopAt.test(line)) {
-                return i;
-            }
-            if (!itemPrefix.isEmpty() && line.length() >= itemPrefix.length() && !line.startsWith(itemPrefix)) {
-                break;
-            }
-        }
-        return startIdx;
-    }
-
-    /**
-     * Inserts a new {@code resultMetadata:} block into the YAMSQL source file immediately after the {@code query:} line.
-     * Used when {@link #OPTION_ADD_RESULT_METADATA} is set and the query had no {@code resultMetadata:} block.
-     */
-    public static final class AddMetadataCorrection implements YamlCorrection {
-        @Nonnull
-        private final YamlReference queryReference;
-        @Nonnull
-        private final List<CheckResultMetadataConfig.ColumnDescriptor> actualColumns;
-
-        AddMetadataCorrection(@Nonnull final YamlReference queryReference,
-                              @Nonnull final List<CheckResultMetadataConfig.ColumnDescriptor> actualColumns) {
-            this.queryReference = queryReference;
-            this.actualColumns = actualColumns;
-        }
-
-        @Override
-        public int getLineNumber() {
-            return queryReference.getLineNumber();
-        }
-
-        @Override
-        public void apply(@Nonnull final List<String> lines) {
-            final int queryLineIdx = queryReference.getLineNumber() - 1; // 1-based → 0-based
-            if (queryLineIdx < 0 || queryLineIdx >= lines.size()) {
-                return;
-            }
-            final String itemPrefix = " ".repeat(indentOf(lines.get(queryLineIdx)));
-            final String cols = actualColumns.stream().map(YamlExecutionContext::buildInlineDescriptor)
-                    .collect(Collectors.joining(", "));
-            // Insert just before the first result:/unorderedResult: config, so that explain:/planHash: lines
-            // that follow the query line are not displaced. Falls back to right after the query line.
-            final int insertIdx = findInsertionPoint(lines, queryLineIdx + 1, itemPrefix,
-                    line -> line.startsWith(itemPrefix + "- result:") || line.startsWith(itemPrefix + "- unorderedResult:"));
-            lines.add(insertIdx, itemPrefix + "- resultMetadata: [" + cols + "]");
-        }
-    }
-
-    public boolean addExplain(@Nonnull final YamlReference queryReference, @Nonnull String actual) {
-        if (!shouldAddExplains()) {
-            return false;
-        }
-        if (editedFileStream.get(queryReference.getResource()) == null) {
-            return false;
-        }
-        synchronized (this) {
-            final List<YamlCorrection> corrections = pendingCorrections
-                    .computeIfAbsent(queryReference.getResource(), k -> new ArrayList<>());
-            final int lineNumber = queryReference.getLineNumber();
-            final boolean alreadyPending = corrections.stream()
-                    .anyMatch(c -> c instanceof AddExplainCorrection && c.getLineNumber() == lineNumber);
-            if (!alreadyPending) {
-                corrections.add(new AddExplainCorrection(queryReference, actual));
-                isDirty.put(queryReference.getResource(), true);
-            }
-        }
-        return true;
-    }
-
-    int pendingAddExplainCorrectionCount(@Nonnull final YamlReference.YamlResource resource) {
-        final List<YamlCorrection> corrections = pendingCorrections.get(resource);
-        if (corrections == null) {
-            return 0;
-        }
-        return (int) corrections.stream().filter(c -> c instanceof AddExplainCorrection).count();
-    }
-
-    /**
-     * Inserts a new {@code explain:} line into the YAMSQL source file immediately before the first config entry
-     * that follows the {@code query:} line. Used when {@link #OPTION_ADD_EXPLAIN} is set and the query had no
-     * {@code explain:} block.
-     */
-    public static final class AddExplainCorrection implements YamlCorrection {
-        @Nonnull
-        private final YamlReference queryReference;
-        @Nonnull
-        private final String actual;
-
-        public AddExplainCorrection(@Nonnull final YamlReference queryReference, @Nonnull final String actual) {
-            this.queryReference = queryReference;
-            this.actual = actual;
-        }
-
-        @Override
-        public int getLineNumber() {
-            return queryReference.getLineNumber();
-        }
-
-        @Override
-        public void apply(@Nonnull final List<String> lines) {
-            final int queryLineIdx = queryReference.getLineNumber() - 1; // 1-based → 0-based
-            if (queryLineIdx < 0 || queryLineIdx >= lines.size()) {
-                return;
-            }
-            final String itemPrefix = " ".repeat(indentOf(lines.get(queryLineIdx)));
-            // Scan forward past any query-string continuation lines to find the first config entry
-            // at the same indentation level, and insert the explain line before it.
-            final int insertIdx = findInsertionPoint(lines, queryLineIdx + 1, itemPrefix,
-                    line -> line.startsWith(itemPrefix + "- "));
-            lines.add(insertIdx, itemPrefix + "- explain: \"" + actual + "\"");
-        }
-    }
-
-    @Nullable
-    public ImmutableMap<PlannerMetricsProto.Identifier, PlannerMetricsProto.Info> getMetricsMap() {
-        return expectedMetricsMap;
-    }
-
-    @Nullable
-    @SuppressWarnings("UnusedReturnValue")
-    public synchronized PlannerMetricsProto.Info putMetrics(@Nonnull final String blockName,
-                                                            @Nonnull final String query,
-                                                            @Nonnull final YamlReference reference,
-                                                            @Nonnull final PlannerMetricsProto.Info info,
-                                                            @Nonnull final List<String> setups) {
-        return actualMetricsMap.put(new QueryAndLocation(blockName, query, reference, setups), info);
-    }
-
-    @SuppressWarnings("UnusedReturnValue")
-    public synchronized void markDirty() {
-        this.isDirtyMetrics = true;
+    @Nonnull
+    public YamlFilesMaintainer getFilesMaintainer() {
+        return filesMaintainer;
     }
 
     public static boolean isInCI() {
@@ -582,45 +211,8 @@ public final class YamlExecutionContext {
     }
 
     public void replaceFilesIfRequired() {
-        final var filePathsWithResourceCount = registeredResources.stream()
-                .map(YamlReference.YamlResource::getPath)
-                .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
-        for (final var resource: registeredResources) {
-            if (!isDirty.getOrDefault(resource, false)) {
-                continue;
-            }
-            // There could arise a common scenario where a YAMSQL file is "opened" as 2 separate resource, coming from
-            // different call stacks. If this file has an EXPLAIN, and warrants correction, that will be a problem if,
-            // for the 2 resources pointing to same file, there is some disagreement on the values. Ideally this should
-            // not happen however, I believe it's still a possibility, mainly with metrics, to be highly sensitive to
-            // the environment in which the query is running. Because of this reason, just fail if we found resources
-            // that are marked as dirty and pointing to the same file as any other (dirty or non-dirty) resource.
-            if (filePathsWithResourceCount.getOrDefault(resource.getPath(), 0L) > 1) {
-                Assertions.fail("Found duplicate entries for writing to file: " + resource.getPath());
-            }
-            // Apply buffered corrections (explain + result-metadata) in descending line-number order before saving.
-            applyPendingCorrections(resource);
-            saveYamlFile(resource);
-        }
-        if (!isDirtyMetrics) {
-            return;
-        }
-        saveMetricsAsBinaryProto();
-        saveMetricsAsYaml();
-    }
-
-    private void saveYamlFile(@Nonnull final YamlReference.YamlResource resource) {
-        try {
-            try (var writer = new PrintWriter(new FileWriter(Path.of(System.getProperty("user.dir")).resolve(Path.of("src", "test", "resources", resource.getPath())).toAbsolutePath().toString(), StandardCharsets.UTF_8))) {
-                for (var line : editedFileStream.get(resource)) {
-                    writer.println(line);
-                }
-            }
-            logger.info("🟢 Source file {} replaced.", resource.getPath());
-        } catch (IOException e) {
-            logger.error("⚠️ Source file {} could not be replaced with corrected file.", resource.getPath());
-            Assertions.fail(e);
-        }
+        metricsMaintainer.saveIfNeeded();
+        filesMaintainer.saveIfNeeded();
     }
 
     public void registerConnectionURI(@Nonnull YamlReference.YamlResource resource, @Nonnull String stringURI) {
@@ -791,129 +383,6 @@ public final class YamlExecutionContext {
         return additionalOptions.getOrDefault(option, defaultValue);
     }
 
-    private void saveMetricsAsBinaryProto() {
-        //
-        // It is possible that some queries are repeated within the same block. These explain queries, if served from
-        // the cache contain their original planner metrics when they were planned, thus they are identical and we
-        // pick one of them. If not served from the cache (for instance by explicitly switching it off) we should
-        // still see the same counters which is all we test for at this moment. If someone adds a testcase that
-        // switches off the cache, executes an explain, changes something about the schema and then runs the same
-        // query in the same block a second time, there will be pain. Don't do that! We log a warning for this case
-        // but continue.
-        //
-        final var condensedMetricsMap = new LinkedHashMap<PlannerMetricsProto.Identifier, PlannerMetricsProto.Info>();
-        for (final var entry : actualMetricsMap.entrySet()) {
-            final var queryAndLocation = entry.getKey();
-            final var identifier = queryAndLocation.getIdentifier();
-            if (condensedMetricsMap.containsKey(identifier)) {
-                logger.warn("⚠️ Repeated query in block {} at {}", queryAndLocation.getBlockName(),
-                        queryAndLocation.getReference());
-            } else {
-                condensedMetricsMap.put(identifier,
-                        entry.getValue());
-            }
-        }
-
-        final var fileName = Path.of(System.getProperty("user.dir"))
-                .resolve(Path.of("src", "test", "resources", metricsBinaryProtoFileName(topLevelResource.getPath())))
-                .toAbsolutePath().toString();
-        try (var fos = new FileOutputStream(fileName)) {
-            for (final var entry : condensedMetricsMap.entrySet()) {
-                PlannerMetricsProto.Entry.newBuilder()
-                        .setIdentifier(entry.getKey())
-                        .setInfo(entry.getValue())
-                        .build()
-                        .writeDelimitedTo(fos);
-            }
-            logger.info("🟢 Planner metrics file {} replaced.", fileName);
-        } catch (final IOException iOE) {
-            logger.error("⚠️ Source file {} could not be replaced with corrected file.", fileName);
-            Assertions.fail(iOE);
-        }
-    }
-
-    private void saveMetricsAsYaml() {
-        final var mmap = LinkedListMultimap.<String, Map<String, Object>>create();
-        for (final var entry : actualMetricsMap.entrySet()) {
-            final var identifier = entry.getKey().getIdentifier();
-            final var info = entry.getValue();
-            final var countersAndTimers = info.getCountersAndTimers();
-            final var infoMap = new LinkedHashMap<String, Object>();
-            infoMap.put("query", identifier.getQuery());
-            // only include setup if it is non-empty, in part so that the PR that adds setup doesn't change every
-            // metric in the yaml files
-            if (identifier.getSetupsCount() > 0) {
-                infoMap.put("setup", identifier.getSetupsList());
-            }
-            infoMap.put("ref", entry.getKey().getReference().toString());
-            infoMap.put("explain", info.getExplain());
-            infoMap.put("task_count", countersAndTimers.getTaskCount());
-            infoMap.put("task_total_time_ms", TimeUnit.NANOSECONDS.toMillis(countersAndTimers.getTaskTotalTimeNs()));
-            infoMap.put("transform_count", countersAndTimers.getTransformCount());
-            infoMap.put("transform_time_ms", TimeUnit.NANOSECONDS.toMillis(countersAndTimers.getTransformTimeNs()));
-            infoMap.put("transform_yield_count", countersAndTimers.getTransformYieldCount());
-            infoMap.put("insert_time_ms", TimeUnit.NANOSECONDS.toMillis(countersAndTimers.getInsertTimeNs()));
-            infoMap.put("insert_new_count", countersAndTimers.getInsertNewCount());
-            infoMap.put("insert_reused_count", countersAndTimers.getInsertReusedCount());
-            mmap.put(identifier.getBlockName(), infoMap);
-        }
-
-        final var fileName = Path.of(System.getProperty("user.dir"))
-                .resolve(Path.of("src", "test", "resources", metricsYamlFileName(topLevelResource.getPath())))
-                .toAbsolutePath().toString();
-        try (var fos = new FileOutputStream(fileName)) {
-            DumperOptions options = new DumperOptions();
-            options.setIndent(4);
-            options.setPrettyFlow(true);
-            options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
-            Yaml yaml = new Yaml(options);
-            yaml.dump(mmap.asMap(), new PrintWriter(fos, false, StandardCharsets.UTF_8));
-            logger.info("🟢 Planner metrics file {} replaced.", fileName);
-        } catch (final IOException iOE) {
-            logger.error("⚠️ Source file {} could not be replaced with corrected file.", fileName);
-            Assertions.fail(iOE);
-        }
-    }
-
-    @Nonnull
-    private static List<String> loadYamlResource(@Nonnull final YamlReference.YamlResource resource) throws RelationalException {
-        final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-        final List<String> inMemoryFile = new ArrayList<>();
-        try (BufferedReader bufferedReader =
-                     new BufferedReader(
-                             new InputStreamReader(Objects.requireNonNull(classLoader.getResourceAsStream(resource.getPath())),
-                                     StandardCharsets.UTF_8))) {
-            for (String line = bufferedReader.readLine(); line != null; line = bufferedReader.readLine()) {
-                inMemoryFile.add(line);
-            }
-        } catch (IOException e) {
-            throw new RelationalException(ErrorCode.INTERNAL_ERROR, e);
-        }
-        return inMemoryFile;
-    }
-
-    @Nonnull
-    private static ImmutableMap<PlannerMetricsProto.Identifier, PlannerMetricsProto.Info> loadMetricsResource(@Nonnull final YamlReference.YamlResource resource) throws RelationalException {
-        final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-        final var fis = classLoader.getResourceAsStream(metricsBinaryProtoFileName(resource.getPath()));
-        final var resultMapBuilder =
-                ImmutableMap.<PlannerMetricsProto.Identifier, PlannerMetricsProto.Info>builder();
-        if (fis == null) {
-            return resultMapBuilder.build();
-        }
-        try {
-            while (true) {
-                final var entry = PlannerMetricsProto.Entry.parseDelimitedFrom(fis);
-                if (entry == null) {
-                    return resultMapBuilder.build();
-                }
-                resultMapBuilder.put(entry.getIdentifier(), entry.getInfo());
-            }
-        } catch (final IOException e) {
-            throw new RelationalException(ErrorCode.INTERNAL_ERROR, e);
-        }
-    }
-
     /**
      * Loads metrics from a YAML file on disk.
      * This method provides YAML parsing capability for metrics diff analysis.
@@ -1051,75 +520,6 @@ public final class YamlExecutionContext {
             return ((Number) value).longValue();
         }
         throw new IllegalArgumentException("Expected numeric value for key: " + key + ", got: " + value);
-    }
-
-    @Nonnull
-    private static String metricsBinaryProtoFileName(@Nonnull final String resourcePath) {
-        return baseName(resourcePath) + ".metrics.binpb";
-    }
-
-    @Nonnull
-    private static String metricsYamlFileName(@Nonnull final String resourcePath) {
-        return baseName(resourcePath) + ".metrics.yaml";
-    }
-
-    @Nonnull
-    private static String baseName(@Nonnull final String resourcePath) {
-        final var tokens = resourcePath.split("\\.(?=[^\\.]+$)");
-        Verify.verify(tokens.length == 2);
-        Verify.verify("yamsql".equals(tokens[1]));
-        return tokens[0];
-    }
-
-    private static class QueryAndLocation {
-        @Nonnull
-        private final PlannerMetricsProto.Identifier identifier;
-        @Nonnull
-        private final YamlReference reference;
-
-        public QueryAndLocation(@Nonnull final String blockName, final String query, @Nonnull final YamlReference reference,
-                                @Nonnull List<String> setups) {
-            identifier = PlannerMetricsProto.Identifier.newBuilder()
-                    .setBlockName(blockName)
-                    .setQuery(query)
-                    .addAllSetups(setups)
-                    .build();
-            this.reference = reference;
-        }
-
-        @Nonnull
-        public PlannerMetricsProto.Identifier getIdentifier() {
-            return identifier;
-        }
-
-        @Nonnull
-        public String getBlockName() {
-            return identifier.getBlockName();
-        }
-
-        @Nonnull
-        public String getQuery() {
-            return identifier.getQuery();
-        }
-
-        @Nonnull
-        public YamlReference getReference() {
-            return reference;
-        }
-
-        @Override
-        public boolean equals(final Object o) {
-            if (!(o instanceof QueryAndLocation)) {
-                return false;
-            }
-            final QueryAndLocation that = (QueryAndLocation)o;
-            return reference.equals(that.reference) && Objects.equals(identifier, that.identifier);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(identifier, reference);
-        }
     }
 
     public static class ContextOptions {

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlExecutionContext.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlExecutionContext.java
@@ -124,7 +124,7 @@ public final class YamlExecutionContext {
 
     public void registerResource(@Nonnull final YamlReference.YamlResource resource) throws RelationalException {
         // topLevelResource is already registered in the constructor
-        if (resource == topLevelResource) {
+        if (topLevelResource.equals(resource)) {
             return;
         }
         if (registeredResources.contains(resource)) {

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlFilesMaintainer.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlFilesMaintainer.java
@@ -206,7 +206,7 @@ public class YamlFilesMaintainer {
         return inMemoryFile;
     }
 
-    private static final class ExplainCorrection implements YamlCorrection {
+    static final class ExplainCorrection implements YamlCorrection {
         @Nonnull
         private final YamlReference reference;
         @Nonnull
@@ -232,7 +232,7 @@ public class YamlFilesMaintainer {
         }
     }
 
-    public static final class AddExplainCorrection implements YamlCorrection {
+    static final class AddExplainCorrection implements YamlCorrection {
         @Nonnull
         private final YamlReference queryReference;
         @Nonnull
@@ -263,7 +263,7 @@ public class YamlFilesMaintainer {
         }
     }
 
-    public static final class MetadataCorrection implements YamlCorrection {
+    static final class MetadataCorrection implements YamlCorrection {
         @Nonnull
         private final YamlReference reference;
         @Nonnull
@@ -316,7 +316,7 @@ public class YamlFilesMaintainer {
         }
     }
 
-    public static final class AddMetadataCorrection implements YamlCorrection {
+    static final class AddMetadataCorrection implements YamlCorrection {
         @Nonnull
         private final YamlReference queryReference;
         @Nonnull

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlFilesMaintainer.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlFilesMaintainer.java
@@ -1,0 +1,420 @@
+/*
+ * YamlFileMaintainer.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.relational.yamltests;
+
+import com.apple.foundationdb.relational.api.exceptions.ErrorCode;
+import com.apple.foundationdb.relational.api.exceptions.RelationalException;
+import com.apple.foundationdb.relational.yamltests.command.queryconfigs.CheckResultMetadataConfig;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Assertions;
+
+import javax.annotation.Nonnull;
+import java.io.BufferedReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+/**
+ * Manages in-place corrections to {@code .yamsql} source files during a maintenance test run.
+ *
+ * <p>When a maintenance config (e.g. {@code CorrectExplains}, {@code AddExplains}) is active,
+ * this class loads each {@code .yamsql} file into an in-memory line buffer at test startup.
+ * As tests execute, correction requests ({@link #correctExplain}, {@link #addExplain},
+ * {@link #correctResultMetadata}, {@link #addResultMetadata}) queue {@link YamlCorrection}
+ * objects against that buffer. At teardown, {@link #saveIfNeeded()} sorts the pending
+ * corrections in descending line-number order — so later edits do not shift the offsets of
+ * earlier ones — applies them to the buffer, and writes the result back to the source tree.
+ */
+public class YamlFilesMaintainer {
+    private static final Logger logger = LogManager.getLogger(YamlFilesMaintainer.class);
+
+    @Nonnull
+    private final Map<YamlReference.YamlResource, List<String>> editedFileStream = new HashMap<>();
+    @Nonnull
+    private final Map<YamlReference.YamlResource, Boolean> isDirty = new HashMap<>();
+    /**
+     * Pending corrections (explain and result-metadata), buffered so they can be applied in descending
+     * line-number order to avoid stale-offset corruption when multiple corrections target the same file.
+     */
+    @Nonnull
+    private final Map<YamlReference.YamlResource, List<YamlCorrection>> pendingCorrections = new HashMap<>();
+
+    public void loadFile(@Nonnull YamlReference.YamlResource resource) throws RelationalException {
+        this.editedFileStream.put(resource, loadYamlResource(resource));
+    }
+
+    private void verifyFileLoaded(@Nonnull final YamlReference reference) {
+        if (editedFileStream.get(reference.getResource()) == null) {
+            throw new IllegalStateException("‼️ YAMSQL file not loaded for resource: " + reference.getResource());
+        }
+    }
+
+    public void correctResultMetadata(@Nonnull final YamlReference reference,
+                                      @Nonnull final List<CheckResultMetadataConfig.ColumnDescriptor> actualColumns) {
+        verifyFileLoaded(reference);
+        synchronized (this) {
+            pendingCorrections
+                    .computeIfAbsent(reference.getResource(), k -> new ArrayList<>())
+                    .add(new MetadataCorrection(reference, new ArrayList<>(actualColumns)));
+            isDirty.put(reference.getResource(), true);
+        }
+    }
+
+    public void addResultMetadata(@Nonnull final YamlReference queryReference,
+                                  @Nonnull final List<CheckResultMetadataConfig.ColumnDescriptor> actualColumns) {
+        verifyFileLoaded(queryReference);
+        synchronized (this) {
+            final List<YamlCorrection> corrections = pendingCorrections
+                    .computeIfAbsent(queryReference.getResource(), k -> new ArrayList<>());
+            // Deduplicate: if a correction for this query line is already pending, skip.
+            // The query could run multiple times depending on repetition, and each of the run calls addResultMetadata independently.
+            // Since the YAML file is parsed only once at the start, all runs see the same parsed config with no resultMetadata yet,
+            // and all queue a correction. The deduplication check prevents all but the first correct from being added.
+            final int lineNumber = queryReference.getLineNumber();
+            final boolean alreadyPending = corrections.stream()
+                    .anyMatch(c -> c instanceof YamlFilesMaintainer.AddMetadataCorrection && c.getLineNumber() == lineNumber);
+            if (!alreadyPending) {
+                corrections.add(new YamlFilesMaintainer.AddMetadataCorrection(queryReference, new ArrayList<>(actualColumns)));
+                isDirty.put(queryReference.getResource(), true);
+            }
+        }
+    }
+
+    public void correctExplain(@Nonnull final YamlReference reference, @Nonnull String actual) {
+        verifyFileLoaded(reference);
+        synchronized (this) {
+            pendingCorrections
+                    .computeIfAbsent(reference.getResource(), k -> new ArrayList<>())
+                    .add(new ExplainCorrection(reference, actual));
+            isDirty.put(reference.getResource(), true);
+        }
+    }
+
+    public void addExplain(@Nonnull final YamlReference queryReference, @Nonnull String actual) {
+        verifyFileLoaded(queryReference);
+        synchronized (this) {
+            final List<YamlCorrection> corrections = pendingCorrections
+                    .computeIfAbsent(queryReference.getResource(), k -> new ArrayList<>());
+            final int lineNumber = queryReference.getLineNumber();
+            final boolean alreadyPending = corrections.stream()
+                    .anyMatch(c -> c instanceof YamlFilesMaintainer.AddExplainCorrection && c.getLineNumber() == lineNumber);
+            if (!alreadyPending) {
+                corrections.add(new YamlFilesMaintainer.AddExplainCorrection(queryReference, actual));
+                isDirty.put(queryReference.getResource(), true);
+            }
+        }
+    }
+
+    private void applyPendingCorrections(@Nonnull final YamlReference.YamlResource resource) {
+        final List<YamlCorrection> corrections = pendingCorrections.get(resource);
+        if (corrections == null || corrections.isEmpty()) {
+            return;
+        }
+        final List<String> lines = editedFileStream.get(resource);
+        if (lines == null) {
+            return;
+        }
+        // Sort descending by line number so each edit only shifts lines that have already been processed.
+        corrections.sort(Comparator.comparingInt(c -> -c.getLineNumber()));
+        for (final YamlCorrection correction : corrections) {
+            correction.apply(lines);
+        }
+    }
+
+    public void saveIfNeeded() {
+        final var filePathsWithResourceCount = editedFileStream.keySet().stream()
+                .map(YamlReference.YamlResource::getPath)
+                .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+        for (final var resource: editedFileStream.keySet()) {
+            if (!isDirty.getOrDefault(resource, false)) {
+                continue;
+            }
+            // There could arise a common scenario where a YAMSQL file is "opened" as 2 separate resource, coming from
+            // different call stacks. If this file has an EXPLAIN, and warrants correction, that will be a problem if,
+            // for the 2 resources pointing to same file, there is some disagreement on the values. Ideally this should
+            // not happen however, I believe it's still a possibility, mainly with metrics, to be highly sensitive to
+            // the environment in which the query is running. Because of this reason, just fail if we found resources
+            // that are marked as dirty and pointing to the same file as any other (dirty or non-dirty) resource.
+            if (filePathsWithResourceCount.getOrDefault(resource.getPath(), 0L) > 1) {
+                Assertions.fail("Found duplicate entries for writing to file: " + resource.getPath());
+            }
+            // Apply buffered corrections (explain + result-metadata) in descending line-number order before saving.
+            applyPendingCorrections(resource);
+            saveYamlFile(resource);
+        }
+    }
+
+    private void saveYamlFile(@Nonnull final YamlReference.YamlResource resource) {
+        try {
+            try (var writer = new PrintWriter(new FileWriter(Path.of(System.getProperty("user.dir")).resolve(Path.of("src", "test", "resources", resource.getPath())).toAbsolutePath().toString(), StandardCharsets.UTF_8))) {
+                for (var line : editedFileStream.get(resource)) {
+                    writer.println(line);
+                }
+            }
+            logger.info("🟢 Source file {} replaced.", resource.getPath());
+        } catch (IOException e) {
+            logger.error("⚠️ Source file {} could not be replaced with corrected file.", resource.getPath());
+            Assertions.fail(e);
+        }
+    }
+
+    @Nonnull
+    private static List<String> loadYamlResource(@Nonnull final YamlReference.YamlResource resource) throws RelationalException {
+        final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        final List<String> inMemoryFile = new ArrayList<>();
+        try (BufferedReader bufferedReader =
+                     new BufferedReader(
+                             new InputStreamReader(Objects.requireNonNull(classLoader.getResourceAsStream(resource.getPath())),
+                                     StandardCharsets.UTF_8))) {
+            for (String line = bufferedReader.readLine(); line != null; line = bufferedReader.readLine()) {
+                inMemoryFile.add(line);
+            }
+        } catch (IOException e) {
+            throw new RelationalException(ErrorCode.INTERNAL_ERROR, e);
+        }
+        return inMemoryFile;
+    }
+
+    private static final class ExplainCorrection implements YamlCorrection {
+        @Nonnull
+        private final YamlReference reference;
+        @Nonnull
+        private final String actual;
+
+        ExplainCorrection(@Nonnull final YamlReference reference, @Nonnull final String actual) {
+            this.reference = reference;
+            this.actual = actual;
+        }
+
+        @Override
+        public int getLineNumber() {
+            return reference.getLineNumber();
+        }
+
+        @Override
+        public void apply(@Nonnull final List<String> lines) {
+            final int idx = reference.getLineNumber() - 1;
+            if (idx >= 0 && idx < lines.size()) {
+                final String itemPrefix = " ".repeat(indentOf(lines.get(idx)));
+                lines.set(idx, itemPrefix + "- explain: \"" + actual + "\"");
+            }
+        }
+    }
+
+    public static final class AddExplainCorrection implements YamlCorrection {
+        @Nonnull
+        private final YamlReference queryReference;
+        @Nonnull
+        private final String actual;
+
+        public AddExplainCorrection(@Nonnull final YamlReference queryReference, @Nonnull final String actual) {
+            this.queryReference = queryReference;
+            this.actual = actual;
+        }
+
+        @Override
+        public int getLineNumber() {
+            return queryReference.getLineNumber();
+        }
+
+        @Override
+        public void apply(@Nonnull final List<String> lines) {
+            final int queryLineIdx = queryReference.getLineNumber() - 1; // 1-based → 0-based
+            if (queryLineIdx < 0 || queryLineIdx >= lines.size()) {
+                return;
+            }
+            final String itemPrefix = " ".repeat(indentOf(lines.get(queryLineIdx)));
+            // Scan forward past any query-string continuation lines to find the first config entry
+            // at the same indentation level, and insert the explain line before it.
+            final int insertIdx = findInsertionPoint(lines, queryLineIdx + 1, itemPrefix,
+                    line -> line.startsWith(itemPrefix + "- "));
+            lines.add(insertIdx, itemPrefix + "- explain: \"" + actual + "\"");
+        }
+    }
+
+    public static final class MetadataCorrection implements YamlCorrection {
+        @Nonnull
+        private final YamlReference reference;
+        @Nonnull
+        private final List<CheckResultMetadataConfig.ColumnDescriptor> actualColumns;
+
+        MetadataCorrection(@Nonnull final YamlReference reference,
+                           @Nonnull final List<CheckResultMetadataConfig.ColumnDescriptor> actualColumns) {
+            this.reference = reference;
+            this.actualColumns = actualColumns;
+        }
+
+        @Override
+        public int getLineNumber() {
+            return reference.getLineNumber();
+        }
+
+        @Override
+        public void apply(@Nonnull final List<String> lines) {
+            final int startIdx = reference.getLineNumber() - 1; // 1-based → 0-based
+            if (startIdx < 0 || startIdx >= lines.size()) {
+                return;
+            }
+            final String startLine = lines.get(startIdx);
+            final int indent = indentOf(startLine);
+
+            // Build replacement lines
+            final List<String> newLines = new ArrayList<>();
+            final String itemPrefix = " ".repeat(indent);
+            final String cols = actualColumns.stream().map(YamlFilesMaintainer::buildInlineDescriptor)
+                    .collect(Collectors.joining(", "));
+            newLines.add(itemPrefix + "- resultMetadata: [" + cols + "]");
+
+            // Find the end of the existing resultMetadata block
+            int endIdx = startIdx + 1;
+            while (endIdx < lines.size()) {
+                final String line = lines.get(endIdx);
+                if (line.isBlank()) {
+                    endIdx++;
+                    continue;
+                }
+                if (indentOf(line) > indent) {
+                    endIdx++;
+                } else {
+                    break;
+                }
+            }
+
+            lines.subList(startIdx, endIdx).clear();
+            lines.addAll(startIdx, newLines);
+        }
+    }
+
+    public static final class AddMetadataCorrection implements YamlCorrection {
+        @Nonnull
+        private final YamlReference queryReference;
+        @Nonnull
+        private final List<CheckResultMetadataConfig.ColumnDescriptor> actualColumns;
+
+        AddMetadataCorrection(@Nonnull final YamlReference queryReference,
+                              @Nonnull final List<CheckResultMetadataConfig.ColumnDescriptor> actualColumns) {
+            this.queryReference = queryReference;
+            this.actualColumns = actualColumns;
+        }
+
+        @Override
+        public int getLineNumber() {
+            return queryReference.getLineNumber();
+        }
+
+        @Override
+        public void apply(@Nonnull final List<String> lines) {
+            final int queryLineIdx = queryReference.getLineNumber() - 1; // 1-based → 0-based
+            if (queryLineIdx < 0 || queryLineIdx >= lines.size()) {
+                return;
+            }
+            final String itemPrefix = " ".repeat(indentOf(lines.get(queryLineIdx)));
+            final String cols = actualColumns.stream().map(YamlFilesMaintainer::buildInlineDescriptor)
+                    .collect(Collectors.joining(", "));
+            // Insert just before the first result:/unorderedResult: config, so that explain:/planHash: lines
+            // that follow the query line are not displaced. Falls back to right after the query line.
+            final int insertIdx = findInsertionPoint(lines, queryLineIdx + 1, itemPrefix,
+                    line -> line.startsWith(itemPrefix + "- result:") || line.startsWith(itemPrefix + "- unorderedResult:"));
+            lines.add(insertIdx, itemPrefix + "- resultMetadata: [" + cols + "]");
+        }
+    }
+
+    private static int indentOf(@Nonnull final String line) {
+        int indent = 0;
+        while (indent < line.length() && line.charAt(indent) == ' ') {
+            indent++;
+        }
+        return indent;
+    }
+
+    private static int findInsertionPoint(@Nonnull final List<String> lines, final int startIdx,
+                                  @Nonnull final String itemPrefix,
+                                  @Nonnull final Predicate<String> stopAt) {
+        for (int i = startIdx; i < lines.size(); i++) {
+            final String line = lines.get(i);
+            if (stopAt.test(line)) {
+                return i;
+            }
+            if (!itemPrefix.isEmpty() && line.length() >= itemPrefix.length() && !line.startsWith(itemPrefix)) {
+                break;
+            }
+        }
+        return startIdx;
+    }
+
+    /**
+     * Builds a single-line inline YAML representation for a {@link CheckResultMetadataConfig.ColumnDescriptor}.
+     * <ul>
+     *   <li>Scalar column: {@code {NAME: TYPE}}</li>
+     *   <li>Struct column (no type name): {@code {NAME: [{FIELD: TYPE}, ...]}}</li>
+     *   <li>Struct column (with type name): {@code {NAME: [structTypeName, {FIELD: TYPE}, ...]}}</li>
+     *   <li>Array-of-scalar column: {@code {NAME: {array: TYPE}}}</li>
+     *   <li>Array-of-array column: {@code {NAME: {array: {array: TYPE}}}}</li>
+     *   <li>Array-of-struct column (no type name): {@code {NAME: {array: [{FIELD: TYPE}, ...]}}}</li>
+     *   <li>Array-of-struct column (with type name): {@code {NAME: {array: [structTypeName, {FIELD: TYPE}, ...]}}}</li>
+     * </ul>
+     */
+    private static String buildInlineDescriptor(@Nonnull final CheckResultMetadataConfig.ColumnDescriptor col) {
+        if (col.isArray && col.fields != null) {
+            final String typePrefix = col.structTypeName != null ? col.structTypeName + ", " : "";
+            final String fields = col.fields.stream().map(YamlFilesMaintainer::buildInlineDescriptor)
+                    .collect(Collectors.joining(", "));
+            return "{" + col.name + ": {array: [" + typePrefix + fields + "]}}";
+        } else if (col.fields != null) {
+            final String typePrefix = col.structTypeName != null ? col.structTypeName + ", " : "";
+            final String fields = col.fields.stream().map(YamlFilesMaintainer::buildInlineDescriptor)
+                    .collect(Collectors.joining(", "));
+            return "{" + col.name + ": [" + typePrefix + fields + "]}";
+        } else {
+            return "{" + col.name + ": " + typeNameToInlineValue(col.typeName) + "}";
+        }
+    }
+
+    /**
+     * Converts an SQL array type name (e.g., {@code "ARRAY(INTEGER)"}) to its {@code {array: ...}} inline YAML
+     * representation. Non-array type names are returned unchanged.
+     * <ul>
+     *   <li>{@code "ARRAY(INTEGER)"} → {@code "{array: INTEGER}"}</li>
+     *   <li>{@code "ARRAY(ARRAY(INTEGER))"} → {@code "{array: {array: INTEGER}}"}</li>
+     *   <li>{@code "BIGINT"} → {@code "BIGINT"}</li>
+     * </ul>
+     */
+    private static String typeNameToInlineValue(@Nonnull final String typeName) {
+        if (typeName.startsWith("ARRAY(") && typeName.endsWith(")")) {
+            final String inner = typeName.substring(6, typeName.length() - 1);
+            return "{array: " + typeNameToInlineValue(inner) + "}";
+        }
+        return typeName;
+    }
+}

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlFilesMaintainer.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlFilesMaintainer.java
@@ -112,9 +112,9 @@ public class YamlFilesMaintainer {
             // and all queue a correction. The deduplication check prevents all but the first correct from being added.
             final int lineNumber = queryReference.getLineNumber();
             final boolean alreadyPending = corrections.stream()
-                    .anyMatch(c -> c instanceof YamlFilesMaintainer.AddMetadataCorrection && c.getLineNumber() == lineNumber);
+                    .anyMatch(c -> c instanceof AddMetadataCorrection && c.getLineNumber() == lineNumber);
             if (!alreadyPending) {
-                corrections.add(new YamlFilesMaintainer.AddMetadataCorrection(queryReference, new ArrayList<>(actualColumns)));
+                corrections.add(new AddMetadataCorrection(queryReference, new ArrayList<>(actualColumns)));
                 isDirty.put(queryReference.getResource(), true);
             }
         }
@@ -137,9 +137,9 @@ public class YamlFilesMaintainer {
                     .computeIfAbsent(queryReference.getResource(), k -> new ArrayList<>());
             final int lineNumber = queryReference.getLineNumber();
             final boolean alreadyPending = corrections.stream()
-                    .anyMatch(c -> c instanceof YamlFilesMaintainer.AddExplainCorrection && c.getLineNumber() == lineNumber);
+                    .anyMatch(c -> c instanceof AddExplainCorrection && c.getLineNumber() == lineNumber);
             if (!alreadyPending) {
-                corrections.add(new YamlFilesMaintainer.AddExplainCorrection(queryReference, actual));
+                corrections.add(new AddExplainCorrection(queryReference, actual));
                 isDirty.put(queryReference.getResource(), true);
             }
         }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlFilesMaintainer.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlFilesMaintainer.java
@@ -56,6 +56,7 @@ import java.util.stream.Collectors;
  * corrections in descending line-number order — so later edits do not shift the offsets of
  * earlier ones — applies them to the buffer, and writes the result back to the source tree.
  */
+@SuppressWarnings({"PMD.GuardLogStatement"})
 public class YamlFilesMaintainer {
     private static final Logger logger = LogManager.getLogger(YamlFilesMaintainer.class);
 

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlFilesMaintainer.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlFilesMaintainer.java
@@ -25,6 +25,7 @@ import com.apple.foundationdb.relational.api.exceptions.RelationalException;
 import com.apple.foundationdb.relational.yamltests.command.queryconfigs.CheckResultMetadataConfig;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.assertj.core.util.VisibleForTesting;
 import org.junit.jupiter.api.Assertions;
 
 import javax.annotation.Nonnull;
@@ -70,6 +71,13 @@ public class YamlFilesMaintainer {
      */
     @Nonnull
     private final Map<YamlReference.YamlResource, List<YamlCorrection>> pendingCorrections = new HashMap<>();
+
+    @VisibleForTesting
+    @Nonnull
+    List<YamlCorrection> getPendingCorrections(@Nonnull final YamlReference.YamlResource resource) {
+        final List<YamlCorrection> corrections = pendingCorrections.get(resource);
+        return corrections != null ? corrections : List.of();
+    }
 
     public void loadFile(@Nonnull YamlReference.YamlResource resource) throws RelationalException {
         this.editedFileStream.put(resource, loadYamlResource(resource));

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlFilesMaintainer.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlFilesMaintainer.java
@@ -1,5 +1,5 @@
 /*
- * YamlFileMaintainer.java
+ * YamlFilesMaintainer.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlMetricsMaintainer.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlMetricsMaintainer.java
@@ -88,12 +88,15 @@ public class YamlMetricsMaintainer {
     private final Map<QueryAndLocation, PlannerMetricsProto.Info> actualMetricsMap;
     private volatile boolean isDirty = false;
 
+    private static final Comparator<QueryAndLocation> ACTUAL_METRICS_ORDER =
+            Comparator.comparing(QueryAndLocation::getReference)
+                    .thenComparing(QueryAndLocation::getBlockName)
+                    .thenComparing(QueryAndLocation::getQuery);
+
     public YamlMetricsMaintainer(@Nonnull YamlReference.YamlResource resource) throws RelationalException {
         this.resource = resource;
         this.expectedMetricsMap = loadMetricsResource(resource);
-        this.actualMetricsMap = new TreeMap<>(Comparator.comparing(QueryAndLocation::getReference)
-                .thenComparing(QueryAndLocation::getBlockName)
-                .thenComparing(QueryAndLocation::getQuery));
+        this.actualMetricsMap = new TreeMap<>(ACTUAL_METRICS_ORDER);
     }
 
     /** Testing constructor: bypasses file loading. */
@@ -101,9 +104,7 @@ public class YamlMetricsMaintainer {
                           @Nonnull ImmutableMap<PlannerMetricsProto.Identifier, PlannerMetricsProto.Info> expectedMetrics) {
         this.resource = resource;
         this.expectedMetricsMap = expectedMetrics;
-        this.actualMetricsMap = new TreeMap<>(Comparator.comparing(QueryAndLocation::getReference)
-                .thenComparing(QueryAndLocation::getBlockName)
-                .thenComparing(QueryAndLocation::getQuery));
+        this.actualMetricsMap = new TreeMap<>(ACTUAL_METRICS_ORDER);
     }
 
     @VisibleForTesting
@@ -126,7 +127,6 @@ public class YamlMetricsMaintainer {
         return expectedMetricsMap.get(identifier);
     }
 
-    @Nullable
     @SuppressWarnings("UnusedReturnValue")
     public synchronized PlannerMetricsProto.Info putMetrics(@Nonnull final PlannerMetricsProto.Identifier identifier,
                                                             @Nonnull final YamlReference reference,

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlMetricsMaintainer.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlMetricsMaintainer.java
@@ -1,5 +1,5 @@
 /*
- * YamlMetricsResource.java
+ * YamlMetricsMaintainer.java
  *
  * This source file is part of the FoundationDB open source project
  *
@@ -109,7 +109,6 @@ public class YamlMetricsMaintainer {
         return actualMetricsMap.put(new QueryAndLocation(blockName, query, reference, setups), info);
     }
 
-    @SuppressWarnings("UnusedReturnValue")
     public synchronized void markDirty() {
         this.isDirty = true;
     }
@@ -118,8 +117,8 @@ public class YamlMetricsMaintainer {
         if (!isDirty) {
             return;
         }
-        saveMetricsAsYaml();
         saveMetricsAsBinaryProto();
+        saveMetricsAsYaml();
     }
 
     private void saveMetricsAsBinaryProto() {

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlMetricsMaintainer.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlMetricsMaintainer.java
@@ -28,6 +28,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.LinkedListMultimap;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.assertj.core.util.VisibleForTesting;
 import org.junit.jupiter.api.Assertions;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
@@ -93,6 +94,31 @@ public class YamlMetricsMaintainer {
         this.actualMetricsMap = new TreeMap<>(Comparator.comparing(QueryAndLocation::getReference)
                 .thenComparing(QueryAndLocation::getBlockName)
                 .thenComparing(QueryAndLocation::getQuery));
+    }
+
+    /** Testing constructor: bypasses file loading. */
+    YamlMetricsMaintainer(@Nonnull YamlReference.YamlResource resource,
+                          @Nonnull ImmutableMap<PlannerMetricsProto.Identifier, PlannerMetricsProto.Info> expectedMetrics) {
+        this.resource = resource;
+        this.expectedMetricsMap = expectedMetrics;
+        this.actualMetricsMap = new TreeMap<>(Comparator.comparing(QueryAndLocation::getReference)
+                .thenComparing(QueryAndLocation::getBlockName)
+                .thenComparing(QueryAndLocation::getQuery));
+    }
+
+    @VisibleForTesting
+    boolean isMetricsDirty() {
+        return isDirty;
+    }
+
+    @VisibleForTesting
+    @Nullable
+    PlannerMetricsProto.Info getActualMetrics(@Nonnull final PlannerMetricsProto.Identifier identifier) {
+        return actualMetricsMap.entrySet().stream()
+                .filter(e -> e.getKey().getIdentifier().equals(identifier))
+                .map(Map.Entry::getValue)
+                .findFirst()
+                .orElse(null);
     }
 
     @Nullable

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlMetricsMaintainer.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlMetricsMaintainer.java
@@ -1,0 +1,299 @@
+/*
+ * YamlMetricsResource.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.relational.yamltests;
+
+import com.apple.foundationdb.relational.api.exceptions.ErrorCode;
+import com.apple.foundationdb.relational.api.exceptions.RelationalException;
+import com.apple.foundationdb.relational.yamltests.generated.stats.PlannerMetricsProto;
+import com.google.common.base.Verify;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.LinkedListMultimap;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Assertions;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Manages planner metrics for a single {@code .yamsql} test file across a test run.
+ *
+ * <p>At construction, the expected metrics are loaded from the companion
+ * {@code .metrics.binpb} binary proto file. During test execution, each {@code EXPLAIN} result
+ * is recorded via {@link #putMetrics} — either preserving the expected value on a match or
+ * storing the actual value on a mismatch. When a maintenance config is active
+ * (e.g. {@code CorrectMetrics}, {@code CorrectExplains}), {@link #markDirty()} signals that
+ * the on-disk files should be updated. At teardown, {@link #saveIfNeeded()} rewrites both the
+ * {@code .metrics.binpb} binary proto and the {@code .metrics.yaml} human-readable file with
+ * the accumulated actual metrics.
+ *
+ * <p>Only the fields listed in {@link #TRACKED_METRIC_FIELDS} are compared between runs;
+ * timing fields are stored for context but not checked.
+ */
+public class YamlMetricsMaintainer {
+    private static final Logger logger = LogManager.getLogger(YamlMetricsMaintainer.class);
+
+    /**
+     * List of metrics field names that are tracked for planner comparison.
+     * These are the core metrics that should be consistent between runs, excluding timing
+     * information which can vary.
+     */
+    public static final List<String> TRACKED_METRIC_FIELDS = List.of(
+            "task_count",
+            "transform_count",
+            "transform_yield_count",
+            "insert_new_count",
+            "insert_reused_count"
+    );
+
+    @Nonnull
+    private final YamlReference.YamlResource resource;
+    @Nonnull
+    private final ImmutableMap<PlannerMetricsProto.Identifier, PlannerMetricsProto.Info> expectedMetricsMap;
+    @Nonnull
+    private final Map<QueryAndLocation, PlannerMetricsProto.Info> actualMetricsMap;
+    private volatile boolean isDirty = false;
+
+    public YamlMetricsMaintainer(@Nonnull YamlReference.YamlResource resource) throws RelationalException {
+        this.resource = resource;
+        this.expectedMetricsMap = loadMetricsResource(resource);
+        this.actualMetricsMap = new TreeMap<>(Comparator.comparing(QueryAndLocation::getReference)
+                .thenComparing(QueryAndLocation::getBlockName)
+                .thenComparing(QueryAndLocation::getQuery));
+    }
+
+    @Nullable
+    public PlannerMetricsProto.Info getMetrics(@Nonnull PlannerMetricsProto.Identifier identifier) {
+        return expectedMetricsMap.get(identifier);
+    }
+
+    @Nullable
+    @SuppressWarnings("UnusedReturnValue")
+    public synchronized PlannerMetricsProto.Info putMetrics(@Nonnull final String blockName,
+                                                            @Nonnull final String query,
+                                                            @Nonnull final YamlReference reference,
+                                                            @Nonnull final PlannerMetricsProto.Info info,
+                                                            @Nonnull final List<String> setups) {
+        return actualMetricsMap.put(new QueryAndLocation(blockName, query, reference, setups), info);
+    }
+
+    @SuppressWarnings("UnusedReturnValue")
+    public synchronized void markDirty() {
+        this.isDirty = true;
+    }
+
+    public void saveIfNeeded() {
+        if (!isDirty) {
+            return;
+        }
+        saveMetricsAsYaml();
+        saveMetricsAsBinaryProto();
+    }
+
+    private void saveMetricsAsBinaryProto() {
+        //
+        // It is possible that some queries are repeated within the same block. These explain queries, if served from
+        // the cache contain their original planner metrics when they were planned, thus they are identical and we
+        // pick one of them. If not served from the cache (for instance by explicitly switching it off) we should
+        // still see the same counters which is all we test for at this moment. If someone adds a testcase that
+        // switches off the cache, executes an explain, changes something about the schema and then runs the same
+        // query in the same block a second time, there will be pain. Don't do that! We log a warning for this case
+        // but continue.
+        //
+        final var condensedMetricsMap = new LinkedHashMap<PlannerMetricsProto.Identifier, PlannerMetricsProto.Info>();
+        for (final var entry : actualMetricsMap.entrySet()) {
+            final var queryAndLocation = entry.getKey();
+            final var identifier = queryAndLocation.getIdentifier();
+            if (condensedMetricsMap.containsKey(identifier)) {
+                logger.warn("⚠️ Repeated query in block {} at {}", queryAndLocation.getBlockName(),
+                        queryAndLocation.getReference());
+            } else {
+                condensedMetricsMap.put(identifier,
+                        entry.getValue());
+            }
+        }
+
+        final var fileName = Path.of(System.getProperty("user.dir"))
+                .resolve(Path.of("src", "test", "resources", metricsBinaryProtoFileName(resource.getPath())))
+                .toAbsolutePath().toString();
+        try (var fos = new FileOutputStream(fileName)) {
+            for (final var entry : condensedMetricsMap.entrySet()) {
+                PlannerMetricsProto.Entry.newBuilder()
+                        .setIdentifier(entry.getKey())
+                        .setInfo(entry.getValue())
+                        .build()
+                        .writeDelimitedTo(fos);
+            }
+            logger.info("🟢 Planner metrics file {} replaced.", fileName);
+        } catch (final IOException iOE) {
+            logger.error("⚠️ Source file {} could not be replaced with corrected file.", fileName);
+            Assertions.fail(iOE);
+        }
+    }
+
+    private void saveMetricsAsYaml() {
+        final var mmap = LinkedListMultimap.<String, Map<String, Object>>create();
+        for (final var entry : actualMetricsMap.entrySet()) {
+            final var identifier = entry.getKey().getIdentifier();
+            final var info = entry.getValue();
+            final var countersAndTimers = info.getCountersAndTimers();
+            final var infoMap = new LinkedHashMap<String, Object>();
+            infoMap.put("query", identifier.getQuery());
+            // only include setup if it is non-empty, in part so that the PR that adds setup doesn't change every
+            // metric in the yaml files
+            if (identifier.getSetupsCount() > 0) {
+                infoMap.put("setup", identifier.getSetupsList());
+            }
+            infoMap.put("ref", entry.getKey().getReference().toString());
+            infoMap.put("explain", info.getExplain());
+            infoMap.put("task_count", countersAndTimers.getTaskCount());
+            infoMap.put("task_total_time_ms", TimeUnit.NANOSECONDS.toMillis(countersAndTimers.getTaskTotalTimeNs()));
+            infoMap.put("transform_count", countersAndTimers.getTransformCount());
+            infoMap.put("transform_time_ms", TimeUnit.NANOSECONDS.toMillis(countersAndTimers.getTransformTimeNs()));
+            infoMap.put("transform_yield_count", countersAndTimers.getTransformYieldCount());
+            infoMap.put("insert_time_ms", TimeUnit.NANOSECONDS.toMillis(countersAndTimers.getInsertTimeNs()));
+            infoMap.put("insert_new_count", countersAndTimers.getInsertNewCount());
+            infoMap.put("insert_reused_count", countersAndTimers.getInsertReusedCount());
+            mmap.put(identifier.getBlockName(), infoMap);
+        }
+
+        final var fileName = Path.of(System.getProperty("user.dir"))
+                .resolve(Path.of("src", "test", "resources", metricsYamlFileName(resource.getPath())))
+                .toAbsolutePath().toString();
+        try (var fos = new FileOutputStream(fileName)) {
+            DumperOptions options = new DumperOptions();
+            options.setIndent(4);
+            options.setPrettyFlow(true);
+            options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+            Yaml yaml = new Yaml(options);
+            yaml.dump(mmap.asMap(), new PrintWriter(fos, false, StandardCharsets.UTF_8));
+            logger.info("🟢 Planner metrics file {} replaced.", fileName);
+        } catch (final IOException iOE) {
+            logger.error("⚠️ Source file {} could not be replaced with corrected file.", fileName);
+            Assertions.fail(iOE);
+        }
+    }
+
+    @Nonnull
+    private static ImmutableMap<PlannerMetricsProto.Identifier, PlannerMetricsProto.Info> loadMetricsResource(@Nonnull final YamlReference.YamlResource resource) throws RelationalException {
+        final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        final var fis = classLoader.getResourceAsStream(metricsBinaryProtoFileName(resource.getPath()));
+        final var resultMapBuilder =
+                ImmutableMap.<PlannerMetricsProto.Identifier, PlannerMetricsProto.Info>builder();
+        if (fis == null) {
+            return resultMapBuilder.build();
+        }
+        try {
+            while (true) {
+                final var entry = PlannerMetricsProto.Entry.parseDelimitedFrom(fis);
+                if (entry == null) {
+                    return resultMapBuilder.build();
+                }
+                resultMapBuilder.put(entry.getIdentifier(), entry.getInfo());
+            }
+        } catch (final IOException e) {
+            throw new RelationalException(ErrorCode.INTERNAL_ERROR, e);
+        }
+    }
+
+    @Nonnull
+    private static String baseName(@Nonnull final String resourcePath) {
+        final var tokens = resourcePath.split("\\.(?=[^\\.]+$)");
+        Verify.verify(tokens.length == 2);
+        Verify.verify("yamsql".equals(tokens[1]));
+        return tokens[0];
+    }
+
+    @Nonnull
+    private static String metricsBinaryProtoFileName(@Nonnull final String resourcePath) {
+        return baseName(resourcePath) + ".metrics.binpb";
+    }
+
+    @Nonnull
+    private static String metricsYamlFileName(@Nonnull final String resourcePath) {
+        return baseName(resourcePath) + ".metrics.yaml";
+    }
+
+    private static class QueryAndLocation {
+        @Nonnull
+        private final PlannerMetricsProto.Identifier identifier;
+        @Nonnull
+        private final YamlReference reference;
+
+        public QueryAndLocation(@Nonnull final String blockName, final String query, @Nonnull final YamlReference reference,
+                                @Nonnull List<String> setups) {
+            identifier = PlannerMetricsProto.Identifier.newBuilder()
+                    .setBlockName(blockName)
+                    .setQuery(query)
+                    .addAllSetups(setups)
+                    .build();
+            this.reference = reference;
+        }
+
+        @Nonnull
+        public PlannerMetricsProto.Identifier getIdentifier() {
+            return identifier;
+        }
+
+        @Nonnull
+        public String getBlockName() {
+            return identifier.getBlockName();
+        }
+
+        @Nonnull
+        public String getQuery() {
+            return identifier.getQuery();
+        }
+
+        @Nonnull
+        public YamlReference getReference() {
+            return reference;
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (!(o instanceof QueryAndLocation)) {
+                return false;
+            }
+            final QueryAndLocation that = (QueryAndLocation)o;
+            return reference.equals(that.reference) && Objects.equals(identifier, that.identifier);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(identifier, reference);
+        }
+    }
+}

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlMetricsMaintainer.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlMetricsMaintainer.java
@@ -62,6 +62,7 @@ import java.util.concurrent.TimeUnit;
  * <p>Only the fields listed in {@link #TRACKED_METRIC_FIELDS} are compared between runs;
  * timing fields are stored for context but not checked.
  */
+@SuppressWarnings({"PMD.GuardLogStatement"})
 public class YamlMetricsMaintainer {
     private static final Logger logger = LogManager.getLogger(YamlMetricsMaintainer.class);
 
@@ -101,12 +102,10 @@ public class YamlMetricsMaintainer {
 
     @Nullable
     @SuppressWarnings("UnusedReturnValue")
-    public synchronized PlannerMetricsProto.Info putMetrics(@Nonnull final String blockName,
-                                                            @Nonnull final String query,
+    public synchronized PlannerMetricsProto.Info putMetrics(@Nonnull final PlannerMetricsProto.Identifier identifier,
                                                             @Nonnull final YamlReference reference,
-                                                            @Nonnull final PlannerMetricsProto.Info info,
-                                                            @Nonnull final List<String> setups) {
-        return actualMetricsMap.put(new QueryAndLocation(blockName, query, reference, setups), info);
+                                                            @Nonnull final PlannerMetricsProto.Info info) {
+        return actualMetricsMap.put(new QueryAndLocation(identifier, reference), info);
     }
 
     public synchronized void markDirty() {
@@ -251,13 +250,8 @@ public class YamlMetricsMaintainer {
         @Nonnull
         private final YamlReference reference;
 
-        public QueryAndLocation(@Nonnull final String blockName, final String query, @Nonnull final YamlReference reference,
-                                @Nonnull List<String> setups) {
-            identifier = PlannerMetricsProto.Identifier.newBuilder()
-                    .setBlockName(blockName)
-                    .setQuery(query)
-                    .addAllSetups(setups)
-                    .build();
+        public QueryAndLocation(@Nonnull final PlannerMetricsProto.Identifier identifier, @Nonnull final YamlReference reference) {
+            this.identifier = identifier;
             this.reference = reference;
         }
 

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/Command.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/Command.java
@@ -96,7 +96,7 @@ public abstract class Command {
                     return null;
             }
         } catch (Exception e) {
-            throw executionContext.wrapContext(e, () -> "‼️ Error parsing command at " + reference, "command", reference);
+            throw YamlExecutionContext.wrapContext(e, () -> "‼️ Error parsing command at " + reference, "command", reference);
         }
     }
 
@@ -104,7 +104,7 @@ public abstract class Command {
         try {
             executeInternal(connection);
         } catch (Throwable e) {
-            throw executionContext.wrapContext(e,
+            throw YamlExecutionContext.wrapContext(e,
                     () -> "‼️ Error executing command at " + getReference() + " against connection for versions " + connection.getVersions(),
                     "command", getReference());
         }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryCommand.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryCommand.java
@@ -99,7 +99,7 @@ public final class QueryCommand extends Command {
                     QueryConfig.parseConfigs(blockName, reference, queryConfigsWithValueList, executionContext);
 
             final List<QueryConfig> skipConfigs = configs.stream().filter(config -> config instanceof QueryConfig.SkipConfig)
-                    .collect(Collectors.toList());
+                    .toList();
             Assert.thatUnchecked(skipConfigs.size() < 2, "Query should not have more than one skip");
             if (!skipConfigs.isEmpty()) {
                 return new SkippedCommand(reference, executionContext,
@@ -155,7 +155,7 @@ public final class QueryCommand extends Command {
                             .anyMatch(config -> Objects.equals(config.getConfigName(), QueryConfig.QUERY_CONFIG_DEBUGGER));
             return new QueryCommand(reference, queryInterpreter, configs, executionContext, hasDebuggerConfig);
         } catch (Exception e) {
-            throw executionContext.wrapContext(e,
+            throw YamlExecutionContext.wrapContext(e,
                     () -> "‼️ Error parsing query command at " + reference, "query", reference);
         }
     }
@@ -193,7 +193,7 @@ public final class QueryCommand extends Command {
             throw tAE;
         } catch (Throwable e) {
             if (maybeExecutionThrowable.get() == null) {
-                maybeExecutionThrowable.set(executionContext.wrapContext(e,
+                maybeExecutionThrowable.set(YamlExecutionContext.wrapContext(e,
                         () -> "‼️ Error executing query command at " + getReference() + " against connection for versions " + connection.getVersions(),
                         String.format(Locale.ROOT, "query [%s] ", executor), getReference()));
             }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryConfig.java
@@ -362,12 +362,11 @@ public abstract class QueryConfig {
             @Override
             protected void checkResultInternal(@Nonnull String currentQuery, @Nonnull Object actual,
                                                @Nonnull String queryDescription, @Nonnull List<String> setups) throws SQLException {
-                if (actual instanceof RelationalResultSet) {
-                    final var resultSet = (RelationalResultSet) actual;
+                if (actual instanceof final RelationalResultSet resultSet) {
                     // slurp
                     boolean valid = true;
                     while (valid) { // suppress check style
-                        valid = ((RelationalResultSet) actual).next();
+                        valid = resultSet.next();
                     }
                     resultSet.close();
                 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryConfig.java
@@ -616,7 +616,7 @@ public abstract class QueryConfig {
     }
 
     static boolean shouldExecuteExplain(final YamlExecutionContext executionContext) {
-        return (! executionContext.getConnectionFactory().isMultiServer());
+        return (!executionContext.getConnectionFactory().isMultiServer());
     }
 
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryExecutor.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryExecutor.java
@@ -310,9 +310,7 @@ public class QueryExecutor {
                                                            final @Nonnull YamlConnection connection) throws SQLException {
         s.setMaxRows(FORCED_MAX_ROWS);
         Object result = executeStatement(s, statementHasQuery, queryString);
-        if (result instanceof RelationalResultSet) {
-            @SuppressWarnings("PMD.CloseResource")
-            RelationalResultSet resultSet = (RelationalResultSet)result;
+        if (result instanceof @SuppressWarnings("PMD.CloseResource") RelationalResultSet resultSet) {
             List<RelationalResultSet> results = new ArrayList<>();
             final RelationalResultSetMetaData metadata = resultSet.getMetaData(); // The first metadata will be used for all
             final boolean hasResult = resultSet.next(); // Initialize result set value retrieval. Has only one row.

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryInterpreter.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryInterpreter.java
@@ -338,7 +338,7 @@ public final class QueryInterpreter {
                 }
             }
         } catch (Exception e) {
-            throw executionContext.wrapContext(e, () -> String.format(Locale.ROOT, "‼️ Error initializing query executor for query %s at %s", query, reference), "query", reference);
+            throw YamlExecutionContext.wrapContext(e, () -> String.format(Locale.ROOT, "‼️ Error initializing query executor for query %s at %s", query, reference), "query", reference);
         }
     }
 

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/queryconfigs/CheckExplainConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/queryconfigs/CheckExplainConfig.java
@@ -56,6 +56,7 @@ import java.util.Objects;
  + * metrics, this will record the actual values via the {@link YamlExecutionContext}, which will save them when the
  + * test completes.
  + */
+@SuppressWarnings("PMD.AvoidCatchingThrowable")
 public class CheckExplainConfig extends QueryConfig {
 
     private static final Logger logger = LogManager.getLogger(CheckExplainConfig.class);

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/queryconfigs/CheckExplainConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/queryconfigs/CheckExplainConfig.java
@@ -95,7 +95,7 @@ public class CheckExplainConfig extends QueryConfig {
         } else if (!isExact) {
             checkExplainContains(queryDescription, actualPlannerMetricsInfo, expectedPlannerMetricsInfo);
         } else {
-            checkExplainAndMetrics(currentQuery, queryDescription, setups, actualPlannerMetricsInfo, expectedPlannerMetricsInfo);
+            checkExplainAndMetrics(queryDescription, identifier,  actualPlannerMetricsInfo, expectedPlannerMetricsInfo);
         }
     }
 
@@ -190,9 +190,8 @@ public class CheckExplainConfig extends QueryConfig {
         QueryCommand.reportTestFailure(diffMessage);
     }
 
-    private void checkExplainAndMetrics(@Nonnull final String currentQuery,
-                                        @Nonnull final String queryDescription,
-                                        @Nonnull final List<String> setups,
+    private void checkExplainAndMetrics(@Nonnull final String queryDescription,
+                                        @Nonnull final PlannerMetricsProto.Identifier identifier,
                                         @Nonnull final PlannerMetricsProto.Info actualPlannerMetricsInfo,
                                         @Nullable final PlannerMetricsProto.Info expectedPlannerMetricsInfo) {
         final var actualPlan = actualPlannerMetricsInfo.getExplain();
@@ -213,31 +212,36 @@ public class CheckExplainConfig extends QueryConfig {
         if (!actualPlannerMetricsInfo.hasCountersAndTimers()) {
             if (explainIsChanged && expectedPlannerMetricsInfo != null) {
                 final var expectedMetricsWithActualPlan = expectedPlannerMetricsInfo.toBuilder().setExplain(actualPlannerMetricsInfo.getExplain()).build();
-                executionContext.getMetricsMaintainer().putMetrics(blockName, currentQuery, getReference(), expectedMetricsWithActualPlan, setups);
-                executionContext.getMetricsMaintainer().markDirty();
+                recordMetrics(identifier, expectedMetricsWithActualPlan, true);
             }
         } else if (expectedPlannerMetricsInfo == null) {
             if (!executionContext.shouldCorrectMetrics()) {
                 QueryCommand.reportTestFailure("‼️ No planner metrics at " + getReference());
             }
-            executionContext.getMetricsMaintainer().putMetrics(blockName, currentQuery, getReference(), actualPlannerMetricsInfo, setups);
-            executionContext.getMetricsMaintainer().markDirty();
+            recordMetrics(identifier, actualPlannerMetricsInfo, true);
             logger.debug(() -> "⭐️ Successfully inserted new planner metrics at " + getReference());
         } else if (areMetricsDifferent(expectedPlannerMetricsInfo, actualPlannerMetricsInfo)) {
             if (!executionContext.shouldCorrectMetrics()) {
                 QueryCommand.reportTestFailure("‼️ Planner metrics have changed for " + getReference());
             }
-            executionContext.getMetricsMaintainer().putMetrics(blockName, currentQuery, getReference(), actualPlannerMetricsInfo, setups);
-            executionContext.getMetricsMaintainer().markDirty();
+            recordMetrics(identifier, actualPlannerMetricsInfo, true);
             logger.debug(() -> "⭐️ Successfully updated planner metrics at " + getReference());
         } else {
             if (explainIsChanged) {
                 final var expectedMetricsWithActualPlan = expectedPlannerMetricsInfo.toBuilder().setExplain(actualPlannerMetricsInfo.getExplain()).build();
-                executionContext.getMetricsMaintainer().putMetrics(blockName, currentQuery, getReference(), expectedMetricsWithActualPlan, setups);
-                executionContext.getMetricsMaintainer().markDirty();
+                recordMetrics(identifier, expectedMetricsWithActualPlan, true);
             } else {
-                executionContext.getMetricsMaintainer().putMetrics(blockName, currentQuery, getReference(), expectedPlannerMetricsInfo, setups);
+                recordMetrics(identifier, expectedPlannerMetricsInfo, false);
             }
+        }
+    }
+
+    private void recordMetrics(@Nonnull final PlannerMetricsProto.Identifier identifier,
+                               @Nonnull final PlannerMetricsProto.Info info,
+                               final boolean dirty) {
+        executionContext.getMetricsMaintainer().putMetrics(identifier, getReference(), info);
+        if (dirty) {
+            executionContext.getMetricsMaintainer().markDirty();
         }
     }
 

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/queryconfigs/CheckExplainConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/queryconfigs/CheckExplainConfig.java
@@ -22,8 +22,8 @@ package com.apple.foundationdb.relational.yamltests.command.queryconfigs;
 
 import com.apple.foundationdb.record.query.plan.cascades.debug.BrowserHelper;
 import com.apple.foundationdb.relational.api.RelationalResultSet;
-import com.apple.foundationdb.relational.api.RelationalStruct;
 import com.apple.foundationdb.relational.yamltests.MaintainYamlTestConfig;
+import com.apple.foundationdb.relational.yamltests.YamlMetricsMaintainer;
 import com.apple.foundationdb.relational.yamltests.YamlReference;
 import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
 import com.apple.foundationdb.relational.yamltests.command.CommandUtil;
@@ -82,141 +82,166 @@ public class CheckExplainConfig extends QueryConfig {
         logger.debug("⛳️ Matching plan for query '{}'", queryDescription);
         final var resultSet = (RelationalResultSet) actual;
         resultSet.next();
-        final var actualPlan = resultSet.getString(1);
-        final var actualDot = resultSet.getString(3);
-        final var metricsMap = executionContext.getMetricsMap();
+        final var actualPlannerMetricsInfo = createPlannerMetricsInfo(resultSet);
         final var identifier = PlannerMetricsProto.Identifier.newBuilder()
                 .setBlockName(blockName)
                 .setQuery(currentQuery)
                 .addAllSetups(setups)
                 .build();
-        final var expectedPlannerMetricsInfo = metricsMap.get(identifier);
+        final var expectedPlannerMetricsInfo = executionContext.getMetricsMaintainer().getMetrics(identifier);
 
-        final String expectedDot = expectedPlannerMetricsInfo == null ? null : expectedPlannerMetricsInfo.getDot();
-
-        checkExplain(queryDescription, actualPlan, actualDot, expectedDot);
-
-        final var actualPlannerMetrics = resultSet.getStruct(6);
-        if (isExact && getVal() != null && actualPlannerMetrics != null) {
-            Objects.requireNonNull(actualDot);
-            checkMetrics(currentQuery, setups, actualPlannerMetrics, expectedPlannerMetricsInfo, actualPlan, actualDot);
+        if (getVal() == null) {
+            addExplain(actualPlannerMetricsInfo);
+        } else if (!isExact) {
+            checkExplainContains(queryDescription, actualPlannerMetricsInfo, expectedPlannerMetricsInfo);
+        } else {
+            checkExplainAndMetrics(currentQuery, queryDescription, setups, actualPlannerMetricsInfo, expectedPlannerMetricsInfo);
         }
     }
 
-    private void checkExplain(final @Nonnull String queryDescription,
-                              final @Nonnull String actualPlan,
-                              final @Nullable String actualDot,
-                              final @Nullable String expectedDot) {
-        // Synthetic explain config (value==null): add the actual plan to the file without comparing.
-        if (getVal() == null) {
-            if (!executionContext.addExplain(getReference(), actualPlan)) {
-                QueryCommand.reportTestFailure("‼️ Cannot add explain plan at " + getReference());
-            } else {
-                logger.debug(() -> "⭐️ Successfully added plan at " + getReference());
-            }
+    private static PlannerMetricsProto.Info createPlannerMetricsInfo(@Nonnull final RelationalResultSet resultSet) throws SQLException {
+        final var builder = PlannerMetricsProto.Info.newBuilder();
+        final var plan = resultSet.getString(1);
+        if (plan == null) {
+            QueryCommand.reportTestFailure("‼️ EXPLAIN result is missing the plan string");
+        } else {
+            builder.setExplain(plan);
+        }
+        final var dot = resultSet.getString(3);
+        if (dot == null) {
+            QueryCommand.reportTestFailure("‼️ EXPLAIN result is missing the DOT representation");
+        } else {
+            builder.setDot(dot);
+        }
+        final var metricsStruct = resultSet.getStruct(6);
+        if (metricsStruct != null) {
+            final var taskCount = metricsStruct.getLong(1);
+            Verify.verify(taskCount > 0);
+            final var taskTotalTimeInNs = metricsStruct.getLong(2);
+            Verify.verify(taskTotalTimeInNs > 0);
+            builder.setCountersAndTimers(PlannerMetricsProto.CountersAndTimers.newBuilder()
+                    .setTaskCount(taskCount)
+                    .setTaskTotalTimeNs(taskTotalTimeInNs)
+                    .setTransformCount(metricsStruct.getLong(3))
+                    .setTransformTimeNs(metricsStruct.getLong(4))
+                    .setTransformYieldCount(metricsStruct.getLong(5))
+                    .setInsertTimeNs(metricsStruct.getLong(6))
+                    .setInsertNewCount(metricsStruct.getLong(7))
+                    .setInsertReusedCount(metricsStruct.getLong(8)));
+        }
+        return builder.build();
+    }
+
+    private void addExplain(@Nonnull final PlannerMetricsProto.Info actualPlannerMetricsInfo) {
+        executionContext.getFilesMaintainer().addExplain(getReference(), actualPlannerMetricsInfo.getExplain());
+        logger.debug(() -> "⭐️ Successfully added plan at " + getReference());
+    }
+
+    private void checkExplainContains(@Nonnull final String queryDescription,
+                                       @Nonnull final PlannerMetricsProto.Info actualPlannerMetricsInfo,
+                                       @Nullable final PlannerMetricsProto.Info expectedPlannerMetricsInfo) {
+        final var actualPlan = actualPlannerMetricsInfo.getExplain();
+        if (actualPlan.contains(Objects.requireNonNull((String) getVal()))) {
+            logger.debug("✅️ plan fragment match!");
+        } else {
+            showPlanDiffIfNeeded(queryDescription, actualPlannerMetricsInfo, expectedPlannerMetricsInfo);
+            calcPlanDiffAndReportFailure(actualPlan);
+        }
+    }
+
+    private void showPlanDiffIfNeeded(@Nonnull final String queryDescription,
+                                      @Nonnull final PlannerMetricsProto.Info actualPlannerMetricsInfo,
+                                      @Nullable final PlannerMetricsProto.Info expectedPlannerMetricsInfo) {
+        if (!executionContext.shouldShowPlanOnDiff()) {
             return;
         }
+        final var actualDot = actualPlannerMetricsInfo.getDot();
+        final var expectedDot = expectedPlannerMetricsInfo == null ? null : expectedPlannerMetricsInfo.getDot();
+        if (!actualDot.isEmpty() && expectedDot != null && !expectedDot.isEmpty()) {
+            BrowserHelper.browse("/showPlanDiff.html",
+                    ImmutableMap.of("$SQL", queryDescription,
+                            "$DOT_EXPECTED", expectedDot,
+                            "$DOT_ACTUAL", actualDot));
+        }
+    }
 
-        var success = isExact ? getVal().equals(actualPlan) : actualPlan.contains((String) getVal());
-        if (success) {
+    private void calcPlanDiffAndReportFailure(@Nonnull final String actualPlan) {
+        final var expectedPlan = getValueString();
+        final var diffGenerator = DiffRowGenerator.create()
+                .showInlineDiffs(true)
+                .inlineDiffByWord(true)
+                .newTag(f -> f ? CommandUtil.Color.RED.toString() : CommandUtil.Color.RESET.toString())
+                .oldTag(f -> f ? CommandUtil.Color.GREEN.toString() : CommandUtil.Color.RESET.toString())
+                .build();
+        final List<DiffRow> diffRows = diffGenerator.generateDiffRows(
+                Collections.singletonList(expectedPlan),
+                Collections.singletonList(actualPlan));
+        final var planDiffs = new StringBuilder();
+        for (final var diffRow : diffRows) {
+            planDiffs.append(diffRow.getOldLine()).append('\n').append(diffRow.getNewLine()).append('\n');
+        }
+        final var diffMessage = String.format(Locale.ROOT, "‼️ plan mismatch at %s:%n" +
+                "⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤%n%s" +
+                "⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤%n" +
+                "↪ expected plan %s:%n%s%n" +
+                "⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤%n" +
+                "↩ actual plan:%n%s",
+                getReference(), planDiffs, (!isExact ? "fragment" : ""), getValueString(), actualPlan);
+        QueryCommand.reportTestFailure(diffMessage);
+    }
+
+    private void checkExplainAndMetrics(@Nonnull final String currentQuery,
+                                        @Nonnull final String queryDescription,
+                                        @Nonnull final List<String> setups,
+                                        @Nonnull final PlannerMetricsProto.Info actualPlannerMetricsInfo,
+                                        @Nullable final PlannerMetricsProto.Info expectedPlannerMetricsInfo) {
+        final var actualPlan = actualPlannerMetricsInfo.getExplain();
+        var explainIsChanged = false;
+        if (Objects.requireNonNull(getVal()).equals(actualPlan)) {
             logger.debug("✅️ plan match!");
         } else {
-            if (executionContext.shouldShowPlanOnDiff() &&
-                    actualDot != null && expectedDot != null) {
-                BrowserHelper.browse("/showPlanDiff.html",
-                        ImmutableMap.of("$SQL", queryDescription,
-                                "$DOT_EXPECTED", expectedDot,
-                                "$DOT_ACTUAL", actualDot));
-            }
-
-            final var expectedPlan = getValueString();
-            final var diffGenerator = DiffRowGenerator.create()
-                    .showInlineDiffs(true)
-                    .inlineDiffByWord(true)
-                    .newTag(f -> f ? CommandUtil.Color.RED.toString() : CommandUtil.Color.RESET.toString())
-                    .oldTag(f -> f ? CommandUtil.Color.GREEN.toString() : CommandUtil.Color.RESET.toString())
-                    .build();
-            final List<DiffRow> diffRows = diffGenerator.generateDiffRows(
-                    Collections.singletonList(expectedPlan),
-                    Collections.singletonList(actualPlan));
-            final var planDiffs = new StringBuilder();
-            for (final var diffRow : diffRows) {
-                planDiffs.append(diffRow.getOldLine()).append('\n').append(diffRow.getNewLine()).append('\n');
-            }
-            if (isExact && (executionContext.shouldCorrectExplains() || executionContext.shouldAddExplains())) {
-                if (!executionContext.correctExplain(getReference(), actualPlan)) {
-                    QueryCommand.reportTestFailure("‼️ Cannot correct explain plan at " + getReference());
-                } else {
-                    logger.debug(() -> "⭐️ Successfully replaced plan at " + getReference());
-                }
+            showPlanDiffIfNeeded(queryDescription, actualPlannerMetricsInfo, expectedPlannerMetricsInfo);
+            if (executionContext.shouldCorrectExplains() || executionContext.shouldAddExplains()) {
+                executionContext.getFilesMaintainer().correctExplain(getReference(), actualPlan);
+                explainIsChanged = true;
+                logger.debug(() -> "⭐️ Successfully replaced plan at " + getReference());
             } else {
-                final var diffMessage = String.format(Locale.ROOT, "‼️ plan mismatch at %s:%n" +
-                        "⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤%n%s" +
-                        "⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤%n" +
-                        "↪ expected plan %s:%n%s%n" +
-                        "⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤%n" +
-                        "↩ actual plan:%n%s",
-                        getReference(), planDiffs, (!isExact ? "fragment" : ""), getValueString(), actualPlan);
-                QueryCommand.reportTestFailure(diffMessage);
+                calcPlanDiffAndReportFailure(actualPlan);
             }
         }
-    }
 
-    private void checkMetrics(final @Nonnull String currentQuery,
-                              final @Nonnull List<String> setups,
-                              final @Nonnull RelationalStruct actualPlannerMetrics,
-                              final @Nullable PlannerMetricsProto.Info expectedPlannerMetricsInfo,
-                              final @Nonnull String actualPlan,
-                              final @Nonnull String actualDot) throws SQLException {
-        final var taskCount = actualPlannerMetrics.getLong(1);
-        Verify.verify(taskCount > 0);
-        final var taskTotalTimeInNs = actualPlannerMetrics.getLong(2);
-        Verify.verify(taskTotalTimeInNs > 0);
-
-        if (expectedPlannerMetricsInfo == null && !executionContext.shouldCorrectMetrics()) {
-            QueryCommand.reportTestFailure("‼️ No planner metrics at " + getReference());
-        }
-        final var actualInfo = PlannerMetricsProto.Info.newBuilder()
-                .setExplain(actualPlan)
-                .setDot(actualDot)
-                .setCountersAndTimers(PlannerMetricsProto.CountersAndTimers.newBuilder()
-                                .setTaskCount(taskCount)
-                                .setTaskTotalTimeNs(taskTotalTimeInNs)
-                                .setTransformCount(actualPlannerMetrics.getLong(3))
-                                .setTransformTimeNs(actualPlannerMetrics.getLong(4))
-                                .setTransformYieldCount(actualPlannerMetrics.getLong(5))
-                                .setInsertTimeNs(actualPlannerMetrics.getLong(6))
-                                .setInsertNewCount(actualPlannerMetrics.getLong(7))
-                                .setInsertReusedCount(actualPlannerMetrics.getLong(8)))
-                .build();
-        if (expectedPlannerMetricsInfo == null) {
-            executionContext.putMetrics(blockName, currentQuery, getReference(), actualInfo, setups);
-            executionContext.markDirty();
+        if (!actualPlannerMetricsInfo.hasCountersAndTimers()) {
+            if (explainIsChanged && expectedPlannerMetricsInfo != null) {
+                final var expectedMetricsWithActualPlan = expectedPlannerMetricsInfo.toBuilder().setExplain(actualPlannerMetricsInfo.getExplain()).build();
+                executionContext.getMetricsMaintainer().putMetrics(blockName, currentQuery, getReference(), expectedMetricsWithActualPlan, setups);
+                executionContext.getMetricsMaintainer().markDirty();
+            }
+        } else if (expectedPlannerMetricsInfo == null) {
+            if (!executionContext.shouldCorrectMetrics()) {
+                QueryCommand.reportTestFailure("‼️ No planner metrics at " + getReference());
+            }
+            executionContext.getMetricsMaintainer().putMetrics(blockName, currentQuery, getReference(), actualPlannerMetricsInfo, setups);
+            executionContext.getMetricsMaintainer().markDirty();
             logger.debug(() -> "⭐️ Successfully inserted new planner metrics at " + getReference());
-        } else {
-            final var expectedCountersAndTimers = expectedPlannerMetricsInfo.getCountersAndTimers();
-            final var actualCountersAndTimers = actualInfo.getCountersAndTimers();
-            final var metricsDescriptor = expectedCountersAndTimers.getDescriptorForType();
-
-            if (areMetricsDifferent(expectedCountersAndTimers, actualCountersAndTimers, metricsDescriptor)) {
-                executionContext.putMetrics(blockName, currentQuery, getReference(), actualInfo, setups);
-                if (executionContext.shouldCorrectMetrics()) {
-                    executionContext.markDirty();
-                    logger.debug(() -> "⭐️ Successfully updated planner metrics at " + getReference());
-                } else {
-                    QueryCommand.reportTestFailure("‼️ Planner metrics have changed for " + getReference());
-                }
-            } else {
-                executionContext.putMetrics(blockName, currentQuery, getReference(), expectedPlannerMetricsInfo, setups);
+        } else if (areMetricsDifferent(expectedPlannerMetricsInfo, actualPlannerMetricsInfo)) {
+            if (!executionContext.shouldCorrectMetrics()) {
+                QueryCommand.reportTestFailure("‼️ Planner metrics have changed for " + getReference());
             }
+            executionContext.getMetricsMaintainer().putMetrics(blockName, currentQuery, getReference(), actualPlannerMetricsInfo, setups);
+            executionContext.getMetricsMaintainer().markDirty();
+            logger.debug(() -> "⭐️ Successfully updated planner metrics at " + getReference());
+        } else {
+            executionContext.getMetricsMaintainer().putMetrics(blockName, currentQuery, getReference(), expectedPlannerMetricsInfo, setups);
         }
     }
 
-    private boolean areMetricsDifferent(final PlannerMetricsProto.CountersAndTimers expectedCountersAndTimers,
-                                        final PlannerMetricsProto.CountersAndTimers actualCountersAndTimers,
-                                        final Descriptors.Descriptor metricsDescriptor) {
+    private boolean areMetricsDifferent(@Nonnull final PlannerMetricsProto.Info expectedPlannerMetricsInfo,
+                                        @Nonnull final PlannerMetricsProto.Info actualPlannerMetricsInfo) {
+        final var expectedCountersAndTimers = expectedPlannerMetricsInfo.getCountersAndTimers();
+        final var actualCountersAndTimers = actualPlannerMetricsInfo.getCountersAndTimers();
+        final var metricsDescriptor = expectedCountersAndTimers.getDescriptorForType();
         boolean different = false;
-        for (String fieldName : YamlExecutionContext.TRACKED_METRIC_FIELDS) {
+        for (String fieldName : YamlMetricsMaintainer.TRACKED_METRIC_FIELDS) {
             // Check each metric. Do NOT short-circuit because we want to log any metrics
             // that have changed (a side effect of isMetricDifferent)
             different |= isMetricDifferent(expectedCountersAndTimers, actualCountersAndTimers,

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/queryconfigs/CheckExplainConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/queryconfigs/CheckExplainConfig.java
@@ -226,13 +226,11 @@ public class CheckExplainConfig extends QueryConfig {
             }
             recordMetrics(identifier, actualPlannerMetricsInfo, true);
             logger.debug(() -> "⭐️ Successfully updated planner metrics at " + getReference());
+        } else if (explainIsChanged) {
+            final var expectedMetricsWithActualPlan = expectedPlannerMetricsInfo.toBuilder().setExplain(actualPlannerMetricsInfo.getExplain()).build();
+            recordMetrics(identifier, expectedMetricsWithActualPlan, true);
         } else {
-            if (explainIsChanged) {
-                final var expectedMetricsWithActualPlan = expectedPlannerMetricsInfo.toBuilder().setExplain(actualPlannerMetricsInfo.getExplain()).build();
-                recordMetrics(identifier, expectedMetricsWithActualPlan, true);
-            } else {
-                recordMetrics(identifier, expectedPlannerMetricsInfo, false);
-            }
+            recordMetrics(identifier, expectedPlannerMetricsInfo, false);
         }
     }
 

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/queryconfigs/CheckExplainConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/queryconfigs/CheckExplainConfig.java
@@ -91,11 +91,11 @@ public class CheckExplainConfig extends QueryConfig {
         final var expectedPlannerMetricsInfo = executionContext.getMetricsMaintainer().getMetrics(identifier);
 
         if (getVal() == null) {
-            addExplain(actualPlannerMetricsInfo);
+            addExplainAndMetrics(identifier, actualPlannerMetricsInfo);
         } else if (!isExact) {
             checkExplainContains(queryDescription, actualPlannerMetricsInfo, expectedPlannerMetricsInfo);
         } else {
-            checkExplainAndMetrics(queryDescription, identifier,  actualPlannerMetricsInfo, expectedPlannerMetricsInfo);
+            checkExplainAndMetrics(queryDescription, identifier, actualPlannerMetricsInfo, expectedPlannerMetricsInfo);
         }
     }
 
@@ -132,13 +132,16 @@ public class CheckExplainConfig extends QueryConfig {
         return builder.build();
     }
 
-    private void addExplain(@Nonnull final PlannerMetricsProto.Info actualPlannerMetricsInfo) {
+    private void addExplainAndMetrics(
+            @Nonnull final PlannerMetricsProto.Identifier identifier,
+            @Nonnull final PlannerMetricsProto.Info actualPlannerMetricsInfo) {
         try {
             executionContext.getFilesMaintainer().addExplain(getReference(), actualPlannerMetricsInfo.getExplain());
         } catch (Throwable throwable) {
             throw YamlExecutionContext.wrapContext(throwable, () -> "‼️ Cannot add explain", QUERY_CONFIG_EXPLAIN, getReference());
         }
         logger.debug(() -> "⭐️ Successfully added plan at " + getReference());
+        recordMetrics(identifier, actualPlannerMetricsInfo, true);
     }
 
     private void checkExplainContains(@Nonnull final String queryDescription,

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/queryconfigs/CheckExplainConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/queryconfigs/CheckExplainConfig.java
@@ -133,7 +133,11 @@ public class CheckExplainConfig extends QueryConfig {
     }
 
     private void addExplain(@Nonnull final PlannerMetricsProto.Info actualPlannerMetricsInfo) {
-        executionContext.getFilesMaintainer().addExplain(getReference(), actualPlannerMetricsInfo.getExplain());
+        try {
+            executionContext.getFilesMaintainer().addExplain(getReference(), actualPlannerMetricsInfo.getExplain());
+        } catch (Throwable throwable) {
+            throw YamlExecutionContext.wrapContext(throwable, () -> "‼️ Cannot add explain", QUERY_CONFIG_EXPLAIN, getReference());
+        }
         logger.debug(() -> "⭐️ Successfully added plan at " + getReference());
     }
 
@@ -201,7 +205,11 @@ public class CheckExplainConfig extends QueryConfig {
         } else {
             showPlanDiffIfNeeded(queryDescription, actualPlannerMetricsInfo, expectedPlannerMetricsInfo);
             if (executionContext.shouldCorrectExplains() || executionContext.shouldAddExplains()) {
-                executionContext.getFilesMaintainer().correctExplain(getReference(), actualPlan);
+                try {
+                    executionContext.getFilesMaintainer().correctExplain(getReference(), actualPlan);
+                } catch (Throwable throwable) {
+                    throw YamlExecutionContext.wrapContext(throwable, () -> "‼️ Cannot correct metrics", QUERY_CONFIG_EXPLAIN, getReference());
+                }
                 explainIsChanged = true;
                 logger.debug(() -> "⭐️ Successfully replaced plan at " + getReference());
             } else {
@@ -213,8 +221,7 @@ public class CheckExplainConfig extends QueryConfig {
         if (!actualPlannerMetricsInfo.hasCountersAndTimers()) {
             // In this case, if there are existing metrics and the plan is changed -> make sure to only update the plan
             if (explainIsChanged && expectedPlannerMetricsInfo != null) {
-                final var expectedMetricsWithActualPlan = expectedPlannerMetricsInfo.toBuilder().setExplain(actualPlannerMetricsInfo.getExplain()).build();
-                recordMetrics(identifier, expectedMetricsWithActualPlan, true);
+                correctExplainAndRecordMetrics(identifier, expectedPlannerMetricsInfo, actualPlannerMetricsInfo.getExplain());
             }
         // actual metrics are there, but existing metrics are not found -> case of new query / changed query
         } else if (expectedPlannerMetricsInfo == null) {
@@ -236,21 +243,29 @@ public class CheckExplainConfig extends QueryConfig {
             logger.debug(() -> "⭐️ Successfully updated planner metrics at " + getReference());
         // both actual and existing are there, and they match. However, the plan has some changes
         } else if (explainIsChanged) {
-            // make sure to only update the plan
-            final var expectedMetricsWithActualPlan = expectedPlannerMetricsInfo.toBuilder().setExplain(actualPlannerMetricsInfo.getExplain()).build();
-            recordMetrics(identifier, expectedMetricsWithActualPlan, true);
-        // Else, just preserve the existing metrics that we have gotten for this query
+            correctExplainAndRecordMetrics(identifier, expectedPlannerMetricsInfo, actualPlannerMetricsInfo.getExplain());
+            // Else, just preserve the existing metrics that we have gotten for this query
         } else {
             recordMetrics(identifier, expectedPlannerMetricsInfo, false);
         }
     }
 
+    private void correctExplainAndRecordMetrics(@Nonnull final PlannerMetricsProto.Identifier identifier,
+                               @Nonnull final PlannerMetricsProto.Info info, @Nonnull String plan) {
+        final var expectedMetricsWithActualPlan = info.toBuilder().setExplain(plan).build();
+        recordMetrics(identifier, expectedMetricsWithActualPlan, true);
+    }
+
     private void recordMetrics(@Nonnull final PlannerMetricsProto.Identifier identifier,
                                @Nonnull final PlannerMetricsProto.Info info,
                                final boolean dirty) {
-        executionContext.getMetricsMaintainer().putMetrics(identifier, getReference(), info);
-        if (dirty) {
-            executionContext.getMetricsMaintainer().markDirty();
+        try {
+            executionContext.getMetricsMaintainer().putMetrics(identifier, getReference(), info);
+            if (dirty) {
+                executionContext.getMetricsMaintainer().markDirty();
+            }
+        } catch (Throwable throwable) {
+            throw YamlExecutionContext.wrapContext(throwable, () -> "‼️ Cannot put metrics", QUERY_CONFIG_EXPLAIN, getReference());
         }
     }
 

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/queryconfigs/CheckExplainConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/queryconfigs/CheckExplainConfig.java
@@ -231,7 +231,13 @@ public class CheckExplainConfig extends QueryConfig {
             executionContext.getMetricsMaintainer().markDirty();
             logger.debug(() -> "⭐️ Successfully updated planner metrics at " + getReference());
         } else {
-            executionContext.getMetricsMaintainer().putMetrics(blockName, currentQuery, getReference(), expectedPlannerMetricsInfo, setups);
+            if (explainIsChanged) {
+                final var expectedMetricsWithActualPlan = expectedPlannerMetricsInfo.toBuilder().setExplain(actualPlannerMetricsInfo.getExplain()).build();
+                executionContext.getMetricsMaintainer().putMetrics(blockName, currentQuery, getReference(), expectedMetricsWithActualPlan, setups);
+                executionContext.getMetricsMaintainer().markDirty();
+            } else {
+                executionContext.getMetricsMaintainer().putMetrics(blockName, currentQuery, getReference(), expectedPlannerMetricsInfo, setups);
+            }
         }
     }
 

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/queryconfigs/CheckExplainConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/queryconfigs/CheckExplainConfig.java
@@ -247,7 +247,7 @@ public class CheckExplainConfig extends QueryConfig {
         // both actual and existing are there, and they match. However, the plan has some changes
         } else if (explainIsChanged) {
             correctExplainAndRecordMetrics(identifier, expectedPlannerMetricsInfo, actualPlannerMetricsInfo.getExplain());
-            // Else, just preserve the existing metrics that we have gotten for this query
+        // Else, just preserve the existing metrics that we have gotten for this query
         } else {
             recordMetrics(identifier, expectedPlannerMetricsInfo, false);
         }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/queryconfigs/CheckExplainConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/queryconfigs/CheckExplainConfig.java
@@ -209,26 +209,37 @@ public class CheckExplainConfig extends QueryConfig {
             }
         }
 
+        // No actual metrics to compare with
         if (!actualPlannerMetricsInfo.hasCountersAndTimers()) {
+            // In this case, if there are existing metrics and the plan is changed -> make sure to only update the plan
             if (explainIsChanged && expectedPlannerMetricsInfo != null) {
                 final var expectedMetricsWithActualPlan = expectedPlannerMetricsInfo.toBuilder().setExplain(actualPlannerMetricsInfo.getExplain()).build();
                 recordMetrics(identifier, expectedMetricsWithActualPlan, true);
             }
+        // actual metrics are there, but existing metrics are not found -> case of new query / changed query
         } else if (expectedPlannerMetricsInfo == null) {
+            // If we CANNOT correct metrics, error out since metrics are ALWAYS expected
             if (!executionContext.shouldCorrectMetrics()) {
                 QueryCommand.reportTestFailure("‼️ No planner metrics at " + getReference());
             }
+            // else, add the actual
             recordMetrics(identifier, actualPlannerMetricsInfo, true);
             logger.debug(() -> "⭐️ Successfully inserted new planner metrics at " + getReference());
+        // both actual and existing are there, but there are differences
         } else if (areMetricsDifferent(expectedPlannerMetricsInfo, actualPlannerMetricsInfo)) {
+            // If we CANNOT correct metrics, error out
             if (!executionContext.shouldCorrectMetrics()) {
                 QueryCommand.reportTestFailure("‼️ Planner metrics have changed for " + getReference());
             }
+            // else, add the actual
             recordMetrics(identifier, actualPlannerMetricsInfo, true);
             logger.debug(() -> "⭐️ Successfully updated planner metrics at " + getReference());
+        // both actual and existing are there, and they match. However, the plan has some changes
         } else if (explainIsChanged) {
+            // make sure to only update the plan
             final var expectedMetricsWithActualPlan = expectedPlannerMetricsInfo.toBuilder().setExplain(actualPlannerMetricsInfo.getExplain()).build();
             recordMetrics(identifier, expectedMetricsWithActualPlan, true);
+        // Else, just preserve the existing metrics that we have gotten for this query
         } else {
             recordMetrics(identifier, expectedPlannerMetricsInfo, false);
         }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/queryconfigs/CheckResultMetadataConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/queryconfigs/CheckResultMetadataConfig.java
@@ -248,12 +248,20 @@ public class CheckResultMetadataConfig extends QueryConfig {
     }
 
     private void addResultMetadata(@Nonnull final List<ColumnDescriptor> actualDescriptors) {
-        executionContext.getFilesMaintainer().addResultMetadata(getReference(), actualDescriptors);
+        try {
+            executionContext.getFilesMaintainer().addResultMetadata(getReference(), actualDescriptors);
+        } catch (Throwable throwable) {
+            throw YamlExecutionContext.wrapContext(throwable, () -> "‼️ Cannot add resultMetadata", QUERY_CONFIG_RESULT_METADATA, getReference());
+        }
         logger.debug(() -> "⭐️ Successfully added resultMetadata at " + getReference());
     }
 
     private void correctMetadata(@Nonnull final List<ColumnDescriptor> actualDescriptors) {
-        executionContext.getFilesMaintainer().correctResultMetadata(getReference(), actualDescriptors);
+        try {
+            executionContext.getFilesMaintainer().correctResultMetadata(getReference(), actualDescriptors);
+        } catch (Throwable throwable) {
+            throw YamlExecutionContext.wrapContext(throwable, () -> "‼️ Cannot correct resultMetadata", QUERY_CONFIG_RESULT_METADATA, getReference());
+        }
         logger.debug(() -> "⭐️ Successfully corrected resultMetadata at " + getReference());
     }
 

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/queryconfigs/CheckResultMetadataConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/queryconfigs/CheckResultMetadataConfig.java
@@ -66,7 +66,7 @@ import java.util.Map;
  *     YAMSQL source file to be updated with the actual column metadata rather than failing the test.
  * </p>
  */
-@SuppressWarnings("PMD.GuardLogStatement")
+@SuppressWarnings({"PMD.AvoidCatchingThrowable", "PMD.GuardLogStatement"})
 public class CheckResultMetadataConfig extends QueryConfig {
     private static final Logger logger = LogManager.getLogger(CheckResultMetadataConfig.class);
 

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/queryconfigs/CheckResultMetadataConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/queryconfigs/CheckResultMetadataConfig.java
@@ -248,19 +248,13 @@ public class CheckResultMetadataConfig extends QueryConfig {
     }
 
     private void addResultMetadata(@Nonnull final List<ColumnDescriptor> actualDescriptors) {
-        if (!executionContext.addResultMetadata(getReference(), actualDescriptors)) {
-            QueryCommand.reportTestFailure("‼️ Cannot add resultMetadata at " + getReference());
-        } else {
-            logger.debug(() -> "⭐️ Successfully added resultMetadata at " + getReference());
-        }
+        executionContext.getFilesMaintainer().addResultMetadata(getReference(), actualDescriptors);
+        logger.debug(() -> "⭐️ Successfully added resultMetadata at " + getReference());
     }
 
     private void correctMetadata(@Nonnull final List<ColumnDescriptor> actualDescriptors) {
-        if (!executionContext.correctResultMetadata(getReference(), actualDescriptors)) {
-            QueryCommand.reportTestFailure("‼️ Cannot correct resultMetadata at " + getReference());
-        } else {
-            logger.debug(() -> "⭐️ Successfully corrected resultMetadata at " + getReference());
-        }
+        executionContext.getFilesMaintainer().correctResultMetadata(getReference(), actualDescriptors);
+        logger.debug(() -> "⭐️ Successfully corrected resultMetadata at " + getReference());
     }
 
     private void reportMetadataMismatch(@Nonnull final List<Map<?, ?>> expectedColumns,

--- a/yaml-tests/src/test/java/com/apple/foundationdb/relational/yamltests/CheckExplainConfigTest.java
+++ b/yaml-tests/src/test/java/com/apple/foundationdb/relational/yamltests/CheckExplainConfigTest.java
@@ -1,0 +1,528 @@
+/*
+ * CheckExplainConfigUnitTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.relational.yamltests;
+
+import com.apple.foundationdb.relational.api.RelationalResultSet;
+import com.apple.foundationdb.relational.api.RelationalStruct;
+import com.apple.foundationdb.relational.yamltests.command.QueryConfig;
+import com.apple.foundationdb.relational.yamltests.command.queryconfigs.CheckExplainConfig;
+import com.apple.foundationdb.relational.yamltests.generated.stats.PlannerMetricsProto;
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
+import org.opentest4j.AssertionFailedError;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pure-Java unit tests for {@link CheckExplainConfig}. No FDB or database connection required.
+ * <p>
+ * Covers:
+ * <ul>
+ *     <li>{@code addExplain} path (synthetic, {@code getVal()==null})</li>
+ *     <li>{@code checkExplainContains} path ({@code !isExact})</li>
+ *     <li>{@code checkExplainAndMetrics} path (exact match, 7 sub-cases)</li>
+ * </ul>
+ * {@link YamlExecutionContext} is mocked so each test controls exactly which options are
+ * active and which maintainers are in use.
+ */
+class CheckExplainConfigTest {
+
+    private static final YamlReference.YamlResource RESOURCE =
+            YamlReference.YamlResource.base("check-explain/shouldPass/contains.yamsql");
+    private static final YamlReference REFERENCE = RESOURCE.withLineNumber(1);
+    private static final String PLAN_A = "SCAN([IS T1])";
+    private static final String PLAN_B = "COVERING([IS T1] -> [ID: KEY[0]])";
+    private static final String PLAN_DOT = "digraph G {}";
+
+    @Test
+    void addExplainQueuesCorrectionWhenFileLoaded() throws Exception {
+        final var filesMaintainer = loadedFilesMaintainer();
+        final var yamlExecutionContext = mockExecutionContext(false, false, true, filesMaintainer, getMetricsMaintainer(null));
+
+        syntheticConfig(yamlExecutionContext).invoke(mockResultSet(PLAN_A, PLAN_DOT, null));
+
+        final var corrections = filesMaintainer.getPendingCorrections(RESOURCE);
+        Assertions.assertEquals(1, corrections.size());
+        Assertions.assertInstanceOf(YamlFilesMaintainer.AddExplainCorrection.class, corrections.get(0));
+    }
+
+    @Test
+    void addExplainThrowsWhenFileNotLoaded() {
+        final var filesMaintainer = new YamlFilesMaintainer(); // file never loaded
+        final var executionContext = mockExecutionContext(false, false, true, filesMaintainer, getMetricsMaintainer(null));
+
+        assertThrows(IllegalStateException.class,
+                () -> syntheticConfig(executionContext).invoke(mockResultSet(PLAN_A, PLAN_DOT, null)));
+    }
+
+    @Test
+    void checkExplainContainsPassesWhenFragmentFound() {
+        final var executionContext = mockExecutionContext(false, false, false, new YamlFilesMaintainer(), getMetricsMaintainer(null));
+
+        // "SCAN" is contained in PLAN_A — no exception
+        Assertions.assertDoesNotThrow(
+                () -> containsConfig(executionContext, "SCAN").invoke(mockResultSet(PLAN_A, PLAN_DOT, null)));
+    }
+
+    @Test
+    void checkExplainContainsThrowsWhenFragmentMissing() {
+        final var executionContext = mockExecutionContext(false, false, false, new YamlFilesMaintainer(), getMetricsMaintainer(null));
+
+        assertThrows(AssertionFailedError.class,
+                () -> containsConfig(executionContext, "INDEX_SCAN").invoke(mockResultSet(PLAN_A, PLAN_DOT, null)));
+    }
+
+    static Stream<Arguments> noMismatchAllFlagsArgs() {
+        return Stream.of(Boolean.TRUE, Boolean.FALSE)
+                .flatMap(checkExplain -> Stream.of(Boolean.TRUE, Boolean.FALSE)
+                        .map(checkMetrics -> Arguments.of(checkExplain, checkMetrics)));
+    }
+
+    // P, M, _, _, EM, AM (4 cases)
+    // Outcome: _, Preserved - No Dirty
+    @ParameterizedTest
+    @MethodSource("noMismatchAllFlagsArgs")
+    void noMismatchAllFlags(boolean correctExplains, boolean correctMetrics) throws Exception {
+        final var expectedMetrics = metricsInfo(PLAN_A, 10, 5);
+        final var metricsMaintainer = getMetricsMaintainer(expectedMetrics);
+        final var filesMaintainer = new YamlFilesMaintainer();
+        final var executionContext = mockExecutionContext(correctExplains, correctMetrics, false, filesMaintainer, metricsMaintainer);
+        exactConfig(executionContext, PLAN_A).invoke(mockResultSet(PLAN_A, PLAN_DOT, metricsStruct(10, 5)));
+        assertNoFileCorrections(filesMaintainer);
+        assertMetricsPreserved(metricsMaintainer, expectedMetrics);
+    }
+
+    static Stream<Arguments> noMismatchNoActualMetricsArgs() {
+        return Stream.of(Boolean.TRUE, Boolean.FALSE)
+                .flatMap(checkExplain -> Stream.of(Boolean.TRUE, Boolean.FALSE)
+                        .flatMap(checkMetrics -> Stream.of(Boolean.TRUE, Boolean.FALSE)
+                                .map(hasExpectedMetrics -> Arguments.of(checkExplain, checkMetrics, hasExpectedMetrics))));
+    }
+
+    // P, _, _, _, _, !AM (16 cases)
+    // Outcome: _, Nothing - No Dirty
+    @ParameterizedTest
+    @MethodSource("noMismatchNoActualMetricsArgs")
+    void noMismatchNoActualMetrics(boolean correctExplains, boolean correctMetrics,
+                                   boolean hasExpectedMetrics) throws Exception {
+        final var expectedInfo = hasExpectedMetrics ? metricsInfo(PLAN_A, 10, 5) : null;
+        final var metricsMaintainer = getMetricsMaintainer(expectedInfo);
+        final var filesMaintainer = new YamlFilesMaintainer();
+        final var executionContext = mockExecutionContext(correctExplains, correctMetrics, false, filesMaintainer, metricsMaintainer);
+        exactConfig(executionContext, PLAN_A).invoke(mockResultSet(PLAN_A, PLAN_DOT, null));
+        assertNoFileCorrections(filesMaintainer);
+        assertMetricsNotWritten(metricsMaintainer);
+    }
+
+    static Stream<Arguments> noMismatchCorrectNoneNoExpectedMetricsArgs() {
+        return Stream.of(Boolean.TRUE, Boolean.FALSE).map(Arguments::of);
+    }
+
+    // P, _, !CE, !CM, !EM, AM (2 cases) — M irrelevant when !EM; both counter values produce the same failure
+    // Outcome: _, FAIL_NO_METRICS
+    @ParameterizedTest
+    @MethodSource("noMismatchCorrectNoneNoExpectedMetricsArgs")
+    void noMismatchCorrectNoneNoExpectedMetrics(boolean metricsMatch) throws SQLException {
+        final var metricsMaintainer = getMetricsMaintainer(null);
+        final var filesMaintainer = new YamlFilesMaintainer();
+        final var executionContext = mockExecutionContext(false, false, false, filesMaintainer, metricsMaintainer);
+        final var struct = metricsMatch ? metricsStruct(10, 5) : metricsStruct(20, 5);
+        final var err = assertThrows(AssertionFailedError.class,
+                () -> exactConfig(executionContext, PLAN_A).invoke(mockResultSet(PLAN_A, PLAN_DOT, struct)));
+        assertTrue(err.getMessage().contains("No planner metrics"));
+    }
+
+    static Stream<Arguments> planMatchMetricsDifferCorrectMetricsArgs() {
+        return Stream.of(Boolean.TRUE, Boolean.FALSE).map(Arguments::of);
+    }
+
+    // P, !M, _, CM, EM, AM (2 cases)
+    // Outcome: _, Written-Dirty
+    @ParameterizedTest
+    @MethodSource("planMatchMetricsDifferCorrectMetricsArgs")
+    void planMatchMetricsDifferCorrectMetrics(boolean correctExplains) throws Exception {
+        final var metricsMaintainer = getMetricsMaintainer(metricsInfo(PLAN_A, 10, 5));
+        final var filesMaintainer = new YamlFilesMaintainer();
+        final var executionContext = mockExecutionContext(correctExplains, true, false, filesMaintainer, metricsMaintainer);
+        exactConfig(executionContext, PLAN_A).invoke(mockResultSet(PLAN_A, PLAN_DOT, metricsStruct(20, 5)));
+        assertNoFileCorrections(filesMaintainer);
+        assertMetricsWritten(metricsMaintainer, PLAN_A, 20);
+    }
+
+    // P, !M, _, !CM, EM, AM (2 cases) — CE free; no correction permitted
+    // Outcome: _, FAIL_METRICS_CHANGED
+    static Stream<Arguments> planMatchMetricsDifferNoCorrectionArgs() {
+        return Stream.of(Boolean.TRUE, Boolean.FALSE).map(ce -> Arguments.of(ce));
+    }
+
+    @ParameterizedTest
+    @MethodSource("planMatchMetricsDifferNoCorrectionArgs")
+    void planMatchMetricsDifferNoCorrection(boolean correctExplains) {
+        final var metricsMaintainer = getMetricsMaintainer(metricsInfo(PLAN_A, 10, 5));
+        final var filesMaintainer = new YamlFilesMaintainer();
+        final var executionContext = mockExecutionContext(correctExplains, false, false, filesMaintainer, metricsMaintainer);
+        final var err = assertThrows(AssertionFailedError.class,
+                () -> exactConfig(executionContext, PLAN_A).invoke(mockResultSet(PLAN_A, PLAN_DOT, metricsStruct(20, 5))));
+        assertTrue(err.getMessage().contains("Planner metrics have changed"));
+    }
+
+    static Stream<Arguments> planMatchBypassGuardArgs() {
+        return Stream.of(
+                Arguments.of(true,  true),  // CE, CM
+                Arguments.of(false, true)   // !CE, CM — only CM bypasses the guard
+        );
+    }
+
+    // P, _, CM, !EM, AM (2 cases) — only CM bypasses FAIL_NO_METRICS; CE alone no longer does
+    // Outcome: _, Written-Dirty
+    @ParameterizedTest
+    @MethodSource("planMatchBypassGuardArgs")
+    void planMatchBypassGuardWritesActual(boolean correctExplains, boolean correctMetrics) throws Exception {
+        final var metricsMaintainer = getMetricsMaintainer(null);
+        final var filesMaintainer = new YamlFilesMaintainer();
+        final var executionContext = mockExecutionContext(correctExplains, correctMetrics, false, filesMaintainer, metricsMaintainer);
+        exactConfig(executionContext, PLAN_A).invoke(mockResultSet(PLAN_A, PLAN_DOT, metricsStruct(20, 5)));
+        assertNoFileCorrections(filesMaintainer);
+        assertMetricsWritten(metricsMaintainer, PLAN_A, 20);
+    }
+
+    // P, _, CE, !CM, !EM, AM (1 case) — CE alone cannot bypass FAIL_NO_METRICS guard
+    // Outcome: _, FAIL_NO_METRICS
+    @Test
+    void planMatchCeOnlyNoExpectedMetricsFails() {
+        final var metricsMaintainer = getMetricsMaintainer(null);
+        final var filesMaintainer = new YamlFilesMaintainer();
+        final var executionContext = mockExecutionContext(true, false, false, filesMaintainer, metricsMaintainer);
+        final var err = assertThrows(AssertionFailedError.class,
+                () -> exactConfig(executionContext, PLAN_A).invoke(mockResultSet(PLAN_A, PLAN_DOT, metricsStruct(20, 5))));
+        assertTrue(err.getMessage().contains("No planner metrics"));
+    }
+
+    static Stream<Arguments> planMismatchWritesExplainUpdatedMetricsArgs() {
+        return Stream.of(Boolean.TRUE, Boolean.FALSE)
+                .flatMap(correctMetrics -> Stream.of(Boolean.TRUE, Boolean.FALSE)
+                        .map(hasActualMetrics -> Arguments.of(correctMetrics, hasActualMetrics)));
+    }
+
+    // !P, M, CE, _, EM, _ (4 cases) — CM free; AM may be present with matching counters or absent
+    // Outcome: F, Written(explain updated)-Dirty
+    @ParameterizedTest
+    @MethodSource("planMismatchWritesExplainUpdatedMetricsArgs")
+    void planMismatchWritesExplainUpdatedMetrics(boolean correctMetrics, boolean hasActualMetrics) throws Exception {
+        final var metricsMaintainer = getMetricsMaintainer(metricsInfo(PLAN_A, 10, 5));
+        final var filesMaintainer = loadedFilesMaintainer();
+        final var executionContext = mockExecutionContext(true, correctMetrics, false, filesMaintainer, metricsMaintainer);
+        final var struct = hasActualMetrics ? metricsStruct(10, 5) : null; // matching counters when present
+        exactConfig(executionContext, PLAN_A).invoke(mockResultSet(PLAN_B, PLAN_DOT, struct));
+        assertExplainCorrectionQueued(filesMaintainer, PLAN_B);
+        assertMetricsWritten(metricsMaintainer, PLAN_B, 10); // new plan, counters from expected
+    }
+
+    // !P, _, CE, CM, !EM, AM (1 case) — only CM bypasses FAIL_NO_METRICS; CE alone no longer does
+    // Outcome: F, Written-Dirty
+    @Test
+    void planMismatchWritesActualMetrics() throws Exception {
+        final var metricsMaintainer = getMetricsMaintainer(null);
+        final var filesMaintainer = loadedFilesMaintainer();
+        final var executionContext = mockExecutionContext(true, true, false, filesMaintainer, metricsMaintainer);
+        exactConfig(executionContext, PLAN_A).invoke(mockResultSet(PLAN_B, PLAN_DOT, metricsStruct(10, 5)));
+        assertExplainCorrectionQueued(filesMaintainer, PLAN_B);
+        assertMetricsWritten(metricsMaintainer, PLAN_B, 10);
+    }
+
+    // !P, _, CE, !CM, !EM, AM (1 case) — CE alone cannot bypass FAIL_NO_METRICS guard
+    // Outcome: F, FAIL_NO_METRICS
+    @Test
+    void planMismatchCeOnlyNoExpectedMetricsFails() throws Exception {
+        final var metricsMaintainer = getMetricsMaintainer(null);
+        final var filesMaintainer = loadedFilesMaintainer();
+        final var executionContext = mockExecutionContext(true, false, false, filesMaintainer, metricsMaintainer);
+        final var err = assertThrows(AssertionFailedError.class,
+                () -> exactConfig(executionContext, PLAN_A).invoke(mockResultSet(PLAN_B, PLAN_DOT, metricsStruct(10, 5))));
+        assertTrue(err.getMessage().contains("No planner metrics"));
+        assertExplainCorrectionQueued(filesMaintainer, PLAN_B);
+    }
+
+    static Stream<Arguments> planMismatchNoMetricsArgs() {
+        return Stream.of(Boolean.TRUE, Boolean.FALSE).map(Arguments::of);
+    }
+
+    // !P, _, CE, _, !EM, !AM (2 cases) — CM free; no metrics to write
+    // Outcome: F, Nothing-No Dirty
+    @ParameterizedTest
+    @MethodSource("planMismatchNoMetricsArgs")
+    void planMismatchNoMetrics(boolean correctMetrics) throws Exception {
+        final var metricsMaintainer = getMetricsMaintainer(null);
+        final var filesMaintainer = loadedFilesMaintainer();
+        final var executionContext = mockExecutionContext(true, correctMetrics, false, filesMaintainer, metricsMaintainer);
+        exactConfig(executionContext, PLAN_A).invoke(mockResultSet(PLAN_B, PLAN_DOT, null));
+        assertExplainCorrectionQueued(filesMaintainer, PLAN_B);
+        assertMetricsNotWritten(metricsMaintainer);
+    }
+
+    static Stream<Arguments> bothMismatchWritesExplainUpdatedMetricsArgs() {
+        return Stream.of(Boolean.TRUE, Boolean.FALSE).map(Arguments::of);
+    }
+
+    // !P, !M, CE, _, EM, !AM (2 cases) — CM free; no actual counters, explain changed, EM present
+    // Outcome: F, Written(explain updated)-Dirty
+    @ParameterizedTest
+    @MethodSource("bothMismatchWritesExplainUpdatedMetricsArgs")
+    void bothMismatchWritesExplainUpdatedMetrics(boolean correctMetrics) throws Exception {
+        final var metricsMaintainer = getMetricsMaintainer(metricsInfo(PLAN_A, 10, 5));
+        final var filesMaintainer = loadedFilesMaintainer();
+        final var executionContext = mockExecutionContext(true, correctMetrics, false, filesMaintainer, metricsMaintainer);
+        exactConfig(executionContext, PLAN_A).invoke(mockResultSet(PLAN_B, PLAN_DOT, null));
+        assertExplainCorrectionQueued(filesMaintainer, PLAN_B);
+        assertMetricsWritten(metricsMaintainer, PLAN_B, 10); // counters from expected
+    }
+
+    static Stream<Arguments> bothMismatchWritesActualMetricsArgs() {
+        return Stream.of(
+                Arguments.of(true, true),   // CM=T, EM
+                Arguments.of(true, false)   // CM=T, !EM
+        );
+    }
+
+    // !P, !M, CE, CM|!EM, AM (2 cases) — CM=T corrects; removed CE-only !EM case (now FAIL_NO_METRICS)
+    // Outcome: F, Written-Dirty
+    @ParameterizedTest
+    @MethodSource("bothMismatchWritesActualMetricsArgs")
+    void bothMismatchWritesActualMetrics(boolean correctMetrics, boolean hasExpectedMetrics) throws Exception {
+        final var metricsMaintainer = getMetricsMaintainer(hasExpectedMetrics ? metricsInfo(PLAN_A, 10, 5) : null);
+        final var filesMaintainer = loadedFilesMaintainer();
+        final var executionContext = mockExecutionContext(true, correctMetrics, false, filesMaintainer, metricsMaintainer);
+        exactConfig(executionContext, PLAN_A).invoke(mockResultSet(PLAN_B, PLAN_DOT, metricsStruct(20, 5)));
+        assertExplainCorrectionQueued(filesMaintainer, PLAN_B);
+        assertMetricsWritten(metricsMaintainer, PLAN_B, 20);
+    }
+
+    // !P, !M, CE, !CM, !EM, AM (1 case) — CE alone cannot bypass FAIL_NO_METRICS guard
+    // Outcome: F, FAIL_NO_METRICS
+    @Test
+    void bothMismatchCeOnlyNoExpectedMetricsFails() throws Exception {
+        final var metricsMaintainer = getMetricsMaintainer(null);
+        final var filesMaintainer = loadedFilesMaintainer();
+        final var executionContext = mockExecutionContext(true, false, false, filesMaintainer, metricsMaintainer);
+        final var err = assertThrows(AssertionFailedError.class,
+                () -> exactConfig(executionContext, PLAN_A).invoke(mockResultSet(PLAN_B, PLAN_DOT, metricsStruct(20, 5))));
+        assertTrue(err.getMessage().contains("No planner metrics"));
+        assertExplainCorrectionQueued(filesMaintainer, PLAN_B);
+    }
+
+    // !P, !M, CE, !CM, EM, AM (1 case) — CE corrects explain but CM absent; metrics check fails
+    // Outcome: F, FAIL_METRICS_CHANGED
+    @Test
+    void bothMismatchFailMetricsChanged() throws Exception {
+        final var metricsMaintainer = getMetricsMaintainer(metricsInfo(PLAN_A, 10, 5));
+        final var filesMaintainer = loadedFilesMaintainer();
+        final var executionContext = mockExecutionContext(true, false, false, filesMaintainer, metricsMaintainer);
+        final var err = assertThrows(AssertionFailedError.class,
+                () -> exactConfig(executionContext, PLAN_A).invoke(mockResultSet(PLAN_B, PLAN_DOT, metricsStruct(20, 5))));
+        assertTrue(err.getMessage().contains("Planner metrics have changed"));
+        assertExplainCorrectionQueued(filesMaintainer, PLAN_B);
+    }
+
+    static Stream<Arguments> bothMismatchNoMetricsArgs() {
+        return Stream.of(Boolean.TRUE, Boolean.FALSE).map(cm -> Arguments.of(cm));
+    }
+
+    // !P, !M, CE, _, !EM, !AM (2 cases) — CM free; no metrics at all
+    // Outcome: F, Nothing-No Dirty
+    @ParameterizedTest
+    @MethodSource("bothMismatchNoMetricsArgs")
+    void bothMismatchNoMetrics(boolean correctMetrics) throws Exception {
+        final var metricsMaintainer = getMetricsMaintainer(null);
+        final var filesMaintainer = loadedFilesMaintainer();
+        final var executionContext = mockExecutionContext(true, correctMetrics, false, filesMaintainer, metricsMaintainer);
+        exactConfig(executionContext, PLAN_A).invoke(mockResultSet(PLAN_B, PLAN_DOT, null));
+        assertExplainCorrectionQueued(filesMaintainer, PLAN_B);
+        assertMetricsNotWritten(metricsMaintainer);
+    }
+
+    static Stream<Arguments> planMismatchDoNotCorrectExplainArgs() {
+        return Stream.of(Boolean.TRUE, Boolean.FALSE)
+                .flatMap(correctMetrics -> Stream.of(Boolean.TRUE, Boolean.FALSE)
+                        .flatMap(hasExpectedMetrics -> Stream.of(Boolean.TRUE, Boolean.FALSE)
+                                .flatMap(hasActualMetrics -> Stream.of(Boolean.TRUE, Boolean.FALSE)
+                                        .map(metricsMatch -> Arguments.of(correctMetrics, hasExpectedMetrics, hasActualMetrics, metricsMatch)))));
+    }
+
+    // !P, _, !CE, _, _, _ (16 cases)
+    // Outcome: _, FAIL_PLAN
+    @ParameterizedTest
+    @MethodSource("planMismatchDoNotCorrectExplainArgs")
+    void planMismatchDoNotCorrectExplain(boolean correctMetrics, boolean hasExpectedMetrics,
+                                         boolean hasActualMetrics, boolean metricsMatch) throws Exception {
+        final var metricsMaintainer = getMetricsMaintainer(hasExpectedMetrics ? metricsInfo(PLAN_A, 10, 5) : null);
+        final var executionContext = mockExecutionContext(false, correctMetrics, false, new YamlFilesMaintainer(), metricsMaintainer);
+        final var struct = hasActualMetrics ? (metricsMatch ? metricsStruct(10, 5) : metricsStruct(20, 5)) : null;
+        final var err = assertThrows(AssertionFailedError.class,
+                () -> exactConfig(executionContext, PLAN_A).invoke(mockResultSet(PLAN_B, PLAN_DOT, struct)));
+        assertTrue(err.getMessage().contains("plan mismatch"));
+    }
+
+    private static void assertNoFileCorrections(@Nonnull YamlFilesMaintainer filesMaintainer) {
+        assertTrue(filesMaintainer.getPendingCorrections(RESOURCE).isEmpty());
+    }
+
+    private static void assertMetricsNotWritten(@Nonnull YamlMetricsMaintainer metricsMaintainer) {
+        assertFalse(metricsMaintainer.isMetricsDirty());
+        Assertions.assertNull(metricsMaintainer.getActualMetrics(buildIdentifier()));
+    }
+
+    private static void assertMetricsPreserved(@Nonnull YamlMetricsMaintainer metricsMaintainer,
+                                                @Nonnull PlannerMetricsProto.Info expected) {
+        assertFalse(metricsMaintainer.isMetricsDirty());
+        Assertions.assertEquals(expected, metricsMaintainer.getActualMetrics(buildIdentifier()));
+    }
+
+    private static void assertMetricsWritten(@Nonnull YamlMetricsMaintainer metricsMaintainer,
+                                              @Nonnull String expectedPlan, long expectedTaskCount) {
+        assertTrue(metricsMaintainer.isMetricsDirty());
+        final var stored = metricsMaintainer.getActualMetrics(buildIdentifier());
+        Assertions.assertNotNull(stored);
+        Assertions.assertEquals(expectedPlan, stored.getExplain());
+        Assertions.assertEquals(expectedTaskCount, stored.getCountersAndTimers().getTaskCount());
+    }
+
+    /** Builds a mocked context wiring in the provided maintainers and option flags. */
+    private static YamlExecutionContext mockExecutionContext(boolean correctExplains, boolean correctMetrics,
+                                                             boolean addExplains,
+                                                             @Nonnull YamlFilesMaintainer filesMaintainer,
+                                                             @Nonnull YamlMetricsMaintainer metricsMaintainer) {
+        final var executionContext = Mockito.mock(YamlExecutionContext.class);
+        Mockito.when(executionContext.shouldCorrectExplains()).thenReturn(correctExplains);
+        Mockito.when(executionContext.shouldCorrectMetrics()).thenReturn(correctMetrics);
+        Mockito.when(executionContext.shouldAddExplains()).thenReturn(addExplains);
+        Mockito.when(executionContext.shouldShowPlanOnDiff()).thenReturn(false);
+        Mockito.when(executionContext.getFilesMaintainer()).thenReturn(filesMaintainer);
+        Mockito.when(executionContext.getMetricsMaintainer()).thenReturn(metricsMaintainer);
+        return executionContext;
+    }
+
+    private static YamlFilesMaintainer loadedFilesMaintainer() throws Exception {
+        final var filesMaintainer = new YamlFilesMaintainer();
+        filesMaintainer.loadFile(RESOURCE);
+        return filesMaintainer;
+    }
+
+    private static YamlMetricsMaintainer getMetricsMaintainer(@Nullable PlannerMetricsProto.Info metricsInfo) {
+        final ImmutableMap<PlannerMetricsProto.Identifier, PlannerMetricsProto.Info> expectedMetricsMap =
+                metricsInfo == null ? ImmutableMap.of() :
+                ImmutableMap.of(buildIdentifier(), metricsInfo);
+        return new YamlMetricsMaintainer(RESOURCE, expectedMetricsMap);
+    }
+
+    private static TestableConfig syntheticConfig(@Nonnull YamlExecutionContext executionContext) {
+        return new TestableConfig(REFERENCE, executionContext, null, true);
+    }
+
+    private static TestableConfig exactConfig(@Nonnull YamlExecutionContext executionContext, @Nonnull String expected) {
+        return new TestableConfig(REFERENCE, executionContext, expected, true);
+    }
+
+    private static TestableConfig containsConfig(@Nonnull YamlExecutionContext executionContext, @Nonnull String fragment) {
+        return new TestableConfig(REFERENCE, executionContext, fragment, false);
+    }
+
+    private static RelationalResultSet mockResultSet(@Nonnull String plan, @Nonnull String planDot,
+                                                     @Nullable RelationalStruct metricsStruct) throws SQLException {
+        final var rs = Mockito.mock(RelationalResultSet.class);
+        Mockito.when(rs.getString(1)).thenReturn(plan);
+        Mockito.when(rs.getString(3)).thenReturn(planDot);
+        Mockito.when(rs.getStruct(6)).thenReturn(metricsStruct);
+        return rs;
+    }
+
+    private static RelationalStruct metricsStruct(long taskCount, long transformCount) throws SQLException {
+        final var s = Mockito.mock(RelationalStruct.class);
+        Mockito.when(s.getLong(1)).thenReturn(taskCount);     // task_count (tracked)
+        Mockito.when(s.getLong(2)).thenReturn(1_000_000L);    // task_total_time_ns (must be > 0)
+        Mockito.when(s.getLong(3)).thenReturn(transformCount); // transform_count (tracked)
+        Mockito.when(s.getLong(4)).thenReturn(1_000L);        // transform_time_ns
+        Mockito.when(s.getLong(5)).thenReturn(0L);            // transform_yield_count (tracked)
+        Mockito.when(s.getLong(6)).thenReturn(1_000L);        // insert_time_ns
+        Mockito.when(s.getLong(7)).thenReturn(0L);            // insert_new_count (tracked)
+        Mockito.when(s.getLong(8)).thenReturn(0L);            // insert_reused_count (tracked)
+        return s;
+    }
+
+    private static PlannerMetricsProto.Info metricsInfo(@Nonnull String plan, long taskCount, long transformCount) {
+        return PlannerMetricsProto.Info.newBuilder()
+                .setExplain(plan)
+                .setDot(PLAN_DOT)
+                .setCountersAndTimers(PlannerMetricsProto.CountersAndTimers.newBuilder()
+                        .setTaskCount(taskCount)
+                        .setTaskTotalTimeNs(1_000_000L)
+                        .setTransformCount(transformCount)
+                        .setTransformTimeNs(1_000L)
+                        .setTransformYieldCount(0L)
+                        .setInsertTimeNs(1_000L)
+                        .setInsertNewCount(0L)
+                        .setInsertReusedCount(0L))
+                .build();
+    }
+
+    private static PlannerMetricsProto.Identifier buildIdentifier() {
+        return PlannerMetricsProto.Identifier.newBuilder()
+                .setBlockName("testBlock")
+                .setQuery("SELECT 1")
+                .build();
+    }
+
+    private static void assertExplainCorrectionQueued(@Nonnull YamlFilesMaintainer filesMaintainer,
+                                                       @Nonnull String expectedPlan) {
+        final var corrections = filesMaintainer.getPendingCorrections(RESOURCE);
+        Assertions.assertEquals(1, corrections.size());
+        final var correction = corrections.get(0);
+        Assertions.assertInstanceOf(YamlFilesMaintainer.ExplainCorrection.class, correction);
+        Assertions.assertEquals(REFERENCE.getLineNumber(), correction.getLineNumber());
+        final var lines = new ArrayList<>(List.of("      - explain: \"OLD\""));
+        correction.apply(lines);
+        assertTrue(lines.get(0).contains(expectedPlan));
+    }
+
+    static class TestableConfig extends CheckExplainConfig {
+        TestableConfig(@Nonnull YamlReference reference, @Nonnull YamlExecutionContext executionContext,
+                       @Nullable Object value, boolean isExact) {
+            super(QueryConfig.QUERY_CONFIG_EXPLAIN, value, reference, executionContext, isExact, "testBlock");
+        }
+
+        void invoke(@Nonnull Object actual) throws SQLException {
+            checkResultInternal("SELECT 1", actual, "SELECT 1", List.of());
+        }
+    }
+}

--- a/yaml-tests/src/test/java/com/apple/foundationdb/relational/yamltests/CheckExplainConfigTest.java
+++ b/yaml-tests/src/test/java/com/apple/foundationdb/relational/yamltests/CheckExplainConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * CheckExplainConfigUnitTest.java
+ * CheckExplainConfigTest.java
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/yaml-tests/src/test/java/com/apple/foundationdb/relational/yamltests/CheckExplainConfigTest.java
+++ b/yaml-tests/src/test/java/com/apple/foundationdb/relational/yamltests/CheckExplainConfigTest.java
@@ -67,23 +67,27 @@ class CheckExplainConfigTest {
     private static final String PLAN_DOT = "digraph G {}";
 
     @Test
-    void addExplainQueuesCorrectionWhenFileLoaded() throws Exception {
+    void addExplainAndMetricsQueuesCorrectionWhenFileLoaded() throws Exception {
         final var filesMaintainer = loadedFilesMaintainer();
-        final var yamlExecutionContext = mockExecutionContext(false, false, true, filesMaintainer, getMetricsMaintainer(null));
+        final var metricsMaintainer = getMetricsMaintainer(null);
+        final var yamlExecutionContext = mockExecutionContext(false, false, true, filesMaintainer, metricsMaintainer);
 
-        syntheticConfig(yamlExecutionContext).invoke(mockResultSet(PLAN_A, PLAN_DOT, null));
+        syntheticConfig(yamlExecutionContext).invoke(mockResultSet(PLAN_A, PLAN_DOT, metricsStruct(10, 5)));
 
         final var corrections = filesMaintainer.getPendingCorrections(RESOURCE);
         Assertions.assertEquals(1, corrections.size());
         Assertions.assertInstanceOf(YamlFilesMaintainer.AddExplainCorrection.class, corrections.get(0));
+        // addExplainAndMetrics now also records the actual metrics for the new query
+        assertMetricsWritten(metricsMaintainer, PLAN_A, 10);
     }
 
     @Test
-    void addExplainThrowsWhenFileNotLoaded() {
+    void addExplainAndMetricsThrowsWhenFileNotLoaded() {
         final var filesMaintainer = new YamlFilesMaintainer(); // file never loaded
         final var executionContext = mockExecutionContext(false, false, true, filesMaintainer, getMetricsMaintainer(null));
 
-        assertThrows(IllegalStateException.class,
+        // the IllegalStateException from verifyFileLoaded is wrapped by wrapContext
+        assertThrows(YamlExecutionContext.YamlExecutionError.class,
                 () -> syntheticConfig(executionContext).invoke(mockResultSet(PLAN_A, PLAN_DOT, null)));
     }
 

--- a/yaml-tests/src/test/java/com/apple/foundationdb/relational/yamltests/YamlCorrectionUnitTest.java
+++ b/yaml-tests/src/test/java/com/apple/foundationdb/relational/yamltests/YamlCorrectionUnitTest.java
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 /**
  * Pure-Java unit tests for YAMSQL file-correction logic. No FDB or database connection required.
  * <p>
- *     Covers {@link YamlExecutionContext.AddExplainCorrection} (file-editing) and the null-value
+ *     Covers {@link YamlFilesMaintainer.AddExplainCorrection} (file-editing) and the null-value
  *     (synthetic) path in {@link CheckExplainConfig} that is triggered when
  *     {@code OPTION_ADD_EXPLAIN} is active and a query has no {@code explain:} block yet.
  * </p>
@@ -190,6 +190,6 @@ class YamlCorrectionUnitTest {
     private static void applyAddExplainCorrection(List<String> lines, int oneBasedLineNumber, String plan) {
         final YamlReference.YamlResource resource = YamlReference.YamlResource.base("test.yamsql");
         final YamlReference ref = resource.withLineNumber(oneBasedLineNumber);
-        new YamlExecutionContext.AddExplainCorrection(ref, plan).apply(lines);
+        new YamlFilesMaintainer.AddExplainCorrection(ref, plan).apply(lines);
     }
 }


### PR DESCRIPTION
### Summary

This PR refactors the `yamsql` maintenance infrastructure and fixes two related correctness issues in how explain corrections interact with planner metrics files.

### Behaviour changes

- Previously, running with `OPTION_CORRECT_EXPLAIN` (e.g. @MaintainYamlTestConfig(CORRECT_EXPLAINS)) would rewrite the explain: string in the `.yamsql` file but leave the `.metrics.binpb`/`.metrics.yaml` files untouched. This required a second maintenance pass with `OPTION_CORRECT_METRICS` to bring back the explain in the metrics file up-to-date, even when the metrics are not supposed to be changed. If this is not done, the explain in metrics file is left out-of-sync for a long time until the `OPTION_CORRECT_METRICS` is used in a totally unrelated PR, thereby polluting its metrics analysis with unrelated changes.  

Now, `OPTION_CORRECT_EXPLAIN` also triggers a metrics file update. When the plan changes but no tracked counters differ, the existing metrics entry is preserved with only the explain field updated to reflect the new plan,
  keeping non-tracked timing fields stable.

- Previously, when metrics that were not changed were "preserved" to disk, the preservation of full `CountersAndTimers` proto happened using fresh actual values — including non-tracked timing fields (`task_total_time_ns`, `transform_time_ns`, `insert_time_ms`). This caused spurious diffs in `.metrics.yaml` on every maintenance run even when no tracked counters changed.

The preservation re-writes the read values, rather than putting "actual" values. This would cause non-tracking metrics to remain stable for metric entries that were intended to "preserve" and not "update".

### Refactoring

- `YamlExecutionContext` was carrying three distinct responsibilities — option/connection management, in-place .yamsql file correction, and metrics files correction. The last 2 were causing methods names to conflict and was causing confusion in what some variables and methods pertain to. This PR factors out this responsibility into their own class:

  - `YamlFilesMaintainer`: owns the in-memory line buffer for .yamsql files and all pending corrections (ExplainCorrection, AddExplainCorrection, MetadataCorrection, AddMetadataCorrection). Methods throw
  IllegalStateException if called before loadFile, replacing a silent return false.
  - `YamlMetricsMaintainer`: owns expectedMetricsMap (loaded from .metrics.binpb), actualMetricsMap (accumulated during the run), and the saveIfNeeded write path. Exposes writeMetrics (put + markDirty atomically).

`YamlExecutionContext` retains the option accessors, connection management, and resource registration, and exposes `getMetricsMaintainer()` / `getFilesMaintainer()` for callers that need direct access.

`CheckExplainConfig` is also refactored around a `PlannerMetricsProto.Info` struct built upfront from the `EXPLAIN` result set (createPlannerMetricsInfo), replacing the scattered column reads. The three execution paths —
  `addExplain` (synthetic, no expected value), `checkExplainContains` (!isExact), `checkExplainAndMetrics` (exact) — are now clearly separated.
