### PR TITLE
Warn that setThreadsPerClientVersion needs an external client

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactory.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactory.java
@@ -573,7 +573,13 @@ public abstract class FDBDatabaseFactory {
     }
 
     /**
-     * Set the number of threads per FDB client version. The default value is 1.
+     * Set the number of threads per FDB client version. The default value is 1
+     * (the multi-threaded client is effectively disabled).
+     * <p>
+     * Setting this above 1 enables FDB's multi-threaded client, which also requires
+     * at least one external client library on the FDB network options, even when the
+     * cluster and the local client are on the same version. See
+     * {@link FDBDatabaseFactoryImpl#setThreadsPerClientVersion(int)}.
      *
      * @param threadsPerClientV the number of threads per client version. Cannot be less than 1.
      *

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactoryImpl.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/provider/foundationdb/FDBDatabaseFactoryImpl.java
@@ -282,7 +282,15 @@ public class FDBDatabaseFactoryImpl extends FDBDatabaseFactory {
     }
 
     /**
-     * Set the number of threads per FDB client version. The default value is 1.
+     * Set the number of threads per FDB client version. The default value is 1
+     * (the multi-threaded client is effectively disabled).
+     * <p>
+     * Setting this above 1 enables FDB's multi-threaded client. That feature also
+     * requires at least one external client library to be configured on the FDB
+     * network options (for example {@code NetworkOptions.addExternalClientDirectory}
+     * or {@code addExternalClientLibrary}), even when the cluster and the local
+     * client are on the same version. See the FDB multi-version client API
+     * documentation.
      *
      * @param threadsPerClientV the number of threads per client version. Cannot be less than 1.
      */


### PR DESCRIPTION
`setThreadsPerClientVersion` above 1 turns on FDB's multi-threaded client, which still needs at least one external client library even when the cluster and local client are the same version. I added that to the javadoc on `FDBDatabaseFactoryImpl` and the deprecated wrapper.

Fixes #1442