### PR TITLE
Configure dependabot to also look at the `actions` folder when updating `github-actions` dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,7 +31,9 @@ updates:
       day: "thursday"
 
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/actions/**/*"
     cooldown:
       default-days: 14
     schedule:

--- a/actions/gradle-test/action.yml
+++ b/actions/gradle-test/action.yml
@@ -65,7 +65,7 @@ runs:
       echo "SUCCESS" >> test-reports/overall.txt
   - name: Publish Test Reports
     if: ${{ !cancelled() }}
-    uses: actions/upload-artifact@v7.0.1
+    uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
     with:
       name: ${{ inputs.report_name }}
       if-no-files-found: ignore

--- a/actions/setup-base-env/action.yml
+++ b/actions/setup-base-env/action.yml
@@ -8,18 +8,17 @@ runs:
   using: "composite"
   steps:
     - name: Setup JDK
-      uses: actions/setup-java@v5.2.0
+      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
       with:
         java-version: '21'
         distribution: 'temurin'
     - name: Setup Gradle
-      # Use setup-gradle v6.1.0
-      uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e
+      uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
       with:
         # Use the MIT-licensed cache provider
         cache-provider: basic
     - name: Setup Python
       id: setup-python
-      uses: actions/setup-python@v6.2.0
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: '3.13'


### PR DESCRIPTION
We define github actions in two different places:

1. The `.github/workflows` folder, which is the default location that dependabot searches through when updating values. Here, we define top-level actions that we expect to run.
1. The `actions` folder and its sub-folders. This is where we define composite action steps that we re-use in our other actions.

The latter was previously being excluded from dependabot, which is why it missed the `actions/cache` verison in #4493. (I had to add it manually.) This adds the folders to the list to check, and it also updates the remaining dependencies there that were not using the exact hash.