### PR TITLE
[cross-schema] Wire secondary-schema stores into the execution context at connection time

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/PredicateWithValueAndRanges.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/predicates/PredicateWithValueAndRanges.java
@@ -45,7 +45,6 @@ import com.apple.foundationdb.record.query.plan.explain.ExplainTokens;
 import com.apple.foundationdb.record.query.plan.explain.ExplainTokensWithPrecedence;
 import com.apple.foundationdb.record.query.plan.explain.ExplainTokensWithPrecedence.Precedence;
 import com.google.auto.service.AutoService;
-import com.apple.foundationdb.record.query.plan.cascades.ComparisonRange;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/RecordStoreAndRecordContextTransaction.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/RecordStoreAndRecordContextTransaction.java
@@ -33,6 +33,8 @@ import com.apple.foundationdb.relational.recordlayer.query.cache.QueryCacheKey;
 import com.google.protobuf.Message;
 
 import javax.annotation.Nonnull;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -45,6 +47,7 @@ import java.util.Optional;
 public class RecordStoreAndRecordContextTransaction implements Transaction {
     FDBRecordStoreBase<Message> store;
     RecordContextTransaction transaction;
+    Map<String, FDBRecordStoreBase<Message>> additionalStores = new HashMap<>();
 
     /**
      * the schema template this transaction is bound to. This is mainly needed when accessing the plan cache
@@ -103,6 +106,18 @@ public class RecordStoreAndRecordContextTransaction implements Transaction {
 
     public FDBRecordStoreBase<Message> getRecordStore() {
         return store;
+    }
+
+    @Nonnull
+    public Map<String, FDBRecordStoreBase<Message>> getAdditionalStores() {
+        return additionalStores;
+    }
+
+    @Nonnull
+    public RecordStoreAndRecordContextTransaction withAdditionalStore(@Nonnull String schemaName,
+                                                                      @Nonnull FDBRecordStoreBase<Message> additionalStore) {
+        this.additionalStores.put(schemaName, additionalStore);
+        return this;
     }
 
     @Nonnull

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/catalog/TransactionBoundDatabase.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/catalog/TransactionBoundDatabase.java
@@ -49,6 +49,8 @@ import com.apple.foundationdb.relational.transactionbound.catalog.HollowStoreCat
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * There can only be 1 Database object per Connection instance, and its lifecycle is managed by the connection
@@ -66,6 +68,7 @@ public class TransactionBoundDatabase extends AbstractDatabase {
     @Nullable
     private final KeySpace keySpace;
     BackingStore store;
+    Map<String, BackingStore> storesBySchemaName = new HashMap<>();
     URI uri;
 
     private static final MetadataOperationsFactory onlyTemporaryFunctionOperationsFactory = new AbstractMetadataOperationsFactory() {
@@ -97,6 +100,9 @@ public class TransactionBoundDatabase extends AbstractDatabase {
         }
         final var recordStoreAndRecordContextTx = transaction.unwrap(RecordStoreAndRecordContextTransaction.class);
         store = BackingRecordStore.fromTransactionWithStore(recordStoreAndRecordContextTx);
+        storesBySchemaName.clear();
+        recordStoreAndRecordContextTx.getAdditionalStores().forEach((schemaName, additionalStore) ->
+                storesBySchemaName.put(schemaName, BackingRecordStore.fromTransactionAndStore(recordStoreAndRecordContextTx, additionalStore)));
         final var boundSchemaTemplate = recordStoreAndRecordContextTx.getBoundSchemaTemplate();
         EmbeddedRelationalConnection connection = new EmbeddedRelationalConnection(this, new HollowStoreCatalog(boundSchemaTemplate, keySpace),
                 ((RecordStoreAndRecordContextTransaction) transaction).getRecordContextTransaction(), options);
@@ -106,7 +112,7 @@ public class TransactionBoundDatabase extends AbstractDatabase {
 
     @Override
     public BackingStore loadRecordStore(@Nonnull String schemaId, @Nonnull FDBRecordStoreBase.StoreExistenceCheck existenceCheck) {
-        return store;
+        return storesBySchemaName.getOrDefault(schemaId, store);
     }
 
     @Override

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/storage/BackingRecordStore.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/storage/BackingRecordStore.java
@@ -221,6 +221,10 @@ public final class BackingRecordStore implements BackingStore {
         return new BackingRecordStore(txn, txn.getRecordStore());
     }
 
+    public static BackingRecordStore fromTransactionAndStore(@Nonnull Transaction txn, @Nonnull FDBRecordStoreBase<Message> store) {
+        return new BackingRecordStore(txn, store);
+    }
+
     @SuppressWarnings("PMD.PreserveStackTrace")
     public static BackingRecordStore load(@Nonnull Transaction txn, @Nonnull StoreConfig config, @Nonnull FDBRecordStoreBase.StoreExistenceCheck existenceCheck) throws RelationalException {
         //TODO(bfines) error handling if this store doesn't exist


### PR DESCRIPTION
## Summary

- `RecordStoreAndRecordContextTransaction` now carries a map of secondary `FDBRecordStoreBase` instances keyed by schema name, populated by the connection layer when a cross-schema query is prepared
- `TransactionBoundDatabase.loadRecordStore(schemaId)` looks up the secondary store map before falling back to the primary store, so `RecordQueryStoreBindingPlan.executePlan` finds the correct store at runtime
- `BackingRecordStore.fromTransactionAndStore` factory method to construct a `BackingRecordStore` wrapping an existing `FDBRecordStoreBase`

## Test plan

- [ ] Cross-schema join queries return correct results end-to-end
- [ ] Single-schema queries unaffected (secondary store map is empty)
