### PR TITLE
Refinements around nullable `ARRAY` types and `NULL` array elements

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/AbstractArrayConstructorValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/AbstractArrayConstructorValue.java
@@ -204,7 +204,14 @@ public abstract class AbstractArrayConstructorValue extends AbstractValue implem
         @SuppressWarnings("java:S6213")
         public <M extends Message> Object eval(@Nullable final FDBRecordStoreBase<M> store, @Nonnull final EvaluationContext context) {
             return Streams.stream(getChildren())
-                    .map(child -> child.eval(store, context))
+                    .map(child -> {
+                        // Reject null elements, as they are currently not supported (Issue #3646), and the null-hostile
+                        // `ImmutableList` would otherwise raise a `NullPointerException`.
+                        final Object element = child.eval(store, context);
+                        SemanticException.check(element != null, SemanticException.ErrorCode.UNSUPPORTED,
+                                "An ARRAY value cannot have NULL elements");
+                        return element;
+                    })
                     .collect(ImmutableList.toImmutableList());
         }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/MessageHelpers.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/MessageHelpers.java
@@ -416,11 +416,8 @@ public class MessageHelpers {
             // from an array literal or from `unwrapIfArray()`), subsequently setting it on the protobuf builder would
             // cause `setField()` to reject the `List<>` with a type mismatch error.
             if (targetType.isNullable() && targetType.isArray()) {
-                Verify.verify(current instanceof List);
                 Verify.verify(targetDescriptor instanceof Descriptors.Descriptor);
-                final var wrapperDescriptor = (Descriptors.Descriptor)targetDescriptor;
-                final var valuesField = Verify.verifyNotNull(wrapperDescriptor.findFieldByName(NullableArrayTypeUtils.getRepeatedFieldName()));
-                return wrapNullableArray(wrapperDescriptor, valuesField, (List<?>)current);
+                return wrapNullableArray((Descriptors.Descriptor)targetDescriptor, current);
             }
 
             return current;
@@ -536,10 +533,26 @@ public class MessageHelpers {
     @Nonnull
     static DynamicMessage wrapNullableArray(@Nonnull final Descriptors.Descriptor targetDescriptor,
                                             @Nonnull final Descriptors.FieldDescriptor targetElementFieldDescriptor,
-                                            final List<? extends Object> array) {
+                                            @Nonnull final List<?> array) {
         final var builder = DynamicMessage.newBuilder(targetDescriptor);
         builder.setField(targetElementFieldDescriptor, array);
         return builder.build();
+    }
+
+    /**
+     * Wrap the given {@code array} into a message, looking up the repeated {@code values} field on the wrapper message
+     * itself.
+     *
+     * @param targetDescriptor Descriptor for the wrapper message holding the array.
+     * @param array the array to wrap, which must be a {@link List}
+     */
+    @Nonnull
+    static DynamicMessage wrapNullableArray(@Nonnull final Descriptors.Descriptor targetDescriptor,
+                                            @Nonnull final Object array) {
+        Verify.verify(array instanceof List);
+        final var valuesField =
+                Verify.verifyNotNull(targetDescriptor.findFieldByName(NullableArrayTypeUtils.getRepeatedFieldName()));
+        return wrapNullableArray(targetDescriptor, valuesField, (List<?>)array);
     }
 
     /**
@@ -559,10 +572,7 @@ public class MessageHelpers {
         if (!fieldType.isArray() || !fieldType.isNullable()) {
             return fieldValue;
         }
-        final Descriptors.Descriptor wrapperDescriptor = fieldDescriptor.getMessageType();
-        final Descriptors.FieldDescriptor valuesField =
-                Verify.verifyNotNull(wrapperDescriptor.findFieldByName(NullableArrayTypeUtils.getRepeatedFieldName()));
-        return wrapNullableArray(wrapperDescriptor, valuesField, (List<?>)fieldValue);
+        return wrapNullableArray(fieldDescriptor.getMessageType(), fieldValue);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/MessageHelpers.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/MessageHelpers.java
@@ -510,7 +510,8 @@ public class MessageHelpers {
         final var coercedObjectsBuilder = ImmutableList.builder();
         for (final var currentObject : currentObjects) {
             // NULL as elements of a collection are currently not supported
-            SemanticException.check(currentObject != null, SemanticException.ErrorCode.UNSUPPORTED);
+            SemanticException.check(currentObject != null, SemanticException.ErrorCode.UNSUPPORTED,
+                    "An ARRAY value cannot have NULL elements");
 
             final var coercedObject =
                     Verify.verifyNotNull(coerceObject(elementsTrie,

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/MessageHelpers.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/MessageHelpers.java
@@ -420,9 +420,7 @@ public class MessageHelpers {
                 Verify.verify(targetDescriptor instanceof Descriptors.Descriptor);
                 final var wrapperDescriptor = (Descriptors.Descriptor)targetDescriptor;
                 final var valuesField = Verify.verifyNotNull(wrapperDescriptor.findFieldByName(NullableArrayTypeUtils.getRepeatedFieldName()));
-                final var wrapperBuilder = DynamicMessage.newBuilder(wrapperDescriptor);
-                wrapperBuilder.setField(valuesField, current);
-                return wrapperBuilder.build();
+                return wrapNullableArray(wrapperDescriptor, valuesField, (List<?>)current);
             }
 
             return current;
@@ -536,12 +534,35 @@ public class MessageHelpers {
      * @param targetDescriptor Descriptor for the wrapper message holding the array.
      */
     @Nonnull
-    private static DynamicMessage wrapNullableArray(@Nonnull final Descriptors.Descriptor targetDescriptor,
-                                                    @Nonnull final Descriptors.FieldDescriptor targetElementFieldDescriptor,
-                                                    final List<? extends Object> array) {
+    static DynamicMessage wrapNullableArray(@Nonnull final Descriptors.Descriptor targetDescriptor,
+                                            @Nonnull final Descriptors.FieldDescriptor targetElementFieldDescriptor,
+                                            final List<? extends Object> array) {
         final var builder = DynamicMessage.newBuilder(targetDescriptor);
         builder.setField(targetElementFieldDescriptor, array);
         return builder.build();
+    }
+
+    /**
+     * Wraps the given field value if the field’s type is a nullable array. A nullable array is stored in a wrapper
+     * message with a single repeated {@code values} field, so the field value must be wrapped accordingly before it can
+     * be set on the enclosing record message.
+     *
+     * @param fieldType the type of the field being set
+     * @param fieldDescriptor the descriptor of the field being set
+     * @param fieldValue the value to set, unwrapped
+     * @return the wrapped {@code fieldValue}, if {@code fieldType} is a nullable array, or the unchanged
+     *         {@code fieldValue} otherwise
+     */
+    @Nonnull
+    static Object wrapIfNullableArray(@Nonnull final Type fieldType, @Nonnull final Descriptors.FieldDescriptor fieldDescriptor,
+                                      @Nonnull final Object fieldValue) {
+        if (!fieldType.isArray() || !fieldType.isNullable()) {
+            return fieldValue;
+        }
+        final Descriptors.Descriptor wrapperDescriptor = fieldDescriptor.getMessageType();
+        final Descriptors.FieldDescriptor valuesField =
+                Verify.verifyNotNull(wrapperDescriptor.findFieldByName(NullableArrayTypeUtils.getRepeatedFieldName()));
+        return wrapNullableArray(wrapperDescriptor, valuesField, (List<?>)fieldValue);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/RecordConstructorValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/RecordConstructorValue.java
@@ -38,7 +38,6 @@ import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.ConstrainedBoolean;
 import com.apple.foundationdb.record.query.plan.cascades.BuiltInFunction;
 import com.apple.foundationdb.record.query.plan.cascades.Column;
-import com.apple.foundationdb.record.query.plan.cascades.NullableArrayTypeUtils;
 import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
 import com.apple.foundationdb.record.query.plan.cascades.typing.TypeRepository;
 import com.apple.foundationdb.record.query.plan.cascades.typing.Typed;
@@ -124,12 +123,7 @@ public class RecordConstructorValue extends AbstractValue implements AggregateVa
             var childResult = deepCopyIfNeeded(typeRepository, fieldType, child.eval(store, context));
             if (childResult != null) {
                 final var fieldDescriptor = fieldDescriptors.get(i);
-                if (fieldType.isArray() && fieldType.isNullable()) {
-                    final var wrappedDescriptor = fieldDescriptor.getMessageType();
-                    final var wrapperBuilder = DynamicMessage.newBuilder(wrappedDescriptor);
-                    wrapperBuilder.setField(wrappedDescriptor.findFieldByName(NullableArrayTypeUtils.getRepeatedFieldName()), childResult);
-                    childResult = wrapperBuilder.build();
-                }
+                childResult = MessageHelpers.wrapIfNullableArray(fieldType, fieldDescriptor, childResult);
                 resultMessageBuilder.setField(fieldDescriptor, childResult);
             } else {
                 Verify.verify(fieldType.isNullable(), "Cannot set a non-nullable field to the NULL value");
@@ -371,11 +365,15 @@ public class RecordConstructorValue extends AbstractValue implements AggregateVa
                 final var fields = Objects.requireNonNull(getResultType().getFields());
 
                 for (final var childAccumulator : childAccumulators) {
-                    final var finalResult = childAccumulator.finish();
+                    Object finalResult = childAccumulator.finish();
                     if (finalResult != null) {
-                        resultMessageBuilder.setField(descriptorForType.findFieldByNumber(fields.get(i).getFieldIndex()), finalResult);
+                        final var field = fields.get(i);
+                        final var fieldType = field.getFieldType();
+                        final var fieldDescriptor = descriptorForType.findFieldByNumber(field.getFieldIndex());
+                        finalResult = MessageHelpers.wrapIfNullableArray(fieldType, fieldDescriptor, finalResult);
+                        resultMessageBuilder.setField(fieldDescriptor, finalResult);
                     }
-                    i ++;
+                    ++i;
                 }
 
                 return resultMessageBuilder.build();

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/DataTypeUtils.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/DataTypeUtils.java
@@ -23,7 +23,6 @@ package com.apple.foundationdb.relational.recordlayer.metadata;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
 import com.apple.foundationdb.record.util.ProtoUtils;
-import com.apple.foundationdb.relational.api.exceptions.ErrorCode;
 import com.apple.foundationdb.relational.api.metadata.DataType;
 import com.apple.foundationdb.relational.util.Assert;
 import com.apple.foundationdb.relational.util.SpotBugsSuppressWarnings;
@@ -114,11 +113,6 @@ public class DataTypeUtils {
                 return Type.Record.fromFieldsWithName(struct.getName(), struct.isNullable(), fields);
             case ARRAY:
                 final var asArray = (DataType.ArrayType) type;
-                // Currently, Record-Layer does not support Nullable array elements. In the Postgres world, the elements of an array are by default nullable,
-                // but since in RL we store the elements as a 'repeated' field, there is not a way to tell if an element is explicitly 'null'.
-                // The current RL behavior loses the nullability information even if the constituent of Type.Array is explicitly marked 'nullable'. Hence,
-                // the check here avoids silently swallowing the requirement.
-                Assert.thatUnchecked(asArray.getElementType().getCode() == DataType.Code.NULL || !asArray.getElementType().isNullable(), ErrorCode.UNSUPPORTED_OPERATION, "No support for nullable array elements.");
                 return new Type.Array(asArray.isNullable(), toRecordLayerType(asArray.getElementType()));
             case ENUM:
                 final var asEnum = (DataType.EnumType) type;

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/SemanticAnalyzer.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/SemanticAnalyzer.java
@@ -732,7 +732,13 @@ public class SemanticAnalyzer {
         }
 
         if (parsedTypeInfo.isRepeated()) {
-            return DataType.ArrayType.from(type.withNullable(false), isNullable);
+            // “Repeated” means an ARRAY type, in which case `isNullable` is the nullability of the array itself and
+            // `type` is the element type. The element type is forced to be non-nullable here, since NULL values in
+            // ARRAYs are currently not supported (Issue #3646). The assert below is a backstop for that normalization.
+            final DataType.ArrayType arrayType = DataType.ArrayType.from(type.withNullable(false), isNullable);
+            Assert.thatUnchecked(!arrayType.getElementType().isNullable(), ErrorCode.UNSUPPORTED_OPERATION,
+                    "Nullable ARRAY elements are not supported.");
+            return arrayType;
         } else {
             return type;
         }

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DdlVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DdlVisitor.java
@@ -179,26 +179,46 @@ public final class DdlVisitor extends DelegatingVisitor<BaseVisitor> {
     }
 
     /**
-     * Visits the column definition and creates a corresponding metadata object. The column is assumed by to {@code Nullable}
-     * by default. I.e., if the user mentions no nullability constraint, the type of the column becomes nullable, which
-     * has implications on the internal representation of repeated types, see {@link com.apple.foundationdb.relational.util.NullableArrayUtils}
-     * for more details.
+     * Visits the given column definition and creates a corresponding metadata object.
+     *
+     * <p>All column definitions carry a {@code {NULL|NOT NULL}} nullability constraint, where {@code NULL} is the
+     * implicit default. Support for {@code NOT NULL} is currently limited to {@code ARRAY} types; all other columns
+     * must be declared nullable ({@code NULL}). This method will raise {@code UNSUPPORTED_OPERATION} otherwise.
+     *
+     * <p>The reason why non-array columns cannot be {@code NOT NULL} is that, currently, at the protobuf level the
+     * corresponding fields are always declared as {@code optional} (regardless of the nullability of the field type),
+     * and vice versa, {@code optional} is interpreted as “nullable”; there is no separate mechanism to represent
+     * nullability at the {@code RecordMetaData} level (Issue #3068). For {@code ARRAY} on the other hand, the protobuf
+     * representation is a {@code repeated} field and nullable arrays do in fact have a dedicated representation, in the
+     * form of a wrapper message that is generated around the {@code repeated} field; see {@link com.apple.foundationdb.relational.util.NullableArrayUtils NullableArrayUtils}
+     * for details. Note also that, for array columns, the nullability constraint pertains to the <i>array</i> type;
+     * there is no way to control the nullability of the <i>element type</i>. The element type is unconditionally
+     * non-nullable (as enforced by {@link SemanticAnalyzer#lookupType}), since {@code NULL} values in arrays are not
+     * supported (Issue #3646).
+     *
      * @param ctx the parse tree.
-     * @return a {@link RecordLayerTable} object that captures all the properties of the column as defined by the user.
+     * @return a {@link RecordLayerColumn} object that captures all the properties of the column as defined by the user.
      */
     @Nonnull
     @Override
     public RecordLayerColumn visitColumnDefinition(@Nonnull RelationalParser.ColumnDefinitionContext ctx) {
-        final var columnId = visitUid(ctx.colName);
-        final var isRepeated = ctx.ARRAY() != null;
-        final var isNullable = ctx.columnConstraint() != null ? (Boolean) ctx.columnConstraint().accept(this) : true;
-        // TODO: We currently do not support NOT NULL for any type other than ARRAY. This is because there is no way to
-        //       specify not "nullability" at the RecordMetaData level. For ARRAY, specifying that is actually possible
-        //       by means of NullableArrayWrapper. In essence, we don't actually need a wrapper per se for non-array types,
-        //       but a way to represent it in RecordMetadata.
-        Assert.thatUnchecked(isRepeated || isNullable, ErrorCode.UNSUPPORTED_OPERATION, "NOT NULL is only allowed for ARRAY column type");
-        containsNullableArray = containsNullableArray || (isRepeated && isNullable);
-        final var columnType = lookupType(ctx.columnType().customType, ctx.columnType().primitiveType(), isNullable, isRepeated);
+        final Identifier columnId = visitUid(ctx.colName);
+        final boolean isArray = ctx.ARRAY() != null;
+        final boolean isNullable
+                = ctx.columnConstraint() != null ? (Boolean)ctx.columnConstraint().accept(this) : true;
+        final RelationalParser.ColumnTypeContext colType = ctx.columnType();
+
+        // ARRAY supports {NULL|NOT NULL} as the nullability constraint; other types support only NULL.
+        Assert.thatUnchecked(
+                isArray || isNullable,
+                ErrorCode.UNSUPPORTED_OPERATION,
+                "NOT NULL is only allowed for ARRAY column type");
+        containsNullableArray = containsNullableArray || (isArray && isNullable);
+
+        // Note: For an ARRAY column, `isNullable` pertains to the array type; the element type yielded by
+        // `lookupType()` is always *not nullable*.
+        final DataType columnType = lookupType(colType.customType, colType.primitiveType(), isNullable, isArray);
+
         return RecordLayerColumn.newBuilder().setName(columnId.getName()).setDataType(columnType).build();
     }
 

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/ExpressionVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/ExpressionVisitor.java
@@ -1160,16 +1160,21 @@ public final class ExpressionVisitor extends DelegatingVisitor<BaseVisitor> {
 
     @Nonnull
     private Expression handleArray(@Nonnull RelationalParser.ArrayConstructorContext ctx) {
-        // Promote array elements to its non-nullable type as record layer doesn't nullable array elements.
-        final var arrayElementValues = visitExpressions(ctx.expressions()).underlying();
-        final var elements =
-                Streams.stream(arrayElementValues)
-                        .map(arrayElementValue ->
-                                Expression.fromUnderlying(
-                                        PromoteValue.inject(arrayElementValue, arrayElementValue.getResultType().notNullable())))
+        // Promote the individual array elements to their respective non-nullable types, as arrays cannot currently
+        // store NULL elements (Issue #3646). NULL literals are rejected here as UNSUPPORTED_OPERATION, as `NullType`
+        // cannot be made non-nullable.
+        final Expressions elements = visitExpressions(ctx.expressions());
+        final ImmutableList<Expression> promotedElements =
+                Streams.stream(elements.underlying())
+                        .map(value -> {
+                            final Type type = value.getResultType();
+                            Assert.thatUnchecked(!type.isNull(), ErrorCode.UNSUPPORTED_OPERATION,
+                                    "An ARRAY value cannot have NULL elements");
+                            return Expression.fromUnderlying(PromoteValue.inject(value, type.notNullable()));
+                        })
                         .collect(ImmutableList.toImmutableList());
-
-        return getDelegate().resolveFunction("__internal_array", false, elements.toArray(new Expression[0]));
+        final Expression[] array = promotedElements.toArray(new Expression[0]);
+        return getDelegate().resolveFunction("__internal_array", false, array);
     }
 
     @Nonnull

--- a/yaml-tests/src/test/resources/arrays.yamsql
+++ b/yaml-tests/src/test/resources/arrays.yamsql
@@ -263,6 +263,16 @@ test_block:
     -
       # X is null for pk=0, so it won't be possible to construct an array.
       - query: select [x[1]] AS arr_1, [pk] AS arr_2 FROM F WHERE pk = 0
-      - supported_version: 4.12.13.0
-      - error: "XXXXX"
+      - supported_version: !current_version
+      - error: UNSUPPORTED_OPERATION
+    -
+      # An array literal cannot contain NULLs (Issue #3646). A NULL literal is rejected while the literal is resolved.
+      - query: select [1, NULL, 3] FROM A WHERE pk = 1
+      - supported_version: !current_version
+      - error: UNSUPPORTED_OPERATION
+    -
+      # Same rejection when the NULL element is typed, in which case it is only caught once the array is evaluated.
+      - query: select [1, CAST(NULL AS INTEGER), 3] FROM A WHERE pk = 1
+      - supported_version: !current_version
+      - error: UNSUPPORTED_OPERATION
 ...


### PR DESCRIPTION
**Report `NULL` array elements as unsupported instead of an internal error**

This change covers two code paths where `NULL` can reach an array. Nulls in arrays are not supported (see Issue #3646). Instead of surfacing an `INTERNAL_ERROR`, they now raise a proper user-facing SQLSTATE, namely `UNSUPPORTED_OPERATION` (which aligns with what `MessageHelpers.coerceArray()` already reports).

1. `ExpressionVisitor.handleArray()` promotes every element to its non-nullable type. For a bare `NULL` literal, as in `[2, 1, NULL, 3]`, this would trigger a verify in `Type.Null.withNullability(false)`, since the `NullType` cannot be made non-nullable.

2. A typed `NULL`, as in `[1, CAST(NULL AS INTEGER)]`, has a nullable `INTEGER` type instead of `NullType`, so it passes that check and is only caught when the array is evaluated. There, `LightArrayConstructorValue.eval()` collects the elements into an `ImmutableList`, which would reject `null` with a `NullPointerException`.

**Move the rejection of nullable `ARRAY` elements from `DataTypeUtils` to the DDL path**

* Remove the assertion that actively rejects nullable array elements from `DataTypeUtils.toRecordLayerType()`.
* Instead, assert this restriction in `SemanticAnalyzer.lookupType()`, right where the array element types get normalized to non-nullable.

`toRecordLayerType()` is the wrong place for the assertion, since it is supposed to be a general type conversion utility. The check dates back to commit https://github.com/FoundationDB/fdb-record-layer/commit/a46ddcc807ba5f0c6ec28c10f3412d38b753d09b. That commit also changed the DDL path to normalize a declared array's element type to non-nullable, and the assertion was added as a backstop for exactly that normalization. However, `lookupType()` is the more suitable place for the assertion, since it resolves every type that is spelled out in SQL.

**Share logic for wrapping nullable arrays**

Introduce a `wrapIfNullableArray()` utility method and use it (and the existing `wrapNullableArray()`) in `MessageHelpers` and `RecordConstructorValue`.