### PR TITLE
Pilot jspecify + NullAway null-checking on fdb-relational-grpc

### DIFF
--- a/fdb-relational-grpc/fdb-relational-grpc.gradle
+++ b/fdb-relational-grpc/fdb-relational-grpc.gradle
@@ -18,6 +18,10 @@
  * limitations under the License.
  */
 
+plugins {
+    alias(libs.plugins.errorprone)
+}
+
 apply from: rootProject.file('gradle/proto.gradle')
 apply from: rootProject.file('gradle/publishing.gradle')
 
@@ -46,7 +50,7 @@ dependencies {
     // server and client, both of which depend on grpc and api.
     implementation project(":fdb-relational-api")
     implementation project(":fdb-extensions")
-    compileOnly(libs.jsr305)
+    compileOnly(libs.jspecify)
     implementation(libs.generatedAnnotation)
     implementation(libs.grpc.commonProtos)
     implementation(libs.grpc.netty)
@@ -59,10 +63,27 @@ dependencies {
     // slf4j binding. Allows RL dependencies to log to same place as Relational
     runtimeOnly(libs.log4j.slf4jBinding)
 
+    errorprone(libs.errorprone.core)
+    errorprone(libs.nullaway)
+
     testImplementation(testFixtures(project(":fdb-relational-api")))
     testImplementation(libs.bundles.test.impl)
     testRuntimeOnly(libs.bundles.test.runtime)
     testImplementation(libs.grpc.testing)
+}
+
+// Pilot: jspecify + NullAway, scoped to this module only. See @NullMarked package-info.java
+// files in com.apple.foundationdb.relational.jdbc / .jdbc.grpc. Generated protobuf/grpc code
+// (com.apple.foundationdb.relational.jdbc.grpc.v1) is carved out via UnannotatedSubPackages.
+tasks.withType(JavaCompile).configureEach {
+    options.errorprone {
+        disableAllChecks = true
+        error("NullAway")
+        option("NullAway:AnnotatedPackages", "com.apple.foundationdb.relational.jdbc")
+        option("NullAway:UnannotatedSubPackages", "com.apple.foundationdb.relational.jdbc.grpc.v1")
+        option("NullAway:JSpecifyMode", "true")
+        option("NullAway:AcknowledgeRestrictiveAnnotations", "true")
+    }
 }
 
 javadoc {

--- a/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/RelationalArrayFacade.java
+++ b/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/RelationalArrayFacade.java
@@ -43,7 +43,8 @@ import com.apple.foundationdb.relational.util.PositionalIndex;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 
-import javax.annotation.Nonnull;
+import org.jspecify.annotations.Nullable;
+
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Types;
@@ -71,7 +72,7 @@ class RelationalArrayFacade implements RelationalArray {
      */
     private final Array delegate;
 
-    RelationalArrayFacade(@Nonnull ColumnMetadata delegateMetadata, Array array) {
+    RelationalArrayFacade(ColumnMetadata delegateMetadata, Array array) {
         this.delegateMetadata = delegateMetadata;
         this.type = Suppliers.memoize(this::computeType);
         this.delegate = array;
@@ -207,6 +208,7 @@ class RelationalArrayFacade implements RelationalArray {
          * Column metadata for the Array Structs.
          * Package-private so protobuf is available to serializer (in same package).
          */
+        @Nullable
         private ColumnMetadata metadata;
 
         RelationalArrayFacadeBuilder() {
@@ -214,36 +216,39 @@ class RelationalArrayFacade implements RelationalArray {
 
         @Override
         public RelationalArray build() {
+            if (metadata == null) {
+                throw new IllegalStateException("Cannot build a RelationalArray with no elements added");
+            }
             return new RelationalArrayFacade(this.metadata, this.builder.build());
         }
 
         @Override
-        public RelationalArrayBuilder addAll(@Nonnull Object... value) throws SQLException {
+        public RelationalArrayBuilder addAll(Object... value) throws SQLException {
             throw new SQLFeatureNotSupportedException();
         }
 
         @Override
-        public RelationalArrayBuilder addBytes(@Nonnull byte[] value) throws SQLException {
+        public RelationalArrayBuilder addBytes(byte[] value) throws SQLException {
             throw new SQLFeatureNotSupportedException();
         }
 
         @Override
-        public RelationalArrayBuilder addString(@Nonnull String value) throws SQLException {
+        public RelationalArrayBuilder addString(String value) throws SQLException {
             throw new SQLFeatureNotSupportedException();
         }
 
         @Override
-        public RelationalArrayBuilder addLong(@Nonnull long value) throws SQLException {
+        public RelationalArrayBuilder addLong(long value) throws SQLException {
             throw new SQLFeatureNotSupportedException();
         }
 
         @Override
-        public RelationalArrayBuilder addUuid(@Nonnull final UUID value) throws SQLException {
+        public RelationalArrayBuilder addUuid(final UUID value) throws SQLException {
             throw new SQLFeatureNotSupportedException();
         }
 
         @Override
-        public RelationalArrayBuilder addObject(@Nonnull final Object value) throws SQLException {
+        public RelationalArrayBuilder addObject(final Object value) throws SQLException {
             throw new SQLFeatureNotSupportedException();
         }
 

--- a/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/RelationalResultSetFacade.java
+++ b/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/RelationalResultSetFacade.java
@@ -35,7 +35,8 @@ import com.apple.foundationdb.relational.util.ExcludeFromJacocoGeneratedReport;
 import com.apple.foundationdb.relational.util.PositionalIndex;
 import com.google.common.base.Suppliers;
 
-import javax.annotation.Nonnull;
+import org.jspecify.annotations.Nullable;
+
 import java.sql.SQLException;
 import java.sql.SQLWarning;
 import java.sql.Types;
@@ -103,15 +104,16 @@ class RelationalResultSetFacade implements RelationalResultSet {
         return this.wasNull;
     }
 
-    private <R> R get(int oneBasedIndex, Function<Column, R> s) {
+    private <R extends @Nullable Object> R get(int oneBasedIndex, Function<Column, R> s) {
         int index = PositionalIndex.toProtobuf(oneBasedIndex);
         Column column = this.delegate.getRow(rowIndex).getColumns().getColumn(index);
         return s.apply(column);
     }
 
     @Override
+    @Nullable
     public String getString(final int oneBasedColumn) throws SQLException {
-        return get(oneBasedColumn, column -> {
+        Function<Column, @Nullable String> f = column -> {
             if (column.hasString()) {
                 // Do I need to update lastColumnReadWasNull for String type?
                 // For primitives only?
@@ -120,7 +122,8 @@ class RelationalResultSetFacade implements RelationalResultSet {
             }
             this.wasNull = true;
             return null;
-        });
+        };
+        return this.<@Nullable String>get(oneBasedColumn, f);
     }
 
     @Override
@@ -184,6 +187,8 @@ class RelationalResultSetFacade implements RelationalResultSet {
     }
 
     @Override
+    @SuppressWarnings("NullAway") // NullAway/JSpecify does not currently track @Nullable on array (byte[]) return types across this unannotated-interface boundary; genuinely returns null for a SQL NULL column, same as before this migration.
+    @Nullable
     public byte[] getBytes(int oneBasedColumn) throws SQLException {
         return get(oneBasedColumn, column -> {
             if (column.hasBinary()) {
@@ -210,6 +215,7 @@ class RelationalResultSetFacade implements RelationalResultSet {
     }
 
     @Override
+    @Nullable
     public String getString(String columnLabel) throws SQLException {
         // TOOD: Do getName for now.
         return getString(
@@ -261,6 +267,7 @@ class RelationalResultSetFacade implements RelationalResultSet {
     }
 
     @Override
+    @Nullable
     public SQLWarning getWarnings() throws SQLException {
         // TODO: Does nothing for now.
         return null;
@@ -277,7 +284,6 @@ class RelationalResultSetFacade implements RelationalResultSet {
     }
 
     @Override
-    @Nonnull
     public Continuation getContinuation() throws SQLException {
         if (hasNext()) {
             throw new SQLException("Continuation can only be returned for the last row");
@@ -293,8 +299,9 @@ class RelationalResultSetFacade implements RelationalResultSet {
     }
 
     @Override
+    @Nullable
     public RelationalStruct getStruct(int oneBasedColumn) throws SQLException {
-        RelationalStruct s = TypeConversion.getStruct(this.delegate, this.rowIndex, oneBasedColumn);
+        @Nullable RelationalStruct s = TypeConversion.getStruct(this.delegate, this.rowIndex, oneBasedColumn);
         wasNull = s == null;
         return s;
     }
@@ -308,16 +315,19 @@ class RelationalResultSetFacade implements RelationalResultSet {
 
     @Override
     @ExcludeFromJacocoGeneratedReport
+    @Nullable
     public UUID getUUID(int oneBasedColumn) throws SQLException {
-        UUID s = TypeConversion.getUUID(this.delegate, this.rowIndex, oneBasedColumn);
+        @Nullable UUID s = TypeConversion.getUUID(this.delegate, this.rowIndex, oneBasedColumn);
         wasNull = s == null;
         return s;
     }
 
     @Override
+    @Nullable
+    @SuppressWarnings("NullAway") // NullAway/JSpecify does not currently narrow @Nullable array (byte[]) locals across this call into TypeConversion.parseVector, despite the explicit null-check above.
     public Object getObject(int oneBasedColumn) throws SQLException {
         int type = getMetaData().getColumnType(oneBasedColumn);
-        final Object o;
+        final @Nullable Object o;
         switch (type) {
             case Types.VARCHAR:
                 o = getString(oneBasedColumn);
@@ -359,7 +369,7 @@ class RelationalResultSetFacade implements RelationalResultSet {
                         break;
                     case VECTOR: {
                         final var bytes = getBytes(oneBasedColumn);
-                        if (wasNull()) {
+                        if (bytes == null) {
                             return null;
                         }
                         o = TypeConversion.parseVector(bytes, ((DataType.VectorType)relationalType).getPrecision());
@@ -380,16 +390,18 @@ class RelationalResultSetFacade implements RelationalResultSet {
     }
 
     @Override
+    @Nullable
     public Object getObject(String columnLabel) throws SQLException {
         return getObject(RelationalStruct.getOneBasedPosition(columnLabel, this));
     }
 
     @Override
+    @Nullable
     public RelationalArray getArray(int oneBasedColumn) throws SQLException {
         int index = PositionalIndex.toProtobuf(oneBasedColumn);
         ColumnMetadata columnMetadata = this.delegate.getMetadata().getColumnMetadata().getColumnMetadata(index);
         Column column = this.delegate.getRow(rowIndex).getColumns().getColumn(index);
-        RelationalArrayFacade array = column == null || !column.hasArray() ? null :
+        @Nullable RelationalArrayFacade array = column == null || !column.hasArray() ? null :
                 new RelationalArrayFacade(columnMetadata.getArrayMetadata(), column.getArray());
         wasNull = array == null;
         return array;

--- a/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/RelationalResultSetMetaDataFacade.java
+++ b/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/RelationalResultSetMetaDataFacade.java
@@ -30,7 +30,6 @@ import com.apple.foundationdb.relational.jdbc.grpc.v1.ResultSetMetadata;
 import com.apple.foundationdb.relational.util.ExcludeFromJacocoGeneratedReport;
 import com.apple.foundationdb.relational.util.PositionalIndex;
 
-import javax.annotation.Nonnull;
 import java.sql.JDBCType;
 import java.sql.SQLException;
 
@@ -50,7 +49,6 @@ class RelationalResultSetMetaDataFacade implements RelationalResultSetMetaData  
         throw new SQLException("Not implemented", ErrorCode.UNSUPPORTED_OPERATION.getErrorCode());
     }
 
-    @Nonnull
     @Override
     public DataType.StructType getRelationalDataType() throws SQLException {
         throw new SQLException("Not implemented", ErrorCode.UNSUPPORTED_OPERATION.getErrorCode());

--- a/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/RelationalRpcContinuation.java
+++ b/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/RelationalRpcContinuation.java
@@ -23,17 +23,15 @@ package com.apple.foundationdb.relational.jdbc;
 import com.apple.foundationdb.relational.api.Continuation;
 import com.apple.foundationdb.relational.jdbc.grpc.v1.RpcContinuation;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.Objects;
 
 public class RelationalRpcContinuation implements Continuation {
     public static final int CURRENT_VERSION = 1;
 
-    @Nonnull
     private final RpcContinuation proto;
 
-    public RelationalRpcContinuation(@Nonnull RpcContinuation proto) {
+    public RelationalRpcContinuation(RpcContinuation proto) {
         this.proto = proto;
     }
 
@@ -47,6 +45,7 @@ public class RelationalRpcContinuation implements Continuation {
 
     @Nullable
     @Override
+    @SuppressWarnings("NullAway") // NullAway/JSpecify does not currently track @Nullable on array (byte[]) return types across this unannotated-interface boundary; genuinely returns null, same as before this migration.
     public byte[] getExecutionState() {
         if (proto.hasInternalState()) {
             return proto.getInternalState().toByteArray();
@@ -56,6 +55,7 @@ public class RelationalRpcContinuation implements Continuation {
     }
 
     @Override
+    @Nullable
     public Reason getReason() {
         if (proto.hasReason()) {
             return TypeConversion.toReason(proto.getReason());
@@ -74,7 +74,6 @@ public class RelationalRpcContinuation implements Continuation {
         return proto.getAtEnd();
     }
 
-    @Nonnull
     public RpcContinuation getProto() {
         return proto;
     }

--- a/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/RelationalStructFacade.java
+++ b/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/RelationalStructFacade.java
@@ -42,8 +42,8 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Suppliers;
 import com.google.protobuf.ByteString;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.ArrayList;
@@ -200,6 +200,8 @@ class RelationalStructFacade implements RelationalStruct {
     }
 
     @Override
+    @SuppressWarnings("NullAway") // NullAway/JSpecify does not currently track @Nullable on array (byte[]) return types across this unannotated-interface boundary; genuinely returns null for a SQL NULL column, same as before this migration.
+    @Nullable
     public byte[] getBytes(int oneBasedColumn) throws SQLException {
         Column c = getColumnInternal(oneBasedColumn);
         if (wasNull) {
@@ -213,11 +215,13 @@ class RelationalStructFacade implements RelationalStruct {
     }
 
     @Override
+    @SuppressWarnings("NullAway") // NullAway/JSpecify does not currently track @Nullable on array (byte[]) return types across this unannotated-interface boundary; getBytes(int) genuinely returns null for a SQL NULL column, same as before this migration.
     public byte[] getBytes(String fieldName) throws SQLException {
         return getBytes(RelationalStruct.getOneBasedPosition(fieldName, this));
     }
 
     @Override
+    @Nullable
     public String getString(int oneBasedColumn) throws SQLException {
         Column c = getColumnInternal(oneBasedColumn);
         if (wasNull) {
@@ -231,11 +235,13 @@ class RelationalStructFacade implements RelationalStruct {
     }
 
     @Override
+    @Nullable
     public String getString(String fieldName) throws SQLException {
         return getString(RelationalStruct.getOneBasedPosition(fieldName, this));
     }
 
     @Override
+    @Nullable
     public Object getObject(int oneBasedColumn) throws SQLException {
         int type = getMetaData().getColumnType(oneBasedColumn);
         Object obj = null;
@@ -288,11 +294,13 @@ class RelationalStructFacade implements RelationalStruct {
     }
 
     @Override
+    @Nullable
     public Object getObject(String fieldName) throws SQLException {
         return getObject(RelationalStruct.getOneBasedPosition(fieldName, this));
     }
 
     @Override
+    @Nullable
     public RelationalStruct getStruct(int oneBasedColumn) throws SQLException {
         Column c = getColumnInternal(oneBasedColumn);
         if (wasNull) {
@@ -312,6 +320,7 @@ class RelationalStructFacade implements RelationalStruct {
     }
 
     @Override
+    @Nullable
     public RelationalArray getArray(int oneBasedColumn) throws SQLException {
         Column c = getColumnInternal(oneBasedColumn);
         if (wasNull) {
@@ -329,6 +338,7 @@ class RelationalStructFacade implements RelationalStruct {
     }
 
     @Override
+    @Nullable
     public UUID getUUID(final int oneBasedPosition) throws SQLException {
         Column c = getColumnInternal(oneBasedPosition);
         if (wasNull) {
@@ -341,7 +351,7 @@ class RelationalStructFacade implements RelationalStruct {
     }
 
     @Nullable
-    private RealVector getVector(final int oneBasedPosition, @Nonnull final DataType.VectorType type) throws SQLException {
+    private RealVector getVector(final int oneBasedPosition, final DataType.VectorType type) throws SQLException {
         Column c = getColumnInternal(oneBasedPosition);
         if (wasNull) {
             return null;
@@ -353,6 +363,7 @@ class RelationalStructFacade implements RelationalStruct {
     }
 
     @Override
+    @Nullable
     public UUID getUUID(final String fieldName) throws SQLException {
         return getUUID(RelationalStruct.getOneBasedPosition(fieldName, this));
     }
@@ -520,7 +531,7 @@ class RelationalStructFacade implements RelationalStruct {
         }
 
         @Override
-        public RelationalStructBuilder addStruct(String fieldName, @Nonnull RelationalStruct struct) throws SQLException {
+        public RelationalStructBuilder addStruct(String fieldName, RelationalStruct struct) throws SQLException {
             // We're building. Must be a RelationalStructFacade instance of RelationalStruct when here. Unwrap.
             // This will allow us to access the backing data and metadata protobufs.
             // Insert the data portion of RelationalStruct here.
@@ -533,7 +544,7 @@ class RelationalStructFacade implements RelationalStruct {
         }
 
         @Override
-        public RelationalStructBuilder addArray(String fieldName, @Nonnull RelationalArray array) throws SQLException {
+        public RelationalStructBuilder addArray(String fieldName, RelationalArray array) throws SQLException {
             // We're building. Must be a RelationalArrayFacade instance of RelationalArray when here. Unwrap.
             // This will allow us to access the backing data and metadata protobufs.
             // Insert the data portion of RelationalStruct here.

--- a/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/TypeConversion.java
+++ b/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/TypeConversion.java
@@ -55,7 +55,8 @@ import com.apple.foundationdb.relational.util.PositionalIndex;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.ByteString;
 
-import javax.annotation.Nonnull;
+import org.jspecify.annotations.Nullable;
+
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 import java.sql.Types;
@@ -65,6 +66,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.function.BiFunction;
+
+import static com.apple.foundationdb.relational.api.Continuation.Reason;
 
 /**
  * Utility for converting types used by JDBC from Relational and FDB such as KeySet, RelationalStruct and RelationalArray.
@@ -82,6 +85,7 @@ public class TypeConversion {
      * @return {@link RelationalStruct} instance pulled from <code>resultSet</code>
      * @throws SQLException If failed get of <code>resultSet</code> metadata.
      */
+    @Nullable
     static RelationalStruct getStruct(ResultSet resultSet, int rowIndex, int oneBasedColumn) {
         int index = PositionalIndex.toProtobuf(oneBasedColumn);
         var metadata =
@@ -90,6 +94,7 @@ public class TypeConversion {
         return column.hasStruct() ? new RelationalStructFacade(metadata, column.getStruct()) : null;
     }
 
+    @Nullable
     static UUID getUUID(ResultSet resultSet, int rowIndex, int oneBasedColumn) {
         int index = PositionalIndex.toProtobuf(oneBasedColumn);
         Column column = resultSet.getRow(rowIndex).getColumns().getColumn(index);
@@ -203,17 +208,17 @@ public class TypeConversion {
         return columnMetadataBuilder.build();
     }
 
-    private static EnumMetadata toEnumMetadata(@Nonnull DataType.EnumType enumType) {
+    private static EnumMetadata toEnumMetadata(DataType.EnumType enumType) {
         final var builder = EnumMetadata.newBuilder().setName(enumType.getName());
         enumType.getValues().forEach(v -> builder.addValues(v.getName()));
         return builder.build();
     }
 
-    private static VectorMetadata toVectorMetadata(@Nonnull DataType.VectorType vectorType) {
+    private static VectorMetadata toVectorMetadata(DataType.VectorType vectorType) {
         return VectorMetadata.newBuilder().setDimensions(vectorType.getDimensions()).setPrecision(vectorType.getPrecision()).build();
     }
 
-    private static Type toProtobufType(@Nonnull DataType type) {
+    private static Type toProtobufType(DataType type) {
         switch (type.getCode()) {
             case LONG:
                 return Type.LONG;
@@ -249,7 +254,7 @@ public class TypeConversion {
     /**
      * The below is about making an Array.
      */
-    private static ColumnMetadata toColumnMetadata(@Nonnull ArrayMetaData metadata)
+    private static ColumnMetadata toColumnMetadata(ArrayMetaData metadata)
             throws SQLException {
         var columnMetadataBuilder = ColumnMetadata.newBuilder()
                 .setName(metadata.getElementName())
@@ -279,7 +284,7 @@ public class TypeConversion {
         return columnMetadataBuilder.build();
     }
 
-    private static StructMetadata toStructMetadataProtobuf(@Nonnull StructMetaData metadata) throws SQLException {
+    private static StructMetadata toStructMetadataProtobuf(StructMetaData metadata) throws SQLException {
         var structMetadataBuilder = StructMetadata.newBuilder();
         for (int oneBasedIndex = 1; oneBasedIndex <= metadata.getColumnCount(); oneBasedIndex++) {
             var columnMetadata = toColumnMetadata(metadata, oneBasedIndex, oneBasedIndex - 1 + metadata.getLeadingPhantomColumnCount());
@@ -384,7 +389,7 @@ public class TypeConversion {
      * @param array the SQL array
      * @return the resulting protobuf array
      */
-    public static Array toArray(@Nonnull java.sql.Array array) throws SQLException {
+    public static Array toArray(java.sql.Array array) throws SQLException {
         Array.Builder builder = Array.newBuilder();
         builder.setElementType(array.getBaseType());
         for (Object o: (Object[])array.getArray()) {
@@ -405,7 +410,7 @@ public class TypeConversion {
      * @return the created column
      * @throws SQLException in case of error
      */
-    public static Column toColumn(int columnType, @Nonnull Object obj) throws SQLException {
+    public static Column toColumn(int columnType, Object obj) throws SQLException {
         if (columnType != DataType.getDataTypeFromObject(obj).getJdbcSqlCode()) {
             throw new SQLException("Column element type does not match object type: " + columnType + " / " + obj.getClass().getSimpleName(),
                     ErrorCode.WRONG_OBJECT_TYPE.getErrorCode());
@@ -454,7 +459,7 @@ public class TypeConversion {
         return builder.build();
     }
 
-    private static Column toColumn(@Nonnull DataType.StructType.Field field, @Nonnull Object value, boolean wasNull) throws SQLException {
+    private static Column toColumn(DataType.StructType.Field field, Object value, boolean wasNull) throws SQLException {
         Column column;
         switch (field.getType().getCode()) {
             case STRUCT:
@@ -533,10 +538,11 @@ public class TypeConversion {
      * @return Column instance made from <code>p</code> whether null or not.
      */
     @VisibleForTesting
-    static <P> Column toColumn(P p, BiFunction<P, Column.Builder, Column.Builder> f) {
+    static <P> Column toColumn(@Nullable P p, BiFunction<P, Column.Builder, Column.Builder> f) {
         return f.apply(p, Column.newBuilder()).build();
     }
 
+    @Nullable
     public static ResultSet toProtobuf(RelationalResultSet relationalResultSet) throws SQLException {
         if (relationalResultSet == null) {
             return null;
@@ -554,7 +560,7 @@ public class TypeConversion {
         return resultSetBuilder.build();
     }
 
-    private static RpcContinuation toContinuation(@Nonnull Continuation existingContinuation) {
+    private static RpcContinuation toContinuation(Continuation existingContinuation) {
         RpcContinuation.Builder builder = RpcContinuation.newBuilder()
                 .setVersion(RelationalRpcContinuation.CURRENT_VERSION)
                 .setAtBeginning(existingContinuation.atBeginning())
@@ -565,14 +571,18 @@ public class TypeConversion {
         if (state != null) {
             builder.setInternalState(ByteString.copyFrom(state));
         }
-        Continuation.Reason reason = existingContinuation.getReason();
+        Reason reason = existingContinuation.getReason();
         if (reason != null) {
-            builder.setReason(toReason(reason));
+            RpcContinuationReason rpcContinuationReason = toReason(reason);
+            if (rpcContinuationReason != null) {
+                builder.setReason(rpcContinuationReason);
+            }
         }
         return builder.build();
     }
 
-    public static RpcContinuationReason toReason(Continuation.Reason reason) {
+    @Nullable
+    public static RpcContinuationReason toReason(Reason reason) {
         if (reason == null) {
             return null;
         }
@@ -588,17 +598,17 @@ public class TypeConversion {
         }
     }
 
-    public static Continuation.Reason toReason(RpcContinuationReason reason) {
+    public static @Nullable Reason toReason(RpcContinuationReason reason) {
         if (reason == null) {
             return null;
         }
         switch (reason) {
             case TRANSACTION_LIMIT_REACHED:
-                return Continuation.Reason.TRANSACTION_LIMIT_REACHED;
+                return Reason.TRANSACTION_LIMIT_REACHED;
             case QUERY_EXECUTION_LIMIT_REACHED:
-                return Continuation.Reason.QUERY_EXECUTION_LIMIT_REACHED;
+                return Reason.QUERY_EXECUTION_LIMIT_REACHED;
             case CURSOR_AFTER_LAST:
-                return Continuation.Reason.CURSOR_AFTER_LAST;
+                return Reason.CURSOR_AFTER_LAST;
             default:
                 throw new IllegalStateException("Unrecognized continuation reason: " + reason);
         }
@@ -606,7 +616,7 @@ public class TypeConversion {
 
     @VisibleForTesting
     @SuppressWarnings("unchecked")
-    static com.apple.foundationdb.relational.jdbc.grpc.v1.Options.Builder toProtobuf(@Nonnull Options options) throws SQLException {
+    static com.apple.foundationdb.relational.jdbc.grpc.v1.Options.Builder toProtobuf(Options options) throws SQLException {
         final var builder = com.apple.foundationdb.relational.jdbc.grpc.v1.Options.newBuilder();
         for (Map.Entry<Options.Name, ?> entry : options.entries()) {
             switch (entry.getKey()) {
@@ -917,7 +927,7 @@ public class TypeConversion {
         }
     }
 
-    private static DataType.EnumType getEnumDataType(@Nonnull EnumMetadata enumMetadata, boolean nullable) {
+    private static DataType.EnumType getEnumDataType(EnumMetadata enumMetadata, boolean nullable) {
         final var enumValues = new ArrayList<DataType.EnumType.EnumValue>();
         int i = 1;
         for (var value: enumMetadata.getValuesList()) {
@@ -926,11 +936,11 @@ public class TypeConversion {
         return DataType.EnumType.from(enumMetadata.getName(), enumValues, nullable);
     }
 
-    private static DataType.VectorType getVectorType(@Nonnull VectorMetadata vectorMetadata, boolean nullable) {
+    private static DataType.VectorType getVectorType(VectorMetadata vectorMetadata, boolean nullable) {
         return DataType.VectorType.of(vectorMetadata.getPrecision(), vectorMetadata.getDimensions(), nullable);
     }
 
-    static DataType getDataType(@Nonnull Type type, @Nonnull ColumnMetadata columnMetadata, boolean nullable) {
+    static DataType getDataType(Type type, ColumnMetadata columnMetadata, boolean nullable) {
         switch (type) {
             case LONG:
                 return nullable ? DataType.Primitives.NULLABLE_LONG.type() : DataType.Primitives.LONG.type();
@@ -965,8 +975,7 @@ public class TypeConversion {
         }
     }
 
-    @Nonnull
-    public static RealVector parseVector(@Nonnull final byte[] bytes, int precision) throws SQLException {
+    public static RealVector parseVector(final byte[] bytes, int precision) throws SQLException {
         if (precision == 16) {
             return HalfRealVector.fromBytes(bytes);
         }

--- a/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/grpc/GrpcSQLExceptionUtil.java
+++ b/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/grpc/GrpcSQLExceptionUtil.java
@@ -32,7 +32,8 @@ import io.grpc.protobuf.StatusProto;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.reflect.Constructor;
@@ -125,6 +126,9 @@ public final class GrpcSQLExceptionUtil {
     @Nullable
     public static SQLException map(StatusRuntimeException statusRuntimeException) {
         Status status = StatusProto.fromThrowable(statusRuntimeException);
+        if (status == null) {
+            return null;
+        }
         return map(status);
     }
 

--- a/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/grpc/package-info.java
+++ b/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/grpc/package-info.java
@@ -21,4 +21,7 @@
 /**
  * Common Utilities used by the Relational gRPC client and server.
  */
+@NullMarked
 package com.apple.foundationdb.relational.jdbc.grpc;
+
+import org.jspecify.annotations.NullMarked;

--- a/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/package-info.java
+++ b/fdb-relational-grpc/src/main/java/com/apple/foundationdb/relational/jdbc/package-info.java
@@ -25,4 +25,7 @@
  * List of {@link com.apple.foundationdb.relational.api.RelationalStruct} into a {@link com.apple.foundationdb.relational.jdbc.grpc.v1.ResultSet}
  * and so on.
  */
+@NullMarked
 package com.apple.foundationdb.relational.jdbc;
+
+import org.jspecify.annotations.NullMarked;

--- a/fdb-relational-grpc/src/test/java/com/apple/foundationdb/relational/jdbc/AbstractMockResultSet.java
+++ b/fdb-relational-grpc/src/test/java/com/apple/foundationdb/relational/jdbc/AbstractMockResultSet.java
@@ -27,6 +27,8 @@ import com.apple.foundationdb.relational.api.RelationalStruct;
 import com.apple.foundationdb.relational.api.exceptions.ErrorCode;
 import com.apple.foundationdb.relational.api.exceptions.RelationalException;
 
+import org.jspecify.annotations.Nullable;
+
 import java.sql.SQLException;
 import java.util.UUID;
 
@@ -36,6 +38,7 @@ import java.util.UUID;
  */
 public abstract class AbstractMockResultSet implements RelationalResultSet {
     private final RelationalResultSetMetaData metadata;
+    @Nullable
     private MockResultSetRow currentRow;
 
     protected AbstractMockResultSet(RelationalResultSetMetaData metadata) {
@@ -44,6 +47,7 @@ public abstract class AbstractMockResultSet implements RelationalResultSet {
 
     protected abstract boolean hasNext();
 
+    @Nullable
     protected abstract MockResultSetRow advanceRow() throws RelationalException;
 
     @Override
@@ -62,74 +66,62 @@ public abstract class AbstractMockResultSet implements RelationalResultSet {
 
     @Override
     public boolean wasNull() throws SQLException {
-        checkCurrentRow();
-        return currentRow.wasNull();
+        return requireCurrentRow().wasNull();
     }
 
     @Override
     public String getString(int columnIndex) throws SQLException {
-        checkCurrentRow();
-        return currentRow.getString(columnIndex);
+        return requireCurrentRow().getString(columnIndex);
     }
 
     @Override
     public boolean getBoolean(int columnIndex) throws SQLException {
-        checkCurrentRow();
-        return currentRow.getBoolean(columnIndex);
+        return requireCurrentRow().getBoolean(columnIndex);
     }
 
     @Override
     public int getInt(int columnIndex) throws SQLException {
-        checkCurrentRow();
-        return currentRow.getInt(columnIndex);
+        return requireCurrentRow().getInt(columnIndex);
     }
 
     @Override
     public long getLong(int columnIndex) throws SQLException {
-        checkCurrentRow();
-        return currentRow.getLong(columnIndex);
+        return requireCurrentRow().getLong(columnIndex);
     }
 
     @Override
     public float getFloat(int columnIndex) throws SQLException {
-        checkCurrentRow();
-        return currentRow.getFloat(columnIndex);
+        return requireCurrentRow().getFloat(columnIndex);
     }
 
     @Override
     public double getDouble(int columnIndex) throws SQLException {
-        checkCurrentRow();
-        return currentRow.getDouble(columnIndex);
+        return requireCurrentRow().getDouble(columnIndex);
     }
 
     @Override
     public byte[] getBytes(int columnIndex) throws SQLException {
-        checkCurrentRow();
-        return currentRow.getBytes(columnIndex);
+        return requireCurrentRow().getBytes(columnIndex);
     }
 
     @Override
     public Object getObject(int columnIndex) throws SQLException {
-        checkCurrentRow();
-        return currentRow.getObject(columnIndex);
+        return requireCurrentRow().getObject(columnIndex);
     }
 
     @Override
     public RelationalStruct getStruct(int oneBasedPosition) throws SQLException {
-        checkCurrentRow();
-        return currentRow.getStruct(oneBasedPosition);
+        return requireCurrentRow().getStruct(oneBasedPosition);
     }
 
     @Override
     public RelationalArray getArray(int oneBasedPosition) throws SQLException {
-        checkCurrentRow();
-        return currentRow.getArray(oneBasedPosition);
+        return requireCurrentRow().getArray(oneBasedPosition);
     }
 
     @Override
     public UUID getUUID(int oneBasedPosition) throws SQLException {
-        checkCurrentRow();
-        return currentRow.getUUID(oneBasedPosition);
+        return requireCurrentRow().getUUID(oneBasedPosition);
     }
 
     @Override
@@ -197,9 +189,10 @@ public abstract class AbstractMockResultSet implements RelationalResultSet {
         return false;
     }
 
-    private void checkCurrentRow() throws SQLException {
+    private MockResultSetRow requireCurrentRow() throws SQLException {
         if (currentRow == null) {
             throw new SQLException("ResultSet exhausted", ErrorCode.INVALID_CURSOR_STATE.getErrorCode());
         }
+        return currentRow;
     }
 }

--- a/fdb-relational-grpc/src/test/java/com/apple/foundationdb/relational/jdbc/MockContinuation.java
+++ b/fdb-relational-grpc/src/test/java/com/apple/foundationdb/relational/jdbc/MockContinuation.java
@@ -22,7 +22,8 @@ package com.apple.foundationdb.relational.jdbc;
 
 import com.apple.foundationdb.relational.api.Continuation;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
@@ -30,15 +31,18 @@ import java.util.Arrays;
  * A testing implementation of a continuation.
  */
 public class MockContinuation implements Continuation {
+    @SuppressWarnings("NullAway") // NullAway/JSpecify does not currently recognize @Nullable on array (byte[]) parameters.
     public static final MockContinuation BEGIN = new MockContinuation(null, null, true, false);
     public static final MockContinuation END = new MockContinuation(null, new byte[0], false, true);
 
+    @Nullable
     private final Reason reason;
+    @Nullable
     private final byte[] executionState;
     private final boolean atBeginning;
     private final boolean atEnd;
 
-    public MockContinuation(Reason reason, byte[] executionState, boolean atBeginning, boolean atEnd) {
+    public MockContinuation(@Nullable Reason reason, @Nullable byte[] executionState, boolean atBeginning, boolean atEnd) {
         this.reason = reason;
         this.executionState = executionState;
         this.atBeginning = atBeginning;
@@ -46,12 +50,14 @@ public class MockContinuation implements Continuation {
     }
 
     @Override
+    @Nullable
     public Reason getReason() {
         return reason;
     }
 
     @Nullable
     @Override
+    @SuppressWarnings("NullAway") // NullAway/JSpecify does not currently track @Nullable on array (byte[]) return types across this unannotated-interface boundary.
     public byte[] getExecutionState() {
         return executionState;
     }

--- a/fdb-relational-grpc/src/test/java/com/apple/foundationdb/relational/jdbc/MockResultSet.java
+++ b/fdb-relational-grpc/src/test/java/com/apple/foundationdb/relational/jdbc/MockResultSet.java
@@ -23,7 +23,8 @@ package com.apple.foundationdb.relational.jdbc;
 import com.apple.foundationdb.relational.api.Continuation;
 import com.apple.foundationdb.relational.api.exceptions.RelationalException;
 
-import javax.annotation.Nonnull;
+import org.jspecify.annotations.Nullable;
+
 import java.sql.SQLException;
 import java.util.Iterator;
 
@@ -33,10 +34,11 @@ import java.util.Iterator;
  */
 public class MockResultSet extends AbstractMockResultSet {
     private final Iterator<? extends MockResultSetRow> rowIterator;
+    @Nullable
     private final Continuation continuation;
     private int currentRowPosition;
 
-    public MockResultSet(MockResultSetMetadata metadata, Iterator<MockResultSetRow> rowIterator, Continuation continuation) {
+    public MockResultSet(MockResultSetMetadata metadata, Iterator<MockResultSetRow> rowIterator, @Nullable Continuation continuation) {
         super(metadata);
         this.rowIterator = rowIterator;
         this.continuation = continuation;
@@ -49,6 +51,7 @@ public class MockResultSet extends AbstractMockResultSet {
     }
 
     @Override
+    @Nullable
     protected MockResultSetRow advanceRow() throws RelationalException {
         if (!hasNext()) {
             return null;
@@ -57,8 +60,8 @@ public class MockResultSet extends AbstractMockResultSet {
         return rowIterator.next();
     }
 
-    @Nonnull
     @Override
+    @SuppressWarnings("NullAway") // deliberately returns whatever was stored, including null, so tests can exercise callers that (mis)trust RelationalResultSet.getContinuation()'s @Nonnull contract.
     public Continuation getContinuation() throws SQLException {
         return continuation;
     }

--- a/fdb-relational-grpc/src/test/java/com/apple/foundationdb/relational/jdbc/MockResultSetMetadata.java
+++ b/fdb-relational-grpc/src/test/java/com/apple/foundationdb/relational/jdbc/MockResultSetMetadata.java
@@ -26,7 +26,6 @@ import com.apple.foundationdb.relational.api.StructMetaData;
 import com.apple.foundationdb.relational.api.exceptions.ErrorCode;
 import com.apple.foundationdb.relational.api.metadata.DataType;
 
-import javax.annotation.Nonnull;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.List;
@@ -60,7 +59,6 @@ public class MockResultSetMetadata implements RelationalResultSetMetaData {
         throw new SQLException("Unsupported operation", ErrorCode.UNSUPPORTED_OPERATION.getErrorCode());
     }
 
-    @Nonnull
     @Override
     public DataType.StructType getRelationalDataType() throws SQLException {
         return type;

--- a/fdb-relational-grpc/src/test/java/com/apple/foundationdb/relational/jdbc/MockResultSetRow.java
+++ b/fdb-relational-grpc/src/test/java/com/apple/foundationdb/relational/jdbc/MockResultSetRow.java
@@ -23,7 +23,6 @@ package com.apple.foundationdb.relational.jdbc;
 import com.apple.foundationdb.relational.api.RelationalArray;
 import com.apple.foundationdb.relational.api.RelationalStruct;
 
-import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.UUID;
 
@@ -34,10 +33,9 @@ import java.util.UUID;
  * throw IndexOutOfBoundsException
  */
 public class MockResultSetRow {
-    @Nonnull
     private final List<?> row;
 
-    public MockResultSetRow(@Nonnull List<?> row) {
+    public MockResultSetRow(List<?> row) {
         this.row = row;
     }
 

--- a/fdb-relational-grpc/src/test/java/com/apple/foundationdb/relational/jdbc/ProtobufConversionTest.java
+++ b/fdb-relational-grpc/src/test/java/com/apple/foundationdb/relational/jdbc/ProtobufConversionTest.java
@@ -83,11 +83,13 @@ public class ProtobufConversionTest {
 
     @Test
     void testResultSetWithContinuation() throws Exception {
+        @SuppressWarnings("NullAway") // NullAway/JSpecify does not currently recognize @Nullable on array (byte[]) parameters.
         MockContinuation continuation = new MockContinuation(Continuation.Reason.TRANSACTION_LIMIT_REACHED, null, false, false);
         RelationalResultSet resultSet = TestUtils.resultSet(
                 continuation,
                 TestUtils.row(1, 2, 3), TestUtils.row(4, 5, 6));
         ResultSet converted = TypeConversion.toProtobuf(resultSet);
+        Assertions.assertNotNull(converted);
 
         Assertions.assertEquals(2, converted.getRowCount());
         assertRow(List.of(1, 2, 3), converted.getRow(0));

--- a/fdb-relational-grpc/src/test/java/com/apple/foundationdb/relational/jdbc/RelationalStructFacadeBuilderTest.java
+++ b/fdb-relational-grpc/src/test/java/com/apple/foundationdb/relational/jdbc/RelationalStructFacadeBuilderTest.java
@@ -41,6 +41,7 @@ public class RelationalStructFacadeBuilderTest {
                 (RelationalStructFacade.RelationalStructFacadeBuilder) RelationalStructFacade.newBuilder();
         SQLException thrown = Assertions.assertThrows(SQLException.class,
                 () -> builder.getZeroBasedOffsetOrThrow("NO SUCH FIELD"));
+        Assertions.assertNotNull(thrown.getMessage());
         Assertions.assertTrue(thrown.getMessage().contains("Unknown"));
     }
 }

--- a/fdb-relational-grpc/src/test/java/com/apple/foundationdb/relational/jdbc/ResultSetContinuationTest.java
+++ b/fdb-relational-grpc/src/test/java/com/apple/foundationdb/relational/jdbc/ResultSetContinuationTest.java
@@ -52,6 +52,7 @@ public class ResultSetContinuationTest {
                 continuation,
                 TestUtils.row(1, 2, 3), TestUtils.row(4, 5, 6));
         ResultSet rsProto = TypeConversion.toProtobuf(resultSet);
+        Assertions.assertNotNull(rsProto);
 
         try (RelationalResultSetFacade deserializedResultSet = new RelationalResultSetFacade(rsProto)) {
             List<List<Integer>> rows = toRows(deserializedResultSet, 3);
@@ -68,6 +69,7 @@ public class ResultSetContinuationTest {
                 continuation,
                 TestUtils.row(1, 2, 3), TestUtils.row(4, 5, 6));
         ResultSet rsProto = TypeConversion.toProtobuf(resultSet);
+        Assertions.assertNotNull(rsProto);
 
         try (RelationalResultSetFacade deserializedResultSet = new RelationalResultSetFacade(rsProto)) {
             // Spend all the rows so we can get the continuation
@@ -84,6 +86,7 @@ public class ResultSetContinuationTest {
                 MockContinuation.BEGIN,
                 TestUtils.row(1, 2, 3), TestUtils.row(4, 5, 6));
         ResultSet rsProto = TypeConversion.toProtobuf(resultSet);
+        Assertions.assertNotNull(rsProto);
 
         try (RelationalResultSetFacade deserializedResultSet = new RelationalResultSetFacade(rsProto)) {
             // No continuation before any row

--- a/fdb-relational-grpc/src/test/java/com/apple/foundationdb/relational/jdbc/TestUtils.java
+++ b/fdb-relational-grpc/src/test/java/com/apple/foundationdb/relational/jdbc/TestUtils.java
@@ -23,11 +23,13 @@ package com.apple.foundationdb.relational.jdbc;
 import com.apple.foundationdb.relational.api.Continuation;
 import com.apple.foundationdb.relational.api.RelationalResultSet;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.Arrays;
 import java.util.List;
 
 public class TestUtils {
-    public static RelationalResultSet resultSet(Continuation continuation, MockResultSetRow... rows) {
+    public static RelationalResultSet resultSet(@Nullable Continuation continuation, MockResultSetRow... rows) {
         return new MockResultSet(
                 new MockResultSetMetadata(),
                 Arrays.stream(rows).iterator(),

--- a/fdb-relational-grpc/src/test/java/com/apple/foundationdb/relational/jdbc/grpc/GrpcSQLExceptionUtilTest.java
+++ b/fdb-relational-grpc/src/test/java/com/apple/foundationdb/relational/jdbc/grpc/GrpcSQLExceptionUtilTest.java
@@ -44,6 +44,7 @@ public class GrpcSQLExceptionUtilTest {
         com.google.rpc.Status status = GrpcSQLExceptionUtil.create(new SQLException(message));
         StatusRuntimeException statusRuntimeException = StatusProto.toStatusRuntimeException(status);
         SQLException sqlException = GrpcSQLExceptionUtil.map(statusRuntimeException);
+        Assertions.assertNotNull(sqlException);
         Assertions.assertEquals(message, sqlException.getMessage());
     }
 
@@ -59,9 +60,12 @@ public class GrpcSQLExceptionUtilTest {
         com.google.rpc.Status status = GrpcSQLExceptionUtil.create(new SQLNonTransientException(message, cause));
         StatusRuntimeException statusRuntimeException = StatusProto.toStatusRuntimeException(status);
         SQLException sqlException = GrpcSQLExceptionUtil.map(statusRuntimeException);
+        Assertions.assertNotNull(sqlException);
         Assertions.assertEquals(message, sqlException.getMessage());
         Assertions.assertTrue(sqlException instanceof SQLNonTransientException);
-        Assertions.assertTrue(sqlException.getCause() instanceof IOException);
-        Assertions.assertEquals(sqlException.getCause().getMessage(), message);
+        Throwable sqlExceptionCause = sqlException.getCause();
+        Assertions.assertNotNull(sqlExceptionCause);
+        Assertions.assertTrue(sqlExceptionCause instanceof IOException);
+        Assertions.assertEquals(sqlExceptionCause.getMessage(), message);
     }
 }

--- a/fdb-relational-server/src/main/java/com/apple/foundationdb/relational/server/FRL.java
+++ b/fdb-relational-server/src/main/java/com/apple/foundationdb/relational/server/FRL.java
@@ -62,6 +62,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -228,7 +229,7 @@ public class FRL implements AutoCloseable {
                     setStatementOptions(options, statement);
                     if (relationalStatement.execute(sql)) {
                         try (RelationalResultSet rs = relationalStatement.getResultSet()) {
-                            resultSet = TypeConversion.toProtobuf(rs);
+                            resultSet = Objects.requireNonNull(TypeConversion.toProtobuf(rs));
                             return Response.query(resultSet);
                         }
                     } else {
@@ -246,7 +247,7 @@ public class FRL implements AutoCloseable {
             setStatementOptions(options, statement);
             if (statement.execute()) {
                 try (RelationalResultSet rs = statement.getResultSet()) {
-                    resultSet = TypeConversion.toProtobuf(rs);
+                    resultSet = Objects.requireNonNull(TypeConversion.toProtobuf(rs));
                     return Response.query(resultSet);
                 }
             } else {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,6 +40,7 @@ guava = "33.6.0-jre"
 icu = "78.3"
 lucene = "8.11.1"
 javaPoet = "1.13.0"
+jspecify = "1.0.0"
 jsr305 = "3.0.2"
 jts = "1.20.0"
 log4j = "2.26.1"
@@ -64,7 +65,9 @@ snakeyaml = "2.6"
 
 # Static analysis dependency versions
 
+errorprone = "2.38.0"
 jacoco = "0.8.14"
+nullaway = "0.12.6"
 spotbugs = "4.10.3"
 
 [libraries]
@@ -92,6 +95,7 @@ gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
 icu = { module = "com.ibm.icu:icu4j", version.ref = "icu" }
 javaPoet = { module = "com.squareup:javapoet", version.ref = "javaPoet" }
+jspecify = { module = "org.jspecify:jspecify", version.ref = "jspecify" }
 jsr305 = { module = "com.google.code.findbugs:jsr305", version.ref = "jsr305" }
 jts = { module = "org.locationtech.jts.io:jts-io-common", version.ref = "jts" }
 log4j-api = { module = "org.apache.logging.log4j:log4j-api", version.ref = "log4j" }
@@ -132,6 +136,8 @@ hamcrest = { module = "org.hamcrest:hamcrest", version.ref = "hamcrest" }
 mockito = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 snakeyaml = { module = "org.yaml:snakeyaml", version.ref = "snakeyaml" }
 spotbugs-annotations = { module = "com.github.spotbugs:spotbugs-annotations", version.ref = "spotbugs" }
+errorprone-core = { module = "com.google.errorprone:error_prone_core", version.ref = "errorprone" }
+nullaway = { module = "com.uber.nullaway:nullaway", version.ref = "nullaway" }
 
 [bundles]
 
@@ -142,6 +148,7 @@ test-compileOnly = [ "autoService", "jsr305" ]
 [plugins]
 
 download = { id = "de.undercouch.download", version = "5.7.0" }
+errorprone = { id = "net.ltgt.errorprone", version = "4.1.0" }
 gitversion = { id = "com.palantir.git-version", version = "5.0.0" }
 jmh = { id = "me.champeau.jmh", version = "0.7.3" }
 protobuf = { id = "com.google.protobuf", version = "0.10.0" }


### PR DESCRIPTION
## Summary

First of a two-PR stack piloting adoption of [jspecify](https://jspecify.dev/) (`@NullMarked`/`@Nullable`) plus [NullAway](https://github.com/uber/NullAway) for compile-time null-checking, ahead of considering a repo-wide rollout via a longer stacked PR series:
1. **This PR** — `fdb-relational-grpc`
2. #4530 — `fdb-relational-jdbc` (stacked on top of this one)

Today the whole codebase uses `javax.annotation.Nonnull`/`Nullable` (JSR-305) with no package-level default and essentially no enforcement beyond SpotBugs' default bytecode-level `NP_*` checks. This PR:
- Adds `org.jspecify:jspecify` and wires NullAway in via the `net.ltgt.errorprone` Gradle plugin, applied **only** inside `fdb-relational-grpc.gradle` — no other module's build is affected, and root `build.gradle`/`gradle/check.gradle` are untouched.
- Marks both packages in this module (`com.apple.foundationdb.relational.jdbc`, `.jdbc.grpc`) `@NullMarked`, and swaps `javax.annotation.Nonnull`/`Nullable` for jspecify's `@Nullable` (non-null is now the default; `@Nonnull` becomes redundant and is dropped).
- Scopes NullAway to this module's own packages via `AnnotatedPackages`, carving out the generated protobuf/grpc stubs (`...jdbc.grpc.v1`) via `UnannotatedSubPackages`, and uses `AcknowledgeRestrictiveAnnotations` so it still gets useful signal at the boundary with this module's still-JSR-305-only dependencies (`fdb-relational-api`, `fdb-extensions`) without requiring them to migrate first.

## What the pilot surfaced

**Real, previously-undocumented nullability**, now explicit (all in `fdb-relational-grpc`, no changes needed to dependency modules):
- Several `get*` accessors in `TypeConversion`, `RelationalResultSetFacade`, `RelationalStructFacade`, and `RelationalRpcContinuation` return `null` for a SQL `NULL` / absent value but had no annotation at all before this change.
- **Latent bug fixed**: `RelationalArrayFacade.RelationalArrayFacadeBuilder.build()` could construct a `RelationalArray` with `null` backing metadata if `addStruct()` was never called, which would NPE later and confusingly (e.g. in `computeType()`). It now fails fast with a clear `IllegalStateException`.
- `GrpcSQLExceptionUtil.map(StatusRuntimeException)` didn't null-check the result of `StatusProto.fromThrowable(...)` (which NullAway's library model correctly flags as `@Nullable`) before dereferencing it.

**Cross-module ripple caught by CI**, not module-local checks: making `TypeConversion.toProtobuf(RelationalResultSet)` explicitly `@Nullable` let SpotBugs (which reads nullability annotations across module boundaries even though NullAway's own enforcement doesn't) catch a real unguarded dereference in the *unmigrated* `fdb-relational-server` module's `FRL.executeInternal()`. Fixed with `Objects.requireNonNull(...)` there. Lesson carried into the rollout: check the full repo build (`./gradlew build -x test -x destructiveTest -x scalarFallbackTest -PspotbugsEnableHtmlReport`, matching CI's `style` job), not just the migrated module's own `check`.

**Tooling limitations worth flagging before a wider rollout:**
- NullAway 0.12.6 in JSpecify mode does not reliably recognize `@Nullable` on **array** (`byte[]`) return types or parameters — neither for override-compatibility checks against unannotated interfaces, nor for plain (non-override) declarations. Worked around with ~6 targeted `@SuppressWarnings("NullAway")` sites with explanatory comments. Since `byte[]` is pervasive in this FDB-based codebase, this is a real consideration for the full rollout, not just an edge case.
- The bundled PMD version this repo currently resolves (6.44.0) cannot parse jspecify's required `Outer.@Nullable Inner` syntax for nullable nested/qualified types (e.g. `Continuation.Reason`). Worked around here with a static import to use the simple name instead; a full rollout may want to bump PMD.
- A generic per-column dispatch helper (`RelationalResultSetFacade.get`) needed the `<R extends @Nullable Object>` bound plus an explicit `<@Nullable String>` type witness at one call site to get correct nullness inference through `Function<Column, R>`.

## Test plan
- [x] `./gradlew :fdb-relational-grpc:compileJava` / `:compileTestJava` — clean
- [x] `./gradlew :fdb-relational-grpc:test` — all pass
- [x] `./gradlew :fdb-relational-grpc:check -PspotbugsEnableHtmlReport` — Checkstyle/PMD/SpotBugs/tests all pass
- [x] `./gradlew build -x test -x destructiveTest -x scalarFallbackTest -PspotbugsEnableHtmlReport` (full repo, matches CI's `style` job) — clean, including the `fdb-relational-server` fix
- [x] CI `style` check passing on this branch