### PR TITLE
Add SET TRANSACTION VARIABLE statement

### DIFF
--- a/fdb-relational-core/src/main/antlr/RelationalLexer.g4
+++ b/fdb-relational-core/src/main/antlr/RelationalLexer.g4
@@ -770,6 +770,7 @@ USE_FRM:                             'USE_FRM';
 USER_RESOURCES:                      'USER_RESOURCES';
 VALIDATION:                          'VALIDATION';
 VALUE:                               'VALUE';
+VARIABLE:                            'VARIABLE';
 VARIABLES:                           'VARIABLES';
 VECTOR:                              'VECTOR';
 VIEW:                                'VIEW';

--- a/fdb-relational-core/src/main/antlr/RelationalParser.g4
+++ b/fdb-relational-core/src/main/antlr/RelationalParser.g4
@@ -656,8 +656,7 @@ showStatement
     ;
 
 setStatement
-    : SET variableClause ('=' | ':=') expression
-      (',' variableClause ('=' | ':=') expression)*                             #setVariable
+    : SET TRANSACTION VARIABLE varName=uid '=' varValue=constant                 #setTransactionVariable
     | SET charSet (charsetName | DEFAULT)          #setCharset
     | SET NAMES
         (charsetName (COLLATE collationName)? | DEFAULT)                        #setNames
@@ -669,10 +668,6 @@ setStatement
 
 
 // details
-
-variableClause
-    : LOCAL_ID | ( ('@' '@')? (GLOBAL | SESSION | LOCAL)  )? uid
-    ;
 
 //    Other administrative statements
 
@@ -1384,7 +1379,7 @@ keywordsCanBeId
     | TEXT | TEMPORARY | TEMPTABLE | THAN | TRADITIONAL
     | TRANSACTION | TRANSACTIONAL | TRIGGERS | TRUNCATE | UNDEFINED | UNDOFILE
     | UNDO_BUFFER_SIZE | UNINSTALL | UNKNOWN | UNTIL | UPGRADE | USA | USER | USE_FRM | USER_RESOURCES
-    | VALIDATION | VALUE | VAR_POP | VAR_SAMP | VARIABLES | VARIANCE | VERSION_TOKEN_ADMIN | VIEW | WAIT | WARNINGS | WITHOUT
+    | VALIDATION | VALUE | VAR_POP | VAR_SAMP | VARIABLE | VARIABLES | VARIANCE | VERSION_TOKEN_ADMIN | VIEW | WAIT | WARNINGS | WITHOUT
     | WRAPPER | X509 | XA | XA_RECOVER_ADMIN | XML
     ;
 

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/ddl/MetadataOperationsFactory.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/api/ddl/MetadataOperationsFactory.java
@@ -25,6 +25,7 @@ import com.apple.foundationdb.relational.api.metadata.SchemaTemplate;
 import com.apple.foundationdb.relational.recordlayer.metadata.RecordLayerInvokedRoutine;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import java.net.URI;
 
@@ -54,4 +55,7 @@ public interface MetadataOperationsFactory {
 
     @Nonnull
     ConstantAction getDropTemporaryFunctionConstantAction(boolean throwIfNotExists, @Nonnull String temporaryFunctionName);
+
+    @Nonnull
+    ConstantAction getSetLocalVariableConstantAction(@Nonnull String name, @Nullable Object value);
 }

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ddl/AbstractMetadataOperationsFactory.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ddl/AbstractMetadataOperationsFactory.java
@@ -27,6 +27,7 @@ import com.apple.foundationdb.relational.api.metadata.SchemaTemplate;
 import com.apple.foundationdb.relational.recordlayer.metadata.RecordLayerInvokedRoutine;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.net.URI;
 
 /**
@@ -81,5 +82,14 @@ public abstract class AbstractMetadataOperationsFactory implements MetadataOpera
     public ConstantAction getDropTemporaryFunctionConstantAction(boolean throwIfNotExists,
                                                                  @Nonnull final String temporaryFunctionName) {
         return NoOpMetadataOperationsFactory.INSTANCE.getDropTemporaryFunctionConstantAction(throwIfNotExists, temporaryFunctionName);
+    }
+
+    // Unlike the other methods above, this is NOT delegated to NoOpMetadataOperationsFactory:
+    // SetLocalVariableConstantAction only touches the transaction's session layer (no catalog
+    // dependencies), so it should be available in every factory context, not silently dropped.
+    @Nonnull
+    @Override
+    public ConstantAction getSetLocalVariableConstantAction(@Nonnull String name, @Nullable Object value) {
+        return new SetLocalVariableConstantAction(name, value);
     }
 }

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ddl/NoOpMetadataOperationsFactory.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ddl/NoOpMetadataOperationsFactory.java
@@ -30,6 +30,7 @@ import com.apple.foundationdb.relational.api.metadata.SchemaTemplate;
 import com.apple.foundationdb.relational.recordlayer.metadata.RecordLayerInvokedRoutine;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.net.URI;
 
 @API(API.Status.EXPERIMENTAL)
@@ -86,6 +87,12 @@ public final class NoOpMetadataOperationsFactory implements MetadataOperationsFa
     @Nonnull
     @Override
     public ConstantAction getDropSchemaTemplateConstantAction(@Nonnull String templateId, boolean throwIfDoesNotExist, @Nonnull Options options) {
+        return NoOpConstantAction.INSTANCE;
+    }
+
+    @Nonnull
+    @Override
+    public ConstantAction getSetLocalVariableConstantAction(@Nonnull String name, @Nullable Object value) {
         return NoOpConstantAction.INSTANCE;
     }
 

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ddl/RecordLayerMetadataOperationsFactory.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ddl/RecordLayerMetadataOperationsFactory.java
@@ -32,6 +32,7 @@ import com.apple.foundationdb.relational.recordlayer.RecordLayerConfig;
 import com.apple.foundationdb.relational.recordlayer.metadata.RecordLayerInvokedRoutine;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.net.URI;
 
 @API(API.Status.EXPERIMENTAL)
@@ -102,6 +103,12 @@ public class RecordLayerMetadataOperationsFactory implements MetadataOperationsF
     public ConstantAction getDropTemporaryFunctionConstantAction(boolean throwIfNotExists,
                                                                  @Nonnull final String temporaryFunctionName) {
         return new DropTemporaryFunctionConstantAction(throwIfNotExists, temporaryFunctionName);
+    }
+
+    @Nonnull
+    @Override
+    public ConstantAction getSetLocalVariableConstantAction(@Nonnull String name, @Nullable Object value) {
+        return new SetLocalVariableConstantAction(name, value);
     }
 
     public static class Builder {

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ddl/SetLocalVariableConstantAction.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ddl/SetLocalVariableConstantAction.java
@@ -1,0 +1,47 @@
+/*
+ * SetLocalVariableConstantAction.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.relational.recordlayer.ddl;
+
+import com.apple.foundationdb.relational.api.Transaction;
+import com.apple.foundationdb.relational.api.ddl.ConstantAction;
+import com.apple.foundationdb.relational.api.exceptions.RelationalException;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class SetLocalVariableConstantAction implements ConstantAction {
+
+    @Nonnull
+    private final String name;
+
+    @Nullable
+    private final Object value;
+
+    public SetLocalVariableConstantAction(@Nonnull String name, @Nullable Object value) {
+        this.name = name;
+        this.value = value;
+    }
+
+    @Override
+    public void execute(@Nonnull Transaction txn) throws RelationalException {
+        txn.setLocalVariable(name, value);
+    }
+}

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ddl/ThrowingMetadataOperationsFactory.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/ddl/ThrowingMetadataOperationsFactory.java
@@ -30,6 +30,7 @@ import com.apple.foundationdb.relational.api.metadata.SchemaTemplate;
 import com.apple.foundationdb.relational.recordlayer.metadata.RecordLayerInvokedRoutine;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.net.URI;
 
 /**
@@ -97,5 +98,11 @@ public final class ThrowingMetadataOperationsFactory implements MetadataOperatio
     @Override
     public ConstantAction getDropTemporaryFunctionConstantAction(boolean throwIfNotExists, @Nonnull String temporaryFunctionName) {
         throw reject("DROP TEMPORARY FUNCTION");
+    }
+
+    @Nonnull
+    @Override
+    public ConstantAction getSetLocalVariableConstantAction(@Nonnull String name, @Nullable Object value) {
+        throw reject("SET TRANSACTION VARIABLE");
     }
 }

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/AstNormalizer.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/AstNormalizer.java
@@ -339,6 +339,14 @@ public final class AstNormalizer extends RelationalParserBaseVisitor<Object> {
     }
 
     @Override
+    public Object visitSetTransactionVariable(@Nonnull RelationalParser.SetTransactionVariableContext ctx) {
+        // SET TRANSACTION VARIABLE embeds the literal value in ProceduralPlan.action, which
+        // withExecutionContext cannot update. Mark it as DDL so the plan cache is bypassed.
+        queryCachingFlags.add(NormalizationResult.QueryCachingFlags.IS_DDL_STATEMENT);
+        return visitChildren(ctx);
+    }
+
+    @Override
     public Object visitUtilityStatement(@Nonnull RelationalParser.UtilityStatementContext ctx) {
         queryCachingFlags.add(NormalizationResult.QueryCachingFlags.IS_UTILITY_STATEMENT);
         return visitChildren(ctx);

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/BaseVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/BaseVisitor.java
@@ -956,10 +956,9 @@ public class BaseVisitor extends RelationalParserBaseVisitor<Object> implements 
         return metadataPlanVisitor.visitShowSchemaTemplatesStatement(ctx);
     }
 
-    @Nonnull
     @Override
-    public Object visitSetVariable(@Nonnull RelationalParser.SetVariableContext ctx) {
-        return visitChildren(ctx);
+    public ProceduralPlan visitSetTransactionVariable(@Nonnull RelationalParser.SetTransactionVariableContext ctx) {
+        return ddlVisitor.visitSetTransactionVariable(ctx);
     }
 
     @Nonnull
@@ -989,12 +988,6 @@ public class BaseVisitor extends RelationalParserBaseVisitor<Object> implements 
     @Nonnull
     @Override
     public Object visitSetNewValueInsideTrigger(@Nonnull RelationalParser.SetNewValueInsideTriggerContext ctx) {
-        return visitChildren(ctx);
-    }
-
-    @Nonnull
-    @Override
-    public Object visitVariableClause(@Nonnull RelationalParser.VariableClauseContext ctx) {
         return visitChildren(ctx);
     }
 

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DdlVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DdlVisitor.java
@@ -29,6 +29,8 @@ import com.apple.foundationdb.record.provider.foundationdb.indexes.VectorOptionK
 import com.apple.foundationdb.record.query.plan.cascades.RawSqlFunction;
 import com.apple.foundationdb.record.query.plan.cascades.UserDefinedFunction;
 import com.apple.foundationdb.record.query.plan.cascades.expressions.LogicalSortExpression;
+import com.apple.foundationdb.record.query.plan.cascades.values.LiteralValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.NullValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.PromoteValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.ThrowsValue;
 import com.apple.foundationdb.relational.api.Options;
@@ -708,6 +710,17 @@ public final class DdlVisitor extends DelegatingVisitor<BaseVisitor> {
         final var functionName = visitFullId(ctx.schemaQualifiedRoutineName).toString();
         var throwIfNotExists = ctx.IF() == null && ctx.EXISTS() == null;
         return ProceduralPlan.of(metadataOperationsFactory.getDropTemporaryFunctionConstantAction(throwIfNotExists, functionName));
+    }
+
+    @Override
+    public ProceduralPlan visitSetTransactionVariable(@Nonnull RelationalParser.SetTransactionVariableContext ctx) {
+        final var varName = getDelegate().normalizeString(ctx.varName.getText());
+        final var expr = getDelegate().getPlanGenerationContext().withDisabledLiteralProcessing(
+                () -> Assert.castUnchecked(visit(ctx.varValue), Expression.class));
+        final var underlying = expr.getUnderlying();
+        final Object value = underlying instanceof NullValue ? null
+                : Assert.castUnchecked(underlying, LiteralValue.class).getLiteralValue();
+        return ProceduralPlan.of(metadataOperationsFactory.getSetLocalVariableConstantAction(varName, value));
     }
 
     @Override

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DelegatingVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DelegatingVisitor.java
@@ -851,10 +851,9 @@ public class DelegatingVisitor<D extends TypedVisitor> implements TypedVisitor {
         return getDelegate().visitShowSchemaTemplatesStatement(ctx);
     }
 
-    @Nonnull
     @Override
-    public Object visitSetVariable(@Nonnull RelationalParser.SetVariableContext ctx) {
-        return getDelegate().visitSetVariable(ctx);
+    public ProceduralPlan visitSetTransactionVariable(@Nonnull RelationalParser.SetTransactionVariableContext ctx) {
+        return getDelegate().visitSetTransactionVariable(ctx);
     }
 
     @Nonnull
@@ -885,12 +884,6 @@ public class DelegatingVisitor<D extends TypedVisitor> implements TypedVisitor {
     @Override
     public Object visitSetNewValueInsideTrigger(@Nonnull RelationalParser.SetNewValueInsideTriggerContext ctx) {
         return getDelegate().visitSetNewValueInsideTrigger(ctx);
-    }
-
-    @Nonnull
-    @Override
-    public Object visitVariableClause(@Nonnull RelationalParser.VariableClauseContext ctx) {
-        return getDelegate().visitVariableClause(ctx);
     }
 
     @Nonnull

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/TypedVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/TypedVisitor.java
@@ -478,9 +478,8 @@ public interface TypedVisitor extends RelationalParserVisitor<Object> {
     @Override
     QueryPlan.MetadataQueryPlan visitShowSchemaTemplatesStatement(@Nonnull RelationalParser.ShowSchemaTemplatesStatementContext ctx);
 
-    @Nonnull
     @Override
-    Object visitSetVariable(@Nonnull RelationalParser.SetVariableContext ctx);
+    ProceduralPlan visitSetTransactionVariable(@Nonnull RelationalParser.SetTransactionVariableContext ctx);
 
     @Nonnull
     @Override
@@ -501,10 +500,6 @@ public interface TypedVisitor extends RelationalParserVisitor<Object> {
     @Nonnull
     @Override
     Object visitSetNewValueInsideTrigger(@Nonnull RelationalParser.SetNewValueInsideTriggerContext ctx);
-
-    @Nonnull
-    @Override
-    Object visitVariableClause(@Nonnull RelationalParser.VariableClauseContext ctx);
 
     @Nonnull
     @Override

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/SetTransactionVariableTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/SetTransactionVariableTests.java
@@ -33,8 +33,8 @@ import java.net.URI;
 
 /**
  * Tests for the {@code SET TRANSACTION VARIABLE} statement. There is no SQL-level way to read a
- * variable's value yet (that's {@code GET_VARIABLE}, added in the next stacked PR), so these
- * assert directly on {@link EmbeddedRelationalConnection#getTransaction()} instead.
+ * variable's value yet, so these assert directly on {@link EmbeddedRelationalConnection#getTransaction()}
+ * instead.
  */
 public class SetTransactionVariableTests {
 

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/SetTransactionVariableTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/SetTransactionVariableTests.java
@@ -1,0 +1,146 @@
+/*
+ * SetTransactionVariableTests.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.relational.recordlayer.query;
+
+import com.apple.foundationdb.relational.recordlayer.EmbeddedRelationalConnection;
+import com.apple.foundationdb.relational.recordlayer.EmbeddedRelationalExtension;
+import com.apple.foundationdb.relational.utils.Ddl;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.net.URI;
+
+/**
+ * Tests for the {@code SET TRANSACTION VARIABLE} statement. There is no SQL-level way to read a
+ * variable's value yet (that's {@code GET_VARIABLE}, added in the next stacked PR), so these
+ * assert directly on {@link EmbeddedRelationalConnection#getTransaction()} instead.
+ */
+public class SetTransactionVariableTests {
+
+    @RegisterExtension
+    @Order(0)
+    public final EmbeddedRelationalExtension relationalExtension = new EmbeddedRelationalExtension();
+
+    @Test
+    void setStoresTheValueInTheTransaction() throws Exception {
+        final String schemaTemplate = "create table t1(pk bigint, primary key(pk))";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/STV")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            final var conn = ddl.setSchemaAndGetConnection();
+            conn.setAutoCommit(false);
+            try (var stmt = conn.createStatement()) {
+                stmt.execute("set transaction variable x = 42");
+                // Unquoted identifiers fold to upper case by default, and a bare decimal literal
+                // parses as an Integer (not Long) unless coerced by a typed column comparison.
+                Assertions.assertThat(conn.unwrap(EmbeddedRelationalConnection.class).getTransaction().getLocalVariables())
+                        .containsEntry("X", 42);
+            }
+            conn.rollback();
+        }
+    }
+
+    @Test
+    void overwritingAVariableReplacesThePreviousValue() throws Exception {
+        final String schemaTemplate = "create table t2(pk bigint, primary key(pk))";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/STV")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            final var conn = ddl.setSchemaAndGetConnection();
+            conn.setAutoCommit(false);
+            try (var stmt = conn.createStatement()) {
+                stmt.execute("set transaction variable x = 1");
+                stmt.execute("set transaction variable x = 2");
+                Assertions.assertThat(conn.unwrap(EmbeddedRelationalConnection.class).getTransaction().getLocalVariables())
+                        .containsEntry("X", 2);
+            }
+            conn.rollback();
+        }
+    }
+
+    @Test
+    void nullIsALegitimateValue() throws Exception {
+        final String schemaTemplate = "create table t3(pk bigint, primary key(pk))";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/STV")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            final var conn = ddl.setSchemaAndGetConnection();
+            conn.setAutoCommit(false);
+            try (var stmt = conn.createStatement()) {
+                stmt.execute("set transaction variable x = null");
+                final var localVars = conn.unwrap(EmbeddedRelationalConnection.class).getTransaction().getLocalVariables();
+                Assertions.assertThat(localVars).containsKey("X");
+                Assertions.assertThat(localVars.get("X")).isNull();
+            }
+            conn.rollback();
+        }
+    }
+
+    @Test
+    void quotedVariableNamePreservesCase() throws Exception {
+        final String schemaTemplate = "create table t4(pk bigint, primary key(pk))";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/STV")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            final var conn = ddl.setSchemaAndGetConnection();
+            conn.setAutoCommit(false);
+            try (var stmt = conn.createStatement()) {
+                stmt.execute("set transaction variable \"myVar\" = 10");
+                Assertions.assertThat(conn.unwrap(EmbeddedRelationalConnection.class).getTransaction().getLocalVariables())
+                        .containsEntry("myVar", 10);
+            }
+            conn.rollback();
+        }
+    }
+
+    @Test
+    void variableNotVisibleInNextTransactionAfterCommit() throws Exception {
+        final String schemaTemplate = "create table t5(pk bigint, primary key(pk))";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/STV")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            final var conn = ddl.setSchemaAndGetConnection();
+            conn.setAutoCommit(false);
+            try (var stmt = conn.createStatement()) {
+                stmt.execute("set transaction variable x = 42");
+            }
+            conn.commit();
+
+            conn.unwrap(EmbeddedRelationalConnection.class).createNewTransaction();
+            conn.setAutoCommit(false);
+            Assertions.assertThat(conn.unwrap(EmbeddedRelationalConnection.class).getTransaction().getLocalVariables())
+                    .doesNotContainKey("x");
+            conn.rollback();
+        }
+    }
+
+    @Test
+    void variableNotVisibleAfterRollback() throws Exception {
+        final String schemaTemplate = "create table t6(pk bigint, primary key(pk))";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/STV")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            final var conn = ddl.setSchemaAndGetConnection();
+            conn.setAutoCommit(false);
+            try (var stmt = conn.createStatement()) {
+                stmt.execute("set transaction variable x = 42");
+            }
+            conn.rollback();
+
+            conn.unwrap(EmbeddedRelationalConnection.class).createNewTransaction();
+            conn.setAutoCommit(false);
+            Assertions.assertThat(conn.unwrap(EmbeddedRelationalConnection.class).getTransaction().getLocalVariables())
+                    .doesNotContainKey("x");
+            conn.rollback();
+        }
+    }
+}


### PR DESCRIPTION
Adds grammar for SET TRANSACTION VARIABLE name = constant, replacing
the unimplemented MySQL-fork SET/variableClause dead grammar it
displaces. Dispatches through a new SetLocalVariableConstantAction
(available in every MetadataOperationsFactory, not just the ones
backed by a real catalog, since it only touches the transaction's
session layer) down to the storage added in the previous PR. Tagged
IS_DDL_STATEMENT so the plan cache is bypassed, since the literal
value is baked directly into the ConstantAction.

There's no SQL-level way to read a variable back yet -- that's
GET_VARIABLE, in the next stacked PR -- so this PR's tests assert
directly on Transaction.getLocalVariables().

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>