### PR TITLE
Correctly derive the nullability of the `COALESCE()` result type

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/VariadicFunctionValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/VariadicFunctionValue.java
@@ -27,6 +27,7 @@ import com.apple.foundationdb.record.ObjectPlanHash;
 import com.apple.foundationdb.record.PlanDeserializer;
 import com.apple.foundationdb.record.PlanHashable;
 import com.apple.foundationdb.record.PlanSerializationContext;
+import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.planprotos.PValue;
 import com.apple.foundationdb.record.planprotos.PVariadicFunctionValue;
 import com.apple.foundationdb.record.planprotos.PVariadicFunctionValue.PPhysicalOperator;
@@ -49,7 +50,7 @@ import com.google.common.base.Verify;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
+import com.google.common.collect.Streams;
 import com.google.protobuf.Message;
 
 import javax.annotation.Nonnull;
@@ -58,12 +59,14 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /**
- * A {@link Value} that applies an arithmetic operation on its child expressions.
+ * A {@link Value} that applies a variadic comparison function, such as {@code GREATEST()}, {@code LEAST()} or
+ * {@code COALESCE()}, to its child expressions.
  */
 @API(API.Status.EXPERIMENTAL)
 public class VariadicFunctionValue extends AbstractValue {
@@ -73,20 +76,23 @@ public class VariadicFunctionValue extends AbstractValue {
     private final PhysicalOperator operator;
     @Nonnull
     private final List<Value> children;
+    @Nonnull
+    private final Type resultType;
 
     @Nonnull
     private static final Supplier<Map<NonnullPair<ComparisonFunction, TypeCode>, PhysicalOperator>> operatorMapSupplier =
             Suppliers.memoize(VariadicFunctionValue::computeOperatorMap);
 
     /**
-     * Constructs a new instance of {@link VariadicFunctionValue}.
-     * @param operator The arithmetic operation.
+     * Constructs a new instance of {@link VariadicFunctionValue}, deriving the result type from the given children.
+     * @param operator The physical operator implementing the comparison function.
      * @param children The children.
      */
     public VariadicFunctionValue(@Nonnull PhysicalOperator operator,
                                  @Nonnull List<Value> children) {
         this.operator = operator;
         this.children = ImmutableList.copyOf(children);
+        this.resultType = computeResultType(operator, this.children);
     }
 
     @Nullable
@@ -99,7 +105,24 @@ public class VariadicFunctionValue extends AbstractValue {
     @Nonnull
     @Override
     public Type getResultType() {
-        return children.get(0).getResultType();
+        return resultType;
+    }
+
+    @Nonnull
+    private static Type computeResultType(@Nonnull final PhysicalOperator operator,
+                                          @Nonnull final List<Value> children) {
+        // Verify that all children have a suitable common type, which is done by injecting promotions in
+        // `encapsulate()`. The argument types may only differ in their nullability, which is combined into the
+        // nullability of the result according to the semantics of the comparison function at hand.
+        Verify.verify(children.size() >= 2, "`VariadicFunctionValue` must have at least two children");
+        final Type maximumType = children.get(0).getResultType();
+        for (final Value child : children.subList(1, children.size())) {
+            final Type childType = child.getResultType();
+            Verify.verify(childType.nullable().equals(maximumType.nullable()),
+                    "`VariadicFunctionValue` children must share a common type, but %s differs from %s",
+                    childType, maximumType);
+        }
+        return maximumType.withNullability(operator.getComparisonFunction().isResultNullable(children));
     }
 
     @Nonnull
@@ -116,7 +139,6 @@ public class VariadicFunctionValue extends AbstractValue {
     @Nonnull
     @Override
     public VariadicFunctionValue withChildren(final Iterable<? extends Value> newChildren) {
-        Verify.verify(Iterables.size(newChildren) >= 2);
         return new VariadicFunctionValue(this.operator, ImmutableList.copyOf(newChildren));
     }
 
@@ -187,37 +209,50 @@ public class VariadicFunctionValue extends AbstractValue {
     }
 
     @Nonnull
-    @SuppressWarnings("PMD.CompareObjectsWithEquals")
     private static Value encapsulate(@Nonnull BuiltInFunction<Value> builtInFunction,
                                      @Nonnull final CallSiteArguments callSiteArguments) {
+        // Determine the common type of the arguments, rejecting the call if they are mutually incompatible.
+        //
+        // All arguments must have a resolved type, with the exception that some (though not all) of them may be of
+        // the unresolved `NullType` (e.g., a NULL literal). `Type.maximumType()` handles such a `NullType` correctly
+        // by returning the appropriate concrete type with its nullability set to true. If *every* argument is NULL,
+        // the overall maximum type will be `NullType` and the operator lookup below will fail.
         final List<? extends Typed> arguments = callSiteArguments.getArgumentsList();
         Verify.verify(arguments.size() >= 2);
-        Type resultType = null;
-        for (final var arg : arguments) {
+        Type maximumType = null;
+        for (final Typed arg : arguments) {
             Type argType = arg.getResultType();
-            // This logic allows one (but not all) of the arguments to be of `NullType`
-            // (e.g., a 'null' literal). In such cases, `Type.maximumType` will correctly
-            // determine the appropriate concrete type *and* set its nullability to `true`,
-            // due to the presence of the `NullType` argument.
-            Verify.verify(argType == Type.NULL || !argType.isUnresolved());
-            if (resultType == null) {
-                resultType = argType;
+            Verify.verify(argType.isNull() || !argType.isUnresolved());
+            if (maximumType == null) {
+                maximumType = argType;
             } else {
-                resultType = Type.maximumType(resultType, argType);
-                SemanticException.check(resultType != null, SemanticException.ErrorCode.INCOMPATIBLE_TYPE);
+                maximumType = Type.maximumType(maximumType, argType);
+                SemanticException.check(maximumType != null, SemanticException.ErrorCode.INCOMPATIBLE_TYPE);
             }
         }
 
+        // Look up the physical operator implementing the comparison function for the common type of the arguments.
+        final ComparisonFunction comparisonFunction = ((ComparisonFn)builtInFunction).getComparisonFunction();
         final PhysicalOperator physicalOperator =
-                getOperatorMap()
-                        .get(NonnullPair.of((((ComparisonFn)builtInFunction).getComparisonFunction()), resultType.getTypeCode()));
-        SemanticException.check(physicalOperator != null, SemanticException.ErrorCode.FUNCTION_UNDEFINED_FOR_GIVEN_ARGUMENT_TYPES);
+                getOperatorMap().get(NonnullPair.of(comparisonFunction, maximumType.getTypeCode()));
+        SemanticException.check(
+                physicalOperator != null,
+                SemanticException.ErrorCode.FUNCTION_UNDEFINED_FOR_GIVEN_ARGUMENT_TYPES);
 
-        final ImmutableList.Builder<Value> promotedArgs = ImmutableList.builder();
-        for (final var arg: arguments) {
-            promotedArgs.add(PromoteValue.inject((Value) arg, resultType));
+        // Determine the result type with the appropriate nullability for the comparison function at hand.
+        final Type resultType = maximumType.withNullability(comparisonFunction.isResultNullable(arguments));
+
+        // Promote each argument to the common type, but keep non-nullable types non-nullable, so that the information
+        // about which arguments are nullable is retained.
+        final Type nullableResultType = resultType.withNullability(true);
+        final ImmutableList.Builder<Value> promotedArguments = ImmutableList.builder();
+        for (final Typed arg : arguments) {
+            final Type promoteToType = arg.getResultType().isNullable() ? nullableResultType : resultType;
+            promotedArguments.add(PromoteValue.inject((Value)arg, promoteToType));
         }
-        return new VariadicFunctionValue(physicalOperator, promotedArgs.build());
+        final ImmutableList<Value> children = promotedArguments.build();
+
+        return new VariadicFunctionValue(physicalOperator, children);
     }
 
     private static Map<NonnullPair<ComparisonFunction, TypeCode>, PhysicalOperator> computeOperatorMap() {
@@ -272,12 +307,56 @@ public class VariadicFunctionValue extends AbstractValue {
     }
 
     /**
-     * Logical operator.
+     * The comparison function that a {@link VariadicFunctionValue} applies. Each function defines how the nullabilities
+     * of the arguments combine into the nullability of the result.
      */
     public enum ComparisonFunction {
+        /**
+         * The {@code GREATEST()} function. Returns {@code NULL} if any of its arguments is {@code NULL}.
+         */
         GREATEST,
+        /**
+         * The {@code LEAST()} function. Returns {@code NULL} if any of its arguments is {@code NULL}.
+         */
         LEAST,
-        COALESCE
+        /**
+         * The {@code COALESCE()} function. Returns its first non-{@code NULL} argument; so it is nullable only if
+         * all its arguments are nullable.
+         */
+        COALESCE(Boolean::logicalAnd);
+
+        @Nonnull
+        private final BinaryOperator<Boolean> nullabilityCombiner;
+
+        /**
+         * Constructs a new instance of {@link ComparisonFunction} whose result is nullable if any of its arguments is
+         * nullable, which is the most common case.
+         */
+        ComparisonFunction() {
+            this(Boolean::logicalOr);
+        }
+
+        /**
+         * Constructs a new instance of {@link ComparisonFunction}.
+         *
+         * The given {@code nullabilityCombiner} combines the nullabilities of the arguments to derive the nullability
+         * of the result.
+         */
+        ComparisonFunction(@Nonnull final BinaryOperator<Boolean> nullabilityCombiner) {
+            this.nullabilityCombiner = nullabilityCombiner;
+        }
+
+        /**
+         * Computes whether the result of this function is nullable, given its arguments.
+         * @param arguments the arguments this function is applied to
+         * @return {@code true} if the result of this function is nullable, {@code false} otherwise
+         */
+        public boolean isResultNullable(@Nonnull final Iterable<? extends Typed> arguments) {
+            return Streams.stream(arguments)
+                    .map(argument -> argument.getResultType().isNullable())
+                    .reduce(nullabilityCombiner)
+                    .orElseThrow(() -> new RecordCoreException("function must have at least one argument"));
+        }
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/VariadicFunctionValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/VariadicFunctionValue.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,15 +84,31 @@ public class VariadicFunctionValue extends AbstractValue {
             Suppliers.memoize(VariadicFunctionValue::computeOperatorMap);
 
     /**
-     * Constructs a new instance of {@link VariadicFunctionValue}, deriving the result type from the given children.
+     * Constructs a new instance of {@link VariadicFunctionValue}.
      * @param operator The physical operator implementing the comparison function.
      * @param children The children.
+     * @param resultType The result type, which must be consistent with the children's types.
      */
-    public VariadicFunctionValue(@Nonnull PhysicalOperator operator,
-                                 @Nonnull List<Value> children) {
+    private VariadicFunctionValue(@Nonnull final PhysicalOperator operator,
+                                  @Nonnull final ImmutableList<Value> children,
+                                  @Nonnull final Type resultType) {
         this.operator = operator;
-        this.children = ImmutableList.copyOf(children);
-        this.resultType = computeResultType(operator, this.children);
+        this.children = children;
+        this.resultType = resultType;
+    }
+
+    /**
+     * Creates a new instance of {@link VariadicFunctionValue}, deriving the result type from the given children.
+     * @param operator The physical operator implementing the comparison function.
+     * @param children The children, of which there must be at least two.
+     * @return a new {@link VariadicFunctionValue}
+     */
+    @Nonnull
+    public static VariadicFunctionValue of(@Nonnull final PhysicalOperator operator,
+                                           @Nonnull final Iterable<? extends Value> children) {
+        final ImmutableList<Value> childrenList = ImmutableList.copyOf(children);
+        final Type resultType = computeResultType(operator, childrenList);
+        return new VariadicFunctionValue(operator, childrenList, resultType);
     }
 
     @Nullable
@@ -139,7 +155,7 @@ public class VariadicFunctionValue extends AbstractValue {
     @Nonnull
     @Override
     public VariadicFunctionValue withChildren(final Iterable<? extends Value> newChildren) {
-        return new VariadicFunctionValue(this.operator, ImmutableList.copyOf(newChildren));
+        return VariadicFunctionValue.of(this.operator, newChildren);
     }
 
     @Override
@@ -199,8 +215,11 @@ public class VariadicFunctionValue extends AbstractValue {
             final Value child = Value.fromValueProto(serializationContext, variadicFunctionValueProto.getChildren(i));
             childrenBuilder.add(child);
         }
-        return new VariadicFunctionValue(PhysicalOperator.fromProto(serializationContext, Objects.requireNonNull(variadicFunctionValueProto.getOperator())),
-                childrenBuilder.build());
+        final ImmutableList<Value> children = childrenBuilder.build();
+        final PhysicalOperator operator = PhysicalOperator.fromProto(
+                serializationContext,
+                Objects.requireNonNull(variadicFunctionValueProto.getOperator()));
+        return VariadicFunctionValue.of(operator, children);
     }
 
     @Nonnull
@@ -219,40 +238,37 @@ public class VariadicFunctionValue extends AbstractValue {
         // the overall maximum type will be `NullType` and the operator lookup below will fail.
         final List<? extends Typed> arguments = callSiteArguments.getArgumentsList();
         Verify.verify(arguments.size() >= 2);
-        Type maximumType = null;
-        for (final Typed arg : arguments) {
-            Type argType = arg.getResultType();
+        Type commonType = arguments.get(0).getResultType();
+        Verify.verify(commonType.isNull() || !commonType.isUnresolved());
+        for (final Typed arg : arguments.subList(1, arguments.size())) {
+            final Type argType = arg.getResultType();
             Verify.verify(argType.isNull() || !argType.isUnresolved());
-            if (maximumType == null) {
-                maximumType = argType;
-            } else {
-                maximumType = Type.maximumType(maximumType, argType);
-                SemanticException.check(maximumType != null, SemanticException.ErrorCode.INCOMPATIBLE_TYPE);
-            }
+            final Type maximumType = Type.maximumType(commonType, argType);
+            SemanticException.check(maximumType != null, SemanticException.ErrorCode.INCOMPATIBLE_TYPE);
+            commonType = maximumType;
         }
 
         // Look up the physical operator implementing the comparison function for the common type of the arguments.
         final ComparisonFunction comparisonFunction = ((ComparisonFn)builtInFunction).getComparisonFunction();
         final PhysicalOperator physicalOperator =
-                getOperatorMap().get(NonnullPair.of(comparisonFunction, maximumType.getTypeCode()));
+                getOperatorMap().get(NonnullPair.of(comparisonFunction, commonType.getTypeCode()));
         SemanticException.check(
                 physicalOperator != null,
                 SemanticException.ErrorCode.FUNCTION_UNDEFINED_FOR_GIVEN_ARGUMENT_TYPES);
 
         // Determine the result type with the appropriate nullability for the comparison function at hand.
-        final Type resultType = maximumType.withNullability(comparisonFunction.isResultNullable(arguments));
+        final Type resultType = commonType.withNullability(comparisonFunction.isResultNullable(arguments));
 
-        // Promote each argument to the common type, but keep non-nullable types non-nullable, so that the information
-        // about which arguments are nullable is retained.
-        final Type nullableResultType = resultType.withNullability(true);
+        // Promote each argument to the common type while retaining its own nullability, so that the information about
+        // which arguments are nullable is not lost.
         final ImmutableList.Builder<Value> promotedArguments = ImmutableList.builder();
         for (final Typed arg : arguments) {
-            final Type promoteToType = arg.getResultType().isNullable() ? nullableResultType : resultType;
+            final Type promoteToType = resultType.withNullability(arg.getResultType().isNullable());
             promotedArguments.add(PromoteValue.inject((Value)arg, promoteToType));
         }
         final ImmutableList<Value> children = promotedArguments.build();
 
-        return new VariadicFunctionValue(physicalOperator, children);
+        return new VariadicFunctionValue(physicalOperator, children, resultType);
     }
 
     private static Map<NonnullPair<ComparisonFunction, TypeCode>, PhysicalOperator> computeOperatorMap() {
@@ -323,7 +339,8 @@ public class VariadicFunctionValue extends AbstractValue {
          * The {@code COALESCE()} function. Returns its first non-{@code NULL} argument; so it is nullable only if
          * all its arguments are nullable.
          */
-        COALESCE(Boolean::logicalAnd);
+        COALESCE(Boolean::logicalAnd),
+        ;
 
         @Nonnull
         private final BinaryOperator<Boolean> nullabilityCombiner;
@@ -339,8 +356,8 @@ public class VariadicFunctionValue extends AbstractValue {
         /**
          * Constructs a new instance of {@link ComparisonFunction}.
          *
-         * The given {@code nullabilityCombiner} combines the nullabilities of the arguments to derive the nullability
-         * of the result.
+         * <p>The given {@code nullabilityCombiner} combines the nullabilities of the arguments to derive the
+         * nullability of the result.
          */
         ComparisonFunction(@Nonnull final BinaryOperator<Boolean> nullabilityCombiner) {
             this.nullabilityCombiner = nullabilityCombiner;

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/VariadicFunctionValueTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/VariadicFunctionValueTest.java
@@ -36,7 +36,7 @@ import com.apple.foundationdb.record.query.plan.cascades.values.VariadicFunction
 import com.apple.foundationdb.record.query.plan.plans.QueryResult;
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.DynamicMessage;
-import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -46,7 +46,11 @@ import org.junit.jupiter.params.support.ParameterDeclarations;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests evaluation of {@link VariadicFunctionValue}.
@@ -56,20 +60,20 @@ class VariadicFunctionValueTest {
     private static final LiteralValue<Integer> INT_1 = new LiteralValue<>(Type.primitiveType(Type.TypeCode.INT), 1);
     private static final LiteralValue<Integer> INT_2 = new LiteralValue<>(Type.primitiveType(Type.TypeCode.INT), 2);
     private static final LiteralValue<Integer> INT_3 = new LiteralValue<>(Type.primitiveType(Type.TypeCode.INT), 3);
-    private static final Typed LIST_INT_1 = AbstractArrayConstructorValue.LightArrayConstructorValue.of(INT_1, INT_2, INT_3);
-    private static final Typed LIST_INT_2 = AbstractArrayConstructorValue.LightArrayConstructorValue.of(INT_3, INT_2, INT_1);
-    private static final Typed LIST_INT_3 = AbstractArrayConstructorValue.LightArrayConstructorValue.of(INT_2, INT_3, INT_1);
-    private static final Typed LIST_INT_NULL = new LiteralValue<>(new Type.Array(Type.primitiveType(Type.TypeCode.INT)), null);
+    private static final Value LIST_INT_1 = AbstractArrayConstructorValue.LightArrayConstructorValue.of(INT_1, INT_2, INT_3);
+    private static final Value LIST_INT_2 = AbstractArrayConstructorValue.LightArrayConstructorValue.of(INT_3, INT_2, INT_1);
+    private static final Value LIST_INT_3 = AbstractArrayConstructorValue.LightArrayConstructorValue.of(INT_2, INT_3, INT_1);
+    private static final Value LIST_INT_NULL = new LiteralValue<>(new Type.Array(Type.primitiveType(Type.TypeCode.INT)), null);
     private static final LiteralValue<Integer> INT_NULL = new LiteralValue<>(Type.primitiveType(Type.TypeCode.INT), null);
     private static final LiteralValue<Long> LONG_1 = new LiteralValue<>(Type.primitiveType(Type.TypeCode.LONG), 1L);
     private static final LiteralValue<Long> LONG_2 = new LiteralValue<>(Type.primitiveType(Type.TypeCode.LONG), 2L);
     private static final LiteralValue<Long> LONG_3 = new LiteralValue<>(Type.primitiveType(Type.TypeCode.LONG), 3L);
-    private static final Typed LIST_LONG_1 = AbstractArrayConstructorValue.LightArrayConstructorValue.of(LONG_1, LONG_2, LONG_3);
+    private static final Value LIST_LONG_1 = AbstractArrayConstructorValue.LightArrayConstructorValue.of(LONG_1, LONG_2, LONG_3);
     private static final LiteralValue<Long> LONG_NULL = new LiteralValue<>(Type.primitiveType(Type.TypeCode.LONG), null);
     private static final LiteralValue<Float> FLOAT_1 = new LiteralValue<>(Type.primitiveType(Type.TypeCode.FLOAT), 1.0F);
     private static final LiteralValue<Float> FLOAT_2 = new LiteralValue<>(Type.primitiveType(Type.TypeCode.FLOAT), 2.0F);
     private static final LiteralValue<Float> FLOAT_3 = new LiteralValue<>(Type.primitiveType(Type.TypeCode.FLOAT), 3.0F);
-    private static final Typed LIST_FLOAT_1 = AbstractArrayConstructorValue.LightArrayConstructorValue.of(FLOAT_1, FLOAT_2, FLOAT_3);
+    private static final Value LIST_FLOAT_1 = AbstractArrayConstructorValue.LightArrayConstructorValue.of(FLOAT_1, FLOAT_2, FLOAT_3);
     private static final LiteralValue<Float> FLOAT_NULL = new LiteralValue<>(Type.primitiveType(Type.TypeCode.FLOAT), null);
     private static final LiteralValue<Double> DOUBLE_1 = new LiteralValue<>(Type.primitiveType(Type.TypeCode.DOUBLE), 1.0);
     private static final LiteralValue<Double> DOUBLE_2 = new LiteralValue<>(Type.primitiveType(Type.TypeCode.DOUBLE), 2.0);
@@ -82,11 +86,15 @@ class VariadicFunctionValueTest {
     private static final LiteralValue<Boolean> BOOLEAN_1 = new LiteralValue<>(Type.primitiveType(Type.TypeCode.BOOLEAN), false);
     private static final LiteralValue<Boolean> BOOLEAN_2 = new LiteralValue<>(Type.primitiveType(Type.TypeCode.BOOLEAN), true);
     private static final LiteralValue<Boolean> BOOLEAN_NULL = new LiteralValue<>(Type.primitiveType(Type.TypeCode.BOOLEAN), null);
-    private static final Typed RECORD_1 = new RecordConstructorValue.RecordFn().encapsulate(CallSiteArguments.ofPositional(STRING_1, INT_1, FLOAT_1));
-    private static final Typed RECORD_2 = new RecordConstructorValue.RecordFn().encapsulate(CallSiteArguments.ofPositional(STRING_2, INT_2, FLOAT_2));
-    private static final Typed RECORD_3 = new RecordConstructorValue.RecordFn().encapsulate(CallSiteArguments.ofPositional(STRING_3, INT_3, FLOAT_3));
-    private static final Typed NULL_TYPED = new LiteralValue<>(Type.primitiveType(Type.TypeCode.NULL), null);
-    private static final Typed RECORD_NAMED = RecordConstructorValue.ofColumns(ImmutableList.of(
+    private static final Value RECORD_1 = (Value)new RecordConstructorValue.RecordFn().encapsulate(CallSiteArguments.ofPositional(STRING_1, INT_1, FLOAT_1));
+    private static final Value RECORD_2 = (Value)new RecordConstructorValue.RecordFn().encapsulate(CallSiteArguments.ofPositional(STRING_2, INT_2, FLOAT_2));
+    private static final Value RECORD_3 = (Value)new RecordConstructorValue.RecordFn().encapsulate(CallSiteArguments.ofPositional(STRING_3, INT_3, FLOAT_3));
+    private static final Value NULL_TYPED = new LiteralValue<>(Type.primitiveType(Type.TypeCode.NULL), null);
+    private static final LiteralValue<Integer> INT_1_NOT_NULLABLE = new LiteralValue<>(Type.primitiveType(Type.TypeCode.INT, false), 1);
+    private static final LiteralValue<Integer> INT_2_NOT_NULLABLE = new LiteralValue<>(Type.primitiveType(Type.TypeCode.INT, false), 2);
+    private static final LiteralValue<Long> LONG_1_NOT_NULLABLE = new LiteralValue<>(Type.primitiveType(Type.TypeCode.LONG, false), 1L);
+    private static final LiteralValue<String> STRING_1_NOT_NULLABLE = new LiteralValue<>(Type.primitiveType(Type.TypeCode.STRING, false), "a");
+    private static final Value RECORD_NAMED = RecordConstructorValue.ofColumns(ImmutableList.of(
             Column.of(Type.Record.Field.of(Type.primitiveType(Type.TypeCode.STRING), Optional.of("f1")), LiteralValue.ofScalar("sz")),
             Column.of(Type.Record.Field.of(Type.primitiveType(Type.TypeCode.INT), Optional.of("f2")), LiteralValue.ofScalar(100)),
             Column.of(Type.Record.Field.of(Type.primitiveType(Type.TypeCode.FLOAT), Optional.of("f3")), LiteralValue.ofScalar(100.0f))
@@ -102,7 +110,18 @@ class VariadicFunctionValueTest {
             Type.Record.Field.of(Type.primitiveType(Type.TypeCode.INT), Optional.of("f2")),
             Type.Record.Field.of(Type.primitiveType(Type.TypeCode.FLOAT), Optional.of("f3"))));
 
-    private static final Typed RECORD_NULL = new LiteralValue<>(recordTypeUnnamed, null);
+    private static final Value RECORD_NULL = new LiteralValue<>(recordTypeUnnamed, null);
+
+    // NULL literals of the very same record and array type as the constants above, but nullable. These exercise
+    // COALESCE() on non-primitive types, where the common type is determined structurally.
+    private static final Value RECORD_1_NULLABLE = new LiteralValue<>(RECORD_1.getResultType().nullable(), null);
+    private static final Value LIST_INT_1_NULLABLE = new LiteralValue<>(LIST_INT_1.getResultType().nullable(), null);
+
+    // Pre-constructed instances of the built-in functions under test. (Since they are stateless, they can be shared by
+    // all test cases.)
+    private static final VariadicFunctionValue.GreatestFn GREATEST_FN = new VariadicFunctionValue.GreatestFn();
+    private static final VariadicFunctionValue.LeastFn LEAST_FN = new VariadicFunctionValue.LeastFn();
+    private static final VariadicFunctionValue.CoalesceFn COALESCE_FN = new VariadicFunctionValue.CoalesceFn();
 
     private static TypeRepository typeRepository;
 
@@ -143,272 +162,382 @@ class VariadicFunctionValueTest {
                                                             final ExtensionContext context) {
             return Stream.of(
                     // Greatest Function
-                    Arguments.of(List.of(INT_1, INT_1), new VariadicFunctionValue.GreatestFn(), 1, false),
-                    Arguments.of(List.of(LONG_1, LONG_1), new VariadicFunctionValue.GreatestFn(), 1L, false),
-                    Arguments.of(List.of(FLOAT_1, FLOAT_1), new VariadicFunctionValue.GreatestFn(), 1.0F, false),
-                    Arguments.of(List.of(DOUBLE_1, DOUBLE_1), new VariadicFunctionValue.GreatestFn(), 1.0, false),
-                    Arguments.of(List.of(STRING_1, STRING_1), new VariadicFunctionValue.GreatestFn(), "a", false),
-                    Arguments.of(List.of(BOOLEAN_1, BOOLEAN_1), new VariadicFunctionValue.GreatestFn(), false, false),
+                    Arguments.of(List.of(INT_1, INT_1), GREATEST_FN, 1, false),
+                    Arguments.of(List.of(LONG_1, LONG_1), GREATEST_FN, 1L, false),
+                    Arguments.of(List.of(FLOAT_1, FLOAT_1), GREATEST_FN, 1.0F, false),
+                    Arguments.of(List.of(DOUBLE_1, DOUBLE_1), GREATEST_FN, 1.0, false),
+                    Arguments.of(List.of(STRING_1, STRING_1), GREATEST_FN, "a", false),
+                    Arguments.of(List.of(BOOLEAN_1, BOOLEAN_1), GREATEST_FN, false, false),
 
-                    Arguments.of(List.of(INT_1, INT_2), new VariadicFunctionValue.GreatestFn(), 2, false),
-                    Arguments.of(List.of(LONG_1, LONG_2), new VariadicFunctionValue.GreatestFn(), 2L, false),
-                    Arguments.of(List.of(FLOAT_1, FLOAT_2), new VariadicFunctionValue.GreatestFn(), 2.0F, false),
-                    Arguments.of(List.of(DOUBLE_1, DOUBLE_2), new VariadicFunctionValue.GreatestFn(), 2.0, false),
-                    Arguments.of(List.of(STRING_1, STRING_2), new VariadicFunctionValue.GreatestFn(), "b", false),
-                    Arguments.of(List.of(BOOLEAN_1, BOOLEAN_2), new VariadicFunctionValue.GreatestFn(), true, false),
+                    Arguments.of(List.of(INT_1, INT_2), GREATEST_FN, 2, false),
+                    Arguments.of(List.of(LONG_1, LONG_2), GREATEST_FN, 2L, false),
+                    Arguments.of(List.of(FLOAT_1, FLOAT_2), GREATEST_FN, 2.0F, false),
+                    Arguments.of(List.of(DOUBLE_1, DOUBLE_2), GREATEST_FN, 2.0, false),
+                    Arguments.of(List.of(STRING_1, STRING_2), GREATEST_FN, "b", false),
+                    Arguments.of(List.of(BOOLEAN_1, BOOLEAN_2), GREATEST_FN, true, false),
 
-                    Arguments.of(List.of(INT_1, INT_2, INT_3), new VariadicFunctionValue.GreatestFn(), 3, false),
-                    Arguments.of(List.of(LONG_1, LONG_2, LONG_3), new VariadicFunctionValue.GreatestFn(), 3L, false),
-                    Arguments.of(List.of(FLOAT_1, FLOAT_2, FLOAT_3), new VariadicFunctionValue.GreatestFn(), 3.0F, false),
-                    Arguments.of(List.of(DOUBLE_1, DOUBLE_2, DOUBLE_3), new VariadicFunctionValue.GreatestFn(), 3.0, false),
-                    Arguments.of(List.of(STRING_1, STRING_2, STRING_3), new VariadicFunctionValue.GreatestFn(), "c", false),
-                    Arguments.of(List.of(BOOLEAN_1, BOOLEAN_2, BOOLEAN_1), new VariadicFunctionValue.GreatestFn(), true, false),
+                    Arguments.of(List.of(INT_1, INT_2, INT_3), GREATEST_FN, 3, false),
+                    Arguments.of(List.of(LONG_1, LONG_2, LONG_3), GREATEST_FN, 3L, false),
+                    Arguments.of(List.of(FLOAT_1, FLOAT_2, FLOAT_3), GREATEST_FN, 3.0F, false),
+                    Arguments.of(List.of(DOUBLE_1, DOUBLE_2, DOUBLE_3), GREATEST_FN, 3.0, false),
+                    Arguments.of(List.of(STRING_1, STRING_2, STRING_3), GREATEST_FN, "c", false),
+                    Arguments.of(List.of(BOOLEAN_1, BOOLEAN_2, BOOLEAN_1), GREATEST_FN, true, false),
 
-                    Arguments.of(List.of(INT_1, INT_2, INT_3, INT_NULL), new VariadicFunctionValue.GreatestFn(), null, false),
-                    Arguments.of(List.of(LONG_1, LONG_2, LONG_3, LONG_NULL), new VariadicFunctionValue.GreatestFn(), null, false),
-                    Arguments.of(List.of(FLOAT_1, FLOAT_2, FLOAT_3, FLOAT_NULL), new VariadicFunctionValue.GreatestFn(), null, false),
-                    Arguments.of(List.of(DOUBLE_1, DOUBLE_2, DOUBLE_3, DOUBLE_NULL), new VariadicFunctionValue.GreatestFn(), null, false),
-                    Arguments.of(List.of(STRING_1, STRING_2, STRING_3, STRING_NULL), new VariadicFunctionValue.GreatestFn(), null, false),
-                    Arguments.of(List.of(BOOLEAN_1, BOOLEAN_2, BOOLEAN_1, BOOLEAN_NULL), new VariadicFunctionValue.GreatestFn(), null, false),
+                    Arguments.of(List.of(INT_1, INT_2, INT_3, INT_NULL), GREATEST_FN, null, false),
+                    Arguments.of(List.of(LONG_1, LONG_2, LONG_3, LONG_NULL), GREATEST_FN, null, false),
+                    Arguments.of(List.of(FLOAT_1, FLOAT_2, FLOAT_3, FLOAT_NULL), GREATEST_FN, null, false),
+                    Arguments.of(List.of(DOUBLE_1, DOUBLE_2, DOUBLE_3, DOUBLE_NULL), GREATEST_FN, null, false),
+                    Arguments.of(List.of(STRING_1, STRING_2, STRING_3, STRING_NULL), GREATEST_FN, null, false),
+                    Arguments.of(List.of(BOOLEAN_1, BOOLEAN_2, BOOLEAN_1, BOOLEAN_NULL), GREATEST_FN, null, false),
 
-                    Arguments.of(List.of(INT_NULL, INT_NULL), new VariadicFunctionValue.GreatestFn(), null, false),
-                    Arguments.of(List.of(LONG_NULL, LONG_NULL), new VariadicFunctionValue.GreatestFn(), null, false),
-                    Arguments.of(List.of(FLOAT_NULL, FLOAT_NULL), new VariadicFunctionValue.GreatestFn(), null, false),
-                    Arguments.of(List.of(DOUBLE_NULL, DOUBLE_NULL), new VariadicFunctionValue.GreatestFn(), null, false),
-                    Arguments.of(List.of(STRING_NULL, STRING_NULL), new VariadicFunctionValue.GreatestFn(), null, false),
-                    Arguments.of(List.of(BOOLEAN_NULL, BOOLEAN_NULL), new VariadicFunctionValue.GreatestFn(), null, false),
+                    Arguments.of(List.of(INT_NULL, INT_NULL), GREATEST_FN, null, false),
+                    Arguments.of(List.of(LONG_NULL, LONG_NULL), GREATEST_FN, null, false),
+                    Arguments.of(List.of(FLOAT_NULL, FLOAT_NULL), GREATEST_FN, null, false),
+                    Arguments.of(List.of(DOUBLE_NULL, DOUBLE_NULL), GREATEST_FN, null, false),
+                    Arguments.of(List.of(STRING_NULL, STRING_NULL), GREATEST_FN, null, false),
+                    Arguments.of(List.of(BOOLEAN_NULL, BOOLEAN_NULL), GREATEST_FN, null, false),
 
-                    Arguments.of(List.of(INT_1, LONG_2), new VariadicFunctionValue.GreatestFn(), 2L, false),
-                    Arguments.of(List.of(LONG_1, INT_2), new VariadicFunctionValue.GreatestFn(), 2L, false),
-                    Arguments.of(List.of(INT_1, FLOAT_2), new VariadicFunctionValue.GreatestFn(), 2F, false),
-                    Arguments.of(List.of(FLOAT_1, INT_2), new VariadicFunctionValue.GreatestFn(), 2F, false),
-                    Arguments.of(List.of(INT_1, DOUBLE_2), new VariadicFunctionValue.GreatestFn(), 2.0, false),
-                    Arguments.of(List.of(DOUBLE_1, INT_2), new VariadicFunctionValue.GreatestFn(), 2.0, false),
+                    Arguments.of(List.of(INT_1, LONG_2), GREATEST_FN, 2L, false),
+                    Arguments.of(List.of(LONG_1, INT_2), GREATEST_FN, 2L, false),
+                    Arguments.of(List.of(INT_1, FLOAT_2), GREATEST_FN, 2F, false),
+                    Arguments.of(List.of(FLOAT_1, INT_2), GREATEST_FN, 2F, false),
+                    Arguments.of(List.of(INT_1, DOUBLE_2), GREATEST_FN, 2.0, false),
+                    Arguments.of(List.of(DOUBLE_1, INT_2), GREATEST_FN, 2.0, false),
 
-                    Arguments.of(List.of(LONG_1, FLOAT_2), new VariadicFunctionValue.GreatestFn(), 2F, false),
-                    Arguments.of(List.of(FLOAT_1, LONG_2), new VariadicFunctionValue.GreatestFn(), 2F, false),
-                    Arguments.of(List.of(LONG_1, DOUBLE_2), new VariadicFunctionValue.GreatestFn(), 2.0, false),
-                    Arguments.of(List.of(DOUBLE_1, LONG_2), new VariadicFunctionValue.GreatestFn(), 2.0, false),
+                    Arguments.of(List.of(LONG_1, FLOAT_2), GREATEST_FN, 2F, false),
+                    Arguments.of(List.of(FLOAT_1, LONG_2), GREATEST_FN, 2F, false),
+                    Arguments.of(List.of(LONG_1, DOUBLE_2), GREATEST_FN, 2.0, false),
+                    Arguments.of(List.of(DOUBLE_1, LONG_2), GREATEST_FN, 2.0, false),
 
-                    Arguments.of(List.of(FLOAT_1, DOUBLE_2), new VariadicFunctionValue.GreatestFn(), 2.0, false),
-                    Arguments.of(List.of(DOUBLE_1, FLOAT_2), new VariadicFunctionValue.GreatestFn(), 2.0, false),
+                    Arguments.of(List.of(FLOAT_1, DOUBLE_2), GREATEST_FN, 2.0, false),
+                    Arguments.of(List.of(DOUBLE_1, FLOAT_2), GREATEST_FN, 2.0, false),
 
-                    Arguments.of(List.of(INT_1, LONG_2, FLOAT_3, DOUBLE_1), new VariadicFunctionValue.GreatestFn(), 3.0, false),
+                    Arguments.of(List.of(INT_1, LONG_2, FLOAT_3, DOUBLE_1), GREATEST_FN, 3.0, false),
 
-                    Arguments.of(List.of(INT_1, LONG_NULL, FLOAT_3, DOUBLE_1), new VariadicFunctionValue.GreatestFn(), null, false),
+                    Arguments.of(List.of(INT_1, LONG_NULL, FLOAT_3, DOUBLE_1), GREATEST_FN, null, false),
 
-                    Arguments.of(List.of(F, INT_1), new VariadicFunctionValue.GreatestFn(), 4L, false),
-                    Arguments.of(List.of(INT_1, F), new VariadicFunctionValue.GreatestFn(), 4L, false),
+                    Arguments.of(List.of(F, INT_1), GREATEST_FN, 4L, false),
+                    Arguments.of(List.of(INT_1, F), GREATEST_FN, 4L, false),
 
-                    Arguments.of(List.of(F, INT_NULL), new VariadicFunctionValue.GreatestFn(), null, false),
-                    Arguments.of(List.of(INT_NULL, F), new VariadicFunctionValue.GreatestFn(), null, false),
+                    Arguments.of(List.of(F, INT_NULL), GREATEST_FN, null, false),
+                    Arguments.of(List.of(INT_NULL, F), GREATEST_FN, null, false),
 
-                    Arguments.of(List.of(INT_1, STRING_1), new VariadicFunctionValue.GreatestFn(), null, true),
-                    Arguments.of(List.of(LONG_1, STRING_1), new VariadicFunctionValue.GreatestFn(), null, true),
-                    Arguments.of(List.of(FLOAT_1, STRING_1), new VariadicFunctionValue.GreatestFn(), null, true),
-                    Arguments.of(List.of(DOUBLE_1, STRING_1), new VariadicFunctionValue.GreatestFn(), null, true),
-                    Arguments.of(List.of(BOOLEAN_1, STRING_1), new VariadicFunctionValue.GreatestFn(), null, true),
+                    Arguments.of(List.of(INT_1, STRING_1), GREATEST_FN, null, true),
+                    Arguments.of(List.of(LONG_1, STRING_1), GREATEST_FN, null, true),
+                    Arguments.of(List.of(FLOAT_1, STRING_1), GREATEST_FN, null, true),
+                    Arguments.of(List.of(DOUBLE_1, STRING_1), GREATEST_FN, null, true),
+                    Arguments.of(List.of(BOOLEAN_1, STRING_1), GREATEST_FN, null, true),
 
-                    Arguments.of(List.of(INT_1, BOOLEAN_1), new VariadicFunctionValue.GreatestFn(), null, true),
-                    Arguments.of(List.of(LONG_1, BOOLEAN_1), new VariadicFunctionValue.GreatestFn(), null, true),
-                    Arguments.of(List.of(FLOAT_1, BOOLEAN_1), new VariadicFunctionValue.GreatestFn(), null, true),
-                    Arguments.of(List.of(DOUBLE_1, BOOLEAN_1), new VariadicFunctionValue.GreatestFn(), null, true),
+                    Arguments.of(List.of(INT_1, BOOLEAN_1), GREATEST_FN, null, true),
+                    Arguments.of(List.of(LONG_1, BOOLEAN_1), GREATEST_FN, null, true),
+                    Arguments.of(List.of(FLOAT_1, BOOLEAN_1), GREATEST_FN, null, true),
+                    Arguments.of(List.of(DOUBLE_1, BOOLEAN_1), GREATEST_FN, null, true),
 
                     // Least Function
-                    Arguments.of(List.of(INT_3, INT_3), new VariadicFunctionValue.LeastFn(), 3, false),
-                    Arguments.of(List.of(LONG_3, LONG_3), new VariadicFunctionValue.LeastFn(), 3L, false),
-                    Arguments.of(List.of(FLOAT_3, FLOAT_3), new VariadicFunctionValue.LeastFn(), 3.0F, false),
-                    Arguments.of(List.of(DOUBLE_3, DOUBLE_3), new VariadicFunctionValue.LeastFn(), 3.0, false),
-                    Arguments.of(List.of(STRING_3, STRING_3), new VariadicFunctionValue.LeastFn(), "c", false),
-                    Arguments.of(List.of(BOOLEAN_2, BOOLEAN_2), new VariadicFunctionValue.LeastFn(), true, false),
+                    Arguments.of(List.of(INT_3, INT_3), LEAST_FN, 3, false),
+                    Arguments.of(List.of(LONG_3, LONG_3), LEAST_FN, 3L, false),
+                    Arguments.of(List.of(FLOAT_3, FLOAT_3), LEAST_FN, 3.0F, false),
+                    Arguments.of(List.of(DOUBLE_3, DOUBLE_3), LEAST_FN, 3.0, false),
+                    Arguments.of(List.of(STRING_3, STRING_3), LEAST_FN, "c", false),
+                    Arguments.of(List.of(BOOLEAN_2, BOOLEAN_2), LEAST_FN, true, false),
 
-                    Arguments.of(List.of(INT_3, INT_2), new VariadicFunctionValue.LeastFn(), 2, false),
-                    Arguments.of(List.of(LONG_3, LONG_2), new VariadicFunctionValue.LeastFn(), 2L, false),
-                    Arguments.of(List.of(FLOAT_3, FLOAT_2), new VariadicFunctionValue.LeastFn(), 2.0F, false),
-                    Arguments.of(List.of(DOUBLE_3, DOUBLE_2), new VariadicFunctionValue.LeastFn(), 2.0, false),
-                    Arguments.of(List.of(STRING_3, STRING_2), new VariadicFunctionValue.LeastFn(), "b", false),
-                    Arguments.of(List.of(BOOLEAN_2, BOOLEAN_1), new VariadicFunctionValue.LeastFn(), false, false),
+                    Arguments.of(List.of(INT_3, INT_2), LEAST_FN, 2, false),
+                    Arguments.of(List.of(LONG_3, LONG_2), LEAST_FN, 2L, false),
+                    Arguments.of(List.of(FLOAT_3, FLOAT_2), LEAST_FN, 2.0F, false),
+                    Arguments.of(List.of(DOUBLE_3, DOUBLE_2), LEAST_FN, 2.0, false),
+                    Arguments.of(List.of(STRING_3, STRING_2), LEAST_FN, "b", false),
+                    Arguments.of(List.of(BOOLEAN_2, BOOLEAN_1), LEAST_FN, false, false),
 
-                    Arguments.of(List.of(INT_1, INT_2, INT_3), new VariadicFunctionValue.LeastFn(), 1, false),
-                    Arguments.of(List.of(LONG_1, LONG_2, LONG_3), new VariadicFunctionValue.LeastFn(), 1L, false),
-                    Arguments.of(List.of(FLOAT_1, FLOAT_2, FLOAT_3), new VariadicFunctionValue.LeastFn(), 1.0F, false),
-                    Arguments.of(List.of(DOUBLE_1, DOUBLE_2, DOUBLE_3), new VariadicFunctionValue.LeastFn(), 1.0, false),
-                    Arguments.of(List.of(STRING_1, STRING_2, STRING_3), new VariadicFunctionValue.LeastFn(), "a", false),
-                    Arguments.of(List.of(BOOLEAN_1, BOOLEAN_2, BOOLEAN_1), new VariadicFunctionValue.LeastFn(), false, false),
+                    Arguments.of(List.of(INT_1, INT_2, INT_3), LEAST_FN, 1, false),
+                    Arguments.of(List.of(LONG_1, LONG_2, LONG_3), LEAST_FN, 1L, false),
+                    Arguments.of(List.of(FLOAT_1, FLOAT_2, FLOAT_3), LEAST_FN, 1.0F, false),
+                    Arguments.of(List.of(DOUBLE_1, DOUBLE_2, DOUBLE_3), LEAST_FN, 1.0, false),
+                    Arguments.of(List.of(STRING_1, STRING_2, STRING_3), LEAST_FN, "a", false),
+                    Arguments.of(List.of(BOOLEAN_1, BOOLEAN_2, BOOLEAN_1), LEAST_FN, false, false),
 
-                    Arguments.of(List.of(INT_1, INT_2, INT_3, INT_NULL), new VariadicFunctionValue.LeastFn(), null, false),
-                    Arguments.of(List.of(LONG_1, LONG_2, LONG_3, LONG_NULL), new VariadicFunctionValue.LeastFn(), null, false),
-                    Arguments.of(List.of(FLOAT_1, FLOAT_2, FLOAT_3, FLOAT_NULL), new VariadicFunctionValue.LeastFn(), null, false),
-                    Arguments.of(List.of(DOUBLE_1, DOUBLE_2, DOUBLE_3, DOUBLE_NULL), new VariadicFunctionValue.LeastFn(), null, false),
-                    Arguments.of(List.of(STRING_1, STRING_2, STRING_3, STRING_NULL), new VariadicFunctionValue.LeastFn(), null, false),
-                    Arguments.of(List.of(BOOLEAN_1, BOOLEAN_2, BOOLEAN_1, BOOLEAN_NULL), new VariadicFunctionValue.LeastFn(), null, false),
+                    Arguments.of(List.of(INT_1, INT_2, INT_3, INT_NULL), LEAST_FN, null, false),
+                    Arguments.of(List.of(LONG_1, LONG_2, LONG_3, LONG_NULL), LEAST_FN, null, false),
+                    Arguments.of(List.of(FLOAT_1, FLOAT_2, FLOAT_3, FLOAT_NULL), LEAST_FN, null, false),
+                    Arguments.of(List.of(DOUBLE_1, DOUBLE_2, DOUBLE_3, DOUBLE_NULL), LEAST_FN, null, false),
+                    Arguments.of(List.of(STRING_1, STRING_2, STRING_3, STRING_NULL), LEAST_FN, null, false),
+                    Arguments.of(List.of(BOOLEAN_1, BOOLEAN_2, BOOLEAN_1, BOOLEAN_NULL), LEAST_FN, null, false),
 
-                    Arguments.of(List.of(INT_NULL, INT_NULL), new VariadicFunctionValue.LeastFn(), null, false),
-                    Arguments.of(List.of(LONG_NULL, LONG_NULL), new VariadicFunctionValue.LeastFn(), null, false),
-                    Arguments.of(List.of(FLOAT_NULL, FLOAT_NULL), new VariadicFunctionValue.LeastFn(), null, false),
-                    Arguments.of(List.of(DOUBLE_NULL, DOUBLE_NULL), new VariadicFunctionValue.LeastFn(), null, false),
-                    Arguments.of(List.of(STRING_NULL, STRING_NULL), new VariadicFunctionValue.LeastFn(), null, false),
-                    Arguments.of(List.of(BOOLEAN_NULL, BOOLEAN_NULL), new VariadicFunctionValue.LeastFn(), null, false),
+                    Arguments.of(List.of(INT_NULL, INT_NULL), LEAST_FN, null, false),
+                    Arguments.of(List.of(LONG_NULL, LONG_NULL), LEAST_FN, null, false),
+                    Arguments.of(List.of(FLOAT_NULL, FLOAT_NULL), LEAST_FN, null, false),
+                    Arguments.of(List.of(DOUBLE_NULL, DOUBLE_NULL), LEAST_FN, null, false),
+                    Arguments.of(List.of(STRING_NULL, STRING_NULL), LEAST_FN, null, false),
+                    Arguments.of(List.of(BOOLEAN_NULL, BOOLEAN_NULL), LEAST_FN, null, false),
 
-                    Arguments.of(List.of(INT_1, LONG_2), new VariadicFunctionValue.LeastFn(), 1L, false),
-                    Arguments.of(List.of(LONG_1, INT_2), new VariadicFunctionValue.LeastFn(), 1L, false),
-                    Arguments.of(List.of(INT_1, FLOAT_2), new VariadicFunctionValue.LeastFn(), 1F, false),
-                    Arguments.of(List.of(FLOAT_1, INT_2), new VariadicFunctionValue.LeastFn(), 1F, false),
-                    Arguments.of(List.of(INT_1, DOUBLE_2), new VariadicFunctionValue.LeastFn(), 1.0, false),
-                    Arguments.of(List.of(DOUBLE_1, INT_2), new VariadicFunctionValue.LeastFn(), 1.0, false),
+                    Arguments.of(List.of(INT_1, LONG_2), LEAST_FN, 1L, false),
+                    Arguments.of(List.of(LONG_1, INT_2), LEAST_FN, 1L, false),
+                    Arguments.of(List.of(INT_1, FLOAT_2), LEAST_FN, 1F, false),
+                    Arguments.of(List.of(FLOAT_1, INT_2), LEAST_FN, 1F, false),
+                    Arguments.of(List.of(INT_1, DOUBLE_2), LEAST_FN, 1.0, false),
+                    Arguments.of(List.of(DOUBLE_1, INT_2), LEAST_FN, 1.0, false),
 
-                    Arguments.of(List.of(LONG_1, FLOAT_2), new VariadicFunctionValue.LeastFn(), 1F, false),
-                    Arguments.of(List.of(FLOAT_1, LONG_2), new VariadicFunctionValue.LeastFn(), 1F, false),
-                    Arguments.of(List.of(LONG_1, DOUBLE_2), new VariadicFunctionValue.LeastFn(), 1.0, false),
-                    Arguments.of(List.of(DOUBLE_1, LONG_2), new VariadicFunctionValue.LeastFn(), 1.0, false),
+                    Arguments.of(List.of(LONG_1, FLOAT_2), LEAST_FN, 1F, false),
+                    Arguments.of(List.of(FLOAT_1, LONG_2), LEAST_FN, 1F, false),
+                    Arguments.of(List.of(LONG_1, DOUBLE_2), LEAST_FN, 1.0, false),
+                    Arguments.of(List.of(DOUBLE_1, LONG_2), LEAST_FN, 1.0, false),
 
-                    Arguments.of(List.of(FLOAT_1, DOUBLE_2), new VariadicFunctionValue.LeastFn(), 1.0, false),
-                    Arguments.of(List.of(DOUBLE_1, FLOAT_2), new VariadicFunctionValue.LeastFn(), 1.0, false),
+                    Arguments.of(List.of(FLOAT_1, DOUBLE_2), LEAST_FN, 1.0, false),
+                    Arguments.of(List.of(DOUBLE_1, FLOAT_2), LEAST_FN, 1.0, false),
 
-                    Arguments.of(List.of(INT_1, LONG_2, FLOAT_3, DOUBLE_1), new VariadicFunctionValue.LeastFn(), 1.0, false),
+                    Arguments.of(List.of(INT_1, LONG_2, FLOAT_3, DOUBLE_1), LEAST_FN, 1.0, false),
 
-                    Arguments.of(List.of(INT_1, LONG_NULL, FLOAT_3, DOUBLE_1), new VariadicFunctionValue.LeastFn(), null, false),
+                    Arguments.of(List.of(INT_1, LONG_NULL, FLOAT_3, DOUBLE_1), LEAST_FN, null, false),
 
-                    Arguments.of(List.of(F, INT_1), new VariadicFunctionValue.LeastFn(), 1L, false),
-                    Arguments.of(List.of(INT_1, F), new VariadicFunctionValue.LeastFn(), 1L, false),
+                    Arguments.of(List.of(F, INT_1), LEAST_FN, 1L, false),
+                    Arguments.of(List.of(INT_1, F), LEAST_FN, 1L, false),
 
-                    Arguments.of(List.of(F, INT_NULL), new VariadicFunctionValue.LeastFn(), null, false),
-                    Arguments.of(List.of(INT_NULL, F), new VariadicFunctionValue.LeastFn(), null, false),
+                    Arguments.of(List.of(F, INT_NULL), LEAST_FN, null, false),
+                    Arguments.of(List.of(INT_NULL, F), LEAST_FN, null, false),
 
-                    Arguments.of(List.of(INT_1, STRING_1), new VariadicFunctionValue.LeastFn(), null, true),
-                    Arguments.of(List.of(LONG_1, STRING_1), new VariadicFunctionValue.LeastFn(), null, true),
-                    Arguments.of(List.of(FLOAT_1, STRING_1), new VariadicFunctionValue.LeastFn(), null, true),
-                    Arguments.of(List.of(DOUBLE_1, STRING_1), new VariadicFunctionValue.LeastFn(), null, true),
-                    Arguments.of(List.of(BOOLEAN_1, STRING_1), new VariadicFunctionValue.LeastFn(), null, true),
+                    Arguments.of(List.of(INT_1, STRING_1), LEAST_FN, null, true),
+                    Arguments.of(List.of(LONG_1, STRING_1), LEAST_FN, null, true),
+                    Arguments.of(List.of(FLOAT_1, STRING_1), LEAST_FN, null, true),
+                    Arguments.of(List.of(DOUBLE_1, STRING_1), LEAST_FN, null, true),
+                    Arguments.of(List.of(BOOLEAN_1, STRING_1), LEAST_FN, null, true),
 
-                    Arguments.of(List.of(INT_1, BOOLEAN_1), new VariadicFunctionValue.LeastFn(), null, true),
-                    Arguments.of(List.of(LONG_1, BOOLEAN_1), new VariadicFunctionValue.LeastFn(), null, true),
-                    Arguments.of(List.of(FLOAT_1, BOOLEAN_1), new VariadicFunctionValue.LeastFn(), null, true),
-                    Arguments.of(List.of(DOUBLE_1, BOOLEAN_1), new VariadicFunctionValue.LeastFn(), null, true),
+                    Arguments.of(List.of(INT_1, BOOLEAN_1), LEAST_FN, null, true),
+                    Arguments.of(List.of(LONG_1, BOOLEAN_1), LEAST_FN, null, true),
+                    Arguments.of(List.of(FLOAT_1, BOOLEAN_1), LEAST_FN, null, true),
+                    Arguments.of(List.of(DOUBLE_1, BOOLEAN_1), LEAST_FN, null, true),
 
                     // Coalesce
-                    Arguments.of(List.of(INT_3, INT_3), new VariadicFunctionValue.CoalesceFn(), 3, false),
-                    Arguments.of(List.of(LONG_3, LONG_3), new VariadicFunctionValue.CoalesceFn(), 3L, false),
-                    Arguments.of(List.of(FLOAT_3, FLOAT_3), new VariadicFunctionValue.CoalesceFn(), 3.0F, false),
-                    Arguments.of(List.of(DOUBLE_3, DOUBLE_3), new VariadicFunctionValue.CoalesceFn(), 3.0, false),
-                    Arguments.of(List.of(STRING_3, STRING_3), new VariadicFunctionValue.CoalesceFn(), "c", false),
-                    Arguments.of(List.of(BOOLEAN_2, BOOLEAN_2), new VariadicFunctionValue.CoalesceFn(), true, false),
-                    Arguments.of(List.of(LIST_INT_1, LIST_INT_1), new VariadicFunctionValue.CoalesceFn(), List.of(1, 2, 3), false),
-                    Arguments.of(List.of(RECORD_1, RECORD_1), new VariadicFunctionValue.CoalesceFn(), getMessageForRecord1(), false),
+                    Arguments.of(List.of(INT_3, INT_3), COALESCE_FN, 3, false),
+                    Arguments.of(List.of(LONG_3, LONG_3), COALESCE_FN, 3L, false),
+                    Arguments.of(List.of(FLOAT_3, FLOAT_3), COALESCE_FN, 3.0F, false),
+                    Arguments.of(List.of(DOUBLE_3, DOUBLE_3), COALESCE_FN, 3.0, false),
+                    Arguments.of(List.of(STRING_3, STRING_3), COALESCE_FN, "c", false),
+                    Arguments.of(List.of(BOOLEAN_2, BOOLEAN_2), COALESCE_FN, true, false),
+                    Arguments.of(List.of(LIST_INT_1, LIST_INT_1), COALESCE_FN, List.of(1, 2, 3), false),
+                    Arguments.of(List.of(RECORD_1, RECORD_1), COALESCE_FN, getMessageForRecord1(), false),
 
-                    Arguments.of(List.of(INT_3, INT_2), new VariadicFunctionValue.CoalesceFn(), 3, false),
-                    Arguments.of(List.of(LONG_3, LONG_2), new VariadicFunctionValue.CoalesceFn(), 3L, false),
-                    Arguments.of(List.of(FLOAT_3, FLOAT_2), new VariadicFunctionValue.CoalesceFn(), 3.0F, false),
-                    Arguments.of(List.of(DOUBLE_3, DOUBLE_2), new VariadicFunctionValue.CoalesceFn(), 3.0, false),
-                    Arguments.of(List.of(STRING_3, STRING_2), new VariadicFunctionValue.CoalesceFn(), "c", false),
-                    Arguments.of(List.of(BOOLEAN_2, BOOLEAN_1), new VariadicFunctionValue.CoalesceFn(), true, false),
-                    Arguments.of(List.of(LIST_INT_1, LIST_INT_2), new VariadicFunctionValue.CoalesceFn(), List.of(1, 2, 3), false),
-                    Arguments.of(List.of(RECORD_1, RECORD_2), new VariadicFunctionValue.CoalesceFn(), getMessageForRecord1(), false),
-                    Arguments.of(List.of(RECORD_1, RECORD_NAMED), new VariadicFunctionValue.CoalesceFn(), getMessageForRecord1(), false),
-                    Arguments.of(List.of(RECORD_NAMED, RECORD_1), new VariadicFunctionValue.CoalesceFn(), getMessageForRecordNamed(), false),
+                    Arguments.of(List.of(INT_3, INT_2), COALESCE_FN, 3, false),
+                    Arguments.of(List.of(LONG_3, LONG_2), COALESCE_FN, 3L, false),
+                    Arguments.of(List.of(FLOAT_3, FLOAT_2), COALESCE_FN, 3.0F, false),
+                    Arguments.of(List.of(DOUBLE_3, DOUBLE_2), COALESCE_FN, 3.0, false),
+                    Arguments.of(List.of(STRING_3, STRING_2), COALESCE_FN, "c", false),
+                    Arguments.of(List.of(BOOLEAN_2, BOOLEAN_1), COALESCE_FN, true, false),
+                    Arguments.of(List.of(LIST_INT_1, LIST_INT_2), COALESCE_FN, List.of(1, 2, 3), false),
+                    Arguments.of(List.of(RECORD_1, RECORD_2), COALESCE_FN, getMessageForRecord1(), false),
+                    Arguments.of(List.of(RECORD_1, RECORD_NAMED), COALESCE_FN, getMessageForRecord1(), false),
+                    Arguments.of(List.of(RECORD_NAMED, RECORD_1), COALESCE_FN, getMessageForRecordNamed(), false),
 
-                    Arguments.of(List.of(INT_1, INT_2, INT_3), new VariadicFunctionValue.CoalesceFn(), 1, false),
-                    Arguments.of(List.of(LONG_1, LONG_2, LONG_3), new VariadicFunctionValue.CoalesceFn(), 1L, false),
-                    Arguments.of(List.of(FLOAT_1, FLOAT_2, FLOAT_3), new VariadicFunctionValue.CoalesceFn(), 1.0F, false),
-                    Arguments.of(List.of(DOUBLE_1, DOUBLE_2, DOUBLE_3), new VariadicFunctionValue.CoalesceFn(), 1.0, false),
-                    Arguments.of(List.of(STRING_1, STRING_2, STRING_3), new VariadicFunctionValue.CoalesceFn(), "a", false),
-                    Arguments.of(List.of(BOOLEAN_1, BOOLEAN_2, BOOLEAN_1), new VariadicFunctionValue.CoalesceFn(), false, false),
-                    Arguments.of(List.of(LIST_INT_1, LIST_INT_2, LIST_INT_3), new VariadicFunctionValue.CoalesceFn(), List.of(1, 2, 3), false),
-                    Arguments.of(List.of(RECORD_1, RECORD_2, RECORD_3), new VariadicFunctionValue.CoalesceFn(), getMessageForRecord1(), false),
+                    Arguments.of(List.of(INT_1, INT_2, INT_3), COALESCE_FN, 1, false),
+                    Arguments.of(List.of(LONG_1, LONG_2, LONG_3), COALESCE_FN, 1L, false),
+                    Arguments.of(List.of(FLOAT_1, FLOAT_2, FLOAT_3), COALESCE_FN, 1.0F, false),
+                    Arguments.of(List.of(DOUBLE_1, DOUBLE_2, DOUBLE_3), COALESCE_FN, 1.0, false),
+                    Arguments.of(List.of(STRING_1, STRING_2, STRING_3), COALESCE_FN, "a", false),
+                    Arguments.of(List.of(BOOLEAN_1, BOOLEAN_2, BOOLEAN_1), COALESCE_FN, false, false),
+                    Arguments.of(List.of(LIST_INT_1, LIST_INT_2, LIST_INT_3), COALESCE_FN, List.of(1, 2, 3), false),
+                    Arguments.of(List.of(RECORD_1, RECORD_2, RECORD_3), COALESCE_FN, getMessageForRecord1(), false),
 
-                    Arguments.of(List.of(INT_1, INT_2, INT_3, INT_NULL), new VariadicFunctionValue.CoalesceFn(), 1, false),
-                    Arguments.of(List.of(LONG_1, LONG_2, LONG_3, LONG_NULL), new VariadicFunctionValue.CoalesceFn(), 1L, false),
-                    Arguments.of(List.of(FLOAT_1, FLOAT_2, FLOAT_3, FLOAT_NULL), new VariadicFunctionValue.CoalesceFn(), 1.0F, false),
-                    Arguments.of(List.of(DOUBLE_1, DOUBLE_2, DOUBLE_3, DOUBLE_NULL), new VariadicFunctionValue.CoalesceFn(), 1.0, false),
-                    Arguments.of(List.of(STRING_1, STRING_2, STRING_3, STRING_NULL), new VariadicFunctionValue.CoalesceFn(), "a", false),
-                    Arguments.of(List.of(BOOLEAN_1, BOOLEAN_2, BOOLEAN_1, BOOLEAN_NULL), new VariadicFunctionValue.CoalesceFn(), false, false),
-                    Arguments.of(List.of(LIST_INT_1, LIST_INT_2, LIST_INT_3, LIST_INT_NULL), new VariadicFunctionValue.CoalesceFn(), List.of(1, 2, 3), false),
-                    Arguments.of(List.of(RECORD_1, RECORD_2, RECORD_3, RECORD_NULL), new VariadicFunctionValue.CoalesceFn(), getMessageForRecord1(), false),
+                    Arguments.of(List.of(INT_1, INT_2, INT_3, INT_NULL), COALESCE_FN, 1, false),
+                    Arguments.of(List.of(LONG_1, LONG_2, LONG_3, LONG_NULL), COALESCE_FN, 1L, false),
+                    Arguments.of(List.of(FLOAT_1, FLOAT_2, FLOAT_3, FLOAT_NULL), COALESCE_FN, 1.0F, false),
+                    Arguments.of(List.of(DOUBLE_1, DOUBLE_2, DOUBLE_3, DOUBLE_NULL), COALESCE_FN, 1.0, false),
+                    Arguments.of(List.of(STRING_1, STRING_2, STRING_3, STRING_NULL), COALESCE_FN, "a", false),
+                    Arguments.of(List.of(BOOLEAN_1, BOOLEAN_2, BOOLEAN_1, BOOLEAN_NULL), COALESCE_FN, false, false),
+                    Arguments.of(List.of(LIST_INT_1, LIST_INT_2, LIST_INT_3, LIST_INT_NULL), COALESCE_FN, List.of(1, 2, 3), false),
+                    Arguments.of(List.of(RECORD_1, RECORD_2, RECORD_3, RECORD_NULL), COALESCE_FN, getMessageForRecord1(), false),
 
-                    Arguments.of(List.of(INT_NULL, INT_1, INT_2, INT_3, INT_NULL), new VariadicFunctionValue.CoalesceFn(), 1, false),
-                    Arguments.of(List.of(LONG_NULL, LONG_1, LONG_2, LONG_3, LONG_NULL), new VariadicFunctionValue.CoalesceFn(), 1L, false),
-                    Arguments.of(List.of(FLOAT_NULL, FLOAT_1, FLOAT_2, FLOAT_3, FLOAT_NULL), new VariadicFunctionValue.CoalesceFn(), 1.0F, false),
-                    Arguments.of(List.of(DOUBLE_NULL, DOUBLE_1, DOUBLE_2, DOUBLE_3, DOUBLE_NULL), new VariadicFunctionValue.CoalesceFn(), 1.0, false),
-                    Arguments.of(List.of(STRING_NULL, STRING_1, STRING_2, STRING_3, STRING_NULL), new VariadicFunctionValue.CoalesceFn(), "a", false),
-                    Arguments.of(List.of(BOOLEAN_NULL, BOOLEAN_1, BOOLEAN_2, BOOLEAN_1, BOOLEAN_NULL), new VariadicFunctionValue.CoalesceFn(), false, false),
-                    Arguments.of(List.of(LIST_INT_NULL, LIST_INT_1, LIST_INT_2, LIST_INT_3, LIST_INT_NULL), new VariadicFunctionValue.CoalesceFn(), List.of(1, 2, 3), false),
-                    Arguments.of(List.of(RECORD_NULL, RECORD_1, RECORD_2, RECORD_3, RECORD_NULL), new VariadicFunctionValue.CoalesceFn(), getMessageForRecord1(), false),
+                    Arguments.of(List.of(INT_NULL, INT_1, INT_2, INT_3, INT_NULL), COALESCE_FN, 1, false),
+                    Arguments.of(List.of(LONG_NULL, LONG_1, LONG_2, LONG_3, LONG_NULL), COALESCE_FN, 1L, false),
+                    Arguments.of(List.of(FLOAT_NULL, FLOAT_1, FLOAT_2, FLOAT_3, FLOAT_NULL), COALESCE_FN, 1.0F, false),
+                    Arguments.of(List.of(DOUBLE_NULL, DOUBLE_1, DOUBLE_2, DOUBLE_3, DOUBLE_NULL), COALESCE_FN, 1.0, false),
+                    Arguments.of(List.of(STRING_NULL, STRING_1, STRING_2, STRING_3, STRING_NULL), COALESCE_FN, "a", false),
+                    Arguments.of(List.of(BOOLEAN_NULL, BOOLEAN_1, BOOLEAN_2, BOOLEAN_1, BOOLEAN_NULL), COALESCE_FN, false, false),
+                    Arguments.of(List.of(LIST_INT_NULL, LIST_INT_1, LIST_INT_2, LIST_INT_3, LIST_INT_NULL), COALESCE_FN, List.of(1, 2, 3), false),
+                    Arguments.of(List.of(RECORD_NULL, RECORD_1, RECORD_2, RECORD_3, RECORD_NULL), COALESCE_FN, getMessageForRecord1(), false),
 
-                    Arguments.of(List.of(INT_NULL, INT_NULL), new VariadicFunctionValue.CoalesceFn(), null, false),
-                    Arguments.of(List.of(LONG_NULL, LONG_NULL), new VariadicFunctionValue.CoalesceFn(), null, false),
-                    Arguments.of(List.of(FLOAT_NULL, FLOAT_NULL), new VariadicFunctionValue.CoalesceFn(), null, false),
-                    Arguments.of(List.of(DOUBLE_NULL, DOUBLE_NULL), new VariadicFunctionValue.CoalesceFn(), null, false),
-                    Arguments.of(List.of(STRING_NULL, STRING_NULL), new VariadicFunctionValue.CoalesceFn(), null, false),
-                    Arguments.of(List.of(BOOLEAN_NULL, BOOLEAN_NULL), new VariadicFunctionValue.CoalesceFn(), null, false),
-                    Arguments.of(List.of(LIST_INT_NULL, LIST_INT_NULL), new VariadicFunctionValue.CoalesceFn(), null, false),
-                    Arguments.of(List.of(RECORD_NULL, RECORD_NULL), new VariadicFunctionValue.CoalesceFn(), null, false),
+                    Arguments.of(List.of(INT_NULL, INT_NULL), COALESCE_FN, null, false),
+                    Arguments.of(List.of(LONG_NULL, LONG_NULL), COALESCE_FN, null, false),
+                    Arguments.of(List.of(FLOAT_NULL, FLOAT_NULL), COALESCE_FN, null, false),
+                    Arguments.of(List.of(DOUBLE_NULL, DOUBLE_NULL), COALESCE_FN, null, false),
+                    Arguments.of(List.of(STRING_NULL, STRING_NULL), COALESCE_FN, null, false),
+                    Arguments.of(List.of(BOOLEAN_NULL, BOOLEAN_NULL), COALESCE_FN, null, false),
+                    Arguments.of(List.of(LIST_INT_NULL, LIST_INT_NULL), COALESCE_FN, null, false),
+                    Arguments.of(List.of(RECORD_NULL, RECORD_NULL), COALESCE_FN, null, false),
 
-                    Arguments.of(List.of(INT_1, LONG_2), new VariadicFunctionValue.CoalesceFn(), 1L, false),
-                    Arguments.of(List.of(LONG_1, INT_2), new VariadicFunctionValue.CoalesceFn(), 1L, false),
-                    Arguments.of(List.of(INT_1, FLOAT_2), new VariadicFunctionValue.CoalesceFn(), 1F, false),
-                    Arguments.of(List.of(FLOAT_1, INT_2), new VariadicFunctionValue.CoalesceFn(), 1F, false),
-                    Arguments.of(List.of(INT_1, DOUBLE_2), new VariadicFunctionValue.CoalesceFn(), 1.0, false),
-                    Arguments.of(List.of(DOUBLE_1, INT_2), new VariadicFunctionValue.CoalesceFn(), 1.0, false),
+                    Arguments.of(List.of(INT_1, LONG_2), COALESCE_FN, 1L, false),
+                    Arguments.of(List.of(LONG_1, INT_2), COALESCE_FN, 1L, false),
+                    Arguments.of(List.of(INT_1, FLOAT_2), COALESCE_FN, 1F, false),
+                    Arguments.of(List.of(FLOAT_1, INT_2), COALESCE_FN, 1F, false),
+                    Arguments.of(List.of(INT_1, DOUBLE_2), COALESCE_FN, 1.0, false),
+                    Arguments.of(List.of(DOUBLE_1, INT_2), COALESCE_FN, 1.0, false),
 
-                    Arguments.of(List.of(LONG_1, FLOAT_2), new VariadicFunctionValue.CoalesceFn(), 1F, false),
-                    Arguments.of(List.of(FLOAT_1, LONG_2), new VariadicFunctionValue.CoalesceFn(), 1F, false),
-                    Arguments.of(List.of(LONG_1, DOUBLE_2), new VariadicFunctionValue.CoalesceFn(), 1.0, false),
-                    Arguments.of(List.of(DOUBLE_1, LONG_2), new VariadicFunctionValue.CoalesceFn(), 1.0, false),
+                    Arguments.of(List.of(LONG_1, FLOAT_2), COALESCE_FN, 1F, false),
+                    Arguments.of(List.of(FLOAT_1, LONG_2), COALESCE_FN, 1F, false),
+                    Arguments.of(List.of(LONG_1, DOUBLE_2), COALESCE_FN, 1.0, false),
+                    Arguments.of(List.of(DOUBLE_1, LONG_2), COALESCE_FN, 1.0, false),
 
-                    Arguments.of(List.of(FLOAT_1, DOUBLE_2), new VariadicFunctionValue.CoalesceFn(), 1.0, false),
-                    Arguments.of(List.of(DOUBLE_1, FLOAT_2), new VariadicFunctionValue.CoalesceFn(), 1.0, false),
+                    Arguments.of(List.of(FLOAT_1, DOUBLE_2), COALESCE_FN, 1.0, false),
+                    Arguments.of(List.of(DOUBLE_1, FLOAT_2), COALESCE_FN, 1.0, false),
 
-                    Arguments.of(List.of(INT_1, LONG_2, FLOAT_3, DOUBLE_1), new VariadicFunctionValue.CoalesceFn(), 1.0, false),
-                    Arguments.of(List.of(INT_1, LONG_NULL, FLOAT_3, DOUBLE_1), new VariadicFunctionValue.CoalesceFn(), 1.0, false),
-                    Arguments.of(List.of(INT_NULL, LONG_NULL, FLOAT_3, DOUBLE_1), new VariadicFunctionValue.CoalesceFn(), 3.0, false),
+                    Arguments.of(List.of(INT_1, LONG_2, FLOAT_3, DOUBLE_1), COALESCE_FN, 1.0, false),
+                    Arguments.of(List.of(INT_1, LONG_NULL, FLOAT_3, DOUBLE_1), COALESCE_FN, 1.0, false),
+                    Arguments.of(List.of(INT_NULL, LONG_NULL, FLOAT_3, DOUBLE_1), COALESCE_FN, 3.0, false),
 
-                    Arguments.of(List.of(LIST_INT_2, LIST_LONG_1), new VariadicFunctionValue.CoalesceFn(), List.of(3L, 2L, 1L), false),
-                    Arguments.of(List.of(LIST_LONG_1, LIST_INT_2), new VariadicFunctionValue.CoalesceFn(), List.of(1L, 2L, 3L), false),
-                    Arguments.of(List.of(LIST_INT_2, LIST_FLOAT_1), new VariadicFunctionValue.CoalesceFn(), List.of(3.0f, 2.0f, 1.0f), false),
-                    Arguments.of(List.of(LIST_FLOAT_1, LIST_INT_2), new VariadicFunctionValue.CoalesceFn(), List.of(1.0f, 2.0f, 3.0f), false),
+                    Arguments.of(List.of(LIST_INT_2, LIST_LONG_1), COALESCE_FN, List.of(3L, 2L, 1L), false),
+                    Arguments.of(List.of(LIST_LONG_1, LIST_INT_2), COALESCE_FN, List.of(1L, 2L, 3L), false),
+                    Arguments.of(List.of(LIST_INT_2, LIST_FLOAT_1), COALESCE_FN, List.of(3.0f, 2.0f, 1.0f), false),
+                    Arguments.of(List.of(LIST_FLOAT_1, LIST_INT_2), COALESCE_FN, List.of(1.0f, 2.0f, 3.0f), false),
 
 
-                    Arguments.of(List.of(RECORD_1, RECORD_2), new VariadicFunctionValue.CoalesceFn(), getMessageForRecord1(), false),
-                    Arguments.of(List.of(RECORD_1, RECORD_NAMED), new VariadicFunctionValue.CoalesceFn(), getMessageForRecord1(), false),
-                    Arguments.of(List.of(NULL_TYPED, RECORD_1), new VariadicFunctionValue.CoalesceFn(), getMessageForRecord1(), false),
+                    Arguments.of(List.of(RECORD_1, RECORD_2), COALESCE_FN, getMessageForRecord1(), false),
+                    Arguments.of(List.of(RECORD_1, RECORD_NAMED), COALESCE_FN, getMessageForRecord1(), false),
+                    Arguments.of(List.of(NULL_TYPED, RECORD_1), COALESCE_FN, getMessageForRecord1(), false),
 
-                    Arguments.of(List.of(F, INT_1), new VariadicFunctionValue.CoalesceFn(), 4L, false),
-                    Arguments.of(List.of(INT_1, F), new VariadicFunctionValue.CoalesceFn(), 1L, false),
+                    Arguments.of(List.of(F, INT_1), COALESCE_FN, 4L, false),
+                    Arguments.of(List.of(INT_1, F), COALESCE_FN, 1L, false),
 
-                    Arguments.of(List.of(F, INT_NULL), new VariadicFunctionValue.CoalesceFn(), 4L, false),
-                    Arguments.of(List.of(INT_NULL, F), new VariadicFunctionValue.CoalesceFn(), 4L, false),
+                    Arguments.of(List.of(F, INT_NULL), COALESCE_FN, 4L, false),
+                    Arguments.of(List.of(INT_NULL, F), COALESCE_FN, 4L, false),
 
-                    Arguments.of(List.of(INT_1, STRING_1), new VariadicFunctionValue.CoalesceFn(), null, true),
-                    Arguments.of(List.of(LONG_1, STRING_1), new VariadicFunctionValue.CoalesceFn(), null, true),
-                    Arguments.of(List.of(FLOAT_1, STRING_1), new VariadicFunctionValue.CoalesceFn(), null, true),
-                    Arguments.of(List.of(DOUBLE_1, STRING_1), new VariadicFunctionValue.CoalesceFn(), null, true),
-                    Arguments.of(List.of(BOOLEAN_1, STRING_1), new VariadicFunctionValue.CoalesceFn(), null, true),
+                    Arguments.of(List.of(INT_1, STRING_1), COALESCE_FN, null, true),
+                    Arguments.of(List.of(LONG_1, STRING_1), COALESCE_FN, null, true),
+                    Arguments.of(List.of(FLOAT_1, STRING_1), COALESCE_FN, null, true),
+                    Arguments.of(List.of(DOUBLE_1, STRING_1), COALESCE_FN, null, true),
+                    Arguments.of(List.of(BOOLEAN_1, STRING_1), COALESCE_FN, null, true),
 
-                    Arguments.of(List.of(INT_1, BOOLEAN_1), new VariadicFunctionValue.CoalesceFn(), null, true),
-                    Arguments.of(List.of(LONG_1, BOOLEAN_1), new VariadicFunctionValue.CoalesceFn(), null, true),
-                    Arguments.of(List.of(FLOAT_1, BOOLEAN_1), new VariadicFunctionValue.CoalesceFn(), null, true),
-                    Arguments.of(List.of(DOUBLE_1, BOOLEAN_1), new VariadicFunctionValue.CoalesceFn(), null, true)
+                    Arguments.of(List.of(INT_1, BOOLEAN_1), COALESCE_FN, null, true),
+                    Arguments.of(List.of(LONG_1, BOOLEAN_1), COALESCE_FN, null, true),
+                    Arguments.of(List.of(FLOAT_1, BOOLEAN_1), COALESCE_FN, null, true),
+                    Arguments.of(List.of(DOUBLE_1, BOOLEAN_1), COALESCE_FN, null, true)
             );
         }
     }
 
+    /**
+     * Verifies that a comparison function evaluates to the expected value, or is rejected as expected.
+     */
     @ParameterizedTest
-    @SuppressWarnings({"rawtypes", "unchecked", "ConstantConditions"})
     @ArgumentsSource(BinaryPredicateTestProvider.class)
-    void testPredicate(List<Value> args, BuiltInFunction function, Object expectedValue, boolean shouldFail) {
+    void testEval(List<Value> args, BuiltInFunction<Value> function, Object expectedValue, boolean shouldFail) {
         if (shouldFail) {
-            try {
-                function.encapsulate(CallSiteArguments.ofPositional(args));
-                Assertions.fail("expected an exception to be thrown");
-            } catch (Exception e) {
-                Assertions.assertTrue(e instanceof SemanticException);
-                Assertions.assertEquals(((SemanticException)e).getErrorCode(), SemanticException.ErrorCode.INCOMPATIBLE_TYPE);
-            }
+            assertThatThrownBy(() -> function.encapsulate(CallSiteArguments.ofPositional(args)))
+                    .isInstanceOf(SemanticException.class)
+                    .extracting(thrown -> ((SemanticException)thrown).getErrorCode())
+                    .isEqualTo(SemanticException.ErrorCode.INCOMPATIBLE_TYPE);
         } else {
-            Typed value = function.encapsulate(CallSiteArguments.ofPositional(args));
-            Assertions.assertTrue(value instanceof VariadicFunctionValue);
-            Object actualValue = ((VariadicFunctionValue)value).eval(null, evaluationContext);
-            Assertions.assertEquals(expectedValue, actualValue);
+            final Typed value = function.encapsulate(CallSiteArguments.ofPositional(args));
+            assertThat(value).isInstanceOf(VariadicFunctionValue.class);
+            assertThat(((VariadicFunctionValue)value).eval(null, evaluationContext)).isEqualTo(expectedValue);
         }
+    }
+
+    /**
+     * Verifies that a comparison function applied to only {@code NULL} arguments is rejected, as no physical operator
+     * is defined for the {@code NULL} type.
+     */
+    @Test
+    void testAllArgumentsNull() {
+        for (final BuiltInFunction<Value> function : List.of(GREATEST_FN, LEAST_FN, COALESCE_FN)) {
+            assertThatThrownBy(() -> function.encapsulate(CallSiteArguments.ofPositional(List.of(NULL_TYPED, NULL_TYPED))))
+                    .as("%s applied to only NULL arguments", function.getFunctionName())
+                    .isInstanceOf(SemanticException.class)
+                    .extracting(thrown -> ((SemanticException)thrown).getErrorCode())
+                    .isEqualTo(SemanticException.ErrorCode.FUNCTION_UNDEFINED_FOR_GIVEN_ARGUMENT_TYPES);
+        }
+    }
+
+    /**
+     * A test case for {@link #testResultType}. Bundles the arguments the function-under-test is applied to together
+     * with the expected type code and the nullability of the result.
+     */
+    record ResultTypeTestCase(BuiltInFunction<Value> function, List<? extends Value> arguments,
+                              Type.TypeCode expectedTypeCode, boolean expectedIsNullable) {
+        @Override
+        public String toString() {
+            // Render each argument with its type code, marking a nullable type with a trailing `?`.
+            // (Note that `Type.toString()` does not indicate nullability, which is what matters in some tests.)
+            final String renderedArguments = arguments.stream()
+                    .map(argument -> {
+                        final Type argumentType = argument.getResultType();
+                        return argument + ":" + argumentType.getTypeCode() + (argumentType.isNullable() ? "?" : "");
+                    })
+                    .collect(Collectors.joining(", ", "(", ")"));
+            return function.getFunctionName() + renderedArguments + " -> " + expectedTypeCode
+                    + (expectedIsNullable ? "?" : "");
+        }
+    }
+
+    static class ResultTypeTestProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(final ParameterDeclarations parameterDeclarations,
+                                                            final ExtensionContext context) {
+            return Stream.of(
+                    // GREATEST() and LEAST() are nullable if any of their arguments is nullable.
+                    new ResultTypeTestCase(GREATEST_FN, List.of(INT_1, INT_2), Type.TypeCode.INT, true),
+                    new ResultTypeTestCase(GREATEST_FN, List.of(INT_1_NOT_NULLABLE, INT_1), Type.TypeCode.INT, true),
+                    new ResultTypeTestCase(GREATEST_FN, List.of(INT_1, INT_1_NOT_NULLABLE), Type.TypeCode.INT, true),
+                    new ResultTypeTestCase(GREATEST_FN, List.of(INT_1_NOT_NULLABLE, F), Type.TypeCode.LONG, true),
+                    new ResultTypeTestCase(GREATEST_FN, List.of(INT_1_NOT_NULLABLE, NULL_TYPED), Type.TypeCode.INT, true),
+                    new ResultTypeTestCase(GREATEST_FN, List.of(INT_1_NOT_NULLABLE, LONG_1_NOT_NULLABLE), Type.TypeCode.LONG, false),
+                    new ResultTypeTestCase(LEAST_FN, List.of(STRING_1_NOT_NULLABLE, STRING_2), Type.TypeCode.STRING, true),
+                    new ResultTypeTestCase(LEAST_FN, List.of(INT_1, INT_1_NOT_NULLABLE), Type.TypeCode.INT, true),
+                    new ResultTypeTestCase(LEAST_FN, List.of(INT_1_NOT_NULLABLE, NULL_TYPED), Type.TypeCode.INT, true),
+                    new ResultTypeTestCase(LEAST_FN, List.of(INT_1_NOT_NULLABLE, LONG_1_NOT_NULLABLE, INT_2_NOT_NULLABLE), Type.TypeCode.LONG, false),
+
+                    // COALESCE() returns its first non-NULL argument, hence its result is nullable only if all of its arguments are nullable.
+                    new ResultTypeTestCase(COALESCE_FN, List.of(INT_1, INT_2), Type.TypeCode.INT, true),
+                    new ResultTypeTestCase(COALESCE_FN, List.of(F, INT_1), Type.TypeCode.LONG, true),
+                    new ResultTypeTestCase(COALESCE_FN, List.of(INT_1, NULL_TYPED), Type.TypeCode.INT, true),
+                    new ResultTypeTestCase(COALESCE_FN, List.of(INT_1_NOT_NULLABLE, INT_2), Type.TypeCode.INT, false),
+                    new ResultTypeTestCase(COALESCE_FN, List.of(INT_1, INT_2_NOT_NULLABLE), Type.TypeCode.INT, false),
+                    new ResultTypeTestCase(COALESCE_FN, List.of(F, INT_1_NOT_NULLABLE), Type.TypeCode.LONG, false),
+                    new ResultTypeTestCase(COALESCE_FN, List.of(INT_1_NOT_NULLABLE, F), Type.TypeCode.LONG, false),
+                    new ResultTypeTestCase(COALESCE_FN, List.of(NULL_TYPED, INT_1_NOT_NULLABLE), Type.TypeCode.INT, false),
+                    new ResultTypeTestCase(COALESCE_FN, List.of(INT_1_NOT_NULLABLE, NULL_TYPED), Type.TypeCode.INT, false),
+                    new ResultTypeTestCase(COALESCE_FN, List.of(INT_1, F, LONG_1_NOT_NULLABLE), Type.TypeCode.LONG, false),
+                    new ResultTypeTestCase(COALESCE_FN, List.of(INT_1, F, LONG_1), Type.TypeCode.LONG, true),
+
+                    // COALESCE() over non-primitive types, where the common type is determined structurally.
+                    new ResultTypeTestCase(COALESCE_FN, List.of(RECORD_1, RECORD_2), Type.TypeCode.RECORD, false),
+                    new ResultTypeTestCase(COALESCE_FN, List.of(RECORD_1_NULLABLE, RECORD_1), Type.TypeCode.RECORD, false),
+                    new ResultTypeTestCase(COALESCE_FN, List.of(RECORD_1, RECORD_1_NULLABLE), Type.TypeCode.RECORD, false),
+                    new ResultTypeTestCase(COALESCE_FN, List.of(RECORD_1_NULLABLE, RECORD_1_NULLABLE), Type.TypeCode.RECORD, true),
+                    new ResultTypeTestCase(COALESCE_FN, List.of(LIST_INT_1, LIST_INT_2), Type.TypeCode.ARRAY, false),
+                    new ResultTypeTestCase(COALESCE_FN, List.of(LIST_INT_1_NULLABLE, LIST_INT_1), Type.TypeCode.ARRAY, false),
+                    new ResultTypeTestCase(COALESCE_FN, List.of(LIST_INT_1, LIST_INT_1_NULLABLE), Type.TypeCode.ARRAY, false),
+                    new ResultTypeTestCase(COALESCE_FN, List.of(LIST_INT_1_NULLABLE, LIST_INT_1_NULLABLE), Type.TypeCode.ARRAY, true),
+
+                    // GREATEST() and LEAST() are not defined for non-primitive types, but COALESCE() is.
+                    new ResultTypeTestCase(COALESCE_FN, List.of(RECORD_1, RECORD_2, RECORD_3), Type.TypeCode.RECORD, false)
+            ).map(Arguments::of);
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ResultTypeTestProvider.class)
+    void testResultType(ResultTypeTestCase testCase) {
+        final List<? extends Value> arguments = testCase.arguments();
+        final boolean expectedIsNullable = testCase.expectedIsNullable();
+
+        final Typed value = testCase.function().encapsulate(CallSiteArguments.ofPositional(arguments));
+        assertThat(value).isInstanceOf(VariadicFunctionValue.class);
+
+        // Check the derived result type.
+        final Type resultType = value.getResultType();
+        assertThat(resultType.getTypeCode()).isEqualTo(testCase.expectedTypeCode());
+        assertThat(resultType.isNullable()).isEqualTo(expectedIsNullable);
+
+        // Check that, while every argument is promoted to the common result type, a non-nullable argument is widened to
+        // a nullable one only if the result type is nullable anyway.
+        final List<? extends Value> children = ImmutableList.copyOf(((VariadicFunctionValue)value).getChildren());
+        for (int i = 0; i < arguments.size(); i++) {
+            final boolean argumentIsNullable = arguments.get(i).getResultType().isNullable();
+            final boolean expectedChildIsNullable = argumentIsNullable || expectedIsNullable;
+            assertThat(children.get(i).getResultType().isNullable())
+                    .as("nullability of promoted argument %d", i)
+                    .isEqualTo(expectedChildIsNullable);
+        }
+
+        // Check that re-deriving the result type from the promoted children, as `withChildren()` and `fromProto()` do,
+        // yields the same type and does not trip the consistency check in `computeResultType()`.
+        assertThat(((VariadicFunctionValue)value).withChildren(children).getResultType()).isEqualTo(resultType);
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/VariadicFunctionValueTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/VariadicFunctionValueTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2015-2022 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,7 @@ import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.junit.jupiter.params.support.ParameterDeclarations;
 
+import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -123,7 +124,7 @@ class VariadicFunctionValueTest {
     private static final VariadicFunctionValue.LeastFn LEAST_FN = new VariadicFunctionValue.LeastFn();
     private static final VariadicFunctionValue.CoalesceFn COALESCE_FN = new VariadicFunctionValue.CoalesceFn();
 
-    private static TypeRepository typeRepository;
+    private static final TypeRepository typeRepository;
 
     static {
         final TypeRepository.Builder typeRepositoryBuilder = TypeRepository.newBuilder().setName("foo").setPackage("a.b.c");
@@ -157,9 +158,10 @@ class VariadicFunctionValueTest {
     }
 
     static class BinaryPredicateTestProvider implements ArgumentsProvider {
+        @Nonnull
         @Override
-        public Stream<? extends Arguments> provideArguments(final ParameterDeclarations parameterDeclarations,
-                                                            final ExtensionContext context) {
+        public Stream<? extends Arguments> provideArguments(@Nonnull final ParameterDeclarations parameterDeclarations,
+                                                            @Nonnull final ExtensionContext context) {
             return Stream.of(
                     // Greatest Function
                     Arguments.of(List.of(INT_1, INT_1), GREATEST_FN, 1, false),
@@ -466,9 +468,10 @@ class VariadicFunctionValueTest {
     }
 
     static class ResultTypeTestProvider implements ArgumentsProvider {
+        @Nonnull
         @Override
-        public Stream<? extends Arguments> provideArguments(final ParameterDeclarations parameterDeclarations,
-                                                            final ExtensionContext context) {
+        public Stream<? extends Arguments> provideArguments(@Nonnull final ParameterDeclarations parameterDeclarations,
+                                                            @Nonnull final ExtensionContext context) {
             return Stream.of(
                     // GREATEST() and LEAST() are nullable if any of their arguments is nullable.
                     new ResultTypeTestCase(GREATEST_FN, List.of(INT_1, INT_2), Type.TypeCode.INT, true),
@@ -525,15 +528,12 @@ class VariadicFunctionValueTest {
         assertThat(resultType.getTypeCode()).isEqualTo(testCase.expectedTypeCode());
         assertThat(resultType.isNullable()).isEqualTo(expectedIsNullable);
 
-        // Check that, while every argument is promoted to the common result type, a non-nullable argument is widened to
-        // a nullable one only if the result type is nullable anyway.
+        // Check that, while every argument is promoted to the common result type, it retains its own nullability.
         final List<? extends Value> children = ImmutableList.copyOf(((VariadicFunctionValue)value).getChildren());
         for (int i = 0; i < arguments.size(); i++) {
-            final boolean argumentIsNullable = arguments.get(i).getResultType().isNullable();
-            final boolean expectedChildIsNullable = argumentIsNullable || expectedIsNullable;
             assertThat(children.get(i).getResultType().isNullable())
                     .as("nullability of promoted argument %d", i)
-                    .isEqualTo(expectedChildIsNullable);
+                    .isEqualTo(arguments.get(i).getResultType().isNullable());
         }
 
         // Check that re-deriving the result type from the promoted children, as `withChildren()` and `fromProto()` do,

--- a/yaml-tests/src/test/resources/aggregate-empty-table.metrics.binpb
+++ b/yaml-tests/src/test/resources/aggregate-empty-table.metrics.binpb
@@ -16,14 +16,14 @@
   5 -> 4 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   6 -> 5 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}à
+}¾
 M
-agg-empty-table-tests4EXPLAIN select count(*) from T1 having count(*) > 0;Ž
-’Î ’D ÃáÊ(0¡Ç88@ÖSCAN([IS T1]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | FILTER coalesce_long(_._0._0, 0l) GREATER_THAN promote(@c13 AS LONG) | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)—digraph G {
+agg-empty-table-tests4EXPLAIN select count(*) from T1 having count(*) > 0;ì
+‚¾ÝÄ@ ÆŽÒ(0Û¥8@ÅSCAN([IS T1]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | FILTER coalesce_long(_._0._0, 0l) GREATER_THAN promote(@c13 AS LONG) | MAP (coalesce_long(_._0._0, 0l) AS _0)†digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
-  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (coalesce_long(q36._0._0, promote(0l AS LONG)) AS _0)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS _0)" ];
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (coalesce_long(q35._0._0, 0l) AS _0)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS _0)" ];
   2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE coalesce_long(q6._0._0, 0l) GREATER_THAN promote(@c13 AS LONG)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS _0 AS _0)" ];
   3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">$q6 OR NULL</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS _0 AS _0)" ];
   4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Streaming Aggregate</td></tr><tr><td align="left">COLLECT (count_star(*) AS _0)</td></tr><tr><td align="left">GROUP BY ()</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS _0 AS _0)" ];
@@ -32,10 +32,10 @@ M
   7 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Primary Storage</td></tr><tr><td align="left">record types: [T1, T2, T3]</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS COL1, LONG AS COL2)" ];
   3 -> 2 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   4 -> 3 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  5 -> 4 [ label=<&nbsp;q32> label="q32" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  5 -> 4 [ label=<&nbsp;q31> label="q31" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   6 -> 5 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   7 -> 6 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  2 -> 1 [ label=<&nbsp;q36> label="q36" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q35> label="q35" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
 }½
 H
 agg-empty-table-tests/EXPLAIN select count(*) from T1 where col1 = 0;ð
@@ -92,14 +92,14 @@ H
   4 -> 3 [ label=<&nbsp;q4> label="q4" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   5 -> 4 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}¶
+}“
 M
-agg-empty-table-tests4EXPLAIN select count(*) from T2 having count(*) > 0;ä
-È¾œª#‚ ´êÀ(40“Às8(@ÎAISCAN(T2_I1 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | FILTER coalesce_long(_._0._0, 0l) GREATER_THAN promote(@c13 AS LONG) | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)ôdigraph G {
+agg-empty-table-tests4EXPLAIN select count(*) from T2 having count(*) > 0;Á
+¸¥–þ~ ¸µÃ(20¾½38$@½AISCAN(T2_I1 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | FILTER coalesce_long(_._0._0, 0l) GREATER_THAN promote(@c13 AS LONG) | MAP (coalesce_long(_._0._0, 0l) AS _0)ãdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
-  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (coalesce_long(q108._0._0, promote(0l AS LONG)) AS _0)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS _0)" ];
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (coalesce_long(q107._0._0, 0l) AS _0)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS _0)" ];
   2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE coalesce_long(q6._0._0, 0l) GREATER_THAN promote(@c13 AS LONG)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS _0 AS _0)" ];
   3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">$q6 OR NULL</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS _0 AS _0)" ];
   4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q4 AS _0)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS _0 AS _0)" ];
@@ -109,7 +109,7 @@ M
   4 -> 3 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   5 -> 4 [ label=<&nbsp;q4> label="q4" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   6 -> 5 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  2 -> 1 [ label=<&nbsp;q108> label="q108" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q107> label="q107" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
 }½
 H
 agg-empty-table-tests/EXPLAIN select count(*) from T2 where col1 = 0;ð
@@ -929,14 +929,14 @@ M
   5 -> 4 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   6 -> 5 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}ô
+}Ò
 a
-)agg-empty-table-tests-after-modifications4EXPLAIN select count(*) from T1 having count(*) > 0;Ž
-’Î ’D ÃáÊ(0¡Ç88@ÖSCAN([IS T1]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | FILTER coalesce_long(_._0._0, 0l) GREATER_THAN promote(@c13 AS LONG) | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)—digraph G {
+)agg-empty-table-tests-after-modifications4EXPLAIN select count(*) from T1 having count(*) > 0;ì
+‚¾ÝÄ@ ÆŽÒ(0Û¥8@ÅSCAN([IS T1]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | FILTER coalesce_long(_._0._0, 0l) GREATER_THAN promote(@c13 AS LONG) | MAP (coalesce_long(_._0._0, 0l) AS _0)†digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
-  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (coalesce_long(q36._0._0, promote(0l AS LONG)) AS _0)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS _0)" ];
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (coalesce_long(q35._0._0, 0l) AS _0)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS _0)" ];
   2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE coalesce_long(q6._0._0, 0l) GREATER_THAN promote(@c13 AS LONG)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS _0 AS _0)" ];
   3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">$q6 OR NULL</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS _0 AS _0)" ];
   4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Streaming Aggregate</td></tr><tr><td align="left">COLLECT (count_star(*) AS _0)</td></tr><tr><td align="left">GROUP BY ()</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS _0 AS _0)" ];
@@ -945,10 +945,10 @@ a
   7 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Primary Storage</td></tr><tr><td align="left">record types: [T1, T2, T3]</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS COL1, LONG AS COL2)" ];
   3 -> 2 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   4 -> 3 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  5 -> 4 [ label=<&nbsp;q32> label="q32" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  5 -> 4 [ label=<&nbsp;q31> label="q31" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   6 -> 5 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   7 -> 6 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  2 -> 1 [ label=<&nbsp;q36> label="q36" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q35> label="q35" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
 }Ñ
 \
 )agg-empty-table-tests-after-modifications/EXPLAIN select count(*) from T1 where col1 = 0;ð
@@ -1005,14 +1005,14 @@ M
   4 -> 3 [ label=<&nbsp;q4> label="q4" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   5 -> 4 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}Ê
+}§
 a
-)agg-empty-table-tests-after-modifications4EXPLAIN select count(*) from T2 having count(*) > 0;ä
-È¾œª#‚ ´êÀ(40“Às8(@ÎAISCAN(T2_I1 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | FILTER coalesce_long(_._0._0, 0l) GREATER_THAN promote(@c13 AS LONG) | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)ôdigraph G {
+)agg-empty-table-tests-after-modifications4EXPLAIN select count(*) from T2 having count(*) > 0;Á
+¸¥–þ~ ¸µÃ(20¾½38$@½AISCAN(T2_I1 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | FILTER coalesce_long(_._0._0, 0l) GREATER_THAN promote(@c13 AS LONG) | MAP (coalesce_long(_._0._0, 0l) AS _0)ãdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
-  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (coalesce_long(q108._0._0, promote(0l AS LONG)) AS _0)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS _0)" ];
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (coalesce_long(q107._0._0, 0l) AS _0)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS _0)" ];
   2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE coalesce_long(q6._0._0, 0l) GREATER_THAN promote(@c13 AS LONG)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS _0 AS _0)" ];
   3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">$q6 OR NULL</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS _0 AS _0)" ];
   4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q4 AS _0)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS _0 AS _0)" ];
@@ -1022,7 +1022,7 @@ a
   4 -> 3 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   5 -> 4 [ label=<&nbsp;q4> label="q4" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   6 -> 5 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  2 -> 1 [ label=<&nbsp;q108> label="q108" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q107> label="q107" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
 }é
 P
 )agg-empty-table-tests-after-modifications#EXPLAIN select count(col2) from T2;”
@@ -1587,26 +1587,26 @@ y
   6 -> 5 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   7 -> 6 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q81> label="q81" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}†
+}Á
 f
-)agg-empty-table-tests-after-modifications9EXPLAIN select count(col1) from t3 having count(col1) = 0›
-¢Èñˆ` ’€Ù('0Ú®°82@çISCAN(T3_I1 <,>) | MAP (_ AS _0) | AGG (count(_._0.COL1) AS _0) GROUP BY () | ON EMPTY NULL | FILTER coalesce_long(_._0._0, promote(0l AS LONG)) EQUALS promote(@c13 AS LONG) | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)’digraph G {
+)agg-empty-table-tests-after-modifications9EXPLAIN select count(col1) from t3 having count(col1) = 0Ö
+’Ï·‹\ Ç­²(%0µ«#8.@ÅISCAN(T3_I1 <,>) | MAP (_ AS _0) | AGG (count(_._0.COL1) AS _0) GROUP BY () | ON EMPTY NULL | FILTER coalesce_long(_._0._0, 0l) EQUALS promote(@c13 AS LONG) | MAP (coalesce_long(_._0._0, 0l) AS _0)ðdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
-  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (coalesce_long(q82._0._0, promote(0l AS LONG)) AS _0)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS _0)" ];
-  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE coalesce_long(q6._0._0, promote(0l AS LONG)) EQUALS promote(@c13 AS LONG)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS _0 AS _0)" ];
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (coalesce_long(q81._0._0, 0l) AS _0)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS _0)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE coalesce_long(q6._0._0, 0l) EQUALS promote(@c13 AS LONG)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS _0 AS _0)" ];
   3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">$q6 OR NULL</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS _0 AS _0)" ];
-  4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Streaming Aggregate</td></tr><tr><td align="left">COLLECT (count(q78._0.COL1) AS _0)</td></tr><tr><td align="left">GROUP BY ()</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS _0 AS _0)" ];
+  4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Streaming Aggregate</td></tr><tr><td align="left">COLLECT (count(q77._0.COL1) AS _0)</td></tr><tr><td align="left">GROUP BY ()</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS _0 AS _0)" ];
   5 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q2 AS _0)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS COL1, LONG AS COL2 AS _0)" ];
   6 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">range: &lt;-âˆž, âˆž&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS COL1, LONG AS COL2)" ];
   7 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">T3_I1</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS COL1, LONG AS COL2)" ];
   3 -> 2 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   4 -> 3 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  5 -> 4 [ label=<&nbsp;q78> label="q78" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  5 -> 4 [ label=<&nbsp;q77> label="q77" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   6 -> 5 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   7 -> 6 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  2 -> 1 [ label=<&nbsp;q82> label="q82" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q81> label="q81" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
 }–
 b
 )agg-empty-table-tests-after-modifications5EXPLAIN select sum(col1) from t3 having sum(col1) = 0¯

--- a/yaml-tests/src/test/resources/aggregate-empty-table.metrics.yaml
+++ b/yaml-tests/src/test/resources/aggregate-empty-table.metrics.yaml
@@ -15,14 +15,14 @@ agg-empty-table-tests:
     ref: aggregate-empty-table.yamsql:48
     explain: SCAN([IS T1]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY ()
         | ON EMPTY NULL | FILTER coalesce_long(_._0._0, 0l) GREATER_THAN promote(@c13
-        AS LONG) | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)
-    task_count: 274
-    task_total_time_ms: 17
-    transform_count: 68
-    transform_time_ms: 5
-    transform_yield_count: 19
+        AS LONG) | MAP (coalesce_long(_._0._0, 0l) AS _0)
+    task_count: 258
+    task_total_time_ms: 11
+    transform_count: 64
+    transform_time_ms: 3
+    transform_yield_count: 17
     insert_time_ms: 0
-    insert_new_count: 26
+    insert_new_count: 22
     insert_reused_count: 2
 -   query: EXPLAIN select count(*) from T1 where col1 = 0;
     ref: aggregate-empty-table.yamsql:52
@@ -66,14 +66,14 @@ agg-empty-table-tests:
     ref: aggregate-empty-table.yamsql:87
     explain: 'AISCAN(T2_I1 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY
         NULL | FILTER coalesce_long(_._0._0, 0l) GREATER_THAN promote(@c13 AS LONG)
-        | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)'
-    task_count: 456
-    task_total_time_ms: 74
-    transform_count: 130
-    transform_time_ms: 34
-    transform_yield_count: 52
-    insert_time_ms: 1
-    insert_new_count: 40
+        | MAP (coalesce_long(_._0._0, 0l) AS _0)'
+    task_count: 440
+    task_total_time_ms: 29
+    transform_count: 126
+    transform_time_ms: 15
+    transform_yield_count: 50
+    insert_time_ms: 0
+    insert_new_count: 36
     insert_reused_count: 4
 -   query: EXPLAIN select count(*) from T2 where col1 = 0;
     ref: aggregate-empty-table.yamsql:91
@@ -683,14 +683,14 @@ agg-empty-table-tests-after-modifications:
     ref: aggregate-empty-table.yamsql:382
     explain: SCAN([IS T1]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY ()
         | ON EMPTY NULL | FILTER coalesce_long(_._0._0, 0l) GREATER_THAN promote(@c13
-        AS LONG) | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)
-    task_count: 274
-    task_total_time_ms: 17
-    transform_count: 68
-    transform_time_ms: 5
-    transform_yield_count: 19
+        AS LONG) | MAP (coalesce_long(_._0._0, 0l) AS _0)
+    task_count: 258
+    task_total_time_ms: 11
+    transform_count: 64
+    transform_time_ms: 3
+    transform_yield_count: 17
     insert_time_ms: 0
-    insert_new_count: 26
+    insert_new_count: 22
     insert_reused_count: 2
 -   query: EXPLAIN select count(*) from T1 where col1 = 0;
     ref: aggregate-empty-table.yamsql:386
@@ -734,14 +734,14 @@ agg-empty-table-tests-after-modifications:
     ref: aggregate-empty-table.yamsql:416
     explain: 'AISCAN(T2_I1 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY
         NULL | FILTER coalesce_long(_._0._0, 0l) GREATER_THAN promote(@c13 AS LONG)
-        | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)'
-    task_count: 456
-    task_total_time_ms: 74
-    transform_count: 130
-    transform_time_ms: 34
-    transform_yield_count: 52
-    insert_time_ms: 1
-    insert_new_count: 40
+        | MAP (coalesce_long(_._0._0, 0l) AS _0)'
+    task_count: 440
+    task_total_time_ms: 29
+    transform_count: 126
+    transform_time_ms: 15
+    transform_yield_count: 50
+    insert_time_ms: 0
+    insert_new_count: 36
     insert_reused_count: 4
 -   query: EXPLAIN select count(col2) from T2;
     ref: aggregate-empty-table.yamsql:491
@@ -1145,16 +1145,15 @@ agg-empty-table-tests-after-modifications:
 -   query: EXPLAIN select count(col1) from t3 having count(col1) = 0
     ref: aggregate-empty-table.yamsql:707
     explain: ISCAN(T3_I1 <,>) | MAP (_ AS _0) | AGG (count(_._0.COL1) AS _0) GROUP
-        BY () | ON EMPTY NULL | FILTER coalesce_long(_._0._0, promote(0l AS LONG))
-        EQUALS promote(@c13 AS LONG) | MAP (coalesce_long(_._0._0, promote(0l AS LONG))
-        AS _0)
-    task_count: 418
-    task_total_time_ms: 42
-    transform_count: 96
-    transform_time_ms: 18
-    transform_yield_count: 39
-    insert_time_ms: 4
-    insert_new_count: 50
+        BY () | ON EMPTY NULL | FILTER coalesce_long(_._0._0, 0l) EQUALS promote(@c13
+        AS LONG) | MAP (coalesce_long(_._0._0, 0l) AS _0)
+    task_count: 402
+    task_total_time_ms: 12
+    transform_count: 92
+    transform_time_ms: 5
+    transform_yield_count: 37
+    insert_time_ms: 0
+    insert_new_count: 46
     insert_reused_count: 6
 -   query: EXPLAIN select sum(col1) from t3 having sum(col1) = 0
     ref: aggregate-empty-table.yamsql:714

--- a/yaml-tests/src/test/resources/aggregate-empty-table.yamsql
+++ b/yaml-tests/src/test/resources/aggregate-empty-table.yamsql
@@ -36,7 +36,7 @@ test_block:
   tests:
     -
       - query: select count(*) from T1;
-      - explain: "SCAN([IS T1]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "SCAN([IS T1]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - resultMetadata: [{_0: BIGINT}]
       - result: [{0}]
     -
@@ -45,16 +45,16 @@ test_block:
       # Note: The ON EMPTY NULL could theoretically be eliminated, since NULL gets mapped a count of 0 and `COUNT(*) > 0`
       # rejects that. However, the analysis does not detect that because it does not substitute the @c13 with 0 currently.
       - query: select count(*) from T1 having count(*) > 0;
-      - explain: "SCAN([IS T1]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | FILTER coalesce_long(_._0._0, 0l) GREATER_THAN promote(@c13 AS LONG) | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "SCAN([IS T1]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | FILTER coalesce_long(_._0._0, 0l) GREATER_THAN promote(@c13 AS LONG) | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - result: []
     -
       - query: select count(*) from T1 where col1 = 0;
-      - explain: "SCAN([IS T1]) | FILTER _.COL1 EQUALS promote(@c10 AS LONG) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "SCAN([IS T1]) | FILTER _.COL1 EQUALS promote(@c10 AS LONG) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - resultMetadata: [{_0: BIGINT}]
       - result: [{0}]
     -
       - query: select count(*) from T1 where col1 > 0;
-      - explain: "SCAN([IS T1]) | FILTER _.COL1 GREATER_THAN promote(@c10 AS LONG) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "SCAN([IS T1]) | FILTER _.COL1 GREATER_THAN promote(@c10 AS LONG) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - resultMetadata: [{_0: BIGINT}]
       - result: [{0}]
     -
@@ -74,7 +74,7 @@ test_block:
       - error: UNSUPPORTED_QUERY
     -
       - query: select count(*) from T2;
-      - explain: "AISCAN(T2_I1 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "AISCAN(T2_I1 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - initialVersionLessThan: 4.0.561.0
       - result: []
       - initialVersionAtLeast: 4.0.561.0
@@ -84,16 +84,16 @@ test_block:
       # that does not match an aggregate index.) The null-on-empty quantifier emits one NULL row and HAVING filters it
       # out. Like above, the ON EMPTY NULL does not get eliminated currently, though it could theoretically be.
       - query: select count(*) from T2 having count(*) > 0;
-      - explain: "AISCAN(T2_I1 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | FILTER coalesce_long(_._0._0, 0l) GREATER_THAN promote(@c13 AS LONG) | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "AISCAN(T2_I1 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | FILTER coalesce_long(_._0._0, 0l) GREATER_THAN promote(@c13 AS LONG) | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - result: []
     -
       - query: select count(*) from T2 where col1 = 0;
-      - explain: "AISCAN(T2_I2 [EQUALS promote(@c10 AS LONG)] BY_GROUP -> [_0: KEY:[0], _1: VALUE:[0]]) | MAP ((_._1 AS _0) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "AISCAN(T2_I2 [EQUALS promote(@c10 AS LONG)] BY_GROUP -> [_0: KEY:[0], _1: VALUE:[0]]) | MAP ((_._1 AS _0) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - resultMetadata: [{_0: BIGINT}]
       - result: [{0}]
     -
       - query: select count(*) from T2 where col1 > 0;
-      - explain: "AISCAN(T2_I2 [[GREATER_THAN promote(@c10 AS LONG)]] BY_GROUP -> [_0: KEY:[0], _1: VALUE:[0]]) | AGG sum_l(_._1) GROUP BY () | MAP ((_._1 AS _0) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "AISCAN(T2_I2 [[GREATER_THAN promote(@c10 AS LONG)]] BY_GROUP -> [_0: KEY:[0], _1: VALUE:[0]]) | AGG sum_l(_._1) GROUP BY () | MAP ((_._1 AS _0) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - resultMetadata: [{_0: BIGINT}]
       - result: [{0}]
     -
@@ -113,17 +113,17 @@ test_block:
       - result: []
     -
       - query: select count(*) from T3;
-      - explain: "ISCAN(T3_I2 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "ISCAN(T3_I2 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - resultMetadata: [{_0: BIGINT}]
       - result: [{0}]
     -
       - query: select count(*) from T3 where col1 = 0;
-      - explain: "ISCAN(T3_I1 [EQUALS promote(@c10 AS LONG)]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "ISCAN(T3_I1 [EQUALS promote(@c10 AS LONG)]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - resultMetadata: [{_0: BIGINT}]
       - result: [{0}]
     -
       - query: select count(*) from T3 where col1 > 0;
-      - explain: "ISCAN(T3_I1 [[GREATER_THAN promote(@c10 AS LONG)]]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "ISCAN(T3_I1 [[GREATER_THAN promote(@c10 AS LONG)]]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - resultMetadata: [{_0: BIGINT}]
       - result: [{0}]
     -
@@ -143,17 +143,17 @@ test_block:
       - result: []
     -
       - query: select count(col2) from T1;
-      - explain: "SCAN([IS T1]) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "SCAN([IS T1]) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - resultMetadata: [{_0: BIGINT}]
       - result: [{0}]
     -
       - query: select count(col2) from T1 where col1 = 0;
-      - explain: "SCAN([IS T1]) | FILTER _.COL1 EQUALS promote(@c10 AS LONG) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "SCAN([IS T1]) | FILTER _.COL1 EQUALS promote(@c10 AS LONG) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - resultMetadata: [{_0: BIGINT}]
       - result: [{0}]
     -
       - query: select count(col2) from T1 where col1 > 0;
-      - explain: "SCAN([IS T1]) | FILTER _.COL1 GREATER_THAN promote(@c10 AS LONG) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "SCAN([IS T1]) | FILTER _.COL1 GREATER_THAN promote(@c10 AS LONG) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - resultMetadata: [{_0: BIGINT}]
       - result: [{0}]
     -
@@ -173,19 +173,19 @@ test_block:
       - error: UNSUPPORTED_QUERY
     -
       - query: select count(col2) from T2;
-      - explain: "AISCAN(T2_I3 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "AISCAN(T2_I3 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - initialVersionLessThan: 4.0.561.0
       - result: []
       - initialVersionAtLeast: 4.0.561.0
       - result: [{0}]
     -
       - query: select count(col2) from T2 where col1 = 0;
-      - explain: "AISCAN(T2_I4 [EQUALS promote(@c10 AS LONG)] BY_GROUP -> [_0: KEY:[0], _1: VALUE:[0]]) | MAP ((_._1 AS _0) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "AISCAN(T2_I4 [EQUALS promote(@c10 AS LONG)] BY_GROUP -> [_0: KEY:[0], _1: VALUE:[0]]) | MAP ((_._1 AS _0) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - resultMetadata: [{_0: BIGINT}]
       - result: [{0}]
     -
       - query: select count(col2) from T2 where col1 > 0;
-      - explain: "AISCAN(T2_I4 [[GREATER_THAN promote(@c10 AS LONG)]] BY_GROUP -> [_0: KEY:[0], _1: VALUE:[0]]) | AGG sum_l(_._1) GROUP BY () | MAP ((_._1 AS _0) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "AISCAN(T2_I4 [[GREATER_THAN promote(@c10 AS LONG)]] BY_GROUP -> [_0: KEY:[0], _1: VALUE:[0]]) | AGG sum_l(_._1) GROUP BY () | MAP ((_._1 AS _0) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - resultMetadata: [{_0: BIGINT}]
       - result: [{0}]
     -
@@ -205,17 +205,17 @@ test_block:
       - result: []
     -
       - query: select count(col2) from T3;
-      - explain: "ISCAN(T3_I1 <,>) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "ISCAN(T3_I1 <,>) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - resultMetadata: [{_0: BIGINT}]
       - result: [{0}]
     -
       - query: select count(col2) from T3 where col1 = 0;
-      - explain: "ISCAN(T3_I1 [EQUALS promote(@c10 AS LONG)]) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "ISCAN(T3_I1 [EQUALS promote(@c10 AS LONG)]) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - resultMetadata: [{_0: BIGINT}]
       - result: [{0}]
     -
       - query: select count(col2) from T3 where col1 > 0;
-      - explain: "ISCAN(T3_I1 [[GREATER_THAN promote(@c10 AS LONG)]]) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "ISCAN(T3_I1 [[GREATER_THAN promote(@c10 AS LONG)]]) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - resultMetadata: [{_0: BIGINT}]
       - result: [{0}]
     -
@@ -374,21 +374,21 @@ test_block:
   tests:
     -
       - query: select count(*) from T1;
-      - explain: "SCAN([IS T1]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "SCAN([IS T1]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - resultMetadata: [{_0: BIGINT}]
       - result: [{0}]
     -
       - query: select count(*) from T1 having count(*) > 0;
-      - explain: "SCAN([IS T1]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | FILTER coalesce_long(_._0._0, 0l) GREATER_THAN promote(@c13 AS LONG) | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "SCAN([IS T1]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | FILTER coalesce_long(_._0._0, 0l) GREATER_THAN promote(@c13 AS LONG) | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - result: []
     -
       - query: select count(*) from T1 where col1 = 0;
-      - explain: "SCAN([IS T1]) | FILTER _.COL1 EQUALS promote(@c10 AS LONG) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "SCAN([IS T1]) | FILTER _.COL1 EQUALS promote(@c10 AS LONG) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - resultMetadata: [{_0: BIGINT}]
       - result: [{0}]
     -
       - query: select count(*) from T1 where col1 > 0;
-      - explain: "SCAN([IS T1]) | FILTER _.COL1 GREATER_THAN promote(@c10 AS LONG) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "SCAN([IS T1]) | FILTER _.COL1 GREATER_THAN promote(@c10 AS LONG) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - resultMetadata: [{_0: BIGINT}]
       - result: [{0}]
     -
@@ -408,12 +408,12 @@ test_block:
       - error: UNSUPPORTED_QUERY
     -
       - query: select count(*) from T2;
-      - explain: "AISCAN(T2_I1 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "AISCAN(T2_I1 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - resultMetadata: [{_0: BIGINT}]
       - result: [{0}]
     -
       - query: select count(*) from T2 having count(*) > 0;
-      - explain: "AISCAN(T2_I1 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | FILTER coalesce_long(_._0._0, 0l) GREATER_THAN promote(@c13 AS LONG) | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "AISCAN(T2_I1 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | FILTER coalesce_long(_._0._0, 0l) GREATER_THAN promote(@c13 AS LONG) | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - result: []
     -
       - query: select count(*) from T2 where col1 = 0;
@@ -488,17 +488,17 @@ test_block:
       - error: UNSUPPORTED_QUERY
     -
       - query: select count(col2) from T2;
-      - explain: "AISCAN(T2_I3 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "AISCAN(T2_I3 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - resultMetadata: [{_0: BIGINT}]
       - result: [{0}]
     -
       - query: select count(col2) from T2 where col1 = 0;
-      - explain: "AISCAN(T2_I4 [EQUALS promote(@c10 AS LONG)] BY_GROUP -> [_0: KEY:[0], _1: VALUE:[0]]) | MAP ((_._1 AS _0) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "AISCAN(T2_I4 [EQUALS promote(@c10 AS LONG)] BY_GROUP -> [_0: KEY:[0], _1: VALUE:[0]]) | MAP ((_._1 AS _0) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - resultMetadata: [{_0: BIGINT}]
       - result: [{0}]
     -
       - query: select count(col2) from T2 where col1 > 0;
-      - explain: "AISCAN(T2_I4 [[GREATER_THAN promote(@c10 AS LONG)]] BY_GROUP -> [_0: KEY:[0], _1: VALUE:[0]]) | AGG sum_l(_._1) GROUP BY () | MAP ((_._1 AS _0) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "AISCAN(T2_I4 [[GREATER_THAN promote(@c10 AS LONG)]] BY_GROUP -> [_0: KEY:[0], _1: VALUE:[0]]) | AGG sum_l(_._1) GROUP BY () | MAP ((_._1 AS _0) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - resultMetadata: [{_0: BIGINT}]
       - result: [{0}]
 #    -
@@ -515,17 +515,17 @@ test_block:
 #      - result: []
     -
       - query: select count(col2) from T3;
-      - explain: "ISCAN(T3_I1 <,>) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "ISCAN(T3_I1 <,>) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - resultMetadata: [{_0: BIGINT}]
       - result: [{0}]
     -
       - query: select count(col2) from T3 where col1 = 0;
-      - explain: "ISCAN(T3_I1 [EQUALS promote(@c10 AS LONG)]) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "ISCAN(T3_I1 [EQUALS promote(@c10 AS LONG)]) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - resultMetadata: [{_0: BIGINT}]
       - result: [{0}]
     -
       - query: select count(col2) from T3 where col1 > 0;
-      - explain: "ISCAN(T3_I1 [[GREATER_THAN promote(@c10 AS LONG)]]) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "ISCAN(T3_I1 [[GREATER_THAN promote(@c10 AS LONG)]]) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - resultMetadata: [{_0: BIGINT}]
       - result: [{0}]
     -
@@ -663,12 +663,12 @@ test_block:
       # pipeline could be eliminated, as the predicate amounts to FALSE.
       - query: select count(col1) from t3 having count(col1) is null
       - supported_version: 4.12.3.0
-      - explain: "ISCAN(T3_I1 <,>) | MAP (_ AS _0) | AGG (count(_._0.COL1) AS _0) GROUP BY () | FILTER coalesce_long(_._0._0, promote(0l AS LONG)) IS_NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "ISCAN(T3_I1 <,>) | MAP (_ AS _0) | AGG (count(_._0.COL1) AS _0) GROUP BY () | FILTER false | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - result: []
     -
       - query: select count(*) from t3 having count(*) is null
       - supported_version: 4.12.3.0
-      - explain: "ISCAN(T3_I2 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | FILTER coalesce_long(_._0._0, 0l) IS_NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "ISCAN(T3_I2 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | FILTER coalesce_long(_._0._0, 0l) IS_NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - result: []
     -
       - query: select max(col1) from t3 group by col2 having col2 is null
@@ -688,12 +688,12 @@ test_block:
     -
       - query: select count(col1) from t3 having count(col1) is null or count(col1) > 100
       - supported_version: 4.12.3.0
-      - explain: "ISCAN(T3_I1 <,>) | MAP (_ AS _0) | AGG (count(_._0.COL1) AS _0) GROUP BY () | ON EMPTY NULL | FILTER coalesce_long(_._0._0, promote(0l AS LONG)) IS_NULL OR coalesce_long(_._0._0, promote(0l AS LONG)) GREATER_THAN promote(@c20 AS LONG) | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "ISCAN(T3_I1 <,>) | MAP (_ AS _0) | AGG (count(_._0.COL1) AS _0) GROUP BY () | ON EMPTY NULL | FILTER coalesce_long(_._0._0, 0l) IS_NULL OR coalesce_long(_._0._0, 0l) GREATER_THAN promote(@c20 AS LONG) | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - result: []
     -
       - query: select count(*) from t3 having count(*) is null or count(*) > 100
       - supported_version: 4.12.3.0
-      - explain: "ISCAN(T3_I2 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | FILTER coalesce_long(_._0._0, 0l) IS_NULL OR coalesce_long(_._0._0, 0l) GREATER_THAN promote(@c20 AS LONG) | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "ISCAN(T3_I2 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | FILTER coalesce_long(_._0._0, 0l) IS_NULL OR coalesce_long(_._0._0, 0l) GREATER_THAN promote(@c20 AS LONG) | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - result: []
     -
       - query: select sum(col1) from t3 having sum(col1) is null or sum(col1) > 100
@@ -704,7 +704,7 @@ test_block:
       # Note: The ON EMPTY NULL cannot be eliminated here, as NULL gets mapped to a count of 0, and the predicate accepts 0.
       - query: select count(col1) from t3 having count(col1) = 0
       - supported_version: 4.12.3.0
-      - explain: "ISCAN(T3_I1 <,>) | MAP (_ AS _0) | AGG (count(_._0.COL1) AS _0) GROUP BY () | ON EMPTY NULL | FILTER coalesce_long(_._0._0, promote(0l AS LONG)) EQUALS promote(@c13 AS LONG) | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "ISCAN(T3_I1 <,>) | MAP (_ AS _0) | AGG (count(_._0.COL1) AS _0) GROUP BY () | ON EMPTY NULL | FILTER coalesce_long(_._0._0, 0l) EQUALS promote(@c13 AS LONG) | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - result: [{0}]
     -
       # Same query as right above, but with the SUM() aggregate instead of COUNT(). Unlike COUNT(), SUM() may yield

--- a/yaml-tests/src/test/resources/aggregate-index-tests-count-empty.yamsql
+++ b/yaml-tests/src/test/resources/aggregate-index-tests-count-empty.yamsql
@@ -33,7 +33,7 @@ test_block:
   tests:
     -
       - query: select count(*) from t1
-      - explain: "AISCAN(MV1 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "AISCAN(MV1 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - initialVersionLessThan: 4.0.561.0
       - result: []
       - initialVersionAtLeast: 4.0.561.0
@@ -46,7 +46,7 @@ test_block:
       - result: []
     -
       - query: select count(col1) from t1
-      - explain: "AISCAN(MV3 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "AISCAN(MV3 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - initialVersionLessThan: 4.0.561.0
       - result: []
       - initialVersionAtLeast: 4.0.561.0
@@ -62,7 +62,7 @@ test_block:
       - result: []
     -
       - query: select count(*) from t2
-      - explain: "ISCAN(MV5 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "ISCAN(MV5 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - resultMetadata: [{_0: BIGINT}]
       - result: [{0}]
     -
@@ -72,7 +72,7 @@ test_block:
       - result: []
     -
       - query: select count(col1) from t2
-      - explain: "ISCAN(MV5 <,>) | MAP (_ AS _0) | AGG (count(_._0.COL1) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "ISCAN(MV5 <,>) | MAP (_ AS _0) | AGG (count(_._0.COL1) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - resultMetadata: [{_0: BIGINT}]
       - result: [{0}]
     -
@@ -82,7 +82,7 @@ test_block:
       - result: []
     -
       - query: select count(col2) from t1 where col1 = 22
-      - explain: "AISCAN(MV6 [EQUALS promote(@c10 AS LONG)] BY_GROUP -> [_0: KEY:[0], _1: KEY:[1], _2: VALUE:[0]]) | AGG sum_l(_._2) GROUP BY (_._0 AS _0) | MAP ((_._2 AS _0) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "AISCAN(MV6 [EQUALS promote(@c10 AS LONG)] BY_GROUP -> [_0: KEY:[0], _1: KEY:[1], _2: VALUE:[0]]) | AGG sum_l(_._2) GROUP BY (_._0 AS _0) | MAP ((_._2 AS _0) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - resultMetadata: [ { _0: BIGINT } ]
       - result: [{0}]
 ...

--- a/yaml-tests/src/test/resources/aggregate-index-tests-count.yamsql
+++ b/yaml-tests/src/test/resources/aggregate-index-tests-count.yamsql
@@ -47,7 +47,7 @@ test_block:
                  {ID: 4, 12, 2}]
     -
       - query: select count(*) from t1
-      - explain: "AISCAN(MV1 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "AISCAN(MV1 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - resultMetadata: [{_0: BIGINT}]
       - result: [{4}]
     -
@@ -57,7 +57,7 @@ test_block:
       - result: [{1}, {3}]
     -
       - query: select count(col1) from t1
-      - explain: "AISCAN(MV3 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "AISCAN(MV3 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - resultMetadata: [{_0: BIGINT}]
       - result: [{2}]
     -
@@ -86,7 +86,7 @@ test_block:
                  {ID: 4, 12, 2, 20}]
     -
       - query: select count(*) from t2
-      - explain: "ISCAN(MV5 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "ISCAN(MV5 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - resultMetadata: [{_0: BIGINT}]
       - result: [{4}]
     -
@@ -96,7 +96,7 @@ test_block:
       - result: [{1}, {3}]
     -
       - query: select count(col1) from t2
-      - explain: "ISCAN(MV5 <,>) | MAP (_ AS _0) | AGG (count(_._0.COL1) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "ISCAN(MV5 <,>) | MAP (_ AS _0) | AGG (count(_._0.COL1) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - resultMetadata: [{_0: BIGINT}]
       - result: [{2}]
     -

--- a/yaml-tests/src/test/resources/create-drop.yamsql
+++ b/yaml-tests/src/test/resources/create-drop.yamsql
@@ -57,7 +57,7 @@ test_block:
   tests:
     -
       - query: select count(*) from "TEMPLATES" where template_name = 'TEMP1'
-      - explain: "SCAN([IS TEMPLATES, EQUALS promote(@c10 AS STRING)]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "SCAN([IS TEMPLATES, EQUALS promote(@c10 AS STRING)]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - result: [{1}]
 ---
 setup:
@@ -97,7 +97,7 @@ test_block:
   tests:
     -
       - query: select count(*) from "DATABASES" where database_id = '/FRL/DB'
-      - explain: "SCAN([IS DATABASES, EQUALS promote(@c10 AS STRING)]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "SCAN([IS DATABASES, EQUALS promote(@c10 AS STRING)]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - result: [{1}]
 ---
 setup:
@@ -163,7 +163,7 @@ test_block:
   tests:
     -
       - query: select count(*) from "SCHEMAS" where database_id = '/FRL/DB'
-      - explain: "SCAN([IS SCHEMAS, EQUALS promote(@c10 AS STRING)]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "SCAN([IS SCHEMAS, EQUALS promote(@c10 AS STRING)]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - result: [{1}]
 ---
 setup:

--- a/yaml-tests/src/test/resources/distinct-from.yamsql
+++ b/yaml-tests/src/test/resources/distinct-from.yamsql
@@ -92,10 +92,10 @@ test_block:
       - result: [{ID: 6, 20, !null }, {ID: 7, 20, !null }, {ID: 8, 20, !null }, {ID: 9, 20, 9}, {ID: 10, 20, 10}]
     -
       - query: select count(*) from t1 WHERE null is not distinct from null
-      - explain: "AISCAN(CNT <,> BY_GROUP -> [_0: VALUE:[0]]) | FILTER NULL NOT_DISTINCT_FROM NULL | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "AISCAN(CNT <,> BY_GROUP -> [_0: VALUE:[0]]) | FILTER NULL NOT_DISTINCT_FROM NULL | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - result: [{10}]
     -
       - query: select count(*) from t1 WHERE 10 is not distinct from 10
-      - explain: "AISCAN(CNT <,> BY_GROUP -> [_0: VALUE:[0]]) | FILTER @c8 NOT_DISTINCT_FROM @c8 | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "AISCAN(CNT <,> BY_GROUP -> [_0: VALUE:[0]]) | FILTER @c8 NOT_DISTINCT_FROM @c8 | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - result: [{10}]
 ...

--- a/yaml-tests/src/test/resources/field-index-tests-proto.yamsql
+++ b/yaml-tests/src/test/resources/field-index-tests-proto.yamsql
@@ -58,7 +58,7 @@ test_block:
       - result: [{ID: !l 5, COL1: !l 10, COL31: !l 5, COL32: !null _, COL2: !l 5}]
     -
       - query: select count(*) from (select * from (select * from (select * from "MyTable"  where ID = 5) as x) as y) as z;
-      - explain: "SCAN([EQUALS promote(@c22 AS LONG)]) | TFILTER MyTable | MAP ((_.ID AS ID, _.COL1 AS COL1, _.COL31 AS COL31, _.COL32 AS COL32, _.COL2 AS COL2) AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "SCAN([EQUALS promote(@c22 AS LONG)]) | TFILTER MyTable | MAP ((_.ID AS ID, _.COL1 AS COL1, _.COL31 AS COL31, _.COL32 AS COL32, _.COL2 AS COL2) AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - result: [{!l 1}]
     -
       - query: select COL31, COL32 from (select * from (select * from "MyTable") as x) as y where ID = 5;
@@ -69,7 +69,7 @@ test_block:
       - result: [{!l 210}]
     -
       - query: select count(COL1) from "MyTable";
-      - explain: "SCAN(<,>) | TFILTER MyTable | MAP (_ AS _0) | AGG (count(_._0.COL1) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "SCAN(<,>) | TFILTER MyTable | MAP (_ AS _0) | AGG (count(_._0.COL1) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - result: [{!l 13}]
     -
       - query: select * from (select * from (select * from (select * from "MyTable"  where ID > 10) as x) as y) as z;

--- a/yaml-tests/src/test/resources/groupby-tests.yamsql
+++ b/yaml-tests/src/test/resources/groupby-tests.yamsql
@@ -159,7 +159,7 @@ test_block:
       - result: [{!l 1}]
     -
       - query: select COUNT(x.col2) from (select col1,col2 from t1) as x;
-      - explain: "ISCAN(I1 <,>) | MAP ((_.COL1 AS COL1, _.COL2 AS COL2) AS _0) | AGG (count(_._0.COL2) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "ISCAN(I1 <,>) | MAP ((_.COL1 AS COL1, _.COL2 AS COL2) AS _0) | AGG (count(_._0.COL2) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - result: [{!l 13}]
     -
       - query: select AVG(x.col2) from (select col1,col2 from t1) as x;
@@ -182,18 +182,18 @@ test_block:
       - result: [{!l 10}]
     -
       - query: select COUNT(*) from T1;
-      - explain: "ISCAN(I1 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "ISCAN(I1 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - result: [{!l 13}]
     -
       - query: select COUNT(col1) from T1;
-      - explain: "ISCAN(I1 <,>) | MAP (_ AS _0) | AGG (count(_._0.COL1) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "ISCAN(I1 <,>) | MAP (_ AS _0) | AGG (count(_._0.COL1) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - result: [{!l 13}]
     -
       - query: select x from t1 group by col1 as x, col2 as x;
       - error: AMBIGUOUS_COLUMN
     -
       - query: SELECT COUNT(*) from T1 WHERE col1 = 20 or col2 = 5
-      - explain: "ISCAN(I1 <,>) | FILTER _.COL1 EQUALS promote(@c10 AS LONG) OR _.COL2 EQUALS promote(@c14 AS LONG) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "ISCAN(I1 <,>) | FILTER _.COL1 EQUALS promote(@c10 AS LONG) OR _.COL2 EQUALS promote(@c14 AS LONG) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - result: [{!l 9}]
     -
       # This used to be planned as a union with an unordered distinct by primary key on top of it, which led
@@ -202,7 +202,7 @@ test_block:
       # but without the state of the already seen primary keys, leading to it not being filtered.
       - query: SELECT COUNT(*) from T1 WHERE col1 = 20 or col2 = 10
       - supported_version: 4.12.1.0
-      - explain: "ISCAN(I1 <,>) | FILTER _.COL1 EQUALS promote(@c10 AS LONG) OR _.COL2 EQUALS promote(@c14 AS LONG) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "ISCAN(I1 <,>) | FILTER _.COL1 EQUALS promote(@c10 AS LONG) OR _.COL2 EQUALS promote(@c14 AS LONG) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - result: [{!l 8}]
     -
       # DISTINCT is not yet supported for any aggregate.

--- a/yaml-tests/src/test/resources/join-tests-outer.metrics.binpb
+++ b/yaml-tests/src/test/resources/join-tests-outer.metrics.binpb
@@ -515,14 +515,14 @@ z
     rankDir=LR;
     2 -> 4 [ color="red" style="invis" ];
   }
-}²0
+}0
 ¹
-left-outer-join¥EXPLAIN SELECT "x"."c", "e"."fname", "e"."lname" FROM (SELECT COUNT(*) AS "c" FROM "dept") "x" LEFT OUTER JOIN "emp" "e" ON "e"."id" >= "x"."c" ORDER BY "e"."fname";ó.
-çŸ·¡ž ×¡½(;0÷»$8M@úISCAN(dept$name <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | FLATMAP q0 -> { COVERING(emp$fname <,> -> [fname: KEY:[0], id: KEY:[2]]) | FILTER _.id GREATER_THAN_OR_EQUALS coalesce_long(q0._0._0, promote(0l AS LONG)) | FETCH | ON EMPTY NULL AS q1 RETURN (coalesce_long(q0._0._0, promote(0l AS LONG)) AS c, q1.fname AS fname, q1.lname AS lname) }×+digraph G {
+left-outer-join¥EXPLAIN SELECT "x"."c", "e"."fname", "e"."lname" FROM (SELECT COUNT(*) AS "c" FROM "dept") "x" LEFT OUTER JOIN "emp" "e" ON "e"."id" >= "x"."c" ORDER BY "e"."fname";Ñ.
+÷Šßõ£ Í…ß(=0Õ”'8S@éISCAN(dept$name <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | FLATMAP q0 -> { COVERING(emp$fname <,> -> [fname: KEY:[0], id: KEY:[2]]) | FILTER _.id GREATER_THAN_OR_EQUALS promote(coalesce_long(q0._0._0, 0l) AS LONG) | FETCH | ON EMPTY NULL AS q1 RETURN (coalesce_long(q0._0._0, 0l) AS c, q1.fname AS fname, q1.lname AS lname) }Æ+digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
-  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Nested Loop Join</td></tr><tr><td align="left">FLATMAP (coalesce_long(q6._0._0, promote(0l AS LONG)) AS c, q12.fname AS fname, q12.lname AS lname)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS c, STRING AS fname, STRING AS lname)" ];
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Nested Loop Join</td></tr><tr><td align="left">FLATMAP (coalesce_long(q6._0._0, 0l) AS c, q12.fname AS fname, q12.lname AS lname)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS c, STRING AS fname, STRING AS lname)" ];
   2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">$q6 OR NULL</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS _0 AS _0)" ];
   3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Streaming Aggregate</td></tr><tr><td align="left">COLLECT (count_star(*) AS _0)</td></tr><tr><td align="left">GROUP BY ()</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS _0 AS _0)" ];
   4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q2 AS _0)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS id, STRING AS name AS _0)" ];
@@ -530,17 +530,17 @@ z
   6 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">dept$name</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS id, STRING AS name)" ];
   7 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">$q12 OR NULL</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS id, STRING AS fname, STRING AS lname, LONG AS dept_id)" ];
   8 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Fetch Records</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="12" tooltip="RELATION(LONG AS id, STRING AS fname, STRING AS lname, LONG AS dept_id)" ];
-  9 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE q67.id GREATER_THAN_OR_EQUALS coalesce_long(q6._0._0, promote(0l AS LONG))</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS id, STRING AS fname, STRING AS lname, LONG AS dept_id)" ];
+  9 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE q68.id GREATER_THAN_OR_EQUALS promote(coalesce_long(q6._0._0, 0l) AS LONG)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS id, STRING AS fname, STRING AS lname, LONG AS dept_id)" ];
   10 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Covering Index Scan</td></tr><tr><td align="left">range: &lt;-âˆž, âˆž&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS id, STRING AS fname, STRING AS lname, LONG AS dept_id)" ];
   11 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">emp$fname</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS id, STRING AS fname, STRING AS lname, LONG AS dept_id)" ];
   3 -> 2 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  4 -> 3 [ label=<&nbsp;q106> label="q106" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  4 -> 3 [ label=<&nbsp;q107> label="q107" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   5 -> 4 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   6 -> 5 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   8 -> 7 [ label=<&nbsp;q12> label="q12" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  9 -> 8 [ label=<&nbsp;q69> label="q69" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  10 -> 9 [ label=<&nbsp;q67> label="q67" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  9 -> 8 [ label=<&nbsp;q70> label="q70" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  10 -> 9 [ label=<&nbsp;q68> label="q68" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   11 -> 10 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   7 -> 1 [ label=<&nbsp;q12> label="q12" color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   {

--- a/yaml-tests/src/test/resources/join-tests-outer.metrics.yaml
+++ b/yaml-tests/src/test/resources/join-tests-outer.metrics.yaml
@@ -238,16 +238,16 @@ left-outer-join:
     ref: join-tests-outer.yamsql:263
     explain: 'ISCAN(dept$name <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP
         BY () | ON EMPTY NULL | FLATMAP q0 -> { COVERING(emp$fname <,> -> [fname:
-        KEY:[0], id: KEY:[2]]) | FILTER _.id GREATER_THAN_OR_EQUALS coalesce_long(q0._0._0,
-        promote(0l AS LONG)) | FETCH | ON EMPTY NULL AS q1 RETURN (coalesce_long(q0._0._0,
-        promote(0l AS LONG)) AS c, q1.fname AS fname, q1.lname AS lname) }'
-    task_count: 615
-    task_total_time_ms: 11
-    transform_count: 158
+        KEY:[0], id: KEY:[2]]) | FILTER _.id GREATER_THAN_OR_EQUALS promote(coalesce_long(q0._0._0,
+        0l) AS LONG) | FETCH | ON EMPTY NULL AS q1 RETURN (coalesce_long(q0._0._0,
+        0l) AS c, q1.fname AS fname, q1.lname AS lname) }'
+    task_count: 631
+    task_total_time_ms: 10
+    transform_count: 163
     transform_time_ms: 5
-    transform_yield_count: 59
+    transform_yield_count: 61
     insert_time_ms: 0
-    insert_new_count: 77
+    insert_new_count: 83
     insert_reused_count: 6
 -   query: EXPLAIN SELECT "d"."name", COUNT(*) FROM "dept" "d" LEFT JOIN "project"
         "p" ON "d"."id" = "p"."emp_id" GROUP BY "d"."name";

--- a/yaml-tests/src/test/resources/join-tests-outer.yamsql
+++ b/yaml-tests/src/test/resources/join-tests-outer.yamsql
@@ -260,7 +260,7 @@ test_block:
       # The result cardinality is bounded by the null-producing side, so the planner can satisfy the ordering by
       # scanning the inner side ordered by `emp$fname`.
       - query: SELECT "x"."c", "e"."fname", "e"."lname" FROM (SELECT COUNT(*) AS "c" FROM "dept") "x" LEFT OUTER JOIN "emp" "e" ON "e"."id" >= "x"."c" ORDER BY "e"."fname";
-      - explain: "ISCAN(dept$name <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | FLATMAP q0 -> { COVERING(emp$fname <,> -> [fname: KEY:[0], id: KEY:[2]]) | FILTER _.id GREATER_THAN_OR_EQUALS coalesce_long(q0._0._0, promote(0l AS LONG)) | FETCH | ON EMPTY NULL AS q1 RETURN (coalesce_long(q0._0._0, promote(0l AS LONG)) AS c, q1.fname AS fname, q1.lname AS lname) }"
+      - explain: "ISCAN(dept$name <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | FLATMAP q0 -> { COVERING(emp$fname <,> -> [fname: KEY:[0], id: KEY:[2]]) | FILTER _.id GREATER_THAN_OR_EQUALS promote(coalesce_long(q0._0._0, 0l) AS LONG) | FETCH | ON EMPTY NULL AS q1 RETURN (coalesce_long(q0._0._0, 0l) AS c, q1.fname AS fname, q1.lname AS lname) }"
       - result: [
           {!l 3, 'Carol', 'Lee'},
           {!l 3, 'Dave', 'Kim'}]
@@ -284,7 +284,7 @@ test_block:
     -
       # Scalar COUNT(*) over a LEFT JOIN.
       - query: SELECT COUNT(*) FROM "emp" "e" LEFT JOIN "dept" "d" ON "e"."dept_id" = "d"."id";
-      - explain: "ISCAN(emp$fname <,>) | FLATMAP q0 -> { COVERING(dept$name <,> -> [id: KEY:[2], name: KEY:[0]]) | FILTER q0.dept_id EQUALS _.id | FETCH | ON EMPTY NULL AS q1 RETURN ((q0.id AS _0, q0.fname AS _1, q0.lname AS _2, q0.dept_id AS _3, q1.id AS _4, q1.name AS _5) AS _0) } | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "ISCAN(emp$fname <,>) | FLATMAP q0 -> { COVERING(dept$name <,> -> [id: KEY:[2], name: KEY:[0]]) | FILTER q0.dept_id EQUALS _.id | FETCH | ON EMPTY NULL AS q1 RETURN ((q0.id AS _0, q0.fname AS _1, q0.lname AS _2, q0.dept_id AS _3, q1.id AS _4, q1.name AS _5) AS _0) } | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - result: [{!l 4}]
     -
       # LEFT JOIN with a derived table (subquery) as the right side.
@@ -303,7 +303,7 @@ test_block:
     -
       # COALESCE on a null-padded column.
       - query: SELECT "e"."fname", COALESCE("d"."name", 'None') FROM "emp" "e" LEFT JOIN "dept" "d" ON "e"."dept_id" = "d"."id";
-      - explain: "ISCAN(emp$fname <,>) | FLATMAP q0 -> { COVERING(dept$name <,> -> [id: KEY:[2], name: KEY:[0]]) | FILTER q0.dept_id EQUALS _.id | FETCH | ON EMPTY NULL AS q1 RETURN (q0.fname AS fname, coalesce_string(q1.name, promote(@c11 AS STRING)) AS _1) }"
+      - explain: "ISCAN(emp$fname <,>) | FLATMAP q0 -> { COVERING(dept$name <,> -> [id: KEY:[2], name: KEY:[0]]) | FILTER q0.dept_id EQUALS _.id | FETCH | ON EMPTY NULL AS q1 RETURN (q0.fname AS fname, coalesce_string(q1.name, @c11) AS _1) }"
       - unorderedResult: [
           {'Alice', 'Engineering'},
           {'Bob', 'Engineering'},
@@ -488,7 +488,7 @@ test_block:
     -
       # RIGHT JOIN with COALESCE on a null-padded column from the SQL-left side.
       - query: SELECT COALESCE("e"."fname", 'None'), "d"."name" FROM "emp" "e" RIGHT JOIN "dept" "d" ON "e"."dept_id" = "d"."id";
-      - explain: "ISCAN(dept$name <,>) | FLATMAP q0 -> { ISCAN(emp$fname <,>) | FILTER _.dept_id EQUALS q0.id | ON EMPTY NULL AS q1 RETURN (coalesce_string(q1.fname, promote(@c7 AS STRING)) AS _0, q0.name AS name) }"
+      - explain: "ISCAN(dept$name <,>) | FLATMAP q0 -> { ISCAN(emp$fname <,>) | FILTER _.dept_id EQUALS q0.id | ON EMPTY NULL AS q1 RETURN (coalesce_string(q1.fname, @c7) AS _0, q0.name AS name) }"
       - unorderedResult: [
           {'Alice', 'Engineering'},
           {'Bob', 'Engineering'},

--- a/yaml-tests/src/test/resources/nested-with-nulls-proto.metrics.binpb
+++ b/yaml-tests/src/test/resources/nested-with-nulls-proto.metrics.binpb
@@ -312,38 +312,38 @@ b
   3 -> 2 [ label=<&nbsp;q20> label="q20" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   4 -> 3 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}…
+}¯
 ]
-nested-with-nulls-proto-tests<EXPLAIN select id from t1 where coalesce(a.b.a, 'a2') = 'a2'Á
-ˆßÇîB åπ¡(0Òï8@ÉSCAN(<,>) | TFILTER T1 | FILTER coalesce_string(_.A.B.A, promote(@c13 AS STRING)) EQUALS promote(@c13 AS STRING) | MAP (_.ID AS ID)√digraph G {
+nested-with-nulls-proto-tests<EXPLAIN select id from t1 where coalesce(a.b.a, 'a2') = 'a2'ñ
+ÊñËø= Åûò(0Ëı8@]SCAN(<,>) | TFILTER T1 | FILTER coalesce_string(_.A.B.A, @c13) EQUALS @c13 | MAP (_.ID AS ID)ôdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
-  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q27.ID AS ID)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID)" ];
-  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE coalesce_string(q2.A.B.A, promote(@c13 AS STRING)) EQUALS promote(@c13 AS STRING)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q26.ID AS ID)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE coalesce_string(q2.A.B.A, @c13) EQUALS @c13</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
   3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Type Filter</td></tr><tr><td align="left">WHERE record IS [T1]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
-  4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
-  5 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Primary Storage</td></tr><tr><td align="left">record types: [T1]</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
+  4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(RECORD)" ];
+  5 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Primary Storage</td></tr><tr><td align="left">record types: [T1]</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(RECORD)" ];
   3 -> 2 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  4 -> 3 [ label=<&nbsp;q20> label="q20" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  4 -> 3 [ label=<&nbsp;q19> label="q19" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   5 -> 4 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  2 -> 1 [ label=<&nbsp;q27> label="q27" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}À
+  2 -> 1 [ label=<&nbsp;q26> label="q26" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}˙
 _
-nested-with-nulls-proto-tests>EXPLAIN select id from t1 where coalesce(a.b.a, 'foo') = 'foo'Á
-ˆßÇîB åπ¡(0Òï8@ÉSCAN(<,>) | TFILTER T1 | FILTER coalesce_string(_.A.B.A, promote(@c13 AS STRING)) EQUALS promote(@c13 AS STRING) | MAP (_.ID AS ID)√digraph G {
+nested-with-nulls-proto-tests>EXPLAIN select id from t1 where coalesce(a.b.a, 'foo') = 'foo'ñ
+ÊñËø= Åûò(0Ëı8@]SCAN(<,>) | TFILTER T1 | FILTER coalesce_string(_.A.B.A, @c13) EQUALS @c13 | MAP (_.ID AS ID)ôdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
-  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q27.ID AS ID)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID)" ];
-  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE coalesce_string(q2.A.B.A, promote(@c13 AS STRING)) EQUALS promote(@c13 AS STRING)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q26.ID AS ID)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE coalesce_string(q2.A.B.A, @c13) EQUALS @c13</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
   3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Type Filter</td></tr><tr><td align="left">WHERE record IS [T1]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
-  4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
-  5 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Primary Storage</td></tr><tr><td align="left">record types: [T1]</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
+  4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(RECORD)" ];
+  5 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Primary Storage</td></tr><tr><td align="left">record types: [T1]</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(RECORD)" ];
   3 -> 2 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  4 -> 3 [ label=<&nbsp;q20> label="q20" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  4 -> 3 [ label=<&nbsp;q19> label="q19" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   5 -> 4 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  2 -> 1 [ label=<&nbsp;q27> label="q27" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q26> label="q26" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
 }ú
 _
 nested-with-nulls-proto-tests>EXPLAIN select id from t1 where coalesce(a.b.a, 'foo') IS NULL∏
@@ -376,22 +376,20 @@ _
   4 -> 3 [ label=<&nbsp;q20> label="q20" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   5 -> 4 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q27> label="q27" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}°
+}ﬁ
 c
-nested-with-nulls-proto-testsBEXPLAIN select id from t1 where coalesce(a.b.a, 'foo') IS NOT NULLπ
-ˆ≤πûB ƒÙa(0ÊÅ8@mSCAN(<,>) | TFILTER T1 | FILTER coalesce_string(_.A.B.A, promote(@c13 AS STRING)) NOT_NULL | MAP (_.ID AS ID)≠digraph G {
+nested-with-nulls-proto-testsBEXPLAIN select id from t1 where coalesce(a.b.a, 'foo') IS NOT NULLˆ
+Î”Û˚A ªìl(0‰à8@)SCAN(<,>) | TFILTER T1 | MAP (_.ID AS ID)Ædigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
-  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q27.ID AS ID)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID)" ];
-  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE coalesce_string(q2.A.B.A, promote(@c13 AS STRING)) NOT_NULL</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
-  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Type Filter</td></tr><tr><td align="left">WHERE record IS [T1]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
-  4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
-  5 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Primary Storage</td></tr><tr><td align="left">record types: [T1]</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
-  3 -> 2 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  4 -> 3 [ label=<&nbsp;q20> label="q20" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  5 -> 4 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  2 -> 1 [ label=<&nbsp;q27> label="q27" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q2.ID AS ID)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Type Filter</td></tr><tr><td align="left">WHERE record IS [T1]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(RECORD)" ];
+  4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Primary Storage</td></tr><tr><td align="left">record types: [T1]</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(RECORD)" ];
+  3 -> 2 [ label=<&nbsp;q20> label="q20" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  4 -> 3 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
 }µ
 W
 nested-with-nulls-proto-tests6EXPLAIN select id from t1 where coalesce(b.a.b, 3) = 3Ÿ
@@ -424,36 +422,34 @@ Y
   4 -> 3 [ label=<&nbsp;q19> label="q19" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   5 -> 4 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q26> label="q26" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}ë
+}å
 \
-nested-with-nulls-proto-tests;EXPLAIN select id from t1 where coalesce(b.a.b, 42) IS NULL∞
-ÊÇÇÏ= êØû(0Æ≈8@hSCAN(<,>) | TFILTER T1 | FILTER coalesce_long(_.B.A.B, promote(@c13 AS LONG)) IS_NULL | MAP (_.ID AS ID)®digraph G {
+nested-with-nulls-proto-tests;EXPLAIN select id from t1 where coalesce(b.a.b, 42) IS NULL´
+ˆ≤ØæB Ü€l(0‘∞8@hSCAN(<,>) | TFILTER T1 | FILTER coalesce_long(_.B.A.B, promote(@c13 AS LONG)) IS_NULL | MAP (_.ID AS ID)§digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
-  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q26.ID AS ID)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID)" ];
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q27.ID AS ID)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID)" ];
   2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE coalesce_long(q2.B.A.B, promote(@c13 AS LONG)) IS_NULL</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
   3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Type Filter</td></tr><tr><td align="left">WHERE record IS [T1]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
-  4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
-  5 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Primary Storage</td></tr><tr><td align="left">record types: [T1]</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
+  4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(RECORD)" ];
+  5 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Primary Storage</td></tr><tr><td align="left">record types: [T1]</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(RECORD)" ];
   3 -> 2 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  4 -> 3 [ label=<&nbsp;q19> label="q19" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  4 -> 3 [ label=<&nbsp;q20> label="q20" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   5 -> 4 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  2 -> 1 [ label=<&nbsp;q26> label="q26" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}ó
+  2 -> 1 [ label=<&nbsp;q27> label="q27" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}€
 `
-nested-with-nulls-proto-tests?EXPLAIN select id from t1 where coalesce(b.a.b, 42) IS NOT NULL≤
-Ê§óô= „˝œ(0öı8@iSCAN(<,>) | TFILTER T1 | FILTER coalesce_long(_.B.A.B, promote(@c13 AS LONG)) NOT_NULL | MAP (_.ID AS ID)©digraph G {
+nested-with-nulls-proto-tests?EXPLAIN select id from t1 where coalesce(b.a.b, 42) IS NOT NULLˆ
+ÎŸèßA úb(0’ß8@)SCAN(<,>) | TFILTER T1 | MAP (_.ID AS ID)Ædigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
-  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q26.ID AS ID)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID)" ];
-  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE coalesce_long(q2.B.A.B, promote(@c13 AS LONG)) NOT_NULL</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
-  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Type Filter</td></tr><tr><td align="left">WHERE record IS [T1]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
-  4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
-  5 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Primary Storage</td></tr><tr><td align="left">record types: [T1]</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
-  3 -> 2 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  4 -> 3 [ label=<&nbsp;q19> label="q19" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  5 -> 4 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  2 -> 1 [ label=<&nbsp;q26> label="q26" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q2.ID AS ID)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Type Filter</td></tr><tr><td align="left">WHERE record IS [T1]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(RECORD)" ];
+  4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Primary Storage</td></tr><tr><td align="left">record types: [T1]</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(RECORD)" ];
+  3 -> 2 [ label=<&nbsp;q20> label="q20" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  4 -> 3 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
 }

--- a/yaml-tests/src/test/resources/nested-with-nulls-proto.metrics.yaml
+++ b/yaml-tests/src/test/resources/nested-with-nulls-proto.metrics.yaml
@@ -223,27 +223,27 @@ nested-with-nulls-proto-tests:
     insert_reused_count: 2
 -   query: EXPLAIN select id from t1 where coalesce(a.b.a, 'a2') = 'a2'
     ref: nested-with-nulls-proto.yamsql:136
-    explain: SCAN(<,>) | TFILTER T1 | FILTER coalesce_string(_.A.B.A, promote(@c13
-        AS STRING)) EQUALS promote(@c13 AS STRING) | MAP (_.ID AS ID)
-    task_count: 246
-    task_total_time_ms: 8
-    transform_count: 66
-    transform_time_ms: 3
-    transform_yield_count: 17
+    explain: SCAN(<,>) | TFILTER T1 | FILTER coalesce_string(_.A.B.A, @c13) EQUALS
+        @c13 | MAP (_.ID AS ID)
+    task_count: 230
+    task_total_time_ms: 9
+    transform_count: 61
+    transform_time_ms: 2
+    transform_yield_count: 15
     insert_time_ms: 0
-    insert_new_count: 25
+    insert_new_count: 21
     insert_reused_count: 2
 -   query: EXPLAIN select id from t1 where coalesce(a.b.a, 'foo') = 'foo'
     ref: nested-with-nulls-proto.yamsql:140
-    explain: SCAN(<,>) | TFILTER T1 | FILTER coalesce_string(_.A.B.A, promote(@c13
-        AS STRING)) EQUALS promote(@c13 AS STRING) | MAP (_.ID AS ID)
-    task_count: 246
-    task_total_time_ms: 8
-    transform_count: 66
-    transform_time_ms: 3
-    transform_yield_count: 17
+    explain: SCAN(<,>) | TFILTER T1 | FILTER coalesce_string(_.A.B.A, @c13) EQUALS
+        @c13 | MAP (_.ID AS ID)
+    task_count: 230
+    task_total_time_ms: 9
+    transform_count: 61
+    transform_time_ms: 2
+    transform_yield_count: 15
     insert_time_ms: 0
-    insert_new_count: 25
+    insert_new_count: 21
     insert_reused_count: 2
 -   query: EXPLAIN select id from t1 where coalesce(a.b.a, 'foo') IS NULL
     ref: nested-with-nulls-proto.yamsql:145
@@ -271,15 +271,14 @@ nested-with-nulls-proto-tests:
     insert_reused_count: 2
 -   query: EXPLAIN select id from t1 where coalesce(a.b.a, 'foo') IS NOT NULL
     ref: nested-with-nulls-proto.yamsql:155
-    explain: SCAN(<,>) | TFILTER T1 | FILTER coalesce_string(_.A.B.A, promote(@c13
-        AS STRING)) NOT_NULL | MAP (_.ID AS ID)
-    task_count: 246
+    explain: SCAN(<,>) | TFILTER T1 | MAP (_.ID AS ID)
+    task_count: 235
     task_total_time_ms: 4
-    transform_count: 66
+    transform_count: 65
     transform_time_ms: 1
     transform_yield_count: 17
     insert_time_ms: 0
-    insert_new_count: 25
+    insert_new_count: 23
     insert_reused_count: 2
 -   query: EXPLAIN select id from t1 where coalesce(b.a.b, 3) = 3
     ref: nested-with-nulls-proto.yamsql:159
@@ -309,23 +308,22 @@ nested-with-nulls-proto-tests:
     ref: nested-with-nulls-proto.yamsql:168
     explain: SCAN(<,>) | TFILTER T1 | FILTER coalesce_long(_.B.A.B, promote(@c13 AS
         LONG)) IS_NULL | MAP (_.ID AS ID)
-    task_count: 230
-    task_total_time_ms: 10
-    transform_count: 61
-    transform_time_ms: 2
-    transform_yield_count: 15
+    task_count: 246
+    task_total_time_ms: 7
+    transform_count: 66
+    transform_time_ms: 1
+    transform_yield_count: 17
     insert_time_ms: 0
-    insert_new_count: 21
+    insert_new_count: 25
     insert_reused_count: 2
 -   query: EXPLAIN select id from t1 where coalesce(b.a.b, 42) IS NOT NULL
     ref: nested-with-nulls-proto.yamsql:173
-    explain: SCAN(<,>) | TFILTER T1 | FILTER coalesce_long(_.B.A.B, promote(@c13 AS
-        LONG)) NOT_NULL | MAP (_.ID AS ID)
-    task_count: 230
-    task_total_time_ms: 10
-    transform_count: 61
-    transform_time_ms: 3
-    transform_yield_count: 15
+    explain: SCAN(<,>) | TFILTER T1 | MAP (_.ID AS ID)
+    task_count: 235
+    task_total_time_ms: 4
+    transform_count: 65
+    transform_time_ms: 1
+    transform_yield_count: 17
     insert_time_ms: 0
-    insert_new_count: 21
+    insert_new_count: 23
     insert_reused_count: 2

--- a/yaml-tests/src/test/resources/nested-with-nulls-proto.yamsql
+++ b/yaml-tests/src/test/resources/nested-with-nulls-proto.yamsql
@@ -133,16 +133,16 @@ test_block:
       - unorderedResult: [{ ID: 100 }, { ID: 101 }, { ID: 102 }, { ID: 103 }, { ID: 104 }, { ID: 105 }, { ID: 106 }, { ID: 107 }]
     -
       - query: select id from t1 where coalesce(a.b.a, 'a2') = 'a2'
-      - explain: "SCAN(<,>) | TFILTER T1 | FILTER coalesce_string(_.A.B.A, promote(@c13 AS STRING)) EQUALS promote(@c13 AS STRING) | MAP (_.ID AS ID)"
+      - explain: "SCAN(<,>) | TFILTER T1 | FILTER coalesce_string(_.A.B.A, @c13) EQUALS @c13 | MAP (_.ID AS ID)"
       - unorderedResult: [ { ID: 100 }, { ID: 101 }, { ID: 102 }, { ID: 103 }, { ID: 107 }]
     -
       - query: select id from t1 where coalesce(a.b.a, 'foo') = 'foo'
-      - explain: "SCAN(<,>) | TFILTER T1 | FILTER coalesce_string(_.A.B.A, promote(@c13 AS STRING)) EQUALS promote(@c13 AS STRING) | MAP (_.ID AS ID)"
+      - explain: "SCAN(<,>) | TFILTER T1 | FILTER coalesce_string(_.A.B.A, @c13) EQUALS @c13 | MAP (_.ID AS ID)"
       - unorderedResult: [{ ID: 103 }, { ID: 107 }]
     -
       # One of the two coalesce values is not null, so this could be simplified to FALSE
       - query: select id from t1 where coalesce(a.b.a, 'foo') IS NULL
-      - explain: "SCAN(<,>) | TFILTER T1 | FILTER coalesce_string(_.A.B.A, promote(@c13 AS STRING)) IS_NULL | MAP (_.ID AS ID)"
+      - explain: "SCAN(<,>) | TFILTER T1 | FILTER coalesce_string(_.A.B.A, @c13) IS_NULL | MAP (_.ID AS ID)"
       - result: []
     -
       # This cannot be simplified to FALSE, as both of the coalesce values are nullable. We could however remove the coalesce entirely
@@ -150,9 +150,9 @@ test_block:
       - explain: "SCAN(<,>) | TFILTER T1 | FILTER coalesce_string(_.A.B.A, NULL) IS_NULL | MAP (_.ID AS ID)"
       - unorderedResult: [{ ID: 103 }, { ID: 107 }]
     -
-      # One of the two coalesce values is not null, so this could be simplified to TRUE
+      # One of the two COALESCE() arguments is not nullable, so the predicate is simplified away.
       - query: select id from t1 where coalesce(a.b.a, 'foo') IS NOT NULL
-      - explain: "SCAN(<,>) | TFILTER T1 | FILTER coalesce_string(_.A.B.A, promote(@c13 AS STRING)) NOT_NULL | MAP (_.ID AS ID)"
+      - explain: "SCAN(<,>) | TFILTER T1 | MAP (_.ID AS ID)"
       - unorderedResult: [{ ID: 100 }, { ID: 101 }, { ID: 102 }, { ID: 103 }, { ID: 104 }, { ID: 105 }, { ID: 106 }, { ID: 107 }]
     -
       - query: select id from t1 where coalesce(b.a.b, 3) = 3
@@ -168,8 +168,8 @@ test_block:
       - explain: "SCAN(<,>) | TFILTER T1 | FILTER coalesce_long(_.B.A.B, promote(@c13 AS LONG)) IS_NULL | MAP (_.ID AS ID)"
       - result: []
     -
-      # One of the two coalesce values is not null, so this could be simplified to TRUE
+      # One of the two COALESCE() arguments is not nullable, so the predicate is simplified away.
       - query: select id from t1 where coalesce(b.a.b, 42) IS NOT NULL
-      - explain: "SCAN(<,>) | TFILTER T1 | FILTER coalesce_long(_.B.A.B, promote(@c13 AS LONG)) NOT_NULL | MAP (_.ID AS ID)"
+      - explain: "SCAN(<,>) | TFILTER T1 | MAP (_.ID AS ID)"
       - unorderedResult: [{ ID: 100 }, { ID: 101 }, { ID: 102 }, { ID: 103 }, { ID: 104 }, { ID: 105 }, { ID: 106 }, { ID: 107 }]
 ...

--- a/yaml-tests/src/test/resources/nested-with-nulls.metrics.binpb
+++ b/yaml-tests/src/test/resources/nested-with-nulls.metrics.binpb
@@ -217,48 +217,49 @@ L
   3 -> 2 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   4 -> 3 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q45> label="q45" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}ﬂ
+}ì
 Y
-nested-with-nulls-tests>EXPLAIN select id from t1 where coalesce(a.a.a, 'blah') = 'a1'Å
-ÛÅ“⁄h ÄÑ ( 0ó⁄.8(@zISCAN(I1 <,>) | FILTER coalesce_string(_.A.A.A, promote(@c13 AS STRING)) EQUALS promote(@c16 AS STRING) | MAP (_.ID AS ID)Ádigraph G {
+nested-with-nulls-tests>EXPLAIN select id from t1 where coalesce(a.a.a, 'blah') = 'a1'µ
+„õ©†
+c Ôßµ(0æ˚-8$@TISCAN(I1 <,>) | FILTER coalesce_string(_.A.A.A, @c13) EQUALS @c16 | MAP (_.ID AS ID)¡digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
-  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q46.ID AS ID)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID)" ];
-  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE coalesce_string(q2.A.A.A, promote(@c13 AS STRING)) EQUALS promote(@c16 AS STRING)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q45.ID AS ID)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE coalesce_string(q2.A.A.A, @c13) EQUALS @c16</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
   3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
   4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">I1</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
   3 -> 2 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   4 -> 3 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  2 -> 1 [ label=<&nbsp;q46> label="q46" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}‡
+  2 -> 1 [ label=<&nbsp;q45> label="q45" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}î
 Z
-nested-with-nulls-tests?EXPLAIN select id from t1 where coalesce(a.a.a, 'blah') = 'a1p'Å
-ÛÅ“⁄h ÄÑ ( 0ó⁄.8(@zISCAN(I1 <,>) | FILTER coalesce_string(_.A.A.A, promote(@c13 AS STRING)) EQUALS promote(@c16 AS STRING) | MAP (_.ID AS ID)Ádigraph G {
+nested-with-nulls-tests?EXPLAIN select id from t1 where coalesce(a.a.a, 'blah') = 'a1p'µ
+„õ©†
+c Ôßµ(0æ˚-8$@TISCAN(I1 <,>) | FILTER coalesce_string(_.A.A.A, @c13) EQUALS @c16 | MAP (_.ID AS ID)¡digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
-  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q46.ID AS ID)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID)" ];
-  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE coalesce_string(q2.A.A.A, promote(@c13 AS STRING)) EQUALS promote(@c16 AS STRING)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q45.ID AS ID)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE coalesce_string(q2.A.A.A, @c13) EQUALS @c16</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
   3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
   4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">I1</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
   3 -> 2 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   4 -> 3 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  2 -> 1 [ label=<&nbsp;q46> label="q46" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}∏
+  2 -> 1 [ label=<&nbsp;q45> label="q45" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}Ø
 ^
-nested-with-nulls-testsCEXPLAIN select id from t1 where coalesce(a.a.a, 'blah') IS NOT NULL’
-ÛÀûÊh ∏ÿÚ( 0®¥8(@dISCAN(I1 <,>) | FILTER coalesce_string(_.A.A.A, promote(@c13 AS STRING)) NOT_NULL | MAP (_.ID AS ID)—digraph G {
+nested-with-nulls-testsCEXPLAIN select id from t1 where coalesce(a.a.a, 'blah') IS NOT NULLÃ
+áø–î
+o ∫≈ﬁ($0ñø.8*@JCOVERING(I1 <,> -> [ID: KEY:[2], A: [B: [A: KEY:[0]]]]) | MAP (_.ID AS ID)‚digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
-  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q46.ID AS ID)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID)" ];
-  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE coalesce_string(q2.A.A.A, promote(@c13 AS STRING)) NOT_NULL</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
-  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
-  4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">I1</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
-  3 -> 2 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  4 -> 3 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  2 -> 1 [ label=<&nbsp;q46> label="q46" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q44.ID AS ID)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Covering Index Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">I1</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q44> label="q44" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
 }ê
 \
 nested-with-nulls-testsAEXPLAIN select id from t1 where coalesce(a.a.a, null) IS NOT NULLØ
@@ -273,34 +274,34 @@ Z
   3 -> 2 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   4 -> 3 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q46> label="q46" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}›
+}ë
 W
-nested-with-nulls-tests<EXPLAIN select id from t1 where coalesce(a.b.a, 'a2') = 'a2'Å
-Ûñ€÷h ‚ç¬( 0ç‡-8(@zISCAN(I1 <,>) | FILTER coalesce_string(_.A.B.A, promote(@c13 AS STRING)) EQUALS promote(@c13 AS STRING) | MAP (_.ID AS ID)Ádigraph G {
+nested-with-nulls-tests<EXPLAIN select id from t1 where coalesce(a.b.a, 'a2') = 'a2'µ
+„•ì·	c ÃÒÄ(0⁄®%8$@TISCAN(I1 <,>) | FILTER coalesce_string(_.A.B.A, @c13) EQUALS @c13 | MAP (_.ID AS ID)¡digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
-  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q46.ID AS ID)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID)" ];
-  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE coalesce_string(q2.A.B.A, promote(@c13 AS STRING)) EQUALS promote(@c13 AS STRING)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q45.ID AS ID)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE coalesce_string(q2.A.B.A, @c13) EQUALS @c13</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
   3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
   4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">I1</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
   3 -> 2 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   4 -> 3 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  2 -> 1 [ label=<&nbsp;q46> label="q46" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}ﬂ
+  2 -> 1 [ label=<&nbsp;q45> label="q45" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}ì
 Y
-nested-with-nulls-tests>EXPLAIN select id from t1 where coalesce(a.b.a, 'foo') = 'foo'Å
-Ûñ€÷h ‚ç¬( 0ç‡-8(@zISCAN(I1 <,>) | FILTER coalesce_string(_.A.B.A, promote(@c13 AS STRING)) EQUALS promote(@c13 AS STRING) | MAP (_.ID AS ID)Ádigraph G {
+nested-with-nulls-tests>EXPLAIN select id from t1 where coalesce(a.b.a, 'foo') = 'foo'µ
+„•ì·	c ÃÒÄ(0⁄®%8$@TISCAN(I1 <,>) | FILTER coalesce_string(_.A.B.A, @c13) EQUALS @c13 | MAP (_.ID AS ID)¡digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
-  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q46.ID AS ID)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID)" ];
-  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE coalesce_string(q2.A.B.A, promote(@c13 AS STRING)) EQUALS promote(@c13 AS STRING)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q45.ID AS ID)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE coalesce_string(q2.A.B.A, @c13) EQUALS @c13</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
   3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
   4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">I1</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
   3 -> 2 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   4 -> 3 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  2 -> 1 [ label=<&nbsp;q46> label="q46" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q45> label="q45" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
 }±
 Y
 nested-with-nulls-tests>EXPLAIN select id from t1 where coalesce(a.b.a, 'foo') IS NULL”
@@ -330,20 +331,18 @@ X
   3 -> 2 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   4 -> 3 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q46> label="q46" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}∑
+}Æ
 ]
-nested-with-nulls-testsBEXPLAIN select id from t1 where coalesce(a.b.a, 'foo') IS NOT NULL’
-Û≠≠‰h ÙÑ‰( 0ñ˙8(@dISCAN(I1 <,>) | FILTER coalesce_string(_.A.B.A, promote(@c13 AS STRING)) NOT_NULL | MAP (_.ID AS ID)—digraph G {
+nested-with-nulls-testsBEXPLAIN select id from t1 where coalesce(a.b.a, 'foo') IS NOT NULLÃ
+á•Œùo Ω¨∞($0∑∞*8*@JCOVERING(I1 <,> -> [ID: KEY:[2], A: [B: [A: KEY:[0]]]]) | MAP (_.ID AS ID)‚digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
-  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q46.ID AS ID)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID)" ];
-  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE coalesce_string(q2.A.B.A, promote(@c13 AS STRING)) NOT_NULL</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
-  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
-  4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">I1</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
-  3 -> 2 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  4 -> 3 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  2 -> 1 [ label=<&nbsp;q46> label="q46" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q44.ID AS ID)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Covering Index Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">I1</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q44> label="q44" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
 }À
 Q
 nested-with-nulls-tests6EXPLAIN select id from t1 where coalesce(b.a.b, 3) = 3ı
@@ -375,29 +374,27 @@ S
 }¶
 V
 nested-with-nulls-tests;EXPLAIN select id from t1 where coalesce(b.a.b, 42) IS NULLÀ
-„ıæ˘c Ç—√(0Ô *8$@_ISCAN(I1 <,>) | FILTER coalesce_long(_.B.A.B, promote(@c13 AS LONG)) IS_NULL | MAP (_.ID AS ID)Ãdigraph G {
+ÛŸ∫·h Ùö¡( 0∑ﬂ)8(@_ISCAN(I1 <,>) | FILTER coalesce_long(_.B.A.B, promote(@c13 AS LONG)) IS_NULL | MAP (_.ID AS ID)Ãdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
-  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q45.ID AS ID)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID)" ];
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q46.ID AS ID)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID)" ];
   2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE coalesce_long(q2.B.A.B, promote(@c13 AS LONG)) IS_NULL</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
   3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
   4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">I1</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
   3 -> 2 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   4 -> 3 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  2 -> 1 [ label=<&nbsp;q45> label="q45" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}¨
+  2 -> 1 [ label=<&nbsp;q46> label="q46" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+}´
 Z
-nested-with-nulls-tests?EXPLAIN select id from t1 where coalesce(b.a.b, 42) IS NOT NULLÕ
-„‰É„c é—‚(0†¬8$@`ISCAN(I1 <,>) | FILTER coalesce_long(_.B.A.B, promote(@c13 AS LONG)) NOT_NULL | MAP (_.ID AS ID)Õdigraph G {
+nested-with-nulls-tests?EXPLAIN select id from t1 where coalesce(b.a.b, 42) IS NOT NULLÃ
+áˇÜºo »¿æ($0Ãß'8*@JCOVERING(I1 <,> -> [ID: KEY:[2], A: [B: [A: KEY:[0]]]]) | MAP (_.ID AS ID)‚digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
-  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q45.ID AS ID)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID)" ];
-  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Predicate Filter</td></tr><tr><td align="left">WHERE coalesce_long(q2.B.A.B, promote(@c13 AS LONG)) NOT_NULL</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
-  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
-  4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">I1</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
-  3 -> 2 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  4 -> 3 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  2 -> 1 [ label=<&nbsp;q45> label="q45" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q44.ID AS ID)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Covering Index Scan</td></tr><tr><td align="left">range: &lt;-‚àû, ‚àû&gt;</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">I1</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS A, STRING AS A, LONG AS B AS A, STRING AS A, LONG AS B AS B AS B)" ];
+  3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q44> label="q44" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
 }

--- a/yaml-tests/src/test/resources/nested-with-nulls.metrics.yaml
+++ b/yaml-tests/src/test/resources/nested-with-nulls.metrics.yaml
@@ -180,40 +180,40 @@ nested-with-nulls-tests:
     insert_reused_count: 4
 -   query: EXPLAIN select id from t1 where coalesce(a.a.a, 'blah') = 'a1'
     ref: nested-with-nulls.yamsql:111
-    explain: ISCAN(I1 <,>) | FILTER coalesce_string(_.A.A.A, promote(@c13 AS STRING))
-        EQUALS promote(@c16 AS STRING) | MAP (_.ID AS ID)
-    task_count: 371
-    task_total_time_ms: 28
-    transform_count: 104
-    transform_time_ms: 9
-    transform_yield_count: 32
+    explain: ISCAN(I1 <,>) | FILTER coalesce_string(_.A.A.A, @c13) EQUALS @c16 | MAP
+        (_.ID AS ID)
+    task_count: 355
+    task_total_time_ms: 21
+    transform_count: 99
+    transform_time_ms: 7
+    transform_yield_count: 30
     insert_time_ms: 0
-    insert_new_count: 40
+    insert_new_count: 36
     insert_reused_count: 4
 -   query: EXPLAIN select id from t1 where coalesce(a.a.a, 'blah') = 'a1p'
     ref: nested-with-nulls.yamsql:115
-    explain: ISCAN(I1 <,>) | FILTER coalesce_string(_.A.A.A, promote(@c13 AS STRING))
-        EQUALS promote(@c16 AS STRING) | MAP (_.ID AS ID)
-    task_count: 371
-    task_total_time_ms: 28
-    transform_count: 104
-    transform_time_ms: 9
-    transform_yield_count: 32
+    explain: ISCAN(I1 <,>) | FILTER coalesce_string(_.A.A.A, @c13) EQUALS @c16 | MAP
+        (_.ID AS ID)
+    task_count: 355
+    task_total_time_ms: 21
+    transform_count: 99
+    transform_time_ms: 7
+    transform_yield_count: 30
     insert_time_ms: 0
-    insert_new_count: 40
+    insert_new_count: 36
     insert_reused_count: 4
 -   query: EXPLAIN select id from t1 where coalesce(a.a.a, 'blah') IS NOT NULL
     ref: nested-with-nulls.yamsql:120
-    explain: ISCAN(I1 <,>) | FILTER coalesce_string(_.A.A.A, promote(@c13 AS STRING))
-        NOT_NULL | MAP (_.ID AS ID)
-    task_count: 371
-    task_total_time_ms: 14
-    transform_count: 104
-    transform_time_ms: 3
-    transform_yield_count: 32
+    explain: 'COVERING(I1 <,> -> [ID: KEY:[2], A: [B: [A: KEY:[0]]]]) | MAP (_.ID
+        AS ID)'
+    task_count: 391
+    task_total_time_ms: 21
+    transform_count: 111
+    transform_time_ms: 5
+    transform_yield_count: 36
     insert_time_ms: 0
-    insert_new_count: 40
-    insert_reused_count: 4
+    insert_new_count: 42
+    insert_reused_count: 5
 -   query: EXPLAIN select id from t1 where coalesce(a.a.a, null) IS NOT NULL
     ref: nested-with-nulls.yamsql:125
     explain: ISCAN(I1 <,>) | FILTER coalesce_string(_.A.A.A, NULL) NOT_NULL | MAP
@@ -228,27 +228,27 @@ nested-with-nulls-tests:
     insert_reused_count: 4
 -   query: EXPLAIN select id from t1 where coalesce(a.b.a, 'a2') = 'a2'
     ref: nested-with-nulls.yamsql:129
-    explain: ISCAN(I1 <,>) | FILTER coalesce_string(_.A.B.A, promote(@c13 AS STRING))
-        EQUALS promote(@c13 AS STRING) | MAP (_.ID AS ID)
-    task_count: 371
-    task_total_time_ms: 28
-    transform_count: 104
-    transform_time_ms: 9
-    transform_yield_count: 32
+    explain: ISCAN(I1 <,>) | FILTER coalesce_string(_.A.B.A, @c13) EQUALS @c13 | MAP
+        (_.ID AS ID)
+    task_count: 355
+    task_total_time_ms: 20
+    transform_count: 99
+    transform_time_ms: 6
+    transform_yield_count: 30
     insert_time_ms: 0
-    insert_new_count: 40
+    insert_new_count: 36
     insert_reused_count: 4
 -   query: EXPLAIN select id from t1 where coalesce(a.b.a, 'foo') = 'foo'
     ref: nested-with-nulls.yamsql:133
-    explain: ISCAN(I1 <,>) | FILTER coalesce_string(_.A.B.A, promote(@c13 AS STRING))
-        EQUALS promote(@c13 AS STRING) | MAP (_.ID AS ID)
-    task_count: 371
-    task_total_time_ms: 28
-    transform_count: 104
-    transform_time_ms: 9
-    transform_yield_count: 32
+    explain: ISCAN(I1 <,>) | FILTER coalesce_string(_.A.B.A, @c13) EQUALS @c13 | MAP
+        (_.ID AS ID)
+    task_count: 355
+    task_total_time_ms: 20
+    transform_count: 99
+    transform_time_ms: 6
+    transform_yield_count: 30
     insert_time_ms: 0
-    insert_new_count: 40
+    insert_new_count: 36
     insert_reused_count: 4
 -   query: EXPLAIN select id from t1 where coalesce(a.b.a, 'foo') IS NULL
     ref: nested-with-nulls.yamsql:138
@@ -276,16 +276,16 @@ nested-with-nulls-tests:
     insert_reused_count: 4
 -   query: EXPLAIN select id from t1 where coalesce(a.b.a, 'foo') IS NOT NULL
     ref: nested-with-nulls.yamsql:148
-    explain: ISCAN(I1 <,>) | FILTER coalesce_string(_.A.B.A, promote(@c13 AS STRING))
-        NOT_NULL | MAP (_.ID AS ID)
-    task_count: 371
-    task_total_time_ms: 14
-    transform_count: 104
-    transform_time_ms: 5
-    transform_yield_count: 32
+    explain: 'COVERING(I1 <,> -> [ID: KEY:[2], A: [B: [A: KEY:[0]]]]) | MAP (_.ID
+        AS ID)'
+    task_count: 391
+    task_total_time_ms: 10
+    transform_count: 111
+    transform_time_ms: 4
+    transform_yield_count: 36
     insert_time_ms: 0
-    insert_new_count: 40
-    insert_reused_count: 4
+    insert_new_count: 42
+    insert_reused_count: 5
 -   query: EXPLAIN select id from t1 where coalesce(b.a.b, 3) = 3
     ref: nested-with-nulls.yamsql:152
     explain: ISCAN(I1 <,>) | FILTER coalesce_long(_.B.A.B, promote(@c13 AS LONG))
@@ -314,23 +314,23 @@ nested-with-nulls-tests:
     ref: nested-with-nulls.yamsql:161
     explain: ISCAN(I1 <,>) | FILTER coalesce_long(_.B.A.B, promote(@c13 AS LONG))
         IS_NULL | MAP (_.ID AS ID)
-    task_count: 355
-    task_total_time_ms: 27
-    transform_count: 99
-    transform_time_ms: 9
-    transform_yield_count: 30
+    task_count: 371
+    task_total_time_ms: 16
+    transform_count: 104
+    transform_time_ms: 5
+    transform_yield_count: 32
     insert_time_ms: 0
-    insert_new_count: 36
+    insert_new_count: 40
     insert_reused_count: 4
 -   query: EXPLAIN select id from t1 where coalesce(b.a.b, 42) IS NOT NULL
     ref: nested-with-nulls.yamsql:166
-    explain: ISCAN(I1 <,>) | FILTER coalesce_long(_.B.A.B, promote(@c13 AS LONG))
-        NOT_NULL | MAP (_.ID AS ID)
-    task_count: 355
-    task_total_time_ms: 7
-    transform_count: 99
-    transform_time_ms: 3
-    transform_yield_count: 30
+    explain: 'COVERING(I1 <,> -> [ID: KEY:[2], A: [B: [A: KEY:[0]]]]) | MAP (_.ID
+        AS ID)'
+    task_count: 391
+    task_total_time_ms: 11
+    transform_count: 111
+    transform_time_ms: 5
+    transform_yield_count: 36
     insert_time_ms: 0
-    insert_new_count: 36
-    insert_reused_count: 4
+    insert_new_count: 42
+    insert_reused_count: 5

--- a/yaml-tests/src/test/resources/nested-with-nulls.yamsql
+++ b/yaml-tests/src/test/resources/nested-with-nulls.yamsql
@@ -108,16 +108,16 @@ test_block:
       - unorderedResult: [{ ID: 100 }]
     -
       - query: select id from t1 where coalesce(a.a.a, 'blah') = 'a1'
-      - explain: "ISCAN(I1 <,>) | FILTER coalesce_string(_.A.A.A, promote(@c13 AS STRING)) EQUALS promote(@c16 AS STRING) | MAP (_.ID AS ID)"
+      - explain: "ISCAN(I1 <,>) | FILTER coalesce_string(_.A.A.A, @c13) EQUALS @c16 | MAP (_.ID AS ID)"
       - unorderedResult: [{ ID: 100 }, { ID: 101 }, { ID: 102 }, { ID: 103 }]
     -
       - query: select id from t1 where coalesce(a.a.a, 'blah') = 'a1p'
-      - explain: "ISCAN(I1 <,>) | FILTER coalesce_string(_.A.A.A, promote(@c13 AS STRING)) EQUALS promote(@c16 AS STRING) | MAP (_.ID AS ID)"
+      - explain: "ISCAN(I1 <,>) | FILTER coalesce_string(_.A.A.A, @c13) EQUALS @c16 | MAP (_.ID AS ID)"
       - unorderedResult: [{ ID: 104 }, { ID: 105 }, { ID: 106 }, { ID: 107 }]
     -
-      # As 'blah' is not nullable, so this predicate could be simplified to TRUE
+      # 'blah' is not nullable, so COALESCE() cannot return NULL and the predicate is simplified away.
       - query: select id from t1 where coalesce(a.a.a, 'blah') IS NOT NULL
-      - explain: "ISCAN(I1 <,>) | FILTER coalesce_string(_.A.A.A, promote(@c13 AS STRING)) NOT_NULL | MAP (_.ID AS ID)"
+      - explain: "COVERING(I1 <,> -> [ID: KEY:[2], A: [B: [A: KEY:[0]]]]) | MAP (_.ID AS ID)"
       - unorderedResult: [{ ID: 100 }, { ID: 101 }, { ID: 102 }, { ID: 103 }, { ID: 104 }, { ID: 105 }, { ID: 106 }, { ID: 107 }]
     -
       # The coalesce could be removed and replaced with a simple field access
@@ -126,16 +126,16 @@ test_block:
       - unorderedResult: [{ ID: 100 }, { ID: 101 }, { ID: 102 }, { ID: 103 }, { ID: 104 }, { ID: 105 }, { ID: 106 }, { ID: 107 }]
     -
       - query: select id from t1 where coalesce(a.b.a, 'a2') = 'a2'
-      - explain: "ISCAN(I1 <,>) | FILTER coalesce_string(_.A.B.A, promote(@c13 AS STRING)) EQUALS promote(@c13 AS STRING) | MAP (_.ID AS ID)"
+      - explain: "ISCAN(I1 <,>) | FILTER coalesce_string(_.A.B.A, @c13) EQUALS @c13 | MAP (_.ID AS ID)"
       - unorderedResult: [ { ID: 100 }, { ID: 101 }, { ID: 102 }, { ID: 103 }, { ID: 107 }]
     -
       - query: select id from t1 where coalesce(a.b.a, 'foo') = 'foo'
-      - explain: "ISCAN(I1 <,>) | FILTER coalesce_string(_.A.B.A, promote(@c13 AS STRING)) EQUALS promote(@c13 AS STRING) | MAP (_.ID AS ID)"
+      - explain: "ISCAN(I1 <,>) | FILTER coalesce_string(_.A.B.A, @c13) EQUALS @c13 | MAP (_.ID AS ID)"
       - unorderedResult: [{ ID: 103 }, { ID: 107 }]
     -
       # One of the two coalesce values is not null, so this could be simplified to FALSE
       - query: select id from t1 where coalesce(a.b.a, 'foo') IS NULL
-      - explain: "ISCAN(I1 <,>) | FILTER coalesce_string(_.A.B.A, promote(@c13 AS STRING)) IS_NULL | MAP (_.ID AS ID)"
+      - explain: "ISCAN(I1 <,>) | FILTER coalesce_string(_.A.B.A, @c13) IS_NULL | MAP (_.ID AS ID)"
       - result: []
     -
       # This cannot be simplified to FALSE, as both of the coalesce values are nullable. We could however remove the coalesce entirely
@@ -143,9 +143,9 @@ test_block:
       - explain: "ISCAN(I1 <,>) | FILTER coalesce_string(_.A.B.A, NULL) IS_NULL | MAP (_.ID AS ID)"
       - unorderedResult: [{ ID: 103 }, { ID: 107 }]
     -
-      # One of the two coalesce values is not null, so this could be simplified to TRUE
+      # One of the two COALESCE() arguments is not nullable, so the predicate is simplified away.
       - query: select id from t1 where coalesce(a.b.a, 'foo') IS NOT NULL
-      - explain: "ISCAN(I1 <,>) | FILTER coalesce_string(_.A.B.A, promote(@c13 AS STRING)) NOT_NULL | MAP (_.ID AS ID)"
+      - explain: "COVERING(I1 <,> -> [ID: KEY:[2], A: [B: [A: KEY:[0]]]]) | MAP (_.ID AS ID)"
       - unorderedResult: [{ ID: 100 }, { ID: 101 }, { ID: 102 }, { ID: 103 }, { ID: 104 }, { ID: 105 }, { ID: 106 }, { ID: 107 }]
     -
       - query: select id from t1 where coalesce(b.a.b, 3) = 3
@@ -161,8 +161,8 @@ test_block:
       - explain: "ISCAN(I1 <,>) | FILTER coalesce_long(_.B.A.B, promote(@c13 AS LONG)) IS_NULL | MAP (_.ID AS ID)"
       - result: []
     -
-      # One of the two coalesce values is not null, so this could be simplified to TRUE
+      # One of the two COALESCE() arguments is not nullable, so the predicate is simplified away.
       - query: select id from t1 where coalesce(b.a.b, 42) IS NOT NULL
-      - explain: "ISCAN(I1 <,>) | FILTER coalesce_long(_.B.A.B, promote(@c13 AS LONG)) NOT_NULL | MAP (_.ID AS ID)"
+      - explain: "COVERING(I1 <,> -> [ID: KEY:[2], A: [B: [A: KEY:[0]]]]) | MAP (_.ID AS ID)"
       - unorderedResult: [{ ID: 100 }, { ID: 101 }, { ID: 102 }, { ID: 103 }, { ID: 104 }, { ID: 105 }, { ID: 106 }, { ID: 107 }]
 ...

--- a/yaml-tests/src/test/resources/null-operator-tests.yamsql
+++ b/yaml-tests/src/test/resources/null-operator-tests.yamsql
@@ -47,7 +47,7 @@ test_block:
       - result: []
     -
       - query: select count(*) from (select * from (select * from T1) as x where ID is not null) as y;
-      - explain: "SCAN([IS T1, [NOT_NULL]]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "SCAN([IS T1, [NOT_NULL]]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - result: [{13}]
 #    -
 #      - query: select count(*) from (select * from (select * from T1) as x where ID != null) as y;

--- a/yaml-tests/src/test/resources/primary-key-tests.yamsql
+++ b/yaml-tests/src/test/resources/primary-key-tests.yamsql
@@ -33,7 +33,7 @@ test_block:
       - error: UNIQUE_CONSTRAINT_VIOLATION
     -
       - query: SELECT COUNT(*) FROM T1
-      - explain: "SCAN([IS T1]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "SCAN([IS T1]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - result: [{0}]
     -
       - query: INSERT INTO T1

--- a/yaml-tests/src/test/resources/record-type-key-tests.yamsql
+++ b/yaml-tests/src/test/resources/record-type-key-tests.yamsql
@@ -112,11 +112,11 @@ test_block:
   tests:
     -
       - query: SELECT count(*) from t1
-      - explain: "ISCAN(I1 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "ISCAN(I1 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - result: [{!l 3}]
     -
       - query: SELECT count(*) from t2
-      - explain: "ISCAN(I2 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "ISCAN(I2 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - result: [{!l 3}]
 ---
 # DML: insert and verify record type key scans still work

--- a/yaml-tests/src/test/resources/standard-tests-metadata.yamsql
+++ b/yaml-tests/src/test/resources/standard-tests-metadata.yamsql
@@ -58,7 +58,7 @@ test_block:
       - result: [{ID: !l 5, !l 10, !l 5}]
     -
       - query: select count(*) from (select * from (select * from (select * from T1  where ID = 5) as x) as y) as z;
-      - explain: "SCAN([EQUALS promote(@c22 AS LONG)]) | TFILTER T1 | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "SCAN([EQUALS promote(@c22 AS LONG)]) | TFILTER T1 | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - result: [{!l 1}]
     -
       - query: select id, col1, col2 from (select * from (select * from (select * from T1  where ID > 10) as x) as y) as z;

--- a/yaml-tests/src/test/resources/standard-tests-proto.yamsql
+++ b/yaml-tests/src/test/resources/standard-tests-proto.yamsql
@@ -59,7 +59,7 @@ test_block:
       - result: [{ID: !l 5, !l 10, !l 5}]
     -
       - query: select count(*) from (select * from (select * from (select * from T1  where ID = 5) as x) as y) as z;
-      - explain: "SCAN([EQUALS promote(@c22 AS LONG)]) | TFILTER T1 | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "SCAN([EQUALS promote(@c22 AS LONG)]) | TFILTER T1 | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - result: [{!l 1}]
     -
       - query: select id, col1, col2 from (select * from (select * from (select * from T1  where ID > 10) as x) as y) as z;

--- a/yaml-tests/src/test/resources/standard-tests.yamsql
+++ b/yaml-tests/src/test/resources/standard-tests.yamsql
@@ -290,7 +290,7 @@ test_block:
       - result: [{ID: !l 5, !l 10, !l 5}]
     -
       - query: select count(*) from (select * from (select * from (select * from T1  where ID = 5) as x) as y) as z;
-      - explain: "SCAN([IS T1, EQUALS promote(@c22 AS LONG)]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)"
+      - explain: "SCAN([IS T1, EQUALS promote(@c22 AS LONG)]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - result: [{!l 1}]
     -
       - query: select * from (select * from (select * from (select * from T1  where ID > 10) as x) as y) as z;

--- a/yaml-tests/src/test/resources/union-empty-tables.metrics.binpb
+++ b/yaml-tests/src/test/resources/union-empty-tables.metrics.binpb
@@ -261,20 +261,19 @@ F
   8 -> 7 [ label=<&nbsp;q10> label="q10" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   9 -> 8 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   6 -> 1 [ label=<&nbsp;q74> label="q74" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}Ê7
+}È7
 ä
-	unnamed-1}EXPLAIN select sum(Y) as S from (select count(*) as Y from t3 where a < 10 group by a union all select count(*) from t4) as X÷6
-¯œ«Ú– “Á¶
-(70ﬂﬂ;8A@ﬁAISCAN(MV10 [[LESS_THAN promote(@c21 AS DOUBLE)]] BY_GROUP -> [_0: KEY:[0], _1: VALUE:[0]]) | MAP (_._1 AS Y) ‚äé SCAN([IS T4]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0) | MAP (_ AS _0) | AGG (sum_l(_._0.Y) AS _0) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS S)÷3digraph G {
+	unnamed-1}EXPLAIN select sum(Y) as S from (select count(*) as Y from t3 where a < 10 group by a union all select count(*) from t4) as XŸ6
+í∑ù™’ ‰ø¸(90Ç´W8E@ﬁAISCAN(MV10 [[LESS_THAN promote(@c21 AS DOUBLE)]] BY_GROUP -> [_0: KEY:[0], _1: VALUE:[0]]) | MAP (_._1 AS Y) ‚äé SCAN([IS T4]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (promote(coalesce_long(_._0._0, 0l) AS LONG) AS _0) | MAP (_ AS _0) | AGG (sum_l(_._0.Y) AS _0) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS S)Ÿ3digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
-  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q26._0._0 AS S)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS S)" ];
-  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">$q26 OR NULL</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS _0 AS _0)" ];
-  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Streaming Aggregate</td></tr><tr><td align="left">COLLECT (sum_l(q98._0.Y) AS _0)</td></tr><tr><td align="left">GROUP BY ()</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS _0 AS _0)" ];
-  4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q22 AS _0)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS Y AS _0)" ];
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q28._0._0 AS S)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS S)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">$q28 OR NULL</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS _0 AS _0)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Streaming Aggregate</td></tr><tr><td align="left">COLLECT (sum_l(q101._0.Y) AS _0)</td></tr><tr><td align="left">GROUP BY ()</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS _0 AS _0)" ];
+  4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q24 AS _0)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS Y AS _0)" ];
   5 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Union All</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="12" tooltip="RELATION(LONG AS Y)" ];
-  6 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (coalesce_long(q16._0._0, promote(0l AS LONG)) AS _0)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS _0)" ];
+  6 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (promote(coalesce_long(q16._0._0, 0l) AS LONG) AS _0)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS _0)" ];
   7 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q6._1 AS Y)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS Y)" ];
   8 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">$q16 OR NULL</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS _0 AS _0)" ];
   9 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">scan type: BY_GROUP</td></tr><tr><td align="left">comparisons: [[LESS_THAN promote(@c21 AS DOUBLE)]]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(DOUBLE AS _0, LONG AS _1)" ];
@@ -283,19 +282,19 @@ F
   12 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q12 AS _0)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS A, DOUBLE AS B AS _0)" ];
   13 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Scan</td></tr><tr><td align="left">comparisons: [IS T4]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS A, DOUBLE AS B)" ];
   14 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Primary Storage</td></tr><tr><td align="left">record types: [T4, T5, T1, T2, T3]</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS A, DOUBLE AS B)" ];
-  3 -> 2 [ label=<&nbsp;q26> label="q26" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  4 -> 3 [ label=<&nbsp;q98> label="q98" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  5 -> 4 [ label=<&nbsp;q22> label="q22" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  6 -> 5 [ label=<&nbsp;q95> label="q95" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  7 -> 5 [ label=<&nbsp;q93> label="q93" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  3 -> 2 [ label=<&nbsp;q28> label="q28" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  4 -> 3 [ label=<&nbsp;q101> label="q101" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  5 -> 4 [ label=<&nbsp;q24> label="q24" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  6 -> 5 [ label=<&nbsp;q98> label="q98" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  7 -> 5 [ label=<&nbsp;q96> label="q96" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   8 -> 6 [ label=<&nbsp;q16> label="q16" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   9 -> 7 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   10 -> 8 [ label=<&nbsp;q16> label="q16" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   11 -> 9 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  12 -> 10 [ label=<&nbsp;q77> label="q77" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  12 -> 10 [ label=<&nbsp;q80> label="q80" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   13 -> 12 [ label=<&nbsp;q12> label="q12" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   14 -> 13 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  2 -> 1 [ label=<&nbsp;q26> label="q26" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q28> label="q28" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
 }ÂC
 r
 	unnamed-1eEXPLAIN select sum(Y) as S from (select count(*) as Y from t3 union all select count(*) from t1) as XÓB

--- a/yaml-tests/src/test/resources/union-empty-tables.metrics.yaml
+++ b/yaml-tests/src/test/resources/union-empty-tables.metrics.yaml
@@ -162,16 +162,16 @@ unnamed-1:
     ref: union-empty-tables.yamsql:81
     explain: 'AISCAN(MV10 [[LESS_THAN promote(@c21 AS DOUBLE)]] BY_GROUP -> [_0: KEY:[0],
         _1: VALUE:[0]]) | MAP (_._1 AS Y) ⊎ SCAN([IS T4]) | MAP (_ AS _0) | AGG (count_star(*)
-        AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l
-        AS LONG)) AS _0) | MAP (_ AS _0) | AGG (sum_l(_._0.Y) AS _0) GROUP BY () |
+        AS _0) GROUP BY () | ON EMPTY NULL | MAP (promote(coalesce_long(_._0._0, 0l)
+        AS LONG) AS _0) | MAP (_ AS _0) | AGG (sum_l(_._0.Y) AS _0) GROUP BY () |
         ON EMPTY NULL | MAP (_._0._0 AS S)'
-    task_count: 760
-    task_total_time_ms: 52
-    transform_count: 208
-    transform_time_ms: 21
-    transform_yield_count: 55
-    insert_time_ms: 0
-    insert_new_count: 65
+    task_count: 786
+    task_total_time_ms: 57
+    transform_count: 213
+    transform_time_ms: 29
+    transform_yield_count: 57
+    insert_time_ms: 1
+    insert_new_count: 69
     insert_reused_count: 3
 -   query: EXPLAIN select sum(Y) as S from (select count(*) as Y from t3 union all
         select count(*) from t1) as X

--- a/yaml-tests/src/test/resources/union-empty-tables.yamsql
+++ b/yaml-tests/src/test/resources/union-empty-tables.yamsql
@@ -30,11 +30,11 @@ test_block:
   tests:
     -
       - query: select sum(col1) as a, count(*) as b from t1
-      - explain: "SCAN([IS T1]) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0, count_star(*) AS _1) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS A, coalesce_long(_._0._1, promote(0l AS LONG)) AS B)"
+      - explain: "SCAN([IS T1]) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0, count_star(*) AS _1) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS A, coalesce_long(_._0._1, 0l) AS B)"
       - unorderedResult: [{A: !null , B: 0}]
     -
       - query: select sum(a) as a, sum(b) as b from (select sum(col1) as a, count(*) as b from t1 union all select sum(col1) as a, count(*) as b from t2) as x
-      - explain: "SCAN([IS T1]) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0, count_star(*) AS _1) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS A, coalesce_long(_._0._1, promote(0l AS LONG)) AS B) ⊎ SCAN([IS T2]) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0, count_star(*) AS _1) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS A, coalesce_long(_._0._1, promote(0l AS LONG)) AS B) | MAP (_ AS _0) | AGG (sum_l(_._0.A) AS _0, sum_l(_._0.B) AS _1) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS A, _._0._1 AS B)"
+      - explain: "SCAN([IS T1]) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0, count_star(*) AS _1) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS A, coalesce_long(_._0._1, 0l) AS B) ⊎ SCAN([IS T2]) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0, count_star(*) AS _1) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS A, coalesce_long(_._0._1, 0l) AS B) | MAP (_ AS _0) | AGG (sum_l(_._0.A) AS _0, sum_l(_._0.B) AS _1) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS A, _._0._1 AS B)"
       - unorderedResult: [{A: !null , B: 0}]
     -
       - query: select col1, col2 from t1 union all select col1, col2 from t1
@@ -78,11 +78,11 @@ test_block:
       - unorderedResult: []
     -
       - query: select sum(Y) as S from (select count(*) as Y from t3 where a < 10 group by a union all select count(*) from t4) as X
-      - explain: "AISCAN(MV10 [[LESS_THAN promote(@c21 AS DOUBLE)]] BY_GROUP -> [_0: KEY:[0], _1: VALUE:[0]]) | MAP (_._1 AS Y) ⊎ SCAN([IS T4]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0) | MAP (_ AS _0) | AGG (sum_l(_._0.Y) AS _0) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS S)"
+      - explain: "AISCAN(MV10 [[LESS_THAN promote(@c21 AS DOUBLE)]] BY_GROUP -> [_0: KEY:[0], _1: VALUE:[0]]) | MAP (_._1 AS Y) ⊎ SCAN([IS T4]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (promote(coalesce_long(_._0._0, 0l) AS LONG) AS _0) | MAP (_ AS _0) | AGG (sum_l(_._0.Y) AS _0) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS S)"
       - unorderedResult: [{0}]
     -
       - query: select sum(Y) as S from (select count(*) as Y from t3 union all select count(*) from t1) as X
-      - explain: "AISCAN(MV10 <,> BY_GROUP -> [_0: KEY:[0], _1: VALUE:[0]]) | AGG sum_l(_._1) GROUP BY () | MAP ((_._1 AS _0) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS Y) ⊎ SCAN([IS T1]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0) | MAP (_ AS _0) | AGG (sum_l(_._0.Y) AS _0) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS S)"
+      - explain: "AISCAN(MV10 <,> BY_GROUP -> [_0: KEY:[0], _1: VALUE:[0]]) | AGG sum_l(_._1) GROUP BY () | MAP ((_._1 AS _0) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS Y) ⊎ SCAN([IS T1]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0) | MAP (_ AS _0) | AGG (sum_l(_._0.Y) AS _0) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS S)"
       - unorderedResult: [{0}]
     -
       - query: select col2 from t1 where exists (select a from t3 where col2 <= id union all select b from t4 where col2 <= id)

--- a/yaml-tests/src/test/resources/union.metrics.binpb
+++ b/yaml-tests/src/test/resources/union.metrics.binpb
@@ -38,21 +38,20 @@
   16 -> 14 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   17 -> 15 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q24> label="q24" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}ð7
+}ó7
 Œ
-union-tests}EXPLAIN select sum(Y) as S from (select count(*) as Y from t3 where a < 10 group by a union all select count(*) from t4) as XÞ6
-øï»½Ð ¦‡Ô
-(70 ÷68A@ÞAISCAN(MV10 [[LESS_THAN promote(@c21 AS DOUBLE)]] BY_GROUP -> [_0: KEY:[0], _1: VALUE:[0]]) | MAP (_._1 AS Y) âŠŽ SCAN([IS T4]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0) | MAP (_ AS _0) | AGG (sum_l(_._0.Y) AS _0) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS S)Þ3digraph G {
+union-tests}EXPLAIN select sum(Y) as S from (select count(*) as Y from t3 where a < 10 group by a union all select count(*) from t4) as Xá6
+’ ¼—Õ Áû(90ì°J8E@ÞAISCAN(MV10 [[LESS_THAN promote(@c21 AS DOUBLE)]] BY_GROUP -> [_0: KEY:[0], _1: VALUE:[0]]) | MAP (_._1 AS Y) âŠŽ SCAN([IS T4]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (promote(coalesce_long(_._0._0, 0l) AS LONG) AS _0) | MAP (_ AS _0) | AGG (sum_l(_._0.Y) AS _0) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS S)á3digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
-  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q26._0._0 AS S)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS S)" ];
-  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">$q26 OR NULL</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS _0 AS _0)" ];
-  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Streaming Aggregate</td></tr><tr><td align="left">COLLECT (sum_l(q98._0.Y) AS _0)</td></tr><tr><td align="left">GROUP BY ()</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS _0 AS _0)" ];
-  4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q22 AS _0)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS Y AS _0)" ];
+  1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q28._0._0 AS S)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS S)" ];
+  2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">$q28 OR NULL</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS _0 AS _0)" ];
+  3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Streaming Aggregate</td></tr><tr><td align="left">COLLECT (sum_l(q101._0.Y) AS _0)</td></tr><tr><td align="left">GROUP BY ()</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS _0 AS _0)" ];
+  4 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q24 AS _0)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS Y AS _0)" ];
   5 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Union All</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="12" tooltip="RELATION(LONG AS Y)" ];
   6 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q6._1 AS Y)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS Y)" ];
-  7 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (coalesce_long(q16._0._0, promote(0l AS LONG)) AS _0)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS _0)" ];
+  7 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (promote(coalesce_long(q16._0._0, 0l) AS LONG) AS _0)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS _0)" ];
   8 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">scan type: BY_GROUP</td></tr><tr><td align="left">comparisons: [[LESS_THAN promote(@c21 AS DOUBLE)]]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(DOUBLE AS _0, LONG AS _1)" ];
   9 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">$q16 OR NULL</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS _0 AS _0)" ];
   10 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">MV10</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, DOUBLE AS A, LONG AS B)" ];
@@ -60,19 +59,19 @@
   12 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Value Computation</td></tr><tr><td align="left">MAP (q12 AS _0)</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS A, DOUBLE AS B AS _0)" ];
   13 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Scan</td></tr><tr><td align="left">comparisons: [IS T4]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS A, DOUBLE AS B)" ];
   14 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Primary Storage</td></tr><tr><td align="left">record types: [T4, T5, T6, T7, T1, T2, T3]</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS A, DOUBLE AS B)" ];
-  3 -> 2 [ label=<&nbsp;q26> label="q26" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  4 -> 3 [ label=<&nbsp;q98> label="q98" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  5 -> 4 [ label=<&nbsp;q22> label="q22" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  6 -> 5 [ label=<&nbsp;q93> label="q93" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  7 -> 5 [ label=<&nbsp;q95> label="q95" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  3 -> 2 [ label=<&nbsp;q28> label="q28" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  4 -> 3 [ label=<&nbsp;q101> label="q101" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  5 -> 4 [ label=<&nbsp;q24> label="q24" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  6 -> 5 [ label=<&nbsp;q96> label="q96" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  7 -> 5 [ label=<&nbsp;q98> label="q98" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   8 -> 6 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   9 -> 7 [ label=<&nbsp;q16> label="q16" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   10 -> 8 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   11 -> 9 [ label=<&nbsp;q16> label="q16" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  12 -> 11 [ label=<&nbsp;q77> label="q77" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  12 -> 11 [ label=<&nbsp;q80> label="q80" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   13 -> 12 [ label=<&nbsp;q12> label="q12" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   14 -> 13 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-  2 -> 1 [ label=<&nbsp;q26> label="q26" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
+  2 -> 1 [ label=<&nbsp;q28> label="q28" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
 }ÎC
 t
 union-testseEXPLAIN select sum(Y) as S from (select count(*) as Y from t3 union all select count(*) from t1) as XÕB

--- a/yaml-tests/src/test/resources/union.metrics.yaml
+++ b/yaml-tests/src/test/resources/union.metrics.yaml
@@ -21,16 +21,16 @@ union-tests:
     ref: union.yamsql:159
     explain: 'AISCAN(MV10 [[LESS_THAN promote(@c21 AS DOUBLE)]] BY_GROUP -> [_0: KEY:[0],
         _1: VALUE:[0]]) | MAP (_._1 AS Y) ⊎ SCAN([IS T4]) | MAP (_ AS _0) | AGG (count_star(*)
-        AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l
-        AS LONG)) AS _0) | MAP (_ AS _0) | AGG (sum_l(_._0.Y) AS _0) GROUP BY () |
+        AS _0) GROUP BY () | ON EMPTY NULL | MAP (promote(coalesce_long(_._0._0, 0l)
+        AS LONG) AS _0) | MAP (_ AS _0) | AGG (sum_l(_._0.Y) AS _0) GROUP BY () |
         ON EMPTY NULL | MAP (_._0._0 AS S)'
-    task_count: 760
-    task_total_time_ms: 59
-    transform_count: 208
-    transform_time_ms: 22
-    transform_yield_count: 55
-    insert_time_ms: 0
-    insert_new_count: 65
+    task_count: 786
+    task_total_time_ms: 48
+    transform_count: 213
+    transform_time_ms: 18
+    transform_yield_count: 57
+    insert_time_ms: 1
+    insert_new_count: 69
     insert_reused_count: 3
 -   query: EXPLAIN select sum(Y) as S from (select count(*) as Y from t3 union all
         select count(*) from t1) as X

--- a/yaml-tests/src/test/resources/union.yamsql
+++ b/yaml-tests/src/test/resources/union.yamsql
@@ -58,7 +58,7 @@ test_block:
   tests:
     -
       - query: select sum(a) as a, sum(b) as b from (select sum(col1) as a, count(*) as b from t1 union all select sum(col1) as a, count(*) as b from t2) as x
-      - explain: "ISCAN(VI1 <,>) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0, count_star(*) AS _1) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS A, coalesce_long(_._0._1, promote(0l AS LONG)) AS B) ⊎ SCAN([IS T2]) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0, count_star(*) AS _1) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS A, coalesce_long(_._0._1, promote(0l AS LONG)) AS B) | MAP (_ AS _0) | AGG (sum_l(_._0.A) AS _0, sum_l(_._0.B) AS _1) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS A, _._0._1 AS B)"
+      - explain: "ISCAN(VI1 <,>) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0, count_star(*) AS _1) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS A, coalesce_long(_._0._1, 0l) AS B) ⊎ SCAN([IS T2]) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0, count_star(*) AS _1) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS A, coalesce_long(_._0._1, 0l) AS B) | MAP (_ AS _0) | AGG (sum_l(_._0.A) AS _0, sum_l(_._0.B) AS _1) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS A, _._0._1 AS B)"
       - unorderedResult: [{A: 74 , B: 13}]
     -
       - query: select col1, col2 from t1 union all select col1, col2 from t1
@@ -156,11 +156,11 @@ test_block:
                           {A: 10.0, B: 20.0}]
     -
       - query: select sum(Y) as S from (select count(*) as Y from t3 where a < 10 group by a union all select count(*) from t4) as X
-      - explain: "AISCAN(MV10 [[LESS_THAN promote(@c21 AS DOUBLE)]] BY_GROUP -> [_0: KEY:[0], _1: VALUE:[0]]) | MAP (_._1 AS Y) ⊎ SCAN([IS T4]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0) | MAP (_ AS _0) | AGG (sum_l(_._0.Y) AS _0) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS S)"
+      - explain: "AISCAN(MV10 [[LESS_THAN promote(@c21 AS DOUBLE)]] BY_GROUP -> [_0: KEY:[0], _1: VALUE:[0]]) | MAP (_._1 AS Y) ⊎ SCAN([IS T4]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (promote(coalesce_long(_._0._0, 0l) AS LONG) AS _0) | MAP (_ AS _0) | AGG (sum_l(_._0.Y) AS _0) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS S)"
       - result: [{S: 2}]
     -
       - query: select sum(Y) as S from (select count(*) as Y from t3 union all select count(*) from t1) as X
-      - explain: "AISCAN(MV10 <,> BY_GROUP -> [_0: KEY:[0], _1: VALUE:[0]]) | AGG sum_l(_._1) GROUP BY () | MAP ((_._1 AS _0) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS Y) ⊎ ISCAN(VI1 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0) | MAP (_ AS _0) | AGG (sum_l(_._0.Y) AS _0) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS S)"
+      - explain: "AISCAN(MV10 <,> BY_GROUP -> [_0: KEY:[0], _1: VALUE:[0]]) | AGG sum_l(_._1) GROUP BY () | MAP ((_._1 AS _0) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS Y) ⊎ ISCAN(VI1 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0) | MAP (_ AS _0) | AGG (sum_l(_._0.Y) AS _0) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS S)"
       - result: [{S: 5}]
     -
       - query: select col2 from t1 where exists (select a from t3 where col2 <= id union all select b from t4 where col2 <= id)
@@ -176,6 +176,6 @@ test_block:
       - error: UNION_INCOMPATIBLE_COLUMNS
     -
       - query: select sum(Y) as S from (select count(*) as Y from t6 union all select count(*) from t7) as X
-      - explain: "AISCAN(MV11 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS Y) ⊎ AISCAN(MV12 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0) | MAP (_ AS _0) | AGG (sum_l(_._0.Y) AS _0) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS S)"
+      - explain: "AISCAN(MV11 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS Y) ⊎ AISCAN(MV12 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0) | MAP (_ AS _0) | AGG (sum_l(_._0.Y) AS _0) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS S)"
       - result: [{0}]
 ...


### PR DESCRIPTION
* In `VariadicFunctionValue`, rework the logic that derives the nullability for `GREATEST()`/`LEAST()` and `COALESCE()`.
* For `COALESCE()`, change the logic so that the result is nullable if **all** of its arguments are nullable. This is in contrast to `GREATEST()`/`LEAST()`, for which the result is nullable if **any** of its arguments are nullable.
* In addition, when promoting arguments to the common result type in `encapsulate()`, make sure to retain each argument’s nullability instead of widening a non-nullable argument to nullable. Note that this also affects `GREATEST()`/`LEAST()`, where a non-nullable argument previously picked up a no-op `promote()` whenever any other argument was nullable.

**Testing**

The refined `COALESCE()` nullability affects 90 explain strings across 18 yamsql files. No query results are changed. The plan changes fall into two groups:

1. Benign changes, where a no-op `promote()` around a `COALESCE()` argument that was only ever there to widen it to nullable now disappears. For example, `coalesce_long(_._0._0, promote(0l AS LONG))` becomes `coalesce_long(_._0._0, 0l)`. Where a nullable result is still required by the surrounding expression, the `promote()` moves outwards to wrap the whole `COALESCE()` instead.

2. Unlocked constant folding. A predicate of the form `COALESCE(…, «non-nullable») IS NOT NULL` can now be recognized as _always true_ and simplified away entirely. In three cases the queries thereby become satisfiable from the index alone, improving an index scan with a residual filter into a `COVERING` index scan.

**Impact**

Beyond query plans, this change may affect the nullability that is reported to JDBC clients for result-set columns that project some form of `COALESCE(…, «non-nullable»)` expression. Notably, this is the case for all `SELECT COUNT(…)` queries, since the `COUNT()` aggregate is wrapped into a `COALESCE(count, 0)` expression by an internal rewrite. Such columns will now be reported as non-nullable.

This fixes #4192.