### PR TITLE
Fix missing directory field in github-actions dependabot entry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,7 @@ updates:
       day: "thursday"
 
   - package-ecosystem: "github-actions"
+    directory: "/"
     cooldown:
       default-days: 14
     schedule:


### PR DESCRIPTION
## Summary

- The `github-actions` entry in `.github/dependabot.yml` has been missing the
  required `directory` field since it was introduced in #4250. This causes
  Dependabot config validation to fail with:
  `The property '#/updates/2' of type object did not match one or more of the
  required schemas`.
- Adds `directory: "/"`, matching the other two entries.

## Test plan

- [ ] Dependabot config validation check passes on this PR