### PR TITLE
Route aggregate index plan breadcrumb values through the match candidate

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/AggregateIndexMatchCandidate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/AggregateIndexMatchCandidate.java
@@ -394,6 +394,11 @@ public class AggregateIndexMatchCandidate implements MatchCandidate, WithBaseQua
     }
 
     @Nonnull
+    public Value getGroupByResultValue() {
+        return groupByResultValue;
+    }
+
+    @Nonnull
     @Override
     public RecordQueryPlan toEquivalentPlan(@Nonnull final PartialMatch partialMatch,
                                             @Nonnull final PlanContext planContext,
@@ -426,7 +431,7 @@ public class AggregateIndexMatchCandidate implements MatchCandidate, WithBaseQua
                 recordTypes.get(0).getName(),
                 indexEntryConverter,
                 selectHavingResultValue,
-                groupByResultValue,
+                getGroupByResultValue(),
                 constraintMaybe);
 
         if (regularMatchInfo.getRollUpToGroupingValues() != null) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/CardinalitiesProperty.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/properties/CardinalitiesProperty.java
@@ -24,6 +24,7 @@ import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.record.EvaluationContext;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.query.plan.bitmap.ComposedBitmapIndexQueryPlan;
+import com.apple.foundationdb.record.query.plan.cascades.AggregateIndexMatchCandidate;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.ExpressionProperty;
 import com.apple.foundationdb.record.query.plan.cascades.Quantifier;
@@ -55,6 +56,7 @@ import com.apple.foundationdb.record.query.plan.cascades.expressions.TempTableSc
 import com.apple.foundationdb.record.query.plan.cascades.expressions.UpdateExpression;
 import com.apple.foundationdb.record.query.plan.cascades.values.LiteralValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.StreamingValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.Value;
 import com.apple.foundationdb.record.query.plan.plans.InComparandSource;
 import com.apple.foundationdb.record.query.plan.plans.InParameterSource;
 import com.apple.foundationdb.record.query.plan.plans.InValuesSource;
@@ -196,26 +198,32 @@ public class CardinalitiesProperty implements ExpressionProperty<CardinalitiesPr
         @Nonnull
         @Override
         public Cardinalities visitRecordQueryAggregateIndexPlan(@Nonnull final RecordQueryAggregateIndexPlan aggregateIndexPlan) {
-            final var groupingValueMaybe = aggregateIndexPlan.getGroupingValueMaybe();
-            if (groupingValueMaybe.isEmpty()) {
-                return Cardinalities.atMostOne();
-            }
-            final var groupingValue = groupingValueMaybe.get();
             final var indexScanPlan = aggregateIndexPlan.getIndexPlan();
             final var matchCandidateOptional = indexScanPlan.getMatchCandidateMaybe();
             if (matchCandidateOptional.isEmpty()) {
                 return Cardinalities.unknownMaxCardinality();
             }
-            final var ordering = matchCandidateOptional.get()
-                    .computeOrderingFromScanComparisons(
-                            indexScanPlan.getScanComparisons(),
-                            indexScanPlan.isReverse(),
-                            false);
-            if (ordering.getEqualityBoundValues().contains(groupingValue)) {
-                return Cardinalities.atMostOne();
-            } else {
-                return Cardinalities.unknownMaxCardinality();
+            final var matchCandidate = matchCandidateOptional.get();
+            if (!(matchCandidate instanceof final AggregateIndexMatchCandidate aggregateIndexMatchCandidate)) {
+                return Cardinalities.unknownCardinalities();
             }
+
+            //
+            // The group by result value holds the grouping value ahead of the aggregate values, so a single child means
+            // the index collapses everything into one group and the scan yields at most one record.
+            //
+            final var groupByColumns = aggregateIndexMatchCandidate.getGroupByResultValue().getChildren();
+            if (Iterables.size(groupByColumns) <= 1) {
+                return Cardinalities.atMostOne();
+            }
+
+            final Value groupingValue = Iterables.get(groupByColumns, 0);
+            final var ordering =
+                    matchCandidate.computeOrderingFromScanComparisons(indexScanPlan.getScanComparisons(),
+                            indexScanPlan.isReverse(), false);
+            return ordering.getEqualityBoundValues().contains(groupingValue)
+                   ? Cardinalities.atMostOne()
+                   : Cardinalities.unknownMaxCardinality();
         }
 
         @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryAggregateIndexPlan.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/plans/RecordQueryAggregateIndexPlan.java
@@ -29,6 +29,7 @@ import com.apple.foundationdb.record.ObjectPlanHash;
 import com.apple.foundationdb.record.PlanDeserializer;
 import com.apple.foundationdb.record.PlanHashable;
 import com.apple.foundationdb.record.PlanSerializationContext;
+import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.planprotos.PRecordQueryAggregateIndexPlan;
@@ -52,6 +53,9 @@ import com.apple.foundationdb.record.query.plan.cascades.explain.NodeInfo;
 import com.apple.foundationdb.record.query.plan.cascades.explain.PlannerGraph;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.AbstractRelationalExpressionWithoutChildren;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.RelationalExpression;
+import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
+import com.apple.foundationdb.record.query.plan.cascades.values.QueriedValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.ThrowsValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.Value;
 import com.apple.foundationdb.record.query.plan.cascades.values.translation.TranslationMap;
 import com.google.auto.service.AutoService;
@@ -67,7 +71,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.StreamSupport;
 
 /**
  * A query plan that reconstructs records from the entries in an aggregate index.
@@ -86,12 +89,10 @@ public class RecordQueryAggregateIndexPlan extends AbstractRelationalExpressionW
     private final String recordTypeName;
     @Nonnull
     private final IndexKeyValueToPartialRecord toRecord;
-    // TODO the following value should not be part of this plan
-    //      https://github.com/FoundationDB/fdb-record-layer/issues/3367
+    // todo replace this attribute with "Type resultType" once we bump the plan hash mode to VC1.
     @Nonnull
     private final Value resultValue;
-    // TODO the following value should not be part of this plan
-    //      https://github.com/FoundationDB/fdb-record-layer/issues/3367
+    // todo remove this attribute once we bump the plan hash mode to VC1.
     @Nonnull
     private final Value groupByResultValue;
     @Nonnull
@@ -104,7 +105,6 @@ public class RecordQueryAggregateIndexPlan extends AbstractRelationalExpressionW
      * @param recordTypeName The name of the base record, used for debugging.
      * @param indexEntryToPartialRecordConverter A converter from index entry to record.
      * @param resultValue the result value this plan produces.
-     * @param groupByResultValue The result value.
      * @param constraint The index filter.
      */
     public RecordQueryAggregateIndexPlan(@Nonnull final RecordQueryIndexPlan indexPlan,
@@ -159,15 +159,6 @@ public class RecordQueryAggregateIndexPlan extends AbstractRelationalExpressionW
     @Nonnull
     public RecordQueryIndexPlan getIndexPlan() {
         return indexPlan;
-    }
-
-    public Optional<Value> getGroupingValueMaybe() {
-        final var hasGroupingValue = StreamSupport.stream(groupByResultValue.getChildren().spliterator(), false).count() > 1;
-        if (hasGroupingValue) {
-            return Optional.of(groupByResultValue.getChildren().iterator().next());
-        } else {
-            return Optional.empty();
-        }
     }
 
     @Nonnull
@@ -247,7 +238,8 @@ public class RecordQueryAggregateIndexPlan extends AbstractRelationalExpressionW
     @Nonnull
     @Override
     public Value getResultValue() {
-        // TODO this is bad since the derivations property or others might pick this up without understanding it
+        // todo this looks wrong and should be replaced with QueriedValue(resultType) once we bump the plan hash mode
+        //  to VC1
         return resultValue;
     }
 
@@ -345,13 +337,14 @@ public class RecordQueryAggregateIndexPlan extends AbstractRelationalExpressionW
 
     @Override
     public int planHash(@Nonnull final PlanHashMode mode) {
-        switch (mode.getKind()) {
-            case LEGACY:
-            case FOR_CONTINUATION:
-                return PlanHashable.objectsPlanHash(mode, BASE_HASH, indexPlan, resultValue);
-            default:
-                throw new UnsupportedOperationException("Hash kind " + mode.getKind() + " is not supported");
+        if (mode.getKind() == PlanHashKind.LEGACY) {
+            return PlanHashable.objectsPlanHash(mode, BASE_HASH, indexPlan, resultValue);
         }
+        return switch (mode) {
+            case VC0 -> PlanHashable.objectsPlanHash(mode, BASE_HASH, indexPlan, resultValue);
+            case VC1 -> PlanHashable.objectsPlanHash(mode, BASE_HASH, indexPlan, resultValue.getResultType());
+            default -> throw new RecordCoreException("unsupported plan hash mode");
+        };
     }
 
     @Nonnull
@@ -389,14 +382,26 @@ public class RecordQueryAggregateIndexPlan extends AbstractRelationalExpressionW
     @Nonnull
     @Override
     public PRecordQueryAggregateIndexPlan toProto(@Nonnull final PlanSerializationContext serializationContext) {
-        return PRecordQueryAggregateIndexPlan.newBuilder()
-                .setIndexPlan(indexPlan.toRecordQueryIndexPlanProto(serializationContext))
-                .setRecordTypeName(recordTypeName)
-                .setToRecord(toRecord.toProto(serializationContext))
-                .setResultValue(resultValue.toValueProto(serializationContext))
-                .setGroupByResultValue(groupByResultValue.toValueProto(serializationContext))
-                .setConstraint(constraint.toProto(serializationContext))
-                .build();
+        return switch (serializationContext.getMode()) {
+            case VL0, VC0 -> PRecordQueryAggregateIndexPlan.newBuilder()
+                    .setIndexPlan(indexPlan.toRecordQueryIndexPlanProto(serializationContext))
+                    .setRecordTypeName(recordTypeName)
+                    .setToRecord(toRecord.toProto(serializationContext))
+                    .setResultValue(resultValue.toValueProto(serializationContext))
+                    .setResultType(resultValue.getResultType().toTypeProto(serializationContext))
+                    .setGroupByResultValue(groupByResultValue.toValueProto(serializationContext))
+                    .setConstraint(constraint.toProto(serializationContext))
+                    .build();
+            case VC1 -> PRecordQueryAggregateIndexPlan.newBuilder()
+                    .setIndexPlan(indexPlan.toRecordQueryIndexPlanProto(serializationContext))
+                    .setRecordTypeName(recordTypeName)
+                    .setToRecord(toRecord.toProto(serializationContext))
+                    .setResultType(resultValue.getResultType().toTypeProto(serializationContext))
+                    .setConstraint(constraint.toProto(serializationContext))
+                    .build();
+            default -> throw new RecordCoreException("unsupported plan hash mode");
+        };
+
     }
 
     @Nonnull
@@ -408,14 +413,32 @@ public class RecordQueryAggregateIndexPlan extends AbstractRelationalExpressionW
     @Nonnull
     public static RecordQueryAggregateIndexPlan fromProto(@Nonnull final PlanSerializationContext serializationContext,
                                                           @Nonnull final PRecordQueryAggregateIndexPlan recordQueryAggregateIndexPlanProto) {
-        return new RecordQueryAggregateIndexPlan(RecordQueryIndexPlan.fromProto(serializationContext, Objects.requireNonNull(recordQueryAggregateIndexPlanProto.getIndexPlan())),
-                Objects.requireNonNull(recordQueryAggregateIndexPlanProto.getRecordTypeName()),
-                IndexKeyValueToPartialRecord.fromProto(serializationContext, Objects.requireNonNull(recordQueryAggregateIndexPlanProto.getToRecord())),
-                Value.fromValueProto(serializationContext, Objects.requireNonNull(recordQueryAggregateIndexPlanProto.getResultValue())),
-                recordQueryAggregateIndexPlanProto.hasGroupByResultValue()
-                ? Value.fromValueProto(serializationContext, Objects.requireNonNull(recordQueryAggregateIndexPlanProto.getGroupByResultValue()))
-                : Value.fromValueProto(serializationContext, Objects.requireNonNull(recordQueryAggregateIndexPlanProto.getResultValue())),
-                QueryPlanConstraint.fromProto(serializationContext, Objects.requireNonNull(recordQueryAggregateIndexPlanProto.getConstraint())));
+        final var indexPlan = RecordQueryIndexPlan.fromProto(serializationContext, Objects.requireNonNull(recordQueryAggregateIndexPlanProto.getIndexPlan()));
+        final var recordTypeName = Objects.requireNonNull(recordQueryAggregateIndexPlanProto.getRecordTypeName());
+        final var indexKeyValueToPartialRecord = IndexKeyValueToPartialRecord.fromProto(serializationContext, Objects.requireNonNull(recordQueryAggregateIndexPlanProto.getToRecord()));
+        final var planConstraint = QueryPlanConstraint.fromProto(serializationContext, Objects.requireNonNull(recordQueryAggregateIndexPlanProto.getConstraint()));
+        Value resultValue;
+        Value groupByResultValue;
+        Type resultType;
+        switch (serializationContext.getMode()) {
+            case VL0:
+            case VC0: {
+                resultValue = Value.fromValueProto(serializationContext, recordQueryAggregateIndexPlanProto.getResultValue());
+                groupByResultValue = recordQueryAggregateIndexPlanProto.hasGroupByResultValue()
+                                     ? Value.fromValueProto(serializationContext, Objects.requireNonNull(recordQueryAggregateIndexPlanProto.getGroupByResultValue()))
+                                     : Value.fromValueProto(serializationContext, Objects.requireNonNull(recordQueryAggregateIndexPlanProto.getResultValue()));
+                break;
+            }
+            case VC1: {
+                resultType = Type.fromTypeProto(serializationContext, recordQueryAggregateIndexPlanProto.getResultType());
+                resultValue = new QueriedValue(resultType);
+                groupByResultValue = new ThrowsValue(Type.nullType());
+                break;
+            }
+            default:
+                throw new RecordCoreException("unsupported plan hash mode");
+        }
+        return new RecordQueryAggregateIndexPlan(indexPlan, recordTypeName, indexKeyValueToPartialRecord, resultValue, groupByResultValue, planConstraint);
     }
 
     /**

--- a/fdb-record-layer-core/src/main/proto/record_query_plan.proto
+++ b/fdb-record-layer-core/src/main/proto/record_query_plan.proto
@@ -1776,9 +1776,10 @@ message PRecordQueryAggregateIndexPlan {
   optional PRecordQueryIndexPlan index_plan = 1;
   optional string record_type_name = 2;
   optional PIndexKeyValueToPartialRecord to_record = 3;
-  optional PValue result_value = 4;
+  optional PValue result_value = 4; // VC0
   optional PQueryPlanConstraint constraint = 5;
-  optional PValue group_by_result_value = 6;
+  optional PValue group_by_result_value = 6; // VC0
+  optional PType result_type = 7; // VC1 onwards.
 }
 
 //


### PR DESCRIPTION
Towards #3367. `RecordQueryAggregateIndexPlan` holds a `resultValue` and a `groupByResultValue` that nothing in the plan itself needs — both are breadcrumbs for later planner logic, and both are reachable through the plan's match candidate. Neither is read by the plan any more: `getGroupingValueMaybe()` is gone, and `CardinalitiesProperty`, its only reader anywhere in the repo, derives the grouping value from the `AggregateIndexMatchCandidate` instead. The two fields survive purely to keep the `VC0` wire format intact, which is what the remaining `todo`s track — they come out once the plan hash mode is bumped.

Under `PlanHashMode.VC1` the plan hashes and serializes only the result *type* rather than the whole value, and `fromProto` rebuilds a `QueriedValue` from it; the group-by result value is not written at all, and deserialization substitutes a `ThrowsValue` so that an accidental reader fails loudly rather than quietly seeing the wrong thing. `VL0` and `VC0` keep hashing and writing both values, so existing continuations stay valid. Worth a reviewer's eye: `VC1` is opt-in and `CURRENT_FOR_CONTINUATION` is still `VC0`, so the default path is untouched, but a deployment already running `VC1` would see outstanding aggregate-index continuations fail validation — if the team counts that as user-visible, `breaking change` is the better label than `enhancement`.
