### PR TITLE
Deduplicate `Expression.pullUp()` and `Expressions.pullUp()`

### DIFF
--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/Expression.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/Expression.java
@@ -50,6 +50,7 @@ import com.google.common.base.Suppliers;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Multimap;
 import com.google.common.collect.Streams;
 
 import javax.annotation.Nonnull;
@@ -231,24 +232,72 @@ public class Expression {
         return false;
     }
 
+    /**
+     * Returns this expression rewritten in terms of the given value, which is simplified on the way. See
+     * {@link #pullUpSimplified} for details.
+     */
     @Nonnull
     public Expression pullUp(@Nonnull Value value, @Nonnull CorrelationIdentifier correlationIdentifier,
                              @Nonnull Set<CorrelationIdentifier> constantAliases) {
-        final var aliasMap = AliasMap.identitiesFor(value.getCorrelatedTo());
-        final var simplifiedValue = value.simplify(EvaluationContext.empty(), aliasMap, constantAliases);
-        final var underlying = getUnderlying();
-        final var pulledUpUnderlying = Assert.notNullUnchecked(underlying.replace(
+        final AliasMap aliasMap = AliasMap.identitiesFor(value.getCorrelatedTo());
+        final Value simplifiedValue = value.simplify(EvaluationContext.empty(), aliasMap, constantAliases);
+        return withUnderlying(pullUpSimplified(getUnderlying(), simplifiedValue, aliasMap, correlationIdentifier,
+                constantAliases));
+    }
+
+    /**
+     * Rewrites the given value in terms of a candidate value, by replacing every sub-value that can be expressed as a
+     * reference into the candidate with such a reference. This is the matching step behind the {@code pullUp()}
+     * methods, on values rather than on expressions, and the place where all of them are documented.
+     *
+     * <p>For example, given {@code SELECT g, COUNT(a) + 1 FROM T GROUP BY g}, the group-by operator computes
+     * {@code (g, COUNT(a))}, and the projection then has to be expressed over that result rather than over {@code T}.
+     * “Pulling up” the {@code COUNT(a) + 1} against it yields {@code _._1._0 + 1}, the group-by result keeping the
+     * grouping columns and the aggregates in separate records. The {@code COUNT(a)} sub-value is matched and replaced
+     * by a reference to the column that holds it, while the {@code + 1} is left alone because it has no counterpart on
+     * the other side.
+     *
+     * <p>The candidate has to arrive simplified, under the same {@code aliasMap} and {@code constantAliases} that are
+     * passed here. Simplification paves the way for the matching by performing certain canonicalization steps (such as
+     * collapsing a record constructor that effectively reconstructs a whole record to just that record), and the
+     * matching is structural, so a value that is canonicalized on one side but not on the other does not match at all.
+     *
+     * <p>Neither value is modified; the result is a new value, or the given one in case nothing matched.
+     *
+     * @param value the value to rewrite
+     * @param simplifiedValue the candidate to express {@code value} in terms of, simplified
+     * @param aliasMap the alias map of equalities to match under
+     * @param correlationIdentifier the alias the resulting references are expressed over
+     * @param constantAliases the aliases that are considered constant
+     * @return {@code value}, rewritten in terms of {@code simplifiedValue}
+     */
+    @Nonnull
+    static Value pullUpSimplified(@Nonnull Value value, @Nonnull Value simplifiedValue, @Nonnull AliasMap aliasMap,
+                                  @Nonnull CorrelationIdentifier correlationIdentifier,
+                                  @Nonnull Set<CorrelationIdentifier> constantAliases) {
+        // Walk the value, “offering” every sub-value for replacement in terms of the candidate.
+        return Assert.notNullUnchecked(value.replace(
                 subExpression -> {
-                    final var pulledUpExpressionMap =
+                    // Match this sub-value against the candidate.
+                    final Multimap<Value, Value> pulledUpExpressionMap =
                             simplifiedValue.pullUp(List.of(subExpression), EvaluationContext.empty(), aliasMap,
                                     constantAliases, correlationIdentifier);
-                    if (pulledUpExpressionMap.containsKey(subExpression)) {
-                        return Iterables.getOnlyElement(pulledUpExpressionMap.get(subExpression));
+                    final Collection<Value> references = pulledUpExpressionMap.get(subExpression);
+
+                    // If the candidate cannot express the sub-value, keep it.
+                    if (references.isEmpty()) {
+                        return subExpression;
                     }
-                    return subExpression;
+
+                    // Reject an ambiguous match. If a candidate exposes the same value twice (e.g., `x AS a` and
+                    // `x AS b`), this can mean the query left a column ambiguous, and we can’t just take a guess here.
+                    Assert.thatUnchecked(references.size() == 1,
+                            ErrorCode.AMBIGUOUS_COLUMN, "Ambiguous columns for %s", subExpression);
+
+                    // Replace the sub-value with the reference the candidate came back with.
+                    return Iterables.getOnlyElement(references);
                 }
         ));
-        return this.withUnderlying(pulledUpUnderlying);
     }
 
     public boolean canBeDerivedFrom(@Nonnull final Expression expression,

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/Expression.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/Expression.java
@@ -234,67 +234,61 @@ public class Expression {
 
     /**
      * Returns this expression rewritten in terms of the given value, which is simplified on the way. See
-     * {@link #pullUpSimplified} for details.
+     * {@link #pullUp} for details.
      */
     @Nonnull
     public Expression pullUp(@Nonnull Value value, @Nonnull CorrelationIdentifier correlationIdentifier,
                              @Nonnull Set<CorrelationIdentifier> constantAliases) {
         final AliasMap aliasMap = AliasMap.identitiesFor(value.getCorrelatedTo());
         final Value simplifiedValue = value.simplify(EvaluationContext.empty(), aliasMap, constantAliases);
-        return withUnderlying(pullUpSimplified(getUnderlying(), simplifiedValue, aliasMap, correlationIdentifier,
+        return withUnderlying(pullUp(getUnderlying(), simplifiedValue, aliasMap, correlationIdentifier,
                 constantAliases));
     }
 
     /**
-     * Rewrites the given value in terms of a candidate value, by replacing every sub-value that can be expressed as a
-     * reference into the candidate with such a reference. This is the matching step behind the {@code pullUp()}
-     * methods, on values rather than on expressions, and the place where all of them are documented.
+     * Rewrites the given {@code value} in terms of a reference value {@code other}, by replacing every sub-value that
+     * can be expressed as a reference into {@code other} with such a reference.
      *
-     * <p>For example, given {@code SELECT g, COUNT(a) + 1 FROM T GROUP BY g}, the group-by operator computes
-     * {@code (g, COUNT(a))}, and the projection then has to be expressed over that result rather than over {@code T}.
-     * “Pulling up” the {@code COUNT(a) + 1} against it yields {@code _._1._0 + 1}, the group-by result keeping the
-     * grouping columns and the aggregates in separate records. The {@code COUNT(a)} sub-value is matched and replaced
-     * by a reference to the column that holds it, while the {@code + 1} is left alone because it has no counterpart on
-     * the other side.
+     * <p>The matching is structural. {@code other} should therefore be passed in its canonical form, simplified under
+     * the same {@code aliasMap} and {@code constantAliases} that are passed here.
      *
-     * <p>The candidate has to arrive simplified, under the same {@code aliasMap} and {@code constantAliases} that are
-     * passed here. Simplification paves the way for the matching by performing certain canonicalization steps (such as
-     * collapsing a record constructor that effectively reconstructs a whole record to just that record), and the
-     * matching is structural, so a value that is canonicalized on one side but not on the other does not match at all.
-     *
-     * <p>Neither value is modified; the result is a new value, or the given one in case nothing matched.
+     * <p>As an example, in a group-by query {@code SELECT g, COUNT(a) + 1 FROM T GROUP BY g}, the group-by operator
+     * computes {@code (g, COUNT(a))}, and the projection then has to be expressed over that result rather than over
+     * {@code T}. “Pulling up” the {@code COUNT(a) + 1} against it yields {@code _._1._0 + 1}. The {@code COUNT(a)}
+     * sub-value is matched and replaced by a reference to the column that holds it, while the {@code + 1} has no
+     * counterpart on the other side and is left alone.
      *
      * @param value the value to rewrite
-     * @param simplifiedValue the candidate to express {@code value} in terms of, simplified
+     * @param other the value in terms of which to express {@code value}
      * @param aliasMap the alias map of equalities to match under
      * @param correlationIdentifier the alias the resulting references are expressed over
      * @param constantAliases the aliases that are considered constant
-     * @return {@code value}, rewritten in terms of {@code simplifiedValue}
+     * @return {@code value}, rewritten in terms of {@code other}
      */
     @Nonnull
-    static Value pullUpSimplified(@Nonnull Value value, @Nonnull Value simplifiedValue, @Nonnull AliasMap aliasMap,
-                                  @Nonnull CorrelationIdentifier correlationIdentifier,
-                                  @Nonnull Set<CorrelationIdentifier> constantAliases) {
-        // Walk the value, “offering” every sub-value for replacement in terms of the candidate.
+    static Value pullUp(@Nonnull Value value, @Nonnull Value other, @Nonnull AliasMap aliasMap,
+                        @Nonnull CorrelationIdentifier correlationIdentifier,
+                        @Nonnull Set<CorrelationIdentifier> constantAliases) {
+        // Walk the value, “offering” every sub-value for replacement in terms of the reference value.
         return Assert.notNullUnchecked(value.replace(
                 subExpression -> {
-                    // Match this sub-value against the candidate.
+                    // Match this sub-value against the reference value.
                     final Multimap<Value, Value> pulledUpExpressionMap =
-                            simplifiedValue.pullUp(List.of(subExpression), EvaluationContext.empty(), aliasMap,
+                            other.pullUp(List.of(subExpression), EvaluationContext.empty(), aliasMap,
                                     constantAliases, correlationIdentifier);
                     final Collection<Value> references = pulledUpExpressionMap.get(subExpression);
 
-                    // If the candidate cannot express the sub-value, keep it.
+                    // If the reference value cannot express the sub-value, keep it.
                     if (references.isEmpty()) {
                         return subExpression;
                     }
 
-                    // Reject an ambiguous match. If a candidate exposes the same value twice (e.g., `x AS a` and
-                    // `x AS b`), this can mean the query left a column ambiguous, and we can’t just take a guess here.
+                    // Reject an ambiguous match. If the reference value exposes the same value twice (e.g., `GROUP BY
+                    // a, a`), the query left the column ambiguous, and we can’t just take a guess here.
                     Assert.thatUnchecked(references.size() == 1,
                             ErrorCode.AMBIGUOUS_COLUMN, "Ambiguous columns for %s", subExpression);
 
-                    // Replace the sub-value with the reference the candidate came back with.
+                    // Replace the sub-value with the reference that came back.
                     return Iterables.getOnlyElement(references);
                 }
         ));

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/Expressions.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/Expressions.java
@@ -104,7 +104,7 @@ public final class Expressions implements Iterable<Expression> {
         final Value simplifiedValue = value.simplify(EvaluationContext.empty(), aliasMap, constantAliases);
         return Expressions.of(stream()
                 .map(expression -> expression.withUnderlying(
-                        Expression.pullUpSimplified(expression.getUnderlying(), simplifiedValue, aliasMap,
+                        Expression.pullUp(expression.getUnderlying(), simplifiedValue, aliasMap,
                                 correlationIdentifier, constantAliases)))
                 .collect(ImmutableList.toImmutableList()));
     }

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/Expressions.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/Expressions.java
@@ -100,26 +100,13 @@ public final class Expressions implements Iterable<Expression> {
     @Nonnull
     public Expressions pullUp(@Nonnull Value value, @Nonnull CorrelationIdentifier correlationIdentifier,
                               @Nonnull Set<CorrelationIdentifier> constantAliases) {
-        final ImmutableList.Builder<Expression> pulledUpOutputBuilder = ImmutableList.builder();
-        final var aliasMap = AliasMap.identitiesFor(value.getCorrelatedTo());
-        final var simplifiedValue = value.simplify(EvaluationContext.empty(), aliasMap, constantAliases);
-        for (final var expression : this) {
-            final var underlying = expression.getUnderlying();
-            final var pulledUpUnderlying = Assert.notNullUnchecked(underlying.replace(
-                    subExpression -> {
-                        final var pulledUpExpressionMap =
-                                simplifiedValue.pullUp(List.of(subExpression), EvaluationContext.empty(), aliasMap,
-                                        constantAliases, correlationIdentifier);
-                        if (pulledUpExpressionMap.containsKey(subExpression)) {
-                            Assert.thatUnchecked(pulledUpExpressionMap.get(subExpression).size() == 1, ErrorCode.AMBIGUOUS_COLUMN, "Ambiguous columns for " + subExpression);
-                            return Iterables.getOnlyElement(pulledUpExpressionMap.get(subExpression));
-                        }
-                        return subExpression;
-                    }
-            ));
-            pulledUpOutputBuilder.add(expression.withUnderlying(pulledUpUnderlying));
-        }
-        return Expressions.of(pulledUpOutputBuilder.build());
+        final AliasMap aliasMap = AliasMap.identitiesFor(value.getCorrelatedTo());
+        final Value simplifiedValue = value.simplify(EvaluationContext.empty(), aliasMap, constantAliases);
+        return Expressions.of(stream()
+                .map(expression -> expression.withUnderlying(
+                        Expression.pullUpSimplified(expression.getUnderlying(), simplifiedValue, aliasMap,
+                                correlationIdentifier, constantAliases)))
+                .collect(ImmutableList.toImmutableList()));
     }
 
     @Nonnull

--- a/yaml-tests/src/test/resources/groupby-tests.yamsql
+++ b/yaml-tests/src/test/resources/groupby-tests.yamsql
@@ -192,6 +192,22 @@ test_block:
       - query: select x from t1 group by col1 as x, col2 as x;
       - error: AMBIGUOUS_COLUMN
     -
+      # Test that a duplicate grouping column is rejected. In particular, this exercises an ambiguity check during
+      # pull-up. The group-by result exposes `col1` twice, so pulling the grouping columns up over that result finds
+      # two references for it and cannot pick one arbitrarily.
+      - query: select max(col2) from t1 group by col1, col1;
+      - supported_version: 4.10.1.0
+      - error: AMBIGUOUS_COLUMN
+    -
+      - query: select col1 from t1 group by col1, col1;
+      - supported_version: 4.10.1.0
+      - error: AMBIGUOUS_COLUMN
+    -
+      # Duplicate grouping column + HAVING.
+      - query: select max(col2) from t1 group by col1, col1 having col1 > 0;
+      - supported_version: 4.10.1.0
+      - error: AMBIGUOUS_COLUMN
+    -
       - query: SELECT COUNT(*) from T1 WHERE col1 = 20 or col2 = 5
       - explain: "ISCAN(I1 <,>) | FILTER _.COL1 EQUALS promote(@c10 AS LONG) OR _.COL2 EQUALS promote(@c14 AS LONG) | MAP (_ AS _0) | AGG (count_star(*) AS _0) GROUP BY () | ON EMPTY NULL | MAP (coalesce_long(_._0._0, 0l) AS _0)"
       - result: [{!l 9}]


### PR DESCRIPTION
The group-by pull-up operation that rewrites an expression in terms of a given value is implemented twice, once in `Expression` and once in `Expressions`. This change deduplicates the code by extracting the main algorithm into a package-private `Expression.pullUp()` overload.

There is one behavior change: The `Expressions` copy asserted that a sub-value pulls up to exactly one reference while the `Expression` copy did not. The shared implementation keeps that assertion, so it now effectively covers the `HAVING` predicate as well. The shared assertion is covered by the added yamsql test cases.