### PR TITLE
Add GET_VARIABLE(name) and make the plan cache type-sensitive

### DIFF
--- a/fdb-relational-core/src/main/antlr/RelationalLexer.g4
+++ b/fdb-relational-core/src/main/antlr/RelationalLexer.g4
@@ -137,6 +137,7 @@ FROM:                                'FROM';
 FULLTEXT:                            'FULLTEXT';
 GENERATED:                           'GENERATED';
 GET:                                 'GET';
+GET_VARIABLE:                        'GET_VARIABLE';
 GRANT:                               'GRANT';
 GROUP:                               'GROUP';
 HAVING:                              'HAVING';

--- a/fdb-relational-core/src/main/antlr/RelationalParser.g4
+++ b/fdb-relational-core/src/main/antlr/RelationalParser.g4
@@ -1013,6 +1013,7 @@ specificFunction
     | CONVERT '(' expression separator=',' convertedDataType ')'    #dataTypeFunctionCall
     | CONVERT '(' expression USING charsetName ')'                  #dataTypeFunctionCall
     | CAST '(' expression AS convertedDataType ')'                  #dataTypeFunctionCall
+    | GET_VARIABLE '(' varName=uid ')'                               #getVariableFunctionCall
     | VALUES '(' fullColumnName ')'                                 #valuesFunctionCall
     | CASE expression caseFuncAlternative+
       (ELSE elseArg=functionArg)? END                               #caseExpressionFunctionCall

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/EmbeddedRelationalPreparedStatement.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/EmbeddedRelationalPreparedStatement.java
@@ -218,11 +218,13 @@ public class EmbeddedRelationalPreparedStatement extends AbstractEmbeddedStateme
     @Override
     @Nonnull
     PlanContext createPlanContext(@Nonnull final FDBRecordStoreBase<?> store, @Nonnull final Options options) throws RelationalException {
+        final var localVars = conn.getTransaction().getLocalVariables();
         return PlanContext.builder()
                 .fromRecordStore(store, options)
                 .fromDatabase(conn.getRecordLayerDatabase())
                 .withMetricsCollector(Assert.notNullUnchecked(conn.getMetricCollector()))
                 .withPreparedParameters(PreparedParams.of(parameters, namedParameters))
+                .withLocalVariables(localVars)
                 .withSchemaTemplate(conn.getTransaction().getBoundSchemaTemplateMaybe().orElse(conn.getSchemaTemplate()))
                 .build();
     }

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/EmbeddedRelationalStatement.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/EmbeddedRelationalStatement.java
@@ -60,11 +60,8 @@ public class EmbeddedRelationalStatement extends AbstractEmbeddedStatement imple
     @Nonnull
     PlanContext createPlanContext(@Nonnull final FDBRecordStoreBase<?> store, @Nonnull final Options options) throws RelationalException {
         final var localVars = conn.getTransaction().getLocalVariables();
-        // Local variables are threaded to the planner via withLocalVariables and resolved through
-        // the dedicated GET_VARIABLE path; they are intentionally NOT injected into the prepared-
-        // parameter map, so that GET_VARIABLE(name) and ?name remain independent namespaces
-        // (mirroring the prepared-statement path). A plain Statement cannot supply prepared
-        // parameters, so this defaults to PreparedParams.empty().
+        // Intentionally not injected into the prepared-parameter map: GET_VARIABLE(name) and ?name
+        // must remain independent namespaces.
         return PlanContext.builder()
                 .fromRecordStore(store, options)
                 .fromDatabase(conn.getRecordLayerDatabase())

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/EmbeddedRelationalStatement.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/EmbeddedRelationalStatement.java
@@ -59,11 +59,18 @@ public class EmbeddedRelationalStatement extends AbstractEmbeddedStatement imple
     @Override
     @Nonnull
     PlanContext createPlanContext(@Nonnull final FDBRecordStoreBase<?> store, @Nonnull final Options options) throws RelationalException {
+        final var localVars = conn.getTransaction().getLocalVariables();
+        // Local variables are threaded to the planner via withLocalVariables and resolved through
+        // the dedicated GET_VARIABLE path; they are intentionally NOT injected into the prepared-
+        // parameter map, so that GET_VARIABLE(name) and ?name remain independent namespaces
+        // (mirroring the prepared-statement path). A plain Statement cannot supply prepared
+        // parameters, so this defaults to PreparedParams.empty().
         return PlanContext.builder()
                 .fromRecordStore(store, options)
                 .fromDatabase(conn.getRecordLayerDatabase())
                 .withMetricsCollector(Assert.notNullUnchecked(conn.getMetricCollector()))
                 .withSchemaTemplate(conn.getTransaction().getBoundSchemaTemplateMaybe().orElse(conn.getSchemaTemplate()))
+                .withLocalVariables(localVars)
                 .build();
     }
 

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/AstNormalizer.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/AstNormalizer.java
@@ -243,14 +243,11 @@ public final class AstNormalizer extends RelationalParserBaseVisitor<Object> {
                     .addLiteral(Type.any(), literal, null, varName, tokenIndex);
         }
         if (allowTokenAddition) {
-            // Fold the variable's CURRENT resolved type into the canonical text, not just its name.
-            // getCanonicalSqlString() is what QueryCacheKey is built from -- if only the name were
-            // hashed here, re-SETting the same variable to an incompatible type between two runs of
-            // identical query text would produce the same cache key and reuse a plan compiled for the
-            // old type. Type.fromObject is the same inference already used for prepared-statement
-            // parameters (see MutablePlanGenerationContext#getObjectType), so this can't diverge from
-            // the type actually bound at planning time; it also naturally distinguishes NULL (no
-            // prior type) from any concretely-typed value.
+            // Fold the variable's CURRENT type into the canonical text, not just its name.
+            // getCanonicalSqlString() is what QueryCacheKey is built from, so hashing only the name
+            // would let re-SETting the variable to an incompatible type between two runs of
+            // identical query text reuse a plan compiled for the old type. This also naturally
+            // distinguishes NULL (no prior type) from any concretely-typed value.
             final var typeTag = Type.fromObject(literal).getTypeCode();
             final String canonicalName = "GET_VARIABLE(" + varName + ":" + typeTag + ")";
             sqlCanonicalizer.append(canonicalName).append(" ");

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/AstNormalizer.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/AstNormalizer.java
@@ -134,6 +134,9 @@ public final class AstNormalizer extends RelationalParserBaseVisitor<Object> {
     private final PreparedParams preparedStatementParameters;
 
     @Nonnull
+    private final Map<String, Object> localVariables;
+
+    @Nonnull
     private final Set<NormalizationResult.QueryCachingFlags> queryCachingFlags;
 
     @Nonnull
@@ -157,7 +160,9 @@ public final class AstNormalizer extends RelationalParserBaseVisitor<Object> {
         literalNodes.put(RelationalParser.NegativeDecimalConstantContext.class, context -> ParseHelpers.parseDecimal(context.getText()));
     }
 
-    private AstNormalizer(@Nonnull final PreparedParams preparedStatementParameters, boolean caseSensitive,
+    private AstNormalizer(@Nonnull final PreparedParams preparedStatementParameters,
+                          @Nonnull final Map<String, Object> localVariables,
+                          boolean caseSensitive,
                           @Nonnull final PlanHashable.PlanHashMode currentPlanHashMode, boolean forExplain) {
         parameterHash = Hashing.murmur3_32_fixed().newHasher().putInt("ParameterHash".hashCode());
         parameterHashSupplier = Suppliers.memoize(() -> parameterHash.hash().asInt())::get;
@@ -165,6 +170,7 @@ public final class AstNormalizer extends RelationalParserBaseVisitor<Object> {
         // needed to collect information that guide query execution (explain flag, continuation string, offset int, and limit int).
         queryHasherContextBuilder = NormalizedQueryExecutionContext.newBuilder().setPlanHashMode(currentPlanHashMode).setForExplain(forExplain);
         this.preparedStatementParameters = preparedStatementParameters;
+        this.localVariables = localVariables;
         allowTokenAddition = true;
         allowLiteralAddition = true;
         queryCachingFlags = EnumSet.noneOf(NormalizationResult.QueryCachingFlags.class);
@@ -217,6 +223,39 @@ public final class AstNormalizer extends RelationalParserBaseVisitor<Object> {
         String uid = SemanticAnalyzer.normalizeString(ctx.getText(), caseSensitive);
         sqlCanonicalizer.append("\"").append(uid).append("\"").append(" ");
         return null;
+    }
+
+    @Override
+    public Object visitGetVariableFunctionCall(@Nonnull RelationalParser.GetVariableFunctionCallContext ctx) {
+        final var varName = Assert.notNullUnchecked(SemanticAnalyzer.normalizeString(ctx.varName.getText(), caseSensitive));
+        final var tokenIndex = ctx.varName.getStart().getTokenIndex();
+        Assert.thatUnchecked(localVariables.containsKey(varName), ErrorCode.UNDEFINED_PARAMETER,
+                () -> "No value found for variable " + varName);
+        final var value = localVariables.get(varName);
+        processGetVariableCall(value, varName, tokenIndex);
+        return value;
+    }
+
+    private void processGetVariableCall(@Nullable final Object literal, @Nonnull final String varName,
+                                         final int tokenIndex) {
+        if (allowLiteralAddition) {
+            queryHasherContextBuilder.getLiteralsBuilder()
+                    .addLiteral(Type.any(), literal, null, varName, tokenIndex);
+        }
+        if (allowTokenAddition) {
+            // Fold the variable's CURRENT resolved type into the canonical text, not just its name.
+            // getCanonicalSqlString() is what QueryCacheKey is built from -- if only the name were
+            // hashed here, re-SETting the same variable to an incompatible type between two runs of
+            // identical query text would produce the same cache key and reuse a plan compiled for the
+            // old type. Type.fromObject is the same inference already used for prepared-statement
+            // parameters (see MutablePlanGenerationContext#getObjectType), so this can't diverge from
+            // the type actually bound at planning time; it also naturally distinguishes NULL (no
+            // prior type) from any concretely-typed value.
+            final var typeTag = Type.fromObject(literal).getTypeCode();
+            final String canonicalName = "GET_VARIABLE(" + varName + ":" + typeTag + ")";
+            sqlCanonicalizer.append(canonicalName).append(" ");
+            parameterHash.putInt(canonicalName.hashCode());
+        }
     }
 
     public int getParameterHash() {
@@ -646,7 +685,8 @@ public final class AstNormalizer extends RelationalParserBaseVisitor<Object> {
                         context.getPlannerConfiguration(),
                         isCaseSensitive,
                         currentPlanHashMode,
-                        query
+                        query,
+                        context.getLocalVariables()
                 ));
     }
 
@@ -659,7 +699,20 @@ public final class AstNormalizer extends RelationalParserBaseVisitor<Object> {
                                                    boolean caseSensitive,
                                                    @Nonnull final PlanHashable.PlanHashMode currentPlanHashMode,
                                                    @Nonnull final String query) throws RelationalException {
-        final var astNormalizer = new AstNormalizer(preparedStatementParameters, caseSensitive, currentPlanHashMode, parseTreeInfo.getQueryType() == ParseTreeInfo.QueryType.DESCRIBE_QUERY);
+        return normalizeAst(schemaTemplate, parseTreeInfo, preparedStatementParameters, plannerConfiguration,
+                caseSensitive, currentPlanHashMode, query, Map.of());
+    }
+
+    @Nonnull
+    private static NormalizationResult normalizeAst(@Nonnull final SchemaTemplate schemaTemplate,
+                                                     @Nonnull final ParseTreeInfoImpl parseTreeInfo,
+                                                     @Nonnull final PreparedParams preparedStatementParameters,
+                                                     @Nonnull final PlannerConfiguration plannerConfiguration,
+                                                     boolean caseSensitive,
+                                                     @Nonnull final PlanHashable.PlanHashMode currentPlanHashMode,
+                                                     @Nonnull final String query,
+                                                     @Nonnull final Map<String, Object> localVariables) throws RelationalException {
+        final var astNormalizer = new AstNormalizer(preparedStatementParameters, localVariables, caseSensitive, currentPlanHashMode, parseTreeInfo.getQueryType() == ParseTreeInfo.QueryType.DESCRIBE_QUERY);
         astNormalizer.visit(parseTreeInfo.getRootContext());
         final var recordLayerSchemaTemplate = Assert.castUnchecked(schemaTemplate, RecordLayerSchemaTemplate.class);
 

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/MutablePlanGenerationContext.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/MutablePlanGenerationContext.java
@@ -57,10 +57,12 @@ import java.sql.Struct;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
 
 import static com.apple.foundationdb.relational.api.exceptions.ErrorCode.DATATYPE_MISMATCH;
+import static com.apple.foundationdb.relational.api.exceptions.ErrorCode.UNDEFINED_PARAMETER;
 
 /**
  * Context keeping state related to plan generation, it also captures execution-specific attributes that influences
@@ -70,6 +72,9 @@ import static com.apple.foundationdb.relational.api.exceptions.ErrorCode.DATATYP
 public class MutablePlanGenerationContext implements QueryExecutionContext {
     @Nonnull
     private final PreparedParams preparedParams;
+
+    @Nonnull
+    private Map<String, Object> localVariables = Map.of();
 
     @Nonnull
     private final Literals.Builder literalsBuilder;
@@ -289,6 +294,15 @@ public class MutablePlanGenerationContext implements QueryExecutionContext {
         return preparedParams;
     }
 
+    @Nonnull
+    public Map<String, Object> getLocalVariables() {
+        return localVariables;
+    }
+
+    public void setLocalVariables(@Nonnull Map<String, Object> localVariables) {
+        this.localVariables = localVariables;
+    }
+
     public void startArrayLiteral() {
         literalsBuilder.startArrayLiteral();
     }
@@ -460,6 +474,14 @@ public class MutablePlanGenerationContext implements QueryExecutionContext {
             duplicateLiteralMaybe.ifPresent(prev -> addEqualityConstraint(prev.getConstantId(), literal.getConstantId(), literalValue.getResultType()));
             constantObjectValues.add(ConstantObjectValue.of(Quantifier.constant(), literal.getConstantId(), literalValue.getResultType()));
         }
+    }
+
+    @Nonnull
+    public Value processLocalVariable(@Nonnull String varName, int tokenIndex) {
+        Assert.thatUnchecked(localVariables.containsKey(varName), UNDEFINED_PARAMETER,
+                () -> "No value found for variable " + varName);
+        final var value = localVariables.get(varName);
+        return processPreparedStatementParameter(value, getObjectType(value), null, varName, tokenIndex);
     }
 
     @Nonnull

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/PlanContext.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/PlanContext.java
@@ -37,6 +37,7 @@ import com.google.common.annotations.VisibleForTesting;
 
 import javax.annotation.Nonnull;
 import java.net.URI;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -64,6 +65,9 @@ public final class PlanContext {
 
     private final boolean isCaseSensitive;
 
+    @Nonnull
+    private final Map<String, Object> localVariables;
+
     /**
      * Creates a new instance of {@link PlanContext} needed for generating plans.
      *
@@ -86,7 +90,8 @@ public final class PlanContext {
                         @Nonnull DdlQueryFactory ddlQueryFactory,
                         @Nonnull URI dbUri,
                         @Nonnull PreparedParams preparedStatementParameters,
-                        boolean isCaseSensitive) {
+                        boolean isCaseSensitive,
+                        @Nonnull Map<String, Object> localVariables) {
         this.metaData = metaData;
         this.metricCollector = metricCollector;
         this.schemaTemplate = schemaTemplate;
@@ -96,6 +101,7 @@ public final class PlanContext {
         this.dbUri = dbUri;
         this.preparedStatementParameters = preparedStatementParameters;
         this.isCaseSensitive = isCaseSensitive;
+        this.localVariables = localVariables;
     }
 
     @Nonnull
@@ -144,6 +150,11 @@ public final class PlanContext {
     }
 
     @Nonnull
+    public Map<String, Object> getLocalVariables() {
+        return localVariables;
+    }
+
+    @Nonnull
     public SchemaTemplate getSchemaTemplate() {
         return schemaTemplate;
     }
@@ -172,6 +183,8 @@ public final class PlanContext {
         private PreparedParams preparedStatementParameters;
 
         private boolean isCaseSensitive;
+
+        private Map<String, Object> localVariables = Map.of();
 
         private Builder() {
         }
@@ -234,6 +247,12 @@ public final class PlanContext {
         }
 
         @Nonnull
+        public Builder withLocalVariables(@Nonnull Map<String, Object> localVariables) {
+            this.localVariables = localVariables;
+            return this;
+        }
+
+        @Nonnull
         private static Optional<Set<String>> getReadableIndexes(@Nonnull RecordMetaData metaData,
                                                                 @Nonnull RecordStoreState storeState) {
             // (yhatem) we should cache this somewhere, or embed it in the caching logic of the {@code FDBRecordStoreBase#createOrOpen}.
@@ -286,7 +305,7 @@ public final class PlanContext {
         public PlanContext build() throws RelationalException {
             verify();
             return new PlanContext(metaData, metricCollector, schemaTemplate, plannerConfiguration, metadataOperationsFactory,
-                    ddlQueryFactory, dbUri, preparedStatementParameters, isCaseSensitive);
+                    ddlQueryFactory, dbUri, preparedStatementParameters, isCaseSensitive, localVariables);
         }
 
         @Nonnull
@@ -305,6 +324,7 @@ public final class PlanContext {
                     .withDdlQueryFactory(planContext.ddlQueryFactory)
                     .withPlannerConfiguration(planContext.plannerConfiguration)
                     .withPreparedParameters(planContext.preparedStatementParameters)
+                    .withLocalVariables(planContext.localVariables)
                     .isCaseSensitive(planContext.isCaseSensitive);
         }
     }

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/PlanGenerator.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/PlanGenerator.java
@@ -257,6 +257,7 @@ public final class PlanGenerator {
 
         final var planGenerationContext = new MutablePlanGenerationContext(planContext.getPreparedStatementParameters(),
                 currentPlanHashMode, ast.getQuery(), ast.getQueryCacheKey().getCanonicalQueryString(), parameterHash);
+        planGenerationContext.setLocalVariables(planContext.getLocalVariables());
         planGenerationContext.setForExplain(ast.getQueryExecutionContext().isForExplain());
         final var metadata = Assert.castUnchecked(planContext.getSchemaTemplate(), RecordLayerSchemaTemplate.class);
         try (var ignored = new PlannerEventStatsCollector.DefaultStatsCollectorController()) {

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/BaseVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/BaseVisitor.java
@@ -1417,6 +1417,11 @@ public class BaseVisitor extends RelationalParserBaseVisitor<Object> implements 
         return expressionVisitor.visitDataTypeFunctionCall(ctx);
     }
 
+    @Override
+    public Expression visitGetVariableFunctionCall(@Nonnull RelationalParser.GetVariableFunctionCallContext ctx) {
+        return expressionVisitor.visitGetVariableFunctionCall(ctx);
+    }
+
     @Nonnull
     @Override
     public Object visitValuesFunctionCall(@Nonnull RelationalParser.ValuesFunctionCallContext ctx) {

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DelegatingVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DelegatingVisitor.java
@@ -1354,6 +1354,11 @@ public class DelegatingVisitor<D extends TypedVisitor> implements TypedVisitor {
         return getDelegate().visitDataTypeFunctionCall(ctx);
     }
 
+    @Override
+    public Object visitGetVariableFunctionCall(@Nonnull RelationalParser.GetVariableFunctionCallContext ctx) {
+        return getDelegate().visitGetVariableFunctionCall(ctx);
+    }
+
     @Nonnull
     @Override
     public Object visitValuesFunctionCall(@Nonnull RelationalParser.ValuesFunctionCallContext ctx) {

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/ExpressionVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/ExpressionVisitor.java
@@ -516,6 +516,16 @@ public final class ExpressionVisitor extends DelegatingVisitor<BaseVisitor> {
 
     @Nonnull
     @Override
+    public Expression visitGetVariableFunctionCall(@Nonnull RelationalParser.GetVariableFunctionCallContext ctx) {
+        final var varName = getDelegate().normalizeString(ctx.varName.getText());
+        final var tokenIndex = ctx.varName.getStart().getTokenIndex();
+        final Value value = getDelegate().getPlanGenerationContext().processLocalVariable(varName, tokenIndex);
+        final var type = DataTypeUtils.toRelationalType(value.getResultType());
+        return Expression.ofUnnamed(type, value);
+    }
+
+    @Nonnull
+    @Override
     public Expression visitFunctionCallExpressionAtom(@Nonnull RelationalParser.FunctionCallExpressionAtomContext ctx) {
         return parseChild(ctx);
     }

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/TypedVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/TypedVisitor.java
@@ -788,6 +788,9 @@ public interface TypedVisitor extends RelationalParserVisitor<Object> {
     @Override
     Object visitDataTypeFunctionCall(@Nonnull RelationalParser.DataTypeFunctionCallContext ctx);
 
+    @Override
+    Object visitGetVariableFunctionCall(@Nonnull RelationalParser.GetVariableFunctionCallContext ctx);
+
     @Nonnull
     @Override
     Object visitValuesFunctionCall(@Nonnull RelationalParser.ValuesFunctionCallContext ctx);

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/AstNormalizerTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/AstNormalizerTests.java
@@ -1771,9 +1771,9 @@ public class AstNormalizerTests {
     @Test
     void visitFullDescribeStatementThrows() throws ReflectiveOperationException {
         final var constructor = AstNormalizer.class.getDeclaredConstructor(
-                PreparedParams.class, boolean.class, PlanHashable.PlanHashMode.class, boolean.class);
+                PreparedParams.class, Map.class, boolean.class, PlanHashable.PlanHashMode.class, boolean.class);
         constructor.setAccessible(true);
-        final AstNormalizer normalizer = constructor.newInstance(PreparedParams.empty(), false, PlanHashable.PlanHashMode.VC0, false);
+        final AstNormalizer normalizer = constructor.newInstance(PreparedParams.empty(), Map.of(), false, PlanHashable.PlanHashMode.VC0, false);
 
         Assertions.assertThatThrownBy(() -> normalizer.visitFullDescribeStatement(new RelationalParser.FullDescribeStatementContext(null, -1)))
                 .isInstanceOf(UncheckedRelationalException.class)

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/LocalVariableTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/LocalVariableTests.java
@@ -1,0 +1,535 @@
+/*
+ * LocalVariableTests.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.relational.recordlayer.query;
+
+import com.apple.foundationdb.relational.api.Options;
+import com.apple.foundationdb.relational.api.exceptions.ErrorCode;
+import com.apple.foundationdb.relational.recordlayer.EmbeddedRelationalConnection;
+import com.apple.foundationdb.relational.recordlayer.EmbeddedRelationalExtension;
+import com.apple.foundationdb.relational.recordlayer.LogAppenderRule;
+import com.apple.foundationdb.relational.recordlayer.Utils;
+import com.apple.foundationdb.relational.utils.Ddl;
+import com.apple.foundationdb.relational.utils.RelationalAssertions;
+import com.apple.foundationdb.relational.utils.ResultSetAssert;
+import org.apache.logging.log4j.Level;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.net.URI;
+import java.util.Base64;
+
+/**
+ * Tests for transaction-scoped local variables (SET TRANSACTION VARIABLE / GET_VARIABLE(name)).
+ * Interaction with table-valued functions is covered separately, in the stacked PR that adds it.
+ */
+public class LocalVariableTests {
+
+    @RegisterExtension
+    @Order(0)
+    public final EmbeddedRelationalExtension relationalExtension = new EmbeddedRelationalExtension();
+
+    public LocalVariableTests() {
+        Utils.enableCascadesDebugger();
+    }
+
+    @Test
+    void setLocalStringVariableAndRead() throws Exception {
+        final String schemaTemplate = "create table t1(pk bigint, name string, primary key(pk))";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/LV")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            try (var stmt = ddl.setSchemaAndGetConnection().createStatement()) {
+                stmt.executeUpdate("insert into t1 values (1, 'alice'), (2, 'bob'), (3, 'carol')");
+            }
+            final var conn = ddl.getConnection();
+            conn.setAutoCommit(false);
+            try (var stmt = conn.createStatement()) {
+                stmt.execute("set transaction variable myname = 'bob'");
+                try (var rs = stmt.executeQuery("select pk, name from t1 where name = GET_VARIABLE(myname)")) {
+                    ResultSetAssert.assertThat(rs).hasNextRow().isRowExactly(2L, "bob").hasNoNextRow();
+                }
+            }
+            conn.rollback();
+        }
+    }
+
+    @Test
+    void setLocalLongVariableAndFilter() throws Exception {
+        final String schemaTemplate = "create table t2(pk bigint, val bigint, primary key(pk))";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/LV")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            try (var stmt = ddl.setSchemaAndGetConnection().createStatement()) {
+                stmt.executeUpdate("insert into t2 values (1, 10), (2, 20), (3, 30), (4, 40)");
+            }
+            final var conn = ddl.getConnection();
+            conn.setAutoCommit(false);
+            try (var stmt = conn.createStatement()) {
+                stmt.execute("set transaction variable target = 20");
+                try (var rs = stmt.executeQuery("select pk from t2 where val = GET_VARIABLE(target)")) {
+                    ResultSetAssert.assertThat(rs).hasNextRow().isRowExactly(2L).hasNoNextRow();
+                }
+            }
+            conn.rollback();
+        }
+    }
+
+    @Test
+    void variableNotVisibleInNextTransaction() throws Exception {
+        final String schemaTemplate = "create table t3(pk bigint, val bigint, primary key(pk))";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/LV")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            final var conn = ddl.setSchemaAndGetConnection();
+            conn.setAutoCommit(false);
+
+            // Set variable in first transaction
+            try (var stmt = conn.createStatement()) {
+                stmt.execute("set transaction variable x = 42");
+            }
+            conn.commit();
+
+            // New transaction — variable must not be visible
+            conn.unwrap(EmbeddedRelationalConnection.class).createNewTransaction();
+            conn.setAutoCommit(false);
+            try (var stmt = conn.createStatement()) {
+                RelationalAssertions.assertThrowsSqlException(
+                        () -> stmt.executeQuery("select GET_VARIABLE(x) from t3"))
+                        .hasErrorCode(ErrorCode.UNDEFINED_PARAMETER);
+            }
+            conn.rollback();
+        }
+    }
+
+    @Test
+    void undefinedVariableThrows() throws Exception {
+        final String schemaTemplate = "create table t4(pk bigint, primary key(pk))";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/LV")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            final var conn = ddl.setSchemaAndGetConnection();
+            conn.setAutoCommit(false);
+            try (var stmt = conn.createStatement()) {
+                RelationalAssertions.assertThrowsSqlException(
+                        () -> stmt.executeQuery("select GET_VARIABLE(undefined) from t4"))
+                        .hasErrorCode(ErrorCode.UNDEFINED_PARAMETER);
+            }
+            conn.rollback();
+        }
+    }
+
+    @Test
+    void planCacheReusedForDifferentValues() throws Exception {
+        final String schemaTemplate = "create table t5(pk bigint, val bigint, primary key(pk))";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/LV")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            try (var stmt = ddl.setSchemaAndGetConnection().createStatement()) {
+                stmt.executeUpdate("insert into t5 values (1, 100), (2, 200), (3, 300)");
+            }
+            final var conn = ddl.getConnection();
+
+            // First value
+            conn.setAutoCommit(false);
+            try (var stmt = conn.createStatement()) {
+                stmt.execute("set transaction variable v = 100");
+                try (var rs = stmt.executeQuery("select pk from t5 where val = GET_VARIABLE(v)")) {
+                    ResultSetAssert.assertThat(rs).hasNextRow().isRowExactly(1L).hasNoNextRow();
+                }
+            }
+            conn.commit();
+
+            // Second value in a new transaction — same plan should be reused
+            conn.unwrap(EmbeddedRelationalConnection.class).createNewTransaction();
+            conn.setAutoCommit(false);
+            try (var stmt = conn.createStatement()) {
+                stmt.execute("set transaction variable v = 200");
+                try (var rs = stmt.executeQuery("select pk from t5 where val = GET_VARIABLE(v)")) {
+                    ResultSetAssert.assertThat(rs).hasNextRow().isRowExactly(2L).hasNoNextRow();
+                }
+            }
+            conn.rollback();
+        }
+    }
+
+    @Test
+    void setLocalBooleanVariable() throws Exception {
+        final String schemaTemplate = "create table t6(pk bigint, active boolean, primary key(pk))";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/LV")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            try (var stmt = ddl.setSchemaAndGetConnection().createStatement()) {
+                stmt.executeUpdate("insert into t6 values (1, true), (2, false), (3, true)");
+            }
+            final var conn = ddl.getConnection();
+            conn.setAutoCommit(false);
+            try (var stmt = conn.createStatement()) {
+                stmt.execute("set transaction variable flag = true");
+                try (var rs = stmt.executeQuery("select pk from t6 where active = GET_VARIABLE(flag)")) {
+                    ResultSetAssert.assertThat(rs)
+                            .hasNextRow().isRowExactly(1L)
+                            .hasNextRow().isRowExactly(3L)
+                            .hasNoNextRow();
+                }
+            }
+            conn.rollback();
+        }
+    }
+
+    @Test
+    void variableOverwriteIsVisible() throws Exception {
+        final String schemaTemplate = "create table t7(pk bigint, val bigint, primary key(pk))";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/LV")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            try (var stmt = ddl.setSchemaAndGetConnection().createStatement()) {
+                stmt.executeUpdate("insert into t7 values (1, 10), (2, 20), (3, 30)");
+            }
+            final var conn = ddl.getConnection();
+            conn.setAutoCommit(false);
+            try (var stmt = conn.createStatement()) {
+                stmt.execute("set transaction variable x = 10");
+                stmt.execute("set transaction variable x = 20");
+                try (var rs = stmt.executeQuery("select pk from t7 where val = GET_VARIABLE(x)")) {
+                    ResultSetAssert.assertThat(rs).hasNextRow().isRowExactly(2L).hasNoNextRow();
+                }
+            }
+            conn.rollback();
+        }
+    }
+
+    @Test
+    void caseSensitiveVariableNames() throws Exception {
+        final String schemaTemplate = "create table t8(pk bigint, val bigint, primary key(pk))";
+        try (var ddl = Ddl.builder()
+                .database(URI.create("/TEST/LVCS"))
+                .relationalExtension(relationalExtension)
+                .withOption(Options.Name.CASE_SENSITIVE_IDENTIFIERS, true)
+                .schemaTemplate(schemaTemplate)
+                .build()) {
+            try (var stmt = ddl.setSchemaAndGetConnection().createStatement()) {
+                stmt.executeUpdate("insert into t8 values (1, 10), (2, 20)");
+            }
+            final var conn = ddl.getConnection();
+            conn.setAutoCommit(false);
+            try (var stmt = conn.createStatement()) {
+                // Quoted variable name "myVar" stores the key with case preserved
+                stmt.execute("set transaction variable \"myVar\" = 10");
+                // GET_VARIABLE("myVar") resolves to 'myVar' — same key → found
+                try (var rs = stmt.executeQuery("select pk from t8 where val = GET_VARIABLE(\"myVar\")")) {
+                    ResultSetAssert.assertThat(rs).hasNextRow().isRowExactly(1L).hasNoNextRow();
+                }
+                // GET_VARIABLE(myvar) is an unquoted identifier; with caseSensitive=true, it preserves
+                // the literal case from the input ('myvar' != 'myVar') → undefined
+                RelationalAssertions.assertThrowsSqlException(
+                        () -> stmt.executeQuery("select pk from t8 where val = GET_VARIABLE(myvar)"))
+                        .hasErrorCode(ErrorCode.UNDEFINED_PARAMETER);
+            }
+            conn.rollback();
+        }
+    }
+
+    @Test
+    void variableNotVisibleAfterAutoCommit() throws Exception {
+        final String schemaTemplate = "create table t9(pk bigint, val bigint, primary key(pk))";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/LV")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            final var conn = ddl.setSchemaAndGetConnection();
+            // autoCommit=true: the SET TRANSACTION VARIABLE statement auto-commits its transaction; the
+            // variable disappears before the next statement runs in its own new transaction.
+            conn.setAutoCommit(true);
+            try (var stmt = conn.createStatement()) {
+                stmt.execute("set transaction variable x = 99");
+            }
+            try (var stmt = conn.createStatement()) {
+                RelationalAssertions.assertThrowsSqlException(
+                        () -> stmt.executeQuery("select pk from t9 where pk = GET_VARIABLE(x)"))
+                        .hasErrorCode(ErrorCode.UNDEFINED_PARAMETER);
+            }
+        }
+    }
+
+    @Test
+    void variableAndPreparedParamCoexist() throws Exception {
+        final String schemaTemplate = "create table t10(pk bigint, val bigint, primary key(pk))";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/LV")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            try (var stmt = ddl.setSchemaAndGetConnection().createStatement()) {
+                stmt.executeUpdate("insert into t10 values (1, 100), (2, 100), (3, 200)");
+            }
+            final var conn = ddl.getConnection();
+            conn.setAutoCommit(false);
+            try (var stmt = conn.createStatement()) {
+                stmt.execute("set transaction variable valfilter = 100");
+            }
+            // Mix a local variable (GET_VARIABLE(valfilter)) with a positional prepared parameter (?)
+            try (var ps = conn.prepareStatement("select pk from t10 where val = GET_VARIABLE(valfilter) and pk = ?")) {
+                ps.setLong(1, 1L);
+                try (var rs = ps.executeQuery()) {
+                    ResultSetAssert.assertThat(rs).hasNextRow().isRowExactly(1L).hasNoNextRow();
+                }
+            }
+            conn.rollback();
+        }
+    }
+
+    @Test
+    void negativeValueVariable() throws Exception {
+        final String schemaTemplate = "create table t11(pk bigint, delta bigint, primary key(pk))";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/LV")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            try (var stmt = ddl.setSchemaAndGetConnection().createStatement()) {
+                stmt.executeUpdate("insert into t11 values (1, -10), (2, 5), (3, -10)");
+            }
+            final var conn = ddl.getConnection();
+            conn.setAutoCommit(false);
+            try (var stmt = conn.createStatement()) {
+                stmt.execute("set transaction variable threshold = -10");
+                try (var rs = stmt.executeQuery("select pk from t11 where delta = GET_VARIABLE(threshold)")) {
+                    ResultSetAssert.assertThat(rs)
+                            .hasNextRow().isRowExactly(1L)
+                            .hasNextRow().isRowExactly(3L)
+                            .hasNoNextRow();
+                }
+            }
+            conn.rollback();
+        }
+    }
+
+    @Test
+    void planCacheHitVerifiedByLog() throws Exception {
+        final String schemaTemplate = "create table t12(pk bigint, val bigint, primary key(pk))";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/LV")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            try (var stmt = ddl.setSchemaAndGetConnection().createStatement()) {
+                stmt.executeUpdate("insert into t12 values (1, 10), (2, 20), (3, 30)");
+            }
+            final var conn = ddl.getConnection();
+            try (var logAppender = LogAppenderRule.of("LocalVariableTests", PlanGenerator.class, Level.INFO)) {
+                // First execution — cache miss expected
+                conn.setAutoCommit(false);
+                try (var stmt = conn.createStatement()) {
+                    stmt.execute("set transaction variable v = 10");
+                    try (var rs = stmt.executeQuery("select pk from t12 where val = GET_VARIABLE(v) options (log query)")) {
+                        ResultSetAssert.assertThat(rs).hasNextRow().isRowExactly(1L).hasNoNextRow();
+                    }
+                }
+                conn.commit();
+                Assertions.assertTrue(logAppender.lastMessageIsCacheMiss(), "first execution should be a cache miss");
+
+                // Second execution with a different value — same plan structure, cache hit expected
+                conn.unwrap(EmbeddedRelationalConnection.class).createNewTransaction();
+                conn.setAutoCommit(false);
+                try (var stmt = conn.createStatement()) {
+                    stmt.execute("set transaction variable v = 20");
+                    try (var rs = stmt.executeQuery("select pk from t12 where val = GET_VARIABLE(v) options (log query)")) {
+                        ResultSetAssert.assertThat(rs).hasNextRow().isRowExactly(2L).hasNoNextRow();
+                    }
+                }
+                conn.rollback();
+                Assertions.assertTrue(logAppender.lastMessageIsCacheHit(), "second execution should be a cache hit");
+            }
+        }
+    }
+
+    @Test
+    void variableValueCapturedInContinuation() throws Exception {
+        // Verifies that the value bound to a local variable at the time a query is first executed
+        // is captured in the continuation, just like a bound prepared-statement parameter.
+        // Changing the variable after the first page is fetched must NOT affect the continuation.
+        final String schemaTemplate = "create table conttbl(pk bigint, name string, primary key(pk))";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/LV")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            try (var stmt = ddl.setSchemaAndGetConnection().createStatement()) {
+                stmt.executeUpdate("insert into conttbl values (1, 'alice'), (2, 'bob'), (3, 'carol'), (4, 'dave'), (5, 'eve')");
+            }
+            final var conn = ddl.getConnection();
+            conn.setAutoCommit(false);
+            try (var stmt = conn.createStatement()) {
+                // Filter: pk >= GET_VARIABLE(min_pk)  (= 2 → rows 2,3,4,5)
+                stmt.execute("set transaction variable min_pk = 2");
+                stmt.setMaxRows(2);
+                // First page: rows 2 and 3
+                final byte[] continuationBytes;
+                try (var rs = stmt.executeQuery("select pk, name from conttbl where pk >= GET_VARIABLE(min_pk)")) {
+                    ResultSetAssert.assertThat(rs)
+                            .hasNextRow().isRowExactly(2L, "bob")
+                            .hasNextRow().isRowExactly(3L, "carol")
+                            .hasNoNextRow();
+                    continuationBytes = rs.getContinuation().serialize();
+                }
+                // Change GET_VARIABLE(min_pk) to a different value — the continuation must ignore this
+                stmt.execute("set transaction variable min_pk = 99");
+                stmt.setMaxRows(10);
+                // Resume via continuation: should still see rows 4 and 5 (original binding min_pk=2)
+                final String encoded = Base64.getEncoder().encodeToString(continuationBytes);
+                try (var rs = stmt.executeQuery("EXECUTE CONTINUATION B64'" + encoded + "'")) {
+                    ResultSetAssert.assertThat(rs)
+                            .hasNextRow().isRowExactly(4L, "dave")
+                            .hasNextRow().isRowExactly(5L, "eve")
+                            .hasNoNextRow();
+                    Assertions.assertTrue(rs.getContinuation().atEnd(), "continuation should be at end after last row");
+                }
+            }
+            conn.rollback();
+        }
+    }
+
+    @Test
+    void sameNameVariableAndNamedParamAreIndependent() throws Exception {
+        // GET_VARIABLE(x) and ?x share the same underlying name "x" but are independent namespaces:
+        // GET_VARIABLE(x) resolves from the transaction's local-variable map, ?x from the prepared-parameter map.
+        final String schemaTemplate = "create table tns(pk bigint, primary key(pk))";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/LV")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            try (var stmt = ddl.setSchemaAndGetConnection().createStatement()) {
+                stmt.executeUpdate("insert into tns values (1), (2), (3)");
+            }
+            final var conn = ddl.getConnection();
+            conn.setAutoCommit(false);
+            try (var stmt = conn.createStatement()) {
+                stmt.execute("set transaction variable x = 1");
+            }
+            // GET_VARIABLE(x) = 1 (from SET TRANSACTION VARIABLE), ?x = 2 (from named prepared param) — both resolve independently
+            try (var ps = conn.prepareStatement("select pk from tns where pk = GET_VARIABLE(x) or pk = ?x")) {
+                ps.setLong("x", 2L);
+                try (var rs = ps.executeQuery()) {
+                    ResultSetAssert.assertThat(rs)
+                            .hasNextRow().isRowExactly(1L)
+                            .hasNextRow().isRowExactly(2L)
+                            .hasNoNextRow();
+                }
+            }
+            conn.rollback();
+        }
+    }
+
+    @Test
+    void namedParamDoesNotResolveToLocalVariableOnPlainStatement() throws Exception {
+        // Regression: GET_VARIABLE(name) and ?name are independent namespaces. On a plain (non-prepared)
+        // Statement a ?name reference cannot be bound, so it must fail with UNDEFINED_PARAMETER and
+        // must NOT silently pick up a same-named local variable's value. Previously the plain-
+        // statement path injected local variables into the named-prepared-parameter map, so
+        // `?x` resolved to `GET_VARIABLE(x)`.
+        final String schemaTemplate = "create table tleak(pk bigint, primary key(pk))";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/LV")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            try (var stmt = ddl.setSchemaAndGetConnection().createStatement()) {
+                stmt.executeUpdate("insert into tleak values (1), (2), (3)");
+            }
+            final var conn = ddl.getConnection();
+            conn.setAutoCommit(false);
+            try (var stmt = conn.createStatement()) {
+                stmt.execute("set transaction variable x = 1");
+                // ?x is an unbound named prepared parameter on a plain Statement; it must not
+                // resolve to the local variable GET_VARIABLE(x) (= 1).
+                RelationalAssertions.assertThrowsSqlException(
+                        () -> stmt.executeQuery("select pk from tleak where pk = ?x"))
+                        .hasErrorCode(ErrorCode.UNDEFINED_PARAMETER);
+            }
+            conn.rollback();
+        }
+    }
+
+    @Test
+    void variableTypeChangeForcesCacheMissNotStaleReuse() throws Exception {
+        // The plan cache key must fold in a variable's CURRENT type, not just its name: reusing a
+        // plan compiled while a variable was BIGINT against a later STRING-valued binding of the
+        // same-named variable would silently misuse a comparand shaped for the wrong type.
+        final String schemaTemplate = "create table t14(pk bigint, primary key(pk))";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/LV")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            try (var stmt = ddl.setSchemaAndGetConnection().createStatement()) {
+                stmt.executeUpdate("insert into t14 values (1)");
+            }
+            final var conn = ddl.getConnection();
+            try (var logAppender = LogAppenderRule.of("LocalVariableTests_typechange", PlanGenerator.class, Level.INFO)) {
+                // First execution: x is BIGINT.
+                conn.setAutoCommit(false);
+                try (var stmt = conn.createStatement()) {
+                    stmt.execute("set transaction variable x = 10");
+                    try (var rs = stmt.executeQuery("select GET_VARIABLE(x) from t14 where pk = 1 options (log query)")) {
+                        ResultSetAssert.assertThat(rs).hasNextRow().isRowExactly(10).hasNoNextRow();
+                    }
+                }
+                conn.commit();
+                Assertions.assertTrue(logAppender.lastMessageIsCacheMiss(), "first execution (BIGINT) should be a cache miss");
+
+                // Second execution: identical query text, but x is now STRING. Must be a cache
+                // miss (a fresh compile), not a hit against the BIGINT-shaped plan, and must
+                // return the STRING value correctly.
+                conn.unwrap(EmbeddedRelationalConnection.class).createNewTransaction();
+                conn.setAutoCommit(false);
+                try (var stmt = conn.createStatement()) {
+                    stmt.execute("set transaction variable x = 'ten'");
+                    try (var rs = stmt.executeQuery("select GET_VARIABLE(x) from t14 where pk = 1 options (log query)")) {
+                        ResultSetAssert.assertThat(rs).hasNextRow().isRowExactly("ten").hasNoNextRow();
+                    }
+                }
+                conn.rollback();
+                Assertions.assertTrue(logAppender.lastMessageIsCacheMiss(), "second execution (STRING) must be a cache miss, not a stale hit against the BIGINT-typed plan");
+            }
+        }
+    }
+
+    @Test
+    void variableNullToTypedTransitionForcesCacheMissNotStaleReuse() throws Exception {
+        // NULL has no intrinsic type. Re-SETting a variable from NULL to a concrete type (or vice
+        // versa) must be treated the same as any other type change for cache purposes. The
+        // variable is used in a WHERE comparison (rather than selected bare) since a NULL-typed
+        // value cannot itself be the declared type of a result-set column.
+        final String schemaTemplate = "create table t15(pk bigint, val bigint, primary key(pk))";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/LV")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            try (var stmt = ddl.setSchemaAndGetConnection().createStatement()) {
+                stmt.executeUpdate("insert into t15 values (1, 7)");
+            }
+            final var conn = ddl.getConnection();
+            try (var logAppender = LogAppenderRule.of("LocalVariableTests_nulltotyped", PlanGenerator.class, Level.INFO)) {
+                // First execution: x is NULL. val = NULL is never true, so no rows match.
+                conn.setAutoCommit(false);
+                try (var stmt = conn.createStatement()) {
+                    stmt.execute("set transaction variable x = null");
+                    try (var rs = stmt.executeQuery("select pk from t15 where val = GET_VARIABLE(x) options (log query)")) {
+                        ResultSetAssert.assertThat(rs).hasNoNextRow();
+                    }
+                }
+                conn.commit();
+                Assertions.assertTrue(logAppender.lastMessageIsCacheMiss(), "first execution (NULL) should be a cache miss");
+
+                // Second execution: identical query text, x is now BIGINT and matches val. Must
+                // be a cache miss, not a stale hit against the NULL-typed plan.
+                conn.unwrap(EmbeddedRelationalConnection.class).createNewTransaction();
+                conn.setAutoCommit(false);
+                try (var stmt = conn.createStatement()) {
+                    stmt.execute("set transaction variable x = 7");
+                    try (var rs = stmt.executeQuery("select pk from t15 where val = GET_VARIABLE(x) options (log query)")) {
+                        ResultSetAssert.assertThat(rs).hasNextRow().isRowExactly(1L).hasNoNextRow();
+                    }
+                }
+                conn.rollback();
+                Assertions.assertTrue(logAppender.lastMessageIsCacheMiss(), "second execution (BIGINT) must be a cache miss, not a stale hit against the NULL-typed plan");
+            }
+        }
+    }
+
+    @Test
+    void getVariableSetToNullReturnsNullWithoutError() throws Exception {
+        // A variable explicitly SET to NULL is a distinct state from never having been SET:
+        // reading it must succeed (not throw UNDEFINED_PARAMETER). Used in a WHERE comparison
+        // (rather than selected bare) since a NULL-typed value cannot itself be the declared type
+        // of a result-set column; per three-valued logic, `val = NULL` matches no rows.
+        final String schemaTemplate = "create table t16(pk bigint, val bigint, primary key(pk))";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/LV")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            try (var stmt = ddl.setSchemaAndGetConnection().createStatement()) {
+                stmt.executeUpdate("insert into t16 values (1, 7)");
+            }
+            final var conn = ddl.getConnection();
+            conn.setAutoCommit(false);
+            try (var stmt = conn.createStatement()) {
+                stmt.execute("set transaction variable x = null");
+                try (var rs = stmt.executeQuery("select pk from t16 where val = GET_VARIABLE(x)")) {
+                    ResultSetAssert.assertThat(rs).hasNoNextRow();
+                }
+            }
+            conn.rollback();
+        }
+    }
+}

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/LocalVariableTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/LocalVariableTests.java
@@ -40,7 +40,7 @@ import java.util.Base64;
 
 /**
  * Tests for transaction-scoped local variables (SET TRANSACTION VARIABLE / GET_VARIABLE(name)).
- * Interaction with table-valued functions is covered separately, in the stacked PR that adds it.
+ * Interaction with table-valued functions is covered separately, in {@code LocalVariableTemporaryFunctionTests}.
  */
 public class LocalVariableTests {
 
@@ -97,13 +97,11 @@ public class LocalVariableTests {
             final var conn = ddl.setSchemaAndGetConnection();
             conn.setAutoCommit(false);
 
-            // Set variable in first transaction
             try (var stmt = conn.createStatement()) {
                 stmt.execute("set transaction variable x = 42");
             }
             conn.commit();
 
-            // New transaction — variable must not be visible
             conn.unwrap(EmbeddedRelationalConnection.class).createNewTransaction();
             conn.setAutoCommit(false);
             try (var stmt = conn.createStatement()) {
@@ -139,7 +137,6 @@ public class LocalVariableTests {
             }
             final var conn = ddl.getConnection();
 
-            // First value
             conn.setAutoCommit(false);
             try (var stmt = conn.createStatement()) {
                 stmt.execute("set transaction variable v = 100");
@@ -149,7 +146,6 @@ public class LocalVariableTests {
             }
             conn.commit();
 
-            // Second value in a new transaction — same plan should be reused
             conn.unwrap(EmbeddedRelationalConnection.class).createNewTransaction();
             conn.setAutoCommit(false);
             try (var stmt = conn.createStatement()) {
@@ -219,14 +215,12 @@ public class LocalVariableTests {
             final var conn = ddl.getConnection();
             conn.setAutoCommit(false);
             try (var stmt = conn.createStatement()) {
-                // Quoted variable name "myVar" stores the key with case preserved
+                // Quoted variable name preserves case
                 stmt.execute("set transaction variable \"myVar\" = 10");
-                // GET_VARIABLE("myVar") resolves to 'myVar' — same key → found
                 try (var rs = stmt.executeQuery("select pk from t8 where val = GET_VARIABLE(\"myVar\")")) {
                     ResultSetAssert.assertThat(rs).hasNextRow().isRowExactly(1L).hasNoNextRow();
                 }
-                // GET_VARIABLE(myvar) is an unquoted identifier; with caseSensitive=true, it preserves
-                // the literal case from the input ('myvar' != 'myVar') → undefined
+                // Unquoted "myvar" is a different, case-preserved key from quoted "myVar" -> undefined
                 RelationalAssertions.assertThrowsSqlException(
                         () -> stmt.executeQuery("select pk from t8 where val = GET_VARIABLE(myvar)"))
                         .hasErrorCode(ErrorCode.UNDEFINED_PARAMETER);
@@ -266,7 +260,7 @@ public class LocalVariableTests {
             try (var stmt = conn.createStatement()) {
                 stmt.execute("set transaction variable valfilter = 100");
             }
-            // Mix a local variable (GET_VARIABLE(valfilter)) with a positional prepared parameter (?)
+            // Mix a local variable with a positional prepared parameter
             try (var ps = conn.prepareStatement("select pk from t10 where val = GET_VARIABLE(valfilter) and pk = ?")) {
                 ps.setLong(1, 1L);
                 try (var rs = ps.executeQuery()) {
@@ -308,7 +302,6 @@ public class LocalVariableTests {
             }
             final var conn = ddl.getConnection();
             try (var logAppender = LogAppenderRule.of("LocalVariableTests", PlanGenerator.class, Level.INFO)) {
-                // First execution — cache miss expected
                 conn.setAutoCommit(false);
                 try (var stmt = conn.createStatement()) {
                     stmt.execute("set transaction variable v = 10");
@@ -319,7 +312,6 @@ public class LocalVariableTests {
                 conn.commit();
                 Assertions.assertTrue(logAppender.lastMessageIsCacheMiss(), "first execution should be a cache miss");
 
-                // Second execution with a different value — same plan structure, cache hit expected
                 conn.unwrap(EmbeddedRelationalConnection.class).createNewTransaction();
                 conn.setAutoCommit(false);
                 try (var stmt = conn.createStatement()) {
@@ -347,10 +339,9 @@ public class LocalVariableTests {
             final var conn = ddl.getConnection();
             conn.setAutoCommit(false);
             try (var stmt = conn.createStatement()) {
-                // Filter: pk >= GET_VARIABLE(min_pk)  (= 2 → rows 2,3,4,5)
+                // Rows with pk >= 2: rows 2,3,4,5
                 stmt.execute("set transaction variable min_pk = 2");
                 stmt.setMaxRows(2);
-                // First page: rows 2 and 3
                 final byte[] continuationBytes;
                 try (var rs = stmt.executeQuery("select pk, name from conttbl where pk >= GET_VARIABLE(min_pk)")) {
                     ResultSetAssert.assertThat(rs)
@@ -359,10 +350,9 @@ public class LocalVariableTests {
                             .hasNoNextRow();
                     continuationBytes = rs.getContinuation().serialize();
                 }
-                // Change GET_VARIABLE(min_pk) to a different value — the continuation must ignore this
+                // Changing the variable must not affect the already-captured continuation
                 stmt.execute("set transaction variable min_pk = 99");
                 stmt.setMaxRows(10);
-                // Resume via continuation: should still see rows 4 and 5 (original binding min_pk=2)
                 final String encoded = Base64.getEncoder().encodeToString(continuationBytes);
                 try (var rs = stmt.executeQuery("EXECUTE CONTINUATION B64'" + encoded + "'")) {
                     ResultSetAssert.assertThat(rs)
@@ -390,7 +380,6 @@ public class LocalVariableTests {
             try (var stmt = conn.createStatement()) {
                 stmt.execute("set transaction variable x = 1");
             }
-            // GET_VARIABLE(x) = 1 (from SET TRANSACTION VARIABLE), ?x = 2 (from named prepared param) — both resolve independently
             try (var ps = conn.prepareStatement("select pk from tns where pk = GET_VARIABLE(x) or pk = ?x")) {
                 ps.setLong("x", 2L);
                 try (var rs = ps.executeQuery()) {
@@ -420,8 +409,6 @@ public class LocalVariableTests {
             conn.setAutoCommit(false);
             try (var stmt = conn.createStatement()) {
                 stmt.execute("set transaction variable x = 1");
-                // ?x is an unbound named prepared parameter on a plain Statement; it must not
-                // resolve to the local variable GET_VARIABLE(x) (= 1).
                 RelationalAssertions.assertThrowsSqlException(
                         () -> stmt.executeQuery("select pk from tleak where pk = ?x"))
                         .hasErrorCode(ErrorCode.UNDEFINED_PARAMETER);
@@ -442,7 +429,6 @@ public class LocalVariableTests {
             }
             final var conn = ddl.getConnection();
             try (var logAppender = LogAppenderRule.of("LocalVariableTests_typechange", PlanGenerator.class, Level.INFO)) {
-                // First execution: x is BIGINT.
                 conn.setAutoCommit(false);
                 try (var stmt = conn.createStatement()) {
                     stmt.execute("set transaction variable x = 10");
@@ -453,9 +439,6 @@ public class LocalVariableTests {
                 conn.commit();
                 Assertions.assertTrue(logAppender.lastMessageIsCacheMiss(), "first execution (BIGINT) should be a cache miss");
 
-                // Second execution: identical query text, but x is now STRING. Must be a cache
-                // miss (a fresh compile), not a hit against the BIGINT-shaped plan, and must
-                // return the STRING value correctly.
                 conn.unwrap(EmbeddedRelationalConnection.class).createNewTransaction();
                 conn.setAutoCommit(false);
                 try (var stmt = conn.createStatement()) {
@@ -483,7 +466,7 @@ public class LocalVariableTests {
             }
             final var conn = ddl.getConnection();
             try (var logAppender = LogAppenderRule.of("LocalVariableTests_nulltotyped", PlanGenerator.class, Level.INFO)) {
-                // First execution: x is NULL. val = NULL is never true, so no rows match.
+                // x is NULL; val = NULL is never true, so no rows match.
                 conn.setAutoCommit(false);
                 try (var stmt = conn.createStatement()) {
                     stmt.execute("set transaction variable x = null");
@@ -494,8 +477,6 @@ public class LocalVariableTests {
                 conn.commit();
                 Assertions.assertTrue(logAppender.lastMessageIsCacheMiss(), "first execution (NULL) should be a cache miss");
 
-                // Second execution: identical query text, x is now BIGINT and matches val. Must
-                // be a cache miss, not a stale hit against the NULL-typed plan.
                 conn.unwrap(EmbeddedRelationalConnection.class).createNewTransaction();
                 conn.setAutoCommit(false);
                 try (var stmt = conn.createStatement()) {


### PR DESCRIPTION
Adds GET_VARIABLE(name) as a dedicated specificFunction grammar
production (like CAST), resolved at AST-normalization time directly
from the transaction's variable map -- not routed through the generic
function catalog, so it keeps the same normalization-time resolution
SqlFunctionCatalog-independent function calls get, without needing an
opaque return type that CAST couldn't pin down later.

The variable's current type is folded into the plan cache key text,
not just its name: re-SETting a variable to a different type between
two runs of identical query text (including a NULL <-> concrete type
transition) now forces a fresh compile instead of silently reusing a
plan shaped for the old type. Referencing a variable that was never
SET in the current transaction still raises UNDEFINED_PARAMETER; one
explicitly SET to NULL is a distinct, legal state and reads back as
NULL.

Local variables are threaded from the transaction into PlanContext and
from there into plan generation, but only for ordinary queries -- table-
valued function bodies don't see them yet, that's the next stacked PR.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>