### PR TITLE
fix problem around collapsed replicated references

### DIFF
--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/ReassignTask.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/ReassignTask.java
@@ -41,6 +41,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -450,12 +451,14 @@ class ReassignTask extends AbstractDeferredTask {
 
     /**
      * Folds the target cluster's collapsed replicas and applies the top-k cutoff. Walks {@code reassignment}'s
-     * ordered (highest-priority-first) replicated references and, for each one whose primary has since been folded
-     * into a collapsed set (a per-replica point lookup in the collapsed store), replaces it with a single reference
-     * to the collapsed area; a later replica that resolves to the same collapsed area is dropped. Because the list is
-     * in descending priority, a collapsed area inherits the highest priority among its members, and duplicates are
-     * recognised by their (synchronously computed) signature without an extra read. Walking stops once {@code k}
-     * references are kept, so the low-priority tail is never read. Returns a {@link Reassignment} whose
+     * ordered (highest-priority-first) replicated references and, for each one that belongs to a collapsed set,
+     * represents that set by a single collapsed-area reference: an already-collapsed representative is kept as-is, and
+     * a member (whose primary was folded, detected by a point lookup in the collapsed store) is replaced by the
+     * collapsed-area reference. Only the first reference seen per signature is kept — because the list is in descending
+     * priority, the collapsed area inherits the highest priority among them — and later references for that signature
+     * are dropped. A same-signature <em>non-member</em> (a live replica, or a duplicate inserted after a collapse and
+     * not yet aggregated) is a distinct record and is kept, not deduped on signature alone. Walking stops once
+     * {@code k} references are kept, so the low-priority tail is never read. Returns a {@link Reassignment} whose
      * {@code assignmentMultimap} additionally holds the kept references under {@code targetClusterId}.
      *
      * @param readTransaction the read transaction
@@ -473,7 +476,9 @@ class ReassignTask extends AbstractDeferredTask {
         final Executor executor = getLocator().getExecutor();
         final List<VectorReference> orderedReplicatedReferences = reassignment.orderedReplicatedReferences();
         final List<VectorReference> keptReplicas = Lists.newArrayList();
-        final Map<UUID, VectorReference> collapsedReplicasBySignature = Maps.newHashMap();
+        // Signatures for which a collapsed-area reference has already been kept; a later replica of the same signature
+        // is a duplicate to drop. Only membership matters, so this is a set rather than a map of the references.
+        final Set<UUID> collapsedSignatures = Sets.newHashSet();
 
         return MoreAsyncUtil.<Void>forLoop(0, null,
                         i -> i < orderedReplicatedReferences.size() && keptReplicas.size() < k,
@@ -481,33 +486,38 @@ class ReassignTask extends AbstractDeferredTask {
                         (i, ignored) -> {
                             final VectorReference replica = orderedReplicatedReferences.get(i);
                             final UUID signature = StorageAdapter.signatureUuid(replica.vector());
-                            if (collapsedReplicasBySignature.containsKey(signature)) {
-                                // already represented by a collapsed-area reference we kept: this is a duplicate, drop it
+                            if (replica.isCollapsed()) {
+                                // This signature's collapsed-area representative — never a member in the collapsed
+                                // store, so no lookup is needed. Keep the first one and claim the signature; a later
+                                // collapsed reference for it is dropped (add() returns false once the signature is
+                                // claimed).
+                                if (collapsedSignatures.add(signature)) {
+                                    keptReplicas.add(replica);
+                                }
                                 return AsyncUtil.DONE;
                             }
+                            // A non-collapsed replica: consult the collapsed store to tell a genuine member from a
+                            // non-member. Dedup only actual members — a same-signature non-member (a live replica, or a
+                            // duplicate inserted after a collapse and not yet aggregated) is a distinct record with its
+                            // own primaryKey and must be kept, not dropped on signature alone.
                             return primitives.fetchCollapsedVectorId(readTransaction, signature,
                                             replica.id().primaryKey())
                                     .thenAccept(storedVectorId -> {
                                         if (storedVectorId == null) {
+                                            // Not a member of any collapsed set: keep it.
                                             keptReplicas.add(replica);
-                                            if (replica.isCollapsed()) {
-                                                // An already-collapsed replica is its signature's collapsed-area
-                                                // representative (not a store member), so register it here so later
-                                                // same-signature members dedupe against it.
-                                                collapsedReplicasBySignature.put(signature, replica);
-                                            }
-                                        } else {
-                                            // The replica's primary has since been folded into a collapsed set.
-                                            // cleanUpVectorReferences has already removed stale references, so the
-                                            // stored id must equal this replica's id.
+                                        } else if (collapsedSignatures.add(signature)) {
+                                            // The first member of this signature whose primary was folded into a
+                                            // collapsed set: replace it with the single collapsed-area reference.
+                                            // cleanUpVectorReferences has removed stale references, so the stored id
+                                            // must equal this replica's id.
                                             Verify.verify(storedVectorId.equals(replica.id()),
                                                     "collapsed-store entry %s does not match replica %s",
                                                     storedVectorId, replica.id());
-                                            final VectorReference collapsedReplica =
-                                                    replica.toCollapsed(signature, signature);
-                                            collapsedReplicasBySignature.put(signature, collapsedReplica);
-                                            keptReplicas.add(collapsedReplica);
+                                            keptReplicas.add(replica.toCollapsed(signature, signature));
                                         }
+                                        // else: a later member of a signature already represented by the collapsed-area
+                                        // reference we kept — drop it.
                                     });
                         },
                         executor)

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/ReassignTask.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/ReassignTask.java
@@ -490,6 +490,12 @@ class ReassignTask extends AbstractDeferredTask {
                                     .thenAccept(storedVectorId -> {
                                         if (storedVectorId == null) {
                                             keptReplicas.add(replica);
+                                            if (replica.isCollapsed()) {
+                                                // An already-collapsed replica is its signature's collapsed-area
+                                                // representative (not a store member), so register it here so later
+                                                // same-signature members dedupe against it.
+                                                collapsedReplicasBySignature.put(signature, replica);
+                                            }
                                         } else {
                                             // The replica's primary has since been folded into a collapsed set.
                                             // cleanUpVectorReferences has already removed stale references, so the

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/guardiann/CollapseScenarioTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/guardiann/CollapseScenarioTest.java
@@ -579,6 +579,118 @@ public class CollapseScenarioTest implements BaseTest {
         assertAllResolvable(guardiann, duplicate, collapsedPrimaryKeys);
     }
 
+    /**
+     * A target cluster holds both an <em>already-collapsed</em> replica for a signature (as a collapsed primary from
+     * another cluster appears once replicated in) and a plain member replica of the <em>same</em> signature whose
+     * primary has been folded. The already-collapsed replica is the collapsed-area representative, not a store member,
+     * so its fold-time lookup {@code fetchCollapsedVectorId(signature, Tuple.from(signature))} returns {@code null} and
+     * it takes {@code foldCollapsedReplicas}' pass-through branch — which registers its signature so the later member is
+     * dropped as a duplicate rather than folded into a second collapsed reference. Both share
+     * {@code primaryKey = Tuple.from(signature)}, so absent that dedup they collide when
+     * {@link AbstractDeferredTask#computeTargetClusterDelta} builds its {@code ImmutableMap}.
+     * <p>
+     * Verifies reassign completes and the two same-signature references collapse to a single collapsed-area reference
+     * keeping the highest replication priority among them (here the already-collapsed replica, given the higher priority
+     * so the fold walks it first). Mirrors {@link #reassignFoldsCollapsedReplicasIntoOneReference} for the all-plain case.
+     */
+    @Test
+    void reassignDedupesAnAlreadyCollapsedReplicaAgainstAMember() throws Exception {
+        final Guardiann guardiann = newGuardiann(1_000, 20); // huge cap: the distinct inserts stay in one cluster
+        final Primitives primitives = guardiann.getLocator().primitives();
+
+        // A real, single cluster of distinct primaries, so reassign has a genuine cluster to dissolve.
+        final int numDistinctPrimaries = 10;
+        final List<PrimaryKeyAndVector> records =
+                VecsDatasetLoaders.loadVectors(SiftTestHelpers.SIFT_SMALL_BASE_PATH, numDistinctPrimaries + 1);
+        for (int i = 1; i <= numDistinctPrimaries; i++) {
+            final Tuple primaryKey = Tuple.from("distinct", i);
+            final RealVector vector = records.get(i).vector();
+            db.run(tr -> {
+                guardiann.insert(tr, primaryKey, vector, null, true).join();
+                return null;
+            });
+        }
+        GuardiannStructureAsserts.runToQuiescence(db, guardiann);
+        final ClusterView cluster = onlyCluster(Objects.requireNonNull(GuardiannStructureAsserts.snapshotStructure(db, guardiann)));
+        final UUID clusterId = cluster.clusterId();
+
+        final RealVector duplicate = duplicateVector();
+
+        // Phase 1: one plain (non-collapsed) member replica whose primary is (below) recorded in the collapsed set.
+        final Tuple memberPrimaryKey = Tuple.from("collapsed-dup", 0);
+        db.run(tr -> {
+            final AccessInfo accessInfo = Objects.requireNonNull(primitives.fetchAccessInfo(tr).join());
+            final Quantizer quantizer = primitives.quantizer(accessInfo);
+            final Transformed<RealVector> transformedDuplicate =
+                    primitives.storageTransform(accessInfo).transform(duplicate);
+            final VectorMetadata memberMetadata =
+                    new VectorMetadata(memberPrimaryKey, RandomHelpers.randomUuid(memberPrimaryKey, true), null);
+            primitives.writeVectorMetadata(tr, memberMetadata);
+            // lower priority than the already-collapsed replica added below, so the fold processes it second
+            primitives.writeVectorReference(tr, quantizer, clusterId,
+                    VectorReference.replicatedCopy(memberMetadata.vectorId(), transformedDuplicate, 0.5d, false));
+            return null;
+        });
+
+        // Derive the signature from the read-back reference (RaBitQ is lossy), exactly as foldCollapsedReplicas sees it.
+        final ClusterView withMember = onlyCluster(Objects.requireNonNull(GuardiannStructureAsserts.snapshotStructure(db, guardiann)));
+        final VectorReference memberReplica = withMember.references().stream()
+                .filter(ref -> !ref.isPrimaryCopy() && !ref.isCollapsed())
+                .findFirst().orElseThrow();
+        final UUID signature = StorageAdapter.signatureUuid(memberReplica.vector());
+
+        // Phase 2: record the member in the collapsed store (so it folds), and add a HIGHER-priority already-collapsed
+        // replica of the same signature. Its primaryKey is Tuple.from(signature); we deliberately write NO collapsed-
+        // store entry for (signature, Tuple.from(signature)), so its fold-time lookup returns null and it passes through.
+        db.run(tr -> {
+            final AccessInfo accessInfo = Objects.requireNonNull(primitives.fetchAccessInfo(tr).join());
+            final Quantizer quantizer = primitives.quantizer(accessInfo);
+            final Transformed<RealVector> transformedDuplicate =
+                    primitives.storageTransform(accessInfo).transform(duplicate);
+            primitives.writeCollapsedVectorId(tr, signature, memberReplica.id());
+            final VectorId collapsedReplicaId =
+                    new VectorId(Tuple.from(signature), RandomHelpers.randomUuid(Tuple.from("already-collapsed"), true));
+            primitives.writeVectorReference(tr, quantizer, clusterId,
+                    VectorReference.replicatedCopy(collapsedReplicaId, transformedDuplicate, 0.99d, true));
+            return null;
+        });
+
+        final ClusterView staged = onlyCluster(Objects.requireNonNull(GuardiannStructureAsserts.snapshotStructure(db, guardiann)));
+        assertThat(staged.references().stream()
+                .filter(ref -> !ref.isPrimaryCopy() && ref.isCollapsed()
+                        && Tuple.from(signature).equals(ref.id().primaryKey()))
+                .toList())
+                .as("precondition: exactly one already-collapsed replica for the signature")
+                .hasSize(1);
+        assertThat(staged.references().stream()
+                .filter(ref -> !ref.isPrimaryCopy() && !ref.isCollapsed()
+                        && signature.equals(StorageAdapter.signatureUuid(ref.vector())))
+                .toList())
+                .as("precondition: exactly one plain member replica of the same signature")
+                .hasSize(1);
+
+        // The already-collapsed replica (processed first, higher priority) registers its signature on the pass-through
+        // branch, so the lower-priority member is dropped as a duplicate rather than folded into a colliding reference.
+        reassignCluster(guardiann, clusterId, staged.transformedCentroid());
+
+        final ClusterView after = onlyCluster(Objects.requireNonNull(GuardiannStructureAsserts.snapshotStructure(db, guardiann)));
+        assertThat(after.references().stream()
+                .filter(ref -> !ref.isPrimaryCopy() && !ref.isCollapsed()
+                        && signature.equals(StorageAdapter.signatureUuid(ref.vector())))
+                .toList())
+                .as("the plain member replica of the collapsed signature must be folded away")
+                .isEmpty();
+        final List<VectorReference> collapsedAreaRefs = after.references().stream()
+                .filter(ref -> ref.isCollapsed() && Tuple.from(signature).equals(ref.id().primaryKey()))
+                .toList();
+        assertThat(collapsedAreaRefs)
+                .as("the same-signature references must collapse to exactly one collapsed-area reference")
+                .hasSize(1);
+        assertThat(collapsedAreaRefs.get(0).replicationPriority())
+                .as("the surviving collapsed reference must keep the highest replication priority among the members")
+                .isEqualTo(0.99d);
+    }
+
     // ---------------------------------------------------------------------------------------------------------
     // Helpers
     // ---------------------------------------------------------------------------------------------------------

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/guardiann/CollapseScenarioTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/guardiann/CollapseScenarioTest.java
@@ -691,6 +691,90 @@ public class CollapseScenarioTest implements BaseTest {
                 .isEqualTo(0.99d);
     }
 
+    /**
+     * The dedup is membership-aware: a same-signature replica that is NOT a member of the collapsed set — a duplicate
+     * inserted after the collapse and not yet aggregated — is a distinct record and must be kept, not dropped merely
+     * because a collapsed-area reference for that signature is present. Stages a higher-priority already-collapsed
+     * replica plus a lower-priority non-member replica of the same signature (present in metadata, absent from the
+     * collapsed store), then verifies reassign keeps BOTH: the single collapsed-area reference and the distinct
+     * non-member replica.
+     */
+    @Test
+    void reassignKeepsAFreshNonMemberReplicaAlongsideACollapsedReference() throws Exception {
+        final Guardiann guardiann = newGuardiann(1_000, 20); // huge cap: the distinct inserts stay in one cluster
+        final Primitives primitives = guardiann.getLocator().primitives();
+
+        // A real, single cluster of distinct primaries, so reassign has a genuine cluster to dissolve.
+        final int numDistinctPrimaries = 10;
+        final List<PrimaryKeyAndVector> records =
+                VecsDatasetLoaders.loadVectors(SiftTestHelpers.SIFT_SMALL_BASE_PATH, numDistinctPrimaries + 1);
+        for (int i = 1; i <= numDistinctPrimaries; i++) {
+            final Tuple primaryKey = Tuple.from("distinct", i);
+            final RealVector vector = records.get(i).vector();
+            db.run(tr -> {
+                guardiann.insert(tr, primaryKey, vector, null, true).join();
+                return null;
+            });
+        }
+        GuardiannStructureAsserts.runToQuiescence(db, guardiann);
+        final UUID clusterId =
+                onlyCluster(Objects.requireNonNull(GuardiannStructureAsserts.snapshotStructure(db, guardiann))).clusterId();
+
+        final RealVector duplicate = duplicateVector();
+
+        // A fresh, non-collapsed duplicate replica: same content (hence same signature) but a distinct primary key and,
+        // crucially, NO collapsed-store entry — the state a duplicate inserted after a collapse leaves.
+        final Tuple freshPrimaryKey = Tuple.from("fresh-dup", 0);
+        db.run(tr -> {
+            final AccessInfo accessInfo = Objects.requireNonNull(primitives.fetchAccessInfo(tr).join());
+            final Quantizer quantizer = primitives.quantizer(accessInfo);
+            final Transformed<RealVector> transformedDuplicate =
+                    primitives.storageTransform(accessInfo).transform(duplicate);
+            final VectorMetadata freshMetadata =
+                    new VectorMetadata(freshPrimaryKey, RandomHelpers.randomUuid(freshPrimaryKey, true), null);
+            primitives.writeVectorMetadata(tr, freshMetadata);
+            primitives.writeVectorReference(tr, quantizer, clusterId,
+                    VectorReference.replicatedCopy(freshMetadata.vectorId(), transformedDuplicate, 0.5d, false));
+            return null;
+        });
+
+        // Derive the signature from the read-back reference (RaBitQ is lossy), exactly as foldCollapsedReplicas sees it.
+        final UUID signature = StorageAdapter.signatureUuid(
+                onlyCluster(Objects.requireNonNull(GuardiannStructureAsserts.snapshotStructure(db, guardiann)))
+                        .references().stream().filter(ref -> !ref.isPrimaryCopy() && !ref.isCollapsed())
+                        .findFirst().orElseThrow().vector());
+
+        // A HIGHER-priority already-collapsed representative for the same signature (processed first). No collapsed-
+        // store entry for (signature, Tuple.from(signature)), so it takes the collapsed short-circuit and claims S.
+        db.run(tr -> {
+            final AccessInfo accessInfo = Objects.requireNonNull(primitives.fetchAccessInfo(tr).join());
+            final Quantizer quantizer = primitives.quantizer(accessInfo);
+            final Transformed<RealVector> transformedDuplicate =
+                    primitives.storageTransform(accessInfo).transform(duplicate);
+            final VectorId collapsedReplicaId =
+                    new VectorId(Tuple.from(signature), RandomHelpers.randomUuid(Tuple.from("already-collapsed"), true));
+            primitives.writeVectorReference(tr, quantizer, clusterId,
+                    VectorReference.replicatedCopy(collapsedReplicaId, transformedDuplicate, 0.99d, true));
+            return null;
+        });
+
+        final ClusterView staged = onlyCluster(Objects.requireNonNull(GuardiannStructureAsserts.snapshotStructure(db, guardiann)));
+        reassignCluster(guardiann, clusterId, staged.transformedCentroid());
+
+        final ClusterView after = onlyCluster(Objects.requireNonNull(GuardiannStructureAsserts.snapshotStructure(db, guardiann)));
+        assertThat(after.references().stream()
+                .filter(ref -> ref.isCollapsed() && Tuple.from(signature).equals(ref.id().primaryKey()))
+                .toList())
+                .as("the collapsed-area reference is kept (exactly one)")
+                .hasSize(1);
+        assertThat(after.references().stream()
+                .filter(ref -> !ref.isPrimaryCopy() && !ref.isCollapsed()
+                        && freshPrimaryKey.equals(ref.id().primaryKey()))
+                .toList())
+                .as("a same-signature non-member replica must be kept, not dropped on signature alone")
+                .hasSize(1);
+    }
+
     // ---------------------------------------------------------------------------------------------------------
     // Helpers
     // ---------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
 # Fix duplicate-key crash when reassign folds an already-collapsed replica with a
  same-signature member

  **Labels:** bug fix · **Target:** main · open as **draft**

  ## Problem

  `ReassignTask.foldCollapsedReplicas` could keep two collapsed references for the
  same signature in a cluster's assignment. Both carry `primaryKey =
  Tuple.from(signature)`, so they collide when
  `AbstractDeferredTask.computeTargetClusterDelta` builds its `ImmutableMap`,
  crashing the reassign with:

  `java.lang.IllegalArgumentException: Multiple entries with same key`

  ## Cause

  The fold claimed a signature only in the freshly-folded branch. An
  **already-collapsed** replica — the collapsed-area representative, replicated in
  from another cluster — took the pass-through branch instead: its
  `fetchCollapsedVectorId(signature, Tuple.from(signature))` returns `null`, since
  the collapsed store holds only members (keyed by their real primary keys), never
  the representative's `Tuple.from(signature)`. So it was kept **without** claiming
  the signature, and a later same-signature member was then folded into a *second*
  collapsed reference — and the two collided.

  ## Fix

  Make the fold's dedup **membership-aware** so at most one collapsed-area reference
  per signature is ever kept, while distinct records are preserved. For each replica
  (highest replication priority first), keyed off a `Set<UUID>` of
  already-represented signatures:

  - **already-collapsed representative** — never a store member, so no lookup: keep
  the first one and claim the signature; drop a later collapsed reference for it.
  - **non-collapsed replica** → look it up in the collapsed store:
    - **not a member** → keep it. This is a live replica, or a duplicate inserted
  after a collapse and not yet aggregated — a distinct record whose own `primaryKey`
  cannot collide with the collapsed-area reference, so it must not be dropped on
  signature alone.
    - **member, first of its signature** → replace it with the single collapsed-area
  reference and claim the signature.
    - **member, signature already represented** → drop it (already covered by the
  kept reference).

  This keeps the crash fixed (one collapsed-area reference per signature) and also
  corrects a related over-drop: a fresh, not-yet-aggregated duplicate of a collapsed
  signature is no longer discarded just because a collapsed reference for that
  signature is present. The cost is one collapsed-store read per non-collapsed
  replica (the previous signature-only guard skipped that read). The dedup tracker
  was also simplified from a `Map<UUID, VectorReference>` to a `Set<UUID>`, since
  only signature membership was ever read.

  ## Testing

  `CollapseScenarioTest` (FDB required):
  - `reassignDedupesAnAlreadyCollapsedReplicaAgainstAMember` — a higher-priority
  already-collapsed replica plus a lower-priority same-signature **member**: verifies
  reassign completes and the two fold to a single collapsed-area reference keeping
  the highest priority. Reproduced the crash before the fix; passes after.
  - `reassignKeepsAFreshNonMemberReplicaAlongsideACollapsedReference` — a collapsed
  reference plus a same-signature **non-member** replica (in metadata, absent from
  the collapsed store): verifies reassign keeps **both**, pinning that non-members
  are not dropped on signature alone.
  - `reassignFoldsCollapsedReplicasIntoOneReference` (the existing all-plain-member
  fold) continues to pass.

  Refreshed to the membership-aware version. The only follow-up left dangling is the
  - `reassignFoldsCollapsedReplicasIntoOneReference` (the existing all-plain-member fold) continues to pass.