### PR TITLE
Refactor `MetaDataProtoEditor.renameRecordType()`

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/MetaDataProtoEditor.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/MetaDataProtoEditor.java
@@ -35,7 +35,6 @@ import com.google.protobuf.Descriptors;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -170,32 +169,6 @@ public class MetaDataProtoEditor {
             }
         }
         throw new MetaDataException("Union descriptor not found");
-    }
-
-    @Nullable
-    private static DescriptorProtos.FieldDescriptorProto.Builder fetchUnionFieldBuilder(
-            @Nonnull DescriptorProtos.FileDescriptorProto.Builder recordsBuilder,
-            @Nonnull DescriptorProtos.DescriptorProto.Builder unionBuilder,
-            @Nonnull Descriptors.Descriptor unionDescriptor,
-            @Nonnull String recordTypeName) {
-        DescriptorProtos.FieldDescriptorProto.Builder foundField = null;
-        if (recordTypeName.contains(".")) {
-            throw new MetaDataException("Record Type Name cannot contain '.'");
-        }
-        if (unionBuilder.getNestedTypeCount() > 0) {
-            throw new MetaDataException("Nested types in union type not supported");
-        }
-        for (DescriptorProtos.FieldDescriptorProto.Builder unionField : unionBuilder.getFieldBuilderList()) {
-            final FieldTypeMatch unionFieldMatch = fieldIsType(recordsBuilder, unionDescriptor, unionField, recordTypeName);
-            if (FieldTypeMatch.MATCHES.equals(unionFieldMatch)
-                    && (foundField == null
-                                || isCanonicalUnionFieldName(unionField.getName(), recordTypeName)
-                                || unionField.getNumber() > foundField.getNumber())) {
-                // Choose the matching field with either a matching name or the highest number.
-                foundField = unionField;
-            }
-        }
-        return foundField;
     }
 
     /**
@@ -540,11 +513,9 @@ public class MetaDataProtoEditor {
      * a collision, however.
      *
      * <p>Validating the mapping as a whole means a batch may be accepted where the equivalent one-by-one renames
-     * would fail, and rejected where they would quietly succeed. A batch that permutes existing names, for instance
-     * swapping {@code Foo} and {@code Bar}, is collision-free and therefore accepted, whereas renaming those types
-     * one at a time would collide on whichever is renamed first. Conversely, a mapping that would make two union
-     * fields share a name is rejected here, while {@code renameRecordType} leaves the second field under its old
-     * name instead of reporting the conflict.
+     * would fail. A batch that permutes existing names, for instance swapping {@code Foo} and {@code Bar}, is
+     * collision-free and therefore accepted, whereas renaming those types one at a time would collide on whichever
+     * is renamed first.
      *
      * @param metadata the metadata builder
      * @param renamer a function mapping each existing top-level record type name to its new name
@@ -560,44 +531,12 @@ public class MetaDataProtoEditor {
             return;
         }
 
-        // Validate that `MetaData.user_defined_functions` is empty.
-        validateNoUserDefinedFunctions(metadata);
-
         // Build the file descriptor exactly once, from the original `MetaData.records` proto. Every descriptor
         // lookup below is done by original name, so we can use this single descriptor for every rename in the mapping.
-        final DescriptorProtos.FileDescriptorProto records = metadata.getRecords();
-        final Descriptors.FileDescriptor fileDesc = RecordMetaDataBuilder.buildFileDescriptor(records, dependencies);
+        final Descriptors.FileDescriptor fileDescriptor =
+                RecordMetaDataBuilder.buildFileDescriptor(metadata.getRecords(), dependencies);
 
-        // Validate the `MetaData.unnested_record_types` constituents.
-        validateRecordTypeUsagesInUnnestedRecordTypes(metadata.getUnnestedRecordTypesBuilderList(), fileDesc, renames);
-
-        // Determine the usage of each renamed type by looking at the union message type within `MetaData.records`.
-        final DescriptorProtos.DescriptorProto.Builder union = fetchUnionBuilder(metadata.getRecordsBuilder());
-        if (union.getNestedTypeCount() > 0) {
-            throw new MetaDataException("Nested types in union type not supported");
-        }
-        determineRecordTypeUnionFieldsAndUsages(renames, fileDesc, union);
-
-        // Validate that renaming the canonical union fields would not cause a collision.
-        validateUnionFieldRenames(union, renames);
-
-        // Rename the canonical union field, if present, for each renamed type.
-        renameUnionFields(renames);
-
-        // Rename every message type in `MetaData.records`, and all field type references.
-        renameRecordTypeUsagesInMessageTypes(metadata.getRecordsBuilder().getMessageTypeBuilderList(), renames, fileDesc);
-
-        // Update `MetaData.record_types` for every top-level RECORD type.
-        renameRecordTypeUsagesInRecordTypes(metadata.getRecordTypesBuilderList(), renames);
-
-        // Update `MetaData.indexes` for every top-level RECORD type.
-        renameRecordTypeUsagesInIndexes(metadata.getIndexesBuilderList(), renames);
-
-        // Update `MetaData.joined_record_types` constituents for every renamed type.
-        renameRecordTypeUsagesInJoinedRecordTypes(metadata.getJoinedRecordTypesBuilderList(), renames);
-
-        // Rename `MetaData.unnested_record_types` constituents for every renamed type.
-        renameRecordTypeUsagesInUnnestedRecordTypes(metadata.getUnnestedRecordTypesBuilderList(), renames);
+        applyRecordTypeRenames(metadata, renames, fileDescriptor);
     }
 
     /**
@@ -605,12 +544,16 @@ public class MetaDataProtoEditor {
      * records descriptor, including {@code NESTED} records or the union descriptor. However, it cannot be used to
      * rename nested messages (i.e., messages defined within other messages) or records defined in imported files.
      *
+     * <p>Unlike {@link #renameRecordTypes}, which can only rename {@code RECORD}-usage top-level types, this method
+     * can rename any of the three: {@code RECORD}, {@code NESTED}, or the union type itself.
+     *
      * <ul>
      * <li>Message names are rewritten.
      * <li>Field types ({@code typeName}) that reference a renamed type are rewritten, whether the reference is direct
      *     or to a nested type of a renamed type.
      * <li>The union usage option is set when the union is renamed.
-     * <li>The canonical {@code _typeName} union field is renamed when possible.
+     * <li>The canonical {@code _typeName} union field is renamed; if the union already has a field under the new
+     *     canonical name, the rename is rejected instead.
      * <li>If the record type has {@code RECORD} usage, the record type list, indexes, and joined record types are
      *     updated.
      * <li>Unnested record type constituents are updated.
@@ -624,8 +567,6 @@ public class MetaDataProtoEditor {
                                         @Nonnull String recordTypeName,
                                         @Nonnull String newRecordTypeName,
                                         @Nonnull Descriptors.FileDescriptor[] dependencies) {
-        // Validate the rename. Rather than calling `metaDataBuilder.getRecordsBuilder()`, create a copy of the records
-        // builder to avoid corrupting the one in `metaDataBuilder` before all validation has been done.
         final DescriptorProtos.FileDescriptorProto records = metaDataBuilder.getRecords();
         boolean found = false;
         for (DescriptorProtos.DescriptorProto messageType : records.getMessageTypeList()) {
@@ -639,240 +580,83 @@ public class MetaDataProtoEditor {
             throw new MetaDataException("No record type found with name " + recordTypeName);
         }
 
+        // Likewise, check for a collision against the metadata's full record type registry, which (unlike
+        // `records.getMessageTypeList()` above) also includes record types imported from a dependency file.
+        for (final String name : getRecordTypes(metaDataBuilder)) {
+            if (!name.equals(recordTypeName) && name.equals(newRecordTypeName)) {
+                throw new MetaDataException("Cannot rename record type to " + newRecordTypeName + " as an imported record type of that name already exists");
+            }
+        }
+
         // Identity transformation requires no work. From here on, we can assume `recordTypeName != newRecordTypeName`,
         // which simplifies things.
         if (recordTypeName.equals(newRecordTypeName)) {
             return;
         }
         final Descriptors.FileDescriptor fileDescriptor = RecordMetaDataBuilder.buildFileDescriptor(records, dependencies);
-        final DescriptorProtos.FileDescriptorProto.Builder recordsBuilder = records.toBuilder();
-
-        // Determine the usage of the original record type by looking through the union builder.
-        // If we find a union field that matches, also update its name to be in the canonical form.
-        DescriptorProtos.DescriptorProto.Builder unionBuilder = fetchUnionBuilder(recordsBuilder);
-        RecordTypeOptions.Usage usage;
-        if (unionBuilder.getName().equals(recordTypeName)) {
-            usage = RecordTypeOptions.Usage.UNION;
-        } else {
-            final Descriptors.Descriptor unionDescriptor = getMessageTypeByName(fileDescriptor, unionBuilder.getName());
-            DescriptorProtos.FieldDescriptorProto.Builder unionFieldBuilder = fetchUnionFieldBuilder(recordsBuilder,
-                    unionBuilder, unionDescriptor, recordTypeName);
-            if (unionFieldBuilder == null) {
-                usage = RecordTypeOptions.Usage.NESTED;
-            } else {
-                usage = RecordTypeOptions.Usage.RECORD;
-                // Change the name to the "canonical" form unless that would cause a field name conflict
-                if (isCanonicalUnionFieldName(unionFieldBuilder.getName(), recordTypeName)) {
-                    String newFieldName = canonicalUnionFieldName(newRecordTypeName);
-                    if (unionBuilder.getFieldBuilderList().stream()
-                            .noneMatch(otherUnionField -> otherUnionField != unionFieldBuilder
-                                    && otherUnionField.getName().equals(newFieldName))) {
-                        unionFieldBuilder.setName(newFieldName);
-                    }
-                }
-            }
-        }
-
-        // Do not allow renaming to the default union name unless the record type is already the union.
-        if (DEFAULT_UNION_NAME.equals(newRecordTypeName) && !RecordTypeOptions.Usage.UNION.equals(usage)) {
-            throw new MetaDataException("Cannot rename record type to the default union name", LogMessageKeys.RECORD_TYPE, recordTypeName);
-        }
-
-        // Rename the record type within the file.
-        renameRecordTypeUsages(recordsBuilder, recordTypeName, newRecordTypeName, fileDescriptor);
-
-        // If the record type is a top-level record type, change its usage elsewhere in the metadata.
-        if (RecordTypeOptions.Usage.RECORD.equals(usage)) {
-            renameTopLevelRecordType(metaDataBuilder, recordTypeName, newRecordTypeName);
-        }
-
-        // Update unnested types (even if the record type is not a top-level type).
-        renameRecordTypeUsagesInUnnested(metaDataBuilder, fileDescriptor, recordTypeName, newRecordTypeName,
-                getMessageTypeByName(fileDescriptor, recordTypeName));
-
-        // Update the file descriptor.
-        metaDataBuilder.setRecords(recordsBuilder);
+        final RecordTypeRename rename = new RecordTypeRename(records.getPackage(), recordTypeName, newRecordTypeName);
+        applyRecordTypeRenames(metaDataBuilder, new RecordTypeRenames(Map.of(recordTypeName, rename)), fileDescriptor);
     }
 
     /**
-     * Renames a record type within the records file. To this end, updates references to it in the fields of every
-     * message type (recursively, including nested types). If it is the union type, also update its usage option.
-     */
-    private static void renameRecordTypeUsages(@Nonnull DescriptorProtos.FileDescriptorProto.Builder recordsBuilder,
-                                               @Nonnull String recordTypeName, @Nonnull String newRecordTypeName,
-                                               @Nonnull Descriptors.FileDescriptor fileDescriptor) {
-        final String namespace = recordsBuilder.getPackage();
-        final String fullRecordTypeName = fullyQualifiedTypeName(namespace, recordTypeName);
-        final String fullNewRecordTypeName = fullyQualifiedTypeName(namespace, newRecordTypeName);
-
-        // Rename the record type within the file.
-        for (DescriptorProtos.DescriptorProto.Builder messageTypeBuilder : recordsBuilder.getMessageTypeBuilderList()) {
-            final Descriptors.Descriptor descriptor = getMessageTypeByName(fileDescriptor, messageTypeBuilder.getName());
-            // Change any fields referencing the old type so that they now reference the new type.
-            renameRecordTypeUsages(namespace, messageTypeBuilder, fullRecordTypeName, fullNewRecordTypeName, descriptor);
-            if (messageTypeBuilder.getName().equals(recordTypeName)) {
-                // If renaming the union type, be sure that the record.usage option is set to UNION.
-                if (isUnion(messageTypeBuilder) && getMessageTypeUsage(messageTypeBuilder) != RecordTypeOptions.Usage.UNION) {
-                    setMessageTypeUsage(messageTypeBuilder, RecordTypeOptions.Usage.UNION);
-                }
-                messageTypeBuilder.setName(newRecordTypeName);
-            }
-        }
-    }
-
-    /**
-     * Renames references to a record type among the fields of a single message type, recursing into its nested types.
-     */
-    private static void renameRecordTypeUsages(@Nonnull String namespace,
-                                               @Nonnull DescriptorProtos.DescriptorProto.Builder messageTypeBuilder,
-                                               @Nonnull String fullRecordTypeName,
-                                               @Nonnull String fullNewRecordTypeName,
-                                               final Descriptors.Descriptor descriptorForMessage) {
-        // Rename any fields within the record type to the new type name.
-        for (DescriptorProtos.FieldDescriptorProto.Builder field : messageTypeBuilder.getFieldBuilderList()) {
-            final FieldTypeMatch fieldTypeMatch = fieldIsType(descriptorForMessage, field, fullRecordTypeName);
-            if (FieldTypeMatch.MATCHES.equals(fieldTypeMatch)) {
-                field.setTypeName(fullNewRecordTypeName);
-            } else if (FieldTypeMatch.MATCHES_AS_NESTED.equals(fieldTypeMatch)) {
-                final String fullOldFieldTypeName = Objects.requireNonNull(
-                        resolveFieldTypeFullName(descriptorForMessage, field),
-                        "A field matching as nested must reference a named type");
-                final String newFieldTypeName = fullNewRecordTypeName + fullOldFieldTypeName.substring(fullRecordTypeName.length());
-                field.setTypeName(newFieldTypeName);
-            }
-        }
-
-        // Rename the record type if used within any nested message types.
-        if (messageTypeBuilder.getNestedTypeCount() > 0) {
-            final String nestedNamespace =
-                    namespace.isEmpty()
-                    ? messageTypeBuilder.getName()
-                    : (namespace + "." + messageTypeBuilder.getName());
-            for (DescriptorProtos.DescriptorProto.Builder nestedTypeBuilder : messageTypeBuilder.getNestedTypeBuilderList()) {
-                final Descriptors.Descriptor nestedDescriptor = Objects.requireNonNull(
-                        descriptorForMessage.findNestedTypeByName(nestedTypeBuilder.getName()),
-                        "FileDescriptor does not have nested type that exists in protobuf");
-                renameRecordTypeUsages(nestedNamespace, nestedTypeBuilder, fullRecordTypeName, fullNewRecordTypeName,
-                        nestedDescriptor);
-            }
-        }
-    }
-
-    /**
-     * Updates the top-level record type list, any index definitions, and any joined record types that reference a
-     * renamed record type. Throws if the metadata has {@code UserDefinedFunctions}, since renaming is not supported
-     * in that case.
-     */
-    private static void renameTopLevelRecordType(@Nonnull RecordMetaDataProto.MetaData.Builder metaDataBuilder,
-                                                 @Nonnull String recordTypeName,
-                                                 @Nonnull String newRecordTypeName) {
-        List<RecordMetaDataProto.RecordType> recordTypes =
-                new ArrayList<>(metaDataBuilder.getRecordTypesBuilderList().size());
-        boolean foundRecordType = false;
-        for (RecordMetaDataProto.RecordType recordType : metaDataBuilder.getRecordTypesList()) {
-            if (recordType.getName().equals(newRecordTypeName)) {
-                // Note: Despite the earlier check in this method, this can still be triggered if there is an imported
-                // record with the given name.
-                throw new MetaDataException("Cannot rename record type to " + newRecordTypeName + " as an imported record type of that name already exists");
-            } else if (recordType.getName().equals(recordTypeName)) {
-                recordTypes.add(recordType.toBuilder().setName(newRecordTypeName).build());
-                foundRecordType = true;
-            } else {
-                recordTypes.add(recordType);
-            }
-        }
-        if (!foundRecordType) {
-            // This shouldn't happen, but if somehow the record type was in the union but not the record type list,
-            // throw an error.
-            throw new MetaDataException("Missing " + recordTypeName + " in record type list");
-        }
-
-        // Rename the record type within any indexes.
-        List<RecordMetaDataProto.Index> indexes = new ArrayList<>(metaDataBuilder.getIndexesList());
-        indexes.replaceAll(index -> {
-            if (!index.getRecordTypeList().contains(recordTypeName)) {
-                return index;
-            }
-            List<String> indexRecordTypes = new ArrayList<>(index.getRecordTypeList());
-            indexRecordTypes.replaceAll(name -> name.equals(recordTypeName) ? newRecordTypeName : name);
-            return index.toBuilder().clearRecordType().addAllRecordType(indexRecordTypes).build();
-        });
-
-        // Update the `metaDataBuilder` with all the renamed things.
-        metaDataBuilder.clearRecordTypes();
-        metaDataBuilder.addAllRecordTypes(recordTypes);
-        metaDataBuilder.clearIndexes();
-        metaDataBuilder.addAllIndexes(indexes);
-        // Unnested types have to be updated even if it’s not a top-level type, so they have their own method.
-        updateJoinedRecordTypes(metaDataBuilder, recordTypeName, newRecordTypeName);
-
-        if (metaDataBuilder.getUserDefinedFunctionsCount() > 0) {
-            // UserDefinedFunctions may be a string that needs parsing to figure out the types it references.
-            throw new MetaDataException("Renaming record types with UserDefinedFunctions is not supported");
-        }
-    }
-
-    /**
-     * Updates joined record types' constituents that reference a renamed record type.
-     */
-    private static void updateJoinedRecordTypes(@Nonnull RecordMetaDataProto.MetaData.Builder metaDataBuilder,
-                                                @Nonnull String recordTypeName,
-                                                @Nonnull String newRecordTypeName) {
-        for (var joined : metaDataBuilder.getJoinedRecordTypesBuilderList()) {
-            for (var constituent : joined.getJoinConstituentsBuilderList()) {
-                if (constituent.getRecordType().equals(recordTypeName)) {
-                    constituent.setRecordType(newRecordTypeName);
-                }
-            }
-        }
-    }
-
-    /**
-     * Updates unnested record types' constituents that reference a renamed record type as their (non-nested) parent.
-     */
-    private static void renameRecordTypeUsagesInUnnested(@Nonnull RecordMetaDataProto.MetaData.Builder metaDataBuilder,
-                                                         @Nonnull Descriptors.FileDescriptor fileDescriptor,
-                                                         @Nonnull String recordTypeName,
-                                                         @Nonnull String newRecordTypeName,
-                                                         @Nonnull Descriptors.Descriptor oldTypeDescriptor) {
-        for (var unnested : metaDataBuilder.getUnnestedRecordTypesBuilderList()) {
-            for (var constituent : unnested.getNestedConstituentsBuilderList()) {
-                // The nested constituents would most likely be nested types, not record types, and thus would not be
-                // renamed.
-                if (constituent.getParent().isEmpty() && constituent.getTypeName().equals(recordTypeName)) {
-                    constituent.setTypeName(newRecordTypeName);
-                } else {
-                    final Descriptors.Descriptor constituentTypeDescriptor = UnnestedRecordTypeBuilder.findDescriptorByName(fileDescriptor,
-                            constituent.getTypeName());
-                    if (constituentTypeDescriptor == null) {
-                        throw new MetaDataException("missing descriptor for nested constituent")
-                                .addLogInfo(LogMessageKeys.EXPECTED, constituent.getTypeName())
-                                .addLogInfo(LogMessageKeys.CONSTITUENT, constituent.getName());
-                    }
-                    if (isNested(constituentTypeDescriptor, oldTypeDescriptor)) {
-                        throw new MetaDataException("Renaming types used by non-parent unnested constituents is not supported");
-                    }
-                }
-            }
-        }
-    }
-
-    /**
-     * Whether the {@code targetDescriptor} is equal to or nested within {@code typeDescriptor}.
+     * Applies {@code renames} to every part of the metadata. Shared by {@link #renameRecordType} and
+     * {@link #renameRecordTypes}, which differ only in how they build and pre-validate the map of renames. The steps
+     * are ordered so that every validation happens before the first mutation, leaving {@code metaDataBuilder}
+     * untouched if any of them raises {@link MetaDataException}.
      *
-     * @param typeDescriptor a type
-     * @param targetDescriptor a type that may or may not be nested in {@code typeDescriptor}
-     * @return {@code true} if the {@code targetDescriptor} is the same as {@code typeDescriptor} or a nested type of it
+     * @param metaDataBuilder the metadata builder to rewrite
+     * @param renames the renames to apply, which must be non-empty and collision-free
+     * @param fileDescriptor the compiled {@code MetaData.records}, as it stands before any rename has been applied
      */
-    private static boolean isNested(@Nonnull Descriptors.Descriptor typeDescriptor,
-                                    @Nonnull Descriptors.Descriptor targetDescriptor) {
-        if (typeDescriptor.equals(targetDescriptor)) {
-            return true;
-        } else if (typeDescriptor.getContainingType() == null) {
-            return false;
-        } else {
-            return isNested(typeDescriptor.getContainingType(), targetDescriptor);
+    private static void applyRecordTypeRenames(@Nonnull RecordMetaDataProto.MetaData.Builder metaDataBuilder,
+                                               @Nonnull RecordTypeRenames renames,
+                                               @Nonnull Descriptors.FileDescriptor fileDescriptor) {
+        // Validate that `MetaData.user_defined_functions` is empty.
+        validateNoUserDefinedFunctions(metaDataBuilder);
+
+        // Validate the `MetaData.unnested_record_types` constituents.
+        validateRecordTypeUsagesInUnnestedRecordTypes(metaDataBuilder.getUnnestedRecordTypesBuilderList(),
+                fileDescriptor, renames);
+
+        // Determine the usage of each renamed type by looking at the union message type within `MetaData.records`.
+        final DescriptorProtos.DescriptorProto.Builder union = fetchUnionBuilder(metaDataBuilder.getRecordsBuilder());
+        if (union.getNestedTypeCount() > 0) {
+            throw new MetaDataException("Nested types in union type not supported");
         }
+        determineRecordTypeUnionFieldsAndUsages(renames, fileDescriptor, union);
+
+        // A RECORD-usage type was found in the union, so it must be registered in `MetaData.record_types` too. This
+        // shouldn't happen, but if somehow a record type was in the union but not the record type list, throw.
+        final Set<String> recordTypeNames = new HashSet<>(getRecordTypes(metaDataBuilder));
+        for (final RecordTypeRename rename : renames.values()) {
+            if (rename.usage == RecordTypeOptions.Usage.RECORD && !recordTypeNames.contains(rename.name)) {
+                throw new MetaDataException("Missing " + rename.name + " in record type list");
+            }
+        }
+
+        // Validate that renaming the canonical union fields would not cause a collision.
+        validateUnionFieldRenames(union, renames);
+
+        // Every validation is now done, so the metadata can be mutated.
+
+        // Rename the canonical union field, if present, for each renamed type.
+        renameUnionFields(renames);
+
+        // Rename every message type in `MetaData.records`, and all field type references.
+        renameRecordTypeUsagesInMessageTypes(metaDataBuilder.getRecordsBuilder().getMessageTypeBuilderList(), renames,
+                fileDescriptor);
+
+        // Update `MetaData.record_types` for every top-level RECORD type.
+        renameRecordTypeUsagesInRecordTypes(metaDataBuilder.getRecordTypesBuilderList(), renames);
+
+        // Update `MetaData.indexes` for every top-level RECORD type.
+        renameRecordTypeUsagesInIndexes(metaDataBuilder.getIndexesBuilderList(), renames);
+
+        // Update `MetaData.joined_record_types` constituents for every renamed type.
+        renameRecordTypeUsagesInJoinedRecordTypes(metaDataBuilder.getJoinedRecordTypesBuilderList(), renames);
+
+        // Rename `MetaData.unnested_record_types` constituents for every renamed type.
+        renameRecordTypeUsagesInUnnestedRecordTypes(metaDataBuilder.getUnnestedRecordTypesBuilderList(), renames);
     }
 
     /**
@@ -944,7 +728,7 @@ public class MetaDataProtoEditor {
     }
 
     /**
-     * A helper for {@link #renameRecordTypes} that determines the {@link RecordTypeOptions.Usage Usage} of each
+     * A helper for {@link #applyRecordTypeRenames} that determines the {@link RecordTypeOptions.Usage Usage} of each
      * renamed type by looking at the union. Fills in the {@code usage} and {@code unionField} of the entries
      * in {@code renames}. Does not mutate {@code fileDescriptor} and {@code unionBuilder}.
      */
@@ -1051,7 +835,7 @@ public class MetaDataProtoEditor {
     }
 
     /**
-     * A helper for {@link #renameRecordTypes} that applies the name mapping in a single walk over the message types
+     * A helper for {@link #applyRecordTypeRenames} that applies the name mapping in a single walk over the message types
      * in {@code MetaData.records}, using the given compiled file descriptor for type resolution. Field type
      * references are resolved (via the original descriptor) to the original type they point at; if that original
      * type is, or is nested within, any renamed type, the reference is rewritten to point at the renamed type.

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBMetaDataStoreTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/FDBMetaDataStoreTest.java
@@ -1812,8 +1812,9 @@ public class FDBMetaDataStoreTest {
 
     /**
      * This is somewhat of a weird case, but validate that if there is a union field for the new record type name that
-     * looks like _NewRecordTypeName (for whatever reason), <em>don't</em> rename the union field to that because getting
-     * the name looking right isn't worth throwing an error.
+     * looks like _NewRecordTypeName (for whatever reason), the rename is rejected rather than performed with the union
+     * field left under its old name. Renaming the canonical union field would collide with that existing field, and a
+     * union whose field names disagree with their record types is confusing enough to be worth an error.
      */
     @Test
     public void renameSimpleWhereUnionFieldIsAlreadyTaken() {
@@ -1846,23 +1847,46 @@ public class FDBMetaDataStoreTest {
         }
         try (FDBRecordContext context = fdb.openContext()) {
             openMetaDataStore(context);
-            renameRecordType("MySimpleRecord", "MyNewSimpleRecord");
-            RecordMetaData metaData = metaDataStore.getRecordMetaData();
-            assertEquals(ImmutableSet.of("MyNewSimpleRecord", "MyOtherRecord"), metaData.getRecordTypes().keySet());
-            assertEquals(ImmutableSet.of("_MySimpleRecord", "_MyNewSimpleRecord"), metaData.getUnionDescriptor().getFields().stream().map(Descriptors.FieldDescriptor::getName).collect(Collectors.toSet()));
-            assertEquals("_MySimpleRecord", metaData.getUnionFieldForRecordType(metaData.getRecordType("MyNewSimpleRecord")).getName());
-            assertEquals("_MyNewSimpleRecord", metaData.getUnionFieldForRecordType(metaData.getRecordType("MyOtherRecord")).getName());
+            final MetaDataException e = assertThrows(MetaDataException.class,
+                    () -> renameRecordType("MySimpleRecord", "MyNewSimpleRecord"));
+            assertEquals("Cannot rename union field to _MyNewSimpleRecord as a field of that name already exists",
+                    e.getMessage());
             context.commit();
         }
+        // The rejected rename must have left the stored metadata untouched.
         try (FDBRecordContext context = fdb.openContext()) {
             openMetaDataStore(context);
             RecordMetaData metaData = metaDataStore.getRecordMetaData();
-            assertEquals(ImmutableSet.of("MyNewSimpleRecord", "MyOtherRecord"), metaData.getRecordTypes().keySet());
+            assertEquals(ImmutableSet.of("MySimpleRecord", "MyOtherRecord"), metaData.getRecordTypes().keySet());
             assertEquals(ImmutableSet.of("_MySimpleRecord", "_MyNewSimpleRecord"), metaData.getUnionDescriptor().getFields().stream().map(Descriptors.FieldDescriptor::getName).collect(Collectors.toSet()));
-            assertEquals("_MySimpleRecord", metaData.getUnionFieldForRecordType(metaData.getRecordType("MyNewSimpleRecord")).getName());
+            assertEquals("_MySimpleRecord", metaData.getUnionFieldForRecordType(metaData.getRecordType("MySimpleRecord")).getName());
             assertEquals("_MyNewSimpleRecord", metaData.getUnionFieldForRecordType(metaData.getRecordType("MyOtherRecord")).getName());
             context.commit();
         }
+    }
+
+    /**
+     * Validate that a record type that has a union field but no entry in the record type list, which should never
+     * happen but is expressible in a hand-built metadata, is reported rather than renamed.
+     */
+    @Test
+    public void renameRecordTypeMissingFromRecordTypeList() {
+        final RecordMetaDataProto.MetaData.Builder builder =
+                RecordMetaData.build(TestRecords1Proto.getDescriptor()).toProto().toBuilder();
+        // Drop MySimpleRecord from the record type list, leaving its _MySimpleRecord union field in place. The union
+        // field is what makes the rename resolve MySimpleRecord as a RECORD-usage type in the first place.
+        final List<RecordMetaDataProto.RecordType> recordTypes = builder.getRecordTypesList().stream()
+                .filter(recordType -> !recordType.getName().equals("MySimpleRecord"))
+                .collect(Collectors.toList());
+        builder.clearRecordTypes().addAllRecordTypes(recordTypes);
+
+        final MetaDataException e = assertThrows(MetaDataException.class,
+                () -> renameRecordType(builder, "MySimpleRecord", "MyNewSimpleRecord"));
+        assertEquals("Missing MySimpleRecord in record type list", e.getMessage());
+        // The rename must be rejected before anything has been rewritten.
+        assertThat(builder.getRecords().getMessageTypeList().stream()
+                        .map(DescriptorProtos.DescriptorProto::getName).collect(Collectors.toList()),
+                hasItem("MySimpleRecord"));
     }
 
     /**
@@ -1960,6 +1984,48 @@ public class FDBMetaDataStoreTest {
             RecordMetaData metaData = metaDataStore.getRecordMetaData();
             assertEquals(RecordMetaDataBuilder.DEFAULT_UNION_NAME, metaData.getUnionDescriptor().getName());
             assertEquals(ImmutableSet.of("MySimpleRecord", "MyOtherRecord"), metaData.getRecordTypes().keySet());
+        }
+    }
+
+    /**
+     * Validate that the union can still be renamed to a name whose canonical union field name is already taken, since
+     * renaming the union does not rename any union field and so cannot collide with one.
+     */
+    @Test
+    public void renameUnionWhereUnionFieldIsAlreadyTaken() {
+        try (FDBRecordContext context = fdb.openContext()) {
+            openMetaDataStore(context);
+            RecordMetaData metaData = RecordMetaData.build(TestRecords1Proto.getDescriptor());
+            metaDataStore.saveRecordMetaData(metaData);
+            // Give MyOtherRecord's union field the name that renaming the union to UnionType would want for itself.
+            metaDataStore.mutateMetaData(metaDataProtoBuilder ->
+                    metaDataProtoBuilder.getRecordsBuilder().getMessageTypeBuilderList().forEach(messageType -> {
+                        if (messageType.getName().equals(RecordMetaDataBuilder.DEFAULT_UNION_NAME)) {
+                            messageType.getFieldBuilderList().forEach(field -> {
+                                if (field.getName().equals("_MyOtherRecord")) {
+                                    field.setName("_UnionType");
+                                }
+                            });
+                        }
+                    })
+            );
+            context.commit();
+        }
+        try (FDBRecordContext context = fdb.openContext()) {
+            openMetaDataStore(context);
+            renameRecordType(RecordMetaDataBuilder.DEFAULT_UNION_NAME, "UnionType");
+            RecordMetaData metaData = metaDataStore.getRecordMetaData();
+            assertEquals("UnionType", metaData.getUnionDescriptor().getName());
+            assertEquals(ImmutableSet.of("MySimpleRecord", "MyOtherRecord"), metaData.getRecordTypes().keySet());
+            assertEquals(ImmutableSet.of("_MySimpleRecord", "_UnionType"),
+                    metaData.getUnionDescriptor().getFields().stream().map(Descriptors.FieldDescriptor::getName).collect(Collectors.toSet()));
+            context.commit();
+        }
+        try (FDBRecordContext context = fdb.openContext()) {
+            openMetaDataStore(context);
+            RecordMetaData metaData = metaDataStore.getRecordMetaData();
+            assertEquals("UnionType", metaData.getUnionDescriptor().getName());
+            assertEquals("_UnionType", metaData.getUnionFieldForRecordType(metaData.getRecordType("MyOtherRecord")).getName());
         }
     }
 
@@ -2161,6 +2227,39 @@ public class FDBMetaDataStoreTest {
             openMetaDataStore(context);
             MetaDataException e = assertThrows(MetaDataException.class, () -> renameRecordType("MyOtherRecord", "MySimpleRecord"));
             assertEquals("Cannot rename record type to MySimpleRecord as an imported record type of that name already exists", e.getMessage());
+        }
+    }
+
+    /**
+     * Validate that a {@code NESTED} record type, too, cannot be renamed to the name of an imported record type, even
+     * though the rename would not otherwise touch the record type list.
+     */
+    @Test
+    public void renameNestedRecordTypeClashingWithImported() {
+        try (FDBRecordContext context = fdb.openContext()) {
+            openMetaDataStore(context);
+            RecordMetaData metaData = RecordMetaData.build(TestRecordsImportedAndNewProto.getDescriptor());
+            metaDataStore.saveRecordMetaData(metaData);
+            // Move the NESTED type out of the way, so that MySimpleRecord names only the imported record type.
+            renameRecordType("MySimpleRecord", "MyLocalSimpleRecord");
+            context.commit();
+        }
+        try (FDBRecordContext context = fdb.openContext()) {
+            openMetaDataStore(context);
+            final MetaDataException e = assertThrows(MetaDataException.class,
+                    () -> renameRecordType("MyLocalSimpleRecord", "MySimpleRecord"));
+            assertEquals("Cannot rename record type to MySimpleRecord as an imported record type of that name already exists",
+                    e.getMessage());
+            context.commit();
+        }
+        // The rejected rename must have left the stored metadata untouched.
+        try (FDBRecordContext context = fdb.openContext()) {
+            openMetaDataStore(context);
+            RecordMetaData metaData = metaDataStore.getRecordMetaData();
+            assertEquals(ImmutableSet.of("MySimpleRecord", "MyOtherRecord"), metaData.getRecordTypes().keySet());
+            assertNotNull(metaData.getRecordsDescriptor().findMessageTypeByName("MyLocalSimpleRecord"));
+            assertEquals("com.apple.foundationdb.record.test1.MySimpleRecord",
+                    metaData.getRecordType("MySimpleRecord").getDescriptor().getFullName());
         }
     }
 


### PR DESCRIPTION
Remove redundant code from the original `renameRecordType()` implementation by reusing the primitives introduced for the batched version `renameRecordTypes()`. Both public methods now delegate to a shared `applyRecordTypeRenames()` method, which orders the steps so that every validation happens before the first mutation.

This refactoring does not affect the behavior, with two exceptions:

* Renaming the canonical union field to a name that collides with another field now results in a `MetaDataException` being thrown from `validateUnionFieldRenames()`, instead of silently leaving the field under its old name.
* The check that rejects a rename colliding with an imported record type now runs for every usage, where previously it ran only for `RECORD`-usage types. Renaming a `NESTED` type, or the union type, onto the name of an imported record type used to succeed, leaving the metadata with a name that resolves ambiguously.