### PR TITLE
Online Indexer: stop retrying an unresolvable partly-built mismatch

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
@@ -110,6 +110,10 @@ public class OnlineIndexer implements AutoCloseable {
     @Nonnull private final Index index; // First target index is used for locks
     @Nonnull private IndexingPolicy indexingPolicy;
     private boolean fallbackToRecordsScan = false;
+    // The first mismatch that was detected during this operation. If the policy adjustments cannot resolve it, this
+    // one - rather than the last one, which reflects an internal fallback - is reported to the caller.
+    @Nullable private IndexingBase.PartlyBuiltException firstPartlyBuiltException = null;
+    private int lastAttemptCount = 0;
 
     @SuppressWarnings("squid:S00107")
     OnlineIndexer(@Nonnull FDBDatabaseRunner runner,
@@ -131,6 +135,7 @@ public class OnlineIndexer implements AutoCloseable {
 
     @Nonnull
     private CompletableFuture<Void> indexingLauncher(Supplier<CompletableFuture<Void>> indexingFunc) {
+        firstPartlyBuiltException = null; // a new operation, forget the previous one's mismatch
         return indexingLauncher(indexingFunc, 0);
     }
 
@@ -150,6 +155,7 @@ public class OnlineIndexer implements AutoCloseable {
     @Nonnull
     private CompletableFuture<Void> indexingCatcher(Throwable ex, Supplier<CompletableFuture<Void>> indexingFunc, int attemptCount, @Nullable IndexingPolicy requestedPolicy) {
         // (skeleton function, a little long but broken to distinct cases)
+        lastAttemptCount = attemptCount;
         if (ex == null) {
             // A happy index it is
             return AsyncUtil.DONE;
@@ -187,30 +193,32 @@ public class OnlineIndexer implements AutoCloseable {
 
             if (desiredAction == IndexingPolicy.DesiredAction.CONTINUE) {
                 // Make an effort to finish indexing. Attempt continuation of the previous method
-                // Here: match the policy to the previous run
+                // Here: match the policy to the previous run. Every adjustment is attempted once
+                if (firstPartlyBuiltException == null) {
+                    firstPartlyBuiltException = partlyBuiltException;
+                }
+                final IndexingBase.PartlyBuiltException reportedException = firstPartlyBuiltException;
                 IndexBuildProto.IndexBuildIndexingStamp.Method method = conflictingIndexingTypeStamp.getMethod();
-                if (method == IndexBuildProto.IndexBuildIndexingStamp.Method.BY_RECORDS && !common.isMultiTarget()) {
-                    // Partly built by records. The fallback indicator should handle the policy
-                    fallbackToRecordsScan = true;
-                    return indexingLauncher(indexingFunc, attemptCount);
+                if (!common.isMultiTarget() && !fallbackToRecordsScan) {
+                    if (method == IndexBuildProto.IndexBuildIndexingStamp.Method.BY_RECORDS ||
+                            method == IndexBuildProto.IndexBuildIndexingStamp.Method.MULTI_TARGET_BY_RECORDS) {
+                        // Here: Partly built by records, possibly in multi target mode.
+                        fallbackToRecordsScan = true;
+                        return indexingLauncher(indexingFunc, attemptCount);
+                    }
+                    if (method == IndexBuildProto.IndexBuildIndexingStamp.Method.BY_INDEX &&
+                            !isPolicySourceIndexOf(conflictingIndexingTypeStamp)) {
+                        // Partly built by index. Retry with the old policy, but preserve the requested policy - in case the old one fails.
+                        Object sourceIndexSubspaceKey = decodeSubspaceKey(conflictingIndexingTypeStamp.getSourceIndexSubspaceKey());
+                        IndexingPolicy origPolicy = indexingPolicy;
+                        indexingPolicy = origPolicy.toBuilder()
+                                .setSourceIndexSubspaceKey(sourceIndexSubspaceKey)
+                                .build();
+                        return indexingLauncher(indexingFunc, attemptCount, origPolicy);
+                    }
                 }
-                if (method == IndexBuildProto.IndexBuildIndexingStamp.Method.MULTI_TARGET_BY_RECORDS && !common.isMultiTarget()) {
-                    // Partly built by records, in multi target mode. We only allow a fallback from multi target
-                    // to a single target, but not to a subset.
-                    fallbackToRecordsScan = true;
-                    return indexingLauncher(indexingFunc, attemptCount);
-                }
-                if (method == IndexBuildProto.IndexBuildIndexingStamp.Method.BY_INDEX && !common.isMultiTarget()) {
-                    // Partly built by index. Retry with the old policy, but preserve the requested policy - in case the old one fails.
-                    Object sourceIndexSubspaceKey = decodeSubspaceKey(conflictingIndexingTypeStamp.getSourceIndexSubspaceKey());
-                    IndexingPolicy origPolicy = indexingPolicy;
-                    indexingPolicy = origPolicy.toBuilder()
-                            .setSourceIndexSubspaceKey(sourceIndexSubspaceKey)
-                            .build();
-                    return indexingLauncher(indexingFunc, attemptCount, origPolicy);
-                }
-                // No other methods (yet). This line should never be reached.
-                throw partlyBuiltException;
+                // Here: no adjustment is left to try
+                throw reportedException;
             }
 
             if (desiredAction == IndexingPolicy.DesiredAction.REBUILD) {
@@ -274,6 +282,14 @@ public class OnlineIndexer implements AutoCloseable {
         throw FDBExceptions.wrapException(ex);
     }
 
+    private boolean isPolicySourceIndexOf(IndexBuildProto.IndexBuildIndexingStamp conflictingIndexingTypeStamp) {
+        // true if the policy already points at the conflicting stamp's source index, hence retrying by this source
+        // index would fail in the very same way
+        final Object policySourceIndexSubspaceKey = indexingPolicy.getSourceIndexSubspaceKey();
+        return policySourceIndexSubspaceKey != null &&
+               policySourceIndexSubspaceKey.equals(decodeSubspaceKey(conflictingIndexingTypeStamp.getSourceIndexSubspaceKey()));
+    }
+
     @Nonnull
     private IndexingByIndex getIndexerByIndex() {
         if (! (indexer instanceof IndexingByIndex)) { // this covers null pointer
@@ -331,6 +347,16 @@ public class OnlineIndexer implements AutoCloseable {
     @VisibleForTesting
     int getConfigLoaderInvocationCount() {
         return common.getConfigLoaderInvocationCount();
+    }
+
+    /**
+     * Get the number of indexing attempts that were made during the last indexing operation. An attempt is retried
+     * only if the indexing policy could be adjusted to handle the failure.
+     * @return the number of indexing attempts
+     */
+    @VisibleForTesting
+    int getLastAttemptCount() {
+        return lastAttemptCount;
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexer.java
@@ -197,7 +197,6 @@ public class OnlineIndexer implements AutoCloseable {
                 if (firstPartlyBuiltException == null) {
                     firstPartlyBuiltException = partlyBuiltException;
                 }
-                final IndexingBase.PartlyBuiltException reportedException = firstPartlyBuiltException;
                 IndexBuildProto.IndexBuildIndexingStamp.Method method = conflictingIndexingTypeStamp.getMethod();
                 if (!common.isMultiTarget() && !fallbackToRecordsScan) {
                     if (method == IndexBuildProto.IndexBuildIndexingStamp.Method.BY_RECORDS ||
@@ -208,7 +207,7 @@ public class OnlineIndexer implements AutoCloseable {
                     }
                     if (method == IndexBuildProto.IndexBuildIndexingStamp.Method.BY_INDEX &&
                             !isPolicySourceIndexOf(conflictingIndexingTypeStamp)) {
-                        // Partly built by index. Retry with the old policy, but preserve the requested policy - in case the old one fails.
+                        // Here: Partly built by index. Retry with the old policy, but preserve the requested policy - in case the old one fails.
                         Object sourceIndexSubspaceKey = decodeSubspaceKey(conflictingIndexingTypeStamp.getSourceIndexSubspaceKey());
                         IndexingPolicy origPolicy = indexingPolicy;
                         indexingPolicy = origPolicy.toBuilder()
@@ -218,7 +217,7 @@ public class OnlineIndexer implements AutoCloseable {
                     }
                 }
                 // Here: no adjustment is left to try
-                throw reportedException;
+                throw firstPartlyBuiltException;
             }
 
             if (desiredAction == IndexingPolicy.DesiredAction.REBUILD) {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMultiTargetTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMultiTargetTest.java
@@ -55,6 +55,7 @@ import static com.apple.foundationdb.record.metadata.Key.Expressions.field;
 import static com.apple.foundationdb.record.metadata.Key.Expressions.recordType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -585,6 +586,71 @@ class OnlineIndexerMultiTargetTest extends OnlineIndexerTest {
         try (FDBRecordContext context = openContext()) {
             assertTrue(recordStore.getIndexState(indexes.get(1)).isReadable());
             context.commit();
+        }
+    }
+
+    @ParameterizedTest
+    @BooleanSource
+    void testMultiTargetPartlyBuiltContinueByIndex(boolean allowTakeover) {
+        // After a multi target crash, continue a single target by a source index. The by-index attempt and the
+        // by-records fallback are each attempted once, and the fallback may take over the multi target stamp only if
+        // the takeover is allowed.
+
+        final int numRecords = 40;
+        final int chunkSize  = 7;
+
+        List<Index> indexes = new ArrayList<>();
+        indexes.add(new Index("indexB", field("num_value_3_indexed"), IndexTypes.VALUE));
+        indexes.add(new Index("indexA", field("num_value_2"), EmptyKeyExpression.EMPTY, IndexTypes.VALUE, IndexOptions.UNIQUE_OPTIONS));
+        indexes.add(new Index("indexC", field("num_value_unique"), EmptyKeyExpression.EMPTY, IndexTypes.VALUE, IndexOptions.UNIQUE_OPTIONS));
+
+        populateData(numRecords);
+
+        FDBRecordStoreTestBase.RecordMetaDataHook hook = allIndexesHook(indexes);
+        openSimpleMetaData(hook);
+        disableAll(indexes);
+
+        // 1. partly build multi
+        buildIndexAndCrashHalfway(chunkSize, 3, new FDBStoreTimer(), newIndexerBuilder(indexes));
+
+        // 2. finish "indexB", to be used as a source index. The others keep the multi target stamp
+        try (OnlineIndexer indexBuilder = newIndexerBuilder(indexes.get(0))
+                .setLimit(chunkSize)
+                .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
+                        .allowTakeoverContinue())
+                .build()) {
+            indexBuilder.buildIndex();
+        }
+
+        // 3. continue "indexA" by a source index
+        try (OnlineIndexer indexBuilder = newIndexerBuilder(indexes.get(1))
+                .setLimit(chunkSize)
+                .setIndexingPolicy(OnlineIndexer.IndexingPolicy.newBuilder()
+                        .setSourceIndex(indexes.get(0).getName())
+                        .allowTakeoverContinue(allowTakeover))
+                .build()) {
+            if (allowTakeover) {
+                indexBuilder.buildIndex();
+            } else {
+                // Without a takeover, neither attempt may continue the multi target build. The reported mismatch is
+                // the requested by-index one, not the internal by-records fallback.
+                final RecordCoreException e = assertThrows(RecordCoreException.class, indexBuilder::buildIndex);
+                final IndexingBase.PartlyBuiltException partlyBuilt = IndexingBase.getAPartlyBuiltExceptionIfApplicable(e);
+                assertNotNull(partlyBuilt, () -> "expected a PartlyBuiltException, got " + e);
+                assertEquals(IndexBuildProto.IndexBuildIndexingStamp.Method.MULTI_TARGET_BY_RECORDS, partlyBuilt.getSavedStamp().getMethod());
+                assertTrue(partlyBuilt.getSavedStamp().getTargetIndexList().containsAll(List.of("indexA", "indexB", "indexC")));
+                assertEquals(IndexBuildProto.IndexBuildIndexingStamp.Method.BY_INDEX, partlyBuilt.getExpectedStamp().getMethod());
+            }
+            // by index, then a single fallback to by records - never up to the attempts recursion limit
+            assertEquals(2, indexBuilder.getLastAttemptCount());
+        }
+
+        if (allowTakeover) {
+            try (FDBRecordContext context = openContext()) {
+                assertTrue(recordStore.getIndexState(indexes.get(1)).isReadable());
+                context.commit();
+            }
+            scrubAndValidate(List.of(indexes.get(0), indexes.get(1)));
         }
     }
 


### PR DESCRIPTION
The `CONTINUE` path in `OnlineIndexer.indexingCatcher` could re-apply an adjustment that was already in effect. An unresolvable "This index was partly built by another method" mismatch was  therefore retried identically until reaching max attempts, ending with a misleading "Too many indexing attempts" error.

 - Every adjustment (fallback to a by-records scan, continuation by the previous source index) is now attempted at most once.
 - The mismatch reported to the caller is the first one, so it names the requested indexing method rather than the internal fallback.
