### PR TITLE
Fix an aggregate over a whole-record argument planning incorrectly

### DIFF
--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/Expression.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/Expression.java
@@ -233,15 +233,17 @@ public class Expression {
     }
 
     /**
-     * Returns this expression rewritten in terms of the given value, which is simplified on the way. See
-     * {@link #pullUp} for details.
+     * Returns this expression rewritten in terms of the given value, simplifying both sides on the way. See
+     * {@link #pullUp(Value, Value, AliasMap, CorrelationIdentifier, Set)} for details.
      */
     @Nonnull
     public Expression pullUp(@Nonnull Value value, @Nonnull CorrelationIdentifier correlationIdentifier,
                              @Nonnull Set<CorrelationIdentifier> constantAliases) {
         final AliasMap aliasMap = AliasMap.identitiesFor(value.getCorrelatedTo());
         final Value simplifiedValue = value.simplify(EvaluationContext.empty(), aliasMap, constantAliases);
-        return withUnderlying(pullUp(getUnderlying(), simplifiedValue, aliasMap, correlationIdentifier,
+        final Value simplifiedUnderlying =
+                getUnderlying().simplify(EvaluationContext.empty(), aliasMap, constantAliases);
+        return withUnderlying(pullUp(simplifiedUnderlying, simplifiedValue, aliasMap, correlationIdentifier,
                 constantAliases));
     }
 
@@ -249,8 +251,8 @@ public class Expression {
      * Rewrites the given {@code value} in terms of a reference value {@code other}, by replacing every sub-value that
      * can be expressed as a reference into {@code other} with such a reference.
      *
-     * <p>The matching is structural. {@code other} should therefore be passed in its canonical form, simplified under
-     * the same {@code aliasMap} and {@code constantAliases} that are passed here.
+     * <p>The matching is structural. Both {@code value} and {@code other} should therefore be passed in their canonical
+     * form, simplified under the same {@code aliasMap} and {@code constantAliases} that are passed here.
      *
      * <p>As an example, in a group-by query {@code SELECT g, COUNT(a) + 1 FROM T GROUP BY g}, the group-by operator
      * computes {@code (g, COUNT(a))}, and the projection then has to be expressed over that result rather than over

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/Expressions.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/Expressions.java
@@ -104,8 +104,10 @@ public final class Expressions implements Iterable<Expression> {
         final Value simplifiedValue = value.simplify(EvaluationContext.empty(), aliasMap, constantAliases);
         return Expressions.of(stream()
                 .map(expression -> expression.withUnderlying(
-                        Expression.pullUp(expression.getUnderlying(), simplifiedValue, aliasMap,
-                                correlationIdentifier, constantAliases)))
+                        Expression.pullUp(
+                                expression.getUnderlying().simplify(EvaluationContext.empty(), aliasMap,
+                                        constantAliases),
+                                simplifiedValue, aliasMap, correlationIdentifier, constantAliases)))
                 .collect(ImmutableList.toImmutableList()));
     }
 

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/OrderByExpression.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/OrderByExpression.java
@@ -86,7 +86,10 @@ public final class OrderByExpression {
                                 Stream.of(orderBy))
                 .map(orderBy -> {
                     final var orderByExpression = orderBy.getExpression();
-                    final var underlying = orderByExpression.getUnderlying();
+                    // Simplify this side as well, so that both sides have the same, canonical shape for purposes of
+                    // the structural matching inside `pullUp()`.
+                    final var underlying = orderByExpression.getUnderlying()
+                            .simplify(EvaluationContext.empty(), aliasMap, constantAliases);
                     final var pulledUpUnderlying = Assert.notNullUnchecked(underlying.replace(
                             subExpression -> {
                                 final var pulledUpExpressionMap =

--- a/yaml-tests/src/test/resources/groupby-tests.yamsql
+++ b/yaml-tests/src/test/resources/groupby-tests.yamsql
@@ -276,4 +276,43 @@ test_block:
       - result: [{!l 10, !l 5}]
       - result: []
       - result: [{!l 20, !l 8}]
+---
+# Aggregates over a record constructor. These are regression tests for Issue #4481. They exercise the interaction of
+# `collapseSimpleSelectMaybe()`, which collapses some of these record constructors, with the group-by pull-up logic.
+test_block:
+  name: aggregate-over-record
+  tests:
+    -
+      # A star-derived record constructor.
+      - query: SELECT COUNT((T1.*)) FROM T1
+      - supported_version: !current_version
+      - result: [{!l 13}]
+    -
+      # Record constructor with every column enumerated in declaration order; gets collapsed like the star-derived form.
+      - query: SELECT COUNT((T1.id, T1.col1, T1.col2)) FROM T1
+      - supported_version: !current_version
+      - result: [{!l 13}]
+    -
+      # The same columns, but out of order. Such a record constructor doesn’t get collapsed.
+      - query: SELECT COUNT((T1.col2, T1.col1, T1.id)) FROM T1
+      - result: [{!l 13}]
+    -
+      # A strict subset of the columns. Doesn’t get collapsed either.
+      - query: SELECT COUNT((T1.id, T1.col2)) FROM T1
+      - result: [{!l 13}]
+    -
+      # The star-derived form again, but with grouping. Here the pull-up has grouping columns to rewrite alongside the
+      # aggregate.
+      - query: SELECT col1, COUNT((T1.*)) FROM T1 GROUP BY col1
+      - supported_version: !current_version
+      - result: [{!l 10, !l 5}, {!l 20, !l 8}]
+    -
+      # The HAVING predicate is normalized as well, not only the projection.
+      - query: SELECT col1 FROM T1 GROUP BY col1 HAVING COUNT((T1.*)) > 5
+      - supported_version: !current_version
+      - result: [{!l 20}]
+    -
+      # An ORDER BY over an aggregate is not supported, whatever the aggregate’s argument looks like.
+      - query: SELECT col1 FROM T1 GROUP BY col1 ORDER BY COUNT((T1.*))
+      - error: UNSUPPORTED_QUERY
 ...


### PR DESCRIPTION
* Change `Expression.pullUp()` to simplify _both_ sides before matching them, rather than only the candidate.
* Change `OrderByExpression.pullUp()` the same way.

An aggregate whose argument effectively reconstructs a whole record, such as `SELECT COUNT((T.*)) FROM T`, failed to plan. In a grouped query the same aggregate value occurs twice, in the group-by expression that computes it and in the projection. In the projection, `pullUp()` has to replace the expression with a reference to the group-by output for the plan to stay correct. This is done by matching the two values structurally. Matching the _unsimplified_ projection against the simplified candidate could not succeed for that argument, since the simplification rules canonicalize `(T.*)` to just `T` via `Values.collapseSimpleSelectMaybe()`.

Fixes #4481.