### PR TITLE
Derive the `ARRAY_AGG()` element type rather than carrying it

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/ArrayAggValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/ArrayAggValue.java
@@ -86,67 +86,46 @@ public class ArrayAggValue extends AbstractValue implements AggregateValue, Stre
     private final Value child;
 
     /**
-     * Element type of the resulting array. Derived from the child’s result type at construction time and carried
-     * explicitly so that it survives serialization.
-     */
-    @Nonnull
-    private final Type elementType;
-
-    /**
      * Whether {@code NULL} inputs are skipped ({@code IGNORE NULLS}) rather than collected ({@code RESPECT NULLS}).
      */
     private final boolean ignoreNulls;
 
-    /**
-     * Descriptor of the wrapper message the accumulator serializes its partial state through. It depends only on
-     * {@link #elementType}, so it is computed once here rather than per accumulator, i.e. per group.
-     */
     @Nonnull
-    private final Supplier<Descriptors.Descriptor> wrapperDescriptorSupplier;
-
-    @Nonnull
-    private final Supplier<Type> resultTypeSupplier;
+    private final Supplier<Type.Array> resultTypeSupplier;
 
     /**
      * Constructs a value whose element type is derived from the child’s result type. Under {@code ignoreNulls},
      * the element type will be non-nullable, since {@code NULL} values are then skipped rather than collected.
      */
     public ArrayAggValue(@Nonnull final Value child, final boolean ignoreNulls) {
-        this(child, ignoreNulls ? child.getResultType().notNullable() : child.getResultType(), ignoreNulls);
-    }
-
-    /**
-     * Constructs a value with the given element type, which is taken as-is.
-     */
-    private ArrayAggValue(@Nonnull final Value child, @Nonnull final Type elementType, final boolean ignoreNulls) {
-        Verify.verify(
-                !ignoreNulls || !elementType.isNullable(),
-                "`elementType` must be non-nullable under IGNORE NULLS");
         this.child = child;
-        this.elementType = elementType;
         this.ignoreNulls = ignoreNulls;
-        this.wrapperDescriptorSupplier = Suppliers.memoize(() -> wrapperDescriptorFor(elementType));
         // Note: The result type is always nullable, since ARRAY_AGG() must yield a NULL array for empty input.
-        this.resultTypeSupplier = Suppliers.memoize(() -> new Type.Array(true, elementType));
+        this.resultTypeSupplier = Suppliers.memoize(
+                () -> new Type.Array(true, ignoreNulls ? child.getResultType().notNullable() : child.getResultType()));
     }
 
     /**
-     * Builds the descriptor of the message the accumulator wraps its collected elements in for serialization.
-     * This produces a message with a single repeated {@code values} field, i.e., the same wrapper a nullable array
-     * uses. Here the wrapper is only a serialization container and is independent of the result type’s nullability.
+     * Resolves the descriptor of the message the accumulator wraps its collected elements in for serialization: a
+     * message with a single repeated {@code values} field, i.e., the same wrapper a nullable array uses.
      *
+     * <p>The descriptor is taken from the given plan-wide repository rather than built on the side, so that a restored
+     * element is backed by the very same descriptor as a freshly collected one. The repository is guaranteed to hold
+     * the wrapper type: it is built from the plan’s used types, and registering this value’s (nullable) array result
+     * type registers the wrapper along with it; see {@link Type.Array#defineProtoType} and
+     * {@link Type.Array#addProtoField}. A repository without it is a plan-construction bug, which the repository
+     * itself reports.
+     *
+     * @param typeRepository the plan-wide repository to resolve the wrapper type in
      * @param elementType the type of the collected elements
      *
      * @return the descriptor of the wrapper message for {@code elementType}
      */
     @Nonnull
-    static Descriptors.Descriptor wrapperDescriptorFor(@Nonnull final Type elementType) {
+    private static Descriptors.Descriptor wrapperDescriptorIn(@Nonnull final TypeRepository typeRepository,
+                                                             @Nonnull final Type elementType) {
         final Type.Record wrapperType = NullableArrayTypeUtils.wrapperTypeFor(elementType);
-        // Build the descriptor through a throwaway repository holding just the wrapper type. The `TypeRepository`
-        // repository that the accumulator converts its elements against is a different, plan-wide one, so the two
-        // cannot be shared.
-        final TypeRepository localRepository = TypeRepository.newBuilder().addTypeIfNeeded(wrapperType).build();
-        return Verify.verifyNotNull(localRepository.getMessageDescriptor(wrapperType));
+        return Verify.verifyNotNull(typeRepository.getMessageDescriptor(wrapperType));
     }
 
     @Nullable
@@ -172,7 +151,8 @@ public class ArrayAggValue extends AbstractValue implements AggregateValue, Stre
     public Accumulator createAccumulatorWithInitialState(
             @Nonnull final TypeRepository typeRepository,
             @Nullable final List<RecordCursorProto.AccumulatorState> initialState) {
-        final Descriptors.Descriptor wrapperDescriptor = wrapperDescriptorSupplier.get();
+        final Type elementType = getElementType();
+        final Descriptors.Descriptor wrapperDescriptor = wrapperDescriptorIn(typeRepository, elementType);
         if (initialState == null) {
             return new ArrayAccumulator(wrapperDescriptor, typeRepository, elementType, ignoreNulls);
         } else {
@@ -180,6 +160,17 @@ public class ArrayAggValue extends AbstractValue implements AggregateValue, Stre
             return new ArrayAccumulator(wrapperDescriptor, typeRepository, elementType, ignoreNulls,
                     initialState.get(0));
         }
+    }
+
+    /**
+     * Returns the element type of the resulting array, i.e. the type of the collected elements. It is derived from the
+     * child’s result type and the null treatment; see {@link #ArrayAggValue(Value, boolean)}.
+     *
+     * @return the type of the collected elements
+     */
+    @Nonnull
+    private Type getElementType() {
+        return Verify.verifyNotNull(resultTypeSupplier.get().getElementType());
     }
 
     /**
@@ -207,11 +198,7 @@ public class ArrayAggValue extends AbstractValue implements AggregateValue, Stre
     @Override
     public ArrayAggValue withChildren(final Iterable<? extends Value> newChildren) {
         Verify.verify(Iterables.size(newChildren) == 1);
-        final Value newChild = Iterables.get(newChildren, 0);
-        // The element type is re-derived from the new child here rather than carried over. That is intentional, since
-        // it has to follow the child if the child’s type changed, and if it did not, the derived type is equal to the
-        // current one anyway, so there is nothing to preserve — including for a value restored from a persisted plan.
-        return new ArrayAggValue(newChild, ignoreNulls);
+        return new ArrayAggValue(Iterables.get(newChildren, 0), ignoreNulls);
     }
 
     @Nonnull
@@ -241,11 +228,8 @@ public class ArrayAggValue extends AbstractValue implements AggregateValue, Stre
     @Nonnull
     @Override
     public ConstrainedBoolean equalsWithoutChildren(@Nonnull final Value other) {
-        return super.equalsWithoutChildren(other).filter(ignored -> {
-            final ArrayAggValue otherArrayAggValue = (ArrayAggValue)other;
-            return ignoreNulls == otherArrayAggValue.ignoreNulls
-                    && elementType.equals(otherArrayAggValue.elementType);
-        });
+        return super.equalsWithoutChildren(other)
+                .filter(ignored -> ignoreNulls == ((ArrayAggValue)other).ignoreNulls);
     }
 
     @Override
@@ -265,7 +249,6 @@ public class ArrayAggValue extends AbstractValue implements AggregateValue, Stre
     public PArrayAggValue toProto(@Nonnull final PlanSerializationContext serializationContext) {
         return PArrayAggValue.newBuilder()
                 .setChild(child.toValueProto(serializationContext))
-                .setElementType(elementType.toTypeProto(serializationContext))
                 .setIgnoreNulls(ignoreNulls)
                 .build();
     }
@@ -281,9 +264,7 @@ public class ArrayAggValue extends AbstractValue implements AggregateValue, Stre
                                           @Nonnull final PArrayAggValue arrayAggValueProto) {
         final Value child = Value.fromValueProto(serializationContext,
                 Objects.requireNonNull(arrayAggValueProto.getChild()));
-        final Type elementType = Type.fromTypeProto(serializationContext,
-                Objects.requireNonNull(arrayAggValueProto.getElementType()));
-        return new ArrayAggValue(child, elementType, arrayAggValueProto.getIgnoreNulls());
+        return new ArrayAggValue(child, arrayAggValueProto.getIgnoreNulls());
     }
 
     /**
@@ -330,8 +311,10 @@ public class ArrayAggValue extends AbstractValue implements AggregateValue, Stre
      * <p>Elements are converted from their runtime representation to protobuf via
      * {@link RecordConstructorValue#deepCopyIfNeeded}. Since the collected elements have to be serialized
      * into the wrapper message anyway, holding them in that form keeps a restored element indistinguishable from a
-     * freshly collected one, so we can let {@link #finish()} hand its result straight to the enclosing
-     * {@link RecordConstructorValue}, whose accumulator path does not do any conversion.
+     * freshly collected one — the wrapper descriptor is resolved from the same plan-wide {@link TypeRepository} the
+     * elements are converted against, so both are backed by the very same descriptors. That lets {@link #finish()}
+     * hand its result straight to the enclosing {@link RecordConstructorValue}, whose accumulator path does not do any
+     * conversion.
      */
     static final class ArrayAccumulator implements Accumulator {
         @Nonnull
@@ -360,7 +343,7 @@ public class ArrayAggValue extends AbstractValue implements AggregateValue, Stre
          * Creates an accumulator for a group that has not seen any rows yet.
          *
          * @param wrapperDescriptor descriptor of the message the partial state is serialized through, as built by
-         *        {@link #wrapperDescriptorFor}
+         *        {@link #wrapperDescriptorIn}
          * @param typeRepository the type repository the collected elements are converted against
          * @param elementType the type of the collected elements
          * @param ignoreNulls whether {@code NULL} inputs are skipped rather than collected
@@ -384,7 +367,7 @@ public class ArrayAggValue extends AbstractValue implements AggregateValue, Stre
          * {@link #getAccumulatorStates()}.
          *
          * @param wrapperDescriptor descriptor of the message the partial state is serialized through, as built by
-         *        {@link #wrapperDescriptorFor}
+         *        {@link #wrapperDescriptorIn}
          * @param typeRepository the type repository the collected elements are converted against
          * @param elementType the type of the collected elements
          * @param ignoreNulls whether {@code NULL} inputs are skipped rather than collected

--- a/fdb-record-layer-core/src/main/proto/record_query_plan.proto
+++ b/fdb-record-layer-core/src/main/proto/record_query_plan.proto
@@ -489,8 +489,9 @@ message PCountValue {
 
 message PArrayAggValue {
   optional PValue child = 1;
-  optional PType element_type = 2;
   optional bool ignore_nulls = 3;
+  // Removed fields that are no longer supported
+  reserved 2; // element_type, now re-derived from `child` and `ignore_nulls`
 }
 
 message PDerivedValue {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/values/ArrayAggValueTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/query/plan/cascades/values/ArrayAggValueTest.java
@@ -53,35 +53,54 @@ class ArrayAggValueTest {
     private static final Type LONG_TYPE = Type.primitiveType(Type.TypeCode.LONG, false);
 
     /**
-     * Restores a new accumulator from the partial state of the given one, in the way a continuation would.
+     * A value together with the type repository its accumulators resolve descriptors against, i.e. the pair that a
+     * single plan execution works with. Restoring from a continuation <em>within</em> one execution reuses that one
+     * repository, which is what makes a restored element share its descriptor with a freshly collected one.
      */
-    @Nonnull
-    private static ArrayAggValue.ArrayAccumulator restore(@Nonnull final Type elementType,
-                                                          final boolean ignoreNulls,
-                                                          @Nonnull final ArrayAggValue.ArrayAccumulator accumulator) {
-        final List<RecordCursorProto.AccumulatorState> states = accumulator.getAccumulatorStates();
-        assertThat(states).hasSize(1);
-        return new ArrayAggValue.ArrayAccumulator(ArrayAggValue.wrapperDescriptorFor(elementType),
-                repositoryFor(elementType), elementType, ignoreNulls, states.get(0));
-    }
+    private static final class Fixture {
+        @Nonnull
+        private final ArrayAggValue value;
+        @Nonnull
+        private final TypeRepository typeRepository;
 
-    /**
-     * Returns a type repository the given element type is registered in, as the accumulator converts its elements
-     * against it.
-     */
-    @Nonnull
-    private static TypeRepository repositoryFor(@Nonnull final Type elementType) {
-        return TypeRepository.newBuilder().addTypeIfNeeded(elementType).build();
-    }
+        private Fixture(@Nonnull final Type elementType, final boolean ignoreNulls) {
+            // The element type is derived from the child, and `notNullable()` is a no-op for the non-nullable types
+            // used here, so the child type doubles as the element type.
+            this.value = new ArrayAggValue(new LiteralValue<>(elementType, null), ignoreNulls);
+            // Mirrors the plan-wide repository, which is built from the plan's used types. Registering the value's
+            // (nullable) array result type registers both the wrapper record the accumulator serializes its partial
+            // state through and the element type it converts its elements against.
+            this.typeRepository = TypeRepository.newBuilder().addTypeIfNeeded(value.getResultType()).build();
+        }
 
-    /**
-     * Returns a new accumulator for the given element type.
-     */
-    @Nonnull
-    private static ArrayAggValue.ArrayAccumulator accumulator(@Nonnull final Type elementType,
-                                                             final boolean ignoreNulls) {
-        return new ArrayAggValue.ArrayAccumulator(ArrayAggValue.wrapperDescriptorFor(elementType),
-                repositoryFor(elementType), elementType, ignoreNulls);
+        @Nonnull
+        private Accumulator accumulator() {
+            return value.createAccumulatorWithInitialState(typeRepository, null);
+        }
+
+        /**
+         * Restores a new accumulator from the partial state of the given one, in the way a continuation would.
+         */
+        @Nonnull
+        private Accumulator restore(@Nonnull final Accumulator accumulator) {
+            final List<RecordCursorProto.AccumulatorState> states = accumulator.getAccumulatorStates();
+            assertThat(states).hasSize(1);
+            return value.createAccumulatorWithInitialState(typeRepository, states);
+        }
+
+        /**
+         * Builds a two-field record message against this fixture's repository, i.e. the way an element arriving from
+         * the input would already be represented.
+         */
+        @Nonnull
+        private Message record(@Nonnull final Type.Record recordType, final long a, final long b) {
+            final Descriptors.Descriptor descriptor = typeRepository.getMessageDescriptor(recordType);
+            assertThat(descriptor).isNotNull();
+            return DynamicMessage.newBuilder(descriptor)
+                    .setField(descriptor.findFieldByName("a"), a)
+                    .setField(descriptor.findFieldByName("b"), b)
+                    .build();
+        }
     }
 
     /**
@@ -89,8 +108,18 @@ class ArrayAggValueTest {
      */
     @Nonnull
     @SuppressWarnings("unchecked")
-    private static List<Object> finish(@Nonnull final ArrayAggValue.ArrayAccumulator accumulator) {
+    private static List<Object> finish(@Nonnull final Accumulator accumulator) {
         return (List<Object>)accumulator.finish();
+    }
+
+    /**
+     * The two-field record type used by the record-element tests.
+     */
+    @Nonnull
+    private static Type.Record recordElementType() {
+        return Type.Record.fromFields(false, List.of(
+                Type.Record.Field.of(LONG_TYPE, Optional.of("a")),
+                Type.Record.Field.of(LONG_TYPE, Optional.of("b"))));
     }
 
     /**
@@ -99,7 +128,7 @@ class ArrayAggValueTest {
      */
     @Test
     void getAccumulatorStatesWithoutRowsReturnsNoState() {
-        final var accumulator = accumulator(LONG_TYPE, true);
+        final var accumulator = new Fixture(LONG_TYPE, true).accumulator();
 
         assertThat(accumulator.getAccumulatorStates()).isEmpty();
         assertThat(finish(accumulator)).isEmpty();
@@ -111,13 +140,14 @@ class ArrayAggValueTest {
      */
     @Test
     void getAccumulatorStatesWithOnlyNullRowsReturnsState() {
-        final var accumulator = accumulator(LONG_TYPE, true);
+        final var fixture = new Fixture(LONG_TYPE, true);
+        final var accumulator = fixture.accumulator();
         accumulator.accumulate(null);
 
         assertThat(accumulator.getAccumulatorStates()).hasSize(1);
         assertThat(finish(accumulator)).isEmpty();
 
-        final var restored = restore(LONG_TYPE, true, accumulator);
+        final var restored = fixture.restore(accumulator);
         assertThat(restored.getAccumulatorStates()).hasSize(1);
         assertThat(finish(restored)).isEmpty();
     }
@@ -128,11 +158,12 @@ class ArrayAggValueTest {
      */
     @Test
     void accumulateAfterRestoringStatePreservesElementsAndOrder() {
-        final var accumulator = accumulator(LONG_TYPE, true);
+        final var fixture = new Fixture(LONG_TYPE, true);
+        final var accumulator = fixture.accumulator();
         accumulator.accumulate(100L);
         accumulator.accumulate(200L);
 
-        final var restored = restore(LONG_TYPE, true, accumulator);
+        final var restored = fixture.restore(accumulator);
         assertThat(finish(restored)).containsExactly(100L, 200L);
 
         restored.accumulate(300L);
@@ -145,10 +176,11 @@ class ArrayAggValueTest {
      */
     @Test
     void accumulateAfterRestoringStateRepeatedlyPreservesElements() {
-        var accumulator = accumulator(LONG_TYPE, true);
+        final var fixture = new Fixture(LONG_TYPE, true);
+        var accumulator = fixture.accumulator();
         for (long i = 1L; i <= 5L; i++) {
             accumulator.accumulate(i);
-            accumulator = restore(LONG_TYPE, true, accumulator);
+            accumulator = fixture.restore(accumulator);
         }
 
         assertThat(finish(accumulator)).containsExactly(1L, 2L, 3L, 4L, 5L);
@@ -159,13 +191,14 @@ class ArrayAggValueTest {
      */
     @Test
     void accumulateNullWithIgnoreNullsSkipsElement() {
-        final var accumulator = accumulator(LONG_TYPE, true);
+        final var fixture = new Fixture(LONG_TYPE, true);
+        final var accumulator = fixture.accumulator();
         accumulator.accumulate(100L);
         accumulator.accumulate(null);
         accumulator.accumulate(200L);
 
         assertThat(finish(accumulator)).containsExactly(100L, 200L);
-        assertThat(finish(restore(LONG_TYPE, true, accumulator))).containsExactly(100L, 200L);
+        assertThat(finish(fixture.restore(accumulator))).containsExactly(100L, 200L);
     }
 
     /**
@@ -174,7 +207,7 @@ class ArrayAggValueTest {
      */
     @Test
     void accumulateNullWithRespectNullsThrowsUnsupported() {
-        final var accumulator = accumulator(LONG_TYPE, false);
+        final var accumulator = new Fixture(LONG_TYPE, false).accumulator();
         accumulator.accumulate(100L);
 
         assertThatThrownBy(() -> accumulator.accumulate(null))
@@ -189,23 +222,43 @@ class ArrayAggValueTest {
      */
     @Test
     void accumulateAfterRestoringStateWithRecordElementsPreservesElements() {
-        final Type.Record elementType = Type.Record.fromFields(false, List.of(
-                Type.Record.Field.of(LONG_TYPE, Optional.of("a")),
-                Type.Record.Field.of(LONG_TYPE, Optional.of("b"))));
-        final Message first = record(elementType, 1L, 2L);
-        final Message second = record(elementType, 3L, 4L);
+        final Type.Record elementType = recordElementType();
+        final var fixture = new Fixture(elementType, true);
+        final Message first = fixture.record(elementType, 1L, 2L);
+        final Message second = fixture.record(elementType, 3L, 4L);
 
-        final var accumulator = accumulator(elementType, true);
+        final var accumulator = fixture.accumulator();
         accumulator.accumulate(first);
-        final var restored = restore(elementType, true, accumulator);
+        final var restored = fixture.restore(accumulator);
         restored.accumulate(second);
 
-        // A restored element is parsed against the accumulator’s own descriptor, so it is compared on the wire rather
-        // than by identity of its descriptor.
+        // The wrapper the partial state is parsed against comes from the same repository the elements are converted
+        // against, so a restored element is backed by the same descriptor as the original and compares equal outright.
+        assertThat(finish(restored)).containsExactly(first, second);
+    }
+
+    /**
+     * Tests that a restored record-typed element is backed by the very same descriptor as a freshly collected one, and
+     * not by one from a repository built on the side. Only then can the enclosing {@link RecordConstructorValue} set
+     * both on the same repeated field of the nullable-array wrapper without a descriptor mismatch.
+     */
+    @Test
+    void restoredRecordElementSharesDescriptorWithFreshlyCollectedOne() {
+        final Type.Record elementType = recordElementType();
+        final var fixture = new Fixture(elementType, true);
+
+        final var accumulator = fixture.accumulator();
+        accumulator.accumulate(fixture.record(elementType, 1L, 2L));
+        // The first element is restored from the partial state, the second is collected directly.
+        final var restored = fixture.restore(accumulator);
+        restored.accumulate(fixture.record(elementType, 3L, 4L));
+
         final List<Object> elements = finish(restored);
         assertThat(elements).hasSize(2);
-        assertThat(((Message)elements.get(0)).toByteString()).isEqualTo(first.toByteString());
-        assertThat(((Message)elements.get(1)).toByteString()).isEqualTo(second.toByteString());
+        assertThat(((Message)elements.get(0)).getDescriptorForType())
+                .isSameAs(((Message)elements.get(1)).getDescriptorForType());
+        assertThat(((Message)elements.get(0)).getDescriptorForType())
+                .isSameAs(fixture.typeRepository.getMessageDescriptor(elementType));
     }
 
     /**
@@ -256,8 +309,9 @@ class ArrayAggValueTest {
     }
 
     /**
-     * Tests that a value survives a round-trip through its proto representation, null treatment and element type
-     * included.
+     * Tests that a value survives a round-trip through its proto representation, null treatment included. The element
+     * type is not serialized: it is re-derived from the deserialized child and the null treatment, which is what the
+     * result-type assertion below pins down.
      */
     @Test
     void serializationRoundTripPreservesValue() {
@@ -301,19 +355,5 @@ class ArrayAggValueTest {
         assertThatThrownBy(() -> new ArrayAggValue.ArrayAggFn()
                 .encapsulate(CallSiteArguments.ofPositional(child, notABooleanLiteral)))
                 .isInstanceOf(RecordCoreException.class);
-    }
-
-    /**
-     * Builds a two-field record message of the given type.
-     */
-    @Nonnull
-    private static Message record(@Nonnull final Type.Record recordType, final long a, final long b) {
-        final TypeRepository typeRepository = TypeRepository.newBuilder().addTypeIfNeeded(recordType).build();
-        final Descriptors.Descriptor descriptor = typeRepository.getMessageDescriptor(recordType);
-        assertThat(descriptor).isNotNull();
-        return DynamicMessage.newBuilder(descriptor)
-                .setField(descriptor.findFieldByName("a"), a)
-                .setField(descriptor.findFieldByName("b"), b)
-                .build();
     }
 }


### PR DESCRIPTION
Builds on #4463. `ArrayAggValue`'s element type is a pure function of the child's result type and the null treatment, so it can be read off the memoized result type rather than held in a field and serialized — which lets the field, the private constructor, the nullability `Verify`, the memoized descriptor supplier, `wrapperDescriptorFor()`, and `PArrayAggValue.element_type` all go away. The accumulator's wrapper descriptor now comes from the `TypeRepository` passed into `createAccumulatorWithInitialState()` instead of a throwaway one built on the side. That is safe by construction: plan repositories are built from the plan's used types, and registering the value's nullable array result type registers the wrapper record with it, in both `Type.Array.defineProtoType()` and `Type.Array.addProtoField()`.

It also removes a latent problem. The accumulator converted elements against the plan-wide repository but parsed its partial state against the throwaway one, so after a mid-group continuation the elements carried descriptors from a repository nothing else in the plan knew about. `setField` tolerates that (it only checks `instanceof MessageLite`), but `getField` verifies containing-type identity, so a restored struct element read with a plan-side `FieldDescriptor` would have thrown — the existing test worked around it by comparing on the wire rather than by descriptor. The tests now route through `createAccumulatorWithInitialState()` and assert message equality plus descriptor identity, which fails without this change. `element_type` is `reserved` rather than reused: old plans still deserialize, but a plan written without it can't be read by a build that still requires it, so this is better squashed into #4463 than merged after it — happy to fold it in there instead, @robert-brunel.
