### PR TITLE
Allow a bare table alias to be passed as an aggregate argument

### DIFF
--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/SemanticAnalyzer.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/SemanticAnalyzer.java
@@ -100,7 +100,6 @@ import java.util.stream.StreamSupport;
  * In addition to that, this class performs metadata resolution tasks, such as resolving tables, validating indexes, and
  * resolving built-in and user-defined functions, which arguably, should be handled in a separate catalog component.
  */
-@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 @API(API.Status.EXPERIMENTAL)
 public class SemanticAnalyzer {
 
@@ -386,26 +385,25 @@ public class SemanticAnalyzer {
      * Raises {@link ErrorCode#INVALID_COLUMN_REFERENCE} when the qualifier does not refer to a record/struct type,
      * e.g. when unnesting a scalar array.
      *
-     * @param optionalQualifier the optional qualifier preceding the {@code *}, or {@link Optional#empty()} for an
-     * unqualified {@code *}
+     * @param qualifier the qualifier preceding the {@code *}, or {@code null} for an unqualified {@code *}
      * @param operators the logical operators in scope for resolving the qualifier
      *
      * @return a {@link Star} expression capturing the expansion
      */
     @Nonnull
-    public Star expandStar(@Nonnull Optional<Identifier> optionalQualifier,
+    public Star expandStar(@Nullable Identifier qualifier,
                            @Nonnull LogicalOperators operators) {
         final var forEachOperators = operators.forEachOnly();
 
         // Case 1: no qualifier, e.g. SELECT * FROM T, R;
-        if (optionalQualifier.isEmpty()) {
+        if (qualifier == null) {
             final var expansion = forEachOperators.getExpressions().nonEphemeralVisible();
             return Star.overQuantifiers(Optional.empty(), Streams.stream(forEachOperators).map(LogicalOperator::getQuantifier)
                     .map(Quantifier::getFlowedObjectValue).collect(ImmutableList.toImmutableList()), "unknown", expansion);
         }
 
         // Case 2: qualifying a table, e.g. SELECT T.* FROM T, R;
-        final var qualifier = optionalQualifier.get();
+        final var optionalQualifier = Optional.of(qualifier);
         final var logicalTableMaybe = Streams.stream(forEachOperators)
                 .filter(table -> table.getName().isPresent() && table.getName().get().equals(qualifier))
                 .findFirst();
@@ -427,7 +425,7 @@ public class SemanticAnalyzer {
         // rather than adhering to what the user _can_ semantically describe in SQL.
         final var individualReferencedColumns = Expressions.of(forEachOperators.getExpressions().stream()
                 .filter(expr -> expr.getName().isPresent() && expr.getName().get().isQualified())
-                .filter(expr -> expr.getName().get().qualifiedWith(optionalQualifier.get()))
+                .filter(expr -> expr.getName().get().qualifiedWith(qualifier))
                 .collect(ImmutableList.toImmutableList()));
         if (!individualReferencedColumns.isEmpty()) {
             return Star.overIndividualExpressions(optionalQualifier, "unknown", individualReferencedColumns);
@@ -482,7 +480,7 @@ public class SemanticAnalyzer {
         return Streams.stream(operators.forEachOnly())
                 .filter(op -> op.getName().equals(identifierOptional))
                 .findFirst()
-                .map(ignored -> Expression.of(expandStar(identifierOptional, operators).getUnderlying(), identifier));
+                .map(ignored -> Expression.of(expandStar(identifier, operators).getUnderlying(), identifier));
     }
 
     @Nonnull

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/SemanticAnalyzer.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/SemanticAnalyzer.java
@@ -391,8 +391,7 @@ public class SemanticAnalyzer {
      * @return a {@link Star} expression capturing the expansion
      */
     @Nonnull
-    public Star expandStar(@Nullable Identifier qualifier,
-                           @Nonnull LogicalOperators operators) {
+    public Star expandStar(@Nullable Identifier qualifier, @Nonnull LogicalOperators operators) {
         final var forEachOperators = operators.forEachOnly();
 
         // Case 1: no qualifier, e.g. SELECT * FROM T, R;
@@ -404,9 +403,7 @@ public class SemanticAnalyzer {
 
         // Case 2: qualifying a table, e.g. SELECT T.* FROM T, R;
         final var optionalQualifier = Optional.of(qualifier);
-        final var logicalTableMaybe = Streams.stream(forEachOperators)
-                .filter(table -> table.getName().isPresent() && table.getName().get().equals(qualifier))
-                .findFirst();
+        final var logicalTableMaybe = findOperator(forEachOperators, qualifier);
         if (logicalTableMaybe.isPresent()) {
             final LogicalOperator logicalTable = logicalTableMaybe.get();
             // Star can only be expanded on a record (struct) type. Examples of non-record qualifier types are scalars
@@ -423,10 +420,7 @@ public class SemanticAnalyzer {
         // differently.
         // This mostly happens when the logical operator encompasses an internal modeling strategy
         // rather than adhering to what the user _can_ semantically describe in SQL.
-        final var individualReferencedColumns = Expressions.of(forEachOperators.getExpressions().stream()
-                .filter(expr -> expr.getName().isPresent() && expr.getName().get().isQualified())
-                .filter(expr -> expr.getName().get().qualifiedWith(qualifier))
-                .collect(ImmutableList.toImmutableList()));
+        final var individualReferencedColumns = findColumnsQualifiedWith(forEachOperators, qualifier);
         if (!individualReferencedColumns.isEmpty()) {
             return Star.overIndividualExpressions(optionalQualifier, "unknown", individualReferencedColumns);
         }
@@ -473,14 +467,70 @@ public class SemanticAnalyzer {
         return Optional.empty();
     }
 
+    /**
+     * Finds the operator that carries {@code qualifier} as its name, if any. The first match wins, on the assumption
+     * that a name is unique among the operators searched.
+     *
+     * @param operators the operators to search
+     * @param qualifier the name to look for
+     * @return the operator so named, or {@code empty()} if there isn’t one
+     */
+    @Nonnull
+    private static Optional<LogicalOperator> findOperator(@Nonnull LogicalOperators operators,
+                                                          @Nonnull Identifier qualifier) {
+        return Streams.stream(operators)
+                .filter(operator -> {
+                    final Identifier name = operator.getName().orElse(null);
+                    return name != null && name.equals(qualifier);
+                })
+                .findFirst();
+    }
+
+    /**
+     * Finds the columns of {@code operators} that are qualified with {@code qualifier}.
+     *
+     * @param operators the operators to search
+     * @param qualifier the qualification to look for
+     * @return the columns so qualified, in the order they occur
+     */
+    @Nonnull
+    private static Expressions findColumnsQualifiedWith(@Nonnull LogicalOperators operators,
+                                                        @Nonnull Identifier qualifier) {
+        return Expressions.of(operators.getExpressions().stream()
+                .filter(expression -> {
+                    final Identifier name = expression.getName().orElse(null);
+                    return name != null && name.isQualified() && name.qualifiedWith(qualifier);
+                })
+                .collect(ImmutableList.toImmutableList()));
+    }
+
+    /**
+     * Resolves an identifier that names a table or an alias in scope to that row as a whole, i.e., as a struct. This
+     * makes something like {@code SELECT T FROM T} equivalent to {@code SELECT (T.*) FROM T}. The implementation
+     * delegates to {@link #expandStar}. Two scopes are recognized, mirroring the cases that {@code expandStar()}
+     * distinguishes:
+     * <ul>
+     * <li>An operator in scope carries {@code identifier} as its name (“case 2”).
+     * <li>No operator is named that way, but columns in scope are qualified with {@code identifier} (“case 2.1”).
+     * </ul>
+     * The second scope arises once the named table operator has been replaced with the result of
+     * {@code generateSelectWhere()}, which is unnamed (while its columns keep their qualification).
+     *
+     * @param identifier the identifier to resolve
+     * @param operators the logical operators in scope
+     * @return the row as a struct-typed expression, or {@code empty()} if the identifier does not name a row in scope
+     */
     @Nonnull
     private Optional<Expression> resolveAsTableRowMaybe(@Nonnull Identifier identifier,
-                                                         @Nonnull LogicalOperators operators) {
-        final var identifierOptional = Optional.of(identifier);
-        return Streams.stream(operators.forEachOnly())
-                .filter(op -> op.getName().equals(identifierOptional))
-                .findFirst()
-                .map(ignored -> Expression.of(expandStar(identifier, operators).getUnderlying(), identifier));
+                                                        @Nonnull LogicalOperators operators) {
+        final LogicalOperators forEachOperators = operators.forEachOnly();
+        // Test the two scopes here rather leaving that to `expandStar()` (which would throw for an unknown qualifier).
+        if (findOperator(forEachOperators, identifier).isEmpty()
+                && findColumnsQualifiedWith(forEachOperators, identifier).isEmpty()) {
+            return Optional.empty();
+        }
+        final Star expandedRow = expandStar(identifier, operators);
+        return Optional.of(Expression.of(expandedRow.getUnderlying(), identifier));
     }
 
     @Nonnull

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/ExpressionVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/ExpressionVisitor.java
@@ -145,7 +145,7 @@ public final class ExpressionVisitor extends DelegatingVisitor<BaseVisitor> {
     @Nonnull
     @Override
     public Expression visitSelectStarElement(@Nonnull RelationalParser.SelectStarElementContext ignored) {
-        return getDelegate().getSemanticAnalyzer().expandStar(Optional.empty(), getDelegate().getLogicalOperators());
+        return getDelegate().getSemanticAnalyzer().expandStar(null, getDelegate().getLogicalOperators());
     }
 
     @Nonnull
@@ -153,7 +153,7 @@ public final class ExpressionVisitor extends DelegatingVisitor<BaseVisitor> {
     public Expression visitSelectQualifierStarElement(@Nonnull RelationalParser.SelectQualifierStarElementContext ctx) {
         final var identifier = visitUid(ctx.uid());
         // the semantics of valid correlations are extended to expanding a (correlated) qualified star.
-        return getDelegate().getSemanticAnalyzer().expandStar(Optional.of(identifier), getDelegate().getLogicalOperatorsIncludingOuter());
+        return getDelegate().getSemanticAnalyzer().expandStar(identifier, getDelegate().getLogicalOperatorsIncludingOuter());
     }
 
     @Nonnull
@@ -962,14 +962,14 @@ public final class ExpressionVisitor extends DelegatingVisitor<BaseVisitor> {
                 final var resultValue = RecordConstructorValue.ofUnnamed(List.of(expression.getUnderlying()));
                 return expression.withUnderlying(resultValue);
             } else {
-                final var star = getDelegate().getSemanticAnalyzer().expandStar(Optional.of(id), getDelegate().getLogicalOperators());
+                final var star = getDelegate().getSemanticAnalyzer().expandStar(id, getDelegate().getLogicalOperators());
                 final var resultValue = star.getUnderlying();
                 // Name the column after the qualifier (table name or alias) that was expanded.
                 return Expression.of(resultValue, id);
             }
         }
         if (ctx.STAR() != null) {
-            final var star = getDelegate().getSemanticAnalyzer().expandStar(Optional.empty(), getDelegate().getLogicalOperators());
+            final var star = getDelegate().getSemanticAnalyzer().expandStar(null, getDelegate().getLogicalOperators());
             final var resultValue = star.getUnderlying();
             // Name the column after the sole for-each quantifier in scope.
             // Both standard joins and PartiQL unnest expansions introduce multiple for-each

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/QueryVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/QueryVisitor.java
@@ -828,7 +828,7 @@ public final class QueryVisitor extends DelegatingVisitor<BaseVisitor> {
         // Note: doing an expansion here means that we don't have access to the pseudo-columns during the update
         // (and wouldn't have access to the invisible columns, see: https://github.com/FoundationDB/fdb-record-layer/pull/3787)
         // That also means that the target type of the update expression needs to match
-        final var output = Expressions.ofSingle(semanticAnalyzer.expandStar(Optional.empty(), getDelegate().getLogicalOperators()));
+        final var output = Expressions.ofSingle(semanticAnalyzer.expandStar(null, getDelegate().getLogicalOperators()));
 
         Optional<Expression> whereMaybe = ctx.whereExpr() == null ? Optional.empty() : Optional.of(visitWhereExpr(ctx.whereExpr()));
         final var updateSource = LogicalOperator.generateSimpleSelect(output, getDelegate().getLogicalOperators(), whereMaybe, Optional.of(tableId), ImmutableSet.of(), false);
@@ -878,7 +878,7 @@ public final class QueryVisitor extends DelegatingVisitor<BaseVisitor> {
         final LogicalOperator tableAccess = getDelegate().getLogicalOperatorCatalog().lookupTableAccess(tableId, semanticAnalyzer);
 
         getDelegate().pushPlanFragment().setOperator(tableAccess);
-        final var output = Expressions.ofSingle(semanticAnalyzer.expandStar(Optional.empty(), getDelegate().getLogicalOperators()));
+        final var output = Expressions.ofSingle(semanticAnalyzer.expandStar(null, getDelegate().getLogicalOperators()));
 
         Optional<Expression> whereMaybe = ctx.whereExpr() == null ? Optional.empty() : Optional.of(visitWhereExpr(ctx.whereExpr()));
         final var deleteSource = LogicalOperator.generateSimpleSelect(output, getDelegate().getLogicalOperators(), whereMaybe, Optional.of(tableId), ImmutableSet.of(), false);

--- a/yaml-tests/src/test/resources/array-agg-tests.metrics.yaml
+++ b/yaml-tests/src/test/resources/array-agg-tests.metrics.yaml
@@ -17,7 +17,7 @@ array-agg-scenario:
 -   query: EXPLAIN SELECT m.mid, r.rid, sq.assets FROM doc_meta m, doc_rev r, (SELECT
         ARRAY_AGG(a.url) AS assets FROM doc_asset a WHERE a.rid = r.rid) sq WHERE
         m.owner IS NOT NULL AND 'featured' IN r.tags AND r.rid = 20
-    ref: array-agg-tests.yamsql:357
+    ref: array-agg-tests.yamsql:391
     explain: SCAN([IS doc_rev, EQUALS promote(@c60 AS LONG)]) | FILTER @c50 IN _.tags
         | FLATMAP q0 -> { ISCAN(doc_asset_by_rid [EQUALS q0.rid]) | MAP (_ AS _0)
         | AGG (array_agg(_._0.url) AS _0) GROUP BY () | ON EMPTY NULL AS q0 RETURN
@@ -36,7 +36,7 @@ array-agg-scenario:
         a.rid AS rid, ARRAY_AGG(a.url) AS assets FROM doc_asset a GROUP BY a.rid)
         sq WHERE m.owner IS NOT NULL AND 'featured' IN r.tags AND r.rid = 20 AND sq.rid
         = r.rid
-    ref: array-agg-tests.yamsql:385
+    ref: array-agg-tests.yamsql:419
     explain: ISCAN(doc_asset_by_rid <,>) | MAP (_ AS _0) | AGG (array_agg(_._0.url)
         AS _0) GROUP BY (_._0.rid AS _0) | FLATMAP q0 -> { SCAN([IS doc_rev, EQUALS
         promote(@c63 AS LONG)]) | FILTER @c53 IN _.tags AND q0._0._0 EQUALS _.rid
@@ -54,7 +54,7 @@ array-agg-scenario:
 -   query: EXPLAIN SELECT m.mid, r.rid, sq.assets FROM doc_meta m, doc_rev r, (SELECT
         ARRAY_AGG((a.*)) AS assets FROM doc_asset a WHERE a.rid = r.rid) sq WHERE
         m.owner IS NOT NULL AND 'featured' IN r.tags AND r.rid = 20
-    ref: array-agg-tests.yamsql:397
+    ref: array-agg-tests.yamsql:431
     explain: SCAN([IS doc_rev, EQUALS promote(@c62 AS LONG)]) | FILTER @c52 IN _.tags
         | FLATMAP q0 -> { ISCAN(doc_asset_by_rid [EQUALS q0.rid]) | MAP (_ AS _0)
         | AGG (array_agg((_._0.aid AS aid, _._0.rid AS rid, _._0.url AS url)) AS _0)

--- a/yaml-tests/src/test/resources/array-agg-tests.yamsql
+++ b/yaml-tests/src/test/resources/array-agg-tests.yamsql
@@ -262,6 +262,40 @@ test_block:
       # Variant with a STRING element type, i.e. a primitive other than the BIGINT used everywhere else in this file.
       - query: SELECT ARRAY_AGG(title) FROM doc_rev
       - result: [{['draft', 'final']}]
+    -
+      # The following tests aggregate rows as a whole by passing a bare table alias to ARRAY_AGG(). The alias resolves
+      # to the row as a struct (just like for `SELECT T FROM T`).
+      - query: SELECT ARRAY_AGG(a) FROM doc_asset a WHERE a.rid = 20
+      - supported_version: !current_version
+      - result: [{[{2, 20, 'b1.png'}, {3, 20, 'b2.png'}]}]
+    -
+      # Control: Outside an aggregate, the bare alias yields the whole row as a struct, as usual.
+      - query: SELECT a FROM doc_asset a WHERE a.rid = 20
+      - result: [{a: {2, 20, 'b1.png'}}, {a: {3, 20, 'b2.png'}}]
+    -
+      # The unaliased table name works the same way.
+      - query: SELECT ARRAY_AGG(doc_asset) FROM doc_asset WHERE rid = 20
+      - supported_version: !current_version
+      - result: [{[{2, 20, 'b1.png'}, {3, 20, 'b2.png'}]}]
+    -
+      # Bare alias with GROUP BY. This yields one array of rows per group.
+      - query: SELECT a.rid, ARRAY_AGG(a) FROM doc_asset a GROUP BY a.rid
+      - supported_version: !current_version
+      - result: [{10, [{1, 10, 'a1.png'}]}, {20, [{2, 20, 'b1.png'}, {3, 20, 'b2.png'}]}]
+    -
+      # In a join, each alias resolves to its own row.
+      - query: SELECT ARRAY_AGG(a), ARRAY_AGG(r) FROM doc_asset a, doc_rev r WHERE a.rid = r.rid AND r.rid = 20
+      - supported_version: !current_version
+      - result: [{[{2, 20, 'b1.png'}, {3, 20, 'b2.png'}], [{20, 'final', ['featured', 'public']}, {20, 'final', ['featured', 'public']}]}]
+    -
+      # A column of the same name takes precedence over the row alias. Here, `array_agg` resolves to the `keywords`
+      # table column, so the aggregate is over BIGINT rather than a struct.
+      - query: SELECT ARRAY_AGG(array_agg) FROM keywords AS array_agg
+      - result: [{[1]}]
+    -
+      # An identifier that names neither a column nor a table in scope fails with UNDEFINED_COLUMN, as usual.
+      - query: SELECT ARRAY_AGG(b) FROM doc_asset a
+      - error: UNDEFINED_COLUMN
 ---
 # ARRAY_AGG() over constant inputs.
 test_block:


### PR DESCRIPTION
Queries such as `SELECT ARRAY_AGG(T) FROM T`, meaning “aggregate the whole row, as a struct”, currently fail with `UNDEFINED_COLUMN`, even though the analogous projection case `SELECT T FROM T` already works. To fix this gap, this change extends `SemanticAnalyzer.resolveAsTableRowMaybe()` to admit a second scope: If no _operator_ carries the name, we look for _columns_ in scope that are qualified with the name. The resolution itself is still delegated to `expandStar()`, which handles this precise case in its “2.1” branch.

Pre-refactoring:

* Make `SemanticAnalyzer.expandStar()` take a `@Nullable Identifier` instead of `Optional<Identifier>`.

Resolves #4515.