### PR TITLE
Simplify the logic for clearing the local version cache

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordContext.java
@@ -152,11 +152,11 @@ public class FDBRecordContext extends FDBTransactionContext implements AutoClose
     @Nullable
     private byte[] versionStamp;
     @Nonnull
-    private AtomicInteger localVersion;
+    private final AtomicInteger localVersion;
     @Nonnull
-    private ConcurrentNavigableMap<byte[], Integer> localVersionCache;
+    private final ConcurrentNavigableMap<byte[], Integer> localVersionCache;
     @Nonnull
-    private ConcurrentNavigableMap<byte[], NonnullPair<MutationType, byte[]>> versionMutationCache;
+    private final ConcurrentNavigableMap<byte[], NonnullPair<MutationType, byte[]>> versionMutationCache;
     @Nonnull
     private final FDBRecordContextConfig config;
     private final long timeoutMillis;

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBRecordStore.java
@@ -1773,25 +1773,12 @@ public class FDBRecordStore extends FDBStoreBase implements FDBRecordStoreBase<M
                 countKeysAndValues(FDBStoreTimer.Counts.DELETE_RECORD_KEY, FDBStoreTimer.Counts.DELETE_RECORD_KEY_BYTES, FDBStoreTimer.Counts.DELETE_RECORD_VALUE_BYTES,
                         oldRecord);
                 addRecordCount(metaData, oldRecord, LITTLE_ENDIAN_INT64_MINUS_ONE);
-                final boolean oldHasIncompleteVersion = oldRecord.hasVersion() && !oldRecord.getVersion().isComplete();
-                if (useOldVersionFormat()) {
+                if (useOldVersionFormat() && metaData.isStoreRecordVersions()) {
+                    // Clear out the version key (including incomplete versions)
                     byte[] versionKey = getSubspace().pack(recordVersionKey(primaryKey));
-                    if (oldHasIncompleteVersion) {
-                        context.removeVersionMutation(versionKey);
-                    } else if (metaData.isStoreRecordVersions()) {
-                        ensureContextActive().clear(versionKey);
-                    }
+                    context.clear(versionKey);
                 }
-                CompletableFuture<Void> updateIndexesFuture = updateSecondaryIndexes(oldRecord, null);
-                if (oldHasIncompleteVersion) {
-                    return updateIndexesFuture.thenApply(vignore -> {
-                        byte[] versionKey = getSubspace().pack(recordVersionKey(primaryKey));
-                        context.removeLocalVersion(versionKey);
-                        return true;
-                    });
-                } else {
-                    return updateIndexesFuture.thenApply(vignore -> true);
-                }
+                return updateSecondaryIndexes(oldRecord, null).thenApply(vignore -> true);
             });
         });
         return context.instrument(FDBStoreTimer.Events.DELETE_RECORD, result);

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/SplitHelper.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/SplitHelper.java
@@ -360,22 +360,29 @@ public class SplitHelper {
                     tr.addWriteConflictRange(keySplitSubspaceRange.begin, keySplitSubspaceRange.end);
                     List<Long> offsets = offsets(previousSizeInfo);
                     for (Long offset : offsets) {
-                        tr.clear(keySplitSubspace.pack(offset));
+                        byte[] keyWithOffset = keySplitSubspace.pack(offset);
+                        if (offset == RECORD_VERSION) {
+                            // Use FDBRecordContext::clear to ensure incomplete version is handled appropriately
+                            context.clear(keyWithOffset);
+                        } else {
+                            tr.clear(keyWithOffset);
+                        }
                     }
                 } else {
                     if (previousSizeInfo.isSplit() || previousSizeInfo.isVersionedInline()) {
-                        tr.clear(keySplitSubspace.range()); // Record might be shorter than previous split.
+                        // Record takes up more than one key, so issue a single range delete (including the local version cache)
+                        context.clear(keySplitSubspace.range());
                     } else {
-                        // Record was previously unsplit and had unsplit suffix because we are splitting long records.
+                        // Record was previously a single key, with the unsplit record suffix.
+                        // Use tr.clear as that one key is _not_ an incomplete version.
                         tr.clear(keySplitSubspace.pack(UNSPLIT_RECORD));
                     }
                 }
             }
         } else {
-            tr.clear(keySplitSubspace.range()); // Clears both unsplit and previous longer split.
+            // Clear the whole range for the record, including any incomplete version information
+            context.clear(keySplitSubspace.range());
         }
-        final byte[] versionKey = keySplitSubspace.pack(RECORD_VERSION);
-        context.getLocalVersion(versionKey).ifPresent(localVersion -> context.removeVersionMutation(versionKey));
     }
 
     /**

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/SplitHelperTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/SplitHelperTest.java
@@ -56,6 +56,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
@@ -72,6 +73,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for checking the validity of the "split helper" utility class that handles breaking
@@ -425,6 +427,91 @@ public class SplitHelperTest extends FDBRecordStoreTestBase {
             saveWithSplit(context, Tuple.from(823L), VERY_LONG_STRING, testConfig, sizes6);
 
             commit(context);
+        }
+    }
+
+    @MethodSource("testConfigsNoVersionInKey")
+    @ParameterizedTest(name = "saveAndDeleteWithIncompleteVersions[{0}]")
+    void saveAndDeleteWithIncompleteVersions(SplitHelperTestConfig testConfig) {
+        this.testConfig = testConfig;
+        final long baseKey = 1725L;
+
+        try (FDBRecordContext context = openContext()) {
+            // With incomplete versions
+            SplitHelper.SizeInfo sizeInfo1 = saveWithSplit(context, Tuple.from(baseKey), SHORT_STRING, FDBRecordVersion.incomplete(context.claimLocalVersion()), testConfig);
+            SplitHelper.SizeInfo sizeInfo2 = saveWithSplit(context, Tuple.from(baseKey + 1L), LONG_STRING, FDBRecordVersion.incomplete(context.claimLocalVersion()), testConfig);
+            SplitHelper.SizeInfo sizeInfo3 = saveWithSplit(context, Tuple.from(baseKey + 2L), VERY_LONG_STRING, FDBRecordVersion.incomplete(context.claimLocalVersion()), testConfig);
+
+            // Delete the records
+            deleteSplit(context, Tuple.from(baseKey), testConfig, sizeInfo1);
+            deleteSplit(context, Tuple.from(baseKey + 1L), testConfig, sizeInfo2);
+            deleteSplit(context, Tuple.from(baseKey + 2L), testConfig, sizeInfo3);
+
+            // All three records should be empty (in the same transaction as the write)
+            loadWithSplit(context, Tuple.from(baseKey), testConfig, null, null);
+            loadWithSplit(context, Tuple.from(baseKey + 1L), testConfig, null, null);
+            loadWithSplit(context, Tuple.from(baseKey + 2L), testConfig, null, null);
+
+            commit(context);
+        }
+        try (FDBRecordContext context = openContext()) {
+            // All three records should be empty (after the transaction is committed)
+            loadWithSplit(context, Tuple.from(baseKey), testConfig, null, null);
+            loadWithSplit(context, Tuple.from(baseKey + 1L), testConfig, null, null);
+            loadWithSplit(context, Tuple.from(baseKey + 2L), testConfig, null, null);
+        }
+    }
+
+    @MethodSource("testConfigsNoVersionInKey")
+    @ParameterizedTest(name = "saveAndDeleteAndUpdateWithIncompleteVersions[{0}]")
+    void saveAndDeleteAndUpdateWithIncompleteVersions(SplitHelperTestConfig testConfig) {
+        this.testConfig = testConfig;
+        final long baseKey = 1250L;
+
+        final SplitHelper.SizeInfo sizeInfo1;
+        final SplitHelper.SizeInfo sizeInfo2;
+        final SplitHelper.SizeInfo sizeInfo3;
+        final byte[] commitVersion;
+        try (FDBRecordContext context = openContext()) {
+            // With incomplete versions
+            SplitHelper.SizeInfo sizeInfo1a = saveWithSplit(context, Tuple.from(baseKey), SHORT_STRING, FDBRecordVersion.incomplete(context.claimLocalVersion()), testConfig);
+            SplitHelper.SizeInfo sizeInfo2a = saveWithSplit(context, Tuple.from(baseKey + 1L), LONG_STRING, FDBRecordVersion.incomplete(context.claimLocalVersion()), testConfig);
+            SplitHelper.SizeInfo sizeInfo3a = saveWithSplit(context, Tuple.from(baseKey + 2L), VERY_LONG_STRING, FDBRecordVersion.incomplete(context.claimLocalVersion()), testConfig);
+
+            // Delete the records
+            deleteSplit(context, Tuple.from(baseKey), testConfig, sizeInfo1a);
+            deleteSplit(context, Tuple.from(baseKey + 1L), testConfig, sizeInfo2a);
+            deleteSplit(context, Tuple.from(baseKey + 2L), testConfig, sizeInfo3a);
+
+            // Save a new copy on top of the old records
+            sizeInfo1 = saveWithSplit(context, Tuple.from(baseKey), LONG_STRING, FDBRecordVersion.incomplete(context.claimLocalVersion()), testConfig);
+            sizeInfo2 = saveWithSplit(context, Tuple.from(baseKey + 1L), VERY_LONG_STRING, FDBRecordVersion.incomplete(context.claimLocalVersion()), testConfig);
+            sizeInfo3 = saveWithSplit(context, Tuple.from(baseKey + 2L), SHORT_STRING, FDBRecordVersion.incomplete(context.claimLocalVersion()), testConfig);
+
+            // Loading the records (in the same transaction as the write) should match the new value
+            if (!testConfig.omitUnsplitSuffix && !testConfig.isDryRun) {
+                if (testConfig.splitLongRecords) {
+                    assertTrue(sizeInfo1.isVersionedInline());
+                    loadWithSplit(context, Tuple.from(baseKey), testConfig, sizeInfo1, LONG_STRING, FDBRecordVersion.incomplete(3));
+                    assertTrue(sizeInfo2.isVersionedInline());
+                    loadWithSplit(context, Tuple.from(baseKey + 1L), testConfig, sizeInfo2, VERY_LONG_STRING, FDBRecordVersion.incomplete(4));
+                }
+                assertTrue(sizeInfo3.isVersionedInline());
+                loadWithSplit(context, Tuple.from(baseKey + 2L), testConfig, sizeInfo3, SHORT_STRING, FDBRecordVersion.incomplete(5));
+            }
+
+            commit(context);
+            commitVersion = Objects.requireNonNull(context.getVersionStamp());
+        }
+        try (FDBRecordContext context = openContext()) {
+            // Values read after commit should match the second write, though with the version filled in
+            if (!testConfig.omitUnsplitSuffix && !testConfig.isDryRun) {
+                if (testConfig.splitLongRecords) {
+                    loadWithSplit(context, Tuple.from(baseKey), testConfig, sizeInfo1, LONG_STRING, FDBRecordVersion.complete(commitVersion, 3));
+                    loadWithSplit(context, Tuple.from(baseKey + 1L), testConfig, sizeInfo2, VERY_LONG_STRING, FDBRecordVersion.complete(commitVersion, 4));
+                }
+                loadWithSplit(context, Tuple.from(baseKey + 2L), testConfig, sizeInfo3, SHORT_STRING, FDBRecordVersion.complete(commitVersion, 5));
+            }
         }
     }
 

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VersionIndexTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/indexes/VersionIndexTest.java
@@ -872,6 +872,7 @@ public class VersionIndexTest {
             assertNull(version);
             versionOptional = recordStore.loadRecordVersion(Tuple.from(1066L));
             assertFalse(versionOptional.isPresent());
+            assertNull(recordStore.loadRecord(Tuple.from(1066L)));
 
             // Save a new record and verify version removed with it after it is deleted
             MySimpleRecord record2 = record.toBuilder().setRecNo(1415L).build();
@@ -884,12 +885,16 @@ public class VersionIndexTest {
             versionOptional = recordStore.loadRecordVersion(Tuple.from(1415L));
             assertTrue(versionOptional.isPresent());
             assertEquals(version, versionOptional.get());
+            FDBStoredRecord<Message> loadedRecord2 = recordStore.loadRecord(Tuple.from(1415L));
+            assertNotNull(loadedRecord2);
+            assertEquals(version, loadedRecord2.getVersion());
 
             assertTrue(recordStore.deleteRecord(Tuple.from(1415L)));
             version = recordStore.evaluateRecordFunction(function, storedRecord2).join();
             assertNull(version);
             versionOptional = recordStore.loadRecordVersion(Tuple.from(1415L));
             assertFalse(versionOptional.isPresent());
+            assertNull(recordStore.loadRecord(Tuple.from(1415L)));
 
             context.commit();
         }
@@ -899,6 +904,7 @@ public class VersionIndexTest {
             // pre-commit hook that writes all the versioned keys and values
             Optional<FDBRecordVersion> versionOptional = recordStore.loadRecordVersion(Tuple.from(1415L));
             assertFalse(versionOptional.isPresent());
+            assertNull(recordStore.loadRecord(Tuple.from(1415L)));
             context.commit();
         }
     }


### PR DESCRIPTION
This simplifies the logic (somewhat) for dealing with incomplete versions living in the `localVersionCache`. This updates the code so that we generally clear that key out with `context.clear()`, which handles:

1. Clearing out the key from the database (i.e., calling `tr.clear(key)` using the transaction's reference)
1. Removing the mutation from the `versionMutationCache`
1. Removing the cached `localVersion` from the `localVersionCache`

This keeps the three data structures in line in a (hopefully) more obvious way. It's not necessarily apparent from the name of the `FDBRecordContext::clear()` method that this does this, but it does, so I've been sure to add comments to the places where we clear out these keys to make that a bit clearer.

This resolves #4520, though it should be noted that this was identified as a bug, but I don't think it was--or at least not in the way suggested. In particular, the pre-existing logic in `FDBRecordStore::deleteTypedRecord` meant that we actually were updating the `localVersionCache`, though it wasn't in the place that was expected.