### PR TITLE
Document how to run style/static-analysis checks locally

### DIFF
--- a/.claude/skills/using-gradle/SKILL.md
+++ b/.claude/skills/using-gradle/SKILL.md
@@ -22,6 +22,27 @@ Compile a single module without running tests:
 ./gradlew :fdb-record-layer-core:compileJava
 ```
 
+# Style / static analysis checks
+
+**Run this before pushing or opening a PR.** CI's `style` job (`.github/workflows/pull_request.yml`)
+runs `./gradlew build -x test -x destructiveTest -x scalarFallbackTest -PspotbugsEnableHtmlReport`,
+which includes Checkstyle, PMD, and SpotBugs across every module. That's slow for local
+iteration — scope it to the modules you actually touched:
+
+```
+./gradlew :fdb-relational-core:check :fdb-record-layer-core:check -x test -x destructiveTest -x scalarFallbackTest -PspotbugsEnableHtmlReport
+```
+
+Reports on failure land at `<module>/.out/reports/checkstyle/*.html`, `<module>/.out/reports/pmd/*.html`,
+and (with `-PspotbugsEnableHtmlReport`) `<module>/.out/reports/spotbugs/*.html`. The failure
+output in the console also prints the exact file, line, and rule.
+
+Common violations you'll hit when merging/rebasing branches by hand:
+- Checkstyle `RedundantImport` — importing a class that's in the same package as the file, or
+  the same class imported twice (easy to introduce when resolving import-block merge conflicts).
+- PMD `UnnecessaryFullyQualifiedName` — using a fully-qualified name (e.g. `java.util.Map`)
+  when the class is already imported under its simple name.
+
 # Running tests
 
 ## Standard test tasks

--- a/.claude/skills/using-gradle/SKILL.md
+++ b/.claude/skills/using-gradle/SKILL.md
@@ -25,12 +25,18 @@ Compile a single module without running tests:
 # Style / static analysis checks
 
 **Run this before pushing or opening a PR.** CI's `style` job (`.github/workflows/pull_request.yml`)
-runs `./gradlew build -x test -x destructiveTest -x scalarFallbackTest -PspotbugsEnableHtmlReport`,
-which includes Checkstyle, PMD, and SpotBugs across every module. That's slow for local
-iteration — scope it to the modules you actually touched:
+runs:
+```
+./gradlew build -x test -x destructiveTest -x scalarFallbackTest -PreleaseBuild=false -PpublishBuild=false -PspotbugsEnableHtmlReport
+```
+which includes Checkstyle, PMD, and SpotBugs across every module. The `-PreleaseBuild=false
+-PpublishBuild=false` pair matters — without it you're not running the same task graph as CI, and
+some failures (e.g. dependency-version-resolution differences gated by `publishBuild`) only show
+up with them set. That's slow for local iteration — scope it to the modules you actually touched,
+keeping the same property flags:
 
 ```
-./gradlew :fdb-relational-core:check :fdb-record-layer-core:check -x test -x destructiveTest -x scalarFallbackTest -PspotbugsEnableHtmlReport
+./gradlew :fdb-relational-core:check :fdb-record-layer-core:check -x test -x destructiveTest -x scalarFallbackTest -PreleaseBuild=false -PpublishBuild=false -PspotbugsEnableHtmlReport
 ```
 
 Reports on failure land at `<module>/.out/reports/checkstyle/*.html`, `<module>/.out/reports/pmd/*.html`,
@@ -42,6 +48,25 @@ Common violations you'll hit when merging/rebasing branches by hand:
   the same class imported twice (easy to introduce when resolving import-block merge conflicts).
 - PMD `UnnecessaryFullyQualifiedName` — using a fully-qualified name (e.g. `java.util.Map`)
   when the class is already imported under its simple name.
+
+Gotchas when doing an incremental, module-by-module rollout of a new annotation library (e.g.
+jspecify) across a dependency graph:
+- SpotBugs analyzes a module's compiled classes together with an aux classpath drawn from its
+  own `compileOnly`/`implementation`/`api` dependencies. If module B depends on module A and A's
+  compiled bytecode now carries annotations from a library that's only a `compileOnly` dependency
+  of A (not `api`), that dependency does **not** propagate to B — SpotBugs then fails B's analysis
+  with "The following classes needed for analysis were missing: ..." (SpotBugs exit code 3) even
+  though B's own source never references the new annotation. Fix by making the new annotation
+  library a `compileOnly` dependency of every module (not just migrated ones), e.g. via a root
+  `subprojects {}` block, so the class is always resolvable regardless of migration order.
+- SpotBugs' `NP_METHOD_PARAMETER_TIGHTENS_ANNOTATION` check does not treat two different
+  nullability-annotation libraries (e.g. JSR-305's `javax.annotation.Nullable` and jspecify's
+  `org.jspecify.annotations.Nullable`) as equivalent when comparing an overriding method's
+  parameter annotation against its superclass — it flags a mismatch even when both sides
+  genuinely agree the parameter is nullable. This surfaces as a wave of new findings as soon as
+  a widely-subclassed base class (e.g. an exception hierarchy root) migrates to the new library,
+  in every not-yet-migrated subclass module. See `NP_METHOD_PARAMETER_TIGHTENS_ANNOTATION` in
+  `gradle/codequality/spotbugs_exclude.xml` for how this project suppresses it.
 
 # Running tests
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,9 @@ JDK 21 is required to build. The code targets Java 17 language compatibility.
 - Always create PRs as **drafts** (`gh pr create --draft`). Let the human decide when it's
   ready for review.
 - Never merge branches or PRs without explicit user consent.
+- Run style/static-analysis checks locally before pushing (see the `using-gradle` skill's
+  "Style / static analysis checks" section) — this mirrors CI's `style` job and catches
+  Checkstyle/PMD/SpotBugs violations before they reach a PR.
 
 ## Test Strategy
 


### PR DESCRIPTION
## Summary

- Adds a "Style / static analysis checks" section to the `using-gradle` skill: the CI-parity
  command (matching `.github/workflows/pull_request.yml`'s `style` job), report locations,
  and a couple of common Checkstyle/PMD violations that show up when hand-resolving merge
  conflicts (redundant same-package imports, unnecessary fully-qualified names).
- Adds a PR Workflow reminder in `AGENTS.md` to run these checks before pushing.

Motivated by hitting exactly these violations while manually rebasing a stack of PRs across a
few months of upstream drift — nothing in the skills documented how to reproduce CI's style
check locally, so it wasn't caught until CI ran.

## Test plan

- [ ] N/A — documentation only