### PR TITLE
Rewrite the materialized view index generator using generated Value visitation

### DIFF
--- a/fdb-java-annotations/fdb-java-annotations.gradle
+++ b/fdb-java-annotations/fdb-java-annotations.gradle
@@ -29,6 +29,12 @@ dependencies {
     implementation(libs.javaPoet)
     compileOnly(libs.autoService)
     annotationProcessor(libs.autoService)
+
+    testImplementation(libs.bundles.test.impl)
+    testRuntimeOnly(libs.bundles.test.runtime)
+    testCompileOnly(libs.bundles.test.compileOnly)
+    // the processor emits @Nonnull, so the annotation has to be on the classpath of the compilation the tests run
+    testRuntimeOnly(libs.jsr305)
 }
 
 publishing {

--- a/fdb-java-annotations/src/main/java/com/apple/foundationdb/annotation/GenerateVisitorAnnotationHelper.java
+++ b/fdb-java-annotations/src/main/java/com/apple/foundationdb/annotation/GenerateVisitorAnnotationHelper.java
@@ -55,6 +55,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * A separate class to support (@link GenerateVisitorAnnotationProcessor) so that dependency on javapoet does not leak to anyone
@@ -98,15 +99,42 @@ class GenerateVisitorAnnotationHelper {
             final var rootTypeMirror = rootTypeElement.asType();
 
             final var packageOfRoot = elementUtils.getPackageOf(rootTypeElement);
-            final var subClassTypeMirrors = moduleElement
+            final var candidateElements = moduleElement
                     .getEnclosedElements()
                     .stream()
-                    .flatMap(packageElement -> packageElement.getEnclosedElements().stream())
+                    .flatMap(GenerateVisitorAnnotationHelper::enclosedTypesRecursively)
                     .filter(element -> element.getKind() == ElementKind.CLASS &&
                             !element.getModifiers().contains(Modifier.ABSTRACT))
+                    .filter(element -> {
+                        final var mirror = element.asType();
+                        return mirror.getKind() == TypeKind.DECLARED && typeUtils.isSubtype(mirror, rootTypeMirror);
+                    })
+                    .collect(Collectors.toList());
+
+            //
+            // The generated visitor lives in the package of the annotated root, so it cannot name a subclass that is
+            // not public, or that is nested inside a type that is not. Silently skipping such a subclass would leave it
+            // without a visitation method and quietly route it to the default one, which is exactly the kind of gap
+            // this generator exists to prevent -- so it is an error instead.
+            //
+            final var inaccessibleElements = candidateElements
+                    .stream()
+                    .filter(element -> !isPublicIncludingEnclosingTypes(element))
+                    .collect(Collectors.toList());
+            if (!inaccessibleElements.isEmpty()) {
+                for (final var inaccessibleElement : inaccessibleElements) {
+                    error(messager, inaccessibleElement,
+                            "%s is a non-public subclass of %s, so the generated visitor cannot name it; make it and "
+                                    + "all of its enclosing types public, or move it out of its enclosing type",
+                            ((TypeElement)inaccessibleElement).getQualifiedName().toString(),
+                            rootTypeElement.getQualifiedName().toString());
+                }
+                return true;
+            }
+
+            final var subClassTypeMirrors = candidateElements
+                    .stream()
                     .map(Element::asType)
-                    .filter(mirror -> mirror.getKind() == TypeKind.DECLARED)
-                    .filter(mirror -> typeUtils.isSubtype(mirror, rootTypeMirror))
                     .collect(Collectors.toList());
 
             try {
@@ -160,19 +188,30 @@ class GenerateVisitorAnnotationHelper {
                                 WildcardTypeName.subtypeOf(Object.class))),
                 "jumpMap", Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL);
 
-        final var initializerStrings = subClassTypeMirrors.stream()
-                .map(typeMirror -> {
-                    final var typeElement = (TypeElement)typeUtils.asElement(typeMirror);
-                    return "Map.entry(" + typeElement.getSimpleName() + ".class, (visitor, element) -> visitor." + methodNameOfVisitMethod(generateVisitor, typeElement) + "((" + typeElement.getSimpleName() + ")element))";
-                })
-                .collect(Collectors.joining(", \n"));
-
-        final var initializerBlock = CodeBlock.builder()
-                .add("$T.ofEntries(" + initializerStrings + ")", ClassName.get(Map.class))
-                .build();
+        //
+        // Emitted through JavaPoet type placeholders rather than by concatenating simple names: a nested type has to be
+        // named as Outer.Inner and needs an import for Outer, and a generic type has to be cast to its
+        // wildcard-parameterized form so that the cast is checked rather than raw.
+        //
+        final var initializerBuilder = CodeBlock.builder();
+        initializerBuilder.add("$T.ofEntries(", ClassName.get(Map.class));
+        boolean firstEntry = true;
+        for (final var typeMirror : subClassTypeMirrors) {
+            final var typeElement = (TypeElement)typeUtils.asElement(typeMirror);
+            if (!firstEntry) {
+                initializerBuilder.add(", \n");
+            }
+            firstEntry = false;
+            initializerBuilder.add("$T.entry($T.class, (visitor, element) -> visitor.$L(($T)element))",
+                    ClassName.get(Map.class),
+                    ClassName.get(typeElement),
+                    methodNameOfVisitMethod(generateVisitor, typeElement),
+                    visitableTypeName(typeElement));
+        }
+        initializerBuilder.add(")");
 
         typeBuilder.addField(jumpMapBuilder
-                .initializer(initializerBlock)
+                .initializer(initializerBuilder.build())
                 .build());
 
         for (final var typeMirror : subClassTypeMirrors) {
@@ -183,7 +222,7 @@ class GenerateVisitorAnnotationHelper {
                             .methodBuilder(methodName)
                             .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
                             .addAnnotation(Nonnull.class)
-                            .addParameter(ParameterSpec.builder(TypeName.get(typeMirror), parameterName).addAnnotation(Nonnull.class).build())
+                            .addParameter(ParameterSpec.builder(visitableTypeName(typeElement), parameterName).addAnnotation(Nonnull.class).build())
                             .returns(typeVariableName);
             typeBuilder.addMethod(specificVisitMethodBuilder.build());
         }
@@ -240,7 +279,7 @@ class GenerateVisitorAnnotationHelper {
                             .addModifiers(Modifier.PUBLIC, Modifier.DEFAULT)
                             .addAnnotation(Nonnull.class)
                             .addAnnotation(Override.class)
-                            .addParameter(ParameterSpec.builder(TypeName.get(typeMirror), parameterName).addAnnotation(Nonnull.class).build())
+                            .addParameter(ParameterSpec.builder(visitableTypeName(typeElement), parameterName).addAnnotation(Nonnull.class).build())
                             .returns(typeVariableName)
                             .addCode(CodeBlock.builder()
                                     .addStatement("return " + defaultMethodName + "(" + parameterName + ")")
@@ -256,6 +295,73 @@ class GenerateVisitorAnnotationHelper {
 
     private static String methodNameOfVisitMethod(@Nonnull final GenerateVisitor generateVisitor, @Nonnull TypeElement typeElement) {
         return generateVisitor.methodPrefix() + typeElement.getSimpleName().toString().replace(generateVisitor.stripPrefix(), "");
+    }
+
+    /**
+     * Returns the given element together with every type nested inside it, at any depth. The original implementation
+     * only looked at the types directly enclosed by a package, which silently skipped every nested subclass of an
+     * annotated root.
+     * <p>
+     * The enclosing type is included alongside its nested types, not replaced by them: a type is routinely both a
+     * dispatch target and a container of nested helpers -- almost every {@code Value}, for instance, nests its own
+     * {@code Deserializer} -- so descending into a type must not remove the type itself from consideration.
+     * </p>
+     *
+     * @param element the element to descend into, a package or a type
+     *
+     * @return a stream of the types enclosed by {@code element}, recursively
+     */
+    @Nonnull
+    private static Stream<Element> enclosedTypesRecursively(@Nonnull final Element element) {
+        return element.getEnclosedElements()
+                .stream()
+                .filter(enclosed -> enclosed.getKind().isClass() || enclosed.getKind().isInterface())
+                .flatMap(enclosed -> Stream.concat(Stream.of(enclosed), enclosedTypesRecursively(enclosed)));
+    }
+
+    /**
+     * Returns whether the given type and all of the types enclosing it are public. A nested type that is not, or that
+     * is nested inside one that is not, cannot be named by the generated visitor interface, which lives in the package
+     * of the annotated root rather than inside the enclosing type.
+     *
+     * @param element the type to check
+     *
+     * @return {@code true} if the type is visible to generated code
+     */
+    private static boolean isPublicIncludingEnclosingTypes(@Nonnull final Element element) {
+        for (Element current = element; current != null && !(current instanceof PackageElement);
+                current = current.getEnclosingElement()) {
+            if (!current.getModifiers().contains(Modifier.PUBLIC)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * The name to use when the generated code needs to refer to the given type.
+     * <p>
+     * A generic type has to be named with a wildcard for each of its type parameters. Using the type as declared would
+     * leak its type variables into the visitor interface, where they are out of scope and, if a type parameter happens
+     * to be named like the visitor's own result variable, silently capture it instead -- {@code LiteralValue<T>} in a
+     * {@code ValueVisitor<T>} reads as "a literal whose type is the visitor's result type", which is not what is meant.
+     * </p>
+     *
+     * @param typeElement the type to name
+     *
+     * @return the type name to emit, wildcard-parameterized if the type is generic
+     */
+    @Nonnull
+    private static TypeName visitableTypeName(@Nonnull final TypeElement typeElement) {
+        final var className = ClassName.get(typeElement);
+        final var typeParameters = typeElement.getTypeParameters();
+        if (typeParameters.isEmpty()) {
+            return className;
+        }
+        final var wildcards = typeParameters.stream()
+                .map(ignored -> (TypeName)WildcardTypeName.subtypeOf(Object.class))
+                .toArray(TypeName[]::new);
+        return ParameterizedTypeName.get(className, wildcards);
     }
 
     @SuppressWarnings("BooleanMethodIsAlwaysInverted")

--- a/fdb-java-annotations/src/test/java/com/apple/foundationdb/annotation/GenerateVisitorAnnotationProcessorTest.java
+++ b/fdb-java-annotations/src/test/java/com/apple/foundationdb/annotation/GenerateVisitorAnnotationProcessorTest.java
@@ -1,0 +1,188 @@
+/*
+ * GenerateVisitorAnnotationProcessorTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.annotation;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import javax.annotation.Nonnull;
+import javax.tools.DiagnosticCollector;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardLocation;
+import javax.tools.ToolProvider;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Compiles sources annotated with {@link GenerateVisitor} and asserts what the processor makes of them.
+ */
+class GenerateVisitorAnnotationProcessorTest {
+
+    @TempDir
+    Path workingDir;
+
+    /**
+     * A hierarchy whose subclasses are nested -- one of them two levels deep, one of them generic, one of them abstract.
+     */
+    private static final String SHAPES = """
+            package fixture;
+
+            import com.apple.foundationdb.annotation.GenerateVisitor;
+
+            @GenerateVisitor
+            public abstract class Shape {
+                public static final class Circle extends Shape {
+                }
+
+                public static final class Box<T> extends Shape {
+                }
+
+                public abstract static class Curved extends Shape {
+                    public static final class Wobble extends Curved {
+                    }
+                }
+            }
+            """;
+
+    @Test
+    void visitsEveryConcreteSubclassIncludingNestedOnes() throws Exception {
+        final var result = compile(SHAPES);
+        assertThat(result.succeeded()).as(result.messages()).isTrue();
+
+        final var visitor = result.generatedSource("fixture/ShapeVisitor.java");
+        assertThat(visitor)
+                .contains("visitCircle")
+                .contains("visitBox")
+                .contains("visitWobble");
+    }
+
+    @Test
+    void skipsAbstractSubclasses() throws Exception {
+        final var visitor = compile(SHAPES).generatedSource("fixture/ShapeVisitor.java");
+        assertThat(visitor).doesNotContain("visitCurved");
+    }
+
+    @Test
+    void namesAGenericSubclassWithWildcards() throws Exception {
+        final var visitor = compile(SHAPES).generatedSource("fixture/ShapeVisitor.java");
+        // the type variable of Box must not reach the visitor, where it would capture the visitor's own result variable
+        assertThat(visitor)
+                .contains("Shape.Box<?> element")
+                .doesNotContain("Shape.Box<T> element");
+    }
+
+    @Test
+    void namesANestedSubclassThroughItsEnclosingType() throws Exception {
+        final var visitor = compile(SHAPES).generatedSource("fixture/ShapeVisitor.java");
+        assertThat(visitor).contains("Shape.Curved.Wobble.class");
+    }
+
+    @Test
+    void generatesAnImplementationThatDefaultsEveryVisitation() throws Exception {
+        final var withDefaults = compile(SHAPES).generatedSource("fixture/ShapeVisitorWithDefaults.java");
+        assertThat(withDefaults)
+                .contains("interface ShapeVisitorWithDefaults")
+                .contains("visitCircle")
+                .contains("visitDefault(element)");
+    }
+
+    @Test
+    void rejectsANonPublicSubclass() throws Exception {
+        final var result = compile("""
+                package fixture;
+
+                import com.apple.foundationdb.annotation.GenerateVisitor;
+
+                @GenerateVisitor
+                public abstract class Thing {
+                    static final class Hidden extends Thing {
+                    }
+                }
+                """);
+        assertThat(result.succeeded()).isFalse();
+        assertThat(result.messages())
+                .contains("fixture.Thing.Hidden is a non-public subclass of fixture.Thing");
+    }
+
+    @Test
+    void rejectsANonPublicEnclosingType() throws Exception {
+        final var result = compile("""
+                package fixture;
+
+                import com.apple.foundationdb.annotation.GenerateVisitor;
+
+                @GenerateVisitor
+                public abstract class Thing {
+                    static class Enclosing {
+                        public static final class Visible extends Thing {
+                        }
+                    }
+                }
+                """);
+        assertThat(result.succeeded()).isFalse();
+        assertThat(result.messages()).contains("is a non-public subclass of fixture.Thing");
+    }
+
+    @Nonnull
+    private Result compile(@Nonnull final String source) throws IOException {
+        final var sourceDir = Files.createDirectories(workingDir.resolve("src/fixture"));
+        final var classesDir = Files.createDirectories(workingDir.resolve("classes"));
+        final var generatedDir = Files.createDirectories(workingDir.resolve("generated"));
+
+        final var typeName = source.replaceAll("(?s).*public abstract class (\\w+).*", "$1");
+        final var sourceFile = sourceDir.resolve(typeName + ".java");
+        Files.writeString(sourceFile, source, StandardCharsets.UTF_8);
+
+        final var compiler = ToolProvider.getSystemJavaCompiler();
+        final var diagnostics = new DiagnosticCollector<JavaFileObject>();
+        try (var fileManager = compiler.getStandardFileManager(diagnostics, null, StandardCharsets.UTF_8)) {
+            fileManager.setLocationFromPaths(StandardLocation.CLASS_OUTPUT, List.of(classesDir));
+            fileManager.setLocationFromPaths(StandardLocation.SOURCE_OUTPUT, List.of(generatedDir));
+            final var succeeded = compiler.getTask(null, fileManager, diagnostics,
+                    List.of("-classpath", System.getProperty("java.class.path"),
+                            "-processor", GenerateVisitorAnnotationProcessor.class.getName()),
+                    null,
+                    fileManager.getJavaFileObjects(sourceFile)).call();
+            return new Result(succeeded, diagnostics.getDiagnostics().stream()
+                    .map(diagnostic -> diagnostic.getMessage(null))
+                    .collect(Collectors.joining("\n")), generatedDir);
+        }
+    }
+
+    /**
+     * What one compilation produced.
+     */
+    private record Result(boolean succeeded, @Nonnull String messages, @Nonnull Path generatedDir) {
+
+        @Nonnull
+        String generatedSource(@Nonnull final String relativePath) throws IOException {
+            final var generated = generatedDir.resolve(relativePath);
+            assertThat(generated).as("generated sources: " + generatedDir).exists();
+            return Files.readString(generated, StandardCharsets.UTF_8);
+        }
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/SimpleValueVisitor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/SimpleValueVisitor.java
@@ -1,0 +1,115 @@
+/*
+ * SimpleValueVisitor.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.cascades.values;
+
+import com.apple.foundationdb.annotation.API;
+import com.google.common.collect.Lists;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+
+/**
+ * An interface for implementors to compute a result over a tree of {@link Value}s, bottom-up.
+ * <p>
+ * This is the {@link Value} counterpart of
+ * {@link com.apple.foundationdb.record.query.plan.cascades.SimpleExpressionVisitor}: the generated
+ * {@link ValueVisitor} only dispatches on the dynamic type of a single value and leaves recursion to its caller, whereas
+ * this interface supplies the recursion and hands each value the results already computed for its children. Implementors
+ * write {@link #evaluateAtValue(Value, List)} and get a fold rather than a walk.
+ * </p>
+ * <p>
+ * {@code evaluateAtValue} is called in visit post-order of the depth-first traversal of the tree: a value is evaluated
+ * only once all of its children have been. Because {@link ValueVisitorWithDefaults} routes every specific visitation
+ * method to {@link #visitDefault(Value)}, an implementor that cares about only a few kinds of value can override those
+ * specific methods and let everything else fold through the default.
+ * </p>
+ * <p>
+ * Note the traversal is over {@link Value#getChildren()} and so is a plain tree walk. Unlike the expression-side
+ * visitor, there is no {@code Reference} to hold several equivalent members and no {@code Quantifier} to hop through,
+ * so there is nothing here corresponding to {@code evaluateAtRef} or {@code evaluateAtQuantifier}. A shared subtree is
+ * visited once per path that reaches it; this interface does no memoization.
+ * </p>
+ *
+ * @param <T> the type of the result this visitor computes
+ */
+@API(API.Status.EXPERIMENTAL)
+public interface SimpleValueVisitor<T> extends ValueVisitorWithDefaults<T> {
+
+    /**
+     * Whether the given value should be visited at all.
+     * <p>
+     * Returning {@code false} prunes that value and the whole subtree beneath it. It is consulted in
+     * {@link Value#acceptVisitor(SimpleValueVisitor)}, which returns {@code null} for a pruned value, and a pruned child
+     * contributes no element to the {@code childResults} handed to its parent. That differs from the expression-side
+     * visitor, where pruning a member of a reference discards the result for the entire reference -- a value's children
+     * are positional operands rather than interchangeable members, so pruning one cannot stand for pruning its parent.
+     * It does mean {@code childResults} is not positionally aligned with {@link Value#getChildren()} once anything is
+     * pruned, so a visitor that relies on operand position should not prune.
+     * </p>
+     *
+     * @param value the value that is about to be visited
+     *
+     * @return {@code true} if the value should be visited
+     */
+    @SuppressWarnings("unused")
+    default boolean shouldVisit(@Nonnull Value value) {
+        return true;
+    }
+
+    /**
+     * Computes the result for the given value from the results computed for its children.
+     *
+     * @param value the value being visited
+     * @param childResults the results computed for the children of {@code value}, in order, excluding any child that
+     *        {@link #shouldVisit(Value)} rejected
+     *
+     * @return the result for {@code value}
+     */
+    @Nonnull
+    T evaluateAtValue(@Nonnull Value value, @Nonnull List<T> childResults);
+
+    @Nonnull
+    @Override
+    default T visitDefault(@Nonnull final Value value) {
+        return evaluateAtValue(value, visitChildren(value));
+    }
+
+    /**
+     * Visits the children of the given value, in order, and collects their results. Recursion goes through
+     * {@link Value#acceptVisitor(SimpleValueVisitor)} so that {@link #shouldVisit(Value)} is honoured in exactly one
+     * place; a child it prunes yields {@code null} there and is left out of the returned list.
+     *
+     * @param value the value whose children to visit
+     *
+     * @return the results computed for the children that were visited
+     */
+    @Nonnull
+    default List<T> visitChildren(@Nonnull final Value value) {
+        final var childResults = Lists.<T>newArrayList();
+        for (final Value child : value.getChildren()) {
+            final var childResult = child.acceptVisitor(this);
+            if (childResult != null) {
+                childResults.add(childResult);
+            }
+        }
+        return childResults;
+    }
+}

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/Value.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/Value.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.query.plan.cascades.values;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.annotation.GenerateVisitor;
 import com.apple.foundationdb.record.EvaluationContext;
 import com.apple.foundationdb.record.PlanHashable;
 import com.apple.foundationdb.record.PlanSerializable;
@@ -92,6 +93,7 @@ import java.util.function.Supplier;
  * A scalar value type.
  */
 @API(API.Status.EXPERIMENTAL)
+@GenerateVisitor
 public interface Value extends Correlated<Value>, TreeLike<Value>, UsesValueEquivalence<Value>, PlanHashable, Typed, Narrowable<Value>, PlanSerializable {
 
     @Nonnull
@@ -782,6 +784,22 @@ public interface Value extends Correlated<Value>, TreeLike<Value>, UsesValueEqui
                             }
                             return null;
                         }));
+    }
+
+
+    /**
+     * Apply the given visitor to this value and its children. Returns {@code null} if
+     * {@link SimpleValueVisitor#shouldVisit(Value)} called on this value returns {@code false}.
+     * @param simpleValueVisitor a {@link ValueVisitor} to evaluate
+     * @param <U> the type of the evaluated property
+     * @return the result of evaluating the property on the subtree rooted at this expression
+     */
+    @Nullable
+    default <U> U acceptVisitor(@Nonnull SimpleValueVisitor<U> simpleValueVisitor) {
+        if (simpleValueVisitor.shouldVisit(this)) {
+            return simpleValueVisitor.visit(this);
+        }
+        return null;
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/values/ValueVisitorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/values/ValueVisitorTest.java
@@ -1,0 +1,217 @@
+/*
+ * ValueVisitorTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.query.plan.cascades.values;
+
+import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Feasibility check for the generated {@code ValueVisitor}: dispatch has to reach a specific visitation method for every
+ * kind of {@link Value}, including the ones nested inside another Value class.
+ * <p>
+ * This lives in the {@code values} package on purpose. Some of the values exercised here have package-private or
+ * protected constructors, and the point is to build real instances rather than to assert on the generated source text.
+ * </p>
+ */
+class ValueVisitorTest {
+
+    /**
+     * Names the specific visitation method it landed in, so a test can tell specific dispatch from the fallback. Only a
+     * handful of methods are overridden -- the rest fall through to {@link #visitDefault}, which is what makes
+     * {@code ValueVisitorWithDefaults} usable over a hierarchy this size.
+     */
+    private static final class NamingVisitor implements ValueVisitorWithDefaults<String> {
+        @Nonnull
+        @Override
+        public String visitDefault(@Nonnull final Value element) {
+            return "default";
+        }
+
+        @Nonnull
+        @Override
+        public String visitLiteralValue(@Nonnull final LiteralValue<?> element) {
+            return "literal";
+        }
+
+        @Nonnull
+        @Override
+        public String visitSum(@Nonnull final NumericAggregationValue.Sum element) {
+            return "sum";
+        }
+
+        @Nonnull
+        @Override
+        public String visitBitmapConstructAgg(@Nonnull final NumericAggregationValue.BitmapConstructAgg element) {
+            return "bitmapConstructAgg";
+        }
+
+        @Nonnull
+        @Override
+        public String visitMinEverValue(@Nonnull final IndexOnlyAggregateValue.MinEverValue element) {
+            return "minEver";
+        }
+    }
+
+    @Nonnull
+    private static final NamingVisitor visitor = new NamingVisitor();
+
+    @Nonnull
+    private static Value literalLong() {
+        return LiteralValue.ofScalar(1L);
+    }
+
+    /**
+     * A generic Value. Before the generator was taught about type parameters this produced
+     * {@code visitLiteralValue(LiteralValue<T> element)}, capturing the visitor's own result variable, and a raw cast
+     * in the dispatch map that failed the build under {@code -Werror}.
+     */
+    @Test
+    void dispatchesToAGenericTopLevelValue() {
+        assertThat(visitor.visit(LiteralValue.ofScalar(42L))).isEqualTo("literal");
+    }
+
+    /**
+     * The cases this whole exercise was about. Each of these is declared inside another Value class, so before the
+     * generator descended into nested types they had no visitation method at all and landed in {@code visitDefault}.
+     */
+    @Test
+    void dispatchesToValuesNestedInsideAnotherValue() {
+        assertThat(visitor.visit(new NumericAggregationValue.Sum(
+                NumericAggregationValue.PhysicalOperator.SUM_L, literalLong())))
+                .isEqualTo("sum");
+
+        assertThat(visitor.visit(new NumericAggregationValue.BitmapConstructAgg(
+                NumericAggregationValue.PhysicalOperator.BITMAP_CONSTRUCT_AGG_L, literalLong())))
+                .isEqualTo("bitmapConstructAgg");
+
+        assertThat(visitor.visit(new IndexOnlyAggregateValue.MinEverValue(
+                IndexOnlyAggregateValue.PhysicalOperator.MIN_EVER_LONG, literalLong())))
+                .isEqualTo("minEver");
+    }
+
+    /**
+     * A Value the visitor does not override still dispatches, just to the fallback. This is the property that keeps a
+     * visitor over 60-odd methods maintainable: adding a new Value does not break existing implementors.
+     */
+    @Test
+    void unhandledValueFallsThroughToDefault() {
+        assertThat(visitor.visit(new NullValue(Type.primitiveType(Type.TypeCode.LONG)))).isEqualTo("default");
+    }
+
+    /**
+     * The dispatch map is keyed on the concrete class, so a nested Value has to appear under its own class literal
+     * rather than being folded into its enclosing one.
+     */
+    @Test
+    void theDispatchMapNamesNestedClassesIndividually() {
+        assertThat(ValueVisitor.jumpMap)
+                .containsKeys(LiteralValue.class,
+                        NumericAggregationValue.Sum.class,
+                        NumericAggregationValue.Min.class,
+                        NumericAggregationValue.Max.class,
+                        NumericAggregationValue.Avg.class,
+                        NumericAggregationValue.BitmapConstructAgg.class,
+                        IndexOnlyAggregateValue.MinEverValue.class,
+                        IndexOnlyAggregateValue.MaxEverValue.class,
+                        RelOpValue.BinaryRelOpValue.class,
+                        RelOpValue.UnaryRelOpValue.class,
+                        AbstractArrayConstructorValue.LightArrayConstructorValue.class);
+        // the enclosing classes are abstract and must not be dispatch targets themselves
+        assertThat(ValueVisitor.jumpMap)
+                .doesNotContainKeys(NumericAggregationValue.class, IndexOnlyAggregateValue.class, RelOpValue.class);
+    }
+
+    /**
+     * Counts every value in the tree, proving {@link SimpleValueVisitor} supplies the recursion that the generated
+     * dispatch-only visitor does not.
+     */
+    private static final class CountingVisitor implements SimpleValueVisitor<Integer> {
+        @Nonnull
+        @Override
+        public Integer evaluateAtValue(@Nonnull final Value value, @Nonnull final List<Integer> childResults) {
+            return 1 + childResults.stream().mapToInt(Integer::intValue).sum();
+        }
+    }
+
+    /**
+     * Renders the tree bottom-up, and overrides one specific visitation method to show that specific dispatch and the
+     * default fold compose: the aggregate is named, everything else falls through to the generic rendering.
+     */
+    private static final class RenderingVisitor implements SimpleValueVisitor<String> {
+        @Nonnull
+        @Override
+        public String evaluateAtValue(@Nonnull final Value value, @Nonnull final List<String> childResults) {
+            return value.getClass().getSimpleName()
+                    + (childResults.isEmpty() ? "" : "(" + String.join(", ", childResults) + ")");
+        }
+
+        @Nonnull
+        @Override
+        public String visitSum(@Nonnull final NumericAggregationValue.Sum element) {
+            return "SUM[" + String.join(", ", visitChildren(element)) + "]";
+        }
+    }
+
+    /**
+     * Prunes literals, to show that {@link SimpleValueVisitor#shouldVisit} keeps a subtree out of the fold entirely.
+     */
+    private static final class LiteralPruningVisitor implements SimpleValueVisitor<Integer> {
+        @Override
+        public boolean shouldVisit(@Nonnull final Value value) {
+            return !(value instanceof LiteralValue);
+        }
+
+        @Nonnull
+        @Override
+        public Integer evaluateAtValue(@Nonnull final Value value, @Nonnull final List<Integer> childResults) {
+            return 1 + childResults.stream().mapToInt(Integer::intValue).sum();
+        }
+    }
+
+    @Nonnull
+    private static Value sumOverLiteral() {
+        return new NumericAggregationValue.Sum(NumericAggregationValue.PhysicalOperator.SUM_L, literalLong());
+    }
+
+    @Test
+    void simpleValueVisitorFoldsTheWholeTree() {
+        // the aggregate plus its single literal child
+        assertThat(new CountingVisitor().visit(sumOverLiteral())).isEqualTo(2);
+        // a bare leaf is just itself
+        assertThat(new CountingVisitor().visit(literalLong())).isEqualTo(1);
+    }
+
+    @Test
+    void simpleValueVisitorLetsASpecificMethodTakeOverWhileStillRecursing() {
+        assertThat(new RenderingVisitor().visit(sumOverLiteral())).isEqualTo("SUM[LiteralValue]");
+    }
+
+    @Test
+    void shouldVisitPrunesASubtreeOutOfTheFold() {
+        // the literal child is pruned, so only the aggregate itself is counted
+        assertThat(new LiteralPruningVisitor().visit(sumOverLiteral())).isEqualTo(1);
+    }
+}

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/ddl/ExtremumEverStorage.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/ddl/ExtremumEverStorage.java
@@ -1,0 +1,78 @@
+/*
+ * ExtremumEverStorage.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.relational.recordlayer.query.ddl;
+
+import com.apple.foundationdb.record.metadata.IndexTypes;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Which form a {@code MIN_EVER} or {@code MAX_EVER} index stores its extremum in, and the index types that form implies.
+ */
+public enum ExtremumEverStorage {
+    /**
+     * The long-based index types, which take a numeric column only. What {@code LEGACY_EXTREMUM_EVER} asks for.
+     */
+    LONG(IndexTypes.MIN_EVER_LONG, IndexTypes.MAX_EVER_LONG),
+    /**
+     * The tuple-based index types, which take a column of any type.
+     */
+    TUPLE(IndexTypes.MIN_EVER_TUPLE, IndexTypes.MAX_EVER_TUPLE);
+
+    @Nonnull
+    private final String minEverIndexType;
+    @Nonnull
+    private final String maxEverIndexType;
+
+    ExtremumEverStorage(@Nonnull final String minEverIndexType, @Nonnull final String maxEverIndexType) {
+        this.minEverIndexType = minEverIndexType;
+        this.maxEverIndexType = maxEverIndexType;
+    }
+
+    @Nonnull
+    public String minEverIndexType() {
+        return minEverIndexType;
+    }
+
+    @Nonnull
+    public String maxEverIndexType() {
+        return maxEverIndexType;
+    }
+
+    /**
+     * Whether this form can only store a numeric column.
+     */
+    public boolean isNumericOnly() {
+        return this == LONG;
+    }
+
+    /**
+     * The storage form the {@code LEGACY_EXTREMUM_EVER} index attribute asks for.
+     *
+     * @param useLegacyExtremumEver whether the definition carried the attribute
+     *
+     * @return the storage form to use
+     */
+    @Nonnull
+    public static ExtremumEverStorage ofLegacyAttribute(final boolean useLegacyExtremumEver) {
+        return useLegacyExtremumEver ? LONG : TUPLE;
+    }
+}

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/ddl/IndexGenerationOptions.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/ddl/IndexGenerationOptions.java
@@ -1,0 +1,36 @@
+/*
+ * IndexGenerationOptions.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.relational.recordlayer.query.ddl;
+
+import javax.annotation.Nonnull;
+
+/**
+ * What the definition asks of the index beyond its key.
+ *
+ * @param unique whether the index enforces uniqueness
+ * @param containsNullableArray whether the table holds a nullable array, which changes how an array field is wrapped
+ * @param emptyKeyAllowed whether an index with no key columns gets an empty key and all its columns in the value, which
+ * is what a vector index without {@code PARTITION BY} needs
+ * @param extremumEverStorage which form an extremum-ever aggregate is stored in
+ */
+public record IndexGenerationOptions(boolean unique, boolean containsNullableArray, boolean emptyKeyAllowed,
+                                     @Nonnull ExtremumEverStorage extremumEverStorage) {
+}

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/ddl/IndexGenerator.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/ddl/IndexGenerator.java
@@ -1,0 +1,76 @@
+/*
+ * IndexGenerator.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.relational.recordlayer.query.ddl;
+
+import com.apple.foundationdb.relational.recordlayer.metadata.RecordLayerIndex;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Turns an index definition into the metadata that stores it.
+ * <p>
+ * A {@code CREATE INDEX} statement arrives as a parse tree, which {@link com.apple.foundationdb.relational.recordlayer.query.visitors.DdlVisitor}
+ * visits. Whatever the syntax, the definition is first expressed as a logical plan -- a tree of
+ * {@link com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpression}s rooted at a
+ * {@link com.apple.foundationdb.record.query.plan.cascades.expressions.LogicalSortExpression}, unoptimised, since it
+ * describes what to store rather than how to read it. An implementation of this interface reads that plan and produces a
+ * {@link RecordLayerIndex}: a name, the type of index, the table it is on, the predicate it is filtered by, and the
+ * {@link com.apple.foundationdb.record.metadata.expressions.KeyExpression} its entries are keyed and valued by. That
+ * index becomes part of the schema template the statement is adding to.
+ * </p>
+ * <p>
+ * There is one implementation per definition syntax, and the plan is where they meet:
+ * </p>
+ * <ul>
+ *     <li>{@code CREATE INDEX mv1 AS SELECT min_ever(col3) FROM T2 GROUP BY col1, col2} is planned as written, and
+ *     {@link MaterializedViewIndexGenerator} reads the plan directly. It yields a {@code MIN_EVER_TUPLE} index keyed by
+ *     {@code field("COL3").groupBy(field("COL1"), field("COL2"))}.</li>
+ *     <li>{@code CREATE VECTOR INDEX mv1 USING HNSW ON v1(b) PARTITION BY (z)} has no query to plan, so
+ *     {@link OnSourceIndexGenerator} synthesises one -- a select over the table projecting the named columns, sorted by
+ *     the partitioning ones -- and hands it to {@link MaterializedViewIndexGenerator}. It yields a {@code VECTOR} index
+ *     keyed by {@code keyWithValue(concat(field("Z"), field("B")), 1)}, the vector sitting in the value.</li>
+ * </ul>
+ * <p>
+ * What this interface provides is that last step alone: given a definition, the metadata for it. An implementation
+ * carries the whole definition -- the plan, the name, the table, and what the definition asks for beyond its key -- so
+ * generating takes no further input, and the syntax it came from stops being visible to the caller.
+ * </p>
+ */
+public interface IndexGenerator {
+
+    /**
+     * Builds the index this generator was configured with.
+     * <p>
+     * The returned builder is not yet built, so a caller that knows something the definition does not carry can still
+     * add it -- a vector index, for instance, sets its index type and engine options afterwards. Nothing is written to
+     * the schema template until the caller builds it and adds it.
+     * </p>
+     *
+     * @return the index the definition asks for
+     *
+     * @throws com.apple.foundationdb.relational.api.exceptions.UncheckedRelationalException with
+     * {@link com.apple.foundationdb.relational.api.exceptions.ErrorCode#UNSUPPORTED_OPERATION} if the definition
+     * describes an index that cannot be stored, such as one over a join, or one whose projection holds a value that no
+     * key expression can express
+     */
+    @Nonnull
+    RecordLayerIndex.Builder generate();
+}

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/ddl/IndexPredicates.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/ddl/IndexPredicates.java
@@ -1,0 +1,63 @@
+/*
+ * IndexPredicates.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.relational.recordlayer.query.ddl;
+
+import com.apple.foundationdb.record.metadata.IndexPredicate;
+import com.apple.foundationdb.record.query.plan.cascades.IndexPredicateExpansion;
+import com.apple.foundationdb.record.query.plan.cascades.predicates.AndPredicate;
+import com.apple.foundationdb.record.query.plan.cascades.predicates.QueryPredicate;
+import com.apple.foundationdb.record.query.plan.planning.BooleanPredicateNormalizer;
+import com.apple.foundationdb.relational.api.exceptions.ErrorCode;
+import com.apple.foundationdb.relational.util.Assert;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+import java.util.Locale;
+
+import static java.util.stream.Collectors.toList;
+
+/**
+ * The form a predicate takes to be stored with an index.
+ */
+final class IndexPredicates {
+
+    private IndexPredicates() {
+    }
+
+    /**
+     * The residual conjunction of the select's predicates, normalised to DNF and checked to be one the deserializer
+     * supports. Falls back to the un-normalised conjunction when the DNF cannot be expressed as ranges.
+     *
+     * @param predicates the predicates the select carries, at least one
+     *
+     * @return the predicate to store
+     */
+    @Nonnull
+    static QueryPredicate normalize(@Nonnull final List<? extends QueryPredicate> predicates) {
+        final var residuals = predicates.stream().map(QueryPredicate::toResidualPredicate).collect(toList());
+        final var conjunction = residuals.size() == 1 ? residuals.get(0) : AndPredicate.and(residuals);
+        final var normalized = BooleanPredicateNormalizer.getDefaultInstanceForDnf()
+                .normalize(conjunction, false).orElse(conjunction);
+        Assert.thatUnchecked(IndexPredicate.isSupported(normalized), ErrorCode.UNSUPPORTED_OPERATION,
+                () -> String.format(Locale.ROOT, "Unsupported predicate '%s'", normalized));
+        return IndexPredicateExpansion.dnfPredicateToRanges(normalized).isEmpty() ? conjunction : normalized;
+    }
+}

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/ddl/IndexSpec.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/ddl/IndexSpec.java
@@ -1,0 +1,487 @@
+/*
+ * IndexSpec.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.relational.recordlayer.query.ddl;
+
+import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
+import com.apple.foundationdb.record.query.plan.cascades.OrderingPart.RequestedSortOrder;
+import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
+import com.apple.foundationdb.record.query.plan.cascades.Reference;
+import com.apple.foundationdb.record.query.plan.cascades.SimpleExpressionVisitor;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.ExplodeExpression;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.FullUnorderedScanExpression;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.GroupByExpression;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.LogicalSortExpression;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.LogicalTypeFilterExpression;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpression;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.SelectExpression;
+import com.apple.foundationdb.record.query.plan.cascades.predicates.QueryPredicate;
+import com.apple.foundationdb.record.query.plan.cascades.typing.PseudoField;
+import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
+import com.apple.foundationdb.record.query.plan.cascades.values.AggregateValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.ArithmeticValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.CardinalityValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.FieldValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.IndexableAggregateValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.LiteralValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.QuantifiedObjectValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.StreamableAggregateValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.Value;
+import com.apple.foundationdb.record.query.plan.cascades.values.Values;
+import com.apple.foundationdb.relational.api.exceptions.ErrorCode;
+import com.apple.foundationdb.relational.util.Assert;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
+
+/**
+ * Everything an index is made of, as read off the plan of the query that defines it: the record type, the predicate, the
+ * group by, and the projection and ordering, both resolved down to the base record. {@link #collect} gathers it in one
+ * bottom-up pass, stating each rule at the node it concerns; {@link #checkValidity} rejects the plans that cannot become
+ * an index.
+ */
+record IndexSpec(int scanCount, @Nullable String recordTypeName, @Nullable QueryPredicate predicate,
+                        @Nullable GroupByExpression groupBy, @Nullable OrderBy orderBy,
+                        @Nullable Projection projection) {
+
+    /**
+     * Collects what the plan of an index-defining query is making.
+     *
+     * @param expression the root of the plan
+     * @param quantifierValues what the plan's quantifiers stand for, from the preceding pass
+     *
+     * @return what the index is made of
+     */
+    @Nonnull
+    public static IndexSpec collect(@Nonnull final RelationalExpression expression,
+                                    @Nonnull final QuantifierValues quantifierValues) {
+        final var visitor = new Visitor(quantifierValues);
+        final var indexSpec = Assert.notNullUnchecked(visitor.visit(expression));
+        // the projection belongs to the root, which the bottom-up traversal cannot single out
+        return indexSpec.withProjection(new ProjectionResolver(quantifierValues)
+                .resolve(expression.getResultValue(), indexSpec.groupBy()));
+    }
+
+    @Override
+    @Nonnull
+    public String recordTypeName() {
+        return Assert.notNullUnchecked(recordTypeName, ErrorCode.UNSUPPORTED_OPERATION,
+                "Unsupported query, expected to find exactly one type filter operator");
+    }
+
+    /**
+     * The columns the index is ordered by, resolved down to the base record, empty when the definition had no
+     * {@code ORDER BY}.
+     */
+    @Nonnull
+    public List<Value> getOrderByValues() {
+        return orderBy == null ? ImmutableList.of() : orderBy.values();
+    }
+
+    /**
+     * The ordering function each order-by column is wrapped in, keyed by identity on {@link #getOrderByValues()}.
+     */
+    @Nonnull
+    public Map<Value, String> getOrderingFunctions() {
+        return orderBy == null ? ImmutableMap.of() : orderBy.orderingFunctions();
+    }
+
+    /**
+     * The projection the index is defined over, resolved down to the base record.
+     */
+    @Override
+    @Nonnull
+    public Projection projection() {
+        return Assert.notNullUnchecked(projection);
+    }
+
+    @Nonnull
+    private IndexSpec withProjection(@Nonnull final Projection newProjection) {
+        return new IndexSpec(scanCount, recordTypeName, predicate, groupBy, orderBy, newProjection);
+    }
+
+    @Nonnull
+    private IndexSpec withOrderBy(@Nonnull final OrderBy newOrderBy) {
+        Assert.thatUnchecked(orderBy == null, ErrorCode.UNSUPPORTED_OPERATION,
+                "Unsupported index definition, more than one sort expression found");
+        return new IndexSpec(scanCount, recordTypeName, predicate, groupBy, newOrderBy, projection);
+    }
+
+    @Nonnull
+    private IndexSpec withScan() {
+        return new IndexSpec(scanCount + 1, recordTypeName, predicate, groupBy, orderBy, projection);
+    }
+
+    @Nonnull
+    private IndexSpec withRecordTypeName(@Nonnull final String newRecordTypeName) {
+        Assert.thatUnchecked(recordTypeName == null, ErrorCode.UNSUPPORTED_OPERATION,
+                "Unsupported query, expected to find exactly one type filter operator");
+        return new IndexSpec(scanCount, newRecordTypeName, predicate, groupBy, orderBy, projection);
+    }
+
+    @Nonnull
+    private IndexSpec withPredicate(@Nonnull final QueryPredicate newPredicate) {
+        return new IndexSpec(scanCount, recordTypeName, newPredicate, groupBy, orderBy, projection);
+    }
+
+    @Nonnull
+    private IndexSpec withGroupBy(@Nonnull final GroupByExpression newGroupBy) {
+        Assert.thatUnchecked(groupBy == null, ErrorCode.UNSUPPORTED_OPERATION,
+                "Unsupported index definition, multiple group by expressions found");
+        return new IndexSpec(scanCount, recordTypeName, predicate, newGroupBy, orderBy, projection);
+    }
+
+    /**
+     * Rejects every definition the generator cannot turn into an index, apart from two: the predicate, checked as it is
+     * collected, and ordering by the aggregate, checked once the index type is known.
+     */
+    public void checkValidity() {
+        // the traversal rejects a second scan as a join, leaving none to reject here
+        Assert.thatUnchecked(scanCount == 1, ErrorCode.UNSUPPORTED_OPERATION,
+                "Unsupported index definition, no iteration generator found");
+        // throws unless exactly one type filter was found
+        recordTypeName();
+
+        final var projection = projection();
+        reject(projection.values().stream()
+                        .filter(value -> value instanceof StreamableAggregateValue && !(value instanceof IndexableAggregateValue))
+                        .collect(toList()),
+                "Unsupported aggregate index definition containing non-indexable aggregation (%s), consider using a value index on the aggregated column instead.");
+        reject(projection.values().stream()
+                        .filter(value -> !isTranslatableColumn(value))
+                        .collect(toList()),
+                "Unsupported index definition, cannot map %s to a key expression");
+        Assert.thatUnchecked(projection.versionValues().size() <= 1, ErrorCode.UNSUPPORTED_OPERATION,
+                "Cannot have index with more than one version column");
+
+        if (projection.aggregate() == null) {
+            Assert.thatUnchecked(getOrderByValues().stream().allMatch(value -> isTranslatableColumn(value)
+                            && !(value instanceof IndexableAggregateValue)),
+                    ErrorCode.UNSUPPORTED_OPERATION,
+                    "Unsupported index definition, order by must be a subset of projection list");
+            if (projection.fieldValues().size() > 1) {
+                Assert.thatUnchecked(!getOrderByValues().isEmpty(), ErrorCode.UNSUPPORTED_OPERATION,
+                        "Unsupported index definition, value indexes must have an order by clause at the top level");
+            }
+        } else {
+            // rejects a covering aggregate index
+            aggregateOrderIndex();
+        }
+    }
+
+    /**
+     * Fails with {@code message}, naming the offending columns, unless there are none.
+     */
+    private static void reject(@Nonnull final List<Value> offendingColumns, @Nonnull final String message) {
+        Assert.thatUnchecked(offendingColumns.isEmpty(), ErrorCode.UNSUPPORTED_OPERATION,
+                () -> String.format(Locale.ROOT, message,
+                        offendingColumns.stream().map(Object::toString).collect(joining(","))));
+    }
+
+    private static boolean isTranslatableColumn(@Nonnull final Value value) {
+        return value instanceof FieldValue
+                || value instanceof IndexableAggregateValue
+                || value instanceof ArithmeticValue
+                || value instanceof CardinalityValue;
+    }
+
+    /**
+     * Where the aggregate appears in the ordering. Walking the ordering also establishes that the rest of it is the
+     * grouping columns in their key order; anything else is a covering aggregate index, which cannot be stored.
+     *
+     * @return the position of the aggregate among the order-by columns, or {@code -1} if it does not appear
+     */
+    public int aggregateOrderIndex() {
+        final var orderByValues = getOrderByValues();
+        if (orderByValues.isEmpty()) {
+            return -1;
+        }
+        final var aggregate = projection().aggregate();
+        final var fieldIterator = projection().fieldValues().iterator();
+        var aggregateOrderIndex = -1;
+        var inOrder = true;
+        for (int i = 0; i < orderByValues.size(); i++) {
+            final var value = orderByValues.get(i);
+            if (value.equals(aggregate)) {
+                Assert.thatUnchecked(aggregateOrderIndex < 0, ErrorCode.UNSUPPORTED_OPERATION,
+                        "Unsupported index definition, aggregate can appear only once in ordering clause");
+                aggregateOrderIndex = i;
+            } else if (fieldIterator.hasNext()) {
+                if (!value.equals(fieldIterator.next())) {
+                    inOrder = false;
+                    break;
+                }
+            } else {
+                inOrder = false;
+                break;
+            }
+        }
+        Assert.thatUnchecked(inOrder && !fieldIterator.hasNext(), ErrorCode.UNSUPPORTED_OPERATION,
+                "Unsupported index definition, attempt to create a covering aggregate index");
+        return aggregateOrderIndex;
+    }
+
+    /**
+     * Combines what the children of one expression found. At most one child may contribute a record type, a predicate, a
+     * group by or a scan; a second scan is a join.
+     */
+    @Nonnull
+    private static IndexSpec merge(@Nonnull final List<IndexSpec> childSpecs) {
+        var merged = new IndexSpec(0, null, null, null, null, null);
+        for (final var childSpec : childSpecs) {
+            // the record type comes first: a join trips this before the scan below, which is the message callers see
+            final var recordTypeName = pickOneRecordTypeName(merged.recordTypeName, childSpec.recordTypeName);
+            Assert.thatUnchecked(merged.scanCount == 0 || childSpec.scanCount == 0,
+                    ErrorCode.UNSUPPORTED_OPERATION,
+                    "Unsupported index definition, join indexes are not supported");
+            merged = new IndexSpec(merged.scanCount + childSpec.scanCount,
+                    recordTypeName,
+                    pickOne(merged.predicate, childSpec.predicate, "predicate"),
+                    pickOne(merged.groupBy, childSpec.groupBy, "group by expression"),
+                    pickOne(merged.orderBy, childSpec.orderBy, "sort expression"), null);
+        }
+        return merged;
+    }
+
+    @Nullable
+    private static String pickOneRecordTypeName(@Nullable final String left, @Nullable final String right) {
+        Assert.thatUnchecked(left == null || right == null, ErrorCode.UNSUPPORTED_OPERATION,
+                "Unsupported query, expected to find exactly one type filter operator");
+        return left == null ? right : left;
+    }
+
+    @Nullable
+    private static <T> T pickOne(@Nullable final T left, @Nullable final T right, @Nonnull final String what) {
+        Assert.thatUnchecked(left == null || right == null, ErrorCode.UNSUPPORTED_OPERATION,
+                () -> String.format(Locale.ROOT, "Unsupported index definition, more than one %s found", what));
+        return left == null ? right : left;
+    }
+
+    /**
+     * The columns the index is ordered by, in order and resolved down to the base record.
+     *
+     * @param values the columns, in the order they are sorted by
+     * @param orderingFunctions the ordering function per column, keyed by identity so that a column appearing twice keeps
+     * a direction per occurrence
+     */
+    public record OrderBy(@Nonnull List<Value> values, @Nonnull Map<Value, String> orderingFunctions) {
+    }
+
+    /**
+     * The columns of the projection, resolved down to the base record. The aggregate and the rest are views over the one
+     * list rather than fields of their own.
+     *
+     * @param values the columns, in the order the definition projects them
+     */
+    public record Projection(@Nonnull List<Value> values) {
+
+        /**
+         * The aggregate the index is over, or {@code null} if it is not an aggregate index. There is at most one.
+         */
+        @Nullable
+        public IndexableAggregateValue aggregate() {
+            return values.stream()
+                    .filter(IndexableAggregateValue.class::isInstance)
+                    .map(IndexableAggregateValue.class::cast)
+                    .findFirst().orElse(null);
+        }
+
+        /**
+         * Everything that is not the aggregate: the columns of a value index key, or the grouping columns.
+         */
+        @Nonnull
+        public List<Value> fieldValues() {
+            return values.stream()
+                    .filter(value -> !(value instanceof IndexableAggregateValue))
+                    .collect(ImmutableList.toImmutableList());
+        }
+
+        @Nonnull
+        private List<Value> versionValues() {
+            return values.stream()
+                    .filter(value -> value instanceof FieldValue
+                            && value.getResultType().equals(PseudoField.ROW_VERSION.getType()))
+                    .collect(ImmutableList.toImmutableList());
+        }
+    }
+
+    /**
+     * The traversal. Each override visits its children, then applies what the node contributes; the checks every node
+     * shares live in {@link #evaluateAtExpression}.
+     */
+    private record Visitor(@Nonnull QuantifierValues quantifierValues) implements SimpleExpressionVisitor<IndexSpec> {
+
+        @Nonnull
+        @Override
+        public IndexSpec evaluateAtExpression(@Nonnull final RelationalExpression expression,
+                                              @Nonnull final List<IndexSpec> childResults) {
+            checkResultValue(expression);
+            return IndexSpec.merge(childResults);
+        }
+
+        @Nonnull
+        @Override
+        public IndexSpec evaluateAtRef(@Nonnull final Reference ref, @Nonnull final List<IndexSpec> memberResults) {
+            return IndexSpec.merge(memberResults);
+        }
+
+        @Nonnull
+        @Override
+        public IndexSpec visitFullUnorderedScanExpression(@Nonnull final FullUnorderedScanExpression expression) {
+            return evaluateAtExpression(expression, visitQuantifiers(expression)).withScan();
+        }
+
+        @Nonnull
+        @Override
+        public IndexSpec visitLogicalTypeFilterExpression(@Nonnull final LogicalTypeFilterExpression expression) {
+            final var recordTypes = expression.getRecordTypes();
+            Assert.thatUnchecked(recordTypes.size() == 1, ErrorCode.UNSUPPORTED_OPERATION,
+                    () -> String.format(Locale.ROOT,
+                            "Unsupported query, expected to find exactly one record type in type filter operator, however found %s",
+                            recordTypes.isEmpty() ? "nothing" : String.join(",", recordTypes)));
+            return evaluateAtExpression(expression, visitQuantifiers(expression))
+                    .withRecordTypeName(recordTypes.stream().findFirst().orElseThrow());
+        }
+
+        @Nonnull
+        @Override
+        public IndexSpec visitGroupByExpression(@Nonnull final GroupByExpression expression) {
+            Assert.thatUnchecked(Values.deconstructRecord(expression.getAggregateValue()).size() <= 1,
+                    ErrorCode.UNSUPPORTED_OPERATION,
+                    "Unsupported index definition, found group by expression with more than one aggregation");
+            return evaluateAtExpression(expression, visitQuantifiers(expression)).withGroupBy(expression);
+        }
+
+        /**
+         * The innermost select owns the predicate; any select above a group by or above a select that already owns one
+         * has to be predicate-free.
+         */
+        @Nonnull
+        @Override
+        public IndexSpec visitSelectExpression(@Nonnull final SelectExpression expression) {
+            final var spec = evaluateAtExpression(expression, visitQuantifiers(expression));
+            final var predicates = ImmutableList.copyOf(expression.getPredicates());
+            if (spec.groupBy() != null || spec.predicate() != null) {
+                Assert.thatUnchecked(predicates.isEmpty(), ErrorCode.UNSUPPORTED_OPERATION,
+                        spec.groupBy() != null
+                        ? "Unsupported index definition, found predicate in select-having"
+                        : "Unsupported index definition, found predicate in inner-select");
+                return spec;
+            }
+            if (predicates.isEmpty()) {
+                return spec;
+            }
+            return spec.withPredicate(IndexPredicates.normalize(predicates));
+        }
+
+        @Nonnull
+        @Override
+        public IndexSpec visitLogicalSortExpression(@Nonnull final LogicalSortExpression expression) {
+            return evaluateAtExpression(expression, visitQuantifiers(expression)).withOrderBy(orderByOf(expression));
+        }
+
+        /**
+         * An explode yields elements rather than records, so it skips the record-typed result check.
+         */
+        @Nonnull
+        @Override
+        public IndexSpec visitExplodeExpression(@Nonnull final ExplodeExpression expression) {
+            return IndexSpec.merge(visitQuantifiers(expression));
+        }
+
+        private static void checkResultValue(@Nonnull final RelationalExpression expression) {
+            Assert.thatUnchecked(expression.getResultValue().getResultType().getTypeCode() == Type.TypeCode.RECORD,
+                    ErrorCode.UNSUPPORTED_OPERATION,
+                    () -> String.format(Locale.ROOT,
+                            "Unsupported index definition, operator %s returns a non-record value",
+                            expression.getClass().getSimpleName()));
+            if (expression.getResultType().getInnerType() instanceof Type.Record) {
+                Assert.thatUnchecked(Values.deconstructRecord(expression.getResultValue())
+                                .stream()
+                                .allMatch(Visitor::isSupportedResultValue),
+                        ErrorCode.UNSUPPORTED_OPERATION,
+                        () -> String.format(Locale.ROOT,
+                                "Unsupported index definition, not all fields can be mapped to key expression in %s",
+                                expression.getClass().getSimpleName()));
+            }
+        }
+
+        private static boolean isSupportedResultValue(@Nonnull final Value value) {
+            return value instanceof FieldValue
+                    || value instanceof QuantifiedObjectValue
+                    || value instanceof AggregateValue
+                    || value instanceof ArithmeticValue
+                    || value instanceof LiteralValue
+                    || value instanceof CardinalityValue;
+        }
+
+        /**
+         * Flattens the ordering into one column per key component, each resolved down to the base record. An ordering part
+         * over a record contributes each of its fields, all with that part's direction.
+         */
+        @Nonnull
+        private OrderBy orderByOf(@Nonnull final LogicalSortExpression expression) {
+            final var aliasMap = AliasMap.ofAliases(Quantifier.current(), expression.getQuantifiers().get(0).getAlias());
+            final ImmutableList.Builder<Value> values = ImmutableList.builder();
+            final Map<Value, String> orderingFunctions = new IdentityHashMap<>();
+            for (final var orderingPart : expression.getOrdering().getOrderingParts()) {
+                final var orderingFunction = orderingFunctionOf(orderingPart.getSortOrder());
+                final var partValue = orderingPart.getValue().rebase(aliasMap);
+                final List<? extends Value> columns =
+                        partValue.getResultType().getTypeCode() == Type.TypeCode.RECORD
+                        ? Values.deconstructRecord(partValue)
+                        : ImmutableList.of(partValue);
+                for (final var column : columns) {
+                    final var value = quantifierValues.resolve(column);
+                    values.add(value);
+                    if (orderingFunction != null) {
+                        orderingFunctions.put(value, orderingFunction);
+                    }
+                }
+            }
+            return new OrderBy(values.build(), orderingFunctions);
+        }
+
+        /**
+         * The ordering function a column is wrapped in to express its sort order, or {@code null} for plain ascending.
+         * Every sort order is named, so a new one is a compile error here.
+         */
+        @Nullable
+        private static String orderingFunctionOf(@Nonnull final RequestedSortOrder sortOrder) {
+            return switch (sortOrder) {
+                case ASCENDING -> null;
+                case DESCENDING -> "order_desc_nulls_last";
+                case ASCENDING_NULLS_LAST -> "order_asc_nulls_last";
+                case DESCENDING_NULLS_FIRST -> "order_desc_nulls_first";
+                case ANY -> throw Assert.failUnchecked(ErrorCode.UNSUPPORTED_OPERATION,
+                        "Unsupported index definition, an index key needs a definite sort order");
+            };
+        }
+    }
+}

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/ddl/MaterializedViewIndexGenerator.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/ddl/MaterializedViewIndexGenerator.java
@@ -1,5 +1,5 @@
 /*
- * IndexGenerator.java
+ * MaterializedViewIndexGenerator.java
  *
  * This source file is part of the FoundationDB open source project
  *
@@ -21,813 +21,161 @@
 package com.apple.foundationdb.relational.recordlayer.query.ddl;
 
 import com.apple.foundationdb.annotation.API;
-import com.apple.foundationdb.record.EvaluationContext;
-import com.apple.foundationdb.record.FunctionNames;
-import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.metadata.IndexOptions;
 import com.apple.foundationdb.record.metadata.IndexPredicate;
 import com.apple.foundationdb.record.metadata.IndexTypes;
-import com.apple.foundationdb.record.metadata.Key;
-import com.apple.foundationdb.record.metadata.expressions.EmptyKeyExpression;
-import com.apple.foundationdb.record.metadata.expressions.FieldKeyExpression;
-import com.apple.foundationdb.record.metadata.expressions.FunctionKeyExpression;
-import com.apple.foundationdb.record.metadata.expressions.GroupingKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
-import com.apple.foundationdb.record.metadata.expressions.ThenKeyExpression;
-import com.apple.foundationdb.record.metadata.expressions.VersionKeyExpression;
-import com.apple.foundationdb.record.query.combinatorics.TopologicalSort;
-import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
-import com.apple.foundationdb.record.query.plan.cascades.Column;
-import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
-import com.apple.foundationdb.record.query.plan.cascades.IndexPredicateExpansion;
-import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
-import com.apple.foundationdb.record.query.plan.cascades.Reference;
-import com.apple.foundationdb.record.query.plan.cascades.expressions.ExplodeExpression;
-import com.apple.foundationdb.record.query.plan.cascades.expressions.FullUnorderedScanExpression;
-import com.apple.foundationdb.record.query.plan.cascades.expressions.GroupByExpression;
-import com.apple.foundationdb.record.query.plan.cascades.expressions.LogicalSortExpression;
-import com.apple.foundationdb.record.query.plan.cascades.expressions.LogicalTypeFilterExpression;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpression;
-import com.apple.foundationdb.record.query.plan.cascades.expressions.SelectExpression;
-import com.apple.foundationdb.record.query.plan.cascades.predicates.AndPredicate;
-import com.apple.foundationdb.record.query.plan.cascades.predicates.QueryPredicate;
-import com.apple.foundationdb.record.query.plan.cascades.typing.PseudoField;
-import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
-import com.apple.foundationdb.record.query.plan.cascades.values.AggregateValue;
-import com.apple.foundationdb.record.query.plan.cascades.values.ArithmeticValue;
-import com.apple.foundationdb.record.query.plan.cascades.values.CardinalityValue;
-import com.apple.foundationdb.record.query.plan.cascades.values.CountValue;
-import com.apple.foundationdb.record.query.plan.cascades.values.FieldValue;
-import com.apple.foundationdb.record.query.plan.cascades.values.IndexableAggregateValue;
-import com.apple.foundationdb.record.query.plan.cascades.values.LiteralValue;
-import com.apple.foundationdb.record.query.plan.cascades.values.NumericAggregationValue;
-import com.apple.foundationdb.record.query.plan.cascades.values.QuantifiedObjectValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.RecordConstructorValue;
-import com.apple.foundationdb.record.query.plan.cascades.values.StreamableAggregateValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.Value;
-import com.apple.foundationdb.record.query.plan.cascades.values.ValueWithChild;
-import com.apple.foundationdb.record.query.plan.cascades.values.Values;
-import com.apple.foundationdb.record.query.plan.planning.BooleanPredicateNormalizer;
-import com.apple.foundationdb.record.util.pair.NonnullPair;
 import com.apple.foundationdb.relational.api.exceptions.ErrorCode;
-import com.apple.foundationdb.relational.api.exceptions.RelationalException;
 import com.apple.foundationdb.relational.recordlayer.metadata.RecordLayerIndex;
-import com.apple.foundationdb.relational.recordlayer.query.FieldValueTrieNode;
 import com.apple.foundationdb.relational.recordlayer.metadata.RecordLayerSchemaTemplate;
 import com.apple.foundationdb.relational.util.Assert;
 import com.apple.foundationdb.relational.util.NullableArrayUtils;
-import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Iterators;
-import com.google.common.collect.Lists;
-import com.google.common.collect.PeekingIterator;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.IdentityHashMap;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
-import static com.apple.foundationdb.record.metadata.Key.Expressions.concat;
-import static com.apple.foundationdb.record.metadata.Key.Expressions.empty;
-import static com.apple.foundationdb.record.metadata.Key.Expressions.field;
-import static com.apple.foundationdb.record.metadata.Key.Expressions.function;
 import static com.apple.foundationdb.record.metadata.Key.Expressions.keyWithValue;
-import static com.apple.foundationdb.record.query.plan.cascades.properties.ReferencesAndDependenciesProperty.referencesAndDependencies;
-import static java.util.stream.Collectors.joining;
-import static java.util.stream.Collectors.toList;
 
 /**
- * Generates a {@link KeyExpression} from a given query plan.
+ * Builds a {@link RecordLayerIndex} from the plan of an index-defining query, out of what three passes produce:
+ * {@link QuantifierValues} maps the plan's quantifiers, {@link IndexSpec} collects and validates what the index is made
+ * of, and {@link ValueToKeyExpressionVisitor} turns the projection into the key.
  */
-@SuppressWarnings({"PMD.TooManyStaticImports", "OptionalUsedAsFieldOrParameterType"})
 @API(API.Status.EXPERIMENTAL)
-public final class MaterializedViewIndexGenerator {
-
-    private static final String BITMAP_BIT_POSITION = "bitmap_bit_position";
-    private static final String BITMAP_BUCKET_OFFSET = "bitmap_bucket_offset";
-
-    /**
-     * Map from each correlation in the query plan to its list of results.
-     */
-    @Nonnull
-    private final IdentityHashMap<CorrelationIdentifier, Value> correlatedKeyExpressions = new IdentityHashMap<>();
-
-    @Nonnull
-    private final List<RelationalExpression> relationalExpressions;
+public final class MaterializedViewIndexGenerator implements IndexGenerator {
 
     @Nonnull
     private final RelationalExpression relationalExpression;
 
-    private final boolean useLegacyBasedExtremumEver;
+    @Nonnull
+    private final RecordLayerSchemaTemplate.Builder schemaTemplateBuilder;
 
-    private MaterializedViewIndexGenerator(@Nonnull RelationalExpression relationalExpression, boolean useLegacyBasedExtremumEver) {
-        collectQuantifiers(relationalExpression);
-        final var partialOrder = referencesAndDependencies().evaluate(Reference.initialOf(relationalExpression));
-        relationalExpressions =
-                TopologicalSort.anyTopologicalOrderPermutation(partialOrder)
-                        .orElseThrow(() -> new RelationalException("graph has cycles", ErrorCode.UNSUPPORTED_OPERATION).toUncheckedWrappedException())
-                        .stream()
-                        .map(Reference::get)
-                        .collect(toList());
+    @Nonnull
+    private final String indexName;
+
+    @Nonnull
+    private final IndexGenerationOptions options;
+
+    private MaterializedViewIndexGenerator(@Nonnull RelationalExpression relationalExpression,
+                                           @Nonnull RecordLayerSchemaTemplate.Builder schemaTemplateBuilder,
+                                           @Nonnull String indexName,
+                                           @Nonnull IndexGenerationOptions options) {
         this.relationalExpression = relationalExpression;
-        this.useLegacyBasedExtremumEver = useLegacyBasedExtremumEver;
+        this.schemaTemplateBuilder = schemaTemplateBuilder;
+        this.indexName = indexName;
+        this.options = options;
+    }
+
+    /**
+     * A generator for one index definition.
+     *
+     * @param relationalExpression the plan of the index-defining query
+     * @param schemaTemplateBuilder the metadata the index is added to
+     * @param indexName the name the definition gives the index
+     * @param options what the definition asks of the index beyond its key
+     *
+     * @return a generator for that definition
+     */
+    @Nonnull
+    public static MaterializedViewIndexGenerator newInstance(@Nonnull RelationalExpression relationalExpression,
+                                                            @Nonnull RecordLayerSchemaTemplate.Builder schemaTemplateBuilder,
+                                                            @Nonnull String indexName,
+                                                            @Nonnull IndexGenerationOptions options) {
+        return new MaterializedViewIndexGenerator(relationalExpression, schemaTemplateBuilder, indexName, options);
     }
 
     @Nonnull
-    public RecordLayerIndex.Builder generate(@Nonnull RecordLayerSchemaTemplate.Builder schemaTemplateBuilder, @Nonnull String indexName,
-                                             boolean isUnique, boolean containsNullableArray, boolean generateKeyValueExpressionWithEmptyKey) {
-        final String recordTypeName = getRecordTypeName();
-        // Have to use the storage name here because the index generator uses it
-        final Type.Record tableType = schemaTemplateBuilder.findTableByStorageName(recordTypeName).getType();
+    @Override
+    public RecordLayerIndex.Builder generate() {
+        final var spec = IndexSpec.collect(relationalExpression,
+                QuantifierValues.collect(relationalExpression));
+        spec.checkValidity();
+
+        final var translation = translateToKeyExpression(spec);
+        final var indexType = translation.indexType();
+        // the record layer indexes by storage name
+        final var tableType = schemaTemplateBuilder.findTableByStorageName(spec.recordTypeName()).getType();
+
         final var indexBuilder = RecordLayerIndex.newBuilder()
                 .setName(indexName)
                 .setTableType(tableType)
-                .setUnique(isUnique);
-
-        collectQuantifiers(relationalExpression);
-
-        final var partialOrder = referencesAndDependencies().evaluate(Reference.initialOf(relationalExpression));
-        final var expressionRefs =
-                TopologicalSort.anyTopologicalOrderPermutation(partialOrder)
-                        .orElseThrow(() -> new RecordCoreException("graph has cycles")).stream().map(Reference::get).collect(toList());
-
-        checkValidity(expressionRefs);
-
-        // add predicates
-        final var predicate = getTopLevelPredicate(Lists.reverse(expressionRefs));
+                .setUnique(options.unique())
+                .setIndexType(indexType);
+        final var predicate = spec.predicate();
         if (predicate != null) {
             indexBuilder.setPredicate(IndexPredicate.fromQueryPredicate(predicate).toProto());
         }
 
-        final var simplifiedValues = collectResultValues(relationalExpression.getResultValue());
-
-        final var unsupportedAggregates = simplifiedValues.stream().filter(sv -> sv instanceof StreamableAggregateValue && !(sv instanceof IndexableAggregateValue)).collect(toList());
-        Assert.thatUnchecked(unsupportedAggregates.isEmpty(), ErrorCode.UNSUPPORTED_OPERATION,
-                () -> String.format(Locale.ROOT, "Unsupported aggregate index definition containing non-indexable aggregation (%s), consider using a value index on the aggregated column instead.", unsupportedAggregates.stream().map(Objects::toString).collect(joining(","))));
-
-        Assert.thatUnchecked(simplifiedValues.stream().allMatch(sv -> sv instanceof FieldValue || sv instanceof IndexableAggregateValue || sv instanceof ArithmeticValue || sv instanceof CardinalityValue));
-        final var aggregateValues = simplifiedValues.stream().filter(sv -> sv instanceof IndexableAggregateValue).collect(toList());
-        final var fieldValues = simplifiedValues.stream().filter(sv -> !(sv instanceof IndexableAggregateValue)).collect(toList());
-        final var versionValues = simplifiedValues.stream().filter(sv -> sv instanceof FieldValue && sv.getResultType().equals(PseudoField.ROW_VERSION.getType())).collect(toList());
-        Assert.thatUnchecked(versionValues.size() <= 1, ErrorCode.UNSUPPORTED_OPERATION, "Cannot have index with more than one version column");
-        final Map<Value, String> orderingFunctions = new IdentityHashMap<>();
-        final var orderByValues = getOrderByValues(relationalExpression, orderingFunctions);
-        if (aggregateValues.isEmpty()) {
-            indexBuilder.setIndexType(versionValues.isEmpty() ? IndexTypes.VALUE : IndexTypes.VERSION);
-            Assert.thatUnchecked(orderByValues.stream().allMatch(sv -> sv instanceof FieldValue || sv instanceof ArithmeticValue || sv instanceof CardinalityValue), ErrorCode.UNSUPPORTED_OPERATION, "Unsupported index definition, order by must be a subset of projection list");
-            if (fieldValues.size() > 1) {
-                Assert.thatUnchecked(!orderByValues.isEmpty(), ErrorCode.UNSUPPORTED_OPERATION, "Unsupported index definition, value indexes must have an order by clause at the top level");
-            }
-            final var reordered = reorderValues(fieldValues, orderByValues);
-            final var expression = generate(reordered, orderingFunctions);
-            var splitPoint = orderByValues.size();
-            if (orderByValues.isEmpty() && !generateKeyValueExpressionWithEmptyKey) {
-                splitPoint = -1;
-            }
-            if (splitPoint != -1 && splitPoint < fieldValues.size()) {
-                indexBuilder.setKeyExpression(KeyExpression.fromProto(NullableArrayUtils.wrapArray(keyWithValue(expression, splitPoint).toKeyExpression(), tableType, containsNullableArray)));
-            } else {
-                indexBuilder.setKeyExpression(KeyExpression.fromProto(NullableArrayUtils.wrapArray(expression.toKeyExpression(), tableType, containsNullableArray)));
-            }
+        var keyExpression = translation.keyExpression();
+        if (spec.projection().aggregate() == null) {
+            keyExpression = splitKeyFromValue(spec, keyExpression, options.emptyKeyAllowed());
         } else {
-            Assert.thatUnchecked(aggregateValues.size() == 1, ErrorCode.UNSUPPORTED_OPERATION, "Unsupported index definition, multiple group by aggregations found");
-            final var aggregateValue = (AggregateValue) aggregateValues.get(0);
-            int aggregateOrderIndex = -1;
-            if (!orderByValues.isEmpty()) {
-                boolean inOrder = true;
-                Iterator<Value> fieldIterator = fieldValues.iterator();
-                for (int i = 0; i < orderByValues.size(); i++) {
-                    Value value = orderByValues.get(i);
-                    if (value.equals(aggregateValue)) {
-                        if (aggregateOrderIndex >= 0) {
-                            Assert.failUnchecked(ErrorCode.UNSUPPORTED_OPERATION, "Unsupported index definition, aggregate can appear only once in ordering clause");
-                        }
-                        aggregateOrderIndex = i;
-                    } else if (fieldIterator.hasNext()) {
-                        Value expectedField = fieldIterator.next();
-                        if (!value.equals(expectedField)) {
-                            inOrder = false;
-                            break;
-                        }
-                    } else {
-                        inOrder = false;
-                        break;
-                    }
-                }
-                if (fieldIterator.hasNext() || !inOrder) {
-                    Assert.failUnchecked(ErrorCode.UNSUPPORTED_OPERATION, "Unsupported index definition, attempt to create a covering aggregate index");
-                }
-            }
-            final Optional<KeyExpression> groupingKeyExpression = fieldValues.isEmpty() ? Optional.empty() : Optional.of(generate(fieldValues, orderingFunctions));
-            final var indexExpressionAndType = generateAggregateIndexKeyExpression(aggregateValue, groupingKeyExpression);
-            final String indexType = Objects.requireNonNull(indexExpressionAndType.getRight());
-            indexBuilder.setIndexType(indexType);
-            indexBuilder.setKeyExpression(KeyExpression.fromProto(NullableArrayUtils.wrapArray(indexExpressionAndType.getLeft().toKeyExpression(), tableType, containsNullableArray)));
-            if (IndexTypes.PERMUTED_MIN.equals(indexType) || IndexTypes.PERMUTED_MAX.equals(indexType)) {
-                int permutedSize = aggregateOrderIndex < 0 ? 0 : (fieldValues.size() - aggregateOrderIndex);
-                indexBuilder.setOption(IndexOptions.PERMUTED_SIZE_OPTION, permutedSize);
-            } else if (aggregateOrderIndex > 0) {
-                Assert.failUnchecked(ErrorCode.UNSUPPORTED_OPERATION, "Unsupported index definition. Cannot order " + indexType + " index by aggregate value");
-            }
+            addAggregatePermutationOptions(indexBuilder, spec, indexType);
         }
+        indexBuilder.setKeyExpression(KeyExpression.fromProto(
+                NullableArrayUtils.wrapArray(keyExpression.toKeyExpression(), tableType, options.containsNullableArray())));
         return indexBuilder;
     }
 
-    @Nonnull
-    private List<Value> collectResultValues(@Nonnull Value value) {
-        final var resultValues = simplify(value);
-        final var isSingleAggregation = resultValues.size() == 1 && resultValues.get(0) instanceof IndexableAggregateValue;
-        final var maybeGroupBy = relationalExpressions.stream().filter(exp -> exp instanceof GroupByExpression).findFirst();
-        if (maybeGroupBy.isPresent()) {
-            // if the final result value contains nothing but the aggregation value, add the grouping values to it.
-            final var groupBy = (GroupByExpression) maybeGroupBy.get();
-            final var groupingValues = groupBy.getGroupingValue();
-            final var adjustResultValues = adjustGroupByFieldPaths(resultValues, groupBy);
-            if (isSingleAggregation) {
-                if (groupingValues == null) {
-                    return adjustResultValues;
-                } else {
-                    final var simplifiedGroupingValues =
-                            Values.deconstructRecord(groupingValues).stream().map(this::dereference)
-                                    .map(v -> v.simplify(EvaluationContext.empty(), AliasMap.emptyMap(),
-                                            Set.of()));
-                    return Stream.concat(adjustResultValues.stream(), simplifiedGroupingValues).collect(toList());
-                }
-            } else {
-                // Make sure the grouping values and the result values are consistent
-                if (groupingValues == null) {
-                    // This shouldn't happen unless there's more than one indexable aggregate value
-                    Assert.failUnchecked(ErrorCode.UNSUPPORTED_OPERATION, "Grouping values absent from aggregate result value");
-                }
-                final var simplifiedGroupingValues =
-                        Values.deconstructRecord(groupingValues).stream()
-                                .map(this::dereference)
-                                .map(v -> v.simplify(EvaluationContext.empty(), AliasMap.emptyMap(),
-                                        Set.of())).iterator();
-                for (Value resultValue : resultValues) {
-                    if (resultValue instanceof IndexableAggregateValue) {
-                        continue;
-                    }
-                    if (!simplifiedGroupingValues.hasNext()) {
-                        Assert.failUnchecked(ErrorCode.UNSUPPORTED_OPERATION, "Aggregate result value contains values missing from the grouping expression");
-                    }
-                    Value groupingValue = simplifiedGroupingValues.next();
-                    if (!resultValue.equals(groupingValue)) {
-                        Assert.failUnchecked(ErrorCode.UNSUPPORTED_OPERATION, "Aggregate result value does not align with grouping value");
-                    }
-                }
-                if (simplifiedGroupingValues.hasNext()) {
-                    Assert.failUnchecked(ErrorCode.UNSUPPORTED_OPERATION, "Grouping value absent from aggregate result value");
-                }
-                return adjustResultValues;
-            }
-        } else {
-            return resultValues;
-        }
-    }
-
-    @Nonnull
-    private static List<Value> adjustGroupByFieldPaths(@Nonnull List<Value> resultValues,
-                                                       @Nonnull GroupByExpression groupByExpression) {
-        /*
-         * This strips the root of the field path from every FieldValue that is referencing an attribute from the
-         * underlying SELECT-WHERE expression.
-         * This is to enable the construction of a valid KeyExpression; it is valid because only single-sourced are
-         * currently allowed in aggregate indexes, in other words, there is no room for ambiguity, even after removing
-         * the root.
-         */
-        final var selectWhereQun = groupByExpression.getQuantifiers().get(0);
-        return resultValues.stream().map(resultValue -> resultValue.replace(value -> {
-            if (!(value instanceof FieldValue)) {
-                return value;
-            }
-            final FieldValue fieldValue = (FieldValue) value;
-            if (!(fieldValue.getChild() instanceof QuantifiedObjectValue)) {
-                return value;
-            }
-            final QuantifiedObjectValue quantifiedObjectValue = (QuantifiedObjectValue) fieldValue.getChild();
-            if (!quantifiedObjectValue.getAlias().equals(selectWhereQun.getAlias())) {
-                return value;
-            }
-            final var fieldAccessors = fieldValue.getFieldPath().getFieldAccessors();
-            return FieldValue.ofFields(fieldValue.getChild(), new FieldValue.FieldPath(fieldAccessors.subList(1, fieldAccessors.size())));
-        })).collect(ImmutableList.toImmutableList());
-    }
-
-    @Nonnull
-    private List<Value> simplify(@Nonnull Value value) {
-        return Values.deconstructRecord(value)
-                .stream()
-                .map(this::dereference)
-                .map(v -> v.simplify(EvaluationContext.empty(), AliasMap.emptyMap(), Set.of()))
-                .collect(toList());
-    }
-
-    @Nonnull
-    private List<Value> getOrderByValues(@Nonnull RelationalExpression relationalExpression,
-                                         @Nonnull Map<Value, String> orderingFunctions) {
-        if (relationalExpression instanceof LogicalSortExpression) {
-            final var logicalSortExpression = (LogicalSortExpression) relationalExpression;
-            final var reverseAliasMap = AliasMap.ofAliases(Quantifier.current(), logicalSortExpression.getQuantifiers().get(0).getAlias());
-            final ImmutableList.Builder<Value> values = ImmutableList.builder();
-            for (var orderingPart : logicalSortExpression.getOrdering().getOrderingParts()) {
-                final String orderingFunction;
-                switch (orderingPart.getSortOrder()) {
-                    case ASCENDING:
-                        orderingFunction = null;
-                        break;
-                    case DESCENDING:
-                        orderingFunction = "order_desc_nulls_last";
-                        break;
-                    case ASCENDING_NULLS_LAST:
-                        orderingFunction = "order_asc_nulls_last";
-                        break;
-                    case DESCENDING_NULLS_FIRST:
-                        orderingFunction = "order_desc_nulls_first";
-                        break;
-                    default:
-                        orderingFunction = null;
-                        break;
-                }
-                if (orderingPart.getValue().getResultType().getTypeCode() == Type.TypeCode.RECORD) {
-                    for (Value value : Values.deconstructRecord(orderingPart.getValue())) {
-                        final var rebased = dereference(value.rebase(reverseAliasMap))
-                                .simplify(EvaluationContext.empty(), AliasMap.emptyMap(), Set.of());
-                        values.add(rebased);
-                        if (orderingFunction != null) {
-                            orderingFunctions.put(rebased, orderingFunction);
-                        }
-                    }
-                } else {
-                    final Value rebased = dereference(orderingPart.getValue().rebase(reverseAliasMap))
-                            .simplify(EvaluationContext.empty(), AliasMap.emptyMap(), Set.of());
-                    values.add(rebased);
-                    if (orderingFunction != null) {
-                        orderingFunctions.put(rebased, orderingFunction);
-                    }
-                }
-            }
-            return values.build();
-        }
-        return List.of();
-    }
-
-    private static List<Value> reorderValues(@Nonnull List<Value> values, @Nonnull List<Value> orderByValues) {
-        Assert.thatUnchecked(values.size() >= orderByValues.size());
-        if (orderByValues.isEmpty()) {
-            return values;
-        }
-        final var remaining = values.stream().filter(v -> !orderByValues.contains(v)).collect(ImmutableList.toImmutableList());
-        return ImmutableList.<Value>builder().addAll(orderByValues).addAll(remaining).build();
-    }
-
-    @SuppressWarnings({"OptionalIsPresent", "deprecation"})
-    @Nonnull
-    private NonnullPair<KeyExpression, String> generateAggregateIndexKeyExpression(@Nonnull AggregateValue aggregateValue,
-                                                                                   @Nonnull Optional<KeyExpression> maybeGroupingExpression) {
-        Assert.thatUnchecked(aggregateValue instanceof IndexableAggregateValue);
-        final var indexableAggregateValue = (IndexableAggregateValue) aggregateValue;
-        final var child = Iterables.getOnlyElement(aggregateValue.getChildren());
-        var indexTypeName = indexableAggregateValue.getIndexTypeName();
-        final KeyExpression groupedValue;
-        final GroupingKeyExpression keyExpression;
-        // COUNT(*) is a special case.
-        if (aggregateValue instanceof CountValue && IndexTypes.COUNT.equals(indexTypeName)) {
-            if (maybeGroupingExpression.isPresent()) {
-                keyExpression = new GroupingKeyExpression(maybeGroupingExpression.get(), 0);
-            } else {
-                keyExpression = new GroupingKeyExpression(EmptyKeyExpression.EMPTY, 0);
-            }
-        } else if (aggregateValue instanceof NumericAggregationValue.BitmapConstructAgg && IndexTypes.BITMAP_VALUE.equals(indexTypeName)) {
-            Assert.thatUnchecked(child instanceof FieldValue || child instanceof ArithmeticValue, "Unsupported index definition, expecting a column argument in aggregation function");
-            groupedValue = generate(List.of(child), Collections.emptyMap());
-            // only support bitmap_construct_agg(bitmap_bit_position(column))
-            // doesn't support bitmap_construct_agg(column)
-            Assert.thatUnchecked(groupedValue instanceof FunctionKeyExpression, "Unsupported index definition, expecting a bitmap_bit_position function in bitmap_construct_agg function");
-            final FunctionKeyExpression functionGroupedValue = (FunctionKeyExpression) groupedValue;
-            Assert.thatUnchecked(BITMAP_BIT_POSITION.equals(functionGroupedValue.getName()), "Unsupported index definition, expecting a bitmap_bit_position function in bitmap_construct_agg function");
-            final var groupedColumnValue = ((ThenKeyExpression) ((FunctionKeyExpression) groupedValue).getArguments()).getChildren().get(0);
-
-            if (maybeGroupingExpression.isPresent()) {
-                final var afterRemove = removeBitmapBucketOffset(maybeGroupingExpression.get());
-                if (afterRemove == null) {
-                    keyExpression = ((FieldKeyExpression) groupedColumnValue).ungrouped();
-                } else {
-                    keyExpression = ((FieldKeyExpression) groupedColumnValue).groupBy(afterRemove);
-                }
-            } else {
-                throw Assert.failUnchecked("Unsupported index definition, unexpected grouping expression " + groupedValue);
-            }
-        } else {
-            Assert.thatUnchecked(child instanceof FieldValue, "Unsupported index definition, expecting a column argument in aggregation function");
-            groupedValue = generate(List.of(child), Collections.emptyMap());
-            Assert.thatUnchecked(groupedValue instanceof FieldKeyExpression || groupedValue instanceof ThenKeyExpression);
-            if (maybeGroupingExpression.isPresent()) {
-                keyExpression = (groupedValue instanceof FieldKeyExpression) ?
-                        ((FieldKeyExpression) groupedValue).groupBy(maybeGroupingExpression.get()) :
-                        ((ThenKeyExpression) groupedValue).groupBy(maybeGroupingExpression.get());
-            } else {
-                keyExpression = (groupedValue instanceof FieldKeyExpression) ?
-                        ((FieldKeyExpression) groupedValue).ungrouped() :
-                        ((ThenKeyExpression) groupedValue).ungrouped();
-            }
-        }
-        // special handling of min_ever and max_ever, depending on index attributes we either create the
-        // long-based version or the tuple-based version.
-        if (IndexTypes.MAX_EVER.equals(indexTypeName)) {
-            if (useLegacyBasedExtremumEver) {
-                final var indexValue = Iterables.getOnlyElement(indexableAggregateValue.getChildren());
-                Verify.verify(indexValue.getResultType().isNumeric(), "only numeric types allowed in " + IndexTypes.MAX_EVER_LONG + " aggregation operation");
-                indexTypeName = IndexTypes.MAX_EVER_LONG;
-            } else {
-                indexTypeName = IndexTypes.MAX_EVER_TUPLE;
-            }
-        } else if (IndexTypes.MIN_EVER.equals(indexTypeName)) {
-            if (useLegacyBasedExtremumEver) {
-                final var indexValue = Iterables.getOnlyElement(indexableAggregateValue.getChildren());
-                Verify.verify(indexValue.getResultType().isNumeric(), "only numeric types allowed in " + IndexTypes.MIN_EVER_LONG + " aggregation operation");
-                indexTypeName = IndexTypes.MIN_EVER_LONG;
-            } else {
-                indexTypeName = IndexTypes.MIN_EVER_TUPLE;
-            }
-        }
-        return NonnullPair.of(keyExpression, indexTypeName);
-    }
-
-    /*
-    remove bitmap_bucket_offset(col) from groupingExpression if it exists
-    return null if groupingExpression only contains bitmap_bucket_offset(col)
+    /**
+     * Translates the projection into the index key, columns in key order: the order-by columns lead a value index, while
+     * an aggregate index keeps the projection's order.
      */
-    @Nullable
-    private KeyExpression removeBitmapBucketOffset(@Nonnull KeyExpression groupingExpression) {
-        // groupingExpression looks like [*, bitmap_bucket_offset(C)+], so it is either a ThenKeyExpression or a FunctionKeyExpression
-        Assert.thatUnchecked(groupingExpression instanceof ThenKeyExpression || groupingExpression instanceof FunctionKeyExpression, "Unsupported index definition, expecting column or function arguments in group by");
-        if (groupingExpression instanceof ThenKeyExpression) {
-            List<KeyExpression> groupingChildren = ((ThenKeyExpression) groupingExpression).getChildren();
-            // check if the last one is bitmap_bucket_offset function, otherwise throws exception
-            Assert.thatUnchecked(groupingChildren.get(groupingChildren.size() - 1) instanceof FunctionKeyExpression && BITMAP_BUCKET_OFFSET.equals(((FunctionKeyExpression) groupingChildren.get(groupingChildren.size() - 1)).getName()), "Unsupported index definition, expecting the last element in group by to be a bitmap_bucket_offset function");
-            // a ThenKeyExpression has at least 2 children
-            if (groupingChildren.size() >= 3) {
-                return new ThenKeyExpression(groupingChildren, 0, groupingChildren.size() - 1);
-            } else {
-                return groupingChildren.get(0);
-            }
-        } else {
-            if (BITMAP_BUCKET_OFFSET.equals(((FunctionKeyExpression) groupingExpression).getName())) {
-                return null;
-            } else {
-                return groupingExpression;
-            }
-        }
+    @Nonnull
+    private ValueToKeyExpressionVisitor.Result translateToKeyExpression(@Nonnull final IndexSpec spec) {
+        final var projection = spec.projection();
+        final var isAggregate = projection.aggregate() != null;
+        final var reorderedValues = isAggregate ? projection.values()
+                                          : reorderValues(projection.fieldValues(), spec.getOrderByValues());
+        return ValueToKeyExpressionVisitor.translate(RecordConstructorValue.ofUnnamed(reorderedValues),
+                isAggregate ? Map.of() : spec.getOrderingFunctions(), options.extremumEverStorage());
     }
 
     @Nonnull
-    private KeyExpression generate(@Nonnull List<Value> fields, @Nonnull Map<Value, String> orderingFunctions) {
-        if (fields.isEmpty()) {
-            return EmptyKeyExpression.EMPTY;
-        } else if (fields.size() == 1) {
-            return toKeyExpression(fields.get(0), orderingFunctions);
+    private static List<Value> reorderValues(@Nonnull final List<Value> allValues, @Nonnull final List<Value> keyValues) {
+        Assert.thatUnchecked(allValues.size() >= keyValues.size());
+        if (keyValues.isEmpty()) {
+            return allValues;
         }
-
-        List<FieldValueTrieNode> trieNodes = new ArrayList<>(fields.size());
-        List<KeyExpression> components = new ArrayList<>(fields.size());
-        PeekingIterator<Value> valueIterator = Iterators.peekingIterator(fields.iterator());
-        while (valueIterator.hasNext()) {
-            if (!(valueIterator.peek() instanceof FieldValue)) {
-                components.add(toKeyExpression(valueIterator.next(), orderingFunctions));
-            } else {
-                FieldValueTrieNode trieNode = FieldValueTrieNode.computeTrieForValues(FieldValue.FieldPath.empty(), valueIterator);
-                trieNode.validateNoOverlaps(trieNodes);
-                trieNodes.add(trieNode);
-
-                components.add(toKeyExpression(trieNode, orderingFunctions));
-            }
-        }
-
-        if (components.size() == 1) {
-            return components.get(0);
-        } else {
-            return concat(components);
-        }
-    }
-
-    @Nonnull
-    private KeyExpression toKeyExpression(Value value, Map<Value, String> orderingFunctions) {
-        var expr = toKeyExpression(value);
-        if (orderingFunctions.containsKey(value)) {
-            return function(orderingFunctions.get(value), expr);
-        } else {
-            return expr;
-        }
+        final var valueValues = allValues.stream()
+                .filter(value -> !keyValues.contains(value))
+                .collect(ImmutableList.toImmutableList());
+        return ImmutableList.<Value>builder().addAll(keyValues).addAll(valueValues).build();
     }
 
     /**
-     * Build the key expression representing the arguments of a {@link FunctionKeyExpression}.
+     * Stores the columns beyond the ordered ones as the index's value rather than as part of its key. With no ordering
+     * clause the caller says whether the key is empty or there is no split at all.
      */
     @Nonnull
-    private static KeyExpression buildArgumentKeyExpression(List<KeyExpression> argumentList) {
-        if (argumentList.isEmpty()) {
-            return empty();
-        } else if (argumentList.size() == 1) {
-            return argumentList.get(0);
-        } else {
-            return concat(argumentList);
+    private static KeyExpression splitKeyFromValue(@Nonnull final IndexSpec spec, @Nonnull final KeyExpression keyExpression,
+                                                   final boolean emptyKeyAllowed) {
+        final var splitPoint = spec.getOrderByValues().size();
+        if (splitPoint == 0 && !emptyKeyAllowed) {
+            return keyExpression;
         }
-    }
-
-    @Nonnull
-    private KeyExpression toKeyExpression(@Nonnull Value value) {
-        if (value instanceof FieldValue) {
-            final FieldValue fieldValue = (FieldValue) value;
-            return toKeyExpression(fieldValue.getFieldPath().getFieldAccessors().iterator(), KeyExpression.FanType.FanOut);
-        } else if (value instanceof CardinalityValue) {
-            // CARDINALITY() consumes an array value. Currently, it can only be applied to a `field` directly. We make
-            // sure here that the field gets accessed with fan-out type `Concatenate` instead of `FanOut` so that it
-            // produces the materialized array.
-            final var it = value.getChildren().iterator();
-            Assert.thatUnchecked(it.hasNext(), "Invalid children list for `CardinalityValue`");
-            final Value childValue = it.next();
-            Assert.thatUnchecked(!it.hasNext(), "Invalid children list for `CardinalityValue`");
-            Assert.thatUnchecked(childValue instanceof FieldValue, "CARDINALITY() must be applied to a `field()` in an index key expression.");
-            final var fieldValue = (FieldValue)childValue;
-            final KeyExpression childKeyExpression = toKeyExpression(fieldValue.getFieldPath().getFieldAccessors().iterator(), KeyExpression.FanType.Concatenate);
-            return function(FunctionNames.CARDINALITY, childKeyExpression);
-        } else if (value instanceof ArithmeticValue) {
-            var children = value.getChildren();
-            var builder = ImmutableList.<KeyExpression>builder();
-            for (Value child : children) {
-                builder.add(toKeyExpression(child));
-            }
-            KeyExpression argumentExpr = buildArgumentKeyExpression(builder.build());
-            final String name = ((ArithmeticValue)value).getLogicalOperator().name().toLowerCase(Locale.ROOT);
-            return function(name, argumentExpr);
-        } else if (value instanceof LiteralValue<?>) {
-            return Key.Expressions.value(((LiteralValue<?>) value).getLiteralValue());
-        } else {
-            Assert.failUnchecked(ErrorCode.UNSUPPORTED_OPERATION, "unable to construct expression");
-            return null;
-        }
-    }
-
-    @Nonnull
-    private static KeyExpression toKeyExpression(@Nonnull FieldValueTrieNode trieNode,
-                                                 @Nonnull Map<Value, String> orderingFunctions) {
-        Assert.notNullUnchecked(trieNode.getChildrenMap());
-        Assert.thatUnchecked(!trieNode.getChildrenMap().isEmpty());
-
-        final var childrenMap = trieNode.getChildrenMap();
-        final var exprConstituents = childrenMap.entrySet().stream().map(nodeEntry -> {
-            final FieldValue.ResolvedAccessor accessor = nodeEntry.getKey();
-            final FieldValueTrieNode node = nodeEntry.getValue();
-            final KeyExpression expr = toFieldKeyExpression(accessor, KeyExpression.FanType.FanOut);
-            if (node.getChildrenMap() != null) {
-                final FieldKeyExpression fieldExpr = Assert.castUnchecked(expr, FieldKeyExpression.class);
-                return fieldExpr.nest(toKeyExpression(node, orderingFunctions));
-            } else if (orderingFunctions.containsKey(node.getValue())) {
-                return function(orderingFunctions.get(node.getValue()), expr);
-            } else {
-                return expr;
-            }
-        }).collect(toList());
-        if (exprConstituents.size() == 1) {
-            return exprConstituents.get(0);
-        } else {
-            return concat(exprConstituents);
-        }
-    }
-
-    private void checkValidity(@Nonnull List<? extends RelationalExpression> expressions) {
-
-        // there must be exactly one type full-unordered-scan, no joins, no self-joins.
-        final var numScans = expressions.stream().filter(r -> r instanceof FullUnorderedScanExpression).count();
-        Assert.thatUnchecked(numScans == 1, ErrorCode.UNSUPPORTED_OPERATION, "Unsupported index definition, %s iteration generator found", numScans == 0 ? "no" : "more than one");
-
-        // there must be at most a single group by
-        final var numGroupBy = expressions.stream().filter(r -> r instanceof GroupByExpression).count();
-        Assert.thatUnchecked(numGroupBy <= 1, ErrorCode.UNSUPPORTED_OPERATION, "Unsupported index definition, multiple group by expressions found");
-
-        // there can be only one aggregation in group by expression (maybe we can relax this in the future).
-        final var groupByContainsOneAggregation = expressions.stream().filter(r -> r instanceof GroupByExpression).map(r -> (GroupByExpression) r).noneMatch(g -> Values.deconstructRecord(g.getAggregateValue()).size() > 1);
-        Assert.thatUnchecked(groupByContainsOneAggregation, ErrorCode.UNSUPPORTED_OPERATION, "Unsupported index definition, found group by expression with more than one aggregation");
-
-        // Result values of each operation must be record-typed. `ExplodeExpression` is excluded because
-        // unnesting a scalar array (e.g., a STRING ARRAY) produces scalar elements, not records.
-        final var allRecordValues = expressions.stream()
-                .filter(r -> !(r instanceof ExplodeExpression))
-                .allMatch(r -> (r.getResultValue().getResultType().getTypeCode() == Type.TypeCode.RECORD));
-        Assert.thatUnchecked(allRecordValues, ErrorCode.UNSUPPORTED_OPERATION, "Unsupported index definition, some operators return non-record values");
-
-        // Fields of result values of each record-typed operation must be simple or arithmetic values.
-        final var allSimpleValues = expressions.stream()
-                .filter(r -> r.getResultType().getInnerType() instanceof Type.Record)
-                .allMatch(r -> Values.deconstructRecord(r.getResultValue()).stream().allMatch(v -> v instanceof FieldValue || v instanceof QuantifiedObjectValue || v instanceof AggregateValue || v instanceof ArithmeticValue || v instanceof LiteralValue || v instanceof CardinalityValue));
-        Assert.thatUnchecked(allSimpleValues, ErrorCode.UNSUPPORTED_OPERATION, "Unsupported index definition, not all fields can be mapped to key expression in");
-    }
-
-    @Nullable
-    public static QueryPredicate getTopLevelPredicate(@Nonnull List<? extends RelationalExpression> expressions) {
-        if (expressions.isEmpty()) {
-            return null;
-        }
-        int currentExpression = 0;
-        if (expressions.get(currentExpression) instanceof LogicalSortExpression) {
-            currentExpression++;
-        }
-        if (expressions.size() > currentExpression && expressions.get(currentExpression) instanceof SelectExpression) {
-            if (expressions.size() > (currentExpression + 1) && expressions.get(currentExpression + 1) instanceof GroupByExpression) {
-                // the above select-having must not contain any predicate.
-                Assert.thatUnchecked(((SelectExpression) expressions.get(currentExpression)).getPredicates().isEmpty(), ErrorCode.UNSUPPORTED_OPERATION, "Unsupported index definition, found predicate in select-having");
-                currentExpression++; // group-by expression.
-                Assert.thatUnchecked(expressions.size() > currentExpression);
-                currentExpression++; // select-where.
-            }
-        }
-        // current expression is either top-level select, or select-where or top-level group by.
-        // make sure any other select statement does not have any predicates defined.
-        for (int i = currentExpression + 1; i < expressions.size(); i++) {
-            if (expressions.get(i) instanceof SelectExpression) {
-                final var innerSelect = (SelectExpression) expressions.get(i);
-                Assert.thatUnchecked(innerSelect.getPredicates().isEmpty(), ErrorCode.UNSUPPORTED_OPERATION, "Unsupported index definition, found predicate in inner-select");
-            }
-        }
-        final var expr = expressions.get(currentExpression);
-        if (!(expr instanceof SelectExpression)) {
-            return null;
-        }
-        final var predicates = ((SelectExpression) expr).getPredicates().stream().map(QueryPredicate::toResidualPredicate).collect(toList());
-        // todo (yhatem) make sure we through if the generated DNF does not meet the deserialization requirements.
-        if (predicates.isEmpty()) {
-            return null;
-        }
-        final var conjunction = predicates.size() == 1 ? predicates.get(0) : AndPredicate.and(predicates);
-        final var result = BooleanPredicateNormalizer.getDefaultInstanceForDnf().normalize(conjunction, false).orElse(conjunction);
-        Assert.thatUnchecked(IndexPredicate.isSupported(result), ErrorCode.UNSUPPORTED_OPERATION, () -> String.format(Locale.ROOT, "Unsupported predicate '%s'", result))    ;
-        if (IndexPredicateExpansion.dnfPredicateToRanges(result).isEmpty()) {
-            return conjunction;
-        }
-        return result;
-    }
-
-    private static final class AnnotatedAccessor extends FieldValue.ResolvedAccessor {
-
-        private final int marker;
-
-        private AnnotatedAccessor(@Nonnull Type.Record.Field field,
-                                  int ordinal,
-                                  int marker) {
-            super(field, ordinal);
-            this.marker = marker;
-        }
-
-        @Nonnull
-        public static AnnotatedAccessor of(@Nonnull FieldValue.ResolvedAccessor resolvedAccessor, int marker) {
-            return new AnnotatedAccessor(resolvedAccessor.getField(), resolvedAccessor.getOrdinal(), marker);
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) {
-                return true;
-            }
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-            if (!super.equals(o)) {
-                return false;
-            }
-            AnnotatedAccessor that = (AnnotatedAccessor) o;
-            return marker == that.marker;
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(super.hashCode(), marker);
-        }
-    }
-
-    private void collectQuantifiers(@Nonnull RelationalExpression relationalExpression) {
-        AtomicInteger counter = new AtomicInteger(0);
-        collectQuantifiersInternal(relationalExpression, counter);
-    }
-
-    private void collectQuantifiersInternal(@Nonnull RelationalExpression relationalExpression, @Nonnull AtomicInteger explodeCounter) {
-        for (final var qun : relationalExpression.getQuantifiers()) {
-            if (qun.getRangesOver().get() instanceof ExplodeExpression) {
-                explodeCounter.incrementAndGet();
-                final var collectionValue = ((ExplodeExpression) qun.getRangesOver().get()).getCollectionValue();
-                if (collectionValue instanceof FieldValue) {
-                    final var field = (FieldValue) collectionValue;
-                    final var fieldAccessors = new ArrayList<>(field.getFieldPath().getFieldAccessors());
-                    fieldAccessors.set(fieldAccessors.size() - 1, AnnotatedAccessor.of(fieldAccessors.get(fieldAccessors.size() - 1), explodeCounter.get()));
-                    correlatedKeyExpressions.put(qun.getAlias(), FieldValue.ofFields(((FieldValue) collectionValue).getChild(), new FieldValue.FieldPath(fieldAccessors)));
-                } else {
-                    correlatedKeyExpressions.put(qun.getAlias(), collectionValue);
-                }
-            } else {
-                correlatedKeyExpressions.put(qun.getAlias(), qun.getRangesOver().get().getResultValue());
-            }
-            collectQuantifiersInternal(qun.getRangesOver().get(), explodeCounter);
-        }
-    }
-
-    @Nonnull
-    private Value dereference(@Nonnull Value value) {
-        if (value instanceof RecordConstructorValue) {
-            return RecordConstructorValue.ofColumns(
-                    ((RecordConstructorValue) value).getColumns()
-                            .stream()
-                            .map(c -> Column.of(c.getField(), dereference(c.getValue())))
-                            .collect(toList()));
-        } else if (value instanceof CountValue) {
-            final var children = StreamSupport.stream(value.getChildren().spliterator(), false).collect(toList());
-            Verify.verify(children.size() <= 1);
-            if (!children.isEmpty()) {
-                return value.withChildren(Collections.singleton(dereference(children.get(0))));
-            } else {
-                return value;
-            }
-        } else if (value instanceof FieldValue || value instanceof IndexableAggregateValue) {
-            final var valueWithChild = (ValueWithChild) value;
-            return valueWithChild.withNewChild(dereference(valueWithChild.getChild()));
-        } else if (value instanceof QuantifiedObjectValue) {
-            return dereference(correlatedKeyExpressions.get(value.getCorrelatedTo().stream().findFirst().orElseThrow()));
-        } else if (value instanceof ArithmeticValue) {
-            final List<Value> newChildren = new ArrayList<>();
-            for (Value v:value.getChildren()) {
-                newChildren.add(dereference(v));
-            }
-            return ((ArithmeticValue) value).withChildren(newChildren);
-        } else {
-            return value;
-        }
-    }
-
-    @Nonnull
-    private KeyExpression toKeyExpression(@Nonnull Iterator<FieldValue.ResolvedAccessor> resolvedAccessors, KeyExpression.FanType fanTypeForArray) {
-        Assert.thatUnchecked(resolvedAccessors.hasNext(), "cannot resolve empty list");
-        final FieldValue.ResolvedAccessor accessor = resolvedAccessors.next();
-        final KeyExpression expression = toFieldKeyExpression(accessor, fanTypeForArray);
-        if (resolvedAccessors.hasNext()) {
-            KeyExpression childExpression = toKeyExpression(resolvedAccessors, fanTypeForArray);
-            final FieldKeyExpression fieldExpression = Assert.castUnchecked(expression, FieldKeyExpression.class);
-            return fieldExpression.nest(childExpression);
-        } else {
-            return expression;
-        }
-    }
-
-    @Nonnull
-    private String getRecordTypeName() {
-        final var expressionRefs = relationalExpressions.stream()
-                .filter(r -> r instanceof LogicalTypeFilterExpression)
-                .map(r -> (LogicalTypeFilterExpression) r)
-                .collect(toList());
-        Assert.thatUnchecked(expressionRefs.size() == 1, ErrorCode.UNSUPPORTED_OPERATION, "Unsupported query, expected to find exactly one type filter operator");
-        final var recordTypes = expressionRefs.get(0).getRecordTypes();
-        Assert.thatUnchecked(recordTypes.size() == 1, ErrorCode.UNSUPPORTED_OPERATION, () -> String.format(Locale.ROOT, "Unsupported query, expected to find exactly one record type in type filter operator, however found %s", recordTypes.isEmpty() ? "nothing" : String.join(",", recordTypes)));
-        return recordTypes.stream().findFirst().orElseThrow();
+        return splitPoint < spec.projection().fieldValues().size()
+               ? keyWithValue(keyExpression, splitPoint) : keyExpression;
     }
 
     /**
-     * Return a {@link FieldKeyExpression} or {@link VersionKeyExpression} for the given field type, as appropriate.
-     *
-     * @param fanTypeForArray The fan-out type to use for the {@code field} key expression in case the field is an
-     * ARRAY. This should be either {@code FanOut} or {@code Concatenate}.
+     * Tells a permuted index how many columns follow the aggregate in its key. Every other aggregate index type keeps the
+     * aggregate last and cannot be ordered by it.
      */
-    @Nonnull
-    private static KeyExpression toFieldKeyExpression(@Nonnull FieldValue.ResolvedAccessor accessor, KeyExpression.FanType fanTypeForArray) {
-        final Type.Record.Field fieldType = accessor.getField();
-        Assert.notNullUnchecked(fieldType.getFieldStorageName());
-        Assert.thatUnchecked(fanTypeForArray == KeyExpression.FanType.FanOut || fanTypeForArray == KeyExpression.FanType.Concatenate);
-        Assert.thatUnchecked(!fieldType.getFieldType().isArray()
-                        || (accessor instanceof AnnotatedAccessor)
-                        || (fanTypeForArray == KeyExpression.FanType.Concatenate),
-                ErrorCode.UNSUPPORTED_OPERATION,
-                "Unsupported index definition, cannot create index on array field '" +
-                fieldType.getFieldName() + "' without unnesting");
-        final Type type = fieldType.getFieldType();
-        if (PseudoField.ROW_VERSION.getType().equals(type) && PseudoField.ROW_VERSION.getFieldName().equals(fieldType.getFieldName())) {
-            return VersionKeyExpression.VERSION;
+    private static void addAggregatePermutationOptions(@Nonnull final RecordLayerIndex.Builder indexBuilder,
+                                                       @Nonnull final IndexSpec spec, @Nonnull final String indexType) {
+        final var aggregateOrderIndex = spec.aggregateOrderIndex();
+        if (IndexTypes.PERMUTED_MIN.equals(indexType) || IndexTypes.PERMUTED_MAX.equals(indexType)) {
+            indexBuilder.setOption(IndexOptions.PERMUTED_SIZE_OPTION,
+                    aggregateOrderIndex < 0 ? 0 : spec.projection().fieldValues().size() - aggregateOrderIndex);
+        } else {
+            Assert.thatUnchecked(aggregateOrderIndex <= 0, ErrorCode.UNSUPPORTED_OPERATION,
+                    "Unsupported index definition. Cannot order " + indexType + " index by aggregate value");
         }
-        final var fanType = type.isArray() ? fanTypeForArray : KeyExpression.FanType.None;
-        // Here we need to use the storage field name, as that will be the name referenced in Protobuf storage.
-        return field(fieldType.getFieldStorageName(), fanType);
-    }
-
-    @Nonnull
-    public static MaterializedViewIndexGenerator from(@Nonnull RelationalExpression relationalExpression, boolean useLongBasedExtremumEver) {
-        return new MaterializedViewIndexGenerator(relationalExpression, useLongBasedExtremumEver);
     }
 }

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/ddl/OnSourceIndexGenerator.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/ddl/OnSourceIndexGenerator.java
@@ -105,7 +105,7 @@ import java.util.stream.Collectors;
  * @see MaterializedViewIndexGenerator
  * @see RecordLayerIndex
  */
-public final class OnSourceIndexGenerator {
+public final class OnSourceIndexGenerator implements IndexGenerator {
 
     @Nonnull
     private final Identifier indexName;
@@ -119,13 +119,8 @@ public final class OnSourceIndexGenerator {
     @Nonnull
     private final LogicalPlanFragment source;
 
-    private final boolean isUnique;
-
-    private final boolean useLegacyExtremum;
-
-    private final boolean useNullableArrays;
-
-    private final boolean generateKeyValueExpressionWithEmptyKey;
+    @Nonnull
+    private final IndexGenerationOptions options;
 
     @Nonnull
     private final Map<String, String> indexOptions;
@@ -133,19 +128,16 @@ public final class OnSourceIndexGenerator {
     @Nonnull
     private final RecordLayerSchemaTemplate.Builder metadataBuilder;
 
-    public OnSourceIndexGenerator(@Nonnull final Identifier indexName, @Nonnull final LogicalPlanFragment source,
+    private OnSourceIndexGenerator(@Nonnull final Identifier indexName, @Nonnull final LogicalPlanFragment source,
                                   @Nonnull final List<IndexedColumn> keyColumns, @Nonnull final List<IndexedColumn> valueColumns,
-                                  final boolean isUnique, final boolean useLegacyExtremum, final boolean useNullableArrays,
-                                  final boolean generateKeyValueExpressionWithEmptyKey, @Nonnull final Map<String, String> indexOptions,
+                                  @Nonnull final IndexGenerationOptions options,
+                                  @Nonnull final Map<String, String> indexOptions,
                                   @Nonnull final RecordLayerSchemaTemplate.Builder metadataBuilder) {
         this.indexName = indexName;
         this.source = source;
         this.keyColumns = ImmutableList.copyOf(keyColumns);
         this.valueColumns = ImmutableList.copyOf(valueColumns);
-        this.isUnique = isUnique;
-        this.useLegacyExtremum = useLegacyExtremum;
-        this.useNullableArrays = useNullableArrays;
-        this.generateKeyValueExpressionWithEmptyKey = generateKeyValueExpressionWithEmptyKey;
+        this.options = options;
         this.indexOptions = ImmutableMap.copyOf(indexOptions);
         this.metadataBuilder = metadataBuilder;
     }
@@ -164,15 +156,16 @@ public final class OnSourceIndexGenerator {
      * the final index structure.
      * <p>
      * The generated index will be ordered according to the key columns and can optionally enforce uniqueness
-     * if configured via {@link Builder#setUnique(boolean)}.
+     * if configured via {@link IndexGenerationOptions#unique()} flag.
      *
      * @return a fully configured {@link RecordLayerIndex} ready to be added to the schema
      */
     @Nonnull
+    @Override
     public RecordLayerIndex.Builder generate() {
-        final var keyIdentifiers = keyColumns.stream().map(IndexedColumn::getIdentifier).collect(ImmutableList.toImmutableList());
+        final var keyIdentifiers = keyColumns.stream().map(IndexedColumn::identifier).collect(ImmutableList.toImmutableList());
         final var keyIdentifiersAsSet = ImmutableSet.copyOf(keyIdentifiers);
-        final var valueIdentifiers = valueColumns.stream().map(IndexedColumn::getIdentifier)
+        final var valueIdentifiers = valueColumns.stream().map(IndexedColumn::identifier)
                 .filter(id -> !keyIdentifiersAsSet.contains(id)).collect(ImmutableList.toImmutableList());
 
         final var topLevelOperator = Iterables.getOnlyElement(source.getLogicalOperators());
@@ -203,8 +196,8 @@ public final class OnSourceIndexGenerator {
                 }).collect(ImmutableList.toImmutableList());
 
         final List<OrderByExpression> orderByExpressions = keyColumns.stream().map(keyColumn -> {
-            final var column = originalOutputMap.get(keyColumn.getIdentifier());
-            Assert.notNullUnchecked(column, ErrorCode.UNDEFINED_COLUMN, () -> "could not find " + keyColumn.getIdentifier());
+            final var column = originalOutputMap.get(keyColumn.identifier());
+            Assert.notNullUnchecked(column, ErrorCode.UNDEFINED_COLUMN, () -> "could not find " + keyColumn.identifier());
             return OrderByExpression.of(Expression.fromColumn(column), keyColumn.isDescending(), keyColumn.isNullsLast());
         }).collect(ImmutableList.toImmutableList());
 
@@ -223,44 +216,15 @@ public final class OnSourceIndexGenerator {
         final var resultingOperator = LogicalOperator.newUnnamedOperator(projectionExpressions,
                 Quantifier.forEach(Reference.initialOf(newSelectExpression)));
         final var indexPlan = LogicalOperator.generateSort(resultingOperator, orderByExpressions, ImmutableSet.of(), Optional.empty());
-        final var indexGenerator = MaterializedViewIndexGenerator.from(indexPlan.getQuantifier().getRangesOver().get(), useLegacyExtremum);
-        final var indexBuilder = indexGenerator.generate(metadataBuilder, indexName.toString(), isUnique, useNullableArrays, generateKeyValueExpressionWithEmptyKey);
-        indexBuilder.addAllOptions(indexOptions);
-        return indexBuilder;
+        final var indexGenerator = MaterializedViewIndexGenerator.newInstance(
+                indexPlan.getQuantifier().getRangesOver().get(), metadataBuilder, indexName.toString(),
+                options);
+        final var indexMetadata = indexGenerator.generate();
+        indexMetadata.addAllOptions(indexOptions);
+        return indexMetadata;
     }
 
-    public static final class IndexedColumn {
-
-        @Nonnull
-        private final Identifier identifier;
-
-        private final boolean isDescending;
-
-        private final boolean isNullsLast;
-
-        private IndexedColumn(@Nonnull final Identifier identifier, boolean isDescending, boolean isNullsLast) {
-            this.identifier = identifier;
-            this.isDescending = isDescending;
-            this.isNullsLast = isNullsLast;
-        }
-
-        @Nonnull
-        public Identifier getIdentifier() {
-            return identifier;
-        }
-
-        public boolean isDescending() {
-            return isDescending;
-        }
-
-        public boolean isNullsLast() {
-            return isNullsLast;
-        }
-
-        @Nonnull
-        public static IndexedColumn of(@Nonnull final Identifier identifier, boolean isDescending, boolean isNullsLast) {
-            return new IndexedColumn(identifier, isDescending, isNullsLast);
-        }
+    public record IndexedColumn(@Nonnull Identifier identifier, boolean isDescending, boolean isNullsLast) {
 
         /**
          * Parses an index column specification from a parser context into an {@link IndexedColumn}.
@@ -275,11 +239,12 @@ public final class OnSourceIndexGenerator {
          *
          * @param columnSpec the parser context containing the column specification
          * @param identifierVisitor the visitor used to extract the column identifier
+         *
          * @return an {@link IndexedColumn} representing the parsed column specification
          */
         @Nonnull
-        public static OnSourceIndexGenerator.IndexedColumn parseColSpec(@Nonnull final RelationalParser.IndexColumnSpecContext columnSpec,
-                                                                        @Nonnull final IdentifierVisitor identifierVisitor) {
+        public static IndexedColumn parseColSpec(@Nonnull final RelationalParser.IndexColumnSpecContext columnSpec,
+                                                 @Nonnull final IdentifierVisitor identifierVisitor) {
             final var columnId = identifierVisitor.visitUid(columnSpec.columnName);
             final var orderContext = columnSpec.orderClause();
 
@@ -287,7 +252,7 @@ public final class OnSourceIndexGenerator {
             boolean nullsLast = false;
 
             if (orderContext == null) {
-                return OnSourceIndexGenerator.IndexedColumn.of(columnId, isDesc, nullsLast);
+                return new IndexedColumn(columnId, isDesc, nullsLast);
             }
 
             isDesc = orderContext.DESC() != null;
@@ -296,14 +261,14 @@ public final class OnSourceIndexGenerator {
             } else {
                 nullsLast = orderContext.LAST() != null;
             }
-            return OnSourceIndexGenerator.IndexedColumn.of(columnId, isDesc, nullsLast);
+            return new IndexedColumn(columnId, isDesc, nullsLast);
         }
 
         @Nonnull
-        public static OnSourceIndexGenerator.IndexedColumn parseUid(@Nonnull final RelationalParser.UidContext uid,
-                                                                    @Nonnull final IdentifierVisitor identifierVisitor) {
+        public static IndexedColumn parseUid(@Nonnull final RelationalParser.UidContext uid,
+                                             @Nonnull final IdentifierVisitor identifierVisitor) {
             final var columnId = identifierVisitor.visitUid(uid);
-            return OnSourceIndexGenerator.IndexedColumn.of(columnId, false, false);
+            return new IndexedColumn(columnId, false, false);
         }
     }
 
@@ -329,13 +294,7 @@ public final class OnSourceIndexGenerator {
         @Nonnull
         private final Map<String, String> indexOptions;
 
-        private boolean isUnique;
-
-        private boolean useLegacyExtremum;
-
-        private boolean useNullableArrays;
-
-        private boolean generateKeyValueExpressionWithEmptyKey;
+        private IndexGenerationOptions options;
 
         private RecordLayerSchemaTemplate.Builder metadataBuilder;
 
@@ -392,27 +351,12 @@ public final class OnSourceIndexGenerator {
             return this;
         }
 
+        /**
+         * What the definition asks of the index beyond its key.
+         */
         @Nonnull
-        public Builder setUnique(boolean isUnique) {
-            this.isUnique = isUnique;
-            return this;
-        }
-
-        @Nonnull
-        public Builder setUseLegacyExtremum(boolean useLegacyExtremum) {
-            this.useLegacyExtremum = useLegacyExtremum;
-            return this;
-        }
-
-        @Nonnull
-        public Builder setUseNullableArrays(boolean useNullableArrays) {
-            this.useNullableArrays = useNullableArrays;
-            return this;
-        }
-
-        @Nonnull
-        public Builder setGenerateKeyValueExpressionWithEmptyKey(boolean generateKeyValueExpressionWithEmptyKey) {
-            this.generateKeyValueExpressionWithEmptyKey = generateKeyValueExpressionWithEmptyKey;
+        public Builder setOptions(@Nonnull final IndexGenerationOptions options) {
+            this.options = options;
             return this;
         }
 
@@ -429,8 +373,8 @@ public final class OnSourceIndexGenerator {
             Assert.notNullUnchecked(indexSource);
             Assert.notNullUnchecked(semanticAnalyzer);
             Assert.notNullUnchecked(metadataBuilder);
-            return new OnSourceIndexGenerator(indexName, indexSource, keyColumns, valueColumns,
-                    isUnique, useLegacyExtremum, useNullableArrays, generateKeyValueExpressionWithEmptyKey,
+            Assert.notNullUnchecked(options);
+            return new OnSourceIndexGenerator(indexName, indexSource, keyColumns, valueColumns, options,
                     indexOptions, metadataBuilder);
         }
     }

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/ddl/ProjectionResolver.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/ddl/ProjectionResolver.java
@@ -1,0 +1,126 @@
+/*
+ * ProjectionResolver.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.relational.recordlayer.query.ddl;
+
+import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.GroupByExpression;
+import com.apple.foundationdb.record.query.plan.cascades.values.FieldValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.IndexableAggregateValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.QuantifiedObjectValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.Value;
+import com.apple.foundationdb.record.query.plan.cascades.values.Values;
+import com.apple.foundationdb.relational.api.exceptions.ErrorCode;
+import com.apple.foundationdb.relational.util.Assert;
+import com.google.common.collect.ImmutableList;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
+
+/**
+ * Turns the result value of an index-defining select into the columns of the index, resolved down to the base record. A
+ * definition projecting nothing but its aggregate has the grouping columns added; one that projects them is checked to
+ * project exactly them, in order.
+ */
+final class ProjectionResolver {
+
+    @Nonnull
+    private final QuantifierValues quantifierValues;
+
+    ProjectionResolver(@Nonnull final QuantifierValues quantifierValues) {
+        this.quantifierValues = quantifierValues;
+    }
+
+    @Nonnull
+    IndexSpec.Projection resolve(@Nonnull final Value resultValue, @Nullable final GroupByExpression groupBy) {
+        final var resultValues = resolveEach(resultValue).collect(toList());
+        if (groupBy == null) {
+            return new IndexSpec.Projection(resultValues);
+        }
+        final var groupingValue = groupBy.getGroupingValue();
+        final var adjusted = adjustGroupByFieldPaths(resultValues, groupBy);
+        if (resultValues.size() != 1 || !(resultValues.get(0) instanceof IndexableAggregateValue)) {
+            checkGroupingColumnsProjected(resultValues, groupingValue);
+            return new IndexSpec.Projection(adjusted);
+        }
+        if (groupingValue == null) {
+            return new IndexSpec.Projection(adjusted);
+        }
+        return new IndexSpec.Projection(Stream.concat(adjusted.stream(), resolveEach(groupingValue)).collect(toList()));
+    }
+
+    /**
+     * Checks that the columns beside the aggregate are exactly the grouping columns, in the order they are grouped by.
+     */
+    private void checkGroupingColumnsProjected(@Nonnull final List<Value> resultValues,
+                                               @Nullable final Value groupingValue) {
+        final var grouping = Assert.notNullUnchecked(groupingValue, ErrorCode.UNSUPPORTED_OPERATION,
+                "Grouping values absent from aggregate result value");
+        final var groupingColumns = resolveEach(grouping).iterator();
+        for (final var resultValue : resultValues) {
+            if (resultValue instanceof IndexableAggregateValue) {
+                continue;
+            }
+            Assert.thatUnchecked(groupingColumns.hasNext(), ErrorCode.UNSUPPORTED_OPERATION,
+                    "Aggregate result value contains values missing from the grouping expression");
+            Assert.thatUnchecked(resultValue.equals(groupingColumns.next()), ErrorCode.UNSUPPORTED_OPERATION,
+                    "Aggregate result value does not align with grouping value");
+        }
+        Assert.thatUnchecked(!groupingColumns.hasNext(), ErrorCode.UNSUPPORTED_OPERATION,
+                "Grouping value absent from aggregate result value");
+    }
+
+    /**
+     * Strips the root of the field path from every column referencing the underlying select-where, leaving a field path of
+     * the base record.
+     */
+    @Nonnull
+    private static List<Value> adjustGroupByFieldPaths(@Nonnull final List<Value> resultValues,
+                                                       @Nonnull final GroupByExpression groupBy) {
+        final var selectWhereAlias = groupBy.getQuantifiers().get(0).getAlias();
+        return resultValues.stream()
+                .map(resultValue -> resultValue.replace(value -> stripSelectWhereRoot(value, selectWhereAlias)))
+                .collect(ImmutableList.toImmutableList());
+    }
+
+    /**
+     * Drops the leading accessor of a field path that starts at the select-where; leaves anything else alone.
+     */
+    @Nonnull
+    private static Value stripSelectWhereRoot(@Nonnull final Value value,
+                                              @Nonnull final CorrelationIdentifier selectWhereAlias) {
+        if (value instanceof final FieldValue fieldValue
+                && fieldValue.getChild() instanceof final QuantifiedObjectValue root
+                && root.getAlias().equals(selectWhereAlias)) {
+            final var accessors = fieldValue.getFieldPath().getFieldAccessors();
+            return FieldValue.ofFields(root, new FieldValue.FieldPath(accessors.subList(1, accessors.size())));
+        }
+        return value;
+    }
+
+    @Nonnull
+    private Stream<Value> resolveEach(@Nonnull final Value record) {
+        return Values.deconstructRecord(record).stream().map(quantifierValues::resolve);
+    }
+}

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/ddl/QuantifierValues.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/ddl/QuantifierValues.java
@@ -1,0 +1,201 @@
+/*
+ * QuantifierValues.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.relational.recordlayer.query.ddl;
+
+import com.apple.foundationdb.record.EvaluationContext;
+import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
+import com.apple.foundationdb.record.query.plan.cascades.CorrelationIdentifier;
+import com.apple.foundationdb.record.query.plan.cascades.Reference;
+import com.apple.foundationdb.record.query.plan.cascades.SimpleExpressionVisitor;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.ExplodeExpression;
+import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpression;
+import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
+import com.apple.foundationdb.record.query.plan.cascades.values.FieldValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.QuantifiedObjectValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.SimpleValueVisitor;
+import com.apple.foundationdb.record.query.plan.cascades.values.Value;
+import com.apple.foundationdb.relational.util.Assert;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * What every quantifier of an index-defining plan stands for, and with it the ability to resolve a value written in terms
+ * of those quantifiers down to the base record. Collected in a pass of its own, ahead of anything that needs it.
+ */
+final class QuantifierValues {
+
+    @Nonnull
+    private final Map<CorrelationIdentifier, Value> valuesByQuantifier;
+
+    private QuantifierValues(@Nonnull final Map<CorrelationIdentifier, Value> valuesByQuantifier) {
+        this.valuesByQuantifier = valuesByQuantifier;
+    }
+
+    /**
+     * Collects the mapping for a plan.
+     *
+     * @param expression the root of the index-defining plan
+     *
+     * @return what each of its quantifiers stands for
+     */
+    @Nonnull
+    public static QuantifierValues collect(@Nonnull final RelationalExpression expression) {
+        return new QuantifierValues(Assert.notNullUnchecked(new Collector().visit(expression)));
+    }
+
+    /**
+     * Resolves a value down to the base record and simplifies it.
+     *
+     * @param value a value written in terms of the plan's quantifiers
+     *
+     * @return the same value with every quantifier replaced by what it stands for
+     */
+    @Nonnull
+    public Value resolve(@Nonnull final Value value) {
+        return dereference(value).simplify(EvaluationContext.empty(), AliasMap.emptyMap(), Set.of());
+    }
+
+    @Nonnull
+    private Value dereference(@Nonnull final Value value) {
+        return Objects.requireNonNull(value.acceptVisitor(new Dereferencer()));
+    }
+
+    /**
+     * Replaces every quantifier with what it stands for, rebuilding the values above it.
+     */
+    private final class Dereferencer implements SimpleValueVisitor<Value> {
+
+        @Nonnull
+        @Override
+        public Value evaluateAtValue(@Nonnull final Value value, @Nonnull final List<Value> childResults) {
+            // a leaf stands for itself
+            return childResults.isEmpty() ? value : value.withChildren(childResults);
+        }
+
+        @Nonnull
+        @Override
+        public Value visitQuantifiedObjectValue(@Nonnull final QuantifiedObjectValue element) {
+            // what a quantifier stands for may reference another
+            return visit(Assert.notNullUnchecked(valuesByQuantifier.get(element.getAlias())));
+        }
+    }
+
+    /**
+     * The traversal. It contributes what a node's own quantifiers stand for, merges that with its children, and validates
+     * nothing.
+     */
+    private static final class Collector implements SimpleExpressionVisitor<Map<CorrelationIdentifier, Value>> {
+
+        /**
+         * Numbers the unnestings, so that two unnestings of the same array field compare unequal. Only distinctness
+         * matters; the number never reaches the key expression.
+         */
+        @Nonnull
+        private final AtomicInteger explodeCounter = new AtomicInteger(0);
+
+        @Nonnull
+        @Override
+        public Map<CorrelationIdentifier, Value> evaluateAtExpression(@Nonnull final RelationalExpression expression,
+                                                                      @Nonnull final List<Map<CorrelationIdentifier, Value>> childResults) {
+            final var merged = merge(childResults);
+            for (final var quantifier : expression.getQuantifiers()) {
+                final var rangesOver = quantifier.getRangesOver().get();
+                // a quantifier over an explode stands for the collection being unnested, not for the explode's result
+                merged.put(quantifier.getAlias(), rangesOver instanceof ExplodeExpression
+                                                  ? unnestedCollectionValue((ExplodeExpression)rangesOver)
+                                                  : rangesOver.getResultValue());
+            }
+            return merged;
+        }
+
+        @Nonnull
+        @Override
+        public Map<CorrelationIdentifier, Value> evaluateAtRef(@Nonnull final Reference ref,
+                                                               @Nonnull final List<Map<CorrelationIdentifier, Value>> memberResults) {
+            return merge(memberResults);
+        }
+
+        @Nonnull
+        private Value unnestedCollectionValue(@Nonnull final ExplodeExpression explode) {
+            final var marker = explodeCounter.incrementAndGet();
+            final var collectionValue = explode.getCollectionValue();
+            if (!(collectionValue instanceof FieldValue)) {
+                return collectionValue;
+            }
+            final var field = (FieldValue)collectionValue;
+            final var fieldAccessors = new ArrayList<>(field.getFieldPath().getFieldAccessors());
+            fieldAccessors.set(fieldAccessors.size() - 1,
+                    AnnotatedAccessor.of(fieldAccessors.get(fieldAccessors.size() - 1), marker));
+            return FieldValue.ofFields(field.getChild(), new FieldValue.FieldPath(fieldAccessors));
+        }
+
+        @Nonnull
+        private static Map<CorrelationIdentifier, Value> merge(@Nonnull final List<Map<CorrelationIdentifier, Value>> results) {
+            final var merged = new LinkedHashMap<CorrelationIdentifier, Value>();
+            results.forEach(merged::putAll);
+            return merged;
+        }
+    }
+
+    /**
+     * A {@link FieldValue.ResolvedAccessor} tagged with which unnesting it came from, which distinguishes two unnestings
+     * of the same array field and marks the field as reached through an unnest.
+     */
+    static final class AnnotatedAccessor extends FieldValue.ResolvedAccessor {
+
+        private final int marker;
+
+        private AnnotatedAccessor(@Nonnull final Type.Record.Field field, final int ordinal, final int marker) {
+            super(field, ordinal);
+            this.marker = marker;
+        }
+
+        @Nonnull
+        static AnnotatedAccessor of(@Nonnull final FieldValue.ResolvedAccessor accessor, final int marker) {
+            return new AnnotatedAccessor(accessor.getField(), accessor.getOrdinal(), marker);
+        }
+
+        // NOTE: equals is asymmetric with ResolvedAccessor, which compares ordinal only. Annotated and plain
+        // accessors must therefore never be keys of the same map.
+        @Override
+        public boolean equals(final Object other) {
+            if (this == other) {
+                return true;
+            }
+            if (other == null || getClass() != other.getClass() || !super.equals(other)) {
+                return false;
+            }
+            return marker == ((AnnotatedAccessor)other).marker;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), marker);
+        }
+    }
+}

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/ddl/ValueToKeyExpressionVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/ddl/ValueToKeyExpressionVisitor.java
@@ -1,0 +1,485 @@
+/*
+ * ValueToKeyExpressionVisitor.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.relational.recordlayer.query.ddl;
+
+import com.apple.foundationdb.record.FunctionNames;
+import com.apple.foundationdb.record.metadata.IndexTypes;
+import com.apple.foundationdb.record.metadata.Key;
+import com.apple.foundationdb.record.metadata.expressions.EmptyKeyExpression;
+import com.apple.foundationdb.record.metadata.expressions.FieldKeyExpression;
+import com.apple.foundationdb.record.metadata.expressions.FunctionKeyExpression;
+import com.apple.foundationdb.record.metadata.expressions.GroupingKeyExpression;
+import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
+import com.apple.foundationdb.record.metadata.expressions.ThenKeyExpression;
+import com.apple.foundationdb.record.metadata.expressions.VersionKeyExpression;
+import com.apple.foundationdb.record.query.plan.cascades.typing.PseudoField;
+import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
+import com.apple.foundationdb.record.query.plan.cascades.values.ArithmeticValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.CardinalityValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.CountValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.FieldValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.IndexOnlyAggregateValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.IndexableAggregateValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.LiteralValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.NumericAggregationValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.RecordConstructorValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.SimpleValueVisitor;
+import com.apple.foundationdb.record.query.plan.cascades.values.Value;
+import com.apple.foundationdb.record.query.plan.cascades.values.Values;
+import com.apple.foundationdb.relational.api.exceptions.ErrorCode;
+import com.apple.foundationdb.relational.api.exceptions.RelationalException;
+import com.apple.foundationdb.relational.recordlayer.query.FieldValueTrieNode;
+import com.apple.foundationdb.relational.util.Assert;
+import com.google.common.base.Verify;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.PeekingIterator;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+import static com.apple.foundationdb.record.metadata.Key.Expressions.concat;
+import static com.apple.foundationdb.record.metadata.Key.Expressions.empty;
+import static com.apple.foundationdb.record.metadata.Key.Expressions.field;
+import static com.apple.foundationdb.record.metadata.Key.Expressions.function;
+
+/**
+ * Translates the result value of an index-defining select into the {@link KeyExpression} the index key is built from, and
+ * reports the type of index that can store it.
+ * <p>
+ * A supported kind of value gets a visitation method; {@link #evaluateAtValue} rejects the rest. The grouping of an
+ * aggregate index is everything in the projection other than the single aggregate. Sort direction comes from the caller,
+ * as an ordering function per column.
+ * </p>
+ */
+final class ValueToKeyExpressionVisitor implements SimpleValueVisitor<KeyExpression> {
+
+    private static final String BITMAP_BIT_POSITION = "bitmap_bit_position";
+    private static final String BITMAP_BUCKET_OFFSET = "bitmap_bucket_offset";
+
+    /**
+     * The ordering function each column is wrapped in, keyed by identity on the values being translated.
+     */
+    @Nonnull
+    private final Map<Value, String> orderingFunctions;
+
+    /**
+     * Which form {@code MIN_EVER} and {@code MAX_EVER} are stored in.
+     */
+    @Nonnull
+    private final ExtremumEverStorage extremumEverStorage;
+
+    /**
+     * The translated grouping columns, or {@code null} when the projection holds none. Set by
+     * {@link #visitRecordConstructorValue} and read by the aggregate it descends into.
+     */
+    @Nullable
+    private KeyExpression groupingExpression;
+
+    /**
+     * The index type the projection calls for: a value index, unless an aggregate or the version pseudo-column says
+     * otherwise.
+     */
+    @Nonnull
+    private String indexType = IndexTypes.VALUE;
+
+    private ValueToKeyExpressionVisitor(@Nonnull final Map<Value, String> orderingFunctions,
+                                        @Nonnull final ExtremumEverStorage extremumEverStorage) {
+        this.orderingFunctions = orderingFunctions;
+        this.extremumEverStorage = extremumEverStorage;
+    }
+
+    //
+    // Entry point.
+    //
+
+    /**
+     * Translates the result value of an index-defining select to the corresponding key expression and index type.
+     *
+     * @param value the result value of the select
+     * @param orderingFunctions the ordering function per column, keyed by identity on the columns of {@code value}
+     * @param extremumEverStorage which form an extremum-ever aggregate is stored in
+     *
+     * @return the key expression and the index type
+     */
+    @Nonnull
+    public static Result translate(@Nonnull final Value value,
+                                   @Nonnull final Map<Value, String> orderingFunctions,
+                                   @Nonnull final ExtremumEverStorage extremumEverStorage) {
+        final var visitor = new ValueToKeyExpressionVisitor(orderingFunctions, extremumEverStorage);
+        return new Result(Objects.requireNonNull(value.acceptVisitor(visitor)), visitor.indexType);
+    }
+
+    /**
+     * What a translation produced.
+     *
+     * @param keyExpression the key the index is built from
+     * @param indexType the type of index that can store it
+     */
+    public record Result(@Nonnull KeyExpression keyExpression, @Nonnull String indexType) {
+    }
+
+    //
+    // Visitation. A record is the projection; every other kind of value is one column of the key.
+    //
+
+    @Nonnull
+    @Override
+    public KeyExpression visitRecordConstructorValue(@Nonnull final RecordConstructorValue element) {
+        final var columns = Values.deconstructRecord(element);
+        final var aggregates = columns.stream()
+                .filter(IndexableAggregateValue.class::isInstance)
+                .collect(ImmutableList.toImmutableList());
+        Assert.thatUnchecked(aggregates.size() <= 1, ErrorCode.UNSUPPORTED_OPERATION,
+                "Unsupported index definition, multiple group by aggregations found");
+        if (aggregates.isEmpty()) {
+            return combine(columns);
+        }
+        final var groupingColumns = columns.stream()
+                .filter(column -> !(column instanceof IndexableAggregateValue))
+                .collect(ImmutableList.toImmutableList());
+        groupingExpression = groupingColumns.isEmpty() ? null : combine(groupingColumns);
+        return visit(aggregates.get(0));
+    }
+
+    @Nonnull
+    @Override
+    public KeyExpression visitFieldValue(@Nonnull final FieldValue fieldValue) {
+        return fieldPathToKeyExpression(fieldValue, KeyExpression.FanType.FanOut);
+    }
+
+    @Nonnull
+    @Override
+    public KeyExpression visitCardinalityValue(@Nonnull final CardinalityValue element) {
+        // CARDINALITY() applies to an array field, accessed with fan type Concatenate to materialize it
+        final var child = Iterables.getOnlyElement(element.getChildren());
+        Assert.thatUnchecked(child instanceof FieldValue,
+                "CARDINALITY() must be applied to a `field()` in an index key expression.");
+        return function(FunctionNames.CARDINALITY,
+                fieldPathToKeyExpression((FieldValue)child, KeyExpression.FanType.Concatenate));
+    }
+
+    @Nonnull
+    @Override
+    public KeyExpression visitArithmeticValue(@Nonnull final ArithmeticValue element) {
+        return function(element.getLogicalOperator().name().toLowerCase(Locale.ROOT),
+                arguments(visitChildren(element)));
+    }
+
+    @Nonnull
+    @Override
+    public KeyExpression visitLiteralValue(@Nonnull final LiteralValue<?> element) {
+        return Key.Expressions.value(element.getLiteralValue());
+    }
+
+    // An aggregate yields a GroupingKeyExpression and records the index type it implies.
+
+    @Nonnull
+    @Override
+    public KeyExpression visitCountValue(@Nonnull final CountValue element) {
+        if (!IndexTypes.COUNT.equals(element.getIndexTypeName())) {
+            return groupedAggregate(element);
+        }
+        // COUNT(*) counts records rather than a column, so there is nothing to group
+        indexType = indexTypeOf(element);
+        return new GroupingKeyExpression(groupingExpression == null ? EmptyKeyExpression.EMPTY : groupingExpression, 0);
+    }
+
+    @Nonnull
+    @Override
+    public KeyExpression visitSum(@Nonnull final NumericAggregationValue.Sum element) {
+        return groupedAggregate(element);
+    }
+
+    @Nonnull
+    @Override
+    public KeyExpression visitMin(@Nonnull final NumericAggregationValue.Min element) {
+        return groupedAggregate(element);
+    }
+
+    @Nonnull
+    @Override
+    public KeyExpression visitMax(@Nonnull final NumericAggregationValue.Max element) {
+        return groupedAggregate(element);
+    }
+
+    @Nonnull
+    @Override
+    public KeyExpression visitMinEverValue(@Nonnull final IndexOnlyAggregateValue.MinEverValue element) {
+        return groupedAggregate(element);
+    }
+
+    @Nonnull
+    @Override
+    public KeyExpression visitMaxEverValue(@Nonnull final IndexOnlyAggregateValue.MaxEverValue element) {
+        return groupedAggregate(element);
+    }
+
+    @Nonnull
+    @Override
+    public KeyExpression visitBitmapConstructAgg(@Nonnull final NumericAggregationValue.BitmapConstructAgg element) {
+        if (!IndexTypes.BITMAP_VALUE.equals(element.getIndexTypeName())) {
+            return groupedAggregate(element);
+        }
+        indexType = indexTypeOf(element);
+        final var child = Iterables.getOnlyElement(element.getChildren());
+        Assert.thatUnchecked(child instanceof FieldValue || child instanceof ArithmeticValue,
+                "Unsupported index definition, expecting a column argument in aggregation function");
+        final var groupedValue = visit(child);
+        // only bitmap_construct_agg(bitmap_bit_position(column)) is supported
+        Assert.thatUnchecked(groupedValue instanceof FunctionKeyExpression
+                        && BITMAP_BIT_POSITION.equals(((FunctionKeyExpression)groupedValue).getName()),
+                "Unsupported index definition, expecting a bitmap_bit_position function in bitmap_construct_agg function");
+        if (groupingExpression == null) {
+            throw Assert.failUnchecked("Unsupported index definition, unexpected grouping expression " + groupedValue);
+        }
+        // a bitmap index implies the bucket offset, so it is not part of the grouping
+        final var grouping = removeBitmapBucketOffset(groupingExpression);
+        final var arguments = (ThenKeyExpression)((FunctionKeyExpression)groupedValue).getArguments();
+        final var groupedColumn = (FieldKeyExpression)arguments.getChildren().get(0);
+        return grouping == null ? groupedColumn.ungrouped() : groupedColumn.groupBy(grouping);
+    }
+
+    @Nonnull
+    @Override
+    public KeyExpression evaluateAtValue(@Nonnull final Value value, @Nonnull final List<KeyExpression> childResults) {
+        // any kind of value with no visitation method of its own
+        throw new RelationalException("unable to construct expression", ErrorCode.UNSUPPORTED_OPERATION).toUncheckedWrappedException();
+    }
+
+    //
+    // Combining columns.
+    //
+
+    /**
+     * Combines sibling columns into one key expression. Adjacent {@link FieldValue}s nest under their shared prefix:
+     * {@code r.s.a, r.s.b} becomes {@code field("R").nest(concat(A, B))}.
+     */
+    @Nonnull
+    private KeyExpression combine(@Nonnull final List<Value> values) {
+        if (values.isEmpty()) {
+            return EmptyKeyExpression.EMPTY;
+        }
+        if (values.size() == 1) {
+            return ordered(values.get(0));
+        }
+        // a run of adjacent field values forms one component; any other value forms its own
+        final List<FieldValueTrieNode> tries = new ArrayList<>(values.size());
+        final List<KeyExpression> components = new ArrayList<>(values.size());
+        final PeekingIterator<Value> valueIterator = Iterators.peekingIterator(values.iterator());
+        while (valueIterator.hasNext()) {
+            components.add(valueIterator.peek() instanceof FieldValue
+                           ? nextFieldPaths(valueIterator, tries)
+                           : ordered(valueIterator.next()));
+        }
+        return concatOf(components);
+    }
+
+    /**
+     * Takes the run of adjacent field values the iterator is positioned on and nests them under their shared prefixes.
+     *
+     * @param tries the tries of the runs before this one; the new trie is validated against them and joins them
+     */
+    @Nonnull
+    private KeyExpression nextFieldPaths(@Nonnull final PeekingIterator<Value> valueIterator,
+                                         @Nonnull final List<FieldValueTrieNode> tries) {
+        final var trie = FieldValueTrieNode.computeTrieForValues(FieldValue.FieldPath.empty(), valueIterator);
+        trie.validateNoOverlaps(tries);
+        tries.add(trie);
+        return trieToKeyExpression(trie);
+    }
+
+    @Nonnull
+    private KeyExpression trieToKeyExpression(@Nonnull final FieldValueTrieNode trie) {
+        final var childrenMap = Assert.notNullUnchecked(trie.getChildrenMap());
+        Assert.thatUnchecked(!childrenMap.isEmpty());
+        final var components = childrenMap.entrySet().stream().map(entry -> {
+            final var node = entry.getValue();
+            final var expression = fieldAccessorToKeyExpression(entry.getKey(), KeyExpression.FanType.FanOut);
+            if (node.getChildrenMap() != null) {
+                return Assert.castUnchecked(expression, FieldKeyExpression.class).nest(trieToKeyExpression(node));
+            }
+            return withOrderingFunction(node.getValue(), expression);
+        }).collect(ImmutableList.toImmutableList());
+        return concatOf(components);
+    }
+
+    @Nonnull
+    private static KeyExpression concatOf(@Nonnull final List<KeyExpression> components) {
+        return components.size() == 1 ? components.get(0) : concat(components);
+    }
+
+    @Nonnull
+    private KeyExpression ordered(@Nonnull final Value column) {
+        return withOrderingFunction(column, Objects.requireNonNull(visit(column)));
+    }
+
+    @Nonnull
+    private KeyExpression withOrderingFunction(@Nonnull final Value column, @Nonnull final KeyExpression expression) {
+        final var orderingFunction = orderingFunctions.get(column);
+        return orderingFunction == null ? expression : function(orderingFunction, expression);
+    }
+
+    //
+    // Field paths.
+    //
+
+    @Nonnull
+    private KeyExpression fieldPathToKeyExpression(@Nonnull final FieldValue fieldValue,
+                                                   @Nonnull final KeyExpression.FanType fanTypeForArray) {
+        return fieldPathToKeyExpression(fieldValue.getFieldPath().getFieldAccessors().iterator(), fanTypeForArray);
+    }
+
+    @Nonnull
+    private KeyExpression fieldPathToKeyExpression(@Nonnull final Iterator<FieldValue.ResolvedAccessor> accessors,
+                                                   @Nonnull final KeyExpression.FanType fanTypeForArray) {
+        Assert.thatUnchecked(accessors.hasNext(), "cannot resolve empty list");
+        final var expression = fieldAccessorToKeyExpression(accessors.next(), fanTypeForArray);
+        if (!accessors.hasNext()) {
+            return expression;
+        }
+        return Assert.castUnchecked(expression, FieldKeyExpression.class)
+                .nest(fieldPathToKeyExpression(accessors, fanTypeForArray));
+    }
+
+    /**
+     * One step of a field path, as a {@link FieldKeyExpression} or, for the version pseudo-column, a
+     * {@link VersionKeyExpression}. Storing the version makes the index a version index.
+     *
+     * @param fanTypeForArray the fan type to use if the field is an ARRAY, either {@code FanOut} or {@code Concatenate}
+     */
+    @Nonnull
+    private KeyExpression fieldAccessorToKeyExpression(@Nonnull final FieldValue.ResolvedAccessor accessor,
+                                                       @Nonnull final KeyExpression.FanType fanTypeForArray) {
+        Assert.thatUnchecked(fanTypeForArray == KeyExpression.FanType.FanOut
+                             || fanTypeForArray == KeyExpression.FanType.Concatenate);
+        final var recordField = accessor.getField();
+        if (isRowVersion(recordField)) {
+            indexType = IndexTypes.VERSION;
+            return VersionKeyExpression.VERSION;
+        }
+        // Protobuf storage references the storage name
+        final var storageName = Assert.notNullUnchecked(recordField.getFieldStorageName());
+        if (!recordField.getFieldType().isArray()) {
+            return field(storageName, KeyExpression.FanType.None);
+        }
+        // an array is indexable only through an unnest, which tags its accessor, or materialized whole
+        Assert.thatUnchecked(accessor instanceof QuantifierValues.AnnotatedAccessor
+                        || fanTypeForArray == KeyExpression.FanType.Concatenate,
+                ErrorCode.UNSUPPORTED_OPERATION,
+                "Unsupported index definition, cannot create index on array field '"
+                        + recordField.getFieldName() + "' without unnesting");
+        return field(storageName, fanTypeForArray);
+    }
+
+    private static boolean isRowVersion(@Nonnull final Type.Record.Field recordField) {
+        return PseudoField.ROW_VERSION.getType().equals(recordField.getFieldType())
+                && PseudoField.ROW_VERSION.getFieldName().equals(recordField.getFieldName());
+    }
+
+    @Nonnull
+    private static KeyExpression arguments(@Nonnull final List<KeyExpression> argumentList) {
+        return argumentList.isEmpty() ? empty() : concatOf(argumentList);
+    }
+
+    //
+    // Aggregates.
+    //
+
+    /**
+     * The shape every aggregate but {@code COUNT(*)} and {@code BITMAP_CONSTRUCT_AGG} takes: the aggregated column,
+     * grouped by the grouping columns, or ungrouped if there are none.
+     */
+    @Nonnull
+    private KeyExpression groupedAggregate(@Nonnull final IndexableAggregateValue aggregateValue) {
+        indexType = indexTypeOf(aggregateValue);
+        final var child = Iterables.getOnlyElement(aggregateValue.getChildren());
+        Assert.thatUnchecked(child instanceof FieldValue,
+                "Unsupported index definition, expecting a column argument in aggregation function");
+        final var groupedValue = visit(child);
+        Assert.thatUnchecked(groupedValue instanceof FieldKeyExpression || groupedValue instanceof ThenKeyExpression);
+        if (groupedValue instanceof final FieldKeyExpression field) {
+            return groupingExpression == null ? field.ungrouped() : field.groupBy(groupingExpression);
+        }
+        final var then = (ThenKeyExpression)groupedValue;
+        return groupingExpression == null ? then.ungrouped() : then.groupBy(groupingExpression);
+    }
+
+    /**
+     * The type of index that can maintain an aggregate: its own, except for {@code MIN_EVER} and {@code MAX_EVER}, whose
+     * storage form the caller chooses.
+     */
+    @Nonnull
+    @SuppressWarnings("deprecation")
+    private String indexTypeOf(@Nonnull final IndexableAggregateValue aggregateValue) {
+        final var indexTypeName = aggregateValue.getIndexTypeName();
+        if (IndexTypes.MIN_EVER.equals(indexTypeName)) {
+            return extremumEverIndexType(extremumEverStorage.minEverIndexType(), aggregateValue);
+        }
+        if (IndexTypes.MAX_EVER.equals(indexTypeName)) {
+            return extremumEverIndexType(extremumEverStorage.maxEverIndexType(), aggregateValue);
+        }
+        return indexTypeName;
+    }
+
+    /**
+     * The extremum-ever index type, checked against the aggregated column.
+     */
+    @Nonnull
+    private String extremumEverIndexType(@Nonnull final String indexType,
+                                         @Nonnull final IndexableAggregateValue aggregateValue) {
+        Verify.verify(!extremumEverStorage.isNumericOnly()
+                        || Iterables.getOnlyElement(aggregateValue.getChildren()).getResultType().isNumeric(),
+                "only numeric types allowed in " + indexType + " aggregation operation");
+        return indexType;
+    }
+
+    /**
+     * Removes {@code bitmap_bucket_offset(col)} from the grouping expression, which looks like
+     * {@code [*, bitmap_bucket_offset(C)]} and so is either a Then or a Function.
+     *
+     * @return {@code null} if the grouping expression contained nothing else
+     */
+    @Nullable
+    private static KeyExpression removeBitmapBucketOffset(@Nonnull final KeyExpression groupingExpression) {
+        Assert.thatUnchecked(groupingExpression instanceof ThenKeyExpression
+                        || groupingExpression instanceof FunctionKeyExpression,
+                "Unsupported index definition, expecting column or function arguments in group by");
+        if (groupingExpression instanceof FunctionKeyExpression) {
+            return BITMAP_BUCKET_OFFSET.equals(((FunctionKeyExpression)groupingExpression).getName())
+                   ? null : groupingExpression;
+        }
+        final List<KeyExpression> children = ((ThenKeyExpression)groupingExpression).getChildren();
+        final var last = children.get(children.size() - 1);
+        Assert.thatUnchecked(last instanceof FunctionKeyExpression
+                        && BITMAP_BUCKET_OFFSET.equals(((FunctionKeyExpression)last).getName()),
+                "Unsupported index definition, expecting the last element in group by to be a bitmap_bucket_offset function");
+        // a ThenKeyExpression has at least two children
+        return children.size() >= 3 ? new ThenKeyExpression(children, 0, children.size() - 1) : children.get(0);
+    }
+}

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DdlVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DdlVisitor.java
@@ -53,6 +53,9 @@ import com.apple.foundationdb.relational.recordlayer.query.PreparedParams;
 import com.apple.foundationdb.relational.recordlayer.query.ProceduralPlan;
 import com.apple.foundationdb.relational.recordlayer.query.QueryParser;
 import com.apple.foundationdb.relational.recordlayer.query.SemanticAnalyzer;
+import com.apple.foundationdb.relational.recordlayer.query.ddl.ExtremumEverStorage;
+import com.apple.foundationdb.relational.recordlayer.query.ddl.IndexGenerationOptions;
+import com.apple.foundationdb.relational.recordlayer.query.ddl.IndexGenerator;
 import com.apple.foundationdb.relational.recordlayer.query.ddl.MaterializedViewIndexGenerator;
 import com.apple.foundationdb.relational.recordlayer.query.ddl.OnSourceIndexGenerator;
 import com.apple.foundationdb.relational.recordlayer.query.functions.CompiledSqlFunction;
@@ -265,9 +268,11 @@ public final class DdlVisitor extends DelegatingVisitor<BaseVisitor> {
 
         final var useLegacyBasedExtremumEver = indexDefinitionContext.indexAttributes() != null && indexDefinitionContext.indexAttributes().indexAttribute().stream().anyMatch(attribute -> attribute.LEGACY_EXTREMUM_EVER() != null);
         final var isUnique = indexDefinitionContext.UNIQUE() != null;
-        final var generator = MaterializedViewIndexGenerator.from(viewPlan, useLegacyBasedExtremumEver);
+        final IndexGenerator generator = MaterializedViewIndexGenerator.newInstance(viewPlan, metadataBuilder,
+                indexId.getName(), new IndexGenerationOptions(isUnique, containsNullableArray, false,
+                        ExtremumEverStorage.ofLegacyAttribute(useLegacyBasedExtremumEver)));
         Assert.thatUnchecked(viewPlan instanceof LogicalSortExpression, ErrorCode.INVALID_COLUMN_REFERENCE, "Cannot create index and order by an expression that is not present in the projection list");
-        return generator.generate(metadataBuilder, indexId.getName(), isUnique, containsNullableArray, false).build();
+        return generator.generate().build();
     }
 
     @Nonnull
@@ -289,10 +294,9 @@ public final class DdlVisitor extends DelegatingVisitor<BaseVisitor> {
                 .setIndexName(indexId)
                 .setIndexSource(getDelegate().getCurrentPlanFragment())
                 .setSemanticAnalyzer(getDelegate().getSemanticAnalyzer())
-                .setUseLegacyExtremum(useLegacyExtremum)
-                .setUseNullableArrays(containsNullableArray)
                 .setMetadataBuilder(metadataBuilder)
-                .setUnique(isUnique);
+                .setOptions(new IndexGenerationOptions(isUnique, containsNullableArray, false,
+                        ExtremumEverStorage.ofLegacyAttribute(useLegacyExtremum)));
 
         indexDefinitionContext.indexColumnList().indexColumnSpec().forEach(colSpec ->
                 indexGeneratorBuilder.addKeyColumn(OnSourceIndexGenerator.IndexedColumn
@@ -328,8 +332,9 @@ public final class DdlVisitor extends DelegatingVisitor<BaseVisitor> {
                 .setSemanticAnalyzer(getDelegate().getSemanticAnalyzer())
                 .addAllIndexOptions(indexOptions)
                 .setMetadataBuilder(metadataBuilder)
-                .setGenerateKeyValueExpressionWithEmptyKey(true)
-                .setUseNullableArrays(containsNullableArray);
+                // a vector index without PARTITION BY has no key columns, so its key is empty
+                .setOptions(new IndexGenerationOptions(false, containsNullableArray, true,
+                        ExtremumEverStorage.TUPLE));
 
         indexDefinitionContext.indexColumnList().indexColumnSpec().forEach(colSpec ->
                 indexGeneratorBuilder.addValueColumn(OnSourceIndexGenerator.IndexedColumn
@@ -339,7 +344,7 @@ public final class DdlVisitor extends DelegatingVisitor<BaseVisitor> {
         final var indexedColumns = indexGeneratorBuilder.getValueColumns();
         Assert.thatUnchecked(indexedColumns.size() == 1, ErrorCode.UNSUPPORTED_OPERATION,
                 () -> "invalid number of indexed columns, only one column is supported, found " + indexedColumns.size() + " columns");
-        final var indexedCol = Iterables.getOnlyElement(indexedColumns).getIdentifier();
+        final var indexedCol = Iterables.getOnlyElement(indexedColumns).identifier();
         final var type = getDelegate().getSemanticAnalyzer().resolveIdentifier(indexedCol, getDelegate().getCurrentPlanFragment())
                 .getDataType();
         Assert.thatUnchecked(type.getCode() == DataType.Code.VECTOR, ErrorCode.SYNTAX_ERROR,

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/api/ddl/IndexTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/api/ddl/IndexTest.java
@@ -1131,6 +1131,19 @@ public class IndexTest {
     }
 
     @Test
+    void createMinEverGroupedByTwoColumns() throws Exception {
+        // the projection holds nothing but the aggregate, so the grouping columns are recovered from the
+        // GroupByExpression rather than from the projection (see IndexSpec.projectionOf)
+        final String stmt = "CREATE SCHEMA TEMPLATE test_template " +
+                "CREATE TABLE T2(col1 bigint, col2 bigint, col3 bigint, primary key(col1)) " +
+                "CREATE INDEX mv1 AS SELECT min_ever(col3) FROM T2 group by col1, col2";
+        indexIs(stmt,
+                field("COL3").groupBy(field("COL1"), field("COL2")),
+                IndexTypes.MIN_EVER_TUPLE
+        );
+    }
+
+    @Test
     void createMaxEverLong() throws Exception {
         final String stmt = "CREATE SCHEMA TEMPLATE test_template " +
                 "CREATE TABLE T1(col1 bigint, col2 bigint, primary key(col1)) " +
@@ -1518,5 +1531,14 @@ public class IndexTest {
                 "CREATE TABLE T(p bigint, b vector(3, float), c bigint, primary key(p))" +
                 "CREATE VECTOR INDEX MV1 USING HNSW ON T(b) INCLUDE (c) PARTITION BY (p) OPTIONS (CONNECTIVITY = 16)";
         shouldFailWith(stmt, ErrorCode.UNSUPPORTED_OPERATION, "INCLUDE clause is not supported for vector indexes");
+    }
+
+    @Test
+    void createIndexOnWholeRowIsNotSupported() throws Exception {
+        final String stmt = "CREATE SCHEMA TEMPLATE test_template " +
+                "CREATE TABLE T2(col1 bigint, col2 bigint, primary key(col1)) " +
+                "CREATE INDEX mv1 AS SELECT T2 FROM T2 ORDER BY col1";
+        shouldFailWith(stmt, ErrorCode.UNSUPPORTED_OPERATION,
+                "Unsupported index definition, cannot map (base().COL1 AS COL1, base().COL2 AS COL2) to a key expression");
     }
 }

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/ddl/ValueToKeyExpressionVisitorTest.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/ddl/ValueToKeyExpressionVisitorTest.java
@@ -1,0 +1,271 @@
+/*
+ * ValueToKeyExpressionVisitorTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.relational.recordlayer.query.ddl;
+
+import com.apple.foundationdb.record.metadata.IndexTypes;
+import com.apple.foundationdb.record.metadata.Key;
+import com.apple.foundationdb.record.metadata.expressions.EmptyKeyExpression;
+import com.apple.foundationdb.record.metadata.expressions.GroupingKeyExpression;
+import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
+import com.apple.foundationdb.record.query.plan.cascades.CallSiteArguments;
+import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
+import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
+import com.apple.foundationdb.record.query.plan.cascades.values.ArithmeticValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.CountValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.FieldValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.IndexOnlyAggregateValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.LiteralValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.NullValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.NumericAggregationValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.QuantifiedObjectValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.RecordConstructorValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.Value;
+import com.apple.foundationdb.relational.api.exceptions.ErrorCode;
+import com.apple.foundationdb.relational.api.exceptions.UncheckedRelationalException;
+import com.apple.foundationdb.relational.api.metadata.DataType;
+import com.apple.foundationdb.relational.recordlayer.metadata.RecordLayerColumn;
+import com.apple.foundationdb.relational.recordlayer.metadata.RecordLayerSchemaTemplate;
+import com.apple.foundationdb.relational.recordlayer.metadata.RecordLayerTable;
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+import java.util.Map;
+
+import static com.apple.foundationdb.record.metadata.Key.Expressions.concat;
+import static com.apple.foundationdb.record.metadata.Key.Expressions.field;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Input projection list -> expected {@link KeyExpression}, for the shapes {@code IndexTest} produces.
+ */
+class ValueToKeyExpressionVisitorTest {
+
+    @Nonnull
+    private static final Type.Record T2_TYPE = t2Type();
+
+    @Nonnull
+    private static Type.Record t2Type() {
+        final var template = RecordLayerSchemaTemplate.newBuilder()
+                .setName("TEST_TEMPLATE")
+                .setVersion(1)
+                .addTable(RecordLayerTable.newBuilder(false)
+                        .setName("T2")
+                        .addColumn(RecordLayerColumn.newBuilder().setName("COL1")
+                                .setDataType(DataType.Primitives.LONG.type()).build())
+                        .addColumn(RecordLayerColumn.newBuilder().setName("COL2")
+                                .setDataType(DataType.Primitives.LONG.type()).build())
+                        .addColumn(RecordLayerColumn.newBuilder().setName("COL3")
+                                .setDataType(DataType.Primitives.LONG.type()).build())
+                        .addPrimaryKeyPart(ImmutableList.of("COL1"))
+                        .build())
+                .build();
+        return Type.Record.fromDescriptor(template.getDescriptor("T2"));
+    }
+
+    @Nonnull
+    private static Value col(@Nonnull final String name) {
+        return FieldValue.ofFieldName(QuantifiedObjectValue.of(Quantifier.current(), T2_TYPE), name);
+    }
+
+    @Nonnull
+    private static KeyExpression translate(@Nonnull final Value... projectedValues) {
+        return translate(RecordConstructorValue.ofUnnamed(List.of(projectedValues)));
+    }
+
+    @Nonnull
+    private static KeyExpression translate(@Nonnull final Value value) {
+        return ValueToKeyExpressionVisitor.translate(value, Map.of(), ExtremumEverStorage.TUPLE).keyExpression();
+    }
+
+    @Nonnull
+    private static String indexType(@Nonnull final ExtremumEverStorage extremumEverStorage,
+                                    @Nonnull final Value... projectedValues) {
+        return ValueToKeyExpressionVisitor
+                .translate(RecordConstructorValue.ofUnnamed(List.of(projectedValues)), Map.of(), extremumEverStorage)
+                .indexType();
+    }
+
+    @Test
+    void singleColumn() {
+        assertThat(translate(col("COL1"))).isEqualTo(field("COL1"));
+    }
+
+    @Test
+    void twoColumns() {
+        assertThat(translate(col("COL1"), col("COL2")))
+                .isEqualTo(concat(field("COL1"), field("COL2")));
+    }
+
+    @Test
+    void threeColumns() {
+        assertThat(translate(col("COL1"), col("COL2"), col("COL3")))
+                .isEqualTo(concat(field("COL1"), field("COL2"), field("COL3")));
+    }
+
+    @Test
+    void literal() {
+        assertThat(translate(LiteralValue.ofScalar(5L))).isEqualTo(Key.Expressions.value(5L));
+    }
+
+    @Test
+    void arithmeticOverColumns() {
+        final var sum = new ArithmeticValue(ArithmeticValue.PhysicalOperator.ADD_LL, col("COL1"), col("COL2"));
+        assertThat(translate(sum))
+                .isEqualTo(Key.Expressions.function("add", concat(field("COL1"), field("COL2"))));
+    }
+
+    @Test
+    void minEverGroupedByOneColumn() {
+        assertThat(translate(minEver(col("COL3")), col("COL1")))
+                .isEqualTo(field("COL3").groupBy(field("COL1")));
+    }
+
+    @Test
+    void minEverGroupedByTwoColumns() {
+        assertThat(translate(minEver(col("COL3")), col("COL1"), col("COL2")))
+                .isEqualTo(field("COL3").groupBy(field("COL1"), field("COL2")));
+    }
+
+    @Test
+    void maxEverGroupedByOneColumn() {
+        assertThat(translate(maxEver(col("COL1")), col("COL2")))
+                .isEqualTo(field("COL1").groupBy(field("COL2")));
+    }
+
+    @Test
+    void minEverUngrouped() {
+        assertThat(translate(minEver(col("COL3"))))
+                .isEqualTo(field("COL3").ungrouped());
+    }
+
+    @Test
+    void sumGroupedByTwoColumns() {
+        assertThat(translate(sum(col("COL2")), col("COL1"), col("COL3")))
+                .isEqualTo(field("COL2").groupBy(field("COL1"), field("COL3")));
+    }
+
+    @Test
+    void maxGroupedByOneColumn() {
+        assertThat(translate(max(col("COL2")), col("COL1")))
+                .isEqualTo(field("COL2").groupBy(field("COL1")));
+    }
+
+    @Test
+    void countStarGroupedByOneColumn() {
+        assertThat(translate(new CountValue(true, col("COL1")), col("COL1")))
+                .isEqualTo(new GroupingKeyExpression(field("COL1"), 0));
+    }
+
+    @Test
+    void countStarUngrouped() {
+        assertThat(translate(new CountValue(true, col("COL1"))))
+                .isEqualTo(new GroupingKeyExpression(EmptyKeyExpression.EMPTY, 0));
+    }
+
+    @Test
+    void countNotNullGroupedByOneColumn() {
+        assertThat(translate(new CountValue(false, col("COL3")), col("COL1")))
+                .isEqualTo(field("COL3").groupBy(field("COL1")));
+    }
+
+    @Test
+    void bareAggregateWithoutARecord() {
+        assertThat(translate(max(col("COL2")))).isEqualTo(field("COL2").ungrouped());
+    }
+
+    @Test
+    void recordHoldingOnlyTheAggregateMatchesTheBareAggregate() {
+        assertThat(translate(RecordConstructorValue.ofUnnamed(List.of(max(col("COL2"))))))
+                .isEqualTo(translate(max(col("COL2"))));
+    }
+
+    @Test
+    void twoAggregatesAreRejected() {
+        final var thrown = Assertions.assertThrows(UncheckedRelationalException.class,
+                () -> translate(sum(col("COL2")), max(col("COL3")), col("COL1")));
+        assertThat(thrown.unwrap().getErrorCode()).isEqualTo(ErrorCode.UNSUPPORTED_OPERATION);
+    }
+
+    @Test
+    void unsupportedValueIsRejected() {
+        final var thrown = Assertions.assertThrows(UncheckedRelationalException.class,
+                () -> translate(new NullValue(Type.primitiveType(Type.TypeCode.LONG))));
+        assertThat(thrown.unwrap().getErrorCode()).isEqualTo(ErrorCode.UNSUPPORTED_OPERATION);
+        // the message evaluateAtValue raises, which is where a value with no visitation method of its own lands
+        assertThat(thrown.getMessage()).contains("unable to construct expression");
+    }
+
+    @Test
+    void unsupportedValueAmongTheProjectedColumnsIsRejected() {
+        final var thrown = Assertions.assertThrows(UncheckedRelationalException.class,
+                () -> translate(col("COL1"), new NullValue(Type.primitiveType(Type.TypeCode.LONG))));
+        assertThat(thrown.unwrap().getErrorCode()).isEqualTo(ErrorCode.UNSUPPORTED_OPERATION);
+        assertThat(thrown.getMessage()).contains("unable to construct expression");
+    }
+
+    @Test
+    void noAggregateImpliesValueIndex() {
+        assertThat(indexType(ExtremumEverStorage.TUPLE, col("COL1"), col("COL2"))).isEqualTo(IndexTypes.VALUE);
+    }
+
+    @Test
+    void sumImpliesSumIndex() {
+        assertThat(indexType(ExtremumEverStorage.TUPLE, sum(col("COL2")), col("COL1"))).isEqualTo(IndexTypes.SUM);
+    }
+
+    @Test
+    void countStarImpliesCountIndex() {
+        assertThat(indexType(ExtremumEverStorage.TUPLE, new CountValue(true, col("COL1")), col("COL1"))).isEqualTo(IndexTypes.COUNT);
+    }
+
+    @Test
+    void minEverImpliesTupleBasedIndex() {
+        assertThat(indexType(ExtremumEverStorage.TUPLE, minEver(col("COL3")), col("COL1"))).isEqualTo(IndexTypes.MIN_EVER_TUPLE);
+    }
+
+    @Test
+    void minEverImpliesLongBasedIndexWithLegacyExtremumEver() {
+        assertThat(indexType(ExtremumEverStorage.LONG, minEver(col("COL3")), col("COL1"))).isEqualTo(IndexTypes.MIN_EVER_LONG);
+    }
+
+    @Nonnull
+    private static Value minEver(@Nonnull final Value child) {
+        return (Value)new IndexOnlyAggregateValue.MinEverFn().encapsulate(CallSiteArguments.ofPositional(child));
+    }
+
+    @Nonnull
+    private static Value maxEver(@Nonnull final Value child) {
+        return (Value)new IndexOnlyAggregateValue.MaxEverFn().encapsulate(CallSiteArguments.ofPositional(child));
+    }
+
+    @Nonnull
+    private static Value sum(@Nonnull final Value child) {
+        return new NumericAggregationValue.Sum(NumericAggregationValue.PhysicalOperator.SUM_L, child);
+    }
+
+    @Nonnull
+    private static Value max(@Nonnull final Value child) {
+        return new NumericAggregationValue.Max(NumericAggregationValue.PhysicalOperator.MAX_L, child);
+    }
+}


### PR DESCRIPTION
The materialized view index generator did everything in one class: it flattened the plan of an index-defining query into a topologically sorted list, interrogated that list with chains of `instanceof` filters and positional arithmetic, resolved values against a correlation map it was still in the middle of building, and interleaved a dozen rejections with the generation itself. This rewrites it as three passes over the plan plus an assembly step, each with a name and a single job.

The first pass records what every quantifier stands for, which is what makes it possible to resolve a value down to the base record. Doing that separately is precisely what the old code could not do, since a value can only be resolved once the whole mapping is known. The second pass collects everything the index is made of — the record type, the predicate, the group by, and the projection and ordering, both resolved. stating each rule at the node it concerns, and then rejects in one step every plan that cannot become an index. The third translates the projection into the index key and reports the type of index that can store it. What is left in the generator is assembling a `RecordLayerIndex` out of those results, which is now some 160 lines.

That third pass dispatches on `Value` through a generated visitor rather than a hand-rolled chain, which needed three fixes to the `@GenerateVisitor` annotation processor first: subclass discovery reached only top-level types, so every nested `Value` was skipped, including the whole extremum-ever and numeric-aggregation family; a non-public subclass was dropped silently instead of failing the build; and generic subclasses were emitted with their own type variables, which does not compile under `-Werror`. `RelationalExpressionVisitor` and `RecordQueryPlanVisitor` are byte-identical before and after. The same change adds `SimpleValueVisitor`, the `Value` counterpart of `SimpleExpressionVisitor`.

Behaviour is meant to be unchanged, and `IndexTest`, the yaml test suites and internal integration test suite all pass against it.  Alongside that, the two DDL entry points, `INDEX AS SELECT` and `INDEX ON`, share an `IndexGenerator` interface, and what a definition asks of an index beyond its key travels as one value object rather than a tail of boolean parameters.