### PR TITLE
Add an index traversal kind to index plans

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexScanComparisons.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexScanComparisons.java
@@ -30,6 +30,7 @@ import com.apple.foundationdb.record.TupleRange;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.planprotos.PIndexScanComparisons;
 import com.apple.foundationdb.record.planprotos.PIndexScanParameters;
+import com.apple.foundationdb.record.query.plan.IndexTraversalKind;
 import com.apple.foundationdb.record.query.plan.ScanComparisons;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
@@ -44,6 +45,7 @@ import com.google.protobuf.Message;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -52,6 +54,23 @@ import java.util.Set;
  */
 @API(API.Status.UNSTABLE)
 public class IndexScanComparisons implements IndexScanParameters {
+    /**
+     * The traversal each of the scan types defined by {@link IndexScanType} walks. {@link IndexScanType#BY_DISTANCE} is
+     * deliberately absent: which structure a vector scan walks depends on the engine backing the index, not on the scan
+     * type, so it is left to the plan to say. See
+     * {@link com.apple.foundationdb.record.query.plan.plans.VectorIndexPlan#getIndexTraversalKind()}.
+     */
+    @Nonnull
+    private static final Map<IndexScanType, IndexTraversalKind> CORE_TRAVERSAL_KINDS =
+            ImmutableMap.<IndexScanType, IndexTraversalKind>builder()
+                    .put(IndexScanType.BY_VALUE, IndexTraversalKind.BY_VALUE)
+                    .put(IndexScanType.BY_VALUE_OVER_SCAN, IndexTraversalKind.BY_VALUE)
+                    .put(IndexScanType.BY_GROUP, IndexTraversalKind.BY_VALUE)
+                    .put(IndexScanType.BY_RANK, IndexTraversalKind.RANKED_SET)
+                    .put(IndexScanType.BY_TIME_WINDOW, IndexTraversalKind.RANKED_SET)
+                    .put(IndexScanType.BY_TEXT_TOKEN, IndexTraversalKind.INVERTED)
+                    .build();
+
     @Nonnull
     private final IndexScanType scanType;
     @Nonnull
@@ -90,6 +109,21 @@ public class IndexScanComparisons implements IndexScanParameters {
     @Override
     public IndexScanType getScanType() {
         return scanType;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Answered from the scan type, which is all these parameters have to go on. A scan type defined elsewhere is not
+     * known here, so it yields {@link IndexTraversalKind#UNKNOWN}; whoever defined it should say what it walks by
+     * overriding this.
+     *
+     * @return the way a scan with these parameters traverses the index
+     */
+    @Nonnull
+    @Override
+    public IndexTraversalKind getIndexTraversalKind() {
+        return Objects.requireNonNullElse(CORE_TRAVERSAL_KINDS.get(scanType), IndexTraversalKind.UNKNOWN);
     }
 
     @Override

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexScanParameters.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexScanParameters.java
@@ -29,6 +29,7 @@ import com.apple.foundationdb.record.PlanSerializationContext;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.planprotos.PIndexScanParameters;
+import com.apple.foundationdb.record.query.plan.IndexTraversalKind;
 import com.apple.foundationdb.record.query.plan.ScanComparisons;
 import com.apple.foundationdb.record.query.plan.cascades.Correlated;
 import com.apple.foundationdb.record.query.plan.explain.ExplainTokensWithPrecedence;
@@ -52,6 +53,22 @@ public interface IndexScanParameters extends PlanHashable, Correlated<IndexScanP
      */
     @Nonnull
     IndexScanType getScanType();
+
+    /**
+     * Get the way a scan with these parameters physically traverses the index. Answered by the parameters rather than
+     * derived from the {@link #getScanType() scan type} centrally, because the set of scan types is open: an index
+     * maintainer defined outside the core knows what its scans walk, and nothing else does.
+     * <p>
+     * The default is {@link IndexTraversalKind#UNKNOWN}, which is the honest answer for parameters that have not been
+     * taught to say. Overriding it is worthwhile for anything that means to be told apart from another access by a cost
+     * criterion.
+     *
+     * @return the way a scan with these parameters traverses the index
+     */
+    @Nonnull
+    default IndexTraversalKind getIndexTraversalKind() {
+        return IndexTraversalKind.UNKNOWN;
+    }
 
     /**
      * Get the bound form of the index scan for use by the maintainer.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexScanParameters.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexScanParameters.java
@@ -55,20 +55,13 @@ public interface IndexScanParameters extends PlanHashable, Correlated<IndexScanP
     IndexScanType getScanType();
 
     /**
-     * Get the way a scan with these parameters physically traverses the index. Answered by the parameters rather than
-     * derived from the {@link #getScanType() scan type} centrally, because the set of scan types is open: an index
-     * maintainer defined outside the core knows what its scans walk, and nothing else does.
-     * <p>
-     * The default is {@link IndexTraversalKind#UNKNOWN}, which is the honest answer for parameters that have not been
-     * taught to say. Overriding it is worthwhile for anything that means to be told apart from another access by a cost
-     * criterion.
-     *
-     * @return the way a scan with these parameters traverses the index
+     * Get the way a scan with these parameters physically traverses the index, such as ordered key-value pairs, a
+     * ranked set, or an R-tree. This is a property of how the index is scanned, not of the index type it is declared
+     * as. Parameters that do not tell one structure from another answer {@link IndexTraversalKind#UNKNOWN}.
+     * @return the index traversal kind
      */
     @Nonnull
-    default IndexTraversalKind getIndexTraversalKind() {
-        return IndexTraversalKind.UNKNOWN;
-    }
+    IndexTraversalKind getIndexTraversalKind();
 
     /**
      * Get the bound form of the index scan for use by the maintainer.

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/MultidimensionalIndexScanComparisons.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/MultidimensionalIndexScanComparisons.java
@@ -32,6 +32,7 @@ import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.planprotos.PIndexScanParameters;
 import com.apple.foundationdb.record.planprotos.PMultidimensionalIndexScanComparisons;
 import com.apple.foundationdb.record.provider.foundationdb.MultidimensionalIndexScanBounds.Hypercube;
+import com.apple.foundationdb.record.query.plan.IndexTraversalKind;
 import com.apple.foundationdb.record.query.plan.ScanComparisons;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
@@ -74,6 +75,20 @@ public class MultidimensionalIndexScanComparisons implements IndexScanParameters
     @Override
     public IndexScanType getScanType() {
         return IndexScanType.BY_VALUE;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * An R-tree, which the scan type does not give away: these parameters report {@link IndexScanType#BY_VALUE}, as the
+     * entries do live in the ordered keyspace, but reaching them is a tree descent rather than a range scan.
+     *
+     * @return the way a scan with these parameters traverses the index
+     */
+    @Nonnull
+    @Override
+    public IndexTraversalKind getIndexTraversalKind() {
+        return IndexTraversalKind.R_TREE;
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/VectorIndexScanComparisons.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/VectorIndexScanComparisons.java
@@ -33,6 +33,7 @@ import com.apple.foundationdb.record.planprotos.PIndexScanParameters;
 import com.apple.foundationdb.record.planprotos.PVectorIndexScanComparisons;
 import com.apple.foundationdb.record.query.expressions.Comparisons;
 import com.apple.foundationdb.record.query.expressions.Comparisons.DistanceRankValueComparison;
+import com.apple.foundationdb.record.query.plan.IndexTraversalKind;
 import com.apple.foundationdb.record.query.plan.ScanComparisons;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
@@ -78,6 +79,22 @@ public final class VectorIndexScanComparisons implements IndexScanParameters {
     @Override
     public IndexScanType getScanType() {
         return IndexScanType.BY_DISTANCE;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * {@link IndexTraversalKind#UNKNOWN}, and deliberately so: every vector scan looks alike here, while what it walks
+     * depends on the engine the index was built with, which is an index option rather than anything these parameters
+     * carry. A plan that knows the engine answers for itself — see
+     * {@link com.apple.foundationdb.record.query.plan.plans.VectorIndexPlan#getIndexTraversalKind()}.
+     *
+     * @return {@link IndexTraversalKind#UNKNOWN}
+     */
+    @Nonnull
+    @Override
+    public IndexTraversalKind getIndexTraversalKind() {
+        return IndexTraversalKind.UNKNOWN;
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VectorIndexEngineKind.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VectorIndexEngineKind.java
@@ -24,9 +24,13 @@ import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.metadata.IndexOptions;
 import com.apple.foundationdb.record.metadata.MetaDataException;
+import com.apple.foundationdb.record.planprotos.PVectorIndexEngineKind;
+import com.apple.foundationdb.record.query.plan.serialization.PlanSerialization;
+import com.google.common.collect.BiMap;
 
 import javax.annotation.Nonnull;
 import java.util.Locale;
+import java.util.Objects;
 
 /**
  * The kinds of vector engine, as selectable through the {@link IndexOptions#VECTOR_ENGINE} index option. Public so
@@ -37,6 +41,10 @@ import java.util.Locale;
 public enum VectorIndexEngineKind {
     HNSW,
     GUARDIANN;
+
+    @Nonnull
+    private static final BiMap<VectorIndexEngineKind, PVectorIndexEngineKind> TO_PROTO =
+            PlanSerialization.protoEnumBiMap(VectorIndexEngineKind.class, PVectorIndexEngineKind.class);
 
     /**
      * Resolves an engine kind from its option string, accepting any letter case. When {@code value} is
@@ -56,5 +64,26 @@ public enum VectorIndexEngineKind {
             case "GUARDIANN" -> GUARDIANN;
             default -> throw new MetaDataException("unknown vector index engine", LogMessageKeys.VALUE, value);
         };
+    }
+
+    /**
+     * Converts this engine kind to its protobuf equivalent, so that a plan can carry it.
+     *
+     * @return the protobuf equivalent of this engine kind
+     */
+    @Nonnull
+    public PVectorIndexEngineKind toProto() {
+        return Objects.requireNonNull(TO_PROTO.get(this));
+    }
+
+    /**
+     * Converts an engine kind back from its protobuf equivalent.
+     *
+     * @param vectorIndexEngineKindProto the protobuf engine kind
+     * @return the engine kind
+     */
+    @Nonnull
+    public static VectorIndexEngineKind fromProto(@Nonnull final PVectorIndexEngineKind vectorIndexEngineKindProto) {
+        return Objects.requireNonNull(TO_PROTO.inverse().get(vectorIndexEngineKindProto));
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/IndexTraversalKind.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/IndexTraversalKind.java
@@ -1,0 +1,121 @@
+/*
+ * IndexTraversalKind.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.IndexScanType;
+import com.apple.foundationdb.record.metadata.IndexTypes;
+import com.apple.foundationdb.record.provider.foundationdb.IndexScanParameters;
+import com.apple.foundationdb.record.provider.foundationdb.MultidimensionalIndexScanComparisons;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryIndexPlan;
+
+import javax.annotation.Nonnull;
+
+/**
+ * The way a plan physically traverses an index, as opposed to the logical
+ * {@link IndexTypes index type} the index is declared as. The distinction is
+ * not just a renaming of the index type: what a scan does at runtime is a property of how it is scanned, not only of
+ * what
+ * it is scanned on. A {@link IndexTypes#RANK rank} index scanned
+ * {@link IndexScanType#BY_RANK} walks a probabilistic skip list, while the very same index scanned
+ * {@link IndexScanType#BY_VALUE} walks ordered key-value pairs, and those two have little in common in terms of what
+ * they cost.
+ * <p>
+ * This is what lets planning and costing reason about an index access by what it will actually do. Two accesses that
+ * are indistinguishable to the cost model may traverse structures with very different access characteristics, and a
+ * cost criterion, or an explicitly stated preference, may want to tell them apart.
+ * <p>
+ * This isn't an enum, for the same reason {@link IndexScanType} isn't: clients can define index maintainers of their
+ * own,
+ * and a maintainer that scans something the core has never heard of needs to be able to name what it walks. Declare a
+ * constant for it as the core does below, and answer with it from
+ * {@link IndexScanParameters#getIndexTraversalKind()}. Kinds are equal exactly when their names are, so a consumer
+ * should compare with {@link #equals(Object)} and always have an answer for a kind it does not recognize.
+ *
+ * @param name The name of the index traversal kind.
+ *
+ * @see IndexScanParameters#getIndexTraversalKind()
+ * @see RecordQueryIndexPlan#getIndexTraversalKind()
+ */
+@API(API.Status.EXPERIMENTAL)
+public record IndexTraversalKind(@Nonnull String name) {
+    /**
+     * A traversal that is not known to whoever was asked, either because the scan is described by an
+     * {@link IndexScanType} that layer does not define, or because it has not been taught to say. A consumer keyed on a
+     * specific traversal should treat this as "not the one I am looking for" rather than as any particular one.
+     */
+    @Nonnull
+    public static final IndexTraversalKind UNKNOWN = new IndexTraversalKind("UNKNOWN");
+    /**
+     * Ordered key-value pairs walked in key order, which is to say FoundationDB's keyspace scanned directly. This is
+     * what {@link IndexScanType#BY_VALUE} and {@link IndexScanType#BY_VALUE_OVER_SCAN} do, on any index whose entries
+     * are plain key-value pairs, and also what {@link IndexScanType#BY_GROUP} does when it reads the aggregate held
+     * against a group key.
+     */
+    @Nonnull
+    public static final IndexTraversalKind BY_VALUE = new IndexTraversalKind("BY_VALUE");
+    /**
+     * A probabilistic skip list walked to resolve an ordinal rank, rather than a key range, into entries. This is what
+     * {@link IndexScanType#BY_RANK} and {@link IndexScanType#BY_TIME_WINDOW} do.
+     */
+    @Nonnull
+    public static final IndexTraversalKind RANKED_SET = new IndexTraversalKind("RANKED_SET");
+    /**
+     * A postings structure walked from a token to the entries containing it, as {@link IndexScanType#BY_TEXT_TOKEN}
+     * does.
+     */
+    @Nonnull
+    public static final IndexTraversalKind INVERTED = new IndexTraversalKind("INVERTED");
+    /**
+     * An R-tree walked for overlap or containment on multi-dimensional data, as a
+     * {@link MultidimensionalIndexScanComparisons multidimensional}
+     * scan does.
+     */
+    @Nonnull
+    public static final IndexTraversalKind R_TREE = new IndexTraversalKind("R_TREE");
+    /**
+     * A hierarchical navigable small world graph walked for approximate nearest neighbors.
+     */
+    @Nonnull
+    public static final IndexTraversalKind HNSW = new IndexTraversalKind("HNSW");
+    /**
+     * A clustered vector structure walked for approximate nearest neighbors.
+     */
+    @Nonnull
+    public static final IndexTraversalKind GUARDIANN = new IndexTraversalKind("GUARDIANN");
+
+    /**
+     * Returns the name of this traversal, which is what distinguishes it from every other one.
+     *
+     * @return the name of this traversal
+     */
+    @Override
+    @Nonnull
+    public String name() {
+        return name;
+    }
+
+    @Nonnull
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/explain/ExplainPlanVisitor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/explain/ExplainPlanVisitor.java
@@ -85,6 +85,7 @@ import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedUnionP
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryUpdatePlan;
 import com.apple.foundationdb.record.query.plan.plans.TempTableInsertPlan;
 import com.apple.foundationdb.record.query.plan.plans.TempTableScanPlan;
+import com.apple.foundationdb.record.query.plan.plans.VectorIndexPlan;
 import com.apple.foundationdb.record.query.plan.sorting.RecordQueryDamPlan;
 import com.apple.foundationdb.record.query.plan.sorting.RecordQuerySortPlan;
 import com.google.common.base.Verify;
@@ -422,6 +423,12 @@ public class ExplainPlanVisitor extends ExplainTokens implements RecordQueryPlan
     @Override
     public ExplainTokens visitInValuesJoinPlan(@Nonnull final RecordQueryInValuesJoinPlan inValuesJoinPlan) {
         return visitInJoinPlan(inValuesJoinPlan);
+    }
+
+    @Nonnull
+    @Override
+    public ExplainTokens visitVectorIndexPlan(@Nonnull final VectorIndexPlan vectorIndexPlan) {
+        return visitIndexPlan(vectorIndexPlan);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/CardinalitiesProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/CardinalitiesProperty.java
@@ -101,6 +101,7 @@ import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedUnionP
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryUpdatePlan;
 import com.apple.foundationdb.record.query.plan.plans.TempTableInsertPlan;
 import com.apple.foundationdb.record.query.plan.plans.TempTableScanPlan;
+import com.apple.foundationdb.record.query.plan.plans.VectorIndexPlan;
 import com.apple.foundationdb.record.query.plan.sorting.RecordQueryDamPlan;
 import com.apple.foundationdb.record.query.plan.sorting.RecordQuerySortPlan;
 import com.google.common.base.Preconditions;
@@ -308,6 +309,12 @@ public class CardinalitiesProperty implements ExpressionProperty<CardinalitiesPr
         @Override
         public Cardinalities visitRecordQueryScoreForRankPlan(@Nonnull final RecordQueryScoreForRankPlan scoreForRankPlan) {
             return fromChild(scoreForRankPlan);
+        }
+
+        @Nonnull
+        @Override
+        public Cardinalities visitVectorIndexPlan(@Nonnull final VectorIndexPlan vectorIndexPlan) {
+            return visitRecordQueryIndexPlan(vectorIndexPlan);
         }
 
         @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/DerivationsProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/DerivationsProperty.java
@@ -95,6 +95,7 @@ import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedUnionP
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryUpdatePlan;
 import com.apple.foundationdb.record.query.plan.plans.TempTableInsertPlan;
 import com.apple.foundationdb.record.query.plan.plans.TempTableScanPlan;
+import com.apple.foundationdb.record.query.plan.plans.VectorIndexPlan;
 import com.apple.foundationdb.record.query.plan.sorting.RecordQueryDamPlan;
 import com.apple.foundationdb.record.query.plan.sorting.RecordQuerySortPlan;
 import com.google.common.base.Verify;
@@ -402,6 +403,12 @@ public class DerivationsProperty implements ExpressionProperty<DerivationsProper
         @Override
         public Derivations visitScoreForRankPlan(@Nonnull final RecordQueryScoreForRankPlan element) {
             throw new RecordCoreException("unsupported plan operator");
+        }
+
+        @Nonnull
+        @Override
+        public Derivations visitVectorIndexPlan(@Nonnull final VectorIndexPlan vectorIndexPlan) {
+            return visitIndexPlan(vectorIndexPlan);
         }
 
         @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/DistinctRecordsProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/DistinctRecordsProperty.java
@@ -73,6 +73,7 @@ import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedDistin
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedPrimaryKeyDistinctPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedUnionPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryUpdatePlan;
+import com.apple.foundationdb.record.query.plan.plans.VectorIndexPlan;
 import com.apple.foundationdb.record.query.plan.sorting.RecordQueryDamPlan;
 import com.apple.foundationdb.record.query.plan.sorting.RecordQuerySortPlan;
 import com.google.common.collect.ImmutableList;
@@ -258,6 +259,12 @@ public class DistinctRecordsProperty implements ExpressionProperty<Boolean> {
         public Boolean visitScoreForRankPlan(@Nonnull final RecordQueryScoreForRankPlan element) {
             // TODO this could be wrong -- but it is the way it was previously encoded
             return true;
+        }
+
+        @Nonnull
+        @Override
+        public Boolean visitVectorIndexPlan(@Nonnull final VectorIndexPlan vectorIndexPlan) {
+            return visitIndexPlan(vectorIndexPlan);
         }
 
         @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/OrderingProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/OrderingProperty.java
@@ -89,6 +89,7 @@ import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedDistin
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedPrimaryKeyDistinctPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedUnionPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryUpdatePlan;
+import com.apple.foundationdb.record.query.plan.plans.VectorIndexPlan;
 import com.apple.foundationdb.record.query.plan.sorting.RecordQueryDamPlan;
 import com.apple.foundationdb.record.query.plan.sorting.RecordQuerySortPlan;
 import com.apple.foundationdb.record.util.pair.Pair;
@@ -356,6 +357,12 @@ public class OrderingProperty implements ExpressionProperty<Ordering> {
         @Override
         public Ordering visitScoreForRankPlan(@Nonnull final RecordQueryScoreForRankPlan element) {
             return Ordering.empty();
+        }
+
+        @Nonnull
+        @Override
+        public Ordering visitVectorIndexPlan(@Nonnull final VectorIndexPlan vectorIndexPlan) {
+            return visitIndexPlan(vectorIndexPlan);
         }
 
         @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/PrimaryKeyProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/PrimaryKeyProperty.java
@@ -74,6 +74,7 @@ import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedDistin
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedPrimaryKeyDistinctPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedUnionPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryUpdatePlan;
+import com.apple.foundationdb.record.query.plan.plans.VectorIndexPlan;
 import com.apple.foundationdb.record.query.plan.sorting.RecordQueryDamPlan;
 import com.apple.foundationdb.record.query.plan.sorting.RecordQuerySortPlan;
 import com.google.common.collect.ImmutableList;
@@ -286,6 +287,12 @@ public class PrimaryKeyProperty implements ExpressionProperty<Optional<List<Valu
         @Override
         public Optional<List<Value>> visitScoreForRankPlan(@Nonnull final RecordQueryScoreForRankPlan scoreForRankPlan) {
             return primaryKeyFromSingleChild(scoreForRankPlan);
+        }
+
+        @Nonnull
+        @Override
+        public Optional<List<Value>> visitVectorIndexPlan(@Nonnull final VectorIndexPlan vectorIndexPlan) {
+            return visitIndexPlan(vectorIndexPlan);
         }
 
         @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/StoredRecordProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/StoredRecordProperty.java
@@ -71,6 +71,7 @@ import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedDistin
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedPrimaryKeyDistinctPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryUnorderedUnionPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryUpdatePlan;
+import com.apple.foundationdb.record.query.plan.plans.VectorIndexPlan;
 import com.apple.foundationdb.record.query.plan.sorting.RecordQueryDamPlan;
 import com.apple.foundationdb.record.query.plan.sorting.RecordQuerySortPlan;
 import com.google.common.collect.ImmutableList;
@@ -246,6 +247,12 @@ public class StoredRecordProperty implements ExpressionProperty<Boolean> {
         @Override
         public Boolean visitScoreForRankPlan(@Nonnull final RecordQueryScoreForRankPlan scoreForRankPlan) {
             return storedRecordsFromSingleChild(scoreForRankPlan);
+        }
+
+        @Nonnull
+        @Override
+        public Boolean visitVectorIndexPlan(@Nonnull final VectorIndexPlan vectorIndexPlan) {
+            return visitIndexPlan(vectorIndexPlan);
         }
 
         @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryIndexPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryIndexPlan.java
@@ -61,6 +61,7 @@ import com.apple.foundationdb.record.provider.foundationdb.KeyValueCursorBase;
 import com.apple.foundationdb.record.provider.foundationdb.MultidimensionalIndexScanComparisons;
 import com.apple.foundationdb.record.provider.foundationdb.UnsupportedRemoteFetchIndexException;
 import com.apple.foundationdb.record.query.plan.AvailableFields;
+import com.apple.foundationdb.record.query.plan.IndexTraversalKind;
 import com.apple.foundationdb.record.query.plan.QueryPlanConstraint;
 import com.apple.foundationdb.record.query.plan.ScanComparisons;
 import com.apple.foundationdb.record.query.plan.cascades.AggregateIndexMatchCandidate;
@@ -414,6 +415,22 @@ public class RecordQueryIndexPlan extends AbstractRelationalExpressionWithoutChi
     @Nonnull
     public IndexFetchMethod getIndexFetchMethod() {
         return indexFetchMethod;
+    }
+
+    /**
+     * Returns the {@link IndexTraversalKind way this plan physically traverses} the index it scans, which is whatever
+     * this plan's {@link #getScanParameters() scan parameters} say it is. Nothing is carried on the plan for this: the
+     * parameters know how the index is scanned, so the kind stays correct through serialization without a field of its
+     * own, and an index maintainer defined outside the core can answer for its own scans.
+     * <p>
+     * A subclass whose traversal does not follow from the scan parameters alone overrides this, as
+     * {@link VectorIndexPlan} does for a scan whose structure depends on the engine backing the index.
+     *
+     * @return the way this plan traverses the index
+     */
+    @Nonnull
+    public IndexTraversalKind getIndexTraversalKind() {
+        return scanParameters.getIndexTraversalKind();
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/VectorIndexPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/VectorIndexPlan.java
@@ -1,0 +1,177 @@
+/*
+ * VectorIndexPlan.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.plans;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
+import com.apple.foundationdb.record.ObjectPlanHash;
+import com.apple.foundationdb.record.PlanDeserializer;
+import com.apple.foundationdb.record.PlanHashable;
+import com.apple.foundationdb.record.PlanSerializationContext;
+import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.planprotos.PRecordQueryPlan;
+import com.apple.foundationdb.record.planprotos.PVectorIndexPlan;
+import com.apple.foundationdb.record.provider.foundationdb.indexes.VectorIndexEngineKind;
+import com.apple.foundationdb.record.query.plan.IndexTraversalKind;
+import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpression;
+import com.google.auto.service.AutoService;
+import com.google.common.base.Verify;
+import com.google.protobuf.Message;
+
+import javax.annotation.Nonnull;
+import java.util.Objects;
+
+/**
+ * A query plan that scans a {@link com.apple.foundationdb.record.metadata.IndexTypes#VECTOR vector} index. It is an
+ * ordinary {@link RecordQueryIndexPlan} in every respect but one: it also carries the
+ * {@link VectorIndexEngineKind engine} backing the index it scans, because a vector scan does not say which structure
+ * it walks. The scan parameters of every vector scan are alike, while the structure underneath is an
+ * {@link com.apple.foundationdb.record.metadata.IndexOptions#VECTOR_ENGINE index option}, so the engine has to be
+ * carried on the plan for {@link #getIndexTraversalKind()} to be able to answer.
+ * <p>
+ * Nothing constructs this plan yet, the planner still produces a plain {@link RecordQueryIndexPlan} for a vector index
+ * scan, and the only way to get one of these is to deserialize it. The class exists ahead of that so the serialization
+ * format is in place before plans in this shape are written.
+ *
+ * @see IndexTraversalKind
+ */
+@API(API.Status.INTERNAL)
+@SpotBugsSuppressWarnings("EQ_DOESNT_OVERRIDE_EQUALS") // equality reaches the engine through equalsWithoutChildren()
+public class VectorIndexPlan extends RecordQueryIndexPlan {
+
+    @Nonnull
+    protected static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("Vector-Index-Plan");
+
+    @Nonnull
+    private final VectorIndexEngineKind engine;
+
+    protected VectorIndexPlan(@Nonnull final PlanSerializationContext serializationContext,
+                              @Nonnull final PVectorIndexPlan vectorIndexPlanProto) {
+        super(serializationContext, Objects.requireNonNull(vectorIndexPlanProto.getSuper()));
+        //
+        // Insist on the engine rather than letting the proto default stand in for it: defaulting to one engine would
+        // quietly report the wrong traversal for a plan written by anything that did not set it.
+        //
+        Verify.verify(vectorIndexPlanProto.hasEngine());
+        this.engine = VectorIndexEngineKind.fromProto(vectorIndexPlanProto.getEngine());
+    }
+
+    // TODO Once the planner starts creating this plan, the methods that copy an index plan — strictlySorted(),
+    //      minimize() and withIndexScanParameters() — need overriding here, as the ones inherited from
+    //      RecordQueryIndexPlan return a plain RecordQueryIndexPlan and would drop the engine.
+
+    /**
+     * Returns the engine backing the index this plan scans.
+     *
+     * @return the engine backing the index this plan scans
+     */
+    @Nonnull
+    public VectorIndexEngineKind getEngine() {
+        return engine;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Answered from the engine rather than from the scan parameters, which are the same for every vector scan however
+     * the index is built.
+     *
+     * @return the way this plan traverses the index
+     */
+    @Nonnull
+    @Override
+    public IndexTraversalKind getIndexTraversalKind() {
+        return switch (engine) {
+            case HNSW -> IndexTraversalKind.HNSW;
+            case GUARDIANN -> IndexTraversalKind.GUARDIANN;
+            default -> throw new RecordCoreException("unknown vector index engine mapping. did you forget to add it?");
+        };
+    }
+
+    @Override
+    public boolean equalsWithoutChildren(@Nonnull final RelationalExpression otherExpression,
+                                         @Nonnull final AliasMap equivalencesMap) {
+        if (!super.equalsWithoutChildren(otherExpression, equivalencesMap)) {
+            return false;
+        }
+        return engine == ((VectorIndexPlan)otherExpression).engine;
+    }
+
+    @Override
+    public int computeHashCodeWithoutChildren() {
+        return Objects.hash(super.computeHashCodeWithoutChildren(), engine);
+    }
+
+    @Override
+    public int planHash(@Nonnull final PlanHashMode mode) {
+        return switch (mode.getKind()) {
+            case LEGACY, FOR_CONTINUATION ->
+                    PlanHashable.objectsPlanHash(mode, BASE_HASH, indexName, scanParameters, reverse, strictlySorted, engine);
+            default -> throw new UnsupportedOperationException("Hash kind " + mode.getKind() + " is not supported");
+        };
+    }
+
+    @Nonnull
+    @Override
+    public Message toProto(@Nonnull final PlanSerializationContext serializationContext) {
+        return toVectorIndexPlanProto(serializationContext);
+    }
+
+    @Nonnull
+    public PVectorIndexPlan toVectorIndexPlanProto(@Nonnull final PlanSerializationContext serializationContext) {
+        return PVectorIndexPlan.newBuilder()
+                .setSuper(toRecordQueryIndexPlanProto(serializationContext))
+                .setEngine(engine.toProto())
+                .build();
+    }
+
+    @Nonnull
+    @Override
+    public PRecordQueryPlan toRecordQueryPlanProto(@Nonnull final PlanSerializationContext serializationContext) {
+        return PRecordQueryPlan.newBuilder().setVectorIndexPlan(toVectorIndexPlanProto(serializationContext)).build();
+    }
+
+    @Nonnull
+    public static VectorIndexPlan fromProto(@Nonnull final PlanSerializationContext serializationContext,
+                                            @Nonnull final PVectorIndexPlan vectorIndexPlanProto) {
+        return new VectorIndexPlan(serializationContext, vectorIndexPlanProto);
+    }
+
+    /**
+     * Deserializer.
+     */
+    @AutoService(PlanDeserializer.class)
+    public static class Deserializer implements PlanDeserializer<PVectorIndexPlan, VectorIndexPlan> {
+        @Nonnull
+        @Override
+        public Class<PVectorIndexPlan> getProtoMessageClass() {
+            return PVectorIndexPlan.class;
+        }
+
+        @Nonnull
+        @Override
+        public VectorIndexPlan fromProto(@Nonnull final PlanSerializationContext serializationContext,
+                                         @Nonnull final PVectorIndexPlan vectorIndexPlanProto) {
+            return VectorIndexPlan.fromProto(serializationContext, vectorIndexPlanProto);
+        }
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/VectorIndexPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/VectorIndexPlan.java
@@ -22,30 +22,42 @@ package com.apple.foundationdb.record.query.plan.plans;
 
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
+import com.apple.foundationdb.record.IndexFetchMethod;
 import com.apple.foundationdb.record.ObjectPlanHash;
 import com.apple.foundationdb.record.PlanDeserializer;
 import com.apple.foundationdb.record.PlanHashable;
 import com.apple.foundationdb.record.PlanSerializationContext;
 import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.apple.foundationdb.record.planprotos.PRecordQueryPlan;
 import com.apple.foundationdb.record.planprotos.PVectorIndexPlan;
+import com.apple.foundationdb.record.provider.foundationdb.IndexScanParameters;
 import com.apple.foundationdb.record.provider.foundationdb.indexes.VectorIndexEngineKind;
 import com.apple.foundationdb.record.query.plan.IndexTraversalKind;
+import com.apple.foundationdb.record.query.plan.QueryPlanConstraint;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
+import com.apple.foundationdb.record.query.plan.cascades.FinalMemoizer;
+import com.apple.foundationdb.record.query.plan.cascades.MatchCandidate;
+import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpression;
+import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryFetchFromPartialRecordPlan.FetchIndexRecords;
 import com.google.auto.service.AutoService;
 import com.google.common.base.Verify;
 import com.google.protobuf.Message;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * A query plan that scans a {@link com.apple.foundationdb.record.metadata.IndexTypes#VECTOR vector} index. It is an
  * ordinary {@link RecordQueryIndexPlan} in every respect but one: it also carries the
- * {@link VectorIndexEngineKind engine} backing the index it scans, because a vector scan does not say which structure
+ * {@link VectorIndexEngineKind kind of engine} backing the index it scans, because a vector scan does not say which structure
  * it walks. The scan parameters of every vector scan are alike, while the structure underneath is an
- * {@link com.apple.foundationdb.record.metadata.IndexOptions#VECTOR_ENGINE index option}, so the engine has to be
+ * {@link com.apple.foundationdb.record.metadata.IndexOptions#VECTOR_ENGINE index option}, so the engine kind has to be
  * carried on the plan for {@link #getIndexTraversalKind()} to be able to answer.
  * <p>
  * Nothing constructs this plan yet, the planner still produces a plain {@link RecordQueryIndexPlan} for a vector index
@@ -55,44 +67,88 @@ import java.util.Objects;
  * @see IndexTraversalKind
  */
 @API(API.Status.INTERNAL)
-@SpotBugsSuppressWarnings("EQ_DOESNT_OVERRIDE_EQUALS") // equality reaches the engine through equalsWithoutChildren()
+@SpotBugsSuppressWarnings("EQ_DOESNT_OVERRIDE_EQUALS") // equality reaches the engine kind through equalsWithoutChildren()
 public class VectorIndexPlan extends RecordQueryIndexPlan {
 
     @Nonnull
     protected static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("Vector-Index-Plan");
 
     @Nonnull
-    private final VectorIndexEngineKind engine;
+    private final VectorIndexEngineKind engineKind;
 
     protected VectorIndexPlan(@Nonnull final PlanSerializationContext serializationContext,
                               @Nonnull final PVectorIndexPlan vectorIndexPlanProto) {
         super(serializationContext, Objects.requireNonNull(vectorIndexPlanProto.getSuper()));
         //
-        // Insist on the engine rather than letting the proto default stand in for it: defaulting to one engine would
+        // Insist on the engine kind rather than letting the proto default stand in for it: defaulting to one kind would
         // quietly report the wrong traversal for a plan written by anything that did not set it.
         //
-        Verify.verify(vectorIndexPlanProto.hasEngine());
-        this.engine = VectorIndexEngineKind.fromProto(vectorIndexPlanProto.getEngine());
+        Verify.verify(vectorIndexPlanProto.hasEngineKind());
+        this.engineKind = VectorIndexEngineKind.fromProto(vectorIndexPlanProto.getEngineKind());
     }
 
-    // TODO Once the planner starts creating this plan, the methods that copy an index plan — strictlySorted(),
-    //      minimize() and withIndexScanParameters() — need overriding here, as the ones inherited from
-    //      RecordQueryIndexPlan return a plain RecordQueryIndexPlan and would drop the engine.
+    private VectorIndexPlan(@Nonnull final String indexName,
+                            @Nullable final KeyExpression commonPrimaryKey,
+                            @Nonnull final IndexScanParameters scanParameters,
+                            @Nonnull final IndexFetchMethod indexFetchMethod,
+                            @Nonnull final FetchIndexRecords fetchIndexRecords,
+                            final boolean reverse,
+                            final boolean strictlySorted,
+                            @Nonnull final Optional<? extends MatchCandidate> matchCandidateOptional,
+                            @Nonnull final Type resultType,
+                            @Nonnull final QueryPlanConstraint constraint,
+                            @Nonnull final VectorIndexEngineKind engineKind) {
+        super(indexName, commonPrimaryKey, scanParameters, indexFetchMethod, fetchIndexRecords, reverse, strictlySorted,
+                matchCandidateOptional, resultType, constraint);
+        this.engineKind = engineKind;
+    }
 
     /**
-     * Returns the engine backing the index this plan scans.
+     * Returns the kind of engine backing the index this plan scans.
      *
-     * @return the engine backing the index this plan scans
+     * @return the kind of engine backing the index this plan scans
      */
     @Nonnull
-    public VectorIndexEngineKind getEngine() {
-        return engine;
+    public VectorIndexEngineKind getEngineKind() {
+        return engineKind;
+    }
+
+    //
+    // The methods that copy an index plan are overridden below rather than inherited. The ones on
+    // RecordQueryIndexPlan return a plain RecordQueryIndexPlan, which would drop the engine kind, and that matters as
+    // soon as anything writes a plan in this shape: a node running this code can deserialize such a plan and go on to
+    // copy it, whether or not this version's planner ever creates one itself.
+    //
+
+    @Nonnull
+    @Override
+    public VectorIndexPlan strictlySorted(@Nonnull final FinalMemoizer memoizer) {
+        return new VectorIndexPlan(getIndexName(), getCommonPrimaryKey(), getScanParameters(), getIndexFetchMethod(),
+                getFetchIndexRecords(), isReverse(), true, getMatchCandidateMaybe(), getResultType(), getConstraint(),
+                engineKind);
+    }
+
+    @Nonnull
+    @Override
+    public VectorIndexPlan minimize(@Nonnull final List<Quantifier.Physical> newQuantifiers) {
+        Verify.verify(newQuantifiers.isEmpty());
+        return new VectorIndexPlan(getIndexName(), getCommonPrimaryKey(), getScanParameters(), getIndexFetchMethod(),
+                getFetchIndexRecords(), isReverse(), isStrictlySorted(), Optional.empty(), getResultType(),
+                getConstraint(), engineKind);
+    }
+
+    @Nonnull
+    @Override
+    protected VectorIndexPlan withIndexScanParameters(@Nonnull final IndexScanParameters newIndexScanParameters) {
+        return new VectorIndexPlan(getIndexName(), getCommonPrimaryKey(), newIndexScanParameters,
+                getIndexFetchMethod(), getFetchIndexRecords(), isReverse(), isStrictlySorted(),
+                getMatchCandidateMaybe(), getResultType(), getConstraint(), engineKind);
     }
 
     /**
      * {@inheritDoc}
      * <p>
-     * Answered from the engine rather than from the scan parameters, which are the same for every vector scan however
+     * Answered from the engine kind rather than from the scan parameters, which are the same for every vector scan however
      * the index is built.
      *
      * @return the way this plan traverses the index
@@ -100,7 +156,7 @@ public class VectorIndexPlan extends RecordQueryIndexPlan {
     @Nonnull
     @Override
     public IndexTraversalKind getIndexTraversalKind() {
-        return switch (engine) {
+        return switch (engineKind) {
             case HNSW -> IndexTraversalKind.HNSW;
             case GUARDIANN -> IndexTraversalKind.GUARDIANN;
             default -> throw new RecordCoreException("unknown vector index engine mapping. did you forget to add it?");
@@ -113,19 +169,19 @@ public class VectorIndexPlan extends RecordQueryIndexPlan {
         if (!super.equalsWithoutChildren(otherExpression, equivalencesMap)) {
             return false;
         }
-        return engine == ((VectorIndexPlan)otherExpression).engine;
+        return engineKind == ((VectorIndexPlan)otherExpression).engineKind;
     }
 
     @Override
     public int computeHashCodeWithoutChildren() {
-        return Objects.hash(super.computeHashCodeWithoutChildren(), engine);
+        return Objects.hash(super.computeHashCodeWithoutChildren(), engineKind);
     }
 
     @Override
     public int planHash(@Nonnull final PlanHashMode mode) {
         return switch (mode.getKind()) {
             case LEGACY, FOR_CONTINUATION ->
-                    PlanHashable.objectsPlanHash(mode, BASE_HASH, indexName, scanParameters, reverse, strictlySorted, engine);
+                    PlanHashable.objectsPlanHash(mode, BASE_HASH, indexName, scanParameters, reverse, strictlySorted, engineKind);
             default -> throw new UnsupportedOperationException("Hash kind " + mode.getKind() + " is not supported");
         };
     }
@@ -140,7 +196,7 @@ public class VectorIndexPlan extends RecordQueryIndexPlan {
     public PVectorIndexPlan toVectorIndexPlanProto(@Nonnull final PlanSerializationContext serializationContext) {
         return PVectorIndexPlan.newBuilder()
                 .setSuper(toRecordQueryIndexPlanProto(serializationContext))
-                .setEngine(engine.toProto())
+                .setEngineKind(engineKind.toProto())
                 .build();
     }
 

--- a/fdb-record-layer-core/src/main/proto/record_query_plan.proto
+++ b/fdb-record-layer-core/src/main/proto/record_query_plan.proto
@@ -1927,7 +1927,7 @@ message PRecordQueryIndexPlan {
 //
 message PVectorIndexPlan {
   optional PRecordQueryIndexPlan super = 1;
-  optional PVectorIndexEngineKind engine = 2;
+  optional PVectorIndexEngineKind engine_kind = 2;
 }
 
 //

--- a/fdb-record-layer-core/src/main/proto/record_query_plan.proto
+++ b/fdb-record-layer-core/src/main/proto/record_query_plan.proto
@@ -1742,6 +1742,7 @@ message PRecordQueryPlan {
     PRecordQueryStreamingAggregationPlan2 streaming_aggregation_plan2 = 38;
     PRecordQueryMultiIntersectionOnValuesPlan multi_intersection_on_values_plan = 39;
     PRecordQueryRecursiveDfsJoinPlan recursive_dfs_join_plan = 40;
+    PVectorIndexPlan vector_index_plan = 41;
   }
 }
 
@@ -1922,6 +1923,14 @@ message PRecordQueryIndexPlan {
 }
 
 //
+// PVectorIndexPlan
+//
+message PVectorIndexPlan {
+  optional PRecordQueryIndexPlan super = 1;
+  optional PVectorIndexEngineKind engine = 2;
+}
+
+//
 // PTempTableScanPlan
 //
 message PTempTableScanPlan {
@@ -1994,6 +2003,11 @@ enum PIndexFetchMethod {
 enum PFetchIndexRecords {
   PRIMARY_KEY = 1;
   SYNTHETIC_CONSTITUENTS = 2;
+}
+
+enum PVectorIndexEngineKind {
+  HNSW = 1;
+  GUARDIANN = 2;
 }
 
 message PQueryPlanConstraint {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/MultidimensionalIndexTestBase.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/MultidimensionalIndexTestBase.java
@@ -55,6 +55,7 @@ import com.apple.foundationdb.record.query.expressions.Query;
 import com.apple.foundationdb.record.query.expressions.QueryComponent;
 import com.apple.foundationdb.record.query.plan.AvailableFields;
 import com.apple.foundationdb.record.query.plan.IndexKeyValueToPartialRecord;
+import com.apple.foundationdb.record.query.plan.IndexTraversalKind;
 import com.apple.foundationdb.record.query.plan.PlannableIndexTypes;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
@@ -1536,6 +1537,12 @@ public abstract class MultidimensionalIndexTestBase extends FDBRecordStoreQueryT
 
         @Nonnull
         @Override
+        public IndexTraversalKind getIndexTraversalKind() {
+            return IndexTraversalKind.R_TREE;
+        }
+
+        @Nonnull
+        @Override
         public IndexScanBounds bind(@Nonnull final FDBRecordStoreBase<?> store, @Nonnull final Index index, @Nonnull final EvaluationContext context) {
             final ImmutableList.Builder<TupleRange> tupleRangesBuilder = ImmutableList.builder();
             for (int i = 0; i < minsInclusive.length; i++) {
@@ -1626,6 +1633,12 @@ public abstract class MultidimensionalIndexTestBase extends FDBRecordStoreQueryT
         @Override
         public IndexScanType getScanType() {
             return IndexScanType.BY_VALUE;
+        }
+
+        @Nonnull
+        @Override
+        public IndexTraversalKind getIndexTraversalKind() {
+            return IndexTraversalKind.R_TREE;
         }
 
         @Nonnull

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/IndexTraversalKindTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/IndexTraversalKindTest.java
@@ -1,0 +1,143 @@
+/*
+ * IndexTraversalKindTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan;
+
+import com.apple.foundationdb.linear.DoubleRealVector;
+import com.apple.foundationdb.record.IndexFetchMethod;
+import com.apple.foundationdb.record.IndexScanType;
+import com.apple.foundationdb.record.provider.foundationdb.IndexScanComparisons;
+import com.apple.foundationdb.record.provider.foundationdb.IndexScanParameters;
+import com.apple.foundationdb.record.provider.foundationdb.MultidimensionalIndexScanComparisons;
+import com.apple.foundationdb.record.provider.foundationdb.VectorIndexScanComparisons;
+import com.apple.foundationdb.record.provider.foundationdb.leaderboard.TimeWindowForFunction;
+import com.apple.foundationdb.record.provider.foundationdb.leaderboard.TimeWindowScanComparisons;
+import com.apple.foundationdb.record.query.expressions.Comparisons;
+import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
+import com.apple.foundationdb.record.query.plan.cascades.values.LiteralValue;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryFetchFromPartialRecordPlan.FetchIndexRecords;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryIndexPlan;
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import javax.annotation.Nonnull;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests of the {@link IndexTraversalKind} each kind of {@link IndexScanParameters} reports, and of the kind a
+ * {@link RecordQueryIndexPlan} takes from them.
+ */
+class IndexTraversalKindTest {
+    static Stream<Arguments> scanParameters() {
+        return Stream.of(
+                Arguments.of("by value", IndexScanComparisons.byValue(), IndexTraversalKind.BY_VALUE),
+                Arguments.of("by value over-scan",
+                        IndexScanComparisons.byValue(null, IndexScanType.BY_VALUE_OVER_SCAN),
+                        IndexTraversalKind.BY_VALUE),
+                Arguments.of("by group", scanBy(IndexScanType.BY_GROUP), IndexTraversalKind.BY_VALUE),
+                Arguments.of("by rank", scanBy(IndexScanType.BY_RANK), IndexTraversalKind.RANKED_SET),
+                Arguments.of("by time window", timeWindowScan(), IndexTraversalKind.RANKED_SET),
+                Arguments.of("by text token", scanBy(IndexScanType.BY_TEXT_TOKEN), IndexTraversalKind.INVERTED),
+                Arguments.of("multidimensional", multidimensionalScan(), IndexTraversalKind.R_TREE),
+                //
+                // A vector scan cannot say: which structure it walks depends on the engine backing the index, which only
+                // VectorIndexPlan knows.
+                //
+                Arguments.of("by distance", vectorScan(), IndexTraversalKind.UNKNOWN),
+                Arguments.of("scan type defined elsewhere", scanBy(new IndexScanType("BY_SOMETHING_ELSE")),
+                        IndexTraversalKind.UNKNOWN));
+    }
+
+    @ParameterizedTest(name = "scanParametersReportTheirTraversalKind[{0}]")
+    @MethodSource("scanParameters")
+    @SuppressWarnings("unused") // the name only names the test case
+    void scanParametersReportTheirTraversalKind(@Nonnull final String name,
+                                                @Nonnull final IndexScanParameters scanParameters,
+                                                @Nonnull final IndexTraversalKind expectedKind) {
+        assertThat(scanParameters.getIndexTraversalKind()).isEqualTo(expectedKind);
+    }
+
+    @ParameterizedTest(name = "indexPlanTraversalKindFollowsScanParameters[{0}]")
+    @MethodSource("scanParameters")
+    @SuppressWarnings("unused") // the name only names the test case
+    void indexPlanTraversalKindFollowsScanParameters(@Nonnull final String name,
+                                                     @Nonnull final IndexScanParameters scanParameters,
+                                                     @Nonnull final IndexTraversalKind expectedKind) {
+        assertThat(indexPlan(scanParameters).getIndexTraversalKind()).isEqualTo(expectedKind);
+    }
+
+    @Test
+    void kindsDefinedElsewhereAreDistinctFromTheOnesDefinedHere() {
+        final IndexTraversalKind spaceFillingCurve = new IndexTraversalKind("SPACE_FILLING_CURVE");
+        assertThat(spaceFillingCurve).isEqualTo(new IndexTraversalKind("SPACE_FILLING_CURVE"))
+                .hasSameHashCodeAs(new IndexTraversalKind("SPACE_FILLING_CURVE"))
+                .isNotEqualTo(IndexTraversalKind.BY_VALUE)
+                .isNotEqualTo(IndexTraversalKind.UNKNOWN);
+        assertThat(spaceFillingCurve.name()).isEqualTo("SPACE_FILLING_CURVE");
+        assertThat(spaceFillingCurve).hasToString("SPACE_FILLING_CURVE");
+    }
+
+    @Nonnull
+    private static IndexScanParameters scanBy(@Nonnull final IndexScanType scanType) {
+        return new IndexScanComparisons(scanType, ScanComparisons.EMPTY);
+    }
+
+    @Nonnull
+    private static IndexScanParameters timeWindowScan() {
+        return new TimeWindowScanComparisons(new TimeWindowForFunction(1, 42L, null, null), ScanComparisons.EMPTY);
+    }
+
+    @Nonnull
+    private static IndexScanParameters multidimensionalScan() {
+        return MultidimensionalIndexScanComparisons.byValue(ScanComparisons.EMPTY,
+                ImmutableList.of(ScanComparisons.EMPTY), ScanComparisons.EMPTY);
+    }
+
+    @Nonnull
+    private static IndexScanParameters vectorScan() {
+        final int numDimensions = 128;
+        final Comparisons.DistanceRankValueComparison distanceRankValueComparison =
+                new Comparisons.DistanceRankValueComparison(Comparisons.Type.DISTANCE_RANK_LESS_THAN_OR_EQUAL,
+                        new LiteralValue<>(Type.Vector.of(false, 64, numDimensions),
+                                new DoubleRealVector(new double[numDimensions])),
+                        new LiteralValue<>(10), null, null);
+        return VectorIndexScanComparisons.byDistance(ScanComparisons.EMPTY, distanceRankValueComparison);
+    }
+
+    @Nonnull
+    private static RecordQueryIndexPlan indexPlan(@Nonnull final IndexScanParameters scanParameters) {
+        return new RecordQueryIndexPlan("an_index",
+                null,
+                scanParameters,
+                IndexFetchMethod.SCAN_AND_FETCH,
+                FetchIndexRecords.PRIMARY_KEY,
+                false,
+                false,
+                Optional.empty(),
+                new Type.Any(),
+                QueryPlanConstraint.noConstraint());
+    }
+}

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/plans/VectorIndexPlanTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/plans/VectorIndexPlanTest.java
@@ -1,0 +1,133 @@
+/*
+ * VectorIndexPlanTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.plans;
+
+import com.apple.foundationdb.linear.DoubleRealVector;
+import com.apple.foundationdb.record.IndexFetchMethod;
+import com.apple.foundationdb.record.PlanSerializationContext;
+import com.apple.foundationdb.record.planprotos.PPlanReference;
+import com.apple.foundationdb.record.planprotos.PVectorIndexPlan;
+import com.apple.foundationdb.record.provider.foundationdb.IndexScanParameters;
+import com.apple.foundationdb.record.provider.foundationdb.VectorIndexScanComparisons;
+import com.apple.foundationdb.record.provider.foundationdb.indexes.VectorIndexEngineKind;
+import com.apple.foundationdb.record.query.expressions.Comparisons;
+import com.apple.foundationdb.record.query.plan.IndexTraversalKind;
+import com.apple.foundationdb.record.query.plan.QueryPlanConstraint;
+import com.apple.foundationdb.record.query.plan.ScanComparisons;
+import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
+import com.apple.foundationdb.record.query.plan.cascades.values.LiteralValue;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryFetchFromPartialRecordPlan.FetchIndexRecords;
+import com.google.common.base.VerifyException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import javax.annotation.Nonnull;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests of {@link VectorIndexPlan}, which, as nothing creates it yet, can only be obtained by deserializing one.
+ */
+class VectorIndexPlanTest {
+    @ParameterizedTest
+    @CsvSource({"HNSW, HNSW", "GUARDIANN, GUARDIANN"})
+    void indexTraversalKindFollowsEngine(@Nonnull final VectorIndexEngineKind engine,
+                                         @Nonnull final IndexTraversalKind expectedKind) {
+        final VectorIndexPlan plan = vectorIndexPlan(engine);
+        assertThat(plan.getEngine()).isEqualTo(engine);
+        assertThat(plan.getIndexTraversalKind()).isEqualTo(expectedKind);
+    }
+
+    @ParameterizedTest
+    @EnumSource(VectorIndexEngineKind.class)
+    void serializationRoundTripPreservesEngine(@Nonnull final VectorIndexEngineKind engine) throws Exception {
+        final VectorIndexPlan plan = vectorIndexPlan(engine);
+
+        PlanSerializationContext serializationContext = PlanSerializationContext.newForCurrentMode();
+        final PPlanReference proto = serializationContext.toPlanReferenceProto(plan);
+        final PPlanReference parsedProto = PPlanReference.parseFrom(proto.toByteArray());
+        serializationContext = PlanSerializationContext.newForCurrentMode();
+        final RecordQueryPlan parsedPlan = serializationContext.fromPlanReferenceProto(parsedProto);
+
+        assertThat(parsedPlan).isInstanceOf(VectorIndexPlan.class);
+        assertThat(((VectorIndexPlan)parsedPlan).getEngine()).isEqualTo(engine);
+        assertThat(plan.semanticEquals(parsedPlan)).isTrue();
+    }
+
+    @Test
+    void deserializationWithoutEngineFails() {
+        final PVectorIndexPlan proto = PVectorIndexPlan.newBuilder()
+                .setSuper(indexPlan().toRecordQueryIndexPlanProto(PlanSerializationContext.newForCurrentMode()))
+                .build();
+        assertThatThrownBy(() -> VectorIndexPlan.fromProto(PlanSerializationContext.newForCurrentMode(), proto))
+                .isInstanceOf(VerifyException.class);
+    }
+
+    @Test
+    void plansWithDifferentEnginesAreNotEqual() {
+        assertThat(vectorIndexPlan(VectorIndexEngineKind.HNSW)
+                .semanticEquals(vectorIndexPlan(VectorIndexEngineKind.GUARDIANN))).isFalse();
+    }
+
+    @Test
+    void plansAreNotEqualToTheirIndexPlanSuper() {
+        assertThat(vectorIndexPlan(VectorIndexEngineKind.HNSW).semanticEquals(indexPlan())).isFalse();
+    }
+
+    @Nonnull
+    private static VectorIndexPlan vectorIndexPlan(@Nonnull final VectorIndexEngineKind engine) {
+        final PlanSerializationContext serializationContext = PlanSerializationContext.newForCurrentMode();
+        final PVectorIndexPlan proto = PVectorIndexPlan.newBuilder()
+                .setSuper(indexPlan().toRecordQueryIndexPlanProto(serializationContext))
+                .setEngine(engine.toProto())
+                .build();
+        return VectorIndexPlan.fromProto(serializationContext, proto);
+    }
+
+    @Nonnull
+    private static RecordQueryIndexPlan indexPlan() {
+        return new RecordQueryIndexPlan("a_vector_index",
+                null,
+                vectorScan(),
+                IndexFetchMethod.SCAN_AND_FETCH,
+                FetchIndexRecords.PRIMARY_KEY,
+                false,
+                false,
+                Optional.empty(),
+                new Type.Any(),
+                QueryPlanConstraint.noConstraint());
+    }
+
+    @Nonnull
+    private static IndexScanParameters vectorScan() {
+        final int numDimensions = 128;
+        final Comparisons.DistanceRankValueComparison distanceRankValueComparison =
+                new Comparisons.DistanceRankValueComparison(Comparisons.Type.DISTANCE_RANK_LESS_THAN_OR_EQUAL,
+                        new LiteralValue<>(Type.Vector.of(false, 64, numDimensions),
+                                new DoubleRealVector(new double[numDimensions])),
+                        new LiteralValue<>(10), null, null);
+        return VectorIndexScanComparisons.byDistance(ScanComparisons.EMPTY, distanceRankValueComparison);
+    }
+}

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/plans/VectorIndexPlanTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/plans/VectorIndexPlanTest.java
@@ -32,10 +32,13 @@ import com.apple.foundationdb.record.query.expressions.Comparisons;
 import com.apple.foundationdb.record.query.plan.IndexTraversalKind;
 import com.apple.foundationdb.record.query.plan.QueryPlanConstraint;
 import com.apple.foundationdb.record.query.plan.ScanComparisons;
+import com.apple.foundationdb.record.query.plan.cascades.Memoizer;
+import com.apple.foundationdb.record.query.plan.cascades.PlannerStage;
 import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
 import com.apple.foundationdb.record.query.plan.cascades.values.LiteralValue;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryFetchFromPartialRecordPlan.FetchIndexRecords;
 import com.google.common.base.VerifyException;
+import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -56,7 +59,7 @@ class VectorIndexPlanTest {
     void indexTraversalKindFollowsEngine(@Nonnull final VectorIndexEngineKind engine,
                                          @Nonnull final IndexTraversalKind expectedKind) {
         final VectorIndexPlan plan = vectorIndexPlan(engine);
-        assertThat(plan.getEngine()).isEqualTo(engine);
+        assertThat(plan.getEngineKind()).isEqualTo(engine);
         assertThat(plan.getIndexTraversalKind()).isEqualTo(expectedKind);
     }
 
@@ -72,7 +75,7 @@ class VectorIndexPlanTest {
         final RecordQueryPlan parsedPlan = serializationContext.fromPlanReferenceProto(parsedProto);
 
         assertThat(parsedPlan).isInstanceOf(VectorIndexPlan.class);
-        assertThat(((VectorIndexPlan)parsedPlan).getEngine()).isEqualTo(engine);
+        assertThat(((VectorIndexPlan)parsedPlan).getEngineKind()).isEqualTo(engine);
         assertThat(plan.semanticEquals(parsedPlan)).isTrue();
     }
 
@@ -96,12 +99,37 @@ class VectorIndexPlanTest {
         assertThat(vectorIndexPlan(VectorIndexEngineKind.HNSW).semanticEquals(indexPlan())).isFalse();
     }
 
+    /**
+     * A plan deserialized from a newer writer can still be copied by this version, so every copy has to keep the engine
+     * kind rather than degrade to a plain {@link RecordQueryIndexPlan}.
+     */
+    @Test
+    void copyingAPlanKeepsTheEngineKind() {
+        final VectorIndexPlan plan = vectorIndexPlan(VectorIndexEngineKind.GUARDIANN);
+
+        assertThat(plan.strictlySorted(Memoizer.noMemoization(PlannerStage.PLANNED)))
+                .isInstanceOf(VectorIndexPlan.class)
+                .extracting(VectorIndexPlan::getEngineKind)
+                .isEqualTo(VectorIndexEngineKind.GUARDIANN);
+        assertThat(plan.strictlySorted(Memoizer.noMemoization(PlannerStage.PLANNED)).isStrictlySorted()).isTrue();
+
+        assertThat(plan.minimize(ImmutableList.of()))
+                .isInstanceOf(VectorIndexPlan.class)
+                .extracting(VectorIndexPlan::getEngineKind)
+                .isEqualTo(VectorIndexEngineKind.GUARDIANN);
+
+        assertThat(plan.withIndexScanParameters(vectorScan()))
+                .isInstanceOf(VectorIndexPlan.class)
+                .extracting(VectorIndexPlan::getEngineKind)
+                .isEqualTo(VectorIndexEngineKind.GUARDIANN);
+    }
+
     @Nonnull
     private static VectorIndexPlan vectorIndexPlan(@Nonnull final VectorIndexEngineKind engine) {
         final PlanSerializationContext serializationContext = PlanSerializationContext.newForCurrentMode();
         final PVectorIndexPlan proto = PVectorIndexPlan.newBuilder()
                 .setSuper(indexPlan().toRecordQueryIndexPlanProto(serializationContext))
-                .setEngine(engine.toProto())
+                .setEngineKind(engine.toProto())
                 .build();
         return VectorIndexPlan.fromProto(serializationContext, proto);
     }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanParameters.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanParameters.java
@@ -33,6 +33,7 @@ import com.apple.foundationdb.record.planprotos.PLuceneScanParameters;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
 import com.apple.foundationdb.record.provider.foundationdb.IndexScanParameters;
 import com.apple.foundationdb.record.query.expressions.Comparisons;
+import com.apple.foundationdb.record.query.plan.IndexTraversalKind;
 import com.apple.foundationdb.record.query.plan.ScanComparisons;
 import com.apple.foundationdb.record.query.plan.cascades.explain.Attribute;
 import com.apple.foundationdb.tuple.Tuple;
@@ -72,6 +73,12 @@ public abstract class LuceneScanParameters implements IndexScanParameters {
     @Override
     public IndexScanType getScanType() {
         return scanType;
+    }
+
+    @Nonnull
+    @Override
+    public IndexTraversalKind getIndexTraversalKind() {
+        return LuceneTraversalKinds.LUCENE;
     }
 
     @Nonnull

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneTraversalKinds.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneTraversalKinds.java
@@ -1,0 +1,39 @@
+/*
+ * LuceneTraversalKinds.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene;
+
+import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.query.plan.IndexTraversalKind;
+
+/**
+ * {@link IndexTraversalKind}s for Lucene.
+ */
+@API(API.Status.EXPERIMENTAL)
+public class LuceneTraversalKinds {
+    /**
+     * A Lucene index, held in a directory of its own rather than as the plain key-value pairs every traversal the core
+     * defines walks. Which of the Lucene scan types is in play does not change that, so they all report this one.
+     */
+    public static final IndexTraversalKind LUCENE = new IndexTraversalKind("LUCENE");
+
+    private LuceneTraversalKinds() {
+    }
+}

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneTraversalKindTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneTraversalKindTest.java
@@ -1,0 +1,62 @@
+/*
+ * LuceneTraversalKindTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.lucene;
+
+import com.apple.foundationdb.record.query.plan.IndexTraversalKind;
+import com.apple.foundationdb.record.query.plan.ScanComparisons;
+import com.apple.foundationdb.record.query.plan.plans.RecordQueryFetchFromPartialRecordPlan.FetchIndexRecords;
+import com.google.common.collect.ImmutableSet;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests that Lucene names the structure its scans traverse, which it can only do because
+ * {@link IndexTraversalKind} is open to kinds defined outside the core.
+ */
+class LuceneTraversalKindTest {
+    @Test
+    void luceneScanParametersReportTheLuceneTraversalKind() {
+        assertThat(luceneScanParameters().getIndexTraversalKind())
+                .isEqualTo(LuceneTraversalKinds.LUCENE)
+                .isNotEqualTo(IndexTraversalKind.BY_VALUE)
+                .isNotEqualTo(IndexTraversalKind.UNKNOWN);
+    }
+
+    @Test
+    void luceneIndexQueryPlanTakesItsTraversalKindFromItsScanParameters() {
+        final LuceneIndexQueryPlan plan = LuceneIndexQueryPlan.of("a_lucene_index",
+                luceneScanParameters(),
+                FetchIndexRecords.PRIMARY_KEY,
+                false,
+                null,
+                null);
+        assertThat(plan.getIndexTraversalKind()).isEqualTo(LuceneTraversalKinds.LUCENE);
+    }
+
+    @Nonnull
+    private static LuceneScanParameters luceneScanParameters() {
+        return new LuceneScanQueryParameters(ScanComparisons.EMPTY,
+                new LuceneAutoCompleteQueryClause("good", false, ImmutableSet.of("text")));
+    }
+}


### PR DESCRIPTION
A query plan that scans an index has, until now, had no way to say what it will physically do at runtime. The logical index type doesn't answer that question, a `rank` index scanned `BY_RANK` walks a probabilistic skip list, while the very same index scanned `BY_VALUE` walks ordered key-value pairs, and the two have little in common in terms of what they cost. 

This change introduces `IndexTraversalKind`, the structure a scan actually traverses, and exposes it through a new `IndexScanParameters#getIndexTraversalKind()` that each kind of scan parameters answers for itself, plus `RecordQueryIndexPlan#getIndexTraversalKind()` for the plan as a whole. The kind is derived from the scan rather than stored on the plan, so no existing plan gains a field and no plan hash changes. Following `IndexScanType`, the kind is deliberately open rather than an enum: an index maintainer defined outside the core can name whatever its scans walk, and Lucene now does exactly that from its own module.

Vector indexes are the one case the scan parameters cannot answer, since which structure a vector scan traverses depends on the engine the index was built with, an index option that the parameters do not carry. This change therefore also adds `VectorIndexPlan`, a `RecordQueryIndexPlan` that carries its engine and reports `HNSW` or `GUARDIANN` accordingly, along with the serialization format for it. Nothing plans `VectorIndexPlan`; it can only arise from deserialization, or from copying one that did; the planner continues to produce a plain `RecordQueryIndexPlan` for vector scans, and the class ships ahead of the planner work so the wire format is settled before plans in this shape are written. Together this gives planning and costing a way to tell two otherwise indistinguishable index accesses apart, whether by a cost criterion or by an explicitly stated preference by the customer.

Marking the PR as breaking change, since the abstract method `getIndexTraversalKind` addition to `IndexScanParameters` which is a public @API(UNSTABLE) interface breaks external implementors at compile time.

This fixes https://github.com/FoundationDB/fdb-record-layer/issues/4428.