### PR TITLE
Sync explains in `.metrics.yaml` after #4440

### DIFF
--- a/yaml-tests/src/test/resources/aggregate-empty-table.metrics.binpb
+++ b/yaml-tests/src/test/resources/aggregate-empty-table.metrics.binpb
@@ -1,7 +1,7 @@
-ˇ
+Ì
 9
-agg-empty-table-tests EXPLAIN select count(*) from T1;¡
-˜ºØë> Ú˙º(0¸É28@èSCAN([IS T1]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)ëdigraph G {
+agg-empty-table-tests EXPLAIN select count(*) from T1;Ø
+˜ºØë> Ú˙º(0¸É28@~SCAN([IS T1]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)ëdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -36,10 +36,10 @@ M
   6 -> 5 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   7 -> 6 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q35> label="q35" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}Ω
+}¨
 H
-agg-empty-table-tests/EXPLAIN select count(*) from T1 where col1 = 0;
-≥–Ÿç	Q ıâ–(0Û©B8@ºSCAN([IS T1]) | FILTER _.COL1 EQUALS promote(@c10 AS LONG) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)ìdigraph G {
+agg-empty-table-tests/EXPLAIN select count(*) from T1 where col1 = 0;ﬂ
+≥–Ÿç	Q ıâ–(0Û©B8@´SCAN([IS T1]) | FILTER _.COL1 EQUALS promote(@c10 AS LONG) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)ìdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -56,10 +56,10 @@ H
   6 -> 5 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   7 -> 6 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}…
+}∏
 H
-agg-empty-table-tests/EXPLAIN select count(*) from T1 where col1 > 0;¸
-≥‘Ä‹Q ÌÖ¸(0á∏;8@¬SCAN([IS T1]) | FILTER _.COL1 GREATER_THAN promote(@c10 AS LONG) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)ôdigraph G {
+agg-empty-table-tests/EXPLAIN select count(*) from T1 where col1 > 0;Î
+≥‘Ä‹Q ÌÖ¸(0á∏;8@±SCAN([IS T1]) | FILTER _.COL1 GREATER_THAN promote(@c10 AS LONG) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)ôdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -76,10 +76,10 @@ H
   6 -> 5 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   7 -> 6 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}—
+}ø
 9
-agg-empty-table-tests EXPLAIN select count(*) from T2;ì
-≠ëÖ»| ıãﬁ(20¢¶Z8#@áAISCAN(T2_I1 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)Îdigraph G {
+agg-empty-table-tests EXPLAIN select count(*) from T2;Å
+≠ëÖ»| ıãﬁ(20¢¶Z8#@vAISCAN(T2_I1 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)Îdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -110,10 +110,10 @@ M
   5 -> 4 [ label=<&nbsp;q4> label="q4" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   6 -> 5 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q107> label="q107" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}Ω
+}¨
 H
-agg-empty-table-tests/EXPLAIN select count(*) from T2 where col1 = 0;
-•◊àì Ñ”◊(20√∏U8!@∫AISCAN(T2_I2 [EQUALS promote(@c10 AS LONG)] BY_GROUP -> [_0: KEY:[0], _1: VALUE:[0]]) | MAP ((_._1 AS _0) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)ïdigraph G {
+agg-empty-table-tests/EXPLAIN select count(*) from T2 where col1 = 0;ﬂ
+•◊àì Ñ”◊(20√∏U8!@©AISCAN(T2_I2 [EQUALS promote(@c10 AS LONG)] BY_GROUP -> [_0: KEY:[0], _1: VALUE:[0]]) | MAP ((_._1 AS _0) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)ïdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -126,10 +126,10 @@ H
   4 -> 3 [ label=<&nbsp;q4> label="q4" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   5 -> 4 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}Í
+}Ÿ
 H
-agg-empty-table-tests/EXPLAIN select count(*) from T2 where col1 > 0;ù
-±ˆôÈÄ ÜŒë(20ˇÄπ8#@‡AISCAN(T2_I2 [[GREATER_THAN promote(@c10 AS LONG)]] BY_GROUP -> [_0: KEY:[0], _1: VALUE:[0]]) | AGG sum_l(_._1) GROUP BY () | MAP ((_._1 AS _0) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)ödigraph G {
+agg-empty-table-tests/EXPLAIN select count(*) from T2 where col1 > 0;å
+±ˆôÈÄ ÜŒë(20ˇÄπ8#@œAISCAN(T2_I2 [[GREATER_THAN promote(@c10 AS LONG)]] BY_GROUP -> [_0: KEY:[0], _1: VALUE:[0]]) | AGG sum_l(_._1) GROUP BY () | MAP ((_._1 AS _0) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)ödigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -183,11 +183,11 @@ digraph G {
   3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">T2_I2</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS COL1, LONG AS COL2)" ];
   3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}Ó
+}›
 9
-agg-empty-table-tests EXPLAIN select count(*) from T3;∞
+agg-empty-table-tests EXPLAIN select count(*) from T3;ü
 á∑Û˛Z º˘Ç
-(%0ΩÜê8-@íISCAN(T3_I2 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)¸digraph G {
+(%0ΩÜê8-@ÅISCAN(T3_I2 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)¸digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -202,10 +202,10 @@ digraph G {
   5 -> 4 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   6 -> 5 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}¨
+}õ
 H
-agg-empty-table-tests/EXPLAIN select count(*) from T3 where col1 = 0;ﬂ
-„‡ùÃú ı√Û(-0±´°8C@≠ISCAN(T3_I1 [EQUALS promote(@c10 AS LONG)]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)èdigraph G {
+agg-empty-table-tests/EXPLAIN select count(*) from T3 where col1 = 0;Œ
+„‡ùÃú ı√Û(-0±´°8C@úISCAN(T3_I1 [EQUALS promote(@c10 AS LONG)]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)èdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -220,10 +220,10 @@ H
   5 -> 4 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   6 -> 5 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}º
+}´
 H
-agg-empty-table-tests/EXPLAIN select count(*) from T3 where col1 > 0;Ô
-Úòî◊ù ë÷˙(.0«†ù8E@µISCAN(T3_I1 [[GREATER_THAN promote(@c10 AS LONG)]]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)ódigraph G {
+agg-empty-table-tests/EXPLAIN select count(*) from T3 where col1 > 0;ﬁ
+Úòî◊ù ë÷˙(.0«†ù8E@§ISCAN(T3_I1 [[GREATER_THAN promote(@c10 AS LONG)]]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)ódigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -287,10 +287,10 @@ V
   4 -> 3 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   5 -> 4 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}ä
+}˘
 <
-agg-empty-table-tests#EXPLAIN select count(col2) from T1;…
-˜ÛÓÂ> Öè£(0†Ú38@íSCAN([IS T1]) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)ñdigraph G {
+agg-empty-table-tests#EXPLAIN select count(col2) from T1;∏
+˜ÛÓÂ> Öè£(0†Ú38@ÅSCAN([IS T1]) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)ñdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -305,10 +305,10 @@ V
   5 -> 4 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   6 -> 5 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}»
+}∑
 K
-agg-empty-table-tests2EXPLAIN select count(col2) from T1 where col1 = 0;¯
-≥èÔ‹	Q ¸ÅÈ(0ÓßH8@øSCAN([IS T1]) | FILTER _.COL1 EQUALS promote(@c10 AS LONG) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)òdigraph G {
+agg-empty-table-tests2EXPLAIN select count(col2) from T1 where col1 = 0;Á
+≥èÔ‹	Q ¸ÅÈ(0ÓßH8@ÆSCAN([IS T1]) | FILTER _.COL1 EQUALS promote(@c10 AS LONG) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)òdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -325,10 +325,10 @@ K
   6 -> 5 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   7 -> 6 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}‘
+}√
 K
-agg-empty-table-tests2EXPLAIN select count(col2) from T1 where col1 > 0;Ñ
-≥Ñõ˝Q ⁄†¶(0ÜªV8@≈SCAN([IS T1]) | FILTER _.COL1 GREATER_THAN promote(@c10 AS LONG) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)ûdigraph G {
+agg-empty-table-tests2EXPLAIN select count(col2) from T1 where col1 > 0;Û
+≥Ñõ˝Q ⁄†¶(0ÜªV8@¥SCAN([IS T1]) | FILTER _.COL1 GREATER_THAN promote(@c10 AS LONG) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)ûdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -345,10 +345,10 @@ K
   6 -> 5 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   7 -> 6 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}’
+}√
 <
-agg-empty-table-tests#EXPLAIN select count(col2) from T2;î
-≠Ÿ±˜| ÛñÌ(20ÅÁâ8#@áAISCAN(T2_I3 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)Îdigraph G {
+agg-empty-table-tests#EXPLAIN select count(col2) from T2;Ç
+≠Ÿ±˜| ÛñÌ(20ÅÁâ8#@vAISCAN(T2_I3 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)Îdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -361,10 +361,10 @@ K
   4 -> 3 [ label=<&nbsp;q4> label="q4" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   5 -> 4 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}¡
+}∞
 K
-agg-empty-table-tests2EXPLAIN select count(col2) from T2 where col1 = 0;Ò
-•ÜÉ÷ Îèå(20®⁄∑8!@∫AISCAN(T2_I4 [EQUALS promote(@c10 AS LONG)] BY_GROUP -> [_0: KEY:[0], _1: VALUE:[0]]) | MAP ((_._1 AS _0) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)ïdigraph G {
+agg-empty-table-tests2EXPLAIN select count(col2) from T2 where col1 = 0;‡
+•ÜÉ÷ Îèå(20®⁄∑8!@©AISCAN(T2_I4 [EQUALS promote(@c10 AS LONG)] BY_GROUP -> [_0: KEY:[0], _1: VALUE:[0]]) | MAP ((_._1 AS _0) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)ïdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -377,10 +377,10 @@ K
   4 -> 3 [ label=<&nbsp;q4> label="q4" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   5 -> 4 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}Ì
+}‹
 K
-agg-empty-table-tests2EXPLAIN select count(col2) from T2 where col1 > 0;ù
-±æèÚÄ Ω≥ø(20Ù¬◊8#@‡AISCAN(T2_I4 [[GREATER_THAN promote(@c10 AS LONG)]] BY_GROUP -> [_0: KEY:[0], _1: VALUE:[0]]) | AGG sum_l(_._1) GROUP BY () | MAP ((_._1 AS _0) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)ödigraph G {
+agg-empty-table-tests2EXPLAIN select count(col2) from T2 where col1 > 0;å
+±æèÚÄ Ω≥ø(20Ù¬◊8#@œAISCAN(T2_I4 [[GREATER_THAN promote(@c10 AS LONG)]] BY_GROUP -> [_0: KEY:[0], _1: VALUE:[0]]) | AGG sum_l(_._1) GROUP BY () | MAP ((_._1 AS _0) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)ödigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -435,10 +435,10 @@ digraph G {
   3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">T2_I4</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS COL1, LONG AS COL2)" ];
   3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}˘
+}Ë
 <
-agg-empty-table-tests#EXPLAIN select count(col2) from T3;∏
-á¬∫ŒZ ˆì…(%0∞´ä8-@ïISCAN(T3_I1 <,>) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)Ådigraph G {
+agg-empty-table-tests#EXPLAIN select count(col2) from T3;ß
+á¬∫ŒZ ˆì…(%0∞´ä8-@ÑISCAN(T3_I1 <,>) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)Ådigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -453,10 +453,10 @@ digraph G {
   5 -> 4 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   6 -> 5 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}∑
+}¶
 K
-agg-empty-table-tests2EXPLAIN select count(col2) from T3 where col1 = 0;Á
-„ŸÉ¢!ú âﬂÉ(-0˜‰Ÿ8C@∞ISCAN(T3_I1 [EQUALS promote(@c10 AS LONG)]) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)îdigraph G {
+agg-empty-table-tests2EXPLAIN select count(col2) from T3 where col1 = 0;÷
+„ŸÉ¢!ú âﬂÉ(-0˜‰Ÿ8C@üISCAN(T3_I1 [EQUALS promote(@c10 AS LONG)]) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)îdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -471,10 +471,10 @@ K
   5 -> 4 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   6 -> 5 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}«
+}∂
 K
-agg-empty-table-tests2EXPLAIN select count(col2) from T3 where col1 > 0;˜
-ÚôÌ≥ù ˇÅ˚(.0√€Ω8E@∏ISCAN(T3_I1 [[GREATER_THAN promote(@c10 AS LONG)]]) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)údigraph G {
+agg-empty-table-tests2EXPLAIN select count(col2) from T3 where col1 > 0;Ê
+ÚôÌ≥ù ˇÅ˚(.0√€Ω8E@ßISCAN(T3_I1 [[GREATER_THAN promote(@c10 AS LONG)]]) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)údigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -911,10 +911,10 @@ W
   4 -> 3 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   5 -> 4 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}ì
+}Å
 M
-)agg-empty-table-tests-after-modifications EXPLAIN select count(*) from T1;¡
-˜ºØë> Ú˙º(0¸É28@èSCAN([IS T1]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)ëdigraph G {
+)agg-empty-table-tests-after-modifications EXPLAIN select count(*) from T1;Ø
+˜ºØë> Ú˙º(0¸É28@~SCAN([IS T1]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)ëdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -949,10 +949,10 @@ a
   6 -> 5 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   7 -> 6 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q35> label="q35" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}—
+}¿
 \
-)agg-empty-table-tests-after-modifications/EXPLAIN select count(*) from T1 where col1 = 0;
-≥–Ÿç	Q ıâ–(0Û©B8@ºSCAN([IS T1]) | FILTER _.COL1 EQUALS promote(@c10 AS LONG) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)ìdigraph G {
+)agg-empty-table-tests-after-modifications/EXPLAIN select count(*) from T1 where col1 = 0;ﬂ
+≥–Ÿç	Q ıâ–(0Û©B8@´SCAN([IS T1]) | FILTER _.COL1 EQUALS promote(@c10 AS LONG) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)ìdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -969,10 +969,10 @@ a
   6 -> 5 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   7 -> 6 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}›
+}Ã
 \
-)agg-empty-table-tests-after-modifications/EXPLAIN select count(*) from T1 where col1 > 0;¸
-≥‘Ä‹Q ÌÖ¸(0á∏;8@¬SCAN([IS T1]) | FILTER _.COL1 GREATER_THAN promote(@c10 AS LONG) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)ôdigraph G {
+)agg-empty-table-tests-after-modifications/EXPLAIN select count(*) from T1 where col1 > 0;Î
+≥‘Ä‹Q ÌÖ¸(0á∏;8@±SCAN([IS T1]) | FILTER _.COL1 GREATER_THAN promote(@c10 AS LONG) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)ôdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -989,10 +989,10 @@ a
   6 -> 5 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   7 -> 6 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}Â
+}”
 M
-)agg-empty-table-tests-after-modifications EXPLAIN select count(*) from T2;ì
-≠ëÖ»| ıãﬁ(20¢¶Z8#@áAISCAN(T2_I1 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)Îdigraph G {
+)agg-empty-table-tests-after-modifications EXPLAIN select count(*) from T2;Å
+≠ëÖ»| ıãﬁ(20¢¶Z8#@vAISCAN(T2_I1 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)Îdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -1023,10 +1023,10 @@ a
   5 -> 4 [ label=<&nbsp;q4> label="q4" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   6 -> 5 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q107> label="q107" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}È
+}◊
 P
-)agg-empty-table-tests-after-modifications#EXPLAIN select count(col2) from T2;î
-≠Ÿ±˜| ÛñÌ(20ÅÁâ8#@áAISCAN(T2_I3 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)Îdigraph G {
+)agg-empty-table-tests-after-modifications#EXPLAIN select count(col2) from T2;Ç
+≠Ÿ±˜| ÛñÌ(20ÅÁâ8#@vAISCAN(T2_I3 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)Îdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -1039,10 +1039,10 @@ P
   4 -> 3 [ label=<&nbsp;q4> label="q4" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   5 -> 4 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}’
+}ƒ
 _
-)agg-empty-table-tests-after-modifications2EXPLAIN select count(col2) from T2 where col1 = 0;Ò
-•ÜÉ÷ Îèå(20®⁄∑8!@∫AISCAN(T2_I4 [EQUALS promote(@c10 AS LONG)] BY_GROUP -> [_0: KEY:[0], _1: VALUE:[0]]) | MAP ((_._1 AS _0) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)ïdigraph G {
+)agg-empty-table-tests-after-modifications2EXPLAIN select count(col2) from T2 where col1 = 0;‡
+•ÜÉ÷ Îèå(20®⁄∑8!@©AISCAN(T2_I4 [EQUALS promote(@c10 AS LONG)] BY_GROUP -> [_0: KEY:[0], _1: VALUE:[0]]) | MAP ((_._1 AS _0) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)ïdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -1055,10 +1055,10 @@ _
   4 -> 3 [ label=<&nbsp;q4> label="q4" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   5 -> 4 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}Å
+}
 _
-)agg-empty-table-tests-after-modifications2EXPLAIN select count(col2) from T2 where col1 > 0;ù
-±æèÚÄ Ω≥ø(20Ù¬◊8#@‡AISCAN(T2_I4 [[GREATER_THAN promote(@c10 AS LONG)]] BY_GROUP -> [_0: KEY:[0], _1: VALUE:[0]]) | AGG sum_l(_._1) GROUP BY () | MAP ((_._1 AS _0) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)ödigraph G {
+)agg-empty-table-tests-after-modifications2EXPLAIN select count(col2) from T2 where col1 > 0;å
+±æèÚÄ Ω≥ø(20Ù¬◊8#@œAISCAN(T2_I4 [[GREATER_THAN promote(@c10 AS LONG)]] BY_GROUP -> [_0: KEY:[0], _1: VALUE:[0]]) | AGG sum_l(_._1) GROUP BY () | MAP ((_._1 AS _0) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)ödigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -1073,10 +1073,10 @@ _
   5 -> 4 [ label=<&nbsp;q96> label="q96" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   6 -> 5 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}ç
+}¸
 P
-)agg-empty-table-tests-after-modifications#EXPLAIN select count(col2) from T3;∏
-á¬∫ŒZ ˆì…(%0∞´ä8-@ïISCAN(T3_I1 <,>) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)Ådigraph G {
+)agg-empty-table-tests-after-modifications#EXPLAIN select count(col2) from T3;ß
+á¬∫ŒZ ˆì…(%0∞´ä8-@ÑISCAN(T3_I1 <,>) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)Ådigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -1091,10 +1091,10 @@ P
   5 -> 4 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   6 -> 5 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}À
+}∫
 _
-)agg-empty-table-tests-after-modifications2EXPLAIN select count(col2) from T3 where col1 = 0;Á
-„ŸÉ¢!ú âﬂÉ(-0˜‰Ÿ8C@∞ISCAN(T3_I1 [EQUALS promote(@c10 AS LONG)]) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)îdigraph G {
+)agg-empty-table-tests-after-modifications2EXPLAIN select count(col2) from T3 where col1 = 0;÷
+„ŸÉ¢!ú âﬂÉ(-0˜‰Ÿ8C@üISCAN(T3_I1 [EQUALS promote(@c10 AS LONG)]) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)îdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -1109,10 +1109,10 @@ _
   5 -> 4 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   6 -> 5 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}€
+} 
 _
-)agg-empty-table-tests-after-modifications2EXPLAIN select count(col2) from T3 where col1 > 0;˜
-ÚôÌ≥ù ˇÅ˚(.0√€Ω8E@∏ISCAN(T3_I1 [[GREATER_THAN promote(@c10 AS LONG)]]) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)údigraph G {
+)agg-empty-table-tests-after-modifications2EXPLAIN select count(col2) from T3 where col1 > 0;Ê
+ÚôÌ≥ù ˇÅ˚(.0√€Ω8E@ßISCAN(T3_I1 [[GREATER_THAN promote(@c10 AS LONG)]]) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)údigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -1437,10 +1437,10 @@ f
   6 -> 5 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   7 -> 6 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q81> label="q81" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}Ö
+}∆
 j
-)agg-empty-table-tests-after-modifications=EXPLAIN select count(col1) from t3 having count(col1) is nullñ
-÷•ÿ∑n ™˘â(*0ª®ú89@¬ISCAN(T3_I1 <,>) | MAP (_ AS _0) | AGG (count(_._0.COL1) AS _0) GROUP BY () | FILTER coalesce_long(_._0._0, promote(0l AS LONG)) IS_NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)≤digraph G {
+)agg-empty-table-tests-after-modifications=EXPLAIN select count(col1) from t3 having count(col1) is null◊
+÷•ÿ∑n ™˘â(*0ª®ú89@ÉISCAN(T3_I1 <,>) | MAP (_ AS _0) | AGG (count(_._0.COL1) AS _0) GROUP BY () | FILTER false | MAP (coalesce_long(_._0._0, 0l) AS _0)≤digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -1455,10 +1455,10 @@ j
   5 -> 4 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   6 -> 5 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q86> label="q86" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}’
+}ƒ
 d
-)agg-empty-table-tests-after-modifications7EXPLAIN select count(*) from t3 having count(*) is nullÏ
-÷°ùªn ‚Ò®(*0⁄ÃÉ89@ÆISCAN(T3_I2 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | FILTER coalesce_long(_._0._0, 0l) IS_NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)údigraph G {
+)agg-empty-table-tests-after-modifications7EXPLAIN select count(*) from t3 having count(*) is null€
+÷°ùªn ‚Ò®(*0⁄ÃÉ89@ùISCAN(T3_I2 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | FILTER coalesce_long(_._0._0, 0l) IS_NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)údigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -1527,10 +1527,10 @@ q
   5 -> 4 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   6 -> 5 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q53> label="q53" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}ô
+}Ê
 
-)agg-empty-table-tests-after-modificationsREXPLAIN select count(col1) from t3 having count(col1) is null or count(col1) > 100ï
-¢‡¶ø` Ãºß('0ı…s82@§ISCAN(T3_I1 <,>) | MAP (_ AS _0) | AGG (count(_._0.COL1) AS _0) GROUP BY () | ON EMPTY NULL | FILTER coalesce_long(_._0._0, promote(0l AS LONG)) IS_NULL OR coalesce_long(_._0._0, promote(0l AS LONG)) GREATER_THAN promote(@c20 AS LONG) | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)–digraph G {
+)agg-empty-table-tests-after-modificationsREXPLAIN select count(col1) from t3 having count(col1) is null or count(col1) > 100‚
+¢‡¶ø` Ãºß('0ı…s82@ÒISCAN(T3_I1 <,>) | MAP (_ AS _0) | AGG (count(_._0.COL1) AS _0) GROUP BY () | ON EMPTY NULL | FILTER coalesce_long(_._0._0, 0l) IS_NULL OR coalesce_long(_._0._0, 0l) GREATER_THAN promote(@c20 AS LONG) | MAP (coalesce_long(_._0._0, 0l) AS _0)–digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -1547,10 +1547,10 @@ q
   6 -> 5 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   7 -> 6 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q82> label="q82" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}ƒ
+}≥
 v
-)agg-empty-table-tests-after-modificationsIEXPLAIN select count(*) from t3 having count(*) is null or count(*) > 100…
-¢ó™ë` Ô∆('0â©n82@ˇISCAN(T3_I2 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | FILTER coalesce_long(_._0._0, 0l) IS_NULL OR coalesce_long(_._0._0, 0l) GREATER_THAN promote(@c20 AS LONG) | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)©digraph G {
+)agg-empty-table-tests-after-modificationsIEXPLAIN select count(*) from t3 having count(*) is null or count(*) > 100∏
+¢ó™ë` Ô∆('0â©n82@ÓISCAN(T3_I2 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | FILTER coalesce_long(_._0._0, 0l) IS_NULL OR coalesce_long(_._0._0, 0l) GREATER_THAN promote(@c20 AS LONG) | MAP (coalesce_long(_._0._0, 0l) AS _0)©digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;

--- a/yaml-tests/src/test/resources/aggregate-empty-table.metrics.yaml
+++ b/yaml-tests/src/test/resources/aggregate-empty-table.metrics.yaml
@@ -2,7 +2,7 @@ agg-empty-table-tests:
 -   query: EXPLAIN select count(*) from T1;
     ref: aggregate-empty-table.yamsql:39
     explain: SCAN([IS T1]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY ()
-        | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)
+        | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)
     task_count: 247
     task_total_time_ms: 8
     transform_count: 62
@@ -28,7 +28,7 @@ agg-empty-table-tests:
     ref: aggregate-empty-table.yamsql:52
     explain: SCAN([IS T1]) | FILTER _.COL1 EQUALS promote(@c10 AS LONG) | MAP (_ AS
         _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0,
-        promote(0l AS LONG)) AS _0)
+        0l) AS _0)
     task_count: 307
     task_total_time_ms: 19
     transform_count: 81
@@ -41,7 +41,7 @@ agg-empty-table-tests:
     ref: aggregate-empty-table.yamsql:57
     explain: SCAN([IS T1]) | FILTER _.COL1 GREATER_THAN promote(@c10 AS LONG) | MAP
         (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0,
-        promote(0l AS LONG)) AS _0)
+        0l) AS _0)
     task_count: 307
     task_total_time_ms: 18
     transform_count: 81
@@ -53,7 +53,7 @@ agg-empty-table-tests:
 -   query: EXPLAIN select count(*) from T2;
     ref: aggregate-empty-table.yamsql:77
     explain: 'AISCAN(T2_I1 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY
-        NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)'
+        NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)'
     task_count: 429
     task_total_time_ms: 38
     transform_count: 124
@@ -79,7 +79,7 @@ agg-empty-table-tests:
     ref: aggregate-empty-table.yamsql:91
     explain: 'AISCAN(T2_I2 [EQUALS promote(@c10 AS LONG)] BY_GROUP -> [_0: KEY:[0],
         _1: VALUE:[0]]) | MAP ((_._1 AS _0) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0,
-        promote(0l AS LONG)) AS _0)'
+        0l) AS _0)'
     task_count: 421
     task_total_time_ms: 40
     transform_count: 127
@@ -92,8 +92,7 @@ agg-empty-table-tests:
     ref: aggregate-empty-table.yamsql:96
     explain: 'AISCAN(T2_I2 [[GREATER_THAN promote(@c10 AS LONG)]] BY_GROUP -> [_0:
         KEY:[0], _1: VALUE:[0]]) | AGG sum_l(_._1) GROUP BY () | MAP ((_._1 AS _0)
-        AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG))
-        AS _0)'
+        AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)'
     task_count: 433
     task_total_time_ms: 43
     transform_count: 128
@@ -141,7 +140,7 @@ agg-empty-table-tests:
 -   query: EXPLAIN select count(*) from T3;
     ref: aggregate-empty-table.yamsql:116
     explain: ISCAN(T3_I2 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY
-        () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)
+        () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)
     task_count: 391
     task_total_time_ms: 50
     transform_count: 90
@@ -153,8 +152,7 @@ agg-empty-table-tests:
 -   query: EXPLAIN select count(*) from T3 where col1 = 0;
     ref: aggregate-empty-table.yamsql:121
     explain: ISCAN(T3_I1 [EQUALS promote(@c10 AS LONG)]) | MAP (_ AS _0) | AGG (count_star(*)
-        AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l
-        AS LONG)) AS _0)
+        AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)
     task_count: 611
     task_total_time_ms: 47
     transform_count: 156
@@ -167,7 +165,7 @@ agg-empty-table-tests:
     ref: aggregate-empty-table.yamsql:126
     explain: ISCAN(T3_I1 [[GREATER_THAN promote(@c10 AS LONG)]]) | MAP (_ AS _0) |
         AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0,
-        promote(0l AS LONG)) AS _0)
+        0l) AS _0)
     task_count: 626
     task_total_time_ms: 49
     transform_count: 157
@@ -215,7 +213,7 @@ agg-empty-table-tests:
 -   query: EXPLAIN select count(col2) from T1;
     ref: aggregate-empty-table.yamsql:146
     explain: SCAN([IS T1]) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) GROUP BY
-        () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)
+        () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)
     task_count: 247
     task_total_time_ms: 14
     transform_count: 62
@@ -228,7 +226,7 @@ agg-empty-table-tests:
     ref: aggregate-empty-table.yamsql:151
     explain: SCAN([IS T1]) | FILTER _.COL1 EQUALS promote(@c10 AS LONG) | MAP (_ AS
         _0) | AGG (count(_._0.COL2) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0,
-        promote(0l AS LONG)) AS _0)
+        0l) AS _0)
     task_count: 307
     task_total_time_ms: 20
     transform_count: 81
@@ -241,7 +239,7 @@ agg-empty-table-tests:
     ref: aggregate-empty-table.yamsql:156
     explain: SCAN([IS T1]) | FILTER _.COL1 GREATER_THAN promote(@c10 AS LONG) | MAP
         (_ AS _0) | AGG (count(_._0.COL2) AS _0) GROUP BY () | ON EMPTY NULL | MAP
-        (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)
+        (coalesce_long(_._0._0, 0l) AS _0)
     task_count: 307
     task_total_time_ms: 18
     transform_count: 81
@@ -253,7 +251,7 @@ agg-empty-table-tests:
 -   query: EXPLAIN select count(col2) from T2;
     ref: aggregate-empty-table.yamsql:176
     explain: 'AISCAN(T2_I3 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY
-        NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)'
+        NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)'
     task_count: 429
     task_total_time_ms: 58
     transform_count: 124
@@ -266,7 +264,7 @@ agg-empty-table-tests:
     ref: aggregate-empty-table.yamsql:183
     explain: 'AISCAN(T2_I4 [EQUALS promote(@c10 AS LONG)] BY_GROUP -> [_0: KEY:[0],
         _1: VALUE:[0]]) | MAP ((_._1 AS _0) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0,
-        promote(0l AS LONG)) AS _0)'
+        0l) AS _0)'
     task_count: 421
     task_total_time_ms: 43
     transform_count: 127
@@ -279,8 +277,7 @@ agg-empty-table-tests:
     ref: aggregate-empty-table.yamsql:188
     explain: 'AISCAN(T2_I4 [[GREATER_THAN promote(@c10 AS LONG)]] BY_GROUP -> [_0:
         KEY:[0], _1: VALUE:[0]]) | AGG sum_l(_._1) GROUP BY () | MAP ((_._1 AS _0)
-        AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG))
-        AS _0)'
+        AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)'
     task_count: 433
     task_total_time_ms: 45
     transform_count: 128
@@ -328,8 +325,7 @@ agg-empty-table-tests:
 -   query: EXPLAIN select count(col2) from T3;
     ref: aggregate-empty-table.yamsql:208
     explain: ISCAN(T3_I1 <,>) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) GROUP
-        BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS
-        _0)
+        BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)
     task_count: 391
     task_total_time_ms: 34
     transform_count: 90
@@ -341,8 +337,7 @@ agg-empty-table-tests:
 -   query: EXPLAIN select count(col2) from T3 where col1 = 0;
     ref: aggregate-empty-table.yamsql:213
     explain: ISCAN(T3_I1 [EQUALS promote(@c10 AS LONG)]) | MAP (_ AS _0) | AGG (count(_._0.COL2)
-        AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l
-        AS LONG)) AS _0)
+        AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)
     task_count: 611
     task_total_time_ms: 69
     transform_count: 156
@@ -355,7 +350,7 @@ agg-empty-table-tests:
     ref: aggregate-empty-table.yamsql:218
     explain: ISCAN(T3_I1 [[GREATER_THAN promote(@c10 AS LONG)]]) | MAP (_ AS _0) |
         AGG (count(_._0.COL2) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0,
-        promote(0l AS LONG)) AS _0)
+        0l) AS _0)
     task_count: 626
     task_total_time_ms: 51
     transform_count: 157
@@ -670,7 +665,7 @@ agg-empty-table-tests-after-modifications:
 -   query: EXPLAIN select count(*) from T1;
     ref: aggregate-empty-table.yamsql:377
     explain: SCAN([IS T1]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY ()
-        | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)
+        | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)
     task_count: 247
     task_total_time_ms: 8
     transform_count: 62
@@ -696,7 +691,7 @@ agg-empty-table-tests-after-modifications:
     ref: aggregate-empty-table.yamsql:386
     explain: SCAN([IS T1]) | FILTER _.COL1 EQUALS promote(@c10 AS LONG) | MAP (_ AS
         _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0,
-        promote(0l AS LONG)) AS _0)
+        0l) AS _0)
     task_count: 307
     task_total_time_ms: 19
     transform_count: 81
@@ -709,7 +704,7 @@ agg-empty-table-tests-after-modifications:
     ref: aggregate-empty-table.yamsql:391
     explain: SCAN([IS T1]) | FILTER _.COL1 GREATER_THAN promote(@c10 AS LONG) | MAP
         (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0,
-        promote(0l AS LONG)) AS _0)
+        0l) AS _0)
     task_count: 307
     task_total_time_ms: 18
     transform_count: 81
@@ -721,7 +716,7 @@ agg-empty-table-tests-after-modifications:
 -   query: EXPLAIN select count(*) from T2;
     ref: aggregate-empty-table.yamsql:411
     explain: 'AISCAN(T2_I1 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY
-        NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)'
+        NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)'
     task_count: 429
     task_total_time_ms: 38
     transform_count: 124
@@ -746,7 +741,7 @@ agg-empty-table-tests-after-modifications:
 -   query: EXPLAIN select count(col2) from T2;
     ref: aggregate-empty-table.yamsql:491
     explain: 'AISCAN(T2_I3 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY
-        NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)'
+        NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)'
     task_count: 429
     task_total_time_ms: 58
     transform_count: 124
@@ -759,7 +754,7 @@ agg-empty-table-tests-after-modifications:
     ref: aggregate-empty-table.yamsql:496
     explain: 'AISCAN(T2_I4 [EQUALS promote(@c10 AS LONG)] BY_GROUP -> [_0: KEY:[0],
         _1: VALUE:[0]]) | MAP ((_._1 AS _0) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0,
-        promote(0l AS LONG)) AS _0)'
+        0l) AS _0)'
     task_count: 421
     task_total_time_ms: 43
     transform_count: 127
@@ -772,8 +767,7 @@ agg-empty-table-tests-after-modifications:
     ref: aggregate-empty-table.yamsql:501
     explain: 'AISCAN(T2_I4 [[GREATER_THAN promote(@c10 AS LONG)]] BY_GROUP -> [_0:
         KEY:[0], _1: VALUE:[0]]) | AGG sum_l(_._1) GROUP BY () | MAP ((_._1 AS _0)
-        AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG))
-        AS _0)'
+        AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)'
     task_count: 433
     task_total_time_ms: 45
     transform_count: 128
@@ -785,8 +779,7 @@ agg-empty-table-tests-after-modifications:
 -   query: EXPLAIN select count(col2) from T3;
     ref: aggregate-empty-table.yamsql:518
     explain: ISCAN(T3_I1 <,>) | MAP (_ AS _0) | AGG (count(_._0.COL2) AS _0) GROUP
-        BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS
-        _0)
+        BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)
     task_count: 391
     task_total_time_ms: 34
     transform_count: 90
@@ -798,8 +791,7 @@ agg-empty-table-tests-after-modifications:
 -   query: EXPLAIN select count(col2) from T3 where col1 = 0;
     ref: aggregate-empty-table.yamsql:523
     explain: ISCAN(T3_I1 [EQUALS promote(@c10 AS LONG)]) | MAP (_ AS _0) | AGG (count(_._0.COL2)
-        AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l
-        AS LONG)) AS _0)
+        AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)
     task_count: 611
     task_total_time_ms: 69
     transform_count: 156
@@ -812,7 +804,7 @@ agg-empty-table-tests-after-modifications:
     ref: aggregate-empty-table.yamsql:528
     explain: ISCAN(T3_I1 [[GREATER_THAN promote(@c10 AS LONG)]]) | MAP (_ AS _0) |
         AGG (count(_._0.COL2) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0,
-        promote(0l AS LONG)) AS _0)
+        0l) AS _0)
     task_count: 626
     task_total_time_ms: 51
     transform_count: 157
@@ -1038,8 +1030,7 @@ agg-empty-table-tests-after-modifications:
 -   query: EXPLAIN select count(col1) from t3 having count(col1) is null
     ref: aggregate-empty-table.yamsql:666
     explain: ISCAN(T3_I1 <,>) | MAP (_ AS _0) | AGG (count(_._0.COL1) AS _0) GROUP
-        BY () | FILTER coalesce_long(_._0._0, promote(0l AS LONG)) IS_NULL | MAP (coalesce_long(_._0._0,
-        promote(0l AS LONG)) AS _0)
+        BY () | FILTER false | MAP (coalesce_long(_._0._0, 0l) AS _0)
     task_count: 470
     task_total_time_ms: 38
     transform_count: 110
@@ -1052,7 +1043,7 @@ agg-empty-table-tests-after-modifications:
     ref: aggregate-empty-table.yamsql:671
     explain: ISCAN(T3_I2 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY
         () | FILTER coalesce_long(_._0._0, 0l) IS_NULL | MAP (coalesce_long(_._0._0,
-        promote(0l AS LONG)) AS _0)
+        0l) AS _0)
     task_count: 470
     task_total_time_ms: 32
     transform_count: 110
@@ -1103,9 +1094,9 @@ agg-empty-table-tests-after-modifications:
         > 100
     ref: aggregate-empty-table.yamsql:691
     explain: ISCAN(T3_I1 <,>) | MAP (_ AS _0) | AGG (count(_._0.COL1) AS _0) GROUP
-        BY () | ON EMPTY NULL | FILTER coalesce_long(_._0._0, promote(0l AS LONG))
-        IS_NULL OR coalesce_long(_._0._0, promote(0l AS LONG)) GREATER_THAN promote(@c20
-        AS LONG) | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)
+        BY () | ON EMPTY NULL | FILTER coalesce_long(_._0._0, 0l) IS_NULL OR coalesce_long(_._0._0,
+        0l) GREATER_THAN promote(@c20 AS LONG) | MAP (coalesce_long(_._0._0, 0l) AS
+        _0)
     task_count: 418
     task_total_time_ms: 30
     transform_count: 96
@@ -1118,8 +1109,8 @@ agg-empty-table-tests-after-modifications:
     ref: aggregate-empty-table.yamsql:696
     explain: ISCAN(T3_I2 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY
         () | ON EMPTY NULL | FILTER coalesce_long(_._0._0, 0l) IS_NULL OR coalesce_long(_._0._0,
-        0l) GREATER_THAN promote(@c20 AS LONG) | MAP (coalesce_long(_._0._0, promote(0l
-        AS LONG)) AS _0)
+        0l) GREATER_THAN promote(@c20 AS LONG) | MAP (coalesce_long(_._0._0, 0l) AS
+        _0)
     task_count: 418
     task_total_time_ms: 25
     transform_count: 96

--- a/yaml-tests/src/test/resources/aggregate-index-tests-count-empty.metrics.binpb
+++ b/yaml-tests/src/test/resources/aggregate-index-tests-count-empty.metrics.binpb
@@ -1,7 +1,7 @@
-“
+¿
 >
-agg-index-tests-count-emptyEXPLAIN select count(*) from t1è
-•Ç‘Óx •ìŒ(.0‚– 8#@ÖAISCAN(MV1 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)Èdigraph G {
+agg-index-tests-count-emptyEXPLAIN select count(*) from t1˝
+•Ç‘Óx •ìŒ(.0‚– 8#@tAISCAN(MV1 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)Èdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -27,10 +27,10 @@ digraph G {
   3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">MV2</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS COL1, LONG AS COL2)" ];
   3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}’
+}√
 A
-agg-index-tests-count-empty"EXPLAIN select count(col1) from t1è
-•›ªóx ¢åõ(.0°Ô!8#@ÖAISCAN(MV3 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)Èdigraph G {
+agg-index-tests-count-empty"EXPLAIN select count(col1) from t1˝
+•›ªóx ¢åõ(.0°Ô!8#@tAISCAN(MV3 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)Èdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -56,10 +56,10 @@ digraph G {
   3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">MV4</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS COL1, LONG AS COL2)" ];
   3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}Ó
+}‹
 >
-agg-index-tests-count-emptyEXPLAIN select count(*) from t2´
-øÜ∏¸L ¨Ó (0∏è"8!@êISCAN(MV5 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)˙digraph G {
+agg-index-tests-count-emptyEXPLAIN select count(*) from t2ô
+øÜ∏¸L ¨Ó (0∏è"8!@ISCAN(MV5 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)˙digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -90,10 +90,10 @@ L
   4 -> 3 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   5 -> 4 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}˘
+}Ë
 A
-agg-index-tests-count-empty"EXPLAIN select count(col1) from t2≥
-ø—ì©L ’∫¶(0†≠8!@ìISCAN(MV5 <,>) | MAP (_ AS _0) | AGG (count(_._0.COL1) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)ˇdigraph G {
+agg-index-tests-count-empty"EXPLAIN select count(col1) from t2¢
+ø—ì©L ’∫¶(0†≠8!@ÇISCAN(MV5 <,>) | MAP (_ AS _0) | AGG (count(_._0.COL1) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)ˇdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -124,10 +124,10 @@ O
   4 -> 3 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   5 -> 4 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}ò
+}á
 Q
-agg-index-tests-count-empty2EXPLAIN select count(col2) from t1 where col1 = 22¬
-•ÑÂ”{ Í¨í(,0ù≤8#@ÌAISCAN(MV6 [EQUALS promote(@c10 AS LONG)] BY_GROUP -> [_0: KEY:[0], _1: KEY:[1], _2: VALUE:[0]]) | AGG sum_l(_._2) GROUP BY (_._0 AS _0) | MAP ((_._2 AS _0) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)¥digraph G {
+agg-index-tests-count-empty2EXPLAIN select count(col2) from t1 where col1 = 22±
+•ÑÂ”{ Í¨í(,0ù≤8#@‹AISCAN(MV6 [EQUALS promote(@c10 AS LONG)] BY_GROUP -> [_0: KEY:[0], _1: KEY:[1], _2: VALUE:[0]]) | AGG sum_l(_._2) GROUP BY (_._0 AS _0) | MAP ((_._2 AS _0) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)¥digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;

--- a/yaml-tests/src/test/resources/aggregate-index-tests-count-empty.metrics.yaml
+++ b/yaml-tests/src/test/resources/aggregate-index-tests-count-empty.metrics.yaml
@@ -2,7 +2,7 @@ agg-index-tests-count-empty:
 -   query: EXPLAIN select count(*) from t1
     ref: aggregate-index-tests-count-empty.yamsql:36
     explain: 'AISCAN(MV1 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY
-        NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)'
+        NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)'
     task_count: 421
     task_total_time_ms: 24
     transform_count: 120
@@ -26,7 +26,7 @@ agg-index-tests-count-empty:
 -   query: EXPLAIN select count(col1) from t1
     ref: aggregate-index-tests-count-empty.yamsql:49
     explain: 'AISCAN(MV3 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY
-        NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)'
+        NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)'
     task_count: 421
     task_total_time_ms: 25
     transform_count: 120
@@ -50,7 +50,7 @@ agg-index-tests-count-empty:
 -   query: EXPLAIN select count(*) from t2
     ref: aggregate-index-tests-count-empty.yamsql:65
     explain: ISCAN(MV5 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY ()
-        | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)
+        | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)
     task_count: 319
     task_total_time_ms: 14
     transform_count: 76
@@ -74,7 +74,7 @@ agg-index-tests-count-empty:
 -   query: EXPLAIN select count(col1) from t2
     ref: aggregate-index-tests-count-empty.yamsql:75
     explain: ISCAN(MV5 <,>) | MAP (_ AS _0) | AGG (count(_._0.COL1) AS _0) GROUP BY
-        () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)
+        () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)
     task_count: 319
     task_total_time_ms: 6
     transform_count: 76
@@ -99,8 +99,8 @@ agg-index-tests-count-empty:
     ref: aggregate-index-tests-count-empty.yamsql:85
     explain: 'AISCAN(MV6 [EQUALS promote(@c10 AS LONG)] BY_GROUP -> [_0: KEY:[0],
         _1: KEY:[1], _2: VALUE:[0]]) | AGG sum_l(_._2) GROUP BY (_._0 AS _0) | MAP
-        ((_._2 AS _0) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l
-        AS LONG)) AS _0)'
+        ((_._2 AS _0) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS
+        _0)'
     task_count: 421
     task_total_time_ms: 9
     transform_count: 123

--- a/yaml-tests/src/test/resources/aggregate-index-tests-count.metrics.binpb
+++ b/yaml-tests/src/test/resources/aggregate-index-tests-count.metrics.binpb
@@ -1,7 +1,7 @@
-Ì
+º
 8
-agg-index-tests-countEXPLAIN select count(*) from t1
-„öİt Ûòª(*0„¹$8#@…AISCAN(MV1 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)édigraph G {
+agg-index-tests-countEXPLAIN select count(*) from t1ı
+„öİt Ûòª(*0„¹$8#@tAISCAN(MV1 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)édigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -27,10 +27,10 @@ digraph G {
   3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">MV2</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS COL1, LONG AS COL2)" ];
   3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}Ï
+}½
 ;
-agg-index-tests-count"EXPLAIN select count(col1) from t1
-³ğöt ¶Îß(*0«È$8#@…AISCAN(MV3 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)édigraph G {
+agg-index-tests-count"EXPLAIN select count(col1) from t1ı
+³ğöt ¶Îß(*0«È$8#@tAISCAN(MV3 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)édigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -56,10 +56,10 @@ digraph G {
   3 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">MV4</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS COL1, LONG AS COL2)" ];
   3 -> 2 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}û
+}é
 K
-(agg-index-tests-count-after-more-insertsEXPLAIN select count(*) from t2«
-¿ëòL ™±Ï(0íù8!@ISCAN(MV5 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)údigraph G {
+(agg-index-tests-count-after-more-insertsEXPLAIN select count(*) from t2™
+¿ëòL ™±Ï(0íù8!@ISCAN(MV5 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)údigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -90,10 +90,10 @@ Y
   4 -> 3 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   5 -> 4 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}†
+}õ
 N
-(agg-index-tests-count-after-more-inserts"EXPLAIN select count(col1) from t2³
-¿ğ¹L Á­ş(0ÍÖ<8!@“ISCAN(MV5 <,>) | MAP (_ AS _0) | AGG (count(_._0.COL1) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)ÿdigraph G {
+(agg-index-tests-count-after-more-inserts"EXPLAIN select count(col1) from t2¢
+¿ğ¹L Á­ş(0ÍÖ<8!@‚ISCAN(MV5 <,>) | MAP (_ AS _0) | AGG (count(_._0.COL1) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)ÿdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;

--- a/yaml-tests/src/test/resources/aggregate-index-tests-count.metrics.yaml
+++ b/yaml-tests/src/test/resources/aggregate-index-tests-count.metrics.yaml
@@ -2,7 +2,7 @@ agg-index-tests-count:
 -   query: EXPLAIN select count(*) from t1
     ref: aggregate-index-tests-count.yamsql:50
     explain: 'AISCAN(MV1 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY
-        NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)'
+        NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)'
     task_count: 413
     task_total_time_ms: 30
     transform_count: 116
@@ -26,7 +26,7 @@ agg-index-tests-count:
 -   query: EXPLAIN select count(col1) from t1
     ref: aggregate-index-tests-count.yamsql:60
     explain: 'AISCAN(MV3 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY
-        NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)'
+        NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)'
     task_count: 413
     task_total_time_ms: 29
     transform_count: 116
@@ -51,7 +51,7 @@ agg-index-tests-count-after-more-inserts:
 -   query: EXPLAIN select count(*) from t2
     ref: aggregate-index-tests-count.yamsql:89
     explain: ISCAN(MV5 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY ()
-        | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)
+        | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)
     task_count: 319
     task_total_time_ms: 17
     transform_count: 76
@@ -75,7 +75,7 @@ agg-index-tests-count-after-more-inserts:
 -   query: EXPLAIN select count(col1) from t2
     ref: aggregate-index-tests-count.yamsql:99
     explain: ISCAN(MV5 <,>) | MAP (_ AS _0) | AGG (count(_._0.COL1) AS _0) GROUP BY
-        () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)
+        () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)
     task_count: 319
     task_total_time_ms: 24
     transform_count: 76

--- a/yaml-tests/src/test/resources/create-drop.metrics.binpb
+++ b/yaml-tests/src/test/resources/create-drop.metrics.binpb
@@ -1,7 +1,7 @@
-™
+ô
 S
-	unnamed-4FEXPLAIN select count(*) from "TEMPLATES" where template_name = 'TEMP1'“
-πÓ¬åS —‰˘(0˛ã8@∂SCAN([IS TEMPLATES, EQUALS promote(@c10 AS STRING)]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)˚digraph G {
+	unnamed-4FEXPLAIN select count(*) from "TEMPLATES" where template_name = 'TEMP1'¡
+πÓ¬åS —‰˘(0˛ã8@•SCAN([IS TEMPLATES, EQUALS promote(@c10 AS STRING)]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)˚digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -16,11 +16,11 @@ S
   5 -> 4 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   6 -> 5 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}û
+}ç
 T
 
-unnamed-10FEXPLAIN select count(*) from "DATABASES" where database_id = '/FRL/DB'≈
-≈‡ÿ∞\ ∏§ç(0Éü8@∂SCAN([IS DATABASES, EQUALS promote(@c10 AS STRING)]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)Ódigraph G {
+unnamed-10FEXPLAIN select count(*) from "DATABASES" where database_id = '/FRL/DB'¥
+≈‡ÿ∞\ ∏§ç(0Éü8@•SCAN([IS DATABASES, EQUALS promote(@c10 AS STRING)]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)Ódigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -35,11 +35,11 @@ unnamed-10FEXPLAIN select count(*) from "DATABASES" where database_id = '/FRL/D
   5 -> 4 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   6 -> 5 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}û
+}ç
 R
 
-unnamed-20DEXPLAIN select count(*) from "SCHEMAS" where database_id = '/FRL/DB'«
-°†≥ﬂç úùó(,0«º8<@¥SCAN([IS SCHEMAS, EQUALS promote(@c10 AS STRING)]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)Òdigraph G {
+unnamed-20DEXPLAIN select count(*) from "SCHEMAS" where database_id = '/FRL/DB'∂
+°†≥ﬂç úùó(,0«º8<@£SCAN([IS SCHEMAS, EQUALS promote(@c10 AS STRING)]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)Òdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;

--- a/yaml-tests/src/test/resources/create-drop.metrics.yaml
+++ b/yaml-tests/src/test/resources/create-drop.metrics.yaml
@@ -3,7 +3,7 @@ unnamed-4:
     ref: create-drop.yamsql:60
     explain: SCAN([IS TEMPLATES, EQUALS promote(@c10 AS STRING)]) | MAP (_ AS _0)
         | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0,
-        promote(0l AS LONG)) AS _0)
+        0l) AS _0)
     task_count: 313
     task_total_time_ms: 12
     transform_count: 83
@@ -17,7 +17,7 @@ unnamed-10:
     ref: create-drop.yamsql:100
     explain: SCAN([IS DATABASES, EQUALS promote(@c10 AS STRING)]) | MAP (_ AS _0)
         | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0,
-        promote(0l AS LONG)) AS _0)
+        0l) AS _0)
     task_count: 325
     task_total_time_ms: 7
     transform_count: 92
@@ -31,7 +31,7 @@ unnamed-20:
     ref: create-drop.yamsql:166
     explain: SCAN([IS SCHEMAS, EQUALS promote(@c10 AS STRING)]) | MAP (_ AS _0) |
         AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0,
-        promote(0l AS LONG)) AS _0)
+        0l) AS _0)
     task_count: 545
     task_total_time_ms: 7
     transform_count: 141

--- a/yaml-tests/src/test/resources/distinct-from.metrics.binpb
+++ b/yaml-tests/src/test/resources/distinct-from.metrics.binpb
@@ -143,10 +143,10 @@ V
   3 -> 2 [ label=<&nbsp;q61> label="q61" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   4 -> 3 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q63> label="q63" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}
+}ﬂ
 _
-not-distinct-from-testsDEXPLAIN select count(*) from t1 WHERE null is not distinct from nullå
-ÃÛ™÷Œ ΩÅå(<0å√S8]@™AISCAN(CNT <,> BY_GROUP -> [_0: VALUE:[0]]) | FILTER NULL NOT_DISTINCT_FROM NULL | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)¿digraph G {
+not-distinct-from-testsDEXPLAIN select count(*) from t1 WHERE null is not distinct from null˚
+ÃÛ™÷Œ ΩÅå(<0å√S8]@ôAISCAN(CNT <,> BY_GROUP -> [_0: VALUE:[0]]) | FILTER NULL NOT_DISTINCT_FROM NULL | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)¿digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -161,10 +161,10 @@ _
   5 -> 4 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   6 -> 5 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}Ë
+}◊
 [
-not-distinct-from-tests@EXPLAIN select count(*) from t1 WHERE 10 is not distinct from 10à
-ÃÃ§ùŒ óﬂœ(<0ÍÏ68]@®AISCAN(CNT <,> BY_GROUP -> [_0: VALUE:[0]]) | FILTER @c8 NOT_DISTINCT_FROM @c8 | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)ædigraph G {
+not-distinct-from-tests@EXPLAIN select count(*) from t1 WHERE 10 is not distinct from 10˜
+ÃÃ§ùŒ óﬂœ(<0ÍÏ68]@óAISCAN(CNT <,> BY_GROUP -> [_0: VALUE:[0]]) | FILTER @c8 NOT_DISTINCT_FROM @c8 | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)ædigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;

--- a/yaml-tests/src/test/resources/distinct-from.metrics.yaml
+++ b/yaml-tests/src/test/resources/distinct-from.metrics.yaml
@@ -123,8 +123,8 @@ not-distinct-from-tests:
 -   query: EXPLAIN select count(*) from t1 WHERE null is not distinct from null
     ref: distinct-from.yamsql:95
     explain: 'AISCAN(CNT <,> BY_GROUP -> [_0: VALUE:[0]]) | FILTER NULL NOT_DISTINCT_FROM
-        NULL | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l
-        AS LONG)) AS _0)'
+        NULL | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS
+        _0)'
     task_count: 844
     task_total_time_ms: 47
     transform_count: 206
@@ -136,8 +136,7 @@ not-distinct-from-tests:
 -   query: EXPLAIN select count(*) from t1 WHERE 10 is not distinct from 10
     ref: distinct-from.yamsql:99
     explain: 'AISCAN(CNT <,> BY_GROUP -> [_0: VALUE:[0]]) | FILTER @c8 NOT_DISTINCT_FROM
-        @c8 | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l
-        AS LONG)) AS _0)'
+        @c8 | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)'
     task_count: 844
     task_total_time_ms: 23
     transform_count: 206

--- a/yaml-tests/src/test/resources/field-index-tests-proto.metrics.binpb
+++ b/yaml-tests/src/test/resources/field-index-tests-proto.metrics.binpb
@@ -1,7 +1,7 @@
-¢
+ë
 è
-field-index-tests-prototEXPLAIN select count(*) from (select * from (select * from (select * from "MyTable"  where ID = 5) as x) as y) as z;ç
-è§ãáb Üÿ¶(0Òπ&8)@áSCAN([EQUALS promote(@c22 AS LONG)]) | TFILTER MyTable | MAP ((_.ID AS ID, _.COL1 AS COL1, _.COL31 AS COL31, _.COL32 AS COL32, _.COL2 AS COL2) AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)Âdigraph G {
+field-index-tests-prototEXPLAIN select count(*) from (select * from (select * from (select * from "MyTable"  where ID = 5) as x) as y) as z;¸
+è§ãáb Üÿ¶(0Òπ&8)@ˆSCAN([EQUALS promote(@c22 AS LONG)]) | TFILTER MyTable | MAP ((_.ID AS ID, _.COL1 AS COL1, _.COL31 AS COL31, _.COL32 AS COL32, _.COL2 AS COL2) AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)Âdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -38,10 +38,10 @@ C
   6 -> 5 [ label=<&nbsp;q25> label="q25" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   7 -> 6 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}€
+} 
 E
-field-index-tests-proto*EXPLAIN select count(COL1) from "MyTable";ë
-ÑçÇö? ¿‘±(0¨ç8@†SCAN(<,>) | TFILTER MyTable | MAP (_ AS _0) | AGG (count(_._0.COL1) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)–digraph G {
+field-index-tests-proto*EXPLAIN select count(COL1) from "MyTable";Ä
+ÑçÇö? ¿‘±(0¨ç8@èSCAN(<,>) | TFILTER MyTable | MAP (_ AS _0) | AGG (count(_._0.COL1) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)–digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;

--- a/yaml-tests/src/test/resources/field-index-tests-proto.metrics.yaml
+++ b/yaml-tests/src/test/resources/field-index-tests-proto.metrics.yaml
@@ -5,7 +5,7 @@ field-index-tests-proto:
     explain: SCAN([EQUALS promote(@c22 AS LONG)]) | TFILTER MyTable | MAP ((_.ID AS
         ID, _.COL1 AS COL1, _.COL31 AS COL31, _.COL32 AS COL32, _.COL2 AS COL2) AS
         _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0,
-        promote(0l AS LONG)) AS _0)
+        0l) AS _0)
     task_count: 399
     task_total_time_ms: 35
     transform_count: 98
@@ -29,8 +29,7 @@ field-index-tests-proto:
 -   query: EXPLAIN select count(COL1) from "MyTable";
     ref: field-index-tests-proto.yamsql:72
     explain: SCAN(<,>) | TFILTER MyTable | MAP (_ AS _0) | AGG (count(_._0.COL1) AS
-        _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS
-        LONG)) AS _0)
+        _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)
     task_count: 260
     task_total_time_ms: 13
     transform_count: 63

--- a/yaml-tests/src/test/resources/groupby-tests.metrics.binpb
+++ b/yaml-tests/src/test/resources/groupby-tests.metrics.binpb
@@ -66,10 +66,10 @@ R
   5 -> 4 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   6 -> 5 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q8> label="q8" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}Ω
+}¨
 T
-group-by-testsBEXPLAIN select COUNT(x.col2) from (select col1,col2 from t1) as x;‰
-Ÿ∏”Û	R ¥øü(0≠–+8%@±ISCAN(I1 <,>) | MAP ((_.COL1 AS COL1, _.COL2 AS COL2) AS _0) | AGG (count(_._0.COL2) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)ídigraph G {
+group-by-testsBEXPLAIN select COUNT(x.col2) from (select col1,col2 from t1) as x;”
+Ÿ∏”Û	R ¥øü(0≠–+8%@†ISCAN(I1 <,>) | MAP ((_.COL1 AS COL1, _.COL2 AS COL2) AS _0) | AGG (count(_._0.COL2) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)ídigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -102,10 +102,10 @@ R
   5 -> 4 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   6 -> 5 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q8> label="q8" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}∂
+}§
 2
-group-by-tests EXPLAIN select COUNT(*) from T1;ˇ
-ø¡íóL È±„(0∫¡8!@èISCAN(I1 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)œdigraph G {
+group-by-tests EXPLAIN select COUNT(*) from T1;Ì
+ø¡íóL È±„(0∫¡8!@~ISCAN(I1 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)œdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -120,10 +120,10 @@ R
   5 -> 4 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   6 -> 5 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}¡
+}∞
 5
-group-by-tests#EXPLAIN select COUNT(col1) from T1;á
-øÂÛËL œÇ»(0°æ$8!@íISCAN(I1 <,>) | MAP (_ AS _0) | AGG (count(_._0.COL1) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)‘digraph G {
+group-by-tests#EXPLAIN select COUNT(col1) from T1;ˆ
+øÂÛËL œÇ»(0°æ$8!@ÅISCAN(I1 <,>) | MAP (_ AS _0) | AGG (count(_._0.COL1) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)‘digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -138,10 +138,10 @@ R
   5 -> 4 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   6 -> 5 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}˝
+}Ï
 M
-group-by-tests;EXPLAIN SELECT COUNT(*) from T1 WHERE col1 = 20 or col2 = 5´
-≥¥˝äÑ íÄì(G0∫ﬂ;8í@„ISCAN(I1 <,>) | FILTER _.COL1 EQUALS promote(@c10 AS LONG) OR _.COL2 EQUALS promote(@c14 AS LONG) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)•digraph G {
+group-by-tests;EXPLAIN SELECT COUNT(*) from T1 WHERE col1 = 20 or col2 = 5ö
+≥¥˝äÑ íÄì(G0∫ﬂ;8í@“ISCAN(I1 <,>) | FILTER _.COL1 EQUALS promote(@c10 AS LONG) OR _.COL2 EQUALS promote(@c14 AS LONG) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)•digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -158,10 +158,10 @@ M
   6 -> 5 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   7 -> 6 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}˛
+}Ì
 N
-group-by-tests<EXPLAIN SELECT COUNT(*) from T1 WHERE col1 = 20 or col2 = 10´
-≥¥˝äÑ íÄì(G0∫ﬂ;8í@„ISCAN(I1 <,>) | FILTER _.COL1 EQUALS promote(@c10 AS LONG) OR _.COL2 EQUALS promote(@c14 AS LONG) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)•digraph G {
+group-by-tests<EXPLAIN SELECT COUNT(*) from T1 WHERE col1 = 20 or col2 = 10ö
+≥¥˝äÑ íÄì(G0∫ﬂ;8í@“ISCAN(I1 <,>) | FILTER _.COL1 EQUALS promote(@c10 AS LONG) OR _.COL2 EQUALS promote(@c14 AS LONG) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)•digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;

--- a/yaml-tests/src/test/resources/groupby-tests.metrics.yaml
+++ b/yaml-tests/src/test/resources/groupby-tests.metrics.yaml
@@ -53,8 +53,7 @@ group-by-tests:
 -   query: EXPLAIN select COUNT(x.col2) from (select col1,col2 from t1) as x;
     ref: groupby-tests.yamsql:162
     explain: ISCAN(I1 <,>) | MAP ((_.COL1 AS COL1, _.COL2 AS COL2) AS _0) | AGG (count(_._0.COL2)
-        AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l
-        AS LONG)) AS _0)
+        AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)
     task_count: 345
     task_total_time_ms: 20
     transform_count: 82
@@ -78,7 +77,7 @@ group-by-tests:
 -   query: EXPLAIN select COUNT(*) from T1;
     ref: groupby-tests.yamsql:185
     explain: ISCAN(I1 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY ()
-        | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)
+        | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)
     task_count: 319
     task_total_time_ms: 10
     transform_count: 76
@@ -90,7 +89,7 @@ group-by-tests:
 -   query: EXPLAIN select COUNT(col1) from T1;
     ref: groupby-tests.yamsql:189
     explain: ISCAN(I1 <,>) | MAP (_ AS _0) | AGG (count(_._0.COL1) AS _0) GROUP BY
-        () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)
+        () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)
     task_count: 319
     task_total_time_ms: 14
     transform_count: 76
@@ -103,8 +102,7 @@ group-by-tests:
     ref: groupby-tests.yamsql:196
     explain: ISCAN(I1 <,>) | FILTER _.COL1 EQUALS promote(@c10 AS LONG) OR _.COL2
         EQUALS promote(@c14 AS LONG) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP
-        BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS
-        _0)
+        BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)
     task_count: 1075
     task_total_time_ms: 25
     transform_count: 260
@@ -117,8 +115,7 @@ group-by-tests:
     ref: groupby-tests.yamsql:205
     explain: ISCAN(I1 <,>) | FILTER _.COL1 EQUALS promote(@c10 AS LONG) OR _.COL2
         EQUALS promote(@c14 AS LONG) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP
-        BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS
-        _0)
+        BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)
     task_count: 1075
     task_total_time_ms: 25
     transform_count: 260

--- a/yaml-tests/src/test/resources/join-tests-outer.metrics.binpb
+++ b/yaml-tests/src/test/resources/join-tests-outer.metrics.binpb
@@ -583,10 +583,10 @@ z
     rankDir=LR;
     5 -> 4 [ color="red" style="invis" ];
   }
-}‹/
+}ú.
 k
-left-outer-joinXEXPLAIN SELECT COUNT(*) FROM "emp" "e" LEFT JOIN "dept" "d" ON "e"."dept_id" = "d"."id";›.
-Íù¼Ýš ÁÖ„(60é¼8F@ûISCAN(emp$fname <,>) | FLATMAP q0 -> { COVERING(dept$name <,> -> [id: KEY:[2], name: KEY:[0]]) | FILTER q0.dept_id EQUALS _.id | FETCH | ON EMPTY NULL AS q1 RETURN ((q0.id AS _0, q0.fname AS _1, q0.lname AS _2, q0.dept_id AS _3, q1.id AS _4, q1.name AS _5) AS _0) } | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)þ*digraph G {
+left-outer-joinXEXPLAIN SELECT COUNT(*) FROM "emp" "e" LEFT JOIN "dept" "d" ON "e"."dept_id" = "d"."id";Š.
+Íù¼Ýš ÁÖ„(60é¼8F@êISCAN(emp$fname <,>) | FLATMAP q0 -> { COVERING(dept$name <,> -> [id: KEY:[2], name: KEY:[0]]) | FILTER q0.dept_id EQUALS _.id | FETCH | ON EMPTY NULL AS q1 RETURN ((q0.id AS _0, q0.fname AS _1, q0.lname AS _2, q0.dept_id AS _3, q1.id AS _4, q1.name AS _5) AS _0) } | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)þ*digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -682,10 +682,10 @@ k
     rankDir=LR;
     2 -> 4 [ color="red" style="invis" ];
   }
-}…"
+}ò!
 Œ
-left-outer-joinyEXPLAIN SELECT "e"."fname", COALESCE("d"."name", 'None') FROM "emp" "e" LEFT JOIN "dept" "d" ON "e"."dept_id" = "d"."id";ó 
-é¼¢Ù„ •»÷(20ø¶8=@òISCAN(emp$fname <,>) | FLATMAP q0 -> { COVERING(dept$name <,> -> [id: KEY:[2], name: KEY:[0]]) | FILTER q0.dept_id EQUALS _.id | FETCH | ON EMPTY NULL AS q1 RETURN (q0.fname AS fname, coalesce_string(q1.name, promote(@c11 AS STRING)) AS _1) }ßdigraph G {
+left-outer-joinyEXPLAIN SELECT "e"."fname", COALESCE("d"."name", 'None') FROM "emp" "e" LEFT JOIN "dept" "d" ON "e"."dept_id" = "d"."id";à 
+é¼¢Ù„ •»÷(20ø¶8=@ßISCAN(emp$fname <,>) | FLATMAP q0 -> { COVERING(dept$name <,> -> [id: KEY:[2], name: KEY:[0]]) | FILTER q0.dept_id EQUALS _.id | FETCH | ON EMPTY NULL AS q1 RETURN (q0.fname AS fname, coalesce_string(q1.name, @c11) AS _1) }ßdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -1209,10 +1209,10 @@ m
     rankDir=LR;
     2 -> 4 [ color="red" style="invis" ];
   }
-}ç
+}Ô
 Ž
-right-outer-joinzEXPLAIN SELECT COALESCE("e"."fname", 'None'), "d"."name" FROM "emp" "e" RIGHT JOIN "dept" "d" ON "e"."dept_id" = "d"."id";Ó
-Ì½Á¸€ ÚëÙ(10Ìî87@ÅISCAN(dept$name <,>) | FLATMAP q0 -> { ISCAN(emp$fname <,>) | FILTER _.dept_id EQUALS q0.id | ON EMPTY NULL AS q1 RETURN (coalesce_string(q1.fname, promote(@c7 AS STRING)) AS _0, q0.name AS name) }ìdigraph G {
+right-outer-joinzEXPLAIN SELECT COALESCE("e"."fname", 'None'), "d"."name" FROM "emp" "e" RIGHT JOIN "dept" "d" ON "e"."dept_id" = "d"."id";À
+Ì½Á¸€ ÚëÙ(10Ìî87@²ISCAN(dept$name <,>) | FLATMAP q0 -> { ISCAN(emp$fname <,>) | FILTER _.dept_id EQUALS q0.id | ON EMPTY NULL AS q1 RETURN (coalesce_string(q1.fname, @c7) AS _0, q0.name AS name) }ìdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;

--- a/yaml-tests/src/test/resources/join-tests-outer.metrics.yaml
+++ b/yaml-tests/src/test/resources/join-tests-outer.metrics.yaml
@@ -271,8 +271,7 @@ left-outer-join:
         KEY:[2], name: KEY:[0]]) | FILTER q0.dept_id EQUALS _.id | FETCH | ON EMPTY
         NULL AS q1 RETURN ((q0.id AS _0, q0.fname AS _1, q0.lname AS _2, q0.dept_id
         AS _3, q1.id AS _4, q1.name AS _5) AS _0) } | AGG (count_star(*) AS _0) GROUP
-        BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS
-        _0)'
+        BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)'
     task_count: 589
     task_total_time_ms: 9
     transform_count: 154
@@ -315,8 +314,8 @@ left-outer-join:
     ref: join-tests-outer.yamsql:306
     explain: 'ISCAN(emp$fname <,>) | FLATMAP q0 -> { COVERING(dept$name <,> -> [id:
         KEY:[2], name: KEY:[0]]) | FILTER q0.dept_id EQUALS _.id | FETCH | ON EMPTY
-        NULL AS q1 RETURN (q0.fname AS fname, coalesce_string(q1.name, promote(@c11
-        AS STRING)) AS _1) }'
+        NULL AS q1 RETURN (q0.fname AS fname, coalesce_string(q1.name, @c11) AS _1)
+        }'
     task_count: 489
     task_total_time_ms: 7
     transform_count: 132
@@ -559,7 +558,7 @@ right-outer-join:
     ref: join-tests-outer.yamsql:491
     explain: ISCAN(dept$name <,>) | FLATMAP q0 -> { ISCAN(emp$fname <,>) | FILTER
         _.dept_id EQUALS q0.id | ON EMPTY NULL AS q1 RETURN (coalesce_string(q1.fname,
-        promote(@c7 AS STRING)) AS _0, q0.name AS name) }
+        @c7) AS _0, q0.name AS name) }
     task_count: 460
     task_total_time_ms: 7
     transform_count: 128

--- a/yaml-tests/src/test/resources/nested-with-nulls-proto.metrics.binpb
+++ b/yaml-tests/src/test/resources/nested-with-nulls-proto.metrics.binpb
@@ -344,10 +344,10 @@ _
   4 -> 3 [ label=<&nbsp;q19> label="q19" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   5 -> 4 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q26> label="q26" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}œ
+}‰
 _
-nested-with-nulls-proto-tests>EXPLAIN select id from t1 where coalesce(a.b.a, 'foo') IS NULL¸
-öØ›ŸB ý»«(0ƒ¥8@lSCAN(<,>) | TFILTER T1 | FILTER coalesce_string(_.A.B.A, promote(@c13 AS STRING)) IS_NULL | MAP (_.ID AS ID)¬digraph G {
+nested-with-nulls-proto-tests>EXPLAIN select id from t1 where coalesce(a.b.a, 'foo') IS NULL¥
+öØ›ŸB ý»«(0ƒ¥8@YSCAN(<,>) | TFILTER T1 | FILTER coalesce_string(_.A.B.A, @c13) IS_NULL | MAP (_.ID AS ID)¬digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;

--- a/yaml-tests/src/test/resources/nested-with-nulls-proto.metrics.yaml
+++ b/yaml-tests/src/test/resources/nested-with-nulls-proto.metrics.yaml
@@ -247,8 +247,8 @@ nested-with-nulls-proto-tests:
     insert_reused_count: 2
 -   query: EXPLAIN select id from t1 where coalesce(a.b.a, 'foo') IS NULL
     ref: nested-with-nulls-proto.yamsql:145
-    explain: SCAN(<,>) | TFILTER T1 | FILTER coalesce_string(_.A.B.A, promote(@c13
-        AS STRING)) IS_NULL | MAP (_.ID AS ID)
+    explain: SCAN(<,>) | TFILTER T1 | FILTER coalesce_string(_.A.B.A, @c13) IS_NULL
+        | MAP (_.ID AS ID)
     task_count: 246
     task_total_time_ms: 10
     transform_count: 66

--- a/yaml-tests/src/test/resources/nested-with-nulls.metrics.binpb
+++ b/yaml-tests/src/test/resources/nested-with-nulls.metrics.binpb
@@ -302,10 +302,10 @@ Y
   3 -> 2 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   4 -> 3 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q45> label="q45" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}±
+}ž
 Y
-nested-with-nulls-tests>EXPLAIN select id from t1 where coalesce(a.b.a, 'foo') IS NULLÓ
-ó•Ñüh …°Í( 0¸ñ8(@cISCAN(I1 <,>) | FILTER coalesce_string(_.A.B.A, promote(@c13 AS STRING)) IS_NULL | MAP (_.ID AS ID)Ðdigraph G {
+nested-with-nulls-tests>EXPLAIN select id from t1 where coalesce(a.b.a, 'foo') IS NULLÀ
+ó•Ñüh …°Í( 0¸ñ8(@PISCAN(I1 <,>) | FILTER coalesce_string(_.A.B.A, @c13) IS_NULL | MAP (_.ID AS ID)Ðdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;

--- a/yaml-tests/src/test/resources/nested-with-nulls.metrics.yaml
+++ b/yaml-tests/src/test/resources/nested-with-nulls.metrics.yaml
@@ -252,8 +252,8 @@ nested-with-nulls-tests:
     insert_reused_count: 4
 -   query: EXPLAIN select id from t1 where coalesce(a.b.a, 'foo') IS NULL
     ref: nested-with-nulls.yamsql:138
-    explain: ISCAN(I1 <,>) | FILTER coalesce_string(_.A.B.A, promote(@c13 AS STRING))
-        IS_NULL | MAP (_.ID AS ID)
+    explain: ISCAN(I1 <,>) | FILTER coalesce_string(_.A.B.A, @c13) IS_NULL | MAP (_.ID
+        AS ID)
     task_count: 371
     task_total_time_ms: 8
     transform_count: 104

--- a/yaml-tests/src/test/resources/null-operator-tests.metrics.binpb
+++ b/yaml-tests/src/test/resources/null-operator-tests.metrics.binpb
@@ -1,7 +1,7 @@
-Ó
+Â
 v
-null-operator-tests_EXPLAIN select count(*) from (select * from (select * from T1) as x where ID is not null) as y;Ø
-ÊÑÄ¹	Ž ­åô((0“Ë/8A@›SCAN([IS T1, [NOT_NULL]]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)›digraph G {
+null-operator-tests_EXPLAIN select count(*) from (select * from (select * from T1) as x where ID is not null) as y;Ç
+ÊÑÄ¹	Ž ­åô((0“Ë/8A@ŠSCAN([IS T1, [NOT_NULL]]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)›digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;

--- a/yaml-tests/src/test/resources/null-operator-tests.metrics.yaml
+++ b/yaml-tests/src/test/resources/null-operator-tests.metrics.yaml
@@ -3,8 +3,7 @@ null-operator-tests:
         ID is not null) as y;
     ref: null-operator-tests.yamsql:50
     explain: SCAN([IS T1, [NOT_NULL]]) | MAP (_ AS _0) | AGG (count_star(*) AS _0)
-        GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG))
-        AS _0)
+        GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)
     task_count: 586
     task_total_time_ms: 19
     transform_count: 142

--- a/yaml-tests/src/test/resources/primary-key-tests.metrics.binpb
+++ b/yaml-tests/src/test/resources/primary-key-tests.metrics.binpb
@@ -1,7 +1,7 @@
-Ž
+ü
 4
-primary-key-testsEXPLAIN SELECT COUNT(*) FROM T1Õ
-÷²Â> ß¬H(0üè8@SCAN([IS T1]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)¦digraph G {
+primary-key-testsEXPLAIN SELECT COUNT(*) FROM T1Ã
+÷²Â> ß¬H(0üè8@~SCAN([IS T1]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)¦digraph G {
   fontname=courier;
   rankdir=BT;
   splines=polyline;

--- a/yaml-tests/src/test/resources/primary-key-tests.metrics.yaml
+++ b/yaml-tests/src/test/resources/primary-key-tests.metrics.yaml
@@ -2,7 +2,7 @@ primary-key-tests:
 -   query: EXPLAIN SELECT COUNT(*) FROM T1
     ref: primary-key-tests.yamsql:36
     explain: SCAN([IS T1]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY ()
-        | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)
+        | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)
     task_count: 247
     task_total_time_ms: 2
     transform_count: 62

--- a/yaml-tests/src/test/resources/record-type-key-tests.metrics.binpb
+++ b/yaml-tests/src/test/resources/record-type-key-tests.metrics.binpb
@@ -120,10 +120,10 @@ index-scan&EXPLAIN SELECT * from t2 where d = 201¸
   1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index Scan</td></tr><tr><td align="left">comparisons: [EQUALS promote(@c8 AS LONG)]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS C, LONG AS D)" ];
   2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Index</td></tr><tr><td align="left">I2</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS C, LONG AS D)" ];
   2 -> 1 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}Ä
+}Ó
 2
-table-isolationEXPLAIN SELECT count(*) from t1…
-øµ√‘L Ö‚Ω(0°”K8!@èISCAN(I1 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)ôdigraph G {
+table-isolationEXPLAIN SELECT count(*) from t1∑
+øµ√‘L Ö‚Ω(0°”K8!@~ISCAN(I1 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)ôdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -138,10 +138,10 @@ index-scan&EXPLAIN SELECT * from t2 where d = 201¸
   5 -> 4 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   6 -> 5 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}Ä
+}Ó
 2
-table-isolationEXPLAIN SELECT count(*) from t2…
-ø”ÇÅ	L ∞ÅÌ(0ÅÅI8!@èISCAN(I2 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)ôdigraph G {
+table-isolationEXPLAIN SELECT count(*) from t2∑
+ø”ÇÅ	L ∞ÅÌ(0ÅÅI8!@~ISCAN(I2 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)ôdigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;

--- a/yaml-tests/src/test/resources/record-type-key-tests.metrics.yaml
+++ b/yaml-tests/src/test/resources/record-type-key-tests.metrics.yaml
@@ -139,7 +139,7 @@ table-isolation:
 -   query: EXPLAIN SELECT count(*) from t1
     ref: record-type-key-tests.yamsql:115
     explain: ISCAN(I1 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY ()
-        | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)
+        | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)
     task_count: 319
     task_total_time_ms: 16
     transform_count: 76
@@ -151,7 +151,7 @@ table-isolation:
 -   query: EXPLAIN SELECT count(*) from t2
     ref: record-type-key-tests.yamsql:119
     explain: ISCAN(I2 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY ()
-        | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)
+        | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)
     task_count: 319
     task_total_time_ms: 18
     transform_count: 76

--- a/yaml-tests/src/test/resources/standard-tests-metadata.metrics.binpb
+++ b/yaml-tests/src/test/resources/standard-tests-metadata.metrics.binpb
@@ -1,7 +1,7 @@
-¸
+Î
 à
-standard-tests-metadatamEXPLAIN select count(*) from (select * from (select * from (select * from T1  where ID = 5) as x) as y) as z;Ó
-èÖ◊Èb æñﬁ(0é©8)@≥SCAN([EQUALS promote(@c22 AS LONG)]) | TFILTER T1 | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)ödigraph G {
+standard-tests-metadatamEXPLAIN select count(*) from (select * from (select * from (select * from T1  where ID = 5) as x) as y) as z;›
+èÖ◊Èb æñﬁ(0é©8)@¢SCAN([EQUALS promote(@c22 AS LONG)]) | TFILTER T1 | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)ödigraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;

--- a/yaml-tests/src/test/resources/standard-tests-metadata.metrics.yaml
+++ b/yaml-tests/src/test/resources/standard-tests-metadata.metrics.yaml
@@ -4,7 +4,7 @@ standard-tests-metadata:
     ref: standard-tests-metadata.yamsql:61
     explain: SCAN([EQUALS promote(@c22 AS LONG)]) | TFILTER T1 | MAP (_ AS _0) | AGG
         (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0,
-        promote(0l AS LONG)) AS _0)
+        0l) AS _0)
     task_count: 399
     task_total_time_ms: 26
     transform_count: 98

--- a/yaml-tests/src/test/resources/standard-tests-proto.metrics.binpb
+++ b/yaml-tests/src/test/resources/standard-tests-proto.metrics.binpb
@@ -26,10 +26,10 @@ j
   3 -> 2 [ label=<&nbsp;q37> label="q37" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   4 -> 3 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}ν
+}ά
 z
-	unnamed-2mEXPLAIN select count(*) from (select * from (select * from (select * from T1  where ID = 5) as x) as y) as z;ξ
-τέb ­ΰΠ(0”ή$8)@³SCAN([EQUALS promote(@c22 AS LONG)]) | TFILTER T1 | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)digraph G {
+	unnamed-2mEXPLAIN select count(*) from (select * from (select * from (select * from T1  where ID = 5) as x) as y) as z;έ
+τέb ­ΰΠ(0”ή$8)@ΆSCAN([EQUALS promote(@c22 AS LONG)]) | TFILTER T1 | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;

--- a/yaml-tests/src/test/resources/standard-tests-proto.metrics.yaml
+++ b/yaml-tests/src/test/resources/standard-tests-proto.metrics.yaml
@@ -30,7 +30,7 @@ unnamed-2:
     ref: standard-tests-proto.yamsql:62
     explain: SCAN([EQUALS promote(@c22 AS LONG)]) | TFILTER T1 | MAP (_ AS _0) | AGG
         (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0,
-        promote(0l AS LONG)) AS _0)
+        0l) AS _0)
     task_count: 399
     task_total_time_ms: 26
     transform_count: 98

--- a/yaml-tests/src/test/resources/standard-tests.metrics.binpb
+++ b/yaml-tests/src/test/resources/standard-tests.metrics.binpb
@@ -197,10 +197,10 @@ b
   1 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Scan</td></tr><tr><td align="left">comparisons: [IS T1, EQUALS promote(@c21 AS LONG)]</td></tr></table>> color="black" shape="plain" style="solid" fillcolor="black" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS COL1, LONG AS COL2)" ];
   2 [ label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="8"><tr><td align="left">Primary Storage</td></tr><tr><td align="left">record types: [T1]</td></tr></table>> color="black" shape="plain" style="filled" fillcolor="lightblue" fontname="courier" fontsize="8" tooltip="RELATION(LONG AS ID, LONG AS COL1, LONG AS COL2)" ];
   2 -> 1 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}
+}π
 
-standard-testsmEXPLAIN select count(*) from (select * from (select * from (select * from T1  where ID = 5) as x) as y) as z;ύ
-ΡΎ‚Ι( Ξ²Δ	()0ΰνώ8B@­SCAN([IS T1, EQUALS promote(@c22 AS LONG)]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0)­digraph G {
+standard-testsmEXPLAIN select count(*) from (select * from (select * from (select * from T1  where ID = 5) as x) as y) as z;μ
+ΡΎ‚Ι( Ξ²Δ	()0ΰνώ8B@SCAN([IS T1, EQUALS promote(@c22 AS LONG)]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)­digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;

--- a/yaml-tests/src/test/resources/standard-tests.metrics.yaml
+++ b/yaml-tests/src/test/resources/standard-tests.metrics.yaml
@@ -201,8 +201,7 @@ standard-tests:
         T1  where ID = 5) as x) as y) as z;
     ref: standard-tests.yamsql:293
     explain: SCAN([IS T1, EQUALS promote(@c22 AS LONG)]) | MAP (_ AS _0) | AGG (count_star(*)
-        AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l
-        AS LONG)) AS _0)
+        AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)
     task_count: 593
     task_total_time_ms: 85
     transform_count: 144

--- a/yaml-tests/src/test/resources/union-empty-tables.metrics.binpb
+++ b/yaml-tests/src/test/resources/union-empty-tables.metrics.binpb
@@ -1,8 +1,8 @@
-Ó
+Â
 A
-	unnamed-14EXPLAIN select sum(col1) as a, count(*) as b from t1
+	unnamed-14EXPLAIN select sum(col1) as a, count(*) as b from t1ü
 ÷ùÛœ> ”Ÿb(0äõ
-8@´SCAN([IS T1]) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0, count_star(*) AS _1) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS A, coalesce_long(_._0._1, promote(0l AS LONG)) AS B)¹digraph G {
+8@£SCAN([IS T1]) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0, count_star(*) AS _1) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS A, coalesce_long(_._0._1, 0l) AS B)¹digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -17,11 +17,11 @@ A
   5 -> 4 [ label=<&nbsp;q2> label="q2" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   6 -> 5 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q6> label="q6" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}“F
+}ñE
 ¥
-	unnamed-1—EXPLAIN select sum(a) as a, sum(b) as b from (select sum(col1) as a, count(*) as b from t1 union all select sum(col1) as a, count(*) as b from t2) as xèD
+	unnamed-1—EXPLAIN select sum(a) as a, sum(b) as b from (select sum(col1) as a, count(*) as b from t1 union all select sum(col1) as a, count(*) as b from t2) as xÆD
 ™¹Ð•
-¥ úê“(*0º "8:@íSCAN([IS T1]) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0, count_star(*) AS _1) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS A, coalesce_long(_._0._1, promote(0l AS LONG)) AS B) âŠŽ SCAN([IS T2]) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0, count_star(*) AS _1) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS A, coalesce_long(_._0._1, promote(0l AS LONG)) AS B) | MAP (_ AS _0) | AGG (sum_l(_._0.A) AS _0, sum_l(_._0.B) AS _1) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS A, _._0._1 AS B)Ù@digraph G {
+¥ úê“(*0º "8:@ËSCAN([IS T1]) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0, count_star(*) AS _1) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS A, coalesce_long(_._0._1, 0l) AS B) âŠŽ SCAN([IS T2]) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0, count_star(*) AS _1) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS A, coalesce_long(_._0._1, 0l) AS B) | MAP (_ AS _0) | AGG (sum_l(_._0.A) AS _0, sum_l(_._0.B) AS _1) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS A, _._0._1 AS B)Ù@digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -295,10 +295,10 @@ F
   13 -> 12 [ label=<&nbsp;q12> label="q12" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   14 -> 13 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q28> label="q28" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}åC
+}ÃC
 r
-	unnamed-1eEXPLAIN select sum(Y) as S from (select count(*) as Y from t3 union all select count(*) from t1) as XîB
-‡ÝÇ–Å ³êî(60Ç‰W8F@¬AISCAN(MV10 <,> BY_GROUP -> [_0: KEY:[0], _1: VALUE:[0]]) | AGG sum_l(_._1) GROUP BY () | MAP ((_._1 AS _0) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS Y) âŠŽ SCAN([IS T1]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0) | MAP (_ AS _0) | AGG (sum_l(_._0.Y) AS _0) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS S) ?digraph G {
+	unnamed-1eEXPLAIN select sum(Y) as S from (select count(*) as Y from t3 union all select count(*) from t1) as XÌB
+‡ÝÇ–Å ³êî(60Ç‰W8F@ŠAISCAN(MV10 <,> BY_GROUP -> [_0: KEY:[0], _1: VALUE:[0]]) | AGG sum_l(_._1) GROUP BY () | MAP ((_._1 AS _0) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS Y) âŠŽ SCAN([IS T1]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0) | MAP (_ AS _0) | AGG (sum_l(_._0.Y) AS _0) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS S) ?digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;

--- a/yaml-tests/src/test/resources/union-empty-tables.metrics.yaml
+++ b/yaml-tests/src/test/resources/union-empty-tables.metrics.yaml
@@ -3,7 +3,7 @@ unnamed-1:
     ref: union-empty-tables.yamsql:33
     explain: SCAN([IS T1]) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0, count_star(*)
         AS _1) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS A, coalesce_long(_._0._1,
-        promote(0l AS LONG)) AS B)
+        0l) AS B)
     task_count: 247
     task_total_time_ms: 4
     transform_count: 62
@@ -17,11 +17,10 @@ unnamed-1:
     ref: union-empty-tables.yamsql:37
     explain: SCAN([IS T1]) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0, count_star(*)
         AS _1) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS A, coalesce_long(_._0._1,
-        promote(0l AS LONG)) AS B) ⊎ SCAN([IS T2]) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1)
-        AS _0, count_star(*) AS _1) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS
-        A, coalesce_long(_._0._1, promote(0l AS LONG)) AS B) | MAP (_ AS _0) | AGG
-        (sum_l(_._0.A) AS _0, sum_l(_._0.B) AS _1) GROUP BY () | ON EMPTY NULL | MAP
-        (_._0._0 AS A, _._0._1 AS B)
+        0l) AS B) ⊎ SCAN([IS T2]) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0, count_star(*)
+        AS _1) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS A, coalesce_long(_._0._1,
+        0l) AS B) | MAP (_ AS _0) | AGG (sum_l(_._0.A) AS _0, sum_l(_._0.B) AS _1)
+        GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS A, _._0._1 AS B)
     task_count: 665
     task_total_time_ms: 21
     transform_count: 165
@@ -179,10 +178,10 @@ unnamed-1:
     ref: union-empty-tables.yamsql:85
     explain: 'AISCAN(MV10 <,> BY_GROUP -> [_0: KEY:[0], _1: VALUE:[0]]) | AGG sum_l(_._1)
         GROUP BY () | MAP ((_._1 AS _0) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0,
-        promote(0l AS LONG)) AS Y) ⊎ SCAN([IS T1]) | MAP (_ AS _0) | AGG (count_star(*)
-        AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l
-        AS LONG)) AS _0) | MAP (_ AS _0) | AGG (sum_l(_._0.Y) AS _0) GROUP BY () |
-        ON EMPTY NULL | MAP (_._0._0 AS S)'
+        0l) AS Y) ⊎ SCAN([IS T1]) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP
+        BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0) | MAP (_ AS
+        _0) | AGG (sum_l(_._0.Y) AS _0) GROUP BY () | ON EMPTY NULL | MAP (_._0._0
+        AS S)'
     task_count: 775
     task_total_time_ms: 54
     transform_count: 197

--- a/yaml-tests/src/test/resources/union.metrics.binpb
+++ b/yaml-tests/src/test/resources/union.metrics.binpb
@@ -1,7 +1,7 @@
-‡F
+åE
 §
-union-tests—EXPLAIN select sum(a) as a, sum(b) as b from (select sum(col1) as a, count(*) as b from t1 union all select sum(col1) as a, count(*) as b from t2) as xÚD
-ã¦‘‡	´ Ãóé(50˜ô*8F@îISCAN(VI1 <,>) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0, count_star(*) AS _1) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS A, coalesce_long(_._0._1, promote(0l AS LONG)) AS B) âŠŽ SCAN([IS T2]) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0, count_star(*) AS _1) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS A, coalesce_long(_._0._1, promote(0l AS LONG)) AS B) | MAP (_ AS _0) | AGG (sum_l(_._0.A) AS _0, sum_l(_._0.B) AS _1) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS A, _._0._1 AS B)Ê@digraph G {
+union-tests—EXPLAIN select sum(a) as a, sum(b) as b from (select sum(col1) as a, count(*) as b from t1 union all select sum(col1) as a, count(*) as b from t2) as x¸D
+ã¦‘‡	´ Ãóé(50˜ô*8F@ÌISCAN(VI1 <,>) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0, count_star(*) AS _1) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS A, coalesce_long(_._0._1, 0l) AS B) âŠŽ SCAN([IS T2]) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0, count_star(*) AS _1) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS A, coalesce_long(_._0._1, 0l) AS B) | MAP (_ AS _0) | AGG (sum_l(_._0.A) AS _0, sum_l(_._0.B) AS _1) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS A, _._0._1 AS B)Ê@digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -72,10 +72,10 @@
   13 -> 12 [ label=<&nbsp;q12> label="q12" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   14 -> 13 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q28> label="q28" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}ÎC
+}¬C
 t
-union-testseEXPLAIN select sum(Y) as S from (select count(*) as Y from t3 union all select count(*) from t1) as XÕB
-ÑÛ‡˜Ô ˜ŒÊ(A0öžS8R@­AISCAN(MV10 <,> BY_GROUP -> [_0: KEY:[0], _1: VALUE:[0]]) | AGG sum_l(_._1) GROUP BY () | MAP ((_._1 AS _0) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS Y) âŠŽ ISCAN(VI1 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0) | MAP (_ AS _0) | AGG (sum_l(_._0.Y) AS _0) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS S)†?digraph G {
+union-testseEXPLAIN select sum(Y) as S from (select count(*) as Y from t3 union all select count(*) from t1) as X³B
+ÑÛ‡˜Ô ˜ŒÊ(A0öžS8R@‹AISCAN(MV10 <,> BY_GROUP -> [_0: KEY:[0], _1: VALUE:[0]]) | AGG sum_l(_._1) GROUP BY () | MAP ((_._1 AS _0) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS Y) âŠŽ ISCAN(VI1 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0) | MAP (_ AS _0) | AGG (sum_l(_._0.Y) AS _0) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS S)†?digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;
@@ -112,10 +112,10 @@ t
   16 -> 14 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   17 -> 15 [ color="gray20" style="solid" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
   2 -> 1 [ label=<&nbsp;q26> label="q26" color="gray20" style="bold" fontname="courier" fontsize="8" arrowhead="normal" arrowtail="none" dir="both" ];
-}á:
+}¿:
 t
-union-testseEXPLAIN select sum(Y) as S from (select count(*) as Y from t6 union all select count(*) from t7) as Xè9
-¿‘ÛÜ ¦Ó¬(>0”ÒI8J@íAISCAN(MV11 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS Y) âŠŽ AISCAN(MV12 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS _0) | MAP (_ AS _0) | AGG (sum_l(_._0.Y) AS _0) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS S)Ù6digraph G {
+union-testseEXPLAIN select sum(Y) as S from (select count(*) as Y from t6 union all select count(*) from t7) as XÆ9
+¿‘ÛÜ ¦Ó¬(>0”ÒI8J@ËAISCAN(MV11 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS Y) âŠŽ AISCAN(MV12 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0) | MAP (_ AS _0) | AGG (sum_l(_._0.Y) AS _0) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS S)Ù6digraph G {
   fontname=courier;
   rankdir=BT;
   splines=line;

--- a/yaml-tests/src/test/resources/union.metrics.yaml
+++ b/yaml-tests/src/test/resources/union.metrics.yaml
@@ -4,11 +4,10 @@ union-tests:
     ref: union.yamsql:61
     explain: ISCAN(VI1 <,>) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0, count_star(*)
         AS _1) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS A, coalesce_long(_._0._1,
-        promote(0l AS LONG)) AS B) ⊎ SCAN([IS T2]) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1)
-        AS _0, count_star(*) AS _1) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS
-        A, coalesce_long(_._0._1, promote(0l AS LONG)) AS B) | MAP (_ AS _0) | AGG
-        (sum_l(_._0.A) AS _0, sum_l(_._0.B) AS _1) GROUP BY () | ON EMPTY NULL | MAP
-        (_._0._0 AS A, _._0._1 AS B)
+        0l) AS B) ⊎ SCAN([IS T2]) | MAP (_ AS _0) | AGG (sum_l(_._0.COL1) AS _0, count_star(*)
+        AS _1) GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS A, coalesce_long(_._0._1,
+        0l) AS B) | MAP (_ AS _0) | AGG (sum_l(_._0.A) AS _0, sum_l(_._0.B) AS _1)
+        GROUP BY () | ON EMPTY NULL | MAP (_._0._0 AS A, _._0._1 AS B)
     task_count: 739
     task_total_time_ms: 18
     transform_count: 180
@@ -38,10 +37,10 @@ union-tests:
     ref: union.yamsql:163
     explain: 'AISCAN(MV10 <,> BY_GROUP -> [_0: KEY:[0], _1: VALUE:[0]]) | AGG sum_l(_._1)
         GROUP BY () | MAP ((_._1 AS _0) AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0,
-        promote(0l AS LONG)) AS Y) ⊎ ISCAN(VI1 <,>) | MAP (_ AS _0) | AGG (count_star(*)
-        AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, promote(0l
-        AS LONG)) AS _0) | MAP (_ AS _0) | AGG (sum_l(_._0.Y) AS _0) GROUP BY () |
-        ON EMPTY NULL | MAP (_._0._0 AS S)'
+        0l) AS Y) ⊎ ISCAN(VI1 <,>) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP
+        BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0) | MAP (_ AS
+        _0) | AGG (sum_l(_._0.Y) AS _0) GROUP BY () | ON EMPTY NULL | MAP (_._0._0
+        AS S)'
     task_count: 849
     task_total_time_ms: 57
     transform_count: 212
@@ -54,10 +53,10 @@ union-tests:
         select count(*) from t7) as X
     ref: union.yamsql:179
     explain: 'AISCAN(MV11 <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY
-        NULL | MAP (coalesce_long(_._0._0, promote(0l AS LONG)) AS Y) ⊎ AISCAN(MV12
-        <,> BY_GROUP -> [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0,
-        promote(0l AS LONG)) AS _0) | MAP (_ AS _0) | AGG (sum_l(_._0.Y) AS _0) GROUP
-        BY () | ON EMPTY NULL | MAP (_._0._0 AS S)'
+        NULL | MAP (coalesce_long(_._0._0, 0l) AS Y) ⊎ AISCAN(MV12 <,> BY_GROUP ->
+        [_0: VALUE:[0]]) | MAP (_ AS _0) | ON EMPTY NULL | MAP (coalesce_long(_._0._0,
+        0l) AS _0) | MAP (_ AS _0) | AGG (sum_l(_._0.Y) AS _0) GROUP BY () | ON EMPTY
+        NULL | MAP (_._0._0 AS S)'
     task_count: 831
     task_total_time_ms: 24
     transform_count: 220


### PR DESCRIPTION
#4439 tried fixing all the out of sync EXPLAINS in `.metrics.yaml` files in anticipation of fixing the issue altogether with #4434. However, #4440 introduced more such cases. 

Now that #4434 is merged, we should have fixed the issues from cause, and hence, should never experience out-of-syncs between EXPLAIN in yamsql file and EXPLAIN in .metrics.yamsql file. It is therefore also relevant to fallouts from #4440 which are the last occurrences of such cases (hopefully).