### PR TITLE
Enable the Gradle configuration cache by default

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -36,6 +36,13 @@ apiVersion=710
 mavenLocalEnabled=false
 org.gradle.daemon=true
 
+# Enable the Configuration Cache.
+# Note: To opt out of the cache in a single build, pass `--no-configuration-cache` to Gradle.
+org.gradle.configuration-cache=true
+# Treat configuration-cache-related problems as errors rather than just warnings. This way, we catch incompatibilities
+# as they are introduced instead of softly disabling the cache with a warning.
+org.gradle.configuration-cache.problems=fail
+
 # Don’t try to auto-provision JDKs. We prefer to only resolve Java toolchains from locally installed JDKs.
 org.gradle.java.installations.auto-download=false
 


### PR DESCRIPTION
Set `org.gradle.configuration-cache=true` in `gradle.properties`. Also set `problems=fail` so that, going forward, we will catch incompatibilities immediately as they are introduced (instead of having Gradle raise just a warning and disable the cache).

Measuring on Gradle 9.7.0, when running the `:fdb-record-layer-core:compileJava` task with everything already up to date, the configuration cache reduces the time from 4.3s to 2.3s on a cold daemon (≈47% faster), and from 0.8s to 0.3s on a warm daemon (≈60% faster). The gains generally grow with the size of the task graph. The full CI-like build, `build -x test -x destructiveTest -x scalarFallbackTest`, drops from 18.1s to 7.9s once everything is up to date.

