### PR TITLE
Reject `NULL` values in `IN` lists during normalization

### DIFF
--- a/docs/sphinx/source/reference/sql_commands/DQL/Operators/IN.rst
+++ b/docs/sphinx/source/reference/sql_commands/DQL/Operators/IN.rst
@@ -39,10 +39,9 @@ Returns:
 
 - ``TRUE`` if the expression equals any value in the list
 - ``FALSE`` if the expression does not match any value in the list
-- ``NULL`` if:
+- ``NULL`` if the expression is ``NULL``
 
-  - The expression is NULL, OR
-  - The expression doesn't match any non-NULL value AND the list contains at least one NULL
+A ``NULL`` in the list itself is not supported. See `NULL Handling`_ below.
 
 Examples
 ========
@@ -168,29 +167,27 @@ Important Notes
 NULL Handling
 -------------
 
-IN has special NULL semantics that can be surprising:
-
-1. If the expression is NULL, IN returns NULL:
+If the expression is ``NULL``, ``IN`` returns ``NULL``, so the row is not returned:
 
 .. code-block:: sql
 
     WHERE NULL IN (1, 2, 3)     -- Returns NULL
 
-2. If the list contains NULL and no match is found, IN returns NULL (not FALSE):
+A ``NULL`` in the list itself is *not supported*. The Relational Layer represents an ``IN`` list as an array, and an array cannot hold a ``NULL`` element, so the query raises a :sql:`WRONG_OBJECT_TYPE` error (error code ``42809``):
 
 .. code-block:: sql
 
-    WHERE 5 IN (1, 2, NULL)     -- Returns NULL (not FALSE)
-    WHERE 1 IN (1, 2, NULL)     -- Returns TRUE
+    -- ERROR: NULL values are not allowed in the IN list
+    WHERE 5 IN (1, 2, NULL)
+    WHERE 5 NOT IN (1, 2, NULL)
 
-3. NOT IN with NULL in the list can produce unexpected results:
+Only a ``NULL`` written directly in the list is rejected before the query runs. An element with a resolved type is accepted, even if its value turns out to be ``NULL`` while the query runs. Such a query raises an :sql:`UNSUPPORTED_OPERATION` error (error code ``0A000``) during execution:
 
 .. code-block:: sql
 
-    -- Be careful with NOT IN when NULLs might be present
-    WHERE 5 NOT IN (1, 2, NULL) -- Returns NULL (not TRUE!)
-
-To avoid NULL-related issues with NOT IN, consider filtering NULLs or using alternative approaches.
+    -- ERROR: An ARRAY value cannot have NULL elements
+    WHERE a IN (1, CAST(NULL AS BIGINT))  -- fails at runtime
+    WHERE a IN (1, nullable_column)       -- fails at runtime if the column is NULL for some row
 
 Equivalence
 -----------

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/AstNormalizer.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/AstNormalizer.java
@@ -81,11 +81,14 @@ import java.util.function.Supplier;
  * </ul>
  * <p>
  * The visitor is designed to be very fast;
- * it does not perform any semantic checks
- * leaving that to {@link com.apple.foundationdb.relational.recordlayer.query.visitors.BaseVisitor}, et al.
+ * it leaves semantic analysis to {@link com.apple.foundationdb.relational.recordlayer.query.visitors.BaseVisitor}, et al.
  * Its main purpose is to lookup queries in the plan cache, and generate enough context to be able to execute a matching
  * physical plan.
  * <br>
+ * It does reject a few things outright, and only where the check has to happen before the plan cache is consulted: an
+ * unsupported clause that would never plan anyway ({@code OFFSET}, {@code LIMIT}), and a {@code NULL} written in an
+ * {@code IN} list. The latter has to be here rather than with the other semantic checks, because a query that hits the
+ * plan cache is never planned, so a check that lives in planning would be skipped for it.
  *
  * <p>
  * Note: this class is currently not thread-safe, I do not see currently any reason for making it so as it is mainly a
@@ -445,6 +448,7 @@ public final class AstNormalizer extends RelationalParserBaseVisitor<Object> {
         } else if (ctx.inList().fullColumnName() != null) {
             visit(ctx.inList().fullColumnName());
         } else {
+            rejectNullItems(ctx.inList().expressions());
             sqlCanonicalizer.append("( ");
             if (ParseHelpers.isConstant(ctx.inList().expressions())) {
                 // todo (yhatem) we should prevent making the constant expressions
@@ -472,6 +476,43 @@ public final class AstNormalizer extends RelationalParserBaseVisitor<Object> {
         }
 
         return null;
+    }
+
+    /**
+     * Rejects a bare {@code NULL} written in an {@code IN} list. An {@code IN} list is represented as an array, and an
+     * array cannot hold a {@code NULL} element. Only the branch that spells the list out is covered; {@code IN ?param}
+     * and {@code IN some.column} write no list, so there is no {@code NULL} to find syntactically.
+     *
+     * <p>This runs during normalization, so it runs for every query, before the plan cache is consulted. That matters:
+     * the same rule also lives in {@link SemanticAnalyzer#validateInListItems}, but that one only runs while a query is
+     * being planned, and planning is skipped on a cache hit. An all-constant list is canonicalized to
+     * {@code IN ( [ ] )}, dropping its constants from the plan cache key, so were a list holding a {@code NULL} ever to
+     * share that key, it would reuse a plan built without one and be checked by nothing. Today the {@code NULL} keyword
+     * itself still reaches the canonical string through {@link #visitTerminal}, so the keys differ.
+     *
+     * @param expressions the items of the {@code IN} list
+     */
+    private void rejectNullItems(@Nonnull final RelationalParser.ExpressionsContext expressions) {
+        for (final var expression : expressions.expression()) {
+            Assert.thatUnchecked(!isNullLiteral(expression), ErrorCode.WRONG_OBJECT_TYPE,
+                    "NULL values are not allowed in the IN list");
+        }
+    }
+
+    /**
+     * Returns {@code true} if the given item is a bare {@code NULL}. Descends through single-child nodes only, so a
+     * {@code NULL} that is merely wrapped is still found, while an expression that happens to contain a {@code NULL}
+     * somewhere below, such as {@code CAST(NULL AS BIGINT)}, is not. Those have a resolved type and are allowed.
+     *
+     * @param tree one item of an {@code IN} list
+     * @return {@code true} if the item is a bare {@code NULL} literal
+     */
+    private static boolean isNullLiteral(@Nonnull final ParseTree tree) {
+        var current = tree;
+        while (!(current instanceof RelationalParser.NullLiteralContext) && current.getChildCount() == 1) {
+            current = current.getChild(0);
+        }
+        return current instanceof RelationalParser.NullLiteralContext;
     }
 
     @Override

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/AstNormalizerTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/AstNormalizerTests.java
@@ -48,6 +48,8 @@ import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.ByteString;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -656,6 +658,37 @@ public class AstNormalizerTests {
                 "select * from t1 where col1 in ( 2 )");
         validateNotEqual("select * from t1 where col1 in ( 1 + 1 )",
                 "select * from t1 where col1 in ( 2 )");
+    }
+
+    /**
+     * An IN list is represented as an array, and an array cannot hold a NULL element. The rejection lives here, in
+     * normalization, rather than with the other semantic checks, because normalization runs for every query while
+     * planning is skipped on a plan cache hit. A list holding a NULL shares its canonical query string with the same
+     * list without it, so it could otherwise reuse that plan and never be checked.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "select * from t1 where col1 in (10, null, 1000)",
+            "select * from t1 where col1 in (10 + 0, null)",
+            "select * from t1 where col1 in (null)",
+            "select * from t1 where col1 not in (10, null)",
+            "select * from t1 where col1 in (10, col2, null)"
+    })
+    void parseInPredicateRejectsNull(@Nonnull final String query) {
+        Assertions.assertThatThrownBy(() -> validate(query, "unreachable", Map.of()))
+                .isInstanceOf(UncheckedRelationalException.class)
+                .hasMessageContaining("NULL values are not allowed in the IN list");
+    }
+
+    /**
+     * Only a bare NULL is rejected. An expression that merely contains a NULL below it has a resolved type, so it is a
+     * usable array element and has to keep working.
+     */
+    @Test
+    void parseInPredicateAcceptsTypedNull() throws Exception {
+        validate("select * from t1 where col1 in (10, cast(null as bigint))",
+                "SELECT * FROM \"T1\" WHERE \"COL1\" IN ( ? , CAST ( NULL AS BIGINT ) ) ",
+                Map.of(constantId(8), 10));
     }
 
     @Test

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/InListNullParameterTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/InListNullParameterTest.java
@@ -1,0 +1,104 @@
+/*
+ * InListNullParameterTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.relational.recordlayer.query;
+
+import com.apple.foundationdb.relational.api.exceptions.ErrorCode;
+import com.apple.foundationdb.relational.recordlayer.EmbeddedRelationalExtension;
+import com.apple.foundationdb.relational.utils.Ddl;
+import com.apple.foundationdb.relational.utils.RelationalAssertions;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.net.URI;
+import java.sql.Types;
+
+/**
+ * An IN list holding a named parameter that is bound to NULL. This is the shape a client sends, since a client binds
+ * values rather than writing literals, so it matters more in practice than a NULL written into the query text.
+ * <br>
+ * A list holding a parameter is not an all-constant list — the grammar lists a prepared parameter as its own
+ * expression atom — so it is built by the array constructor at run time rather than coalesced into one array literal.
+ * The element only turns out to be null while the query runs, which used to reach an {@code ImmutableList} and come
+ * back as a bare {@code NullPointerException}.
+ */
+public class InListNullParameterTest {
+
+    private static final String SCHEMA_TEMPLATE = "CREATE TABLE T(id bigint, name string, PRIMARY KEY(id))";
+
+    @RegisterExtension
+    @Order(0)
+    public final EmbeddedRelationalExtension relationalExtension = new EmbeddedRelationalExtension();
+
+    @Test
+    void nullBoundIntoAnInListIsReported() throws Exception {
+        try (var ddl = ddl()) {
+            try (var statement = ddl.setSchemaAndGetConnection().prepareStatement("SELECT id FROM T WHERE id IN (?p)")) {
+                statement.setNull("p", Types.BIGINT);
+                RelationalAssertions.assertThrowsSqlException(statement::executeQuery)
+                        .hasErrorCode(ErrorCode.UNSUPPORTED_OPERATION)
+                        .hasMessageContaining("An ARRAY value cannot have NULL elements");
+            }
+        }
+    }
+
+    @Test
+    void nullBoundBesideALiteralIsReported() throws Exception {
+        try (var ddl = ddl()) {
+            try (var statement = ddl.setSchemaAndGetConnection().prepareStatement("SELECT id FROM T WHERE id IN (1, ?p)")) {
+                statement.setNull("p", Types.BIGINT);
+                RelationalAssertions.assertThrowsSqlException(statement::executeQuery)
+                        .hasErrorCode(ErrorCode.UNSUPPORTED_OPERATION)
+                        .hasMessageContaining("An ARRAY value cannot have NULL elements");
+            }
+        }
+    }
+
+    /**
+     * The same query with a value bound, so that the check above is known to be about the NULL and not about the shape
+     * of the query.
+     */
+    @Test
+    void valueBoundIntoAnInListWorks() throws Exception {
+        try (var ddl = ddl()) {
+            try (var statement = ddl.setSchemaAndGetConnection().prepareStatement("SELECT id FROM T WHERE id IN (?p)")) {
+                statement.setLong("p", 2L);
+                try (var resultSet = statement.executeQuery()) {
+                    Assertions.assertThat(resultSet.next()).isTrue();
+                    Assertions.assertThat(resultSet.getLong(1)).isEqualTo(2L);
+                    Assertions.assertThat(resultSet.next()).isFalse();
+                }
+            }
+        }
+    }
+
+    private Ddl ddl() throws Exception {
+        final var ddl = Ddl.builder().database(URI.create("/TEST/PN"))
+                .relationalExtension(relationalExtension)
+                .schemaTemplate(SCHEMA_TEMPLATE)
+                .build();
+        try (var insert = ddl.setSchemaAndGetConnection().createStatement()) {
+            insert.executeUpdate("INSERT INTO T VALUES (1, 'a'), (2, 'b')");
+        }
+        return ddl;
+    }
+}

--- a/yaml-tests/src/test/resources/arrays.yamsql
+++ b/yaml-tests/src/test/resources/arrays.yamsql
@@ -42,6 +42,11 @@ test_block:
       - supported_version: 4.11.1.0
       - error: INTERNAL_ERROR
     -
+      # An array cannot hold a NULL element.
+      - query: INSERT INTO A_NOT_NULL VALUES (0, [1, NULL])
+      - supported_version: !current_version
+      - error: UNSUPPORTED_OPERATION
+    -
       # INSERT + basic SELECT for a not-nullable INTEGER ARRAY.
       - query: INSERT INTO A_NOT_NULL VALUES (0, []), (1, [1]), (2, [1, 2])
       - count: 3

--- a/yaml-tests/src/test/resources/in-predicate.yamsql
+++ b/yaml-tests/src/test/resources/in-predicate.yamsql
@@ -63,6 +63,9 @@ setup:
 ---
 test_block:
   tests:
+    # Note †: Some of the test cases from here down to the ‡ cases feature all-constant IN lists (with no NULLs). For
+    # plan caching purposes, all-constant IN lists such as `IN (1, 3, 5, 7)` are canonicalized to `IN ( [ ] )`, dropping
+    # the constants from the plan cache key.
     -
       # LONG value matched against IN list of only LONG values
       - query: select a, b from ta where b in (1, 3, 5, 7)
@@ -124,9 +127,41 @@ test_block:
       - initialVersionLessThan: 4.6.4.0
       - result: [{A: 8, 1}, {A: 8, 1}]
     -
-      # _ matched against IN list containing NULL value
+      # A NULL value in an IN list is not supported and raises a WRONG_OBJECT_TYPE or UNSUPPORTED_OPERATION error.
+      #
+      # Note: The test cases marked ‡ should stay below the cases marked † at the top of this block. This is to verify
+      # that the query canonicalization does not incorrectly cause the plans that are planted above to get reused when
+      # there are NULLs.
+      #
+      # ‡ Case 1: An all-constant IN list.
       - query: select a, b from ta where b in (1, null, 2, 1, 3, null)
       - error: WRONG_OBJECT_TYPE
+    -
+      # ‡ Case 2: NULL in a list that is not all constants (so the list is not coalesced into a single array literal).
+      - query: select a, b from ta where b in (1 + 0, null)
+      - supported_version: !current_version
+      - error: WRONG_OBJECT_TYPE
+    -
+      # ‡ Case 3: Same list as Case 2, but negated. NOT IN goes through the same check.
+      - query: select a, b from ta where b not in (1 + 0, null)
+      - supported_version: !current_version
+      - error: WRONG_OBJECT_TYPE
+    -
+      # ‡ Case 4: A lone NULL as the entire list.
+      - query: select a, b from ta where b in (null)
+      - supported_version: !current_version
+      - error: WRONG_OBJECT_TYPE
+    -
+      # ‡ Case 5: NULL in an all-constant list, negated. This is the counterpart to Case 1.
+      - query: select a, b from ta where b not in (1, null)
+      - supported_version: !current_version
+      - error: WRONG_OBJECT_TYPE
+    -
+      # ‡ Case 6: No literal NULL to normalize. The `t_link.color` field is NULL in every row, so the array is built
+      # with a NULL element at runtime and rejected.
+      - query: select id from t_child where t_link.name in ('p1', t_link.color)
+      - supported_version: !current_version
+      - error: UNSUPPORTED_OPERATION
     -
       # DOUBLE value matched against IN list of DOUBLE values
       - query: select a, c from ta where c in (4.56, 3.45, 2.34)


### PR DESCRIPTION
`IN` lists are represented as arrays, which cannot currently hold a `NULL` element (Issue #3646). This rule is enforced in `SemanticAnalyzer.validateInListItems()`, but the validation only runs while a query is being planned, so it is skipped entirely on a plan cache hit. This change therefore adds a corresponding check in `AstNormalizer.visitInPredicate()`, which runs for every query before the cache is consulted. Note that the check only detects a bare `NULL` literal. An element with a resolved type such as `CAST(NULL AS BIGINT)` is still allowed and fails at run time if it turns out to be `NULL`.

This change also corrects the documentation of the `NULL` semantics in `IN.rst`, which described three-valued behavior that is not actually implemented.