### PR TITLE
Indexer heartbeat during drain merge

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexDeferredMaintenanceControl.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexDeferredMaintenanceControl.java
@@ -27,6 +27,8 @@ import javax.annotation.Nullable;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 
 /**
  * Some store's indexes may need merging on some occasions. This helper module should allow the caller
@@ -48,7 +50,8 @@ public class IndexDeferredMaintenanceControl {
     private LastStep lastStep = LastStep.NONE;
     @Nullable
     private UUID mergeSessionId = null;
-
+    @Nullable
+    private Function<FDBRecordStore, CompletableFuture<Void>> preCommitCallback = null;
 
     /**
      * During the deferred operation, each step should record its action. If exception occurs, this will help identify the cause.
@@ -283,5 +286,22 @@ public class IndexDeferredMaintenanceControl {
      */
     public void setRepartitionCapped(final boolean repartitionCapped) {
         this.repartitionCapped = repartitionCapped;
+    }
+
+    /**
+     * Set by the caller - a preCommit callback to be called by a deferred maintenance operation.
+     * @param preCommitCallback the callback, or null (default) for none
+     */
+    public void setPreCommitCallback(@Nullable final Function<FDBRecordStore, CompletableFuture<Void>> preCommitCallback) {
+        this.preCommitCallback = preCommitCallback;
+    }
+
+    /**
+     * Get the preCommit callback. See {@link #setPreCommitCallback(Function)}.
+     * @return the callback or a null
+     */
+    @Nullable
+    public Function<FDBRecordStore, CompletableFuture<Void>> getPreCommitCallback() {
+        return preCommitCallback;
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
@@ -967,7 +967,7 @@ public abstract class IndexingBase {
     }
 
     private CompletableFuture<Void> updateHeartbeat(FDBRecordStore store, Index index) {
-        return heartbeat == null ?
+        return heartbeat == null || !store.getIndexState(index).isWriteOnly() ?
                AsyncUtil.DONE :
                heartbeat.checkAndUpdateHeartbeat(store, index);
     }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
@@ -425,7 +425,7 @@ public abstract class IndexingBase {
     @Nonnull
     private CompletableFuture<Void> drainPendingQueueIfNeeded(Index index) {
         return common.getQueuedIndexes().contains(index) ?
-               getIndexingDrainer(index).drainPendingQueue() :
+               getIndexingDrainer(index).drainPendingQueue(store -> updateHeartbeat(store, index)) :
                AsyncUtil.DONE;
     }
 
@@ -1100,7 +1100,7 @@ public abstract class IndexingBase {
             return AsyncUtil.DONE;
         }
         return AsyncUtil.whenAll(indexesToDrain.stream()
-                .map(index -> getIndexingDrainer(index).drainPendingQueue()
+                .map(index -> getIndexingDrainer(index).drainPendingQueue(store -> updateHeartbeat(store, index))
                 ).toList());
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingBase.java
@@ -1091,7 +1091,7 @@ public abstract class IndexingBase {
             return AsyncUtil.DONE;
         }
         return AsyncUtil.whenAll(indexesToMerge.stream()
-                .map(index -> getIndexingMerger(index).mergeIndex()
+                .map(index -> getIndexingMerger(index).mergeIndex(store -> updateHeartbeat(store, index))
         ).toList());
     }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMerger.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingMerger.java
@@ -74,7 +74,7 @@ public class IndexingMerger {
     }
 
     @SuppressWarnings("squid:S3776") // cognitive complexity is high, candidate for refactoring
-    CompletableFuture<Void> mergeIndex() {
+    CompletableFuture<Void> mergeIndex(final Function<FDBRecordStore, CompletableFuture<Void>> heartbeatUpdater) {
         final AtomicInteger failureCountLimit = new AtomicInteger(1000);
         AtomicReference<IndexDeferredMaintenanceControl> mergeControlRef = new AtomicReference<>();
         final FDBStoreTimer timer = common.getRunner().getTimer();
@@ -94,9 +94,8 @@ public class IndexingMerger {
                                     mergeControl.setRepartitionDocumentCount(repartitionDocumentCount);
                                     mergeControl.setLastStep(IndexDeferredMaintenanceControl.LastStep.NONE);
                                     mergeControl.setRepartitionCapped(false);
-                                    // Stable across this run's re-invocations and distinct per concurrent merge
-                                    // process, so a maintainer can hold a per-partition lease across transactions.
                                     mergeControl.setMergeSessionId(common.getIndexerId());
+                                    mergeControl.setPreCommitCallback(heartbeatUpdater);
                                     return store.getIndexMaintainer(index).mergeIndex();
                                 })
                                 .thenApply(ignore -> false)

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingPendingWriteQueue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingPendingWriteQueue.java
@@ -61,6 +61,8 @@ public final class IndexingPendingWriteQueue {
 
     private static final String DISABLE_INDEX_COMMIT_HOOK = "disableIndexPendingWriteQueueOverflow:";
 
+    private static final String HEARTBEAT_COMMIT_HOOK = "pendingWriteQueueDrainHeartbeat:";
+
     private final Index index;
     private final IndexingCommon common;
 
@@ -82,10 +84,9 @@ public final class IndexingPendingWriteQueue {
                 ThrottledRetryingIterator.builder(
                                 common.getRunner().getDatabase(),
                                 contextConfigBuilder,
-                                cursorFactory(),
+                                cursorFactory(heartbeatUpdater),
                                 this::handleOneItem)
                         .withMaxRecordsDeletesPerSec(MAX_RECORDS_DELETE_PER_SECOND)
-                        .withTransactionPreCommitHook(heartbeatUpdater)
                         .build();
         return iterator.iterateAll(common.getRecordStoreBuilder().copyBuilder())
                 .whenComplete((v, e) -> {
@@ -98,8 +99,13 @@ public final class IndexingPendingWriteQueue {
     }
 
     @Nonnull
-    private CursorFactory<PendingWritesQueueEntry<IndexBuildProto.PendingWritesQueueEntry>> cursorFactory() {
+    private CursorFactory<PendingWritesQueueEntry<IndexBuildProto.PendingWritesQueueEntry>> cursorFactory(
+            final Function<FDBRecordStore, CompletableFuture<Void>> heartbeatUpdater) {
         return (store, lastResult, rowLimit) -> {
+            // The iterator opens a transaction (and calls this factory) per drained range, so this registers the
+            // heartbeat update once per such transaction, to be written just before that transaction is committed.
+            store.getContext().getOrCreateCommitCheck(HEARTBEAT_COMMIT_HOOK + index.getName(),
+                    name -> () -> heartbeatUpdater.apply(store));
             final byte[] continuation = lastResult == null ? null : lastResult.getContinuation().toBytes();
             final ScanProperties scanProperties = ScanProperties.FORWARD_SCAN.with(props -> props.setReturnedRowLimit(rowLimit));
             return getIndexingQueue(store).getQueueCursor(store.getContext(), scanProperties, continuation);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingPendingWriteQueue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexingPendingWriteQueue.java
@@ -45,6 +45,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 
 /**
  * Use {@link PendingWritesQueue} to defer index updates while an index is being built.
@@ -73,7 +74,7 @@ public final class IndexingPendingWriteQueue {
     }
 
     @SuppressWarnings("PMD.CloseResource")
-    CompletableFuture<Void> drainPendingQueue() {
+    CompletableFuture<Void> drainPendingQueue(final Function<FDBRecordStore, CompletableFuture<Void>> heartbeatUpdater) {
         // Called by the indexer: update the index and then remove every queue item
         final FDBRecordContextConfig.Builder contextConfigBuilder =
                 FDBRecordContextConfig.newBuilder().setTimer(common.getRunner().getTimer());
@@ -84,6 +85,7 @@ public final class IndexingPendingWriteQueue {
                                 cursorFactory(),
                                 this::handleOneItem)
                         .withMaxRecordsDeletesPerSec(MAX_RECORDS_DELETE_PER_SECOND)
+                        .withTransactionPreCommitHook(heartbeatUpdater)
                         .build();
         return iterator.iterateAll(common.getRecordStoreBuilder().copyBuilder())
                 .whenComplete((v, e) -> {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/runners/throttled/ThrottledRetryingIterator.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/runners/throttled/ThrottledRetryingIterator.java
@@ -51,6 +51,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
  * An iterator that can handle resource constraints and failures.
@@ -91,6 +92,8 @@ public class ThrottledRetryingIterator<T> implements AutoCloseable {
     private final Consumer<QuotaManager> transactionSuccessNotification;
     @Nullable
     private final Consumer<QuotaManager> transactionInitNotification;
+    @Nullable
+    private final Function<FDBRecordStore, CompletableFuture<Void>> transactionPreCommitHook;
     private final int numOfRetries;
     private final boolean commitWhenDone;
 
@@ -116,6 +119,7 @@ public class ThrottledRetryingIterator<T> implements AutoCloseable {
         this.maxRecordDeletesPerSec = builder.maxRecordDeletesPerSec;
         this.transactionSuccessNotification = builder.transactionSuccessNotification;
         this.transactionInitNotification = builder.transactionInitNotification;
+        this.transactionPreCommitHook = builder.transactionPreCommitHook;
         this.cursorRowsLimit = 0;
         this.numOfRetries = builder.numOfRetries;
         this.commitWhenDone = builder.commitWhenDone;
@@ -219,7 +223,9 @@ public class ThrottledRetryingIterator<T> implements AutoCloseable {
                     });
                 }, executor)
                     .whenComplete((r, e) ->
-                            cursor.close());
+                            cursor.close())
+                    // let the user write to this transaction before it gets committed
+                    .thenCompose(ignore -> preCommit(store));
             });
         }).thenApply(ignore -> cont.get());
     }
@@ -325,6 +331,10 @@ public class ThrottledRetryingIterator<T> implements AutoCloseable {
                nowMillis() - rangeIterationStartTimeMilliseconds;
     }
 
+    private CompletableFuture<Void> preCommit(FDBRecordStore store) {
+        return transactionPreCommitHook == null ? AsyncUtil.DONE : transactionPreCommitHook.apply(store);
+    }
+
     private static void runUnlessNull(@Nullable Consumer<QuotaManager> func, QuotaManager quotaManager) {
         if (func != null) {
             func.accept(quotaManager);
@@ -422,6 +432,8 @@ public class ThrottledRetryingIterator<T> implements AutoCloseable {
         private final ItemHandler<T> singleItemHandler;
         private Consumer<QuotaManager> transactionSuccessNotification;
         private Consumer<QuotaManager> transactionInitNotification;
+        @Nullable
+        private Function<FDBRecordStore, CompletableFuture<Void>> transactionPreCommitHook;
         private int transactionTimeQuotaMillis;
         private int maxRecordDeletesPerTransaction;
         private int maxRecordScannedPerSec;
@@ -500,6 +512,17 @@ public class ThrottledRetryingIterator<T> implements AutoCloseable {
          */
         public Builder<T> withTransactionInitNotification(Consumer<QuotaManager> transactionInitNotification) {
             this.transactionInitNotification = transactionInitNotification;
+            return this;
+        }
+
+        /**
+         * Set the callback to invoke after a successful range iteration, just before its transaction is committed.
+         * Defaults to null (no callback).
+         * @param transactionPreCommitHook the callback invoked every time a transaction is about to be committed
+         * @return this builder
+         */
+        public Builder<T> withTransactionPreCommitHook(@Nullable Function<FDBRecordStore, CompletableFuture<Void>> transactionPreCommitHook) {
+            this.transactionPreCommitHook = transactionPreCommitHook;
             return this;
         }
 

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/runners/throttled/ThrottledRetryingIterator.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/runners/throttled/ThrottledRetryingIterator.java
@@ -51,7 +51,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 /**
  * An iterator that can handle resource constraints and failures.
@@ -92,8 +91,6 @@ public class ThrottledRetryingIterator<T> implements AutoCloseable {
     private final Consumer<QuotaManager> transactionSuccessNotification;
     @Nullable
     private final Consumer<QuotaManager> transactionInitNotification;
-    @Nullable
-    private final Function<FDBRecordStore, CompletableFuture<Void>> transactionPreCommitHook;
     private final int numOfRetries;
     private final boolean commitWhenDone;
 
@@ -119,7 +116,6 @@ public class ThrottledRetryingIterator<T> implements AutoCloseable {
         this.maxRecordDeletesPerSec = builder.maxRecordDeletesPerSec;
         this.transactionSuccessNotification = builder.transactionSuccessNotification;
         this.transactionInitNotification = builder.transactionInitNotification;
-        this.transactionPreCommitHook = builder.transactionPreCommitHook;
         this.cursorRowsLimit = 0;
         this.numOfRetries = builder.numOfRetries;
         this.commitWhenDone = builder.commitWhenDone;
@@ -223,9 +219,7 @@ public class ThrottledRetryingIterator<T> implements AutoCloseable {
                     });
                 }, executor)
                     .whenComplete((r, e) ->
-                            cursor.close())
-                    // let the user write to this transaction before it gets committed
-                    .thenCompose(ignore -> preCommit(store));
+                            cursor.close());
             });
         }).thenApply(ignore -> cont.get());
     }
@@ -331,10 +325,6 @@ public class ThrottledRetryingIterator<T> implements AutoCloseable {
                nowMillis() - rangeIterationStartTimeMilliseconds;
     }
 
-    private CompletableFuture<Void> preCommit(FDBRecordStore store) {
-        return transactionPreCommitHook == null ? AsyncUtil.DONE : transactionPreCommitHook.apply(store);
-    }
-
     private static void runUnlessNull(@Nullable Consumer<QuotaManager> func, QuotaManager quotaManager) {
         if (func != null) {
             func.accept(quotaManager);
@@ -432,8 +422,6 @@ public class ThrottledRetryingIterator<T> implements AutoCloseable {
         private final ItemHandler<T> singleItemHandler;
         private Consumer<QuotaManager> transactionSuccessNotification;
         private Consumer<QuotaManager> transactionInitNotification;
-        @Nullable
-        private Function<FDBRecordStore, CompletableFuture<Void>> transactionPreCommitHook;
         private int transactionTimeQuotaMillis;
         private int maxRecordDeletesPerTransaction;
         private int maxRecordScannedPerSec;
@@ -512,17 +500,6 @@ public class ThrottledRetryingIterator<T> implements AutoCloseable {
          */
         public Builder<T> withTransactionInitNotification(Consumer<QuotaManager> transactionInitNotification) {
             this.transactionInitNotification = transactionInitNotification;
-            return this;
-        }
-
-        /**
-         * Set the callback to invoke after a successful range iteration, just before its transaction is committed.
-         * Defaults to null (no callback).
-         * @param transactionPreCommitHook the callback invoked every time a transaction is about to be committed
-         * @return this builder
-         */
-        public Builder<T> withTransactionPreCommitHook(@Nullable Function<FDBRecordStore, CompletableFuture<Void>> transactionPreCommitHook) {
-            this.transactionPreCommitHook = transactionPreCommitHook;
             return this;
         }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMergeTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/OnlineIndexerMergeTest.java
@@ -25,6 +25,7 @@ import com.apple.foundationdb.FDBException;
 import com.apple.foundationdb.Transaction;
 import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.record.EvaluationContext;
+import com.apple.foundationdb.record.IndexBuildProto;
 import com.apple.foundationdb.record.IndexEntry;
 import com.apple.foundationdb.record.IndexScanType;
 import com.apple.foundationdb.record.IsolationLevel;
@@ -42,6 +43,7 @@ import com.apple.foundationdb.record.metadata.IndexRecordFunction;
 import com.apple.foundationdb.record.metadata.IndexValidator;
 import com.apple.foundationdb.record.metadata.Key;
 import com.apple.foundationdb.record.provider.foundationdb.indexes.InvalidIndexEntry;
+import com.apple.foundationdb.record.provider.foundationdb.indexing.IndexingHeartbeat;
 import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpacePath;
 import com.apple.foundationdb.record.provider.foundationdb.properties.RecordLayerPropertyStorage;
 import com.apple.foundationdb.record.query.QueryToKeyMatcher;
@@ -63,8 +65,10 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
@@ -72,6 +76,7 @@ import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -378,6 +383,69 @@ public class OnlineIndexerMergeTest extends FDBRecordStoreConcurrentTestBase {
         assertEquals(1, attemptCount.get());
     }
 
+    @Test
+    void testMergePreCommitCallbackUpdatesHeartbeatDuringBuild() {
+        final String indexType = "heartbeatDuringBuildIndex";
+        final AtomicBoolean callbackPresent = new AtomicBoolean(false);
+        final AtomicReference<Map<UUID, IndexBuildProto.IndexBuildHeartbeat>> heartbeatsSeen = new AtomicReference<>();
+        TestFactory.register(indexType, observeHeartbeatDuringMerge(callbackPresent, heartbeatsSeen), true);
+
+        final FDBRecordStore.Builder storeBuilder = createStoreWithUnbuiltIndex(indexType, 20);
+        try (OnlineIndexer indexer = OnlineIndexer.newBuilder()
+                .setRecordStoreBuilder(storeBuilder)
+                .setTargetIndexesByName(List.of(INDEX_NAME))
+                .build()) {
+            indexer.buildIndex();
+        }
+
+        assertThat(callbackPresent).isTrue();
+        // The write-only index of this ongoing build has exactly one heartbeat: this indexer's
+        assertThat(heartbeatsSeen.get()).hasSize(1);
+        final IndexBuildProto.IndexBuildHeartbeat heartbeat = heartbeatsSeen.get().values().iterator().next();
+        assertThat(heartbeat.getInfo()).isEqualTo(IndexBuildProto.IndexBuildIndexingStamp.Method.BY_RECORDS.toString());
+        assertThat(heartbeat.getHeartbeatTimeMilliseconds()).isPositive();
+        // And it is cleared once the index becomes readable
+        assertNoHeartbeatsLeft(storeBuilder);
+    }
+
+    @Test
+    void testMergePreCommitCallbackSkipsHeartbeatForRegularMerge() {
+        final String indexType = "heartbeatRegularMergeIndex";
+        final AtomicBoolean callbackPresent = new AtomicBoolean(false);
+        final AtomicReference<Map<UUID, IndexBuildProto.IndexBuildHeartbeat>> heartbeatsSeen = new AtomicReference<>();
+        TestFactory.register(indexType, observeHeartbeatDuringMerge(callbackPresent, heartbeatsSeen));
+
+        final FDBRecordStore.Builder storeBuilder = createStore(indexType);
+        try (OnlineIndexer indexer = OnlineIndexer.newBuilder()
+                .setRecordStoreBuilder(storeBuilder)
+                .setTargetIndexesByName(List.of(INDEX_NAME))
+                .build()) {
+            indexer.mergeIndex();
+        }
+
+        assertThat(callbackPresent).isTrue();
+        assertThat(heartbeatsSeen.get()).isEmpty();
+        assertNoHeartbeatsLeft(storeBuilder);
+    }
+
+    @Nonnull
+    private static Function<IndexMaintainerState, CompletableFuture<Void>> observeHeartbeatDuringMerge(
+            final AtomicBoolean callbackPresent,
+            final AtomicReference<Map<UUID, IndexBuildProto.IndexBuildHeartbeat>> heartbeatsSeen) {
+        return state -> {
+            adjustMergeControl(state);
+            final Function<FDBRecordStore, CompletableFuture<Void>> preCommitCallback =
+                    state.store.getIndexDeferredMaintenanceControl().getPreCommitCallback();
+            callbackPresent.set(preCommitCallback != null);
+            if (preCommitCallback == null) {
+                return AsyncUtil.DONE;
+            }
+            return preCommitCallback.apply(state.store)
+                    .thenCompose(ignore -> IndexingHeartbeat.getIndexingHeartbeats(state.store, state.index, 0))
+                    .thenAccept(heartbeatsSeen::set);
+        };
+    }
+
     @Nonnull
     private FDBRecordStore.Builder createStore(@Nonnull final String indexType) {
         Index index = new Index(INDEX_NAME, Key.Expressions.field("num_value_2"),
@@ -395,6 +463,36 @@ public class OnlineIndexerMergeTest extends FDBRecordStoreConcurrentTestBase {
         return storeBuilder;
     }
 
+    @Nonnull
+    private FDBRecordStore.Builder createStoreWithUnbuiltIndex(@Nonnull final String indexType, final int numRecords) {
+        final FDBRecordStore.Builder storeBuilder = createStore(indexType);
+        try (FDBRecordContext context = openContext(RecordLayerPropertyStorage.getEmptyInstance())) {
+            final FDBRecordStore store = storeBuilder.copyBuilder().setContext(context).open();
+            store.markIndexDisabled(INDEX_NAME).join();
+            context.commit();
+        }
+        try (FDBRecordContext context = openContext(RecordLayerPropertyStorage.getEmptyInstance())) {
+            // The index is disabled, hence saving these records does not call its maintainer
+            final FDBRecordStore store = storeBuilder.copyBuilder().setContext(context).open();
+            for (int i = 0; i < numRecords; i++) {
+                store.saveRecord(TestRecords1Proto.MySimpleRecord.newBuilder()
+                        .setRecNo(i)
+                        .setNumValue2(i % 5)
+                        .build());
+            }
+            context.commit();
+        }
+        return storeBuilder;
+    }
+
+    private void assertNoHeartbeatsLeft(@Nonnull final FDBRecordStore.Builder storeBuilder) {
+        try (FDBRecordContext context = openContext(RecordLayerPropertyStorage.getEmptyInstance())) {
+            final FDBRecordStore store = storeBuilder.copyBuilder().setContext(context).open();
+            final Index index = store.getRecordMetaData().getIndex(INDEX_NAME);
+            assertThat(IndexingHeartbeat.getIndexingHeartbeats(store, index, 0).join()).isEmpty();
+        }
+    }
+
     private static <T> @Nonnull List<T> repeat(final T value, final int count) {
         return Stream.generate(() -> value).limit(count).collect(Collectors.toList());
     }
@@ -407,7 +505,12 @@ public class OnlineIndexerMergeTest extends FDBRecordStoreConcurrentTestBase {
     public static class TestFactory implements IndexMaintainerFactory {
         static Map<String, Function<IndexMaintainerState, IndexMaintainer>> maintainers = new HashMap<>();
 
-        static void register(String name, Function<IndexMaintainerState, CompletableFuture<Void>> mergeImplementation) {
+        private static void register(String name, Function<IndexMaintainerState, CompletableFuture<Void>> mergeImplementation) {
+            register(name, mergeImplementation, false);
+        }
+
+        private static void register(String name, Function<IndexMaintainerState, CompletableFuture<Void>> mergeImplementation,
+                             boolean buildable) {
             maintainers.put(name, state -> new IndexMaintainer(state) {
                 @Nonnull
                 @Override
@@ -418,13 +521,20 @@ public class OnlineIndexerMergeTest extends FDBRecordStoreConcurrentTestBase {
                 @Nonnull
                 @Override
                 public <M extends Message> CompletableFuture<Void> update(@Nullable final FDBIndexableRecord<M> oldRecord, @Nullable final FDBIndexableRecord<M> newRecord) {
-                    throw new UnsupportedOperationException();
+                    if (!buildable) {
+                        throw new UnsupportedOperationException();
+                    }
+                    state.store.getIndexDeferredMaintenanceControl().setMergeRequiredIndexes(state.index);
+                    return AsyncUtil.DONE;
                 }
 
                 @Nonnull
                 @Override
                 public <M extends Message> CompletableFuture<Void> updateWhileWriteOnly(@Nullable final FDBIndexableRecord<M> oldRecord, @Nullable final FDBIndexableRecord<M> newRecord) {
-                    throw new UnsupportedOperationException();
+                    if (!buildable) {
+                        throw new UnsupportedOperationException();
+                    }
+                    return update(oldRecord, newRecord);
                 }
 
                 @Nonnull
@@ -480,7 +590,10 @@ public class OnlineIndexerMergeTest extends FDBRecordStoreConcurrentTestBase {
 
                 @Override
                 public boolean isIdempotent() {
-                    throw new UnsupportedOperationException();
+                    if (!buildable) {
+                        throw new UnsupportedOperationException();
+                    }
+                    return true;
                 }
 
                 @Nonnull
@@ -521,7 +634,9 @@ public class OnlineIndexerMergeTest extends FDBRecordStoreConcurrentTestBase {
                     "wrappedFdbExceptionIndex",
                     "mergeTimeoutIndex",
                     "timeoutExceptionIndex",
-                    "nonRetriableRepartitionIndex"
+                    "nonRetriableRepartitionIndex",
+                    "heartbeatDuringBuildIndex",
+                    "heartbeatRegularMergeIndex"
             );
         }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/runners/throttled/ThrottledIteratorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/runners/throttled/ThrottledIteratorTest.java
@@ -61,7 +61,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -182,23 +181,25 @@ class ThrottledIteratorTest extends FDBRecordStoreTestBase {
     }
 
     @Test
-    void testThrottleIteratorPreCommitHook() throws Exception {
-        // Iterate in a few transactions, verify that the hook is called once per transaction and that its writes are
-        // committed with the range that was iterated
+    void testThrottleIteratorRunsCursorCommitChecks() throws Exception {
         final int numRecords = 42;
         final int deleteLimit = 10;
         final int expectedTransactions = numRecords / deleteLimit + 1; // a transaction per delete limit, plus the one that exhausts the source
-        final AtomicInteger hookCount = new AtomicInteger(0);
+        final AtomicInteger checkCount = new AtomicInteger(0);
 
         final ItemHandler<Integer> itemHandler = (store, item, quotaManager) -> {
             quotaManager.deleteCountInc();
             return AsyncUtil.DONE;
         };
-        final Function<FDBRecordStore, CompletableFuture<Void>> preCommitHook = store ->
-                // Delay a little, to ensure that the write of this asynchronous hook makes it into the transaction
-                MoreAsyncUtil.delayedFuture(2, TimeUnit.MILLISECONDS, store.getContext().getDatabase().getScheduledExecutor())
-                        .thenRun(() -> store.ensureContextActive()
-                                .set(hookSubspace(store).pack(Tuple.from(hookCount.incrementAndGet())), new byte[0]));
+        final CursorFactory<Integer> innerCursorFactory = intCursor(numRecords, null);
+        final CursorFactory<Integer> cursorFactory = (store, lastResult, rowLimit) -> {
+            store.getContext().getOrCreateCommitCheck("throttledIteratorTestCheck", name -> () ->
+                    // Delay a little, to ensure that the write of this asynchronous check makes it into the transaction
+                    MoreAsyncUtil.delayedFuture(2, TimeUnit.MILLISECONDS, store.getContext().getDatabase().getScheduledExecutor())
+                            .thenRun(() -> store.ensureContextActive()
+                                    .set(commitCheckSubspace(store).pack(Tuple.from(checkCount.incrementAndGet())), new byte[0])));
+            return innerCursorFactory.createCursor(store, lastResult, rowLimit);
+        };
 
         final FDBRecordStore.Builder storeBuilder;
         try (FDBRecordContext context = openContext()) {
@@ -207,28 +208,28 @@ class ThrottledIteratorTest extends FDBRecordStoreTestBase {
             commit(context);
         }
         try (ThrottledRetryingIterator<Integer> throttledIterator =
-                     iteratorBuilder(numRecords, itemHandler, null, null, -1, deleteLimit, -1, -1, null)
-                             .withTransactionPreCommitHook(preCommitHook)
+                     ThrottledRetryingIterator.builder(fdb, cursorFactory, itemHandler)
+                             .withMaxRecordsDeletesPerTransaction(deleteLimit)
                              .build()) {
             throttledIterator.iterateAll(storeBuilder).join();
         }
 
-        assertThat(hookCount.get()).isEqualTo(expectedTransactions);
+        assertThat(checkCount.get()).isEqualTo(expectedTransactions);
 
-        // Every one of the hook's writes was committed
+        // Every one of the checks' writes was committed
         try (FDBRecordContext context = openContext()) {
             openSimpleRecordStore(context);
-            final List<KeyValue> hookKeys = context.ensureActive()
-                    .getRange(hookSubspace(recordStore).range())
+            final List<KeyValue> checkKeys = context.ensureActive()
+                    .getRange(commitCheckSubspace(recordStore).range())
                     .asList().join();
-            assertThat(hookKeys).hasSize(expectedTransactions);
+            assertThat(checkKeys).hasSize(expectedTransactions);
         }
     }
 
-    private static Subspace hookSubspace(final FDBRecordStore store) {
-        // Note: the hook's keys must be written under a valid keyspace, else they would precede the store's header key.
+    private static Subspace commitCheckSubspace(final FDBRecordStore store) {
+        // Note: the check's keys must be written under a valid keyspace, else they would precede the store's header key.
         // The index build keyspace is a legit (and, in this test, otherwise unused) part of the store.
-        return store.getSubspace().subspace(Tuple.from(FDBRecordStoreKeyspace.INDEX_BUILD_SPACE.key(), "preCommitHook"));
+        return store.getSubspace().subspace(Tuple.from(FDBRecordStoreKeyspace.INDEX_BUILD_SPACE.key(), "commitCheck"));
     }
 
     @CsvSource({"-1", "0", "50", "100"})

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/runners/throttled/ThrottledIteratorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/runners/throttled/ThrottledIteratorTest.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.provider.foundationdb.runners.throttled;
 
+import com.apple.foundationdb.KeyValue;
 import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.async.MoreAsyncUtil;
 import com.apple.foundationdb.record.RecordCursor;
@@ -32,8 +33,10 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBDatabaseRunner;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContextConfig;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStore;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreKeyspace;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreTestBase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoredRecord;
+import com.apple.foundationdb.subspace.Subspace;
 import com.apple.foundationdb.tuple.Tuple;
 import com.apple.test.BooleanSource;
 import com.apple.test.ParameterizedTestUtils;
@@ -58,6 +61,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -175,6 +179,56 @@ class ThrottledIteratorTest extends FDBRecordStoreTestBase {
         } else {
             assertThat(successTransactionCount.get()).isEqualTo(numRecords / deleteLimit + 1);
         }
+    }
+
+    @Test
+    void testThrottleIteratorPreCommitHook() throws Exception {
+        // Iterate in a few transactions, verify that the hook is called once per transaction and that its writes are
+        // committed with the range that was iterated
+        final int numRecords = 42;
+        final int deleteLimit = 10;
+        final int expectedTransactions = numRecords / deleteLimit + 1; // a transaction per delete limit, plus the one that exhausts the source
+        final AtomicInteger hookCount = new AtomicInteger(0);
+
+        final ItemHandler<Integer> itemHandler = (store, item, quotaManager) -> {
+            quotaManager.deleteCountInc();
+            return AsyncUtil.DONE;
+        };
+        final Function<FDBRecordStore, CompletableFuture<Void>> preCommitHook = store ->
+                // Delay a little, to ensure that the write of this asynchronous hook makes it into the transaction
+                MoreAsyncUtil.delayedFuture(2, TimeUnit.MILLISECONDS, store.getContext().getDatabase().getScheduledExecutor())
+                        .thenRun(() -> store.ensureContextActive()
+                                .set(hookSubspace(store).pack(Tuple.from(hookCount.incrementAndGet())), new byte[0]));
+
+        final FDBRecordStore.Builder storeBuilder;
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context);
+            storeBuilder = recordStore.asBuilder();
+            commit(context);
+        }
+        try (ThrottledRetryingIterator<Integer> throttledIterator =
+                     iteratorBuilder(numRecords, itemHandler, null, null, -1, deleteLimit, -1, -1, null)
+                             .withTransactionPreCommitHook(preCommitHook)
+                             .build()) {
+            throttledIterator.iterateAll(storeBuilder).join();
+        }
+
+        assertThat(hookCount.get()).isEqualTo(expectedTransactions);
+
+        // Every one of the hook's writes was committed
+        try (FDBRecordContext context = openContext()) {
+            openSimpleRecordStore(context);
+            final List<KeyValue> hookKeys = context.ensureActive()
+                    .getRange(hookSubspace(recordStore).range())
+                    .asList().join();
+            assertThat(hookKeys).hasSize(expectedTransactions);
+        }
+    }
+
+    private static Subspace hookSubspace(final FDBRecordStore store) {
+        // Note: the hook's keys must be written under a valid keyspace, else they would precede the store's header key.
+        // The index build keyspace is a legit (and, in this test, otherwise unused) part of the store.
+        return store.getSubspace().subspace(Tuple.from(FDBRecordStoreKeyspace.INDEX_BUILD_SPACE.key(), "preCommitHook"));
     }
 
     @CsvSource({"-1", "0", "50", "100"})

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryWrapper.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryWrapper.java
@@ -592,11 +592,13 @@ public class FDBDirectoryWrapper implements AutoCloseable {
                                                          @Nullable final Integer partitionId) {
         // Note - since this directory wrapper was already created, agility context should be unused in the next line's path
         final PendingWriteQueue writeQueue = getPendingWriteQueue();
+        final IndexDeferredMaintenanceControl mergeControl = state.store.getIndexDeferredMaintenanceControl();
         final ThrottledRetryingIterator<PendingWriteQueue.QueueEntry> iterator = ThrottledRetryingIterator.builder(
                         agilityContext.getCallerContext().getDatabase(),
                         agilityContext.getCallerContext().getConfig().toBuilder(),
                         cursorFactory(writeQueue),
                         handleOneItemFactory(writeQueue, groupingKey, partitionId))
+                .withTransactionPreCommitHook(mergeControl.getPreCommitCallback())
                 .build();
         return iterator.iterateAll(state.store.asBuilder())
                 .whenComplete((v, e) -> {

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryWrapper.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryWrapper.java
@@ -597,7 +597,6 @@ public class FDBDirectoryWrapper implements AutoCloseable {
                         agilityContext.getCallerContext().getConfig().toBuilder(),
                         cursorFactory(writeQueue),
                         handleOneItemFactory(writeQueue, groupingKey, partitionId))
-                .withCommitWhenDone(true)
                 .build();
         return iterator.iterateAll(state.store.asBuilder())
                 .whenComplete((v, e) -> {

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryWrapper.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryWrapper.java
@@ -74,6 +74,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Function;
 
 /**
  * Wrapper containing an {@link FDBDirectory} and cached accessor objects (like {@link IndexWriter}s). This object
@@ -88,6 +89,8 @@ public class FDBDirectoryWrapper implements AutoCloseable {
     // Lucene Optimized Codec Singleton
     private static final Codec CODEC = LuceneOptimizedCodec.CODEC;
     public static final boolean USE_COMPOUND_FILE = true;
+
+    private static final String DRAIN_PRE_COMMIT_HOOK = "luceneQueueDrainPreCommit:";
 
     private final IndexMaintainerState state;
     private final FDBDirectory directory;
@@ -596,9 +599,8 @@ public class FDBDirectoryWrapper implements AutoCloseable {
         final ThrottledRetryingIterator<PendingWriteQueue.QueueEntry> iterator = ThrottledRetryingIterator.builder(
                         agilityContext.getCallerContext().getDatabase(),
                         agilityContext.getCallerContext().getConfig().toBuilder(),
-                        cursorFactory(writeQueue),
+                        cursorFactory(writeQueue, mergeControl.getPreCommitCallback()),
                         handleOneItemFactory(writeQueue, groupingKey, partitionId))
-                .withTransactionPreCommitHook(mergeControl.getPreCommitCallback())
                 .build();
         return iterator.iterateAll(state.store.asBuilder())
                 .whenComplete((v, e) -> {
@@ -610,8 +612,13 @@ public class FDBDirectoryWrapper implements AutoCloseable {
                 });
     }
 
-    private CursorFactory<PendingWriteQueue.QueueEntry> cursorFactory(PendingWriteQueue pendingWriteQueue) {
+    private CursorFactory<PendingWriteQueue.QueueEntry> cursorFactory(PendingWriteQueue pendingWriteQueue,
+                                                                      @Nullable Function<FDBRecordStore, CompletableFuture<Void>> preCommitCallback) {
         return (@Nonnull FDBRecordStore store, @Nullable RecordCursorResult<PendingWriteQueue.QueueEntry> lastResult, int rowLimit) -> {
+            if (preCommitCallback != null) {
+                store.getContext().getOrCreateCommitCheck(DRAIN_PRE_COMMIT_HOOK + state.index.getName(),
+                        name -> () -> preCommitCallback.apply(store));
+            }
             byte[] continuation = lastResult == null ? null : lastResult.getContinuation().toBytes();
             ScanProperties scanProperties = ScanProperties.FORWARD_SCAN.with(executeProperties -> executeProperties.setReturnedRowLimit(rowLimit));
             // Note: null could have been used instead of continuation as the preceding items should have been deleted. However,


### PR DESCRIPTION
Long drain/merge operations during online indexing may cause the indexing process to appear as stale. Make sure to update the heartbeats.