### PR TITLE
Clean up completed entries from the `LockRegistry`

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/locking/AsyncLock.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/locking/AsyncLock.java
@@ -34,6 +34,9 @@ import java.util.concurrent.CompletableFuture;
  */
 @API(API.Status.INTERNAL)
 public class AsyncLock {
+    @Nonnull
+    public static final AsyncLock READY = new AsyncLock(null, AsyncUtil.DONE, AsyncUtil.DONE, AsyncUtil.DONE, AsyncUtil.DONE);
+
     // All the read tasks that are pending up till the current lock instance.
     @Nonnull
     private final CompletableFuture<Void> pendingReads;
@@ -46,6 +49,8 @@ public class AsyncLock {
     // waiting tasks that the current lock instance is waiting upon.
     @Nonnull
     private final CompletableFuture<Void> waitFuture;
+    @Nonnull
+    private final CompletableFuture<Void> allWorkFuture;
     @Nullable
     private final StoreTimer timer;
 
@@ -57,6 +62,7 @@ public class AsyncLock {
         this.pendingWrites = pendingWrites;
         this.taskFuture = taskFuture;
         this.waitFuture = waitFuture;
+        this.allWorkFuture = CompletableFuture.allOf(pendingReads, pendingWrites, taskFuture);
         if (timer != null) {
             timer.increment(FDBStoreTimer.Counts.LOCKS_ATTEMPTED);
         }
@@ -84,6 +90,14 @@ public class AsyncLock {
         final CompletableFuture<Void> taskFuture = new CompletableFuture<>();
         final CompletableFuture<Void> newPendingWrites = waitFuture.thenCompose(ignore -> taskFuture);
         return new AsyncLock(timer, AsyncUtil.DONE, newPendingWrites, taskFuture, waitFuture);
+    }
+
+    /**
+     * Schedule a task to run as clean up. This will run after the lock has been released, and after
+     * all pending reads or writes have completed.
+     */
+    void runAsCleanUp(@Nonnull Runnable runnable) {
+        allWorkFuture.whenComplete((r, e) -> runnable.run());
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/locking/AsyncLock.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/locking/AsyncLock.java
@@ -71,25 +71,27 @@ public class AsyncLock {
     /**
      * Constructs a new {@link AsyncLock} from the calling lock by stacking the new read future to its pending tasks.
      *
+     * @param newTimer timer to use to instrument the new lock
      * @return A pair of the new {@link AsyncLock} to be handed over to the consumer.
      */
-    AsyncLock withNewRead() {
+    AsyncLock withNewRead(@Nullable final StoreTimer newTimer) {
         final CompletableFuture<Void> waitFuture = pendingWrites;
         final CompletableFuture<Void> taskFuture = new CompletableFuture<>();
         final CompletableFuture<Void> newPendingReads = CompletableFuture.allOf(this.pendingReads, waitFuture.thenCompose(ignore -> taskFuture));
-        return new AsyncLock(timer, newPendingReads, this.pendingWrites, taskFuture, waitFuture);
+        return new AsyncLock(newTimer, newPendingReads, this.pendingWrites, taskFuture, waitFuture);
     }
 
     /**
      * Constructs a new {@link AsyncLock} from the calling lock by stacking the new write future to its pending tasks.
      *
+     * @param newTimer timer to use to instrument the new lock
      * @return A pair of the new {@link AsyncLock} to be handed over to the consumer.
      */
-    AsyncLock withNewWrite() {
+    AsyncLock withNewWrite(@Nullable final StoreTimer newTimer) {
         final CompletableFuture<Void> waitFuture = CompletableFuture.allOf(this.pendingReads, this.pendingWrites);
         final CompletableFuture<Void> taskFuture = new CompletableFuture<>();
         final CompletableFuture<Void> newPendingWrites = waitFuture.thenCompose(ignore -> taskFuture);
-        return new AsyncLock(timer, AsyncUtil.DONE, newPendingWrites, taskFuture, waitFuture);
+        return new AsyncLock(newTimer, AsyncUtil.DONE, newPendingWrites, taskFuture, waitFuture);
     }
 
     /**

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/locking/LockRegistry.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/locking/LockRegistry.java
@@ -23,9 +23,11 @@ package com.apple.foundationdb.record.locking;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
+import com.google.common.annotations.VisibleForTesting;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -191,5 +193,15 @@ public class LockRegistry {
             timer.record(FDBStoreTimer.DetailEvents.LOCKS_REGISTERED, System.nanoTime() - startTime);
         }
         return newLock;
+    }
+
+    /**
+     * Get the underlying registry of locks for each lock identifier. Intended for testing only.
+     *
+     * @return an unmodifiable view of the registry's locks
+     */
+    @VisibleForTesting
+    Map<LockIdentifier, AsyncLock> getHeldLocks() {
+        return Collections.unmodifiableMap(heldLocks);
     }
 }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/locking/LockRegistry.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/locking/LockRegistry.java
@@ -21,7 +21,6 @@
 package com.apple.foundationdb.record.locking;
 
 import com.apple.foundationdb.annotation.API;
-import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 
@@ -90,7 +89,7 @@ import java.util.function.UnaryOperator;
 public class LockRegistry {
 
     @Nonnull
-    private final Map<LockIdentifier, AtomicReference<AsyncLock>> heldLocks = new ConcurrentHashMap<>();
+    private final Map<LockIdentifier, AsyncLock> heldLocks = new ConcurrentHashMap<>();
     @Nullable
     private final StoreTimer timer;
 
@@ -105,6 +104,7 @@ public class LockRegistry {
      * @param id the {@link LockIdentifier} for the resource.
      * @return the {@link CompletableFuture} of T that will be produced after the lock access has been granted.
      */
+    @Nonnull
     public CompletableFuture<AsyncLock> acquireReadLock(@Nonnull final LockIdentifier id) {
         return acquire(id, AsyncLock::withNewRead);
     }
@@ -116,16 +116,19 @@ public class LockRegistry {
      * @param id the {@link LockIdentifier} for the resource.
      * @return the {@link CompletableFuture} of T that will be produced after the lock access has been granted.
      */
+    @Nonnull
     public CompletableFuture<AsyncLock> acquireWriteLock(@Nonnull final LockIdentifier id) {
         return acquire(id, AsyncLock::withNewWrite);
     }
 
+    @Nonnull
     private CompletableFuture<AsyncLock> acquire(@Nonnull final LockIdentifier id, @Nonnull final UnaryOperator<AsyncLock> getNewLock) {
-        final AsyncLock lock = updateRefAndGetNewLock(id, getNewLock);
+        final AsyncLock lock = updateHeldLock(id, getNewLock);
+        CompletableFuture<Void> future = lock.onAcquired();
         if (timer != null) {
-            timer.instrument(FDBStoreTimer.DetailEvents.LOCKS_ACQUIRED, lock.onAcquired()).thenApply(ignore -> lock);
+            future = timer.instrument(FDBStoreTimer.DetailEvents.LOCKS_ACQUIRED, future);
         }
-        return lock.onAcquired().thenApply(ignore -> lock);
+        return future.thenApply(ignore -> lock);
     }
 
     /**
@@ -137,6 +140,7 @@ public class LockRegistry {
      * @param operation to be called after the access is granted.
      * @return the {@link CompletableFuture} of T which is the result of the operation.
      */
+    @Nonnull
     public <T> CompletableFuture<T> doWithReadLock(@Nonnull final LockIdentifier id, @Nonnull final Supplier<CompletableFuture<T>> operation) {
         return doOp(id, operation, AsyncLock::withNewRead);
     }
@@ -150,10 +154,12 @@ public class LockRegistry {
      * @param operation to be called after the access is granted.
      * @return the {@link CompletableFuture} of T which is the result of the operation.
      */
+    @Nonnull
     public <T> CompletableFuture<T> doWithWriteLock(@Nonnull final LockIdentifier id, @Nonnull final Supplier<CompletableFuture<T>> operation) {
         return doOp(id, operation, AsyncLock::withNewWrite);
     }
 
+    @Nonnull
     private <T> CompletableFuture<T> doOp(@Nonnull final LockIdentifier id, @Nonnull final Supplier<CompletableFuture<T>> operation,
                                           @Nonnull final UnaryOperator<AsyncLock> getNewLock) {
         final AtomicReference<AsyncLock> lockRef = new AtomicReference<>();
@@ -163,11 +169,24 @@ public class LockRegistry {
         }).whenComplete((ignore, err) -> lockRef.get().release());
     }
 
-    private AsyncLock updateRefAndGetNewLock(@Nonnull final LockIdentifier identifier, @Nonnull final UnaryOperator<AsyncLock> getNewLock) {
+    @Nonnull
+    private AsyncLock updateHeldLock(@Nonnull final LockIdentifier identifier, @Nonnull final UnaryOperator<AsyncLock> getNewLock) {
         final long startTime = System.nanoTime();
-        final AtomicReference<AsyncLock> parentLockRef = heldLocks.computeIfAbsent(identifier, ignore ->
-                new AtomicReference<>(new AsyncLock(timer, AsyncUtil.DONE, AsyncUtil.DONE, AsyncUtil.DONE, AsyncUtil.DONE)));
-        final AsyncLock newLock = parentLockRef.updateAndGet(getNewLock);
+        final AsyncLock newLock = heldLocks.compute(identifier, (ignore, parent) -> {
+            // Chain the new lock off of the latest lock for this ID (or a default "ready lock" that allows the new
+            // lock to be ready immediately)
+            if (parent == null) {
+                parent = AsyncLock.READY;
+            }
+            return getNewLock.apply(parent);
+        });
+        // Clean up: remove this item from the heldLocks map if it is still the most recently registered lock for this key in the map.
+        // This can only be done when no future task needs to wait on this lock, so all of its pending writes and pending reads must
+        // have finished, and it must be released.
+        // Note that it is not enough for the lock to have been released, as if newLock is a read lock, its parent lock may still
+        // be ongoing when newLock is released. If we cleaned up the entry from the map at that point, then we could end up scheduling
+        // a write operation concurrently with the parent lock.
+        newLock.runAsCleanUp(() -> heldLocks.compute(identifier, (ignore, current) -> current == newLock ? null : current));
         if (timer != null) {
             timer.record(FDBStoreTimer.DetailEvents.LOCKS_REGISTERED, System.nanoTime() - startTime);
         }

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/locking/LockRegistry.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/locking/LockRegistry.java
@@ -108,7 +108,7 @@ public class LockRegistry {
      */
     @Nonnull
     public CompletableFuture<AsyncLock> acquireReadLock(@Nonnull final LockIdentifier id) {
-        return acquire(id, AsyncLock::withNewRead);
+        return acquire(id, lock -> lock.withNewRead(timer));
     }
 
     /**
@@ -120,7 +120,7 @@ public class LockRegistry {
      */
     @Nonnull
     public CompletableFuture<AsyncLock> acquireWriteLock(@Nonnull final LockIdentifier id) {
-        return acquire(id, AsyncLock::withNewWrite);
+        return acquire(id, lock -> lock.withNewWrite(timer));
     }
 
     @Nonnull
@@ -144,7 +144,7 @@ public class LockRegistry {
      */
     @Nonnull
     public <T> CompletableFuture<T> doWithReadLock(@Nonnull final LockIdentifier id, @Nonnull final Supplier<CompletableFuture<T>> operation) {
-        return doOp(id, operation, AsyncLock::withNewRead);
+        return doOp(id, operation, lock -> lock.withNewRead(timer));
     }
 
     /**
@@ -158,7 +158,7 @@ public class LockRegistry {
      */
     @Nonnull
     public <T> CompletableFuture<T> doWithWriteLock(@Nonnull final LockIdentifier id, @Nonnull final Supplier<CompletableFuture<T>> operation) {
-        return doOp(id, operation, AsyncLock::withNewWrite);
+        return doOp(id, operation, lock -> lock.withNewWrite(timer));
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/cursors/AsyncLockCursorTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/cursors/AsyncLockCursorTest.java
@@ -20,12 +20,12 @@
 
 package com.apple.foundationdb.record.cursors;
 
-import com.apple.foundationdb.record.LockRegistryTest;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordCursorResult;
 import com.apple.foundationdb.record.locking.AsyncLock;
 import com.apple.foundationdb.record.locking.LockIdentifier;
+import com.apple.foundationdb.record.locking.LockRegistryTest;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreTestBase;
 import com.apple.foundationdb.record.util.pair.NonnullPair;

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/locking/LockRegistryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/locking/LockRegistryTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2015-2018 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,15 +18,13 @@
  * limitations under the License.
  */
 
-package com.apple.foundationdb.record;
+package com.apple.foundationdb.record.locking;
 
 import com.apple.foundationdb.async.AsyncUtil;
-import com.apple.foundationdb.record.locking.AsyncLock;
-import com.apple.foundationdb.record.locking.LockIdentifier;
-import com.apple.foundationdb.record.locking.LockRegistry;
 import com.apple.foundationdb.record.util.pair.NonnullPair;
 import com.apple.foundationdb.subspace.Subspace;
 import com.apple.foundationdb.tuple.Tuple;
+import com.apple.test.BooleanSource;
 import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -46,6 +44,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test for {@link LockRegistry}.
@@ -72,7 +72,7 @@ public class LockRegistryTest {
 
     @ParameterizedTest
     @MethodSource("argumentsForTests")
-    public void orderedWriteTest(final int numRuns) {
+    void orderedWriteTest(final int numRuns) {
         final List<Integer> resource = new ArrayList<>();
         final List<NonnullPair<AtomicReference<AsyncLock>, CompletableFuture<Void>>> writeLockAndWaits = new ArrayList<>();
         for (int i = 0; i < numRuns; i++) {
@@ -85,13 +85,14 @@ public class LockRegistryTest {
         }
         checkAllCompletedNormally(futures);
         for (int i = 0; i < numRuns; i++) {
-            Assertions.assertEquals(i, resource.get(i));
+            assertThat(resource.get(i))
+                    .isEqualTo(i);
         }
     }
 
     @ParameterizedTest
     @MethodSource("argumentsForTests")
-    public void sharedReadsExclusiveWriteTest(final int numRuns) throws ExecutionException, InterruptedException {
+    void sharedReadsExclusiveWriteTest(final int numRuns) throws ExecutionException, InterruptedException {
         final List<Integer> resource = IntStream.range(0, numRuns).boxed().collect(Collectors.toList());
 
         // get 2 read locks, that will be shared
@@ -105,28 +106,37 @@ public class LockRegistryTest {
 
         final List<CompletableFuture<Void>> futures = new ArrayList<>();
         futures.add(runWithLock(() -> {
-            Assertions.assertEquals(numRuns * 2, resource.size());
+            assertThat(resource)
+                    .hasSize(numRuns * 2);
             for (int i = 0; i < numRuns * 2; i++) {
-                Assertions.assertEquals(i, resource.get(i));
+                assertThat(resource.get(i))
+                        .isEqualTo(i);
             }
         }, readLockAndWait4));
         futures.add(runWithLock(() -> {
-            Assertions.assertEquals(numRuns * 2, resource.size());
+            assertThat(resource)
+                    .hasSize(numRuns * 2);
             for (int i = 0; i < numRuns * 2; i++) {
-                Assertions.assertEquals(i, resource.get(i));
+                assertThat(resource.get(i))
+                        .isEqualTo(i);
             }
         }, readLockAndWait3));
         checkWaiting(futures);
         futures.add(runWithLock(() -> {
+            assertThat(resource)
+                    .hasSize(numRuns);
             Assertions.assertEquals(numRuns, resource.size());
             for (int i = 0; i < numRuns; i++) {
-                Assertions.assertEquals(i, resource.get(i));
+                assertThat(resource.get(i))
+                        .isEqualTo(i);
             }
         }, readLockAndWait2));
         futures.add(runWithLock(() -> {
-            Assertions.assertEquals(numRuns, resource.size());
+            assertThat(resource)
+                    .hasSize(numRuns);
             for (int i = 0; i < numRuns; i++) {
-                Assertions.assertEquals(i, resource.get(i));
+                assertThat(resource.get(i))
+                        .isEqualTo(i);
             }
         }, readLockAndWait1));
         // checks that the initial 2 reads get to completion
@@ -134,7 +144,8 @@ public class LockRegistryTest {
         // other 2 are still waiting
         checkWaiting(ImmutableList.of(futures.get(0), futures.get(1)));
         futures.add(runWithLock(() -> {
-            Assertions.assertEquals(numRuns, resource.size());
+            assertThat(resource)
+                    .hasSize(numRuns);
             for (int i = 0; i < numRuns; i++) {
                 resource.add(numRuns + i);
             }
@@ -144,7 +155,7 @@ public class LockRegistryTest {
     }
 
     @Test
-    public void writeWaitForReadTest() throws InterruptedException {
+    void writeWaitForReadTest() throws InterruptedException {
         final NonnullPair<AtomicReference<AsyncLock>, CompletableFuture<Void>> readLockAndWait = acquireReadLock();
         final NonnullPair<AtomicReference<AsyncLock>, CompletableFuture<Void>> writeLockAndWait = acquireWriteLock();
 
@@ -158,7 +169,7 @@ public class LockRegistryTest {
     }
 
     @Test
-    public void writeWaitForMultipleReadsTest() throws InterruptedException {
+    void writeWaitForMultipleReadsTest() throws InterruptedException {
         // get multiple read locks
         final NonnullPair<AtomicReference<AsyncLock>, CompletableFuture<Void>> readLockAndWait1 = acquireReadLock();
         final NonnullPair<AtomicReference<AsyncLock>, CompletableFuture<Void>> readLockAndWait2 = acquireReadLock();
@@ -178,7 +189,31 @@ public class LockRegistryTest {
     }
 
     @Test
-    public void writeWaitForWriteTest() throws InterruptedException {
+    void writeWaitsEvenIfLastReadWasReleasedAtAcquisition() {
+        // start two reads
+        final NonnullPair<AtomicReference<AsyncLock>, CompletableFuture<Void>> readLockAndWait1 = acquireReadLock();
+        final NonnullPair<AtomicReference<AsyncLock>, CompletableFuture<Void>> readLockAndWait2 = acquireReadLock();
+        checkAllCompletedNormally(ImmutableList.of(readLockAndWait1.getRight(), readLockAndWait2.getRight()));
+
+        // release the second one, so the most recent lock for this ID should be marked as released
+        readLockAndWait2.getLeft().get().release();
+        assertThat(registry.getHeldLocks())
+                .hasEntrySatisfying(identifier, lockInRegistry -> assertThat(lockInRegistry.isLockReleased()).isTrue());
+
+        // new write lock has to wait for the first read even though the top lock in the registry is already released
+        final NonnullPair<AtomicReference<AsyncLock>, CompletableFuture<Void>> writeLockAndWait = acquireWriteLock();
+        assertThat(writeLockAndWait.getRight())
+                .isNotDone();
+
+        readLockAndWait1.getLeft().get().release();
+        assertThat(writeLockAndWait.getRight())
+                .isCompleted();
+        assertThat(writeLockAndWait.getLeft())
+                .hasValueSatisfying(writeLock -> assertThat(writeLock).isNotNull().isSameAs(registry.getHeldLocks().get(identifier)));
+    }
+
+    @Test
+    void writeWaitForWriteTest() throws InterruptedException {
         final NonnullPair<AtomicReference<AsyncLock>, CompletableFuture<Void>> writeLockAndWait1 = acquireWriteLock();
         final NonnullPair<AtomicReference<AsyncLock>, CompletableFuture<Void>> writeLockAndWait2 = acquireWriteLock();
 
@@ -191,8 +226,31 @@ public class LockRegistryTest {
         checkAllCompletedNormally(ImmutableList.of(writeLockAndWait2.getRight()));
     }
 
+    @ParameterizedTest
+    @BooleanSource
+    void writeProceedsIfParentFails(boolean parentIsWrite) {
+        final CompletableFuture<Void> parentOperation = new CompletableFuture<>();
+        final CompletableFuture<Integer> childOperation = CompletableFuture.completedFuture(1);
+
+        final CompletableFuture<Void> parentUnderLock = parentIsWrite ? registry.doWithWriteLock(identifier, () -> parentOperation) : registry.doWithReadLock(identifier, () -> parentOperation);
+        final CompletableFuture<Integer> writeUnderLock = registry.doWithWriteLock(identifier, () -> childOperation);
+
+        // Write should not have started as the parent has not completed
+        assertThat(writeUnderLock)
+                .isNotDone();
+
+        // Complete the parent operation with an error
+        parentOperation.completeExceptionally(new Throwable("error for test"));
+        assertThat(parentUnderLock)
+                .isCompletedExceptionally();
+
+        // Now the child write should proceed (completing immediately) and should complete successfully
+        assertThat(writeUnderLock)
+                .isCompletedWithValue(1);
+    }
+
     @Test
-    public void multipleReadsWaitForWriteTest() throws InterruptedException {
+    void multipleReadsWaitForWriteTest() throws InterruptedException {
         final NonnullPair<AtomicReference<AsyncLock>, CompletableFuture<Void>> writeLockAndWait = acquireWriteLock();
         // get multiple read lock
         final NonnullPair<AtomicReference<AsyncLock>, CompletableFuture<Void>> readLockAndWait1 = acquireReadLock();
@@ -208,7 +266,7 @@ public class LockRegistryTest {
     }
 
     @Test
-    public void doWithReadLockTest() throws InterruptedException, ExecutionException {
+    void doWithReadLockTest() throws InterruptedException, ExecutionException {
         final NonnullPair<AtomicReference<AsyncLock>, CompletableFuture<Void>> writeLockAndWait1 = acquireWriteLock();
         final CompletableFuture<Integer> read = registry.doWithReadLock(identifier, () -> CompletableFuture.completedFuture(1));
         final NonnullPair<AtomicReference<AsyncLock>, CompletableFuture<Void>> writeLockAndWait2 = acquireWriteLock();
@@ -226,7 +284,7 @@ public class LockRegistryTest {
     }
 
     @Test
-    public void readsDependOnEachOtherTest() throws ExecutionException, InterruptedException {
+    void readsDependOnEachOtherTest() throws ExecutionException, InterruptedException {
         final CompletableFuture<Void> future1 = new CompletableFuture<>();
         final CompletableFuture<Void> future2 = new CompletableFuture<>();
         final NonnullPair<AtomicReference<AsyncLock>, CompletableFuture<Void>> readLockAndWait1 = acquireReadLock();
@@ -251,6 +309,94 @@ public class LockRegistryTest {
             }
         }, readLockAndWait2));
         checkAllCompletedNormally(tasks);
+    }
+
+    @ParameterizedTest(name = "cleanUpWhenDone[writeLock={0}]")
+    @BooleanSource
+    void cleanUpWhenDone(boolean writeLock) {
+        assertThat(registry.getHeldLocks())
+                .isEmpty();
+
+        // As the lock was not previously held, it should immediately be ready
+        final NonnullPair<AtomicReference<AsyncLock>, CompletableFuture<Void>> lockAndWait = writeLock ? acquireWriteLock() : acquireReadLock();
+        assertThat(lockAndWait.getRight())
+                .isDone();
+        assertThat(lockAndWait.getLeft())
+                .hasValueSatisfying(lockInRef -> assertThat(lockInRef).isNotNull());
+        assertThat(registry.getHeldLocks())
+                .hasEntrySatisfying(identifier, lockInMap -> assertThat(lockInMap).isSameAs(lockAndWait.getLeft().get()));
+
+        // Release the lock
+        lockAndWait.getLeft().get().release();
+
+        // The map entry should now be cleared out
+        assertThat(registry.getHeldLocks())
+                .isEmpty();
+    }
+
+    @ParameterizedTest(name = "cleanUpWhenAllWorkIsDone[oldestFirst={0}]")
+    @BooleanSource
+    void cleanUpWhenAllWorkIsDone(boolean oldestFirst) {
+        assertThat(registry.getHeldLocks())
+                .isEmpty();
+
+        // Acquire two read locks. They should both be immediately acquired
+        final NonnullPair<AtomicReference<AsyncLock>, CompletableFuture<Void>> lockAndWait1 = acquireReadLock();
+        final NonnullPair<AtomicReference<AsyncLock>, CompletableFuture<Void>> lockAndWait2 = acquireReadLock();
+        assertThat(lockAndWait1.getRight())
+                .isDone();
+        assertThat(lockAndWait2.getRight())
+                .isDone();
+        assertThat(lockAndWait1.getLeft())
+                .hasValueSatisfying(lockInRef -> assertThat(lockInRef).isNotNull());
+        assertThat(lockAndWait2.getLeft())
+                .hasValueSatisfying(lockInRef -> assertThat(lockInRef).isNotNull());
+
+        // The registry should hold the second lock in its map
+        assertThat(registry.getHeldLocks())
+                .hasEntrySatisfying(identifier, lockInMap -> assertThat(lockInMap).isSameAs(lockAndWait2.getLeft().get()));
+
+        // Release one lock
+        if (oldestFirst) {
+            lockAndWait1.getLeft().get().release();
+        } else {
+            lockAndWait2.getLeft().get().release();
+        }
+
+        // The registry should still point to the second lock
+        assertThat(registry.getHeldLocks())
+                .hasEntrySatisfying(identifier, lockInMap -> assertThat(lockInMap).isSameAs(lockAndWait2.getLeft().get()));
+
+        // Release the other lock
+        if (oldestFirst) {
+            lockAndWait2.getLeft().get().release();
+        } else {
+            lockAndWait1.getLeft().get().release();
+        }
+
+        // Now the entry in the registry should be released
+        assertThat(registry.getHeldLocks())
+                .isEmpty();
+    }
+
+    @ParameterizedTest
+    @BooleanSource
+    void cleanUpEvenIfTaskFails(boolean writeLock) {
+        final CompletableFuture<Void> underlyingFuture = new CompletableFuture<>();
+        final CompletableFuture<Void> futureUnderLock = writeLock ? registry.doWithWriteLock(identifier, () -> underlyingFuture) : registry.doWithReadLock(identifier, () -> underlyingFuture);
+        assertThat(futureUnderLock)
+                .isNotDone();
+        assertThat(registry.getHeldLocks())
+                .containsKey(identifier);
+
+        // Complete the underlying operation
+        underlyingFuture.completeExceptionally(new Throwable("error for test"));
+        assertThat(futureUnderLock)
+                .isCompletedExceptionally();
+
+        // The lock future failed but the cleanup of the lock registry should still be run
+        assertThat(registry.getHeldLocks())
+                .isEmpty();
     }
 
     private NonnullPair<AtomicReference<AsyncLock>, CompletableFuture<Void>> acquireWriteLock() {
@@ -287,15 +433,17 @@ public class LockRegistryTest {
             Assertions.fail("Tasks didn't complete normally", e);
         }
         for (CompletableFuture<T> f: futures) {
-            Assertions.assertTrue(f.isDone());
-            Assertions.assertFalse(f.isCompletedExceptionally());
+            assertThat(f)
+                    .isDone()
+                    .isNotCompletedExceptionally();
         }
     }
 
     public static <T> void checkWaiting(@Nonnull List<CompletableFuture<T>> futures) throws InterruptedException {
-        Thread.sleep(1000);
+        Thread.sleep(100);
         for (CompletableFuture<T> f: futures) {
-            Assertions.assertFalse(f.isDone());
+            assertThat(f)
+                    .isNotDone();
         }
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/locking/LockRegistryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/locking/LockRegistryTest.java
@@ -21,10 +21,12 @@
 package com.apple.foundationdb.record.locking;
 
 import com.apple.foundationdb.async.AsyncUtil;
+import com.apple.foundationdb.async.MoreAsyncUtil;
 import com.apple.foundationdb.record.util.pair.NonnullPair;
 import com.apple.foundationdb.subspace.Subspace;
 import com.apple.foundationdb.tuple.Tuple;
 import com.apple.test.BooleanSource;
+import com.apple.test.RandomSeedSource;
 import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -33,14 +35,23 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nonnull;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Random;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -445,5 +456,105 @@ public class LockRegistryTest {
             assertThat(f)
                     .isNotDone();
         }
+    }
+
+    /**
+     * Stress test of the lock registry. It operates by maintaining two maps, an {@code expectedValues}
+     * mapping and a {@code currentValues} mapping. It then creates a series of random read and write
+     * operations. Each operation operates on a randomly selected {@link LockIdentifier}. It will execute
+     * the task immediately against the {@code expectedValues} structure, and then also schedule a second task
+     * to operate against the {@code curretnValues} structure that (1) acquires a lock from the registry and
+     * (2) injects a random delay. In this way, this test asserts that the execution order imposed by the
+     * lock registry is the same as a single-threaded executor. That is, any read must wait for any previously
+     * scheduled write on the value associated with the lock ID to complete, and any write must wait for
+     * any previously scheduled read or write.
+     *
+     * <p>
+     * This test is not deterministic, as the exact completion order can depend on thread scheduling.
+     * However, a seed is provided for the pseudo-random number generator that is used to generate the
+     * tasks and the delays so that there is some amount of repeatability.
+     * </p>
+     *
+     * @param seed used to construct the pseudo-random number generator for semi-repeatable test cases
+     * @throws Exception an error hit while running the test
+     */
+    @ParameterizedTest(name = "lockRegistryStressTest[seed={0}]")
+    @RandomSeedSource(value = {0x0fdb5eed, 0xba5eba11})
+    void lockRegistryStressTest(long seed) throws Exception {
+        final Map<LockIdentifier, AtomicInteger> expectedValues = new ConcurrentHashMap<>();
+        final Map<LockIdentifier, AtomicInteger> currentValues = new ConcurrentHashMap<>();
+
+        final Deque<CompletableFuture<Void>> currentWork = new ArrayDeque<>();
+        final RuntimeException errorFromTask = new RuntimeException("thrown in task");
+        final Random random = new Random(seed);
+        final int opCount = 10000;
+        final int concurrency = 100;
+        int started = 0;
+        int done = 0;
+        while (done < opCount) {
+            while (started < opCount && currentWork.size() < concurrency) {
+                // Pick a random lock via a Gaussian distribution. This ensures that we have a mix of
+                // locks with a contention (those near the median) as well as locks which are rarely
+                // hit, so the held lock goes in and out of existence
+                int idNum = (int) random.nextGaussian(0, 5);
+                final LockIdentifier lockId = new LockIdentifier(new Subspace(Tuple.from(idNum)));
+                final AtomicInteger expected = expectedValues.computeIfAbsent(lockId, ignore -> new AtomicInteger());
+                // Fail a sample of tasks to validate that we aren't accidentally chaining a callback off of only a successful future
+                final boolean fail = random.nextDouble() < 0.2;
+                if (random.nextDouble() < 0.1) {
+                    // Write operation.
+                    int newValue = expected.incrementAndGet();
+                    currentWork.add(registry.doWithWriteLock(lockId, supplyWithRandomDelay(random, () -> {
+                        final AtomicInteger currentValue = currentValues.computeIfAbsent(lockId, ignore -> new AtomicInteger());
+                        int newCurrentValue = currentValue.incrementAndGet();
+                        assertThat(newCurrentValue)
+                                .as("new value for lock ID %s should match expected", lockId)
+                                .isEqualTo(newValue);
+                        if (fail) {
+                            throw errorFromTask;
+                        }
+                    })));
+                } else {
+                    // Read operation.
+                    final int expectedInt = expected.intValue();
+                    currentWork.add(registry.doWithReadLock(lockId, supplyWithRandomDelay(random, () -> {
+                        final AtomicInteger currentValue = currentValues.computeIfAbsent(lockId, ignore -> new AtomicInteger());
+                        assertThat(currentValue.get())
+                                .as("value for lock ID %s should match expected", lockId)
+                                .isEqualTo(expectedInt);
+                        if (fail) {
+                            throw errorFromTask;
+                        }
+                    })));
+                }
+                started++;
+            }
+            waitForTask(Objects.requireNonNull(currentWork.peekFirst()), errorFromTask);
+            while (!currentWork.isEmpty() && currentWork.peekFirst().isDone()) {
+                waitForTask(currentWork.removeFirst(), errorFromTask);
+                done++;
+            }
+        }
+        assertThat(currentWork)
+                .isEmpty();
+        assertThat(registry.getHeldLocks())
+                .isEmpty();
+    }
+
+    private void waitForTask(@Nonnull CompletableFuture<Void> future, @Nonnull RuntimeException allowedError) throws InterruptedException, TimeoutException {
+        try {
+            future.get(1, TimeUnit.SECONDS);
+        } catch (ExecutionException e) {
+            // If the task fails, it should fail with the allowed error.
+            // We do not use assertThatThrownBy here, as only a sample of tasks fail.
+            assertThat(e.getCause())
+                    .isSameAs(allowedError);
+        }
+    }
+
+    @Nonnull
+    private Supplier<CompletableFuture<Void>> supplyWithRandomDelay(@Nonnull Random random, @Nonnull Runnable r) {
+        long delay = random.nextInt(10);
+        return () -> MoreAsyncUtil.delayedFuture(delay, TimeUnit.MILLISECONDS).thenRunAsync(r, executorService);
     }
 }

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/locking/LockRegistryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/locking/LockRegistryTest.java
@@ -22,22 +22,29 @@ package com.apple.foundationdb.record.locking;
 
 import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.async.MoreAsyncUtil;
+import com.apple.foundationdb.record.logging.KeyValueLogMessage;
+import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.util.pair.NonnullPair;
 import com.apple.foundationdb.subspace.Subspace;
 import com.apple.foundationdb.tuple.Tuple;
 import com.apple.test.BooleanSource;
 import com.apple.test.RandomSeedSource;
 import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -62,12 +69,15 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Test for {@link LockRegistry}.
  */
 public class LockRegistryTest {
+    private static final Logger LOGGER = LoggerFactory.getLogger(LockRegistryTest.class);
 
     @Nonnull
     private final ExecutorService executorService = Executors.newFixedThreadPool(8);
 
     @Nonnull
-    final LockRegistry registry = new LockRegistry(null);
+    final FDBStoreTimer timer = new FDBStoreTimer();
+    @Nonnull
+    final LockRegistry registry = new LockRegistry(timer);
 
     @Nonnull
     final LockIdentifier identifier = new LockIdentifier(new Subspace(Tuple.from(1, 2, 3)));
@@ -79,6 +89,15 @@ public class LockRegistryTest {
                 Arguments.of(1000),
                 Arguments.of(5000)
         );
+    }
+
+    @AfterEach
+    void logRegistryStats() {
+        if (LOGGER.isInfoEnabled()) {
+            KeyValueLogMessage message = KeyValueLogMessage.build("ran lock registry test");
+            message.addKeysAndValues(timer.getKeysAndValues());
+            LOGGER.info(message.toString());
+        }
     }
 
     @ParameterizedTest
@@ -481,11 +500,11 @@ public class LockRegistryTest {
     @ParameterizedTest(name = "lockRegistryStressTest[seed={0}]")
     @RandomSeedSource(value = {0x0fdb5eed, 0xba5eba11})
     void lockRegistryStressTest(long seed) throws Exception {
-        final Map<LockIdentifier, AtomicInteger> expectedValues = new ConcurrentHashMap<>();
+        final Map<LockIdentifier, AtomicInteger> expectedValues = new HashMap<>();
         final Map<LockIdentifier, AtomicInteger> currentValues = new ConcurrentHashMap<>();
 
         final Deque<CompletableFuture<Void>> currentWork = new ArrayDeque<>();
-        final RuntimeException errorFromTask = new RuntimeException("thrown in task");
+        final RuntimeException errorThrownInTasks = new RuntimeException("thrown in task");
         final Random random = new Random(seed);
         final int opCount = 10000;
         final int concurrency = 100;
@@ -493,45 +512,12 @@ public class LockRegistryTest {
         int done = 0;
         while (done < opCount) {
             while (started < opCount && currentWork.size() < concurrency) {
-                // Pick a random lock via a Gaussian distribution. This ensures that we have a mix of
-                // locks with a contention (those near the median) as well as locks which are rarely
-                // hit, so the held lock goes in and out of existence
-                int idNum = (int) random.nextGaussian(0, 5);
-                final LockIdentifier lockId = new LockIdentifier(new Subspace(Tuple.from(idNum)));
-                final AtomicInteger expected = expectedValues.computeIfAbsent(lockId, ignore -> new AtomicInteger());
-                // Fail a sample of tasks to validate that we aren't accidentally chaining a callback off of only a successful future
-                final boolean fail = random.nextDouble() < 0.2;
-                if (random.nextDouble() < 0.1) {
-                    // Write operation.
-                    int newValue = expected.incrementAndGet();
-                    currentWork.add(registry.doWithWriteLock(lockId, supplyWithRandomDelay(random, () -> {
-                        final AtomicInteger currentValue = currentValues.computeIfAbsent(lockId, ignore -> new AtomicInteger());
-                        int newCurrentValue = currentValue.incrementAndGet();
-                        assertThat(newCurrentValue)
-                                .as("new value for lock ID %s should match expected", lockId)
-                                .isEqualTo(newValue);
-                        if (fail) {
-                            throw errorFromTask;
-                        }
-                    })));
-                } else {
-                    // Read operation.
-                    final int expectedInt = expected.intValue();
-                    currentWork.add(registry.doWithReadLock(lockId, supplyWithRandomDelay(random, () -> {
-                        final AtomicInteger currentValue = currentValues.computeIfAbsent(lockId, ignore -> new AtomicInteger());
-                        assertThat(currentValue.get())
-                                .as("value for lock ID %s should match expected", lockId)
-                                .isEqualTo(expectedInt);
-                        if (fail) {
-                            throw errorFromTask;
-                        }
-                    })));
-                }
+                currentWork.add(createRandomTask(random, errorThrownInTasks, expectedValues, currentValues));
                 started++;
             }
-            waitForTask(Objects.requireNonNull(currentWork.peekFirst()), errorFromTask);
+            waitForTask(Objects.requireNonNull(currentWork.peekFirst()), errorThrownInTasks);
             while (!currentWork.isEmpty() && currentWork.peekFirst().isDone()) {
-                waitForTask(currentWork.removeFirst(), errorFromTask);
+                waitForTask(currentWork.removeFirst(), errorThrownInTasks);
                 done++;
             }
         }
@@ -539,6 +525,63 @@ public class LockRegistryTest {
                 .isEmpty();
         assertThat(registry.getHeldLocks())
                 .isEmpty();
+        // Make sure that after all operations have completed, the expected values and current values match
+        assertThat(currentValues)
+                .hasSameSizeAs(expectedValues)
+                .allSatisfy((lockId, currentValue) ->
+                        assertThat(expectedValues)
+                                .hasEntrySatisfying(lockId, expectedValue ->
+                                        assertThat(expectedValue.get())
+                                                .as("current and expected values for lock ID %s should match after all tasks are run", lockId)
+                                                .isEqualTo(currentValue.get())
+                                )
+                );
+        assertThat(timer.getCount(FDBStoreTimer.DetailEvents.LOCKS_REGISTERED))
+                .isEqualTo(opCount);
+        assertThat(timer.getCount(FDBStoreTimer.DetailEvents.LOCKS_ACQUIRED))
+                .isEqualTo(opCount);
+        assertThat(timer.getCount(FDBStoreTimer.Counts.LOCKS_ATTEMPTED))
+                .isEqualTo(opCount);
+        assertThat(timer.getCount(FDBStoreTimer.Counts.LOCKS_RELEASED))
+                .isEqualTo(opCount);
+    }
+
+    @Nonnull
+    private CompletableFuture<Void> createRandomTask(@Nonnull Random r, @Nonnull RuntimeException errorThrownInTask, @Nonnull Map<LockIdentifier, AtomicInteger> expectedValues, @Nonnull Map<LockIdentifier, AtomicInteger> currentValues) {
+        // Pick a random lock via a Gaussian distribution. This ensures that we have a mix of
+        // locks with a contention (those with IDs near the median) as well as lock IDs which
+        // are rarely hit
+        final int idNum = (int) r.nextGaussian(0, 5);
+        final LockIdentifier lockId = new LockIdentifier(new Subspace(Tuple.from(idNum)));
+        final AtomicInteger expected = expectedValues.computeIfAbsent(lockId, ignore -> new AtomicInteger());
+        // Fail a sample of tasks to validate that we aren't accidentally chaining a callback off of only a successful future
+        final boolean fail = r.nextDouble() < 0.2;
+        if (r.nextDouble() < 0.1) {
+            // Write operation.
+            int newValue = expected.incrementAndGet();
+            return registry.doWithWriteLock(lockId, supplyWithRandomDelay(r, () -> {
+                final AtomicInteger currentValue = currentValues.computeIfAbsent(lockId, ignore -> new AtomicInteger());
+                int newCurrentValue = currentValue.incrementAndGet();
+                assertThat(newCurrentValue)
+                        .as("new value for lock ID %s should match expected", lockId)
+                        .isEqualTo(newValue);
+                if (fail) {
+                    throw errorThrownInTask;
+                }
+            }));
+        } else {
+            // Read operation.
+            final int expectedInt = expected.intValue();
+            return registry.doWithReadLock(lockId, supplyWithRandomDelay(r, () -> {
+                final AtomicInteger currentValue = currentValues.computeIfAbsent(lockId, ignore -> new AtomicInteger());
+                assertThat(currentValue.get())
+                        .as("value for lock ID %s should match expected", lockId)
+                        .isEqualTo(expectedInt);
+                if (fail) {
+                    throw errorThrownInTask;
+                }
+            }));
+        }
     }
 
     private void waitForTask(@Nonnull CompletableFuture<Void> future, @Nonnull RuntimeException allowedError) throws InterruptedException, TimeoutException {

--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/locking/LockRegistryTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/locking/LockRegistryTest.java
@@ -32,7 +32,6 @@ import com.apple.test.RandomSeedSource;
 import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -56,7 +55,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -500,8 +498,8 @@ public class LockRegistryTest {
     @ParameterizedTest(name = "lockRegistryStressTest[seed={0}]")
     @RandomSeedSource(value = {0x0fdb5eed, 0xba5eba11})
     void lockRegistryStressTest(long seed) throws Exception {
-        final Map<LockIdentifier, AtomicInteger> expectedValues = new HashMap<>();
-        final Map<LockIdentifier, AtomicInteger> currentValues = new ConcurrentHashMap<>();
+        final Map<LockIdentifier, Integer> expectedValues = new HashMap<>();
+        final Map<LockIdentifier, Integer> currentValues = new ConcurrentHashMap<>();
 
         final Deque<CompletableFuture<Void>> currentWork = new ArrayDeque<>();
         final RuntimeException errorThrownInTasks = new RuntimeException("thrown in task");
@@ -527,15 +525,7 @@ public class LockRegistryTest {
                 .isEmpty();
         // Make sure that after all operations have completed, the expected values and current values match
         assertThat(currentValues)
-                .hasSameSizeAs(expectedValues)
-                .allSatisfy((lockId, currentValue) ->
-                        assertThat(expectedValues)
-                                .hasEntrySatisfying(lockId, expectedValue ->
-                                        assertThat(expectedValue.get())
-                                                .as("current and expected values for lock ID %s should match after all tasks are run", lockId)
-                                                .isEqualTo(currentValue.get())
-                                )
-                );
+                .isEqualTo(expectedValues);
         assertThat(timer.getCount(FDBStoreTimer.DetailEvents.LOCKS_REGISTERED))
                 .isEqualTo(opCount);
         assertThat(timer.getCount(FDBStoreTimer.DetailEvents.LOCKS_ACQUIRED))
@@ -547,36 +537,34 @@ public class LockRegistryTest {
     }
 
     @Nonnull
-    private CompletableFuture<Void> createRandomTask(@Nonnull Random r, @Nonnull RuntimeException errorThrownInTask, @Nonnull Map<LockIdentifier, AtomicInteger> expectedValues, @Nonnull Map<LockIdentifier, AtomicInteger> currentValues) {
+    private CompletableFuture<Void> createRandomTask(@Nonnull Random r, @Nonnull RuntimeException errorThrownInTask, @Nonnull Map<LockIdentifier, Integer> expectedValues, @Nonnull Map<LockIdentifier, Integer> currentValues) {
         // Pick a random lock via a Gaussian distribution. This ensures that we have a mix of
         // locks with a contention (those with IDs near the median) as well as lock IDs which
         // are rarely hit
         final int idNum = (int) r.nextGaussian(0, 5);
         final LockIdentifier lockId = new LockIdentifier(new Subspace(Tuple.from(idNum)));
-        final AtomicInteger expected = expectedValues.computeIfAbsent(lockId, ignore -> new AtomicInteger());
+        final int expected = expectedValues.computeIfAbsent(lockId, ignore -> 0);
         // Fail a sample of tasks to validate that we aren't accidentally chaining a callback off of only a successful future
         final boolean fail = r.nextDouble() < 0.2;
         if (r.nextDouble() < 0.1) {
             // Write operation.
-            int newValue = expected.incrementAndGet();
+            expectedValues.put(lockId, expected + 1);
             return registry.doWithWriteLock(lockId, supplyWithRandomDelay(r, () -> {
-                final AtomicInteger currentValue = currentValues.computeIfAbsent(lockId, ignore -> new AtomicInteger());
-                int newCurrentValue = currentValue.incrementAndGet();
-                assertThat(newCurrentValue)
+                final int currentValue = currentValues.compute(lockId, (id, value) -> value == null ? 1 : value + 1);
+                assertThat(currentValue)
                         .as("new value for lock ID %s should match expected", lockId)
-                        .isEqualTo(newValue);
+                        .isEqualTo(expected + 1);
                 if (fail) {
                     throw errorThrownInTask;
                 }
             }));
         } else {
             // Read operation.
-            final int expectedInt = expected.intValue();
             return registry.doWithReadLock(lockId, supplyWithRandomDelay(r, () -> {
-                final AtomicInteger currentValue = currentValues.computeIfAbsent(lockId, ignore -> new AtomicInteger());
-                assertThat(currentValue.get())
+                final int currentValue = currentValues.computeIfAbsent(lockId, ignore -> 0);
+                assertThat(currentValue)
                         .as("value for lock ID %s should match expected", lockId)
-                        .isEqualTo(expectedInt);
+                        .isEqualTo(expected);
                 if (fail) {
                     throw errorThrownInTask;
                 }


### PR DESCRIPTION
This updates the `LockRegistry` so that it cleans up entries that are no longer necessary. It does this by scheduling a clean up task to delete the entry for the given key from the map, but only if the most recently registered lock for that key still matches the current lock. It is safe to do this when that lock is equivalent to the behavior when there is no lock present, which is to say, when the lock's pending reads and writes are all done, along with the lock's task.

Note that we cannot clean up the lock if the only thing that has happened is that the lock has been released. The reason for this is that if we have a key that has:

1. A read lock `l1`
1. A second read lock `l2` with parent `l1`

So assume `l2` is the current lock in `heldLocks` for a given lock identifier. The `l1` and `l2` tasks can be executed at the same time, so if `l2` removed the entry for the lock in `heldLocks` when it was done, then we'd have nothing to stop a new write operation `l3` from being acquired before `l1` had actually finished, breaking our contract. We instead need to wait for `l1` to also complete, which is done by having the clean-up operation wait on `l2`'s pending reads (even if `l2` is a read lock).

This resolves #4544.