### PR TITLE
Decode the doubled-quote escape in string literals

### DIFF
--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/AstNormalizer.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/AstNormalizer.java
@@ -148,7 +148,11 @@ public final class AstNormalizer extends RelationalParserBaseVisitor<Object> {
             return ctx.FALSE() == null;
         });
         literalNodes.put(RelationalParser.BytesConstantContext.class, context -> ParseHelpers.parseBytes(context.getText()));
-        literalNodes.put(RelationalParser.StringConstantContext.class, context -> SemanticAnalyzer.normalizeString(context.getText(), false));
+        // Must decode exactly as ExpressionVisitor.visitStringLiteral does: this is the value the
+        // literal is extracted as for the plan cache, and a literal that caches differently from the
+        // way it evaluates is a cache that answers with the wrong constant.
+        literalNodes.put(RelationalParser.StringConstantContext.class, context ->
+                SemanticAnalyzer.normalizeStringLiteral(((RelationalParser.StringConstantContext) context).stringLiteral()));
         literalNodes.put(RelationalParser.DecimalConstantContext.class, context -> ParseHelpers.parseDecimal(context.getText()));
         literalNodes.put(RelationalParser.NegativeDecimalConstantContext.class, context -> ParseHelpers.parseDecimal(context.getText()));
     }

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/SemanticAnalyzer.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/SemanticAnalyzer.java
@@ -130,7 +130,11 @@ public class SemanticAnalyzer {
     }
 
     /**
-     * If a string is single- or double-quoted, removes the quotation, otherwise, upper-case it.
+     * If a string is double-quoted, removes the quotation, otherwise, upper-case it.
+     * <p>
+     * Refuses a single-quoted input. That is a string literal, and stripping its delimiters leaves the
+     * doubled-quote escape in the value; literals go through {@link #normalizeStringLiteral(String)}.
+     * No identifier can arrive here in single quotes, since {@code uid : simpleId | DOUBLE_QUOTE_ID}.
      *
      * @param string The input string
      * @param caseSensitive if {@code true}, the input string is taken as-is, upper-cased otherwise
@@ -141,6 +145,22 @@ public class SemanticAnalyzer {
         if (string == null) {
             return null;
         }
+        Assert.thatUnchecked(!isQuoted(string, "'"), ErrorCode.INTERNAL_ERROR,
+                () -> string + " is a string literal, it cannot be normalized as an identifier");
+        return unquoteOrUpperCase(string, caseSensitive);
+    }
+
+    /**
+     * {@link #normalizeString} without the refusal. A decorated literal needs this:
+     * {@code 'a' COLLATE 'utf8'} renders as {@code 'a'COLLATE'utf8'}, which the refusal would catch,
+     * and it has to keep producing what it produced before.
+     *
+     * @param string the input string, known not to be a string literal
+     * @param caseSensitive if {@code true}, the input string is taken as-is, upper-cased otherwise
+     * @return the normalized string
+     */
+    @Nonnull
+    private static String unquoteOrUpperCase(@Nonnull final String string, boolean caseSensitive) {
         if (isQuoted(string, "'") || isQuoted(string, "\"")) {
             return string.substring(1, string.length() - 1);
         } else if (caseSensitive) {
@@ -167,8 +187,8 @@ public class SemanticAnalyzer {
      * only reading that is correct for both, and it also gives the adjacent-literal run the
      * concatenation the grammar's {@code STRING_LITERAL+} implies.
      * <p>
-     * Charset-prefixed, national and {@code COLLATE}-decorated literals are deliberately left to
-     * {@link #normalizeString}: they are rejected upstream of the value path and this method must not
+     * Charset-prefixed, national and {@code COLLATE}-decorated literals deliberately keep the
+     * normalization they had: they are rejected upstream of the value path and this method must not
      * change what they produce.
      *
      * @param stringLiteral the {@code stringLiteral} context to decode
@@ -179,11 +199,11 @@ public class SemanticAnalyzer {
         if (stringLiteral.STRING_CHARSET_NAME() != null
                 || stringLiteral.START_NATIONAL_STRING_LITERAL() != null
                 || stringLiteral.COLLATE() != null) {
-            return normalizeString(stringLiteral.getText(), false);
+            return unquoteOrUpperCase(stringLiteral.getText(), false);
         }
         final List<TerminalNode> parts = stringLiteral.STRING_LITERAL();
         if (parts.isEmpty()) {
-            return normalizeString(stringLiteral.getText(), false);
+            return unquoteOrUpperCase(stringLiteral.getText(), false);
         }
         final StringBuilder builder = new StringBuilder();
         for (final TerminalNode part : parts) {

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/SemanticAnalyzer.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/SemanticAnalyzer.java
@@ -75,6 +75,7 @@ import com.google.common.collect.Streams;
 import com.google.protobuf.ByteString;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.tree.ParseTree;
+import org.antlr.v4.runtime.tree.TerminalNode;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -147,6 +148,63 @@ public class SemanticAnalyzer {
         } else {
             return string.toUpperCase(Locale.ROOT);
         }
+    }
+
+    /**
+     * Normalizes a string literal, decoding the doubled-quote escape that the lexer defines.
+     * <p>
+     * {@code RelationalLexer.g4} spells a single-quoted string as
+     * {@code fragment SQUOTA_STRING: '\'' ('\'\'' | ~('\''))* '\'';}. The {@code '\'\''} alternative
+     * admits a doubled quote as one unit <em>inside</em> the string, which is only meaningful if it
+     * denotes a single quote character. {@link #normalizeString} strips the outer delimiters and
+     * returns the remainder verbatim, so it leaves that escape undecoded and {@code 'it''s'} evaluates
+     * to the five characters {@code it''s} rather than the four characters {@code it's}.
+     * <p>
+     * This works from the literal TOKENS rather than from {@code getText()} because the text form is
+     * ambiguous: ANTLR's {@code getText()} concatenates tokens without their original spacing, so the
+     * two-token run {@code 'a' 'b'} and the single escaped literal {@code 'a''b'} both render as
+     * {@code 'a''b'} and cannot be told apart afterwards. Decoding each token and then joining is the
+     * only reading that is correct for both, and it also gives the adjacent-literal run the
+     * concatenation the grammar's {@code STRING_LITERAL+} implies.
+     * <p>
+     * Charset-prefixed, national and {@code COLLATE}-decorated literals are deliberately left to
+     * {@link #normalizeString}: they are rejected upstream of the value path and this method must not
+     * change what they produce.
+     *
+     * @param stringLiteral the {@code stringLiteral} context to decode
+     * @return the decoded string value
+     */
+    @Nullable
+    public static String normalizeStringLiteral(@Nonnull final RelationalParser.StringLiteralContext stringLiteral) {
+        if (stringLiteral.STRING_CHARSET_NAME() != null
+                || stringLiteral.START_NATIONAL_STRING_LITERAL() != null
+                || stringLiteral.COLLATE() != null) {
+            return normalizeString(stringLiteral.getText(), false);
+        }
+        final List<TerminalNode> parts = stringLiteral.STRING_LITERAL();
+        if (parts.isEmpty()) {
+            return normalizeString(stringLiteral.getText(), false);
+        }
+        final StringBuilder builder = new StringBuilder();
+        for (final TerminalNode part : parts) {
+            builder.append(unquoteSingleQuoted(part.getText()));
+        }
+        return builder.toString();
+    }
+
+    /**
+     * Removes the delimiters from one {@code STRING_LITERAL} token and decodes its doubled-quote
+     * escapes.
+     *
+     * @param token the raw token text, including its delimiters
+     * @return the decoded characters the token denotes
+     */
+    @Nonnull
+    private static String unquoteSingleQuoted(@Nonnull final String token) {
+        if (!isQuoted(token, "'") || token.length() < 2) {
+            return token;
+        }
+        return token.substring(1, token.length() - 1).replace("''", "'");
     }
 
     /**

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/SemanticAnalyzer.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/SemanticAnalyzer.java
@@ -187,20 +187,21 @@ public class SemanticAnalyzer {
         }
         final StringBuilder builder = new StringBuilder();
         for (final TerminalNode part : parts) {
-            builder.append(unquoteSingleQuoted(part.getText()));
+            builder.append(normalizeStringLiteral(part.getText()));
         }
         return builder.toString();
     }
 
     /**
      * Removes the delimiters from one {@code STRING_LITERAL} token and decodes its doubled-quote
-     * escapes.
+     * escapes. The grammar spells some literals as a bare token rather than through the
+     * {@code stringLiteral} rule, among them enum values and the {@code LIKE} escape character.
      *
      * @param token the raw token text, including its delimiters
      * @return the decoded characters the token denotes
      */
     @Nonnull
-    private static String unquoteSingleQuoted(@Nonnull final String token) {
+    public static String normalizeStringLiteral(@Nonnull final String token) {
         if (!isQuoted(token, "'") || token.length() < 2) {
             return token;
         }

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DdlVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DdlVisitor.java
@@ -479,7 +479,7 @@ public final class DdlVisitor extends DelegatingVisitor<BaseVisitor> {
         // (yhatem) we have control over the ENUM values' numbers.
         final List<DataType.EnumType.EnumValue> enumValues = new ArrayList<>(ctx.STRING_LITERAL().size());
         for (int i = 0; i < ctx.STRING_LITERAL().size(); i++) {
-            enumValues.add(DataType.EnumType.EnumValue.of(Assert.notNullUnchecked(getDelegate().normalizeString(ctx.STRING_LITERAL(i).getText())), i));
+            enumValues.add(DataType.EnumType.EnumValue.of(SemanticAnalyzer.normalizeStringLiteral(ctx.STRING_LITERAL(i).getText()), i));
         }
         return DataType.EnumType.from(enumId.getName(), enumValues, false);
     }

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/ExpressionVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/ExpressionVisitor.java
@@ -672,7 +672,7 @@ public final class ExpressionVisitor extends DelegatingVisitor<BaseVisitor> {
     private Expression visitLikePredicate(@Nonnull Expression operand, @Nonnull RelationalParser.LikePredicateContext ctx) {
         final LiteralValue<?> escapeValue;
         if (ctx.escape != null) {
-            final var escapeChar = getDelegate().normalizeString(ctx.escape.getText());
+            final var escapeChar = SemanticAnalyzer.normalizeStringLiteral(ctx.escape.getText());
             escapeValue = new LiteralValue<>(escapeChar);
         } else {
             escapeValue = new LiteralValue<>(null);

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/ExpressionVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/ExpressionVisitor.java
@@ -825,7 +825,7 @@ public final class ExpressionVisitor extends DelegatingVisitor<BaseVisitor> {
         Assert.isNullUnchecked(ctx.START_NATIONAL_STRING_LITERAL(), ErrorCode.UNSUPPORTED_QUERY, "national string literal is not supported");
         Assert.isNullUnchecked(ctx.COLLATE(), ErrorCode.UNSUPPORTED_QUERY, "collation is not supported");
         final var value = getDelegate().getPlanGenerationContext().processQueryLiteral(Type.primitiveType(Type.TypeCode.STRING),
-                getDelegate().normalizeString(ctx.getText()),
+                SemanticAnalyzer.normalizeStringLiteral(ctx),
                 ctx.getStart().getTokenIndex());
         return Expression.ofUnnamed(value);
     }

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/AstNormalizerTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/AstNormalizerTests.java
@@ -592,6 +592,30 @@ public class AstNormalizerTests {
                         constantId(9), List.of("foo", "bar")));
     }
 
+    /**
+     * The stripped literal is the constant the plan cache is keyed on and later bound with, so it has
+     * to decode the way {@code ExpressionVisitor.visitStringLiteral} does. A literal that caches
+     * differently from the way it evaluates is a cache that answers with the wrong constant.
+     */
+    @Test
+    void stripStringLiteralWithEscapedQuote() throws RelationalException {
+        validate("select 'it''s', '''' from t1",
+                "SELECT ? , ? FROM \"T1\" ",
+                Map.of(constantId(1), "it's",
+                        constantId(3), "'"));
+    }
+
+    /**
+     * Adjacent literals are separate tokens and concatenate. {@code getText()} renders this run
+     * identically to {@code 'a''b'}, which is why the stripping works from the tokens.
+     */
+    @Test
+    void stripAdjacentStringLiterals() throws RelationalException {
+        validate("select 'a' 'b' from t1",
+                "SELECT ? FROM \"T1\" ",
+                Map.of(constantId(1), "ab"));
+    }
+
     @Test
     void stripDecimalLiteral() throws RelationalException {
         validate("select 1, 2.3, 4.5f, -8, -9.1, -2.3f from t1",

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/StringLiteralNormalizationTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/StringLiteralNormalizationTest.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.relational.recordlayer.query;
 
+import com.apple.foundationdb.record.util.ProtoUtils;
 import com.apple.foundationdb.relational.generated.RelationalLexer;
 import com.apple.foundationdb.relational.generated.RelationalParser;
 import org.antlr.v4.runtime.CharStreams;
@@ -36,9 +37,9 @@ import java.util.stream.Stream;
  * Tests for the decoding of string literals, which the lexer defines: {@code SQUOTA_STRING} admits a
  * doubled quote as one unit inside a single-quoted string, denoting a single quote character.
  *
- * <p>The cases are supplied as {@link Arguments} rather than through {@code @CsvSource} on purpose —
- * the CSV parser uses the single quote as its own quote character and would strip the delimiters off
- * every literal here before the test ever saw them.
+ * <p>The cases are supplied as {@link Arguments} rather than through {@code @CsvSource} on purpose,
+ * because the CSV parser uses the single quote as its own quote character and would strip the
+ * delimiters off every literal here before the test ever saw them.
  */
 public class StringLiteralNormalizationTest {
 
@@ -72,6 +73,18 @@ public class StringLiteralNormalizationTest {
     @MethodSource("literals")
     void decodesTheDoubledQuoteEscape(final String literal, final String expected) {
         Assertions.assertEquals(expected, SemanticAnalyzer.normalizeStringLiteral(parseStringLiteral(literal)));
+    }
+
+    /**
+     * The token overload has to agree with the rule on every single-token input, otherwise the same
+     * literal denotes one string in a projection and another in an enum definition.
+     */
+    @ParameterizedTest(name = "token {0} decodes to {1}")
+    @MethodSource("literals")
+    void theTokenOverloadDecodesAsTheRuleDoes(final String literal, final String expected) {
+        Assertions.assertEquals(expected, SemanticAnalyzer.normalizeStringLiteral(literal));
+        Assertions.assertEquals(SemanticAnalyzer.normalizeStringLiteral(parseStringLiteral(literal)),
+                SemanticAnalyzer.normalizeStringLiteral(literal));
     }
 
     /**
@@ -147,5 +160,23 @@ public class StringLiteralNormalizationTest {
         Assertions.assertNotNull(ctx.STRING_CHARSET_NAME(), "fixture no longer parses as a decorated literal");
         Assertions.assertEquals(SemanticAnalyzer.normalizeString(ctx.getText(), false),
                 SemanticAnalyzer.normalizeStringLiteral(ctx));
+    }
+
+    /**
+     * The decoding cannot change what an enum value means: the name becomes a protobuf enum value
+     * identifier, and neither {@code it's} nor {@code it''s} matches {@code [A-Za-z_][A-Za-z0-9_]*}.
+     * This pins the guard that makes it unobservable, so admitting a quote there does not silently
+     * arm the decoding.
+     */
+    @Test
+    void anEnumValueCarryingTheEscapeIsRejectedWhicheverWayItDecodes() {
+        Assertions.assertThrows(ProtoUtils.InvalidNameException.class,
+                () -> ProtoUtils.toProtoBufCompliantName(SemanticAnalyzer.normalizeStringLiteral("'it''s'")));
+        Assertions.assertThrows(ProtoUtils.InvalidNameException.class,
+                () -> ProtoUtils.toProtoBufCompliantName("it''s"));
+
+        // Control: without it, a method rejecting everything passes.
+        Assertions.assertEquals("plain", ProtoUtils.toProtoBufCompliantName(
+                SemanticAnalyzer.normalizeStringLiteral("'plain'")));
     }
 }

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/StringLiteralNormalizationTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/StringLiteralNormalizationTest.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.relational.recordlayer.query;
 
 import com.apple.foundationdb.record.util.ProtoUtils;
+import com.apple.foundationdb.relational.api.exceptions.UncheckedRelationalException;
 import com.apple.foundationdb.relational.generated.RelationalLexer;
 import com.apple.foundationdb.relational.generated.RelationalParser;
 import org.antlr.v4.runtime.CharStreams;
@@ -160,6 +161,39 @@ public class StringLiteralNormalizationTest {
         Assertions.assertNotNull(ctx.STRING_CHARSET_NAME(), "fixture no longer parses as a decorated literal");
         Assertions.assertEquals(SemanticAnalyzer.normalizeString(ctx.getText(), false),
                 SemanticAnalyzer.normalizeStringLiteral(ctx));
+    }
+
+    /**
+     * A single-quoted input is a caller that routed a literal into the identifier path. Nothing in
+     * the grammar reaches here that way, since {@code uid : simpleId | DOUBLE_QUOTE_ID}.
+     */
+    @Test
+    void theIdentifierNormalizationRefusesAStringLiteral() {
+        Assertions.assertThrows(UncheckedRelationalException.class,
+                () -> SemanticAnalyzer.normalizeString("'it''s'", false));
+        Assertions.assertThrows(UncheckedRelationalException.class,
+                () -> SemanticAnalyzer.normalizeString("'plain'", true));
+
+        // Controls: what the method is for still works.
+        Assertions.assertEquals("Mixed", SemanticAnalyzer.normalizeString("\"Mixed\"", false));
+        Assertions.assertEquals("MIXED", SemanticAnalyzer.normalizeString("Mixed", false));
+        Assertions.assertEquals("Mixed", SemanticAnalyzer.normalizeString("Mixed", true));
+        Assertions.assertNull(SemanticAnalyzer.normalizeString(null, false));
+    }
+
+    /**
+     * {@code collationName : uid | STRING_LITERAL}, so a collated literal can render as text that
+     * both starts and ends with a quote. The query is refused upstream with
+     * {@code UNSUPPORTED_QUERY}; the extraction running before that must not pre-empt it with an
+     * internal error.
+     */
+    @Test
+    void collatedLiteralIsNotMistakenForAnIdentifier() {
+        final var ctx = parseStringLiteral("'a' COLLATE 'utf8'");
+        Assertions.assertNotNull(ctx.COLLATE(), "fixture no longer parses as a collated literal");
+        Assertions.assertTrue(ctx.getText().startsWith("'") && ctx.getText().endsWith("'"),
+                "fixture no longer renders as text a refusal would catch: " + ctx.getText());
+        Assertions.assertDoesNotThrow(() -> SemanticAnalyzer.normalizeStringLiteral(ctx));
     }
 
     /**

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/StringLiteralNormalizationTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/StringLiteralNormalizationTest.java
@@ -1,0 +1,151 @@
+/*
+ * StringLiteralNormalizationTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2021-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.relational.recordlayer.query;
+
+import com.apple.foundationdb.relational.generated.RelationalLexer;
+import com.apple.foundationdb.relational.generated.RelationalParser;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+/**
+ * Tests for the decoding of string literals, which the lexer defines: {@code SQUOTA_STRING} admits a
+ * doubled quote as one unit inside a single-quoted string, denoting a single quote character.
+ *
+ * <p>The cases are supplied as {@link Arguments} rather than through {@code @CsvSource} on purpose —
+ * the CSV parser uses the single quote as its own quote character and would strip the delimiters off
+ * every literal here before the test ever saw them.
+ */
+public class StringLiteralNormalizationTest {
+
+    @SuppressWarnings("PMD.CloseResource") // the ANTLR streams hold no OS resources
+    private static RelationalParser.StringLiteralContext parseStringLiteral(final String literal) {
+        final var lexer = new RelationalLexer(CharStreams.fromString(literal));
+        final var parser = new RelationalParser(new CommonTokenStream(lexer));
+        return parser.stringLiteral();
+    }
+
+    static Stream<Arguments> literals() {
+        return Stream.of(
+                // Controls. An implementation that only strips the outer delimiters already answers
+                // these correctly, which is precisely why they cannot detect the defect.
+                Arguments.of("'abc'", "abc"),
+                Arguments.of("''", ""),
+                // The escape denotes one quote character.
+                Arguments.of("'it''s'", "it's"),
+                Arguments.of("''''", "'"),
+                Arguments.of("'a''''b'", "a''b"),
+                Arguments.of("'''abc'", "'abc"),
+                Arguments.of("'abc'''", "abc'")
+        );
+    }
+
+    /**
+     * Before the escape was decoded, {@code 'it''s'} evaluated to the five characters {@code it''s},
+     * so the value carried the escape rather than the character it denotes.
+     */
+    @ParameterizedTest(name = "{0} decodes to {1}")
+    @MethodSource("literals")
+    void decodesTheDoubledQuoteEscape(final String literal, final String expected) {
+        Assertions.assertEquals(expected, SemanticAnalyzer.normalizeStringLiteral(parseStringLiteral(literal)));
+    }
+
+    /**
+     * Adjacent literals are separate tokens and concatenate.
+     *
+     * <p>This is why the decoding works from the TOKENS rather than from {@code getText()}: ANTLR
+     * drops the original spacing, so {@code 'a' 'b'} and {@code 'a''b'} render identically and cannot
+     * be told apart once concatenated. Decoding each token and then joining is the only reading that
+     * is correct for both.
+     */
+    @Test
+    void adjacentLiteralsConcatenateAndAreNotConfusedWithAnEscape() {
+        Assertions.assertEquals("ab", SemanticAnalyzer.normalizeStringLiteral(parseStringLiteral("'a' 'b'")));
+        Assertions.assertEquals("a'b", SemanticAnalyzer.normalizeStringLiteral(parseStringLiteral("'a''b'")));
+
+        // The two inputs above share one text once ANTLR concatenates their tokens. Asserting that
+        // here means a future rewrite which goes back to getText() cannot pass this class.
+        Assertions.assertEquals(parseStringLiteral("'a' 'b'").getText(), parseStringLiteral("'a''b'").getText());
+    }
+
+    static Stream<Arguments> roundTrips() {
+        return Stream.of(
+                Arguments.of(""),
+                Arguments.of("a"),
+                Arguments.of("it's"),
+                Arguments.of("'"),
+                Arguments.of("''"),
+                Arguments.of("'leading"),
+                Arguments.of("trailing'"),
+                Arguments.of("a'b'c"),
+                Arguments.of("no quotes here"),
+                Arguments.of("tab\tand newline\n"),
+                Arguments.of("unicode äöü"),
+                Arguments.of("back\\slash"),
+                Arguments.of("\"double quotes\"")
+        );
+    }
+
+    /**
+     * Round-trips an arbitrary string through the grammar's own encoding and back.
+     *
+     * <p>This is the check that the decoding agrees with ANTLR rather than with a reading of the
+     * lexer rule. {@code SQUOTA_STRING} is
+     * {@code '\'' ('\'\'' | ~('\''))* '\''}, so the encoding of a string is: wrap in quotes, double
+     * every interior quote. The test applies that encoding, hands the result to the REAL generated
+     * lexer, decodes, and requires the original back. If the decoder and the lexer disagree about
+     * what the escape means, the round trip cannot hold.
+     *
+     * <p>It also asserts the lexer produced exactly ONE {@code STRING_LITERAL} token. Without that,
+     * a case where the lexer split the input into several tokens could still round-trip through the
+     * concatenating decoder and hide the disagreement.
+     */
+    @ParameterizedTest(name = "round trip {0}")
+    @MethodSource("roundTrips")
+    void decodingInvertsTheGrammarsEncoding(final String raw) {
+        final var literal = "'" + raw.replace("'", "''") + "'";
+        final var ctx = parseStringLiteral(literal);
+        Assertions.assertEquals(1, ctx.STRING_LITERAL().size(),
+                "lexer did not read " + literal + " as a single STRING_LITERAL token");
+        Assertions.assertEquals(raw, SemanticAnalyzer.normalizeStringLiteral(ctx));
+    }
+
+    /**
+     * A charset-decorated literal keeps its previous handling. Those are rejected upstream of the
+     * value path, and this decoding must not start producing a value for them.
+     *
+     * <p>The charset name is upper case because the lexer spells it that way
+     * ({@code UTF8: 'UTF8';}); a lower-case {@code _utf8} does not lex as a charset name at all.
+     */
+    @Test
+    void decoratedLiteralsAreLeftToTheLegacyNormalization() {
+        final var ctx = parseStringLiteral("_UTF8'a'");
+        Assertions.assertNotNull(ctx.STRING_CHARSET_NAME(), "fixture no longer parses as a decorated literal");
+        Assertions.assertEquals(SemanticAnalyzer.normalizeString(ctx.getText(), false),
+                SemanticAnalyzer.normalizeStringLiteral(ctx));
+    }
+}

--- a/yaml-tests/src/test/resources/like.yamsql
+++ b/yaml-tests/src/test/resources/like.yamsql
@@ -423,6 +423,12 @@ test_block:
       - error: INVALID_ESCAPE_CHARACTER
       - initialVersionLessThan: 4.13.1.0
       - error: INTERNAL_ERROR
+    # Escape character ', pattern '%. Undecoded, the escape was the two
+    # characters '' and this was rejected as too long.
+    -
+      - query: select * from A WHERE A1 LIKE '''%' ESCAPE ''''
+      - supported_version: !current_version
+      - result: [{'%'}]
     -
       - query: select * from A WHERE A1 LIKE '\%'
       - unorderedResult: [{'\\||%'}, {'\xyz'}]

--- a/yaml-tests/src/test/resources/literal-tests.yamsql
+++ b/yaml-tests/src/test/resources/literal-tests.yamsql
@@ -79,4 +79,51 @@ test_block:
       - query: select * from B where 6 = coalesce(5, 6)
       - explain: "SCAN([IS B]) | FILTER coalesce_int(@c9, @c5) EQUALS @c5"
       - result: []
+---
+test_block:
+  name: string-literal-escape
+  preset: single_repetition_ordered
+  tests:
+    # A doubled quote inside a string literal denotes ONE quote character.
+    # The lexer says so: SQUOTA_STRING admits '' as a unit inside the string
+    # (RelationalLexer.g4). Before this was decoded, 'it''s' evaluated to the
+    # five characters it''s.
+    -
+      - query: select 'it''s' from B where b1 = 1
+      - supported_version: !current_version
+      - result: [{"it's"}]
+    # A literal that is nothing but one escaped quote.
+    -
+      - query: select '''' from B where b1 = 1
+      - supported_version: !current_version
+      - result: [{"'"}]
+    # The decode runs on the write path too, so the STORED value is the
+    # decoded one and an equality predicate written with the escape matches it.
+    -
+      - query: insert into B values (7, 'it''s', 7)
+      - count: 1
+    -
+      - query: select b2 from B where b1 = 7
+      - supported_version: !current_version
+      - result: [{"it's"}]
+    -
+      - query: select b1 from B where b2 = 'it''s'
+      - supported_version: !current_version
+      - result: [{7}]
+    # Adjacent literals are separate tokens and concatenate. getText() renders
+    # this run identically to the escaped literal above, which is why the
+    # decode works from the tokens rather than from the concatenated text.
+    -
+      - query: select 'a' 'b' from B where b1 = 1
+      - supported_version: !current_version
+      - result: [{'ab'}]
+    # Controls: an empty literal and a plain one are unaffected. The empty
+    # literal is the case an outer-strip-only decoder already got right, which
+    # is why nothing here caught the bug before.
+    -
+      - query: select '' from B where b1 = 1
+      - result: [{''}]
+    -
+      - query: select 'abc' from B where b1 = 1
+      - result: [{'abc'}]
 ...


### PR DESCRIPTION
The lexer defines a doubled single quote as an escape inside a string literal.
From `fdb-relational-core/src/main/antlr/RelationalLexer.g4:1369`:

```antlr
fragment SQUOTA_STRING: '\'' ('\'\'' | ~('\''))* '\'';
```

The `'\'\''` alternative admits the doubled quote as one unit inside the string,
which only makes sense if it denotes a single quote character.

`SemanticAnalyzer.normalizeString` doesn't decode it
(`SemanticAnalyzer.java:143-153`):

```java
if (isQuoted(string, "'") || isQuoted(string, "\"")) {
    return string.substring(1, string.length() - 1);
}
```

It removes the delimiters and returns the rest as-is, so the escape survives
into the value:

```sql
SELECT 'it''s';   -- it''s (5 chars), should be it's (4 chars)
SELECT '''';      -- ''    (2 chars), should be '    (1 char)
```

The same decoding runs on the write path:

```sql
INSERT INTO T VALUES (1, 'it''s');
SELECT s FROM T WHERE s = 'it''s';
```

The stored value carries the escape. That predicate still matches, because both
sides are undecoded.

### The fix

Decode the escape from the literal tokens instead of from `getText()`.

ANTLR concatenates tokens without their spacing, so `'a' 'b'` and `'a''b'`
produce the same text. Decoding per token handles both, and gives the adjacent
run the concatenation `STRING_LITERAL+` implies.

`ExpressionVisitor.visitStringLiteral` and `AstNormalizer` both change,
otherwise a literal caches differently from how it evaluates.

### How i found it

i am building a Go port of the Record Layer that reuses this grammar. Running
the same queries against both engines, the Go side decodes the escape and this
one does not, so the same INSERT stores 4 characters there and 5 here.
