### PR TITLE
Adopt jspecify + NullAway null-checking on fdb-relational-jdbc

### DIFF
--- a/fdb-relational-jdbc/fdb-relational-jdbc.gradle
+++ b/fdb-relational-jdbc/fdb-relational-jdbc.gradle
@@ -22,6 +22,7 @@ import org.yaml.snakeyaml.Yaml
 
 plugins {
     alias(libs.plugins.shadow)
+    alias(libs.plugins.errorprone)
 }
 
 
@@ -31,12 +32,16 @@ dependencies {
     implementation project(":fdb-relational-api")
     implementation project(":fdb-relational-grpc")
     implementation project(":fdb-extensions")
+    compileOnly(libs.jspecify)
     implementation(libs.grpc.inprocess)
     implementation(libs.grpc.netty)
     implementation(libs.grpc.protobuf)
     implementation(libs.grpc.stub)
     implementation(libs.grpc.services)
     implementation(libs.dropwizard)
+
+    errorprone(libs.errorprone.core)
+    errorprone(libs.nullaway)
 
     testImplementation(libs.bundles.test.impl)
     testRuntimeOnly(libs.bundles.test.runtime)
@@ -48,6 +53,20 @@ dependencies {
     // FDB Relational core test fixture in the TEST context only -- not in main!!!!
     testImplementation(testFixtures(project(":fdb-relational-core")))
     testImplementation(libs.grpc.testing)
+}
+
+// Pilot: jspecify + NullAway, scoped to this module only. See @NullMarked package-info.java in
+// com.apple.foundationdb.relational.jdbc (this module shares that package name with
+// fdb-relational-grpc's non-grpc package, but each module's compileJava only analyzes its own
+// classes). Companion PR to the fdb-relational-grpc pilot.
+tasks.withType(JavaCompile).configureEach {
+    options.errorprone {
+        disableAllChecks = true
+        error("NullAway")
+        option("NullAway:AnnotatedPackages", "com.apple.foundationdb.relational.jdbc")
+        option("NullAway:JSpecifyMode", "true")
+        option("NullAway:AcknowledgeRestrictiveAnnotations", "true")
+    }
 }
 
 // We only set FDB_CLUSTER_FILE here, to help ensure that none of the other tests use it, but these tests depend on

--- a/fdb-relational-jdbc/src/main/java/com/apple/foundationdb/relational/jdbc/JDBCArrayImpl.java
+++ b/fdb-relational-jdbc/src/main/java/com/apple/foundationdb/relational/jdbc/JDBCArrayImpl.java
@@ -22,7 +22,6 @@ package com.apple.foundationdb.relational.jdbc;
 
 import com.apple.foundationdb.relational.api.SqlTypeNamesSupport;
 
-import javax.annotation.Nonnull;
 import java.sql.Array;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -37,10 +36,9 @@ import java.util.Map;
  * {@link RelationalArrayFacade#getArray()} returns a type other than a Java array).
  */
 public class JDBCArrayImpl implements Array {
-    @Nonnull
     private final com.apple.foundationdb.relational.jdbc.grpc.v1.column.Array underlying;
 
-    public JDBCArrayImpl(@Nonnull final com.apple.foundationdb.relational.jdbc.grpc.v1.column.Array underlying) {
+    public JDBCArrayImpl(final com.apple.foundationdb.relational.jdbc.grpc.v1.column.Array underlying) {
         this.underlying = underlying;
     }
 
@@ -102,7 +100,6 @@ public class JDBCArrayImpl implements Array {
      * Package protected getter.
      * @return the underlying protobuf struct
      */
-    @Nonnull
     com.apple.foundationdb.relational.jdbc.grpc.v1.column.Array getUnderlying() {
         return underlying;
     }

--- a/fdb-relational-jdbc/src/main/java/com/apple/foundationdb/relational/jdbc/JDBCRelationalConnection.java
+++ b/fdb-relational-jdbc/src/main/java/com/apple/foundationdb/relational/jdbc/JDBCRelationalConnection.java
@@ -51,8 +51,8 @@ import io.grpc.StatusRuntimeException;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.protobuf.StatusProto;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import java.io.Closeable;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
@@ -67,6 +67,7 @@ import java.sql.Struct;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -104,6 +105,7 @@ class JDBCRelationalConnection implements RelationalConnection {
     private volatile boolean closed;
     private final ManagedChannel managedChannel;
     private final String database;
+    @Nullable
     private String schema;
     private final JDBCServiceGrpc.JDBCServiceBlockingStub blockingStub;
     private final JDBCServiceGrpc.JDBCServiceStub asyncStub;
@@ -111,12 +113,14 @@ class JDBCRelationalConnection implements RelationalConnection {
      * Handler for server transactional responses.
      * Used to receive and buffer the results, synchronizing response after requests have been sent.
      */
+    @Nullable
     private StatefulServerConnection serverConnection;
 
     /**
      * If inprocess, this will be set and needs to be called on close.
      * Its an in-process server instance started by us.
      */
+    @Nullable
     private Closeable closeable;
 
     private Options options;
@@ -190,11 +194,11 @@ class JDBCRelationalConnection implements RelationalConnection {
         return this.blockingStub;
     }
 
-    public StatementResponse execute(String sql, Options options, Collection<Parameter> parameters) throws SQLException {
+    public StatementResponse execute(String sql, Options options, @Nullable Collection<Parameter> parameters) throws SQLException {
         StatementRequest.Builder builder = StatementRequest.newBuilder()
                 .setSql(sql)
                 .setDatabase(getDatabase()) // TODO: for transactional execution these are not required
-                .setSchema(getSchema())
+                .setSchema(Objects.requireNonNullElse(getSchema(), ""))
                 .setOptions(TypeConversion.toProtobuf(options));
         if (parameters != null) {
             builder.setParameters(Parameters.newBuilder().addAllParameter(parameters).build());
@@ -209,7 +213,7 @@ class JDBCRelationalConnection implements RelationalConnection {
                 TransactionalRequest.Builder transactionRequest = TransactionalRequest.newBuilder()
                         .setExecuteRequest(builder);
                 // Wait here until a response arrives
-                final TransactionalResponse response = serverConnection.sendRequest(transactionRequest.build());
+                final TransactionalResponse response = Objects.requireNonNull(serverConnection).sendRequest(transactionRequest.build());
                 checkForResponseError(response);
                 if (!response.hasExecuteResponse()) {
                     throw new JdbcConnectionException("Wrong kind of response received, expected ExecuteResponse");
@@ -226,11 +230,11 @@ class JDBCRelationalConnection implements RelationalConnection {
         }
     }
 
-    public InsertResponse insert(@Nonnull String tableName, @Nonnull List<RelationalStruct> data) throws SQLException {
+    public InsertResponse insert(String tableName, List<RelationalStruct> data) throws SQLException {
         InsertRequest.Builder builder = InsertRequest.newBuilder()
                 .setDataResultSet(TypeConversion.toResultSetProtobuf(data))
                 .setDatabase(getDatabase())
-                .setSchema(getSchema())
+                .setSchema(Objects.requireNonNullElse(getSchema(), ""))
                 .setTableName(tableName)
                 .setOptions(TypeConversion.toProtobuf(options));
         try {
@@ -242,7 +246,7 @@ class JDBCRelationalConnection implements RelationalConnection {
                 TransactionalRequest.Builder transactionalRequest = TransactionalRequest.newBuilder()
                         .setInsertRequest(builder);
                 // Wait here until a response arrives
-                final TransactionalResponse response = serverConnection.sendRequest(transactionalRequest.build());
+                final TransactionalResponse response = Objects.requireNonNull(serverConnection).sendRequest(transactionalRequest.build());
                 checkForResponseError(response);
                 if (!response.hasInsertResponse()) {
                     throw new JdbcConnectionException("Wrong kind of response received, expected InsertResponse");
@@ -269,7 +273,7 @@ class JDBCRelationalConnection implements RelationalConnection {
                 TransactionalRequest.Builder transactionRequest = TransactionalRequest.newBuilder()
                         .setCommitRequest(CommitRequest.newBuilder().build());
                 // wait here for response
-                final TransactionalResponse response = serverConnection.sendRequest(transactionRequest.build());
+                final TransactionalResponse response = Objects.requireNonNull(serverConnection).sendRequest(transactionRequest.build());
                 checkForResponseError(response);
                 if (!response.hasCommitResponse()) {
                     throw new JdbcConnectionException("Wrong kind of response received, expected CommitResponse");
@@ -293,7 +297,7 @@ class JDBCRelationalConnection implements RelationalConnection {
             } else {
                 TransactionalRequest.Builder transactionRequest = TransactionalRequest.newBuilder()
                         .setRollbackRequest(RollbackRequest.newBuilder().build());
-                final TransactionalResponse response = serverConnection.sendRequest(transactionRequest.build());
+                final TransactionalResponse response = Objects.requireNonNull(serverConnection).sendRequest(transactionRequest.build());
                 checkForResponseError(response);
                 if (!response.hasRollbackResponse()) {
                     throw new JdbcConnectionException("Wrong kind of response received, expected RollbackResponse");
@@ -352,7 +356,7 @@ class JDBCRelationalConnection implements RelationalConnection {
                 TransactionalRequest.Builder transactionRequest = TransactionalRequest.newBuilder()
                         .setEnableAutoCommitRequest(EnableAutoCommitRequest.newBuilder().setOptions(TypeConversion.toProtobuf(options)).build());
                 // wait here for response
-                final TransactionalResponse response = serverConnection.sendRequest(transactionRequest.build());
+                final TransactionalResponse response = Objects.requireNonNull(serverConnection).sendRequest(transactionRequest.build());
                 checkForResponseError(response);
                 if (!response.hasEnableAutoCommitResponse()) {
                     throw new JdbcConnectionException("Wrong kind of response received, expected EnableAutoCommitResponse");
@@ -366,7 +370,7 @@ class JDBCRelationalConnection implements RelationalConnection {
                 }
             }
             this.autoCommit = true;
-            serverConnection.close();
+            Objects.requireNonNull(serverConnection).close();
             serverConnection = null;
         }
     }
@@ -392,6 +396,7 @@ class JDBCRelationalConnection implements RelationalConnection {
     }
 
     @Override
+    @Nullable
     public SQLWarning getWarnings() throws SQLException {
         // TODO: For now just return null
         return null;
@@ -414,6 +419,7 @@ class JDBCRelationalConnection implements RelationalConnection {
     }
 
     @Override
+    @Nullable
     public Struct createStruct(String typeName, Object[] attributes) throws SQLException {
         // TODO: Implement: https://github.com/FoundationDB/fdb-record-layer/issues/4064
         return null;
@@ -457,18 +463,18 @@ class JDBCRelationalConnection implements RelationalConnection {
         return new JDBCRelationalDatabaseMetaData(this, getStub().getMetaData(request));
     }
 
-    @Nonnull
     @Override
     public Options getOptions() {
         return options;
     }
 
     @Override
-    public void setOption(@Nonnull Options.Name name, Object value) throws SQLException {
+    public void setOption(Options.Name name, Object value) throws SQLException {
         options = options.withOption(name, value);
     }
 
     @Override
+    @Nullable
     public URI getPath() {
         return null;
     }
@@ -479,6 +485,7 @@ class JDBCRelationalConnection implements RelationalConnection {
     }
 
     @Override
+    @Nullable
     public String getSchema() throws SQLException {
         return this.schema;
     }

--- a/fdb-relational-jdbc/src/main/java/com/apple/foundationdb/relational/jdbc/JDBCRelationalDatabaseMetaData.java
+++ b/fdb-relational-jdbc/src/main/java/com/apple/foundationdb/relational/jdbc/JDBCRelationalDatabaseMetaData.java
@@ -29,7 +29,6 @@ import com.apple.foundationdb.relational.jdbc.grpc.v1.DatabaseMetaDataResponse;
 import com.apple.foundationdb.relational.util.BuildVersion;
 import com.apple.foundationdb.relational.util.ExcludeFromJacocoGeneratedReport;
 
-import javax.annotation.Nonnull;
 import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.DriverManager;
@@ -108,7 +107,6 @@ class JDBCRelationalDatabaseMetaData implements RelationalDatabaseMetaData {
         return level == getDefaultTransactionIsolation();
     }
 
-    @Nonnull
     @Override
     @ExcludeFromJacocoGeneratedReport
     public RelationalResultSet getSchemas() throws SQLException {
@@ -131,7 +129,6 @@ class JDBCRelationalDatabaseMetaData implements RelationalDatabaseMetaData {
         }
     }
 
-    @Nonnull
     @Override
     @ExcludeFromJacocoGeneratedReport
     public RelationalResultSet getColumns(String catalog, String schema, String table, String column) throws SQLException {

--- a/fdb-relational-jdbc/src/main/java/com/apple/foundationdb/relational/jdbc/JDBCRelationalDriver.java
+++ b/fdb-relational-jdbc/src/main/java/com/apple/foundationdb/relational/jdbc/JDBCRelationalDriver.java
@@ -25,7 +25,8 @@ import com.apple.foundationdb.relational.api.Options;
 import com.apple.foundationdb.relational.api.RelationalConnection;
 import com.apple.foundationdb.relational.api.RelationalDriver;
 
-import javax.annotation.Nonnull;
+import org.jspecify.annotations.Nullable;
+
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.sql.DriverManager;
@@ -58,13 +59,15 @@ public class JDBCRelationalDriver implements RelationalDriver {
     }
 
     @Override
+    @Nullable
     public RelationalConnection connect(String url, Properties info) throws SQLException {
         return connect(URI.create(url), Options.fromProperties(info));
     }
 
     @Override
-    public RelationalConnection connect(@Nonnull URI url,
-                                        @Nonnull Options connectionOptions) throws SQLException {
+    @Nullable
+    public RelationalConnection connect(URI url,
+                                        Options connectionOptions) throws SQLException {
         final var urlString = url.toString();
         if (!acceptsURL(urlString)) {
             return null;

--- a/fdb-relational-jdbc/src/main/java/com/apple/foundationdb/relational/jdbc/JDBCRelationalPreparedStatement.java
+++ b/fdb-relational-jdbc/src/main/java/com/apple/foundationdb/relational/jdbc/JDBCRelationalPreparedStatement.java
@@ -26,7 +26,8 @@ import com.apple.foundationdb.relational.api.exceptions.ErrorCode;
 import com.apple.foundationdb.relational.jdbc.grpc.v1.Parameter;
 import com.apple.foundationdb.relational.util.ExcludeFromJacocoGeneratedReport;
 
-import javax.annotation.Nonnull;
+import org.jspecify.annotations.Nullable;
+
 import java.sql.Array;
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -53,7 +54,7 @@ class JDBCRelationalPreparedStatement implements RelationalPreparedStatement {
 
     private final String sql;
 
-    JDBCRelationalPreparedStatement(@Nonnull String sql, @Nonnull final JDBCRelationalConnection connection) throws SQLException {
+    JDBCRelationalPreparedStatement(String sql, final JDBCRelationalConnection connection) throws SQLException {
         this.statement = new JDBCRelationalStatement(connection);
         this.sql = sql;
     }
@@ -238,6 +239,7 @@ class JDBCRelationalPreparedStatement implements RelationalPreparedStatement {
     }
 
     @Override
+    @Nullable
     public SQLWarning getWarnings() throws SQLException {
         return this.statement.getWarnings();
     }

--- a/fdb-relational-jdbc/src/main/java/com/apple/foundationdb/relational/jdbc/JDBCRelationalStatement.java
+++ b/fdb-relational-jdbc/src/main/java/com/apple/foundationdb/relational/jdbc/JDBCRelationalStatement.java
@@ -38,8 +38,8 @@ import com.apple.foundationdb.relational.jdbc.grpc.v1.StatementResponse;
 import com.apple.foundationdb.relational.util.SpotBugsSuppressWarnings;
 import io.grpc.StatusRuntimeException;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.SQLWarning;
@@ -48,11 +48,11 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 
 
 class JDBCRelationalStatement implements RelationalStatement {
     private volatile boolean closed;
-    @Nonnull
     private final JDBCRelationalConnection connection;
     @Nullable
     private RelationalResultSet currentResultSet;
@@ -81,7 +81,7 @@ class JDBCRelationalStatement implements RelationalStatement {
     private Options options;
 
     @SpotBugsSuppressWarnings(value = "CT_CONSTRUCTOR_THROW", justification = "Should consider refactoring but throwing exceptions for now")
-    JDBCRelationalStatement(@Nonnull final JDBCRelationalConnection connection) throws SQLException {
+    JDBCRelationalStatement(final JDBCRelationalConnection connection) throws SQLException {
         this.connection = connection;
         this.options = connection.getOptions().withChild(Options.NONE);
     }
@@ -101,9 +101,9 @@ class JDBCRelationalStatement implements RelationalStatement {
     }
 
     @Override
-    public RelationalResultSet executeQuery(@Nonnull String sql) throws SQLException {
+    public RelationalResultSet executeQuery(String sql) throws SQLException {
         if (execute(sql)) {
-            return this.currentResultSet;
+            return Objects.requireNonNull(this.currentResultSet);
         } else {
             throw new SQLException("Cannot call executeQuery with an update statement", ErrorCode.INVALID_PARAMETER.getErrorCode());
         }
@@ -116,16 +116,16 @@ class JDBCRelationalStatement implements RelationalStatement {
      * @return ResultSet object that contains the data produced by the given query; never null
      * @throws SQLException if a database access error occurs or this method is called on a closed Statement
      */
-    RelationalResultSet executeQuery(@Nonnull String sql, Collection<Parameter> parameters) throws SQLException {
+    RelationalResultSet executeQuery(String sql, @Nullable Collection<Parameter> parameters) throws SQLException {
         if (execute(sql, parameters)) {
-            return currentResultSet;
+            return Objects.requireNonNull(currentResultSet);
         } else {
             throw new SQLException(String.format(Locale.ROOT, "query '%s' does not return result set, use JDBC executeUpdate method instead", sql), ErrorCode.NO_RESULT_SET.getErrorCode());
         }
     }
 
     @Override
-    public int executeUpdate(@Nonnull String sql) throws SQLException {
+    public int executeUpdate(String sql) throws SQLException {
         return executeUpdate(sql, (Collection<Parameter>) null);
     }
 
@@ -137,7 +137,7 @@ class JDBCRelationalStatement implements RelationalStatement {
      *  that return nothing
      * @throws SQLException if a database access error occurs or this method is called on a closed Statement
      */
-    int executeUpdate(@Nonnull String sql, Collection<Parameter> parameters) throws SQLException {
+    int executeUpdate(String sql, @Nullable Collection<Parameter> parameters) throws SQLException {
         if (execute(sql, parameters)) {
             throw new SQLException(String.format(Locale.ROOT, "query '%s' returns a result set, use JDBC executeQuery method instead", sql), ErrorCode.EXECUTE_UPDATE_RETURNED_RESULT_SET.getErrorCode());
         }
@@ -151,7 +151,7 @@ class JDBCRelationalStatement implements RelationalStatement {
      * @return true if the execution produced a result set, false otherwise
      * @throws SQLException if a database access error occurs or this method is called on a closed Statement
      */
-    boolean execute(@Nonnull String sql, Collection<Parameter> parameters) throws SQLException {
+    boolean execute(String sql, @Nullable Collection<Parameter> parameters) throws SQLException {
         StatementResponse response = execute(sql, this.options, parameters);
         this.currentResultSet = response.hasResultSet() ?
                 new RelationalResultSetFacade(response.getResultSet()) : RelationalResultSetFacade.EMPTY;
@@ -169,7 +169,7 @@ class JDBCRelationalStatement implements RelationalStatement {
      * @throws SQLException if a database access error occurs or this method is called on a closed Statement
      */
     @SuppressWarnings({"PMD.UnusedFormalParameter"}) // Will use it later.
-    private StatementResponse execute(@Nonnull String sql, @Nonnull Options options, Collection<Parameter> parameters)
+    private StatementResponse execute(String sql, Options options, @Nullable Collection<Parameter> parameters)
             throws SQLException {
         checkOpen();
         // Punt on transaction/autocommit consideration for now (autocommit==true).
@@ -204,6 +204,7 @@ class JDBCRelationalStatement implements RelationalStatement {
     }
 
     @Override
+    @Nullable
     public SQLWarning getWarnings() throws SQLException {
         // TODO: For now just return null.
         return null;
@@ -245,17 +246,17 @@ class JDBCRelationalStatement implements RelationalStatement {
         return this.closed;
     }
 
-    @Nonnull
     @Override
+    @SuppressWarnings("NullAway") // returns null, violating the @Nonnull contract of RelationalDirectAccessStatement#executeGet. Temporary until implemented; see the SpotBugsSuppressWarnings below.
     @SpotBugsSuppressWarnings(value = "NP_NONNULL_RETURN_VIOLATION", justification = "Temporary until implemented.")
-    public RelationalResultSet executeGet(@Nonnull String tableName, @Nonnull KeySet keySet, @Nonnull Options options) throws SQLException {
+    public RelationalResultSet executeGet(String tableName, KeySet keySet, Options options) throws SQLException {
         checkOpen();
         GetResponse getResponse;
         try {
             getResponse = this.connection.getStub().get(GetRequest.newBuilder()
                     .setKeySet(TypeConversion.toProtobuf(keySet))
                     .setDatabase(this.connection.getDatabase())
-                    .setSchema(this.connection.getSchema())
+                    .setSchema(Objects.requireNonNullElse(this.connection.getSchema(), ""))
                     .setTableName(tableName)
                     .build());
         } catch (StatusRuntimeException statusRuntimeException) {
@@ -270,10 +271,10 @@ class JDBCRelationalStatement implements RelationalStatement {
         return getResponse == null ? null : new RelationalResultSetFacade(getResponse.getResultSet());
     }
 
-    @Nonnull
     @Override
+    @SuppressWarnings("NullAway") // returns null, violating the @Nonnull contract of RelationalDirectAccessStatement#executeScan. Temporary until implemented; see the SpotBugsSuppressWarnings below.
     @SpotBugsSuppressWarnings(value = "NP_NONNULL_RETURN_VIOLATION", justification = "Temporary until implemented.")
-    public RelationalResultSet executeScan(@Nonnull String tableName, @Nonnull KeySet keySet, @Nonnull Options options)
+    public RelationalResultSet executeScan(String tableName, KeySet keySet, Options options)
             throws SQLException {
         checkOpen();
         ScanResponse response;
@@ -281,7 +282,7 @@ class JDBCRelationalStatement implements RelationalStatement {
             response = this.connection.getStub().scan(ScanRequest.newBuilder()
                     .setKeySet(TypeConversion.toProtobuf(keySet))
                     .setDatabase(this.connection.getDatabase())
-                    .setSchema(this.connection.getSchema())
+                    .setSchema(Objects.requireNonNullElse(this.connection.getSchema(), ""))
                     .setTableName(tableName)
                     .build());
         } catch (StatusRuntimeException statusRuntimeException) {
@@ -296,7 +297,7 @@ class JDBCRelationalStatement implements RelationalStatement {
     }
 
     @Override
-    public int executeInsert(@Nonnull String tableName, @Nonnull List<RelationalStruct> data, @Nonnull Options options)
+    public int executeInsert(String tableName, List<RelationalStruct> data, Options options)
             throws SQLException {
         checkOpen();
         InsertResponse insertResponse = connection.insert(tableName, data);
@@ -305,13 +306,13 @@ class JDBCRelationalStatement implements RelationalStatement {
     }
 
     @Override
-    public int executeDelete(@Nonnull String tableName, @Nonnull Iterator<KeySet> keys, @Nonnull Options options) throws SQLException {
+    public int executeDelete(String tableName, Iterator<KeySet> keys, Options options) throws SQLException {
         checkOpen();
         return -1;
     }
 
     @Override
-    public void executeDeleteRange(@Nonnull String tableName, @Nonnull KeySet keyPrefix, @Nonnull Options options) throws SQLException {
+    public void executeDeleteRange(String tableName, KeySet keyPrefix, Options options) throws SQLException {
         checkOpen();
     }
 }

--- a/fdb-relational-jdbc/src/main/java/com/apple/foundationdb/relational/jdbc/JDBCURI.java
+++ b/fdb-relational-jdbc/src/main/java/com/apple/foundationdb/relational/jdbc/JDBCURI.java
@@ -22,7 +22,8 @@ package com.apple.foundationdb.relational.jdbc;
 
 import com.apple.foundationdb.annotation.API;
 
-import javax.annotation.Nonnull;
+import org.jspecify.annotations.Nullable;
+
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URLDecoder;
@@ -63,6 +64,7 @@ public final class JDBCURI {
      * @param map Map to search.
      * @return First value in values list or null if no values found.
      */
+    @Nullable
     public static String getFirstValue(String key, Map<String, List<String>> map) {
         List<String> values = map.get(key);
         return values == null ? null : values.get(0);
@@ -74,7 +76,6 @@ public final class JDBCURI {
      * @param  uri JDBC Connect URL.
      * @return Map of lists of query string parameters keyed by query parameter name.
      */
-    @Nonnull
     public static Map<String, List<String>> splitQuery(URI uri) {
         final Map<String, List<String>> params = new LinkedHashMap<>();
         if (uri.getQuery() == null || uri.getQuery().length() <= 0) {

--- a/fdb-relational-jdbc/src/main/java/com/apple/foundationdb/relational/jdbc/ParameterHelper.java
+++ b/fdb-relational-jdbc/src/main/java/com/apple/foundationdb/relational/jdbc/ParameterHelper.java
@@ -34,11 +34,13 @@ import com.apple.foundationdb.relational.jdbc.grpc.v1.column.Uuid;
 import com.apple.foundationdb.relational.jdbc.grpc.v1.column.VectorMetadata;
 import com.google.protobuf.ByteString;
 
-import javax.annotation.Nonnull;
+import org.jspecify.annotations.Nullable;
+
 import java.sql.Array;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 public class ParameterHelper {
@@ -114,7 +116,7 @@ public class ParameterHelper {
                 .build();
     }
 
-    public static int getVectorPrecision(@Nonnull final RealVector vector) throws SQLException {
+    public static int getVectorPrecision(final RealVector vector) throws SQLException {
         if (vector instanceof DoubleRealVector) {
             return 64;
         }
@@ -162,7 +164,7 @@ public class ParameterHelper {
                 .build();
     }
 
-    public static Parameter ofObject(Object x) throws SQLException {
+    public static Parameter ofObject(@Nullable Object x) throws SQLException {
         // We need to keep an exception for the case of Array, because JDBC client array creations does not inherit
         // RelationalArray. Since the Relational dataType works with Relational constructs, this is an exception. We
         // should probably strive to bring this under Relational umbrella, until then treat the case separately.
@@ -172,23 +174,23 @@ public class ParameterHelper {
         final DataType type = DataType.getDataTypeFromObject(x);
         switch (type.getCode()) {
             case LONG:
-                return ofLong((Long)x);
+                return ofLong((Long)Objects.requireNonNull(x));
             case INTEGER:
-                return ofInt((Integer)x);
+                return ofInt((Integer)Objects.requireNonNull(x));
             case BOOLEAN:
-                return ofBoolean((Boolean)x);
+                return ofBoolean((Boolean)Objects.requireNonNull(x));
             case BYTES:
-                return ofBytes((byte[])x);
+                return ofBytes((byte[])Objects.requireNonNull(x));
             case FLOAT:
-                return ofFloat((Float)x);
+                return ofFloat((Float)Objects.requireNonNull(x));
             case DOUBLE:
-                return ofDouble((Double)x);
+                return ofDouble((Double)Objects.requireNonNull(x));
             case STRING:
-                return ofString((String)x);
+                return ofString((String)Objects.requireNonNull(x));
             case UUID:
-                return ofUUID((UUID)x);
+                return ofUUID((UUID)Objects.requireNonNull(x));
             case VECTOR:
-                return ofVector((RealVector)x);
+                return ofVector((RealVector)Objects.requireNonNull(x));
             case NULL:
                 return ofNull(type.getJdbcSqlCode()); // TODO: This would be generic null...
             default:

--- a/fdb-relational-jdbc/src/main/java/com/apple/foundationdb/relational/jdbc/StatefulServerConnection.java
+++ b/fdb-relational-jdbc/src/main/java/com/apple/foundationdb/relational/jdbc/StatefulServerConnection.java
@@ -24,10 +24,11 @@ import com.apple.foundationdb.relational.jdbc.grpc.v1.TransactionalRequest;
 import com.apple.foundationdb.relational.jdbc.grpc.v1.TransactionalResponse;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
+import java.util.Objects;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -51,6 +52,7 @@ public final class StatefulServerConnection implements StreamObserver<Transactio
     /**
      * An RPC observer for outgoing requests.
      */
+    @Nullable
     private StreamObserver<TransactionalRequest> requestSender;
 
     /**
@@ -79,7 +81,7 @@ public final class StatefulServerConnection implements StreamObserver<Transactio
     public TransactionalResponse sendRequest(TransactionalRequest request) {
         checkClosed();
         try {
-            requestSender.onNext(request);
+            Objects.requireNonNull(requestSender).onNext(request);
         } catch (StatusRuntimeException ex) {
             // Close the connection when failed to send to server
             close(ex);

--- a/fdb-relational-jdbc/src/main/java/com/apple/foundationdb/relational/jdbc/package-info.java
+++ b/fdb-relational-jdbc/src/main/java/com/apple/foundationdb/relational/jdbc/package-info.java
@@ -58,7 +58,10 @@
  * phenomenon as we learn of the type of exceptions we'll be seeing. We've installed an interceptor for the JDBCService
  * to catch unhandled SQLExceptions and which we can enhance as we learn more about the types of problems we'll see.
  */
+@NullMarked
 package com.apple.foundationdb.relational.jdbc;
+
+import org.jspecify.annotations.NullMarked;
 
 // Names in this package are overwrought; we are in the relational.jdbc package yet names have a JDBCRelational prefix.
 // Ideally, the JDBCRelationalDriver class (com.apple.foundationdb.relational.jdbc.JDBCRelationalDriver) would be known as

--- a/fdb-relational-jdbc/src/test/java/com/apple/foundationdb/relational/jdbc/JDBCParameterizedQueryComparisonTest.java
+++ b/fdb-relational-jdbc/src/test/java/com/apple/foundationdb/relational/jdbc/JDBCParameterizedQueryComparisonTest.java
@@ -31,6 +31,7 @@ import com.apple.foundationdb.test.FDBTestEnvironment;
 import com.apple.test.ParameterizedTestUtils;
 import com.apple.test.RandomizedTestUtils;
 import com.google.protobuf.ByteString;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -41,8 +42,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.sql.Array;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -70,9 +69,7 @@ import java.util.stream.Stream;
  */
 public class JDBCParameterizedQueryComparisonTest {
 
-    @Nonnull
     private static final String SYS_DB_PATH = "/" + RelationalKeyspaceProvider.SYS;
-    @Nonnull
     private static final String SCHEMA_NAME = "test_schema";
     private static final long PRIMARY_KEY = 1;
 
@@ -93,172 +90,156 @@ public class JDBCParameterizedQueryComparisonTest {
      */
     enum TypeTestCase {
         BIGINT("bigint", "", "BIGINT") {
-            @Nonnull
             @Override
-            Object createValue(@Nonnull Connection conn, @Nonnull Random random) {
+            Object createValue(Connection conn, Random random) {
                 return random.nextLong();
             }
 
             @Override
-            void setTyped(@Nonnull PreparedStatement statement, int parameterIndex, @Nonnull Object val) throws SQLException {
+            void setTyped(PreparedStatement statement, int parameterIndex, Object val) throws SQLException {
                 statement.setLong(parameterIndex, (Long)val);
             }
 
-            @Nonnull
             @Override
-            Object getTyped(@Nonnull ResultSet resultSet, int columnIndex) throws SQLException {
+            Object getTyped(ResultSet resultSet, int columnIndex) throws SQLException {
                 return resultSet.getLong(columnIndex);
             }
         },
         INTEGER("integer", "", "INTEGER") {
-            @Nonnull
             @Override
-            Object createValue(@Nonnull Connection conn, @Nonnull Random random) {
+            Object createValue(Connection conn, Random random) {
                 return random.nextInt();
             }
 
             @Override
-            void setTyped(@Nonnull PreparedStatement statement, int parameterIndex, @Nonnull Object val) throws SQLException {
+            void setTyped(PreparedStatement statement, int parameterIndex, Object val) throws SQLException {
                 statement.setInt(parameterIndex, (Integer)val);
             }
 
-            @Nonnull
             @Override
-            Object getTyped(@Nonnull ResultSet resultSet, int columnIndex) throws SQLException {
+            Object getTyped(ResultSet resultSet, int columnIndex) throws SQLException {
                 return resultSet.getInt(columnIndex);
             }
         },
         DOUBLE("double", "", "DOUBLE") {
-            @Nonnull
             @Override
-            Object createValue(@Nonnull Connection conn, @Nonnull Random random) {
+            Object createValue(Connection conn, Random random) {
                 return random.nextDouble();
             }
 
             @Override
-            void setTyped(@Nonnull PreparedStatement statement, int parameterIndex, @Nonnull Object val) throws SQLException {
+            void setTyped(PreparedStatement statement, int parameterIndex, Object val) throws SQLException {
                 statement.setDouble(parameterIndex, (Double)val);
             }
 
-            @Nonnull
             @Override
-            Object getTyped(@Nonnull ResultSet resultSet, int columnIndex) throws SQLException {
+            Object getTyped(ResultSet resultSet, int columnIndex) throws SQLException {
                 return resultSet.getDouble(columnIndex);
             }
 
             @Override
-            void assertEquals(@Nonnull String message, @Nonnull Object expected, @Nonnull Object actual) {
+            void assertEquals(String message, Object expected, Object actual) {
                 Assertions.assertEquals(((Number)expected).doubleValue(),
                         ((Number)actual).doubleValue(), 1e-10, message);
             }
         },
         FLOAT("float", "", "FLOAT") {
-            @Nonnull
             @Override
-            Object createValue(@Nonnull Connection conn, @Nonnull Random random) {
+            Object createValue(Connection conn, Random random) {
                 return random.nextFloat();
             }
 
             @Override
-            void setTyped(@Nonnull PreparedStatement statement, int parameterIndex, @Nonnull Object val) throws SQLException {
+            void setTyped(PreparedStatement statement, int parameterIndex, Object val) throws SQLException {
                 statement.setFloat(parameterIndex, (Float)val);
             }
 
-            @Nonnull
             @Override
-            Object getTyped(@Nonnull ResultSet resultSet, int columnIndex) throws SQLException {
+            Object getTyped(ResultSet resultSet, int columnIndex) throws SQLException {
                 return resultSet.getFloat(columnIndex);
             }
 
             @Override
-            void assertEquals(@Nonnull String message, @Nonnull Object expected, @Nonnull Object actual) {
+            void assertEquals(String message, Object expected, Object actual) {
                 Assertions.assertEquals(((Number)expected).floatValue(),
                         ((Number)actual).floatValue(), 0.001f, message);
             }
         },
         STRING("string", "", "STRING") {
-            @Nonnull
             @Override
-            Object createValue(@Nonnull Connection conn, @Nonnull Random random) {
+            Object createValue(Connection conn, Random random) {
                 return randomAlphanumericString(random, random.nextInt(20) + 1);
             }
 
             @Override
-            void setTyped(@Nonnull PreparedStatement statement, int parameterIndex, @Nonnull Object val) throws SQLException {
+            void setTyped(PreparedStatement statement, int parameterIndex, Object val) throws SQLException {
                 statement.setString(parameterIndex, (String)val);
             }
 
-            @Nonnull
             @Override
-            Object getTyped(@Nonnull ResultSet resultSet, int columnIndex) throws SQLException {
+            Object getTyped(ResultSet resultSet, int columnIndex) throws SQLException {
                 return resultSet.getString(columnIndex);
             }
         },
         BOOLEAN("boolean", "", "BOOLEAN") {
-            @Nonnull
             @Override
-            Object createValue(@Nonnull Connection conn, @Nonnull Random random) {
+            Object createValue(Connection conn, Random random) {
                 return random.nextBoolean();
             }
 
             @Override
-            void setTyped(@Nonnull PreparedStatement statement, int parameterIndex, @Nonnull Object val) throws SQLException {
+            void setTyped(PreparedStatement statement, int parameterIndex, Object val) throws SQLException {
                 statement.setBoolean(parameterIndex, (Boolean)val);
             }
 
-            @Nonnull
             @Override
-            Object getTyped(@Nonnull ResultSet resultSet, int columnIndex) throws SQLException {
+            Object getTyped(ResultSet resultSet, int columnIndex) throws SQLException {
                 return resultSet.getBoolean(columnIndex);
             }
         },
         BYTES("bytes", "", "BINARY") {
-            @Nonnull
             @Override
-            Object createValue(@Nonnull Connection conn, @Nonnull Random random) {
+            Object createValue(Connection conn, Random random) {
                 byte[] bytes = new byte[random.nextInt(20) + 1];
                 random.nextBytes(bytes);
                 return bytes;
             }
 
             @Override
-            void setTyped(@Nonnull PreparedStatement statement, int parameterIndex, @Nonnull Object val) throws SQLException {
+            void setTyped(PreparedStatement statement, int parameterIndex, Object val) throws SQLException {
                 statement.setBytes(parameterIndex, (byte[])val);
             }
 
-            @Nonnull
             @Override
-            Object getTyped(@Nonnull ResultSet resultSet, int columnIndex) throws SQLException {
+            Object getTyped(ResultSet resultSet, int columnIndex) throws SQLException {
                 return resultSet.getBytes(columnIndex);
             }
 
             @Override
-            void assertEquals(@Nonnull String message, @Nonnull Object expected, @Nonnull Object actual) {
+            void assertEquals(String message, Object expected, Object actual) {
                 Assertions.assertArrayEquals((byte[])expected, (byte[])actual, message);
             }
         },
         STRUCT("MyStruct", "CREATE TYPE AS STRUCT MyStruct (f0 bigint, f1 string)", null) {
-            @Nonnull
             @Override
-            Object createValue(@Nonnull Connection conn, @Nonnull Random random) throws SQLException {
+            Object createValue(Connection conn, Random random) throws SQLException {
                 return conn.createStruct("MyStruct", new Object[] {random.nextLong(),
                         randomAlphanumericString(random, random.nextInt(20) + 1)});
             }
 
             @Override
-            void setTyped(@Nonnull PreparedStatement statement, int parameterIndex, @Nonnull Object val) throws SQLException {
+            void setTyped(PreparedStatement statement, int parameterIndex, Object val) throws SQLException {
                 statement.setObject(parameterIndex, val);
             }
 
-            @Nonnull
             @Override
-            Object getTyped(@Nonnull ResultSet resultSet, int columnIndex) throws SQLException {
+            Object getTyped(ResultSet resultSet, int columnIndex) throws SQLException {
                 RelationalResultSet rrs = resultSet.unwrap(RelationalResultSet.class);
                 return rrs.getStruct(columnIndex);
             }
 
             @Override
-            void assertEquals(@Nonnull String message, @Nonnull Object expected, @Nonnull Object actual) {
+            void assertEquals(String message, Object expected, Object actual) {
                 try {
                     RelationalStruct expStruct = (RelationalStruct)expected;
                     RelationalStruct actStruct = (RelationalStruct)actual;
@@ -275,9 +256,7 @@ public class JDBCParameterizedQueryComparisonTest {
             }
         };
 
-        @Nonnull
         private final String columnDdl;
-        @Nonnull
         private final String extraTypeDdl;
         /**
          * The SQL type name for use with {@code createArrayOf}, or {@code null} if this type cannot be an array
@@ -286,7 +265,7 @@ public class JDBCParameterizedQueryComparisonTest {
         @Nullable
         private final String arrayTypeName;
 
-        TypeTestCase(@Nonnull String columnDdl, @Nonnull String extraTypeDdl,
+        TypeTestCase(String columnDdl, String extraTypeDdl,
                      @Nullable String arrayTypeName) {
             this.columnDdl = columnDdl;
             this.extraTypeDdl = extraTypeDdl;
@@ -296,20 +275,17 @@ public class JDBCParameterizedQueryComparisonTest {
         /**
          * Create a random value of this type, suitable for insertion into the test table.
          */
-        @Nonnull
-        abstract Object createValue(@Nonnull Connection conn, @Nonnull Random random) throws SQLException;
+        abstract Object createValue(Connection conn, Random random) throws SQLException;
 
-        abstract void setTyped(@Nonnull PreparedStatement statement, int parameterIndex, @Nonnull Object val) throws SQLException;
+        abstract void setTyped(PreparedStatement statement, int parameterIndex, Object val) throws SQLException;
 
-        @Nonnull
-        abstract Object getTyped(@Nonnull ResultSet resultSet, int columnIndex) throws SQLException;
+        abstract Object getTyped(ResultSet resultSet, int columnIndex) throws SQLException;
 
-        void assertEquals(@Nonnull String message, @Nonnull Object expected, @Nonnull Object actual) {
+        void assertEquals(String message, Object expected, Object actual) {
             Assertions.assertEquals(expected, actual, message);
         }
 
-        @Nonnull
-        private static String randomAlphanumericString(@Nonnull Random random, int length) {
+        private static String randomAlphanumericString(Random random, int length) {
             char[] chars = new char[length];
             for (int i = 0; i < length; i++) {
                 chars[i] = (char)('a' + random.nextInt(26));
@@ -324,8 +300,7 @@ public class JDBCParameterizedQueryComparisonTest {
          * {@link JDBCArrayImpl#getResultSet()} throws {@code SQLFeatureNotSupportedException}.
          * See <a href="https://github.com/FoundationDB/fdb-record-layer/issues/3665">#3665</a>
          */
-        @Nonnull
-        static List<Object> extractArrayElements(@Nonnull Object arrayObj) throws SQLException {
+        static List<Object> extractArrayElements(Object arrayObj) throws SQLException {
             List<Object> elements = new ArrayList<>();
             if (arrayObj instanceof RelationalArray) {
                 RelationalResultSet rs = ((RelationalArray)arrayObj).getResultSet();
@@ -386,7 +361,6 @@ public class JDBCParameterizedQueryComparisonTest {
         }
     }
 
-    @Nonnull
     static Stream<Arguments> testCases() {
         return ParameterizedTestUtils.cartesianProduct(
                 RandomizedTestUtils.randomSeeds(),
@@ -399,7 +373,7 @@ public class JDBCParameterizedQueryComparisonTest {
 
     @ParameterizedTest
     @MethodSource("testCases")
-    void testParameterizedInsertAndSelect(long seed, @Nonnull TypeTestCase testCase,
+    void testParameterizedInsertAndSelect(long seed, TypeTestCase testCase,
                                           boolean useTypedSetter, boolean useTypedGetter,
                                           boolean insertWithJdbc, boolean readWithJdbc) throws Exception {
         if (insertWithJdbc || readWithJdbc) {
@@ -433,7 +407,7 @@ public class JDBCParameterizedQueryComparisonTest {
 
     @ParameterizedTest
     @MethodSource("testCases")
-    void testArrayOfTypeInsertAndSelect(long seed, @Nonnull TypeTestCase testCase, boolean useTypedSetter,
+    void testArrayOfTypeInsertAndSelect(long seed, TypeTestCase testCase, boolean useTypedSetter,
                                         boolean insertWithJdbc, boolean readWithJdbc) throws Exception {
         Assumptions.assumeFalse(testCase == TypeTestCase.STRUCT,
                 "createArrayOf does not support STRUCT in either implementation");
@@ -468,7 +442,7 @@ public class JDBCParameterizedQueryComparisonTest {
         }
     }
 
-    private void assertArrayEquals(@Nonnull String message, @Nonnull Object expected, @Nonnull Object actual) {
+    private void assertArrayEquals(String message, Object expected, Object actual) {
         try {
             List<Object> expectedElements = TypeTestCase.extractArrayElements(expected);
             List<Object> actualElements = TypeTestCase.extractArrayElements(actual);
@@ -483,19 +457,16 @@ public class JDBCParameterizedQueryComparisonTest {
         }
     }
 
-    @Nonnull
-    private static List<ByteString> asListOfByteStrings(@Nonnull List<Object> elements) {
+    private static List<ByteString> asListOfByteStrings(List<Object> elements) {
         return elements.stream().map(obj -> ByteString.copyFrom((byte[])obj)).collect(Collectors.toList());
     }
 
-    @Nonnull
     private static RelationalConnection getJdbcCatalogConnection() throws SQLException {
         String uri = "jdbc:relational://" + SYS_DB_PATH + "?schema=" + RelationalKeyspaceProvider.CATALOG
                 + "&server=" + serverName;
         return DriverManager.getConnection(uri).unwrap(RelationalConnection.class);
     }
 
-    @Nonnull
     private Connection getConnection(boolean useJdbc) throws SQLException {
         if (useJdbc) {
             String uri = "jdbc:relational://" + dbPath + "?schema=" + SCHEMA_NAME
@@ -506,7 +477,7 @@ public class JDBCParameterizedQueryComparisonTest {
         }
     }
 
-    private void createSchema(@Nonnull String columnDdl, @Nonnull String extraTypeDdl) throws SQLException {
+    private void createSchema(String columnDdl, String extraTypeDdl) throws SQLException {
         try (RelationalConnection conn = getJdbcCatalogConnection()) {
             try (RelationalStatement stmt = conn.createStatement()) {
                 String createTemplate = "CREATE SCHEMA TEMPLATE \"" + templateName + "\" " +
@@ -521,22 +492,21 @@ public class JDBCParameterizedQueryComparisonTest {
 
     @FunctionalInterface
     interface ValueSetter {
-        void set(@Nonnull PreparedStatement statement, @Nonnull Object value) throws SQLException;
+        void set(PreparedStatement statement, Object value) throws SQLException;
     }
 
     @FunctionalInterface
     interface ValueReader {
-        @Nonnull
-        Object read(@Nonnull ResultSet resultSet) throws SQLException;
+        Object read(ResultSet resultSet) throws SQLException;
     }
 
     @FunctionalInterface
     interface EqualityAssertion {
-        void assertEquals(@Nonnull String message, @Nonnull Object expected, @Nonnull Object actual);
+        void assertEquals(String message, Object expected, Object actual);
     }
 
-    private void insert(@Nonnull Connection conn, @Nonnull Object value,
-                        @Nonnull ValueSetter setter) throws SQLException {
+    private void insert(Connection conn, Object value,
+                        ValueSetter setter) throws SQLException {
         try (PreparedStatement statement = conn.prepareStatement(
                 "INSERT INTO test_table (pk, val) VALUES (?, ?)")) {
             statement.setLong(1, PRIMARY_KEY);
@@ -545,8 +515,8 @@ public class JDBCParameterizedQueryComparisonTest {
         }
     }
 
-    private void readAndAssert(@Nonnull Connection conn, @Nonnull Object expectedValue,
-                               @Nonnull ValueReader reader, @Nonnull EqualityAssertion assertion) throws SQLException {
+    private void readAndAssert(Connection conn, Object expectedValue,
+                               ValueReader reader, EqualityAssertion assertion) throws SQLException {
         try (PreparedStatement statement = conn.prepareStatement(
                 "SELECT val FROM test_table WHERE pk = ?")) {
             statement.setLong(1, PRIMARY_KEY);

--- a/fdb-relational-jdbc/src/test/java/com/apple/foundationdb/relational/jdbc/JDBCRelationalDatabaseMetaDataTest.java
+++ b/fdb-relational-jdbc/src/test/java/com/apple/foundationdb/relational/jdbc/JDBCRelationalDatabaseMetaDataTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.sql.SQLException;
+import java.util.Objects;
 import java.util.Properties;
 
 public class JDBCRelationalDatabaseMetaDataTest {
@@ -40,7 +41,7 @@ public class JDBCRelationalDatabaseMetaDataTest {
     public static void beforeAll() throws SQLException {
         DatabaseMetaDataResponse response = DatabaseMetaDataResponse.newBuilder().build();
         JDBCRelationalDriver driver = new JDBCRelationalDriver();
-        connection = driver.connect(JDBCURI.JDBC_BASE_URL + "example.com", new Properties()).unwrap(RelationalConnection.class);
+        connection = Objects.requireNonNull(driver.connect(JDBCURI.JDBC_BASE_URL + "example.com", new Properties())).unwrap(RelationalConnection.class);
         databaseMetaData = new JDBCRelationalDatabaseMetaData(connection, response);
     }
 

--- a/fdb-relational-jdbc/src/test/java/com/apple/foundationdb/relational/jdbc/ParameterHelperTest.java
+++ b/fdb-relational-jdbc/src/test/java/com/apple/foundationdb/relational/jdbc/ParameterHelperTest.java
@@ -26,10 +26,10 @@ import com.apple.foundationdb.relational.jdbc.grpc.v1.column.NullColumn;
 import com.apple.foundationdb.relational.jdbc.grpc.v1.column.Type;
 import com.apple.foundationdb.relational.jdbc.grpc.v1.column.Uuid;
 import com.google.protobuf.ByteString;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import javax.annotation.Nullable;
 import java.sql.SQLException;
 import java.util.UUID;
 import java.util.function.Consumer;
@@ -109,11 +109,11 @@ public class ParameterHelperTest {
         });
     }
 
-    private static void checkValue(Object value, Parameter actual, Type expectedType, Function<Column, Boolean> typeChecker, Function<Column, Object> typeGetter) {
+    private static void checkValue(@Nullable Object value, Parameter actual, Type expectedType, Function<Column, Boolean> typeChecker, Function<Column, Object> typeGetter) {
         checkValue(value, actual, expectedType, typeChecker, typeGetter, null);
     }
 
-    private static void checkValue(Object value, Parameter actual, Type expectedType, Function<Column, Boolean> typeChecker,
+    private static void checkValue(@Nullable Object value, Parameter actual, Type expectedType, Function<Column, Boolean> typeChecker,
                                    Function<Column, Object> typeGetter, @Nullable Consumer<Object> customAssert) {
         Assertions.assertEquals(expectedType, actual.getMetadata().getType());
         Assertions.assertTrue(actual.hasParameter());

--- a/fdb-relational-jdbc/src/test/java/com/apple/foundationdb/relational/jdbc/ServerSideExceptionsOnClientSideTest.java
+++ b/fdb-relational-jdbc/src/test/java/com/apple/foundationdb/relational/jdbc/ServerSideExceptionsOnClientSideTest.java
@@ -80,6 +80,7 @@ public class ServerSideExceptionsOnClientSideTest {
                     }
                 } catch (SQLException sqlException) {
                     Assertions.assertEquals(sqlException.getSQLState(), ErrorCode.SYNTAX_ERROR.getErrorCode());
+                    Assertions.assertNotNull(sqlException.getMessage());
                     Assertions.assertTrue(sqlException.getMessage().contains(badSql));
                     Assertions.assertTrue(sqlException.getMessage().contains("syntax error"));
                 }
@@ -91,6 +92,7 @@ public class ServerSideExceptionsOnClientSideTest {
                         throw new RuntimeException("Should not get to here!");
                     }
                 } catch (StatusRuntimeException statusRuntimeException) {
+                    Assertions.assertNotNull(statusRuntimeException.getMessage());
                     Assertions.assertTrue(statusRuntimeException.getMessage().contains("Empty sql"));
                 }
             }


### PR DESCRIPTION
Second of a two-PR stack adopting jspecify + NullAway null-checking — stacked on #4532 (`fdb-relational-grpc`). Same treatment applied to `fdb-relational-jdbc`. See inline comments for specific findings.
