### PR TITLE
Reject duplicate index maintainer factory registrations

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexMaintainerFactoryRegistryImpl.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/IndexMaintainerFactoryRegistryImpl.java
@@ -21,14 +21,13 @@
 package com.apple.foundationdb.record.provider.foundationdb;
 
 import com.apple.foundationdb.annotation.API;
-import com.apple.foundationdb.record.logging.KeyValueLogMessage;
+import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.MetaDataException;
 import com.apple.foundationdb.record.provider.foundationdb.indexes.SlidingWindowIndexMaintainerFactory;
 import com.apple.foundationdb.record.util.ServiceLoaderProvider;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.google.common.annotations.VisibleForTesting;
 
 import javax.annotation.Nonnull;
 import java.util.HashMap;
@@ -39,8 +38,6 @@ import java.util.Map;
  */
 @API(API.Status.INTERNAL)
 public class IndexMaintainerFactoryRegistryImpl implements IndexMaintainerFactoryRegistry {
-    @Nonnull
-    private static final Logger LOGGER = LoggerFactory.getLogger(IndexMaintainerFactoryRegistryImpl.class);
     @Nonnull
     protected static final IndexMaintainerFactoryRegistryImpl INSTANCE = new IndexMaintainerFactoryRegistryImpl();
 
@@ -54,15 +51,30 @@ public class IndexMaintainerFactoryRegistryImpl implements IndexMaintainerFactor
 
     @Nonnull
     protected static Map<String, IndexMaintainerFactory> initRegistry() {
+        return buildRegistry(ServiceLoaderProvider.load(IndexMaintainerFactory.class));
+    }
+
+    /**
+     * Maps each index type to the factory that maintains it. An index type may be claimed by only one factory.
+     *
+     * @param factories the factories found on the class path
+     *
+     * @return the index type to factory map
+     *
+     * @throws RecordCoreException if two factories claim the same index type
+     */
+    @Nonnull
+    @VisibleForTesting
+    static Map<String, IndexMaintainerFactory> buildRegistry(@Nonnull final Iterable<IndexMaintainerFactory> factories) {
         final Map<String, IndexMaintainerFactory> registry = new HashMap<>();
-        for (IndexMaintainerFactory factory : ServiceLoaderProvider.load(IndexMaintainerFactory.class)) {
+        for (IndexMaintainerFactory factory : factories) {
             for (String type : factory.getIndexTypes()) {
-                if (registry.containsKey(type)) {
-                    if (LOGGER.isWarnEnabled()) {
-                        LOGGER.warn(KeyValueLogMessage.of("duplicate index maintainer", LogMessageKeys.INDEX_TYPE, type));
-                    }
-                } else {
-                    registry.put(type, factory);
+                final var existingFactory = registry.put(type, factory);
+                if (existingFactory != null) {
+                    throw new RecordCoreException("duplicate index maintainer factory for index type",
+                            LogMessageKeys.INDEX_TYPE, type,
+                            LogMessageKeys.VALUE, existingFactory.getClass().getName() + ", "
+                                                  + factory.getClass().getName());
                 }
             }
         }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/IndexMaintainerFactoryRegistryImplTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/IndexMaintainerFactoryRegistryImplTest.java
@@ -1,0 +1,114 @@
+/*
+ * IndexMaintainerFactoryRegistryImplTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.record.provider.foundationdb;
+
+import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.logging.LogMessageKeys;
+import com.apple.foundationdb.record.metadata.Index;
+import com.apple.foundationdb.record.metadata.IndexTypes;
+import com.apple.foundationdb.record.metadata.IndexValidator;
+import com.apple.foundationdb.record.provider.foundationdb.indexes.ValueIndexMaintainerFactory;
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+
+import static com.apple.foundationdb.record.metadata.Key.Expressions.field;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+
+/**
+ * Tests for {@link IndexMaintainerFactoryRegistryImpl}.
+ */
+class IndexMaintainerFactoryRegistryImplTest {
+
+    @Test
+    void factoriesClaimingDistinctTypesAreAllRegistered() {
+        final var valueFactory = new StubFactory("stub_value");
+        final var rankFactory = new StubFactory("stub_rank", "stub_rank_long");
+
+        final var registry = IndexMaintainerFactoryRegistryImpl.buildRegistry(
+                ImmutableList.of(valueFactory, rankFactory));
+
+        assertThat(registry).containsOnlyKeys("stub_value", "stub_rank", "stub_rank_long");
+        assertThat(registry.get("stub_value")).isSameAs(valueFactory);
+        assertThat(registry.get("stub_rank")).isSameAs(rankFactory);
+        assertThat(registry.get("stub_rank_long")).isSameAs(rankFactory);
+    }
+
+    @Test
+    void twoFactoriesClaimingTheSameTypeAreRejected() {
+        final var thrown = catchThrowableOfType(RecordCoreException.class,
+                () -> IndexMaintainerFactoryRegistryImpl.buildRegistry(
+                        ImmutableList.of(new StubFactory("stub_value"), new StubFactory("stub_value"))));
+
+        assertThat(thrown).hasMessageContaining("duplicate index maintainer factory");
+        assertThat(thrown.getLogInfo())
+                .containsEntry(LogMessageKeys.INDEX_TYPE.toString(), "stub_value");
+    }
+
+    @Test
+    void oneFactoryClaimingTheSameTypeTwiceIsRejected() {
+        final var thrown = catchThrowableOfType(RecordCoreException.class,
+                () -> IndexMaintainerFactoryRegistryImpl.buildRegistry(
+                        ImmutableList.of(new StubFactory("stub_value", "stub_value"))));
+
+        assertThat(thrown).hasMessageContaining("duplicate index maintainer factory");
+        assertThat(thrown.getLogInfo())
+                .containsEntry(LogMessageKeys.INDEX_TYPE.toString(), "stub_value");
+    }
+
+    @Test
+    void theRegistryOnTheClassPathBuilds() {
+        final var index = new Index("stub_index", field("field"), IndexTypes.VALUE);
+
+        assertThat(IndexMaintainerFactoryRegistryImpl.instance().getIndexMaintainerFactory(index))
+                .isInstanceOf(ValueIndexMaintainerFactory.class);
+    }
+
+    private static final class StubFactory implements IndexMaintainerFactory {
+        @Nonnull
+        private final List<String> indexTypes;
+
+        StubFactory(@Nonnull final String... indexTypes) {
+            this.indexTypes = ImmutableList.copyOf(indexTypes);
+        }
+
+        @Nonnull
+        @Override
+        public Iterable<String> getIndexTypes() {
+            return indexTypes;
+        }
+
+        @Nonnull
+        @Override
+        public IndexValidator getIndexValidator(final Index index) {
+            throw new UnsupportedOperationException("not used");
+        }
+
+        @Nonnull
+        @Override
+        public IndexMaintainer getIndexMaintainer(@Nonnull final IndexMaintainerState state) {
+            throw new UnsupportedOperationException("not used");
+        }
+    }
+}


### PR DESCRIPTION
`IndexMaintainerFactoryRegistryImpl` builds its index-type-to-factory map from the factories the service loader finds. When two claimed the same index type it logged a warning and kept whichever it saw first, so which factory maintains and plans that type depended on class path order. 

It is now a `RecordCoreException` naming the type and both factories, raised while the registry is built, so a misconfigured class path is reported at once. The same hard failure already applies to the sibling deserializer registry, which collects into a Guava `ImmutableMap.Builder`.

Breaking for anyone carrying two factories for one index type: drop the redundant one, or give it its own type. Nothing in this repository is affected, every factory across core, lucene and spatial, main and test, declares distinct types.