### PR TITLE
Report NULL in an IN list consistently

### DIFF
--- a/docs/sphinx/source/reference/sql_commands/DQL/Operators/IN.rst
+++ b/docs/sphinx/source/reference/sql_commands/DQL/Operators/IN.rst
@@ -39,10 +39,9 @@ Returns:
 
 - ``TRUE`` if the expression equals any value in the list
 - ``FALSE`` if the expression does not match any value in the list
-- ``NULL`` if:
+- ``NULL`` if the expression is NULL
 
-  - The expression is NULL, OR
-  - The expression doesn't match any non-NULL value AND the list contains at least one NULL
+A NULL in the list itself is not supported. See `NULL Handling`_ below.
 
 Examples
 ========
@@ -168,29 +167,29 @@ Important Notes
 NULL Handling
 -------------
 
-IN has special NULL semantics that can be surprising:
-
-1. If the expression is NULL, IN returns NULL:
+If the expression is NULL, IN returns NULL, so the row is not returned:
 
 .. code-block:: sql
 
     WHERE NULL IN (1, 2, 3)     -- Returns NULL
 
-2. If the list contains NULL and no match is found, IN returns NULL (not FALSE):
+A NULL in the list itself is **not supported**. The Relational Layer represents an IN list as an array, and an
+array cannot hold a NULL element, so the query raises a :sql:`WRONG_OBJECT_TYPE` error (error code ``42809``):
 
 .. code-block:: sql
 
-    WHERE 5 IN (1, 2, NULL)     -- Returns NULL (not FALSE)
-    WHERE 1 IN (1, 2, NULL)     -- Returns TRUE
+    WHERE 5 IN (1, 2, NULL)     -- ERROR: NULL values are not allowed in the IN list
+    WHERE 5 NOT IN (1, 2, NULL) -- ERROR: NULL values are not allowed in the IN list
 
-3. NOT IN with NULL in the list can produce unexpected results:
+Only a NULL written directly in the list is rejected before the query runs. An element with a resolved type is
+accepted, even if its value turns out to be NULL while the query runs. Such a query raises an
+:sql:`UNSUPPORTED_OPERATION` error (error code ``0A000``) during execution:
 
 .. code-block:: sql
 
-    -- Be careful with NOT IN when NULLs might be present
-    WHERE 5 NOT IN (1, 2, NULL) -- Returns NULL (not TRUE!)
-
-To avoid NULL-related issues with NOT IN, consider filtering NULLs or using alternative approaches.
+    -- ERROR: NULL is not allowed as an array element
+    WHERE a IN (1, CAST(NULL AS BIGINT))  -- accepted, then fails at run time
+    WHERE a IN (1, nullable_column)       -- fails at run time if the column is NULL for some row
 
 Equivalence
 -----------

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/AbstractArrayConstructorValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/AbstractArrayConstructorValue.java
@@ -203,9 +203,17 @@ public abstract class AbstractArrayConstructorValue extends AbstractValue implem
         @Override
         @SuppressWarnings("java:S6213")
         public <M extends Message> Object eval(@Nullable final FDBRecordStoreBase<M> store, @Nonnull final EvaluationContext context) {
-            return Streams.stream(getChildren())
-                    .map(child -> child.eval(store, context))
-                    .collect(ImmutableList.toImmutableList());
+            final var elements = ImmutableList.<Object>builder();
+            for (final var child : getChildren()) {
+                final var element = child.eval(store, context);
+                // An array cannot hold a NULL element. Check it here, where the element that caused it is known.
+                // Otherwise `ImmutableList` rejects it with a bare NullPointerException that names neither the array
+                // nor the element.
+                SemanticException.check(element != null, SemanticException.ErrorCode.UNSUPPORTED,
+                        "NULL is not allowed as an array element");
+                elements.add(element);
+            }
+            return elements.build();
         }
 
         @Nonnull

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/AstNormalizer.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/AstNormalizer.java
@@ -81,11 +81,14 @@ import java.util.function.Supplier;
  * </ul>
  * <p>
  * The visitor is designed to be very fast;
- * it does not perform any semantic checks
- * leaving that to {@link com.apple.foundationdb.relational.recordlayer.query.visitors.BaseVisitor}, et al.
+ * it leaves semantic analysis to {@link com.apple.foundationdb.relational.recordlayer.query.visitors.BaseVisitor}, et al.
  * Its main purpose is to lookup queries in the plan cache, and generate enough context to be able to execute a matching
  * physical plan.
  * <br>
+ * It does reject a few things outright, and only where the check has to happen before the plan cache is consulted: an
+ * unsupported clause that would never plan anyway ({@code OFFSET}, {@code LIMIT}), and a {@code NULL} written in an
+ * {@code IN} list. The latter has to be here rather than with the other semantic checks, because a query that hits the
+ * plan cache is never planned, so a check that lives in planning would be skipped for it.
  *
  * <p>
  * Note: this class is currently not thread-safe, I do not see currently any reason for making it so as it is mainly a
@@ -445,6 +448,7 @@ public final class AstNormalizer extends RelationalParserBaseVisitor<Object> {
         } else if (ctx.inList().fullColumnName() != null) {
             visit(ctx.inList().fullColumnName());
         } else {
+            rejectNullItems(ctx.inList().expressions());
             sqlCanonicalizer.append("( ");
             if (ParseHelpers.isConstant(ctx.inList().expressions())) {
                 // todo (yhatem) we should prevent making the constant expressions
@@ -472,6 +476,40 @@ public final class AstNormalizer extends RelationalParserBaseVisitor<Object> {
         }
 
         return null;
+    }
+
+    /**
+     * Rejects a bare {@code NULL} written in an {@code IN} list. An {@code IN} list is represented as an array, and an
+     * array cannot hold a {@code NULL} element.
+     * <br>
+     * This runs during normalization, so it runs for every query, before the plan cache is consulted. That matters:
+     * the same rule also lives in {@link SemanticAnalyzer#validateInListItems}, but that one only runs while a query is
+     * being planned, and planning is skipped on a cache hit. A list holding a {@code NULL} shares its canonical query
+     * string with the same list without it, so it can reuse that plan and never be checked at all.
+     *
+     * @param expressions the items of the {@code IN} list
+     */
+    private void rejectNullItems(@Nonnull final RelationalParser.ExpressionsContext expressions) {
+        for (final var expression : expressions.expression()) {
+            Assert.thatUnchecked(!isNullLiteral(expression), ErrorCode.WRONG_OBJECT_TYPE,
+                    "NULL values are not allowed in the IN list");
+        }
+    }
+
+    /**
+     * Returns {@code true} if the given item is a bare {@code NULL}. Descends through single-child nodes only, so a
+     * {@code NULL} that is merely wrapped is still found, while an expression that happens to contain a {@code NULL}
+     * somewhere below, such as {@code CAST(NULL AS BIGINT)}, is not. Those have a resolved type and are allowed.
+     *
+     * @param tree one item of an {@code IN} list
+     * @return {@code true} if the item is a bare {@code NULL} literal
+     */
+    private static boolean isNullLiteral(@Nonnull final ParseTree tree) {
+        var current = tree;
+        while (!(current instanceof RelationalParser.NullLiteralContext) && current.getChildCount() == 1) {
+            current = current.getChild(0);
+        }
+        return current instanceof RelationalParser.NullLiteralContext;
     }
 
     @Override

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/ExpressionVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/ExpressionVisitor.java
@@ -1164,9 +1164,14 @@ public final class ExpressionVisitor extends DelegatingVisitor<BaseVisitor> {
         final var arrayElementValues = visitExpressions(ctx.expressions()).underlying();
         final var elements =
                 Streams.stream(arrayElementValues)
-                        .map(arrayElementValue ->
-                                Expression.fromUnderlying(
-                                        PromoteValue.inject(arrayElementValue, arrayElementValue.getResultType().notNullable())))
+                        .map(arrayElementValue -> {
+                            // An array cannot hold a NULL element. Say so, instead of letting `notNullable()` below
+                            // fail on a NULL type with a bare VerifyException that carries no message.
+                            Assert.thatUnchecked(!arrayElementValue.getResultType().isNull(),
+                                    ErrorCode.UNSUPPORTED_OPERATION, "NULL is not allowed as an array element");
+                            return Expression.fromUnderlying(
+                                    PromoteValue.inject(arrayElementValue, arrayElementValue.getResultType().notNullable()));
+                        })
                         .collect(ImmutableList.toImmutableList());
 
         return getDelegate().resolveFunction("__internal_array", false, elements.toArray(new Expression[0]));

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/AstNormalizerTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/AstNormalizerTests.java
@@ -48,6 +48,8 @@ import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.ByteString;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -656,6 +658,40 @@ public class AstNormalizerTests {
                 "select * from t1 where col1 in ( 2 )");
         validateNotEqual("select * from t1 where col1 in ( 1 + 1 )",
                 "select * from t1 where col1 in ( 2 )");
+    }
+
+    /**
+     * An IN list is represented as an array, and an array cannot hold a NULL element. The rejection lives here, in
+     * normalization, rather than with the other semantic checks, because normalization runs for every query while
+     * planning is skipped on a plan cache hit. A list holding a NULL shares its canonical query string with the same
+     * list without it, so it could otherwise reuse that plan and never be checked.
+     * <br>
+     * Every shape of a written IN list is covered by one check, because normalization sees the parse tree before it
+     * splits the all-constant case from the rest.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "select * from t1 where col1 in (10, null, 1000)",
+            "select * from t1 where col1 in (10 + 0, null)",
+            "select * from t1 where col1 in (null)",
+            "select * from t1 where col1 not in (10, null)",
+            "select * from t1 where col1 in (10, col2, null)"
+    })
+    void parseInPredicateRejectsNull(@Nonnull final String query) {
+        Assertions.assertThatThrownBy(() -> validate(query, "unreachable", Map.of()))
+                .isInstanceOf(UncheckedRelationalException.class)
+                .hasMessageContaining("NULL values are not allowed in the IN list");
+    }
+
+    /**
+     * Only a bare NULL is rejected. An expression that merely contains a NULL below it has a resolved type, so it is a
+     * usable array element and has to keep working.
+     */
+    @Test
+    void parseInPredicateAcceptsTypedNull() throws Exception {
+        validate("select * from t1 where col1 in (10, cast(null as bigint))",
+                "SELECT * FROM \"T1\" WHERE \"COL1\" IN ( ? , CAST ( NULL AS BIGINT ) ) ",
+                Map.of(constantId(8), 10));
     }
 
     @Test

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/InListNullParameterTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/InListNullParameterTest.java
@@ -1,0 +1,104 @@
+/*
+ * InListNullParameterTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.relational.recordlayer.query;
+
+import com.apple.foundationdb.relational.api.exceptions.ErrorCode;
+import com.apple.foundationdb.relational.recordlayer.EmbeddedRelationalExtension;
+import com.apple.foundationdb.relational.utils.Ddl;
+import com.apple.foundationdb.relational.utils.RelationalAssertions;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.net.URI;
+import java.sql.Types;
+
+/**
+ * An IN list holding a named parameter that is bound to NULL. This is the shape a client sends, since a client binds
+ * values rather than writing literals, so it matters more in practice than a NULL written into the query text.
+ * <br>
+ * A list holding a parameter is not an all-constant list — the grammar lists a prepared parameter as its own
+ * expression atom — so it is built by the array constructor at run time rather than coalesced into one array literal.
+ * The element only turns out to be null while the query runs, which used to reach an {@code ImmutableList} and come
+ * back as a bare {@code NullPointerException}.
+ */
+public class InListNullParameterTest {
+
+    private static final String SCHEMA_TEMPLATE = "CREATE TABLE T(id bigint, name string, PRIMARY KEY(id))";
+
+    @RegisterExtension
+    @Order(0)
+    public final EmbeddedRelationalExtension relationalExtension = new EmbeddedRelationalExtension();
+
+    @Test
+    void nullBoundIntoAnInListIsReported() throws Exception {
+        try (var ddl = ddl()) {
+            try (var statement = ddl.setSchemaAndGetConnection().prepareStatement("SELECT id FROM T WHERE id IN (?p)")) {
+                statement.setNull("p", Types.BIGINT);
+                RelationalAssertions.assertThrowsSqlException(statement::executeQuery)
+                        .hasErrorCode(ErrorCode.UNSUPPORTED_OPERATION)
+                        .hasMessageContaining("NULL is not allowed as an array element");
+            }
+        }
+    }
+
+    @Test
+    void nullBoundBesideALiteralIsReported() throws Exception {
+        try (var ddl = ddl()) {
+            try (var statement = ddl.setSchemaAndGetConnection().prepareStatement("SELECT id FROM T WHERE id IN (1, ?p)")) {
+                statement.setNull("p", Types.BIGINT);
+                RelationalAssertions.assertThrowsSqlException(statement::executeQuery)
+                        .hasErrorCode(ErrorCode.UNSUPPORTED_OPERATION)
+                        .hasMessageContaining("NULL is not allowed as an array element");
+            }
+        }
+    }
+
+    /**
+     * The same query with a value bound, so that the check above is known to be about the NULL and not about the shape
+     * of the query.
+     */
+    @Test
+    void valueBoundIntoAnInListWorks() throws Exception {
+        try (var ddl = ddl()) {
+            try (var statement = ddl.setSchemaAndGetConnection().prepareStatement("SELECT id FROM T WHERE id IN (?p)")) {
+                statement.setLong("p", 2L);
+                try (var resultSet = statement.executeQuery()) {
+                    Assertions.assertThat(resultSet.next()).isTrue();
+                    Assertions.assertThat(resultSet.getLong(1)).isEqualTo(2L);
+                    Assertions.assertThat(resultSet.next()).isFalse();
+                }
+            }
+        }
+    }
+
+    private Ddl ddl() throws Exception {
+        final var ddl = Ddl.builder().database(URI.create("/TEST/PN"))
+                .relationalExtension(relationalExtension)
+                .schemaTemplate(SCHEMA_TEMPLATE)
+                .build();
+        try (var insert = ddl.setSchemaAndGetConnection().createStatement()) {
+            insert.executeUpdate("INSERT INTO T VALUES (1, 'a'), (2, 'b')");
+        }
+        return ddl;
+    }
+}

--- a/yaml-tests/src/test/resources/arrays.yamsql
+++ b/yaml-tests/src/test/resources/arrays.yamsql
@@ -42,6 +42,11 @@ test_block:
       - supported_version: 4.11.1.0
       - error: INTERNAL_ERROR
     -
+      # An array cannot hold a NULL element. This used to fail with a bare VerifyException carrying no message.
+      - query: INSERT INTO A_NOT_NULL VALUES (0, [1, null])
+      - supported_version: !current_version
+      - error: UNSUPPORTED_OPERATION
+    -
       # INSERT + basic SELECT for a not-nullable INTEGER ARRAY.
       - query: INSERT INTO A_NOT_NULL VALUES (0, []), (1, [1]), (2, [1, 2])
       - count: 3
@@ -264,5 +269,9 @@ test_block:
       # X is null for pk=0, so it won't be possible to construct an array.
       - query: select [x[1]] AS arr_1, [pk] AS arr_2 FROM F WHERE pk = 0
       - supported_version: 4.12.13.0
+      # Used to surface as a NullPointerException, which carries no error code at all.
+      - initialVersionAtLeast: !current_version
+      - error: UNSUPPORTED_OPERATION
+      - initialVersionLessThan: !current_version
       - error: "XXXXX"
 ...

--- a/yaml-tests/src/test/resources/in-predicate.yamsql
+++ b/yaml-tests/src/test/resources/in-predicate.yamsql
@@ -128,6 +128,32 @@ test_block:
       - query: select a, b from ta where b in (1, null, 2, 1, 3, null)
       - error: WRONG_OBJECT_TYPE
     -
+      # An IN list is an array, and an array cannot hold a NULL element. The rejection has to happen before the plan
+      # cache is consulted, because a query that hits the cache is never planned. These four write the NULL out, so
+      # they are caught during normalization. They sit after the constant IN lists on the same column above on
+      # purpose: those plant plans that a null-bearing list could otherwise reuse.
+      - query: select a, b from ta where b in (1 + 0, null)
+      - supported_version: !current_version
+      - error: WRONG_OBJECT_TYPE
+    -
+      - query: select a, b from ta where b not in (1 + 0, null)
+      - supported_version: !current_version
+      - error: WRONG_OBJECT_TYPE
+    -
+      - query: select a, b from ta where b in (null)
+      - supported_version: !current_version
+      - error: WRONG_OBJECT_TYPE
+    -
+      - query: select a, b from ta where b not in (1, null)
+      - supported_version: !current_version
+      - error: WRONG_OBJECT_TYPE
+    -
+      # No NULL is written here, so normalization cannot see one. `t_link.color` is null in every row of t_child, so
+      # the array is built with a null element while the query runs. That used to surface as a NullPointerException.
+      - query: select id from t_child where t_link.name in ('p1', t_link.color)
+      - supported_version: !current_version
+      - error: UNSUPPORTED_OPERATION
+    -
       # DOUBLE value matched against IN list of DOUBLE values
       - query: select a, c from ta where c in (4.56, 3.45, 2.34)
       - explain: "ISCAN(F1 <,>) | FLATMAP q0 -> { EXPLODE arrayDistinct(@c9) | FILTER q0.C EQUALS _ AS q1 RETURN (q0.A AS A, q0.C AS C) }"


### PR DESCRIPTION
A NULL in an IN list is not supported. But the refusal came back three different ways depending on how the list happened to be written, and two of them were a raw `NullPointerException` reaching the client with no `ErrorCode` at all.

Tested on `main`, table `T(id bigint, v bigint)` with rows `(1, 10)`, `(2, null)`, `(5, 5)`:
```
SELECT id FROM T WHERE id IN (1, null, 2)       -- WRONG_OBJECT_TYPE, but only on a plan cache miss
SELECT id FROM T WHERE id IN (1+0, null, 2)     -- NullPointerException
SELECT id FROM T WHERE id NOT IN (1+0, null, 2) -- NullPointerException
SELECT id FROM T WHERE id IN (1, v)             -- NullPointerException (v is null in one row)
SELECT id FROM T WHERE id IN (?p)               -- NullPointerException (p bound with setNull)
```

## Cause

An IN list is represented as an array — the operator's signature is literally `(any, array)` — and an array cannot hold a NULL element. That one rule is enforced in three unrelated places, and only the first produces a usable message.

`SemanticAnalyzer.validateInListItems` rejects a `Type.NULL` element with `WRONG_OBJECT_TYPE`. It only runs for an all-constant list, and only while a query is being planned.

`AbstractArrayConstructorValue.eval` collects the evaluated children into an `ImmutableList`, which forbids null. Every other form of the list ends up here: a list that is not all constants, a list holding a column, a list holding a parameter. It dies inside with no context.

`ExpressionVisitor.handleArray` calls `.notNullable()` on each element's type, and `Type.Null.withNullability(false)` is an unconditional `Verify` failure whose message is the string `"null"`.

## Why the first one is unreliable too

A check that depends on literal values but runs while planning is skipped on a plan cache hit. The NULL check is exactly that kind of check.

It works today only by accident: a text NULL leaks into the canonical query string, because `visitTerminal` ignores `allowTokenAddition`, so a null-bearing IN list gets a cache key of its own and can never reuse another query's plan. And since it is always rejected while planning, no plan is ever cached under that key either — so every execution plans afresh and is rejected the same way.

Remove that leak and the key is no longer its own. If the cache is warmed by a null-free constant list on the same column first, the null-bearing one then reuses that plan, never calls `visitInList` at all, and fails during execution instead of being rejected. Same query, two different errors, decided only by what ran before it.

## Fix

`AstNormalizer.visitInPredicate` rejects a NULL written in an IN list, with the same `WRONG_OBJECT_TYPE` and the same message as before. Normalization runs for every query before the plan cache is consulted, so the rejection no longer depends on whether the query happens to be planned. One check covers every written form — all-constant, not-all-constant, and a function body — because it sits ahead of the split between those paths. `NOT IN` goes through the same method.

Only a bare NULL is rejected. The walk descends through single-child nodes only, so a wrapped NULL is found while an expression that merely contains one below it, such as `CAST(NULL AS BIGINT)`, is not: that has a resolved type and is a usable element.

`AbstractArrayConstructorValue.eval` checks each evaluated element and fails with `NULL is not allowed as an array element`. This is what covers the cases normalization cannot see, where the element only turns out to be null while the query runs — a column, or a bound parameter. It is the right single place: the constructor is evaluated before `arrayDistinct` and before `coerceArray`, so nothing downstream sees a null. It also cannot break anything, because `ImmutableList` never accepted a null either: every input that now reaches the check used to reach an NPE.

`ExpressionVisitor.handleArray` gives the same message before `.notNullable()` can throw. This is not about IN lists — it is an explicit `[1, null]` constructor — but it is the same rule and the same message, and it costs three lines.

Nothing is newly allowed. The rule is unchanged; only the reporting is.

`SemanticAnalyzer.validateInListItems` keeps its NULL check, which is now redundant in practice: its only caller is the all-constant branch of `visitInList`, the only constant whose type is `Type.NULL` is a bare NULL literal, and normalization now rejects that first. It is kept on purpose. The new check is syntactic and the old one is type-level, so a future syntax that produces a NULL-typed constant would slip past the first and be caught by the second. Without it, such an element would instead reach `Literals.finishArrayLiteral` and come out as a generic `DATATYPE_MISMATCH` about element types rather than saying what is actually wrong.

## Two error codes, on purpose

A NULL written in the list keeps `WRONG_OBJECT_TYPE` (42809), so nothing changes for the case that already worked, including `in-predicate.yamsql:126-129`.

An element that only turns out to be null while the query runs gives `UNSUPPORTED_OPERATION` (0A000). That is what `MessageHelpers.coerceArray` already uses for the same situation, and `SemanticException.ErrorCode` has no code that maps to `WRONG_OBJECT_TYPE` — adding one would mean touching `ExceptionUtil.translateErrorCode`, which is wider than this fix needs to be.
