### PR TITLE
Thread local variables through table-valued function resolution

### DIFF
--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/RecordLayerInvokedRoutine.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/RecordLayerInvokedRoutine.java
@@ -23,12 +23,16 @@ package com.apple.foundationdb.relational.recordlayer.metadata;
 import com.apple.foundationdb.record.query.plan.cascades.UserDefinedFunction;
 import com.apple.foundationdb.relational.api.metadata.InvokedRoutine;
 import com.apple.foundationdb.relational.recordlayer.query.PreparedParams;
-import com.apple.foundationdb.relational.recordlayer.util.MemoizedFunction;
 import com.apple.foundationdb.relational.util.Assert;
 
 import javax.annotation.Nonnull;
+import java.util.AbstractMap;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Objects;
-import java.util.function.Function;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiFunction;
 
 public class RecordLayerInvokedRoutine implements InvokedRoutine {
 
@@ -46,8 +50,13 @@ public class RecordLayerInvokedRoutine implements InvokedRoutine {
 
     private final boolean isTemporary;
 
+    // The raw (un-memoized) provider, kept so that toBuilder() can hand it back to the builder
+    // without triggering a second memoize() wrap in the constructor.
     @Nonnull
-    private final Function<Boolean, UserDefinedFunction> userDefinedFunctionProvider;
+    private final BiFunction<Boolean, Map<String, Object>, UserDefinedFunction> rawUserDefinedFunctionProvider;
+
+    @Nonnull
+    private final BiFunction<Boolean, Map<String, Object>, UserDefinedFunction> userDefinedFunctionProvider;
 
     @Nonnull
     private final UserDefinedFunction serializableFunction;
@@ -57,15 +66,39 @@ public class RecordLayerInvokedRoutine implements InvokedRoutine {
                                      @Nonnull final String name,
                                      @Nonnull final PreparedParams preparedParams,
                                      boolean isTemporary,
-                                     @Nonnull final Function<Boolean, UserDefinedFunction> userDefinedFunctionProvider,
+                                     @Nonnull final BiFunction<Boolean, Map<String, Object>, UserDefinedFunction> userDefinedFunctionProvider,
                                      @Nonnull final UserDefinedFunction serializableFunction) {
         this.description = description;
         this.normalizedDescription = normalizedDescription;
         this.name = name;
         this.preparedParams = preparedParams;
         this.isTemporary = isTemporary;
-        this.userDefinedFunctionProvider = MemoizedFunction.memoize(userDefinedFunctionProvider::apply);
+        this.rawUserDefinedFunctionProvider = userDefinedFunctionProvider;
+        this.userDefinedFunctionProvider = memoize(userDefinedFunctionProvider);
         this.serializableFunction = serializableFunction;
+    }
+
+    // Memoizes by (isCaseSensitive, snapshot of localVars) so that:
+    // - the same function instance is reused when local variables haven't changed (preserving the
+    //   assertSame guarantee that plan-sharing relies on), and
+    // - a new compilation is triggered when local variable values change (fixing the stale-value
+    //   bug that existed when the old memoization keyed only on isCaseSensitive).
+    // The cache is bounded by the transaction lifetime: RecordLayerInvokedRoutine is created by
+    // CREATE TEMPORARY FUNCTION (per-transaction) and discarded when the transaction ends, so at
+    // most one entry per distinct localVars snapshot seen within a single transaction is retained.
+    // The snapshot is an unmodifiable LinkedHashMap copy rather than a Guava ImmutableMap because
+    // local-variable values are legitimately nullable (e.g. SET TRANSACTION VARIABLE x = NULL) and
+    // ImmutableMap forbids null values; a LinkedHashMap tolerates nulls while still providing
+    // value-based equals()/hashCode() for correct cache-key lookups.
+    @Nonnull
+    private static BiFunction<Boolean, Map<String, Object>, UserDefinedFunction> memoize(
+            @Nonnull final BiFunction<Boolean, Map<String, Object>, UserDefinedFunction> fn) {
+        final var cache = new ConcurrentHashMap<Map.Entry<Boolean, Map<String, Object>>, UserDefinedFunction>();
+        return (isCaseSensitive, localVars) -> {
+            final var snapshot = Collections.unmodifiableMap(new LinkedHashMap<String, Object>(localVars));
+            final var key = new AbstractMap.SimpleImmutableEntry<>(isCaseSensitive, snapshot);
+            return cache.computeIfAbsent(key, k -> fn.apply(k.getKey(), k.getValue()));
+        };
     }
 
     @Nonnull
@@ -86,7 +119,7 @@ public class RecordLayerInvokedRoutine implements InvokedRoutine {
     }
 
     @Nonnull
-    public Function<Boolean, UserDefinedFunction> getUserDefinedFunctionProvider() {
+    public BiFunction<Boolean, Map<String, Object>, UserDefinedFunction> getUserDefinedFunctionProvider() {
         return userDefinedFunctionProvider;
     }
 
@@ -140,7 +173,7 @@ public class RecordLayerInvokedRoutine implements InvokedRoutine {
                 .setDescription(getDescription())
                 .setNormalizedDescription(getNormalizedDescription())
                 .setTemporary(isTemporary())
-                .withUserDefinedFunctionProvider(getUserDefinedFunctionProvider())
+                .withUserDefinedFunctionProvider(rawUserDefinedFunctionProvider)
                 .withSerializableFunction(asSerializableFunction());
     }
 
@@ -149,7 +182,7 @@ public class RecordLayerInvokedRoutine implements InvokedRoutine {
         private String normalizedDescription;
         private PreparedParams preparedParams;
         private String name;
-        private Function<Boolean, UserDefinedFunction> userDefinedFunctionProvider;
+        private BiFunction<Boolean, Map<String, Object>, UserDefinedFunction> userDefinedFunctionProvider;
         private UserDefinedFunction serializableFunction;
         private boolean isTemporary;
 
@@ -175,7 +208,7 @@ public class RecordLayerInvokedRoutine implements InvokedRoutine {
         }
 
         @Nonnull
-        public Builder withUserDefinedFunctionProvider(@Nonnull final Function<Boolean, UserDefinedFunction> userDefinedFunctionProvider) {
+        public Builder withUserDefinedFunctionProvider(@Nonnull final BiFunction<Boolean, Map<String, Object>, UserDefinedFunction> userDefinedFunctionProvider) {
             this.userDefinedFunctionProvider = userDefinedFunctionProvider;
             return this;
         }

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/RecordLayerInvokedRoutine.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/RecordLayerInvokedRoutine.java
@@ -78,18 +78,10 @@ public class RecordLayerInvokedRoutine implements InvokedRoutine {
         this.serializableFunction = serializableFunction;
     }
 
-    // Memoizes by (isCaseSensitive, snapshot of localVars) so that:
-    // - the same function instance is reused when local variables haven't changed (preserving the
-    //   assertSame guarantee that plan-sharing relies on), and
-    // - a new compilation is triggered when local variable values change (fixing the stale-value
-    //   bug that existed when the old memoization keyed only on isCaseSensitive).
-    // The cache is bounded by the transaction lifetime: RecordLayerInvokedRoutine is created by
-    // CREATE TEMPORARY FUNCTION (per-transaction) and discarded when the transaction ends, so at
-    // most one entry per distinct localVars snapshot seen within a single transaction is retained.
-    // The snapshot is an unmodifiable LinkedHashMap copy rather than a Guava ImmutableMap because
-    // local-variable values are legitimately nullable (e.g. SET TRANSACTION VARIABLE x = NULL) and
-    // ImmutableMap forbids null values; a LinkedHashMap tolerates nulls while still providing
-    // value-based equals()/hashCode() for correct cache-key lookups.
+    // Keyed on (isCaseSensitive, snapshot of localVars): reuses the same instance when variables
+    // haven't changed, recompiles when they have. Bounded by the transaction's lifetime, since this
+    // routine is discarded when the transaction ends. Uses a LinkedHashMap snapshot rather than an
+    // ImmutableMap because local-variable values may legitimately be null.
     @Nonnull
     private static BiFunction<Boolean, Map<String, Object>, UserDefinedFunction> memoize(
             @Nonnull final BiFunction<Boolean, Map<String, Object>, UserDefinedFunction> fn) {

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/serde/RecordMetadataDeserializer.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/metadata/serde/RecordMetadataDeserializer.java
@@ -48,6 +48,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -149,10 +150,10 @@ public class RecordMetadataDeserializer {
 
     @Nonnull
     @VisibleForTesting
-    protected static Function<Boolean, UserDefinedFunction> getSqlFunctionCompiler(@Nonnull final String name,
+    protected static BiFunction<Boolean, Map<String, Object>, UserDefinedFunction> getSqlFunctionCompiler(@Nonnull final String name,
                                                                                    @Nonnull final Supplier<RecordLayerSchemaTemplate> metadata,
                                                                                    @Nonnull final String functionBody) {
-        return isCaseSensitive -> RoutineParser.sqlFunctionParser(metadata.get()).parseFunction(functionBody, isCaseSensitive);
+        return (isCaseSensitive, localVars) -> RoutineParser.sqlFunctionParser(metadata.get()).parseFunction(functionBody, isCaseSensitive);
     }
 
     @Nonnull
@@ -182,7 +183,7 @@ public class RecordMetadataDeserializer {
         return RecordLayerInvokedRoutine.newBuilder()
                 .setName(name)
                 .setDescription(body)
-                .withUserDefinedFunctionProvider(ignored -> userDefinedScalarFunction)
+                .withUserDefinedFunctionProvider((ignored, localVars) -> userDefinedScalarFunction)
                 .withSerializableFunction(userDefinedScalarFunction);
     }
 

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/AstNormalizer.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/AstNormalizer.java
@@ -251,8 +251,8 @@ public final class AstNormalizer extends RelationalParserBaseVisitor<Object> {
         final var varName = Assert.notNullUnchecked(SemanticAnalyzer.normalizeString(ctx.varName.getText(), caseSensitive));
         final var tokenIndex = ctx.varName.getStart().getTokenIndex();
         if (insideTempFunctionBody && deferMissingVarsInFunctionBodies && !localVariables.containsKey(varName)) {
-            // Variable not yet set; emit a placeholder so the canonical form is deterministic. The
-            // actual value is injected via withExecutionContext at call time.
+            // Variable not yet set; emit a placeholder so the canonical form is deterministic.
+            // The real value is resolved later, at invocation time, by normalizeFunctionBody.
             if (allowTokenAddition) {
                 final var placeholder = "GET_VARIABLE(" + varName + ")";
                 sqlCanonicalizer.append(placeholder).append(" ");

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/AstNormalizer.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/AstNormalizer.java
@@ -136,6 +136,13 @@ public final class AstNormalizer extends RelationalParserBaseVisitor<Object> {
     @Nonnull
     private final Map<String, Object> localVariables;
 
+    private boolean insideTempFunctionBody = false;
+
+    // True when processing the original CREATE TEMPORARY FUNCTION statement; false during
+    // re-normalization of function bodies at query execution time. When false, missing local
+    // variables inside function bodies are an error (UNDEFINED_PARAMETER), not a placeholder.
+    private final boolean deferMissingVarsInFunctionBodies;
+
     @Nonnull
     private final Set<NormalizationResult.QueryCachingFlags> queryCachingFlags;
 
@@ -163,7 +170,8 @@ public final class AstNormalizer extends RelationalParserBaseVisitor<Object> {
     private AstNormalizer(@Nonnull final PreparedParams preparedStatementParameters,
                           @Nonnull final Map<String, Object> localVariables,
                           boolean caseSensitive,
-                          @Nonnull final PlanHashable.PlanHashMode currentPlanHashMode, boolean forExplain) {
+                          @Nonnull final PlanHashable.PlanHashMode currentPlanHashMode, boolean forExplain,
+                          boolean deferMissingVarsInFunctionBodies) {
         parameterHash = Hashing.murmur3_32_fixed().newHasher().putInt("ParameterHash".hashCode());
         parameterHashSupplier = Suppliers.memoize(() -> parameterHash.hash().asInt())::get;
         sqlCanonicalizer = new StringBuilder();
@@ -176,6 +184,14 @@ public final class AstNormalizer extends RelationalParserBaseVisitor<Object> {
         queryCachingFlags = EnumSet.noneOf(NormalizationResult.QueryCachingFlags.class);
         queryOptions = Options.builder();
         this.caseSensitive = caseSensitive;
+        this.deferMissingVarsInFunctionBodies = deferMissingVarsInFunctionBodies;
+    }
+
+    private AstNormalizer(@Nonnull final PreparedParams preparedStatementParameters,
+                          @Nonnull final Map<String, Object> localVariables,
+                          boolean caseSensitive,
+                          @Nonnull final PlanHashable.PlanHashMode currentPlanHashMode, boolean forExplain) {
+        this(preparedStatementParameters, localVariables, caseSensitive, currentPlanHashMode, forExplain, false);
     }
 
     @Override
@@ -215,7 +231,12 @@ public final class AstNormalizer extends RelationalParserBaseVisitor<Object> {
     public Object visitCreateTempFunction(final RelationalParser.CreateTempFunctionContext ctx) {
         final var functionName = SemanticAnalyzer.normalizeString(ctx.tempSqlInvokedFunction().functionSpecification().schemaQualifiedRoutineName.getText(), caseSensitive);
         queryHasherContextBuilder.getLiteralsBuilder().setScope(functionName);
-        return visitChildren(ctx);
+        insideTempFunctionBody = true;
+        try {
+            return visitChildren(ctx);
+        } finally {
+            insideTempFunctionBody = false;
+        }
     }
 
     @Override
@@ -229,6 +250,16 @@ public final class AstNormalizer extends RelationalParserBaseVisitor<Object> {
     public Object visitGetVariableFunctionCall(@Nonnull RelationalParser.GetVariableFunctionCallContext ctx) {
         final var varName = Assert.notNullUnchecked(SemanticAnalyzer.normalizeString(ctx.varName.getText(), caseSensitive));
         final var tokenIndex = ctx.varName.getStart().getTokenIndex();
+        if (insideTempFunctionBody && deferMissingVarsInFunctionBodies && !localVariables.containsKey(varName)) {
+            // Variable not yet set; emit a placeholder so the canonical form is deterministic. The
+            // actual value is injected via withExecutionContext at call time.
+            if (allowTokenAddition) {
+                final var placeholder = "GET_VARIABLE(" + varName + ")";
+                sqlCanonicalizer.append(placeholder).append(" ");
+                parameterHash.putInt(placeholder.hashCode());
+            }
+            return null;
+        }
         Assert.thatUnchecked(localVariables.containsKey(varName), ErrorCode.UNDEFINED_PARAMETER,
                 () -> "No value found for variable " + varName);
         final var value = localVariables.get(varName);
@@ -709,7 +740,7 @@ public final class AstNormalizer extends RelationalParserBaseVisitor<Object> {
                                                      @Nonnull final PlanHashable.PlanHashMode currentPlanHashMode,
                                                      @Nonnull final String query,
                                                      @Nonnull final Map<String, Object> localVariables) throws RelationalException {
-        final var astNormalizer = new AstNormalizer(preparedStatementParameters, localVariables, caseSensitive, currentPlanHashMode, parseTreeInfo.getQueryType() == ParseTreeInfo.QueryType.DESCRIBE_QUERY);
+        final var astNormalizer = new AstNormalizer(preparedStatementParameters, localVariables, caseSensitive, currentPlanHashMode, parseTreeInfo.getQueryType() == ParseTreeInfo.QueryType.DESCRIBE_QUERY, true);
         astNormalizer.visit(parseTreeInfo.getRootContext());
         final var recordLayerSchemaTemplate = Assert.castUnchecked(schemaTemplate, RecordLayerSchemaTemplate.class);
 
@@ -731,9 +762,13 @@ public final class AstNormalizer extends RelationalParserBaseVisitor<Object> {
                     continue;
                 }
                 final var recordLayerRoutine = (RecordLayerInvokedRoutine)temporaryRoutine;
-                final var functionAstResult = normalizeAst(schemaTemplate,
+                // For the function body cache-key normalization: use the CREATE-time ?param bindings from
+                // the routine itself, and pass SELECT-time GET_VARIABLE bindings separately so they resolve
+                // as local variables rather than named parameters.
+                final var functionAstResult = normalizeFunctionBody(schemaTemplate,
                         QueryParser.parse(recordLayerRoutine.getDescription()),
                         recordLayerRoutine.getPreparedParams(),
+                        localVariables,
                         plannerConfiguration,
                         caseSensitive,
                         currentPlanHashMode,
@@ -741,6 +776,34 @@ public final class AstNormalizer extends RelationalParserBaseVisitor<Object> {
                 astNormalizer.queryHasherContextBuilder.getLiteralsBuilder().importLiterals(functionAstResult.queryExecutionContext.getLiterals());
             }
         }
+        return new NormalizationResult(
+                recordLayerSchemaTemplate.getName(),
+                QueryCacheKey.of(astNormalizer.getCanonicalSqlString(), getQuerySpecificPlannerConfig(plannerConfiguration, astNormalizer.getQueryOptions()),
+                        recordLayerSchemaTemplate.getTransactionBoundMetadataAsString(),
+                        recordLayerSchemaTemplate.getVersion()),
+                astNormalizer.getQueryExecutionParameters(),
+                parseTreeInfo.getRootContext(),
+                astNormalizer.getQueryCachingFlags(),
+                astNormalizer.getQueryOptions(),
+                query);
+    }
+
+    // Re-normalizes a temporary function body during query execution. Unlike the outer normalizeAst,
+    // this does NOT defer missing local variables — if a variable referenced in the function body is
+    // absent from localVariables, UNDEFINED_PARAMETER is thrown at invocation time.
+    @Nonnull
+    private static NormalizationResult normalizeFunctionBody(@Nonnull final SchemaTemplate schemaTemplate,
+                                                              @Nonnull final ParseTreeInfoImpl parseTreeInfo,
+                                                              @Nonnull final PreparedParams preparedStatementParameters,
+                                                              @Nonnull final Map<String, Object> localVariables,
+                                                              @Nonnull final PlannerConfiguration plannerConfiguration,
+                                                              boolean caseSensitive,
+                                                              @Nonnull final PlanHashable.PlanHashMode currentPlanHashMode,
+                                                              @Nonnull final String query) throws RelationalException {
+        final var astNormalizer = new AstNormalizer(preparedStatementParameters, localVariables, caseSensitive, currentPlanHashMode,
+                parseTreeInfo.getQueryType() == ParseTreeInfo.QueryType.DESCRIBE_QUERY, false);
+        astNormalizer.visit(parseTreeInfo.getRootContext());
+        final var recordLayerSchemaTemplate = Assert.castUnchecked(schemaTemplate, RecordLayerSchemaTemplate.class);
         return new NormalizationResult(
                 recordLayerSchemaTemplate.getName(),
                 QueryCacheKey.of(astNormalizer.getCanonicalSqlString(), getQuerySpecificPlannerConfig(plannerConfiguration, astNormalizer.getQueryOptions()),

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/LogicalOperator.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/LogicalOperator.java
@@ -69,6 +69,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -212,7 +213,7 @@ public class LogicalOperator {
                     () -> String.format(Locale.ROOT,
                             "AT clause requires an array-typed column, but '%s' is a function",
                             identifier));
-            return semanticAnalyzer.resolveTableFunction(identifier, Expressions.empty(), false)
+            return semanticAnalyzer.resolveTableFunction(identifier, Expressions.empty(), false, Map.of())
                     .withNewSharedReferenceAndAlias(alias);
         } else {
             final var correlatedField = semanticAnalyzer.resolveCorrelatedIdentifier(identifier,

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/SemanticAnalyzer.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/SemanticAnalyzer.java
@@ -1058,7 +1058,7 @@ public class SemanticAnalyzer {
         Assert.thatUnchecked(functionCatalog.containsFunction(functionName), ErrorCode.UNSUPPORTED_QUERY,
                 () -> String.format(Locale.ROOT, "Unsupported operator %s", functionName));
 
-        final var catalogedFunction = functionCatalog.lookupFunction(functionName, arguments);
+        final var catalogedFunction = functionCatalog.lookupFunction(functionName, arguments, Map.of());
         processFunctionSideEffects(catalogedFunction);
 
         final var argumentList = ImmutableList.<Value>builderWithExpectedSize(arguments.size() + 1)
@@ -1150,12 +1150,12 @@ public class SemanticAnalyzer {
      */
     @Nonnull
     public LogicalOperator resolveTableFunction(@Nonnull final Identifier functionName, @Nonnull final Expressions arguments,
-                                                boolean flattenSingleItemRecords) {
+                                                boolean flattenSingleItemRecords, @Nonnull final Map<String, Object> localVariables) {
         Assert.thatUnchecked(functionCatalog.containsFunction(functionName.getName()), ErrorCode.UNDEFINED_FUNCTION,
                 () -> String.format(Locale.ROOT, "Unknown function %s", functionName));
         final var callSiteArguments = arguments.toCallSiteArguments(flattenSingleItemRecords);
 
-        final var tableFunction = functionCatalog.lookupFunction(functionName.getName(), callSiteArguments);
+        final var tableFunction = functionCatalog.lookupFunction(functionName.getName(), callSiteArguments, localVariables);
         if (tableFunction instanceof BuiltInFunction) {
             Assert.thatUnchecked(tableFunction instanceof BuiltInTableFunction, functionName + " is not a table-valued function");
         }

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/functions/SqlFunctionCatalog.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/functions/SqlFunctionCatalog.java
@@ -28,6 +28,7 @@ import com.apple.foundationdb.record.query.plan.cascades.values.Value;
 import com.apple.foundationdb.relational.recordlayer.metadata.RecordLayerSchemaTemplate;
 
 import javax.annotation.Nonnull;
+import java.util.Map;
 import java.util.stream.StreamSupport;
 
 import static java.util.stream.Collectors.toList;
@@ -43,10 +44,13 @@ public interface SqlFunctionCatalog {
      * is the first time it was looked up, i.e. the compilation is lazily, and only once.
      * @param name The name of the function.
      * @param arguments The arguments passed with the invocation of the function.
+     * @param localVariables The current transaction's local variables, made available to a table-valued
+     *                       function body being lazily compiled so it can resolve its own GET_VARIABLE references.
      * @return the function instance.
      */
     @Nonnull
-    CatalogedFunction lookupFunction(@Nonnull String name, @Nonnull CallSiteArguments arguments);
+    CatalogedFunction lookupFunction(@Nonnull String name, @Nonnull CallSiteArguments arguments,
+                                     @Nonnull Map<String, Object> localVariables);
 
     /**
      * Checks whether a function exists in the catalog. Note that invoking this method shall not trigger compiling
@@ -66,7 +70,7 @@ public interface SqlFunctionCatalog {
      *     <ul>user-defined table-valued functions, lazily-compiled</ul>
      * </li>
      * The user-defined functions are loaded from the passed {@code metadata} argument, they are only compiled when
-     * looked up with {@link SqlFunctionCatalog#lookupFunction(String, CallSiteArguments)}, and their compiled version is
+     * looked up with {@link SqlFunctionCatalog#lookupFunction(String, CallSiteArguments, Map)}, and their compiled version is
      * cached so it is done at most once.
      *
      * @param metadata The metadata used to load any user-defined functions.

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/functions/SqlFunctionCatalogImpl.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/functions/SqlFunctionCatalogImpl.java
@@ -34,6 +34,7 @@ import com.google.common.collect.ImmutableMap;
 
 import javax.annotation.Nonnull;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -49,15 +50,16 @@ final class SqlFunctionCatalogImpl implements SqlFunctionCatalog {
     @Nonnull
     private final UserDefinedFunctionCatalog userDefinedFunctionCatalog;
 
-    private SqlFunctionCatalogImpl(boolean isCaseSensitive) {
-        this.userDefinedFunctionCatalog = new UserDefinedFunctionCatalog(isCaseSensitive);
+    private SqlFunctionCatalogImpl() {
+        this.userDefinedFunctionCatalog = new UserDefinedFunctionCatalog();
     }
 
     @Nonnull
     @Override
-    public CatalogedFunction lookupFunction(@Nonnull final String name, @Nonnull final CallSiteArguments arguments) {
+    public CatalogedFunction lookupFunction(@Nonnull final String name, @Nonnull final CallSiteArguments arguments,
+                                            @Nonnull final Map<String, Object> localVariables) {
         final var builtInFunctionMaybe = lookupBuiltInFunction(name, arguments);
-        final var userDefinedFunctionMaybe = lookupUserDefinedFunction(name, arguments);
+        final var userDefinedFunctionMaybe = lookupUserDefinedFunction(name, arguments, localVariables);
         if (builtInFunctionMaybe.isPresent() && userDefinedFunctionMaybe.isPresent()) {
             // this should never happen.
             Assert.failUnchecked(ErrorCode.INTERNAL_ERROR, "multiple definition of '" + name + "' found in the catalog");
@@ -84,8 +86,9 @@ final class SqlFunctionCatalogImpl implements SqlFunctionCatalog {
 
     @Nonnull
     private Optional<? extends CatalogedFunction> lookupUserDefinedFunction(@Nonnull final String name,
-                                                                            @Nonnull final CallSiteArguments arguments) {
-        return userDefinedFunctionCatalog.lookup(name, arguments);
+                                                                            @Nonnull final CallSiteArguments arguments,
+                                                                            @Nonnull final Map<String, Object> localVariables) {
+        return userDefinedFunctionCatalog.lookup(name, arguments, localVariables);
     }
 
     @Override
@@ -100,7 +103,7 @@ final class SqlFunctionCatalogImpl implements SqlFunctionCatalog {
     }
 
     public void registerUserDefinedFunction(@Nonnull final String functionName,
-                                            @Nonnull final Function<Boolean, ? extends UserDefinedFunction> functionSupplier) {
+                                            @Nonnull final Function<Map<String, Object>, ? extends UserDefinedFunction> functionSupplier) {
         userDefinedFunctionCatalog.registerFunction(functionName, functionSupplier);
     }
 
@@ -164,11 +167,11 @@ final class SqlFunctionCatalogImpl implements SqlFunctionCatalog {
     @Nonnull
     public static SqlFunctionCatalogImpl newInstance(@Nonnull final RecordLayerSchemaTemplate metadata,
                                                      boolean isCaseSensitive) {
-        final var functionCatalog = new SqlFunctionCatalogImpl(isCaseSensitive);
+        final var functionCatalog = new SqlFunctionCatalogImpl();
         metadata.getInvokedRoutines().forEach(func ->
                 functionCatalog.registerUserDefinedFunction(
                         Assert.notNullUnchecked(func.getName()),
-                        func.getUserDefinedFunctionProvider()));
+                        localVars -> func.getUserDefinedFunctionProvider().apply(isCaseSensitive, localVars)));
         return functionCatalog;
     }
 }

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/functions/UserDefinedFunctionCatalog.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/functions/UserDefinedFunctionCatalog.java
@@ -33,17 +33,14 @@ import java.util.function.Function;
 final class UserDefinedFunctionCatalog {
 
     @Nonnull
-    private final Map<String, Function<Boolean, ? extends UserDefinedFunction>> functionsMap;
+    private final Map<String, Function<Map<String, Object>, ? extends UserDefinedFunction>> functionsMap;
 
-    private final boolean isCaseSensitive;
-
-    UserDefinedFunctionCatalog(boolean isCaseSensitive) {
-        this.isCaseSensitive = isCaseSensitive;
+    UserDefinedFunctionCatalog() {
         this.functionsMap = new LinkedHashMap<>();
     }
 
     void registerFunction(@Nonnull final String functionName,
-                          @Nonnull final Function<Boolean, ? extends UserDefinedFunction> function) {
+                          @Nonnull final Function<Map<String, Object>, ? extends UserDefinedFunction> function) {
         functionsMap.put(functionName, function);
     }
 
@@ -52,14 +49,15 @@ final class UserDefinedFunctionCatalog {
     }
 
     @Nonnull
-    public Optional<CatalogedFunction> lookup(@Nonnull final String functionName, @Nonnull final CallSiteArguments arguments) {
+    public Optional<CatalogedFunction> lookup(@Nonnull final String functionName, @Nonnull final CallSiteArguments arguments,
+                                              @Nonnull final Map<String, Object> localVariables) {
         final var functionSupplier = functionsMap.get(functionName);
         if (functionSupplier == null) {
             return Optional.empty();
         }
 
         // lazy-compile the function
-        final var function = functionSupplier.apply(isCaseSensitive);
+        final var function = functionSupplier.apply(localVariables);
 
         // These validations don't include checking if the type of the provided arguments matches the expected function
         // parameter types or the provided values can be promoted to the expected types. Instead, this is delegated

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/BaseVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/BaseVisitor.java
@@ -268,7 +268,8 @@ public class BaseVisitor extends RelationalParserBaseVisitor<Object> implements 
 
     @Nonnull
     public LogicalOperator resolveTableValuedFunction(@Nonnull Identifier functionName, @Nonnull Expressions arguments) {
-        return getSemanticAnalyzer().resolveTableFunction(functionName, arguments, true);
+        return getSemanticAnalyzer().resolveTableFunction(functionName, arguments, true,
+                mutablePlanGenerationContext.getLocalVariables());
     }
 
     @Override

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DdlVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DdlVisitor.java
@@ -649,10 +649,8 @@ public final class DdlVisitor extends DelegatingVisitor<BaseVisitor> {
             // delay the compilation of table-valued temporary functions for later
             return builder
                     .withUserDefinedFunctionProvider((ignore, localVarsMap) -> {
-                        // Merge SELECT-time local variable bindings into the CREATE-time PreparedParams so that
-                        // GET_VARIABLE refs inside the body resolve to their current values. We add (not
-                        // replace) so that ?param bindings already present from the CREATE-time context are
-                        // preserved.
+                        // Temporarily swap in the SELECT-time local variables so GET_VARIABLE refs in
+                        // the body resolve to their current values, then restore the CREATE-time state.
                         if (localVarsMap != null && !localVarsMap.isEmpty()) {
                             final var prev = getDelegate().getPlanGenerationContext().getLocalVariables();
                             getDelegate().getPlanGenerationContext().setLocalVariables(localVarsMap);

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DdlVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/DdlVisitor.java
@@ -648,12 +648,27 @@ public final class DdlVisitor extends DelegatingVisitor<BaseVisitor> {
         if (!isMacro && isTemporary) {
             // delay the compilation of table-valued temporary functions for later
             return builder
-                    .withUserDefinedFunctionProvider(ignore -> visitSqlInvokedFunction(functionSpecCtx, bodyCtx, isTemporary))
+                    .withUserDefinedFunctionProvider((ignore, localVarsMap) -> {
+                        // Merge SELECT-time local variable bindings into the CREATE-time PreparedParams so that
+                        // GET_VARIABLE refs inside the body resolve to their current values. We add (not
+                        // replace) so that ?param bindings already present from the CREATE-time context are
+                        // preserved.
+                        if (localVarsMap != null && !localVarsMap.isEmpty()) {
+                            final var prev = getDelegate().getPlanGenerationContext().getLocalVariables();
+                            getDelegate().getPlanGenerationContext().setLocalVariables(localVarsMap);
+                            try {
+                                return visitSqlInvokedFunction(functionSpecCtx, bodyCtx, isTemporary);
+                            } finally {
+                                getDelegate().getPlanGenerationContext().setLocalVariables(prev);
+                            }
+                        }
+                        return visitSqlInvokedFunction(functionSpecCtx, bodyCtx, isTemporary);
+                    })
                     .withSerializableFunction(new RawSqlFunction(functionName, functionDefinition))
                     .build();
         } else {
             final var userDefinedFunction = visitSqlInvokedFunction(functionSpecCtx, bodyCtx, isTemporary);
-            builder.withUserDefinedFunctionProvider(ignore -> userDefinedFunction);
+            builder.withUserDefinedFunctionProvider((ignore, localVars) -> userDefinedFunction);
             if (isMacro) {
                 return builder.withSerializableFunction(userDefinedFunction).build();
             } else {

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/ddl/MetadataOperationsFactoryTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/ddl/MetadataOperationsFactoryTests.java
@@ -84,7 +84,7 @@ public class MetadataOperationsFactoryTests {
     void createTemporaryFunctionOperationDoesNotChangeInvokedRoutine() throws RelationalException {
         final var mockedInvokedRoutine = Mockito.mock(RecordLayerInvokedRoutine.class);
         final var mockedUdf = Mockito.mock(UserDefinedFunction.class);
-        when(mockedInvokedRoutine.getUserDefinedFunctionProvider()).thenReturn((ignore) -> mockedUdf);
+        when(mockedInvokedRoutine.getUserDefinedFunctionProvider()).thenReturn((ignore, localVars) -> mockedUdf);
         when(mockedInvokedRoutine.getName()).thenReturn("routine1");
         final var schemaTemplate = RecordLayerSchemaTemplate.newBuilder()
                 .setName("TestSchemaTemplate")

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/metadata/SchemaTemplateSerDeTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/metadata/SchemaTemplateSerDeTests.java
@@ -71,7 +71,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -583,7 +583,7 @@ public class SchemaTemplateSerDeTests {
                 .setName(funcName)
                 .setDescription(funcDescription)
                 .setTemporary(true)
-                .withUserDefinedFunctionProvider(ignored -> new CompiledFunctionStub())
+                .withUserDefinedFunctionProvider((ignored, localVars) -> new CompiledFunctionStub())
                 .withSerializableFunction(new RawSqlFunction(funcName, funcDescription))
                 .build());
 
@@ -627,7 +627,7 @@ public class SchemaTemplateSerDeTests {
             schemaTemplateBuilder.addInvokedRoutine(RecordLayerInvokedRoutine.newBuilder()
                     .setName(functionName)
                     .setDescription(functionDescription)
-                    .withUserDefinedFunctionProvider(igored -> new CompiledFunctionStub())
+                    .withUserDefinedFunctionProvider((igored, localVars) -> new CompiledFunctionStub())
                     .withSerializableFunction(new RawSqlFunction(functionName, functionDescription))
                     .build());
         }
@@ -1035,11 +1035,11 @@ public class SchemaTemplateSerDeTests {
             final List<RecordLayerInvokedRoutine> invokedRoutines = schemaBuilder.getInvokedRoutines();
             for (RecordLayerInvokedRoutine routine : invokedRoutines) {
                 final String name = routine.getName();
-                final Function<Boolean, UserDefinedFunction> provider = routine.getUserDefinedFunctionProvider();
+                final BiFunction<Boolean, Map<String, Object>, UserDefinedFunction> provider = routine.getUserDefinedFunctionProvider();
                 final RecordLayerInvokedRoutine.Builder routineBuilder = routine.toBuilder();
-                routineBuilder.withUserDefinedFunctionProvider(isCaseSensitive -> {
+                routineBuilder.withUserDefinedFunctionProvider((isCaseSensitive, localVars) -> {
                     invocationsCount.merge(name, 1, Integer::sum);
-                    return provider.apply(isCaseSensitive);
+                    return provider.apply(isCaseSensitive, localVars);
                 });
                 schemaBuilder.removeInvokedRoutine(name);
                 schemaBuilder.addInvokedRoutine(routineBuilder.build());

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/AstNormalizerTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/AstNormalizerTests.java
@@ -410,7 +410,7 @@ public class AstNormalizerTests {
                         .setDescription(functionDdl)
                         .setNormalizedDescription(canonicalFunctionDdl)
                         // invoking the compiled routine should only happen during plan generation.
-                        .withUserDefinedFunctionProvider(ignored -> new CompiledSqlFunction("", List.of(), List.of(),
+                        .withUserDefinedFunctionProvider((ignored, localVars) -> new CompiledSqlFunction("", List.of(), List.of(),
                                 List.of(), Optional.empty(), null, Literals.empty()) {
                             @Nonnull
                             @Override

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/LocalVariableTemporaryFunctionTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/LocalVariableTemporaryFunctionTests.java
@@ -1,0 +1,330 @@
+/*
+ * LocalVariableTemporaryFunctionTests.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.relational.recordlayer.query;
+
+import com.apple.foundationdb.relational.api.exceptions.ErrorCode;
+import com.apple.foundationdb.relational.recordlayer.EmbeddedRelationalConnection;
+import com.apple.foundationdb.relational.recordlayer.EmbeddedRelationalExtension;
+import com.apple.foundationdb.relational.recordlayer.LogAppenderRule;
+import com.apple.foundationdb.relational.recordlayer.Utils;
+import com.apple.foundationdb.relational.utils.Ddl;
+import com.apple.foundationdb.relational.utils.RelationalAssertions;
+import com.apple.foundationdb.relational.utils.ResultSetAssert;
+import org.apache.logging.log4j.Level;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.net.URI;
+
+/**
+ * Tests for the interaction between transaction-scoped local variables (SET TRANSACTION VARIABLE /
+ * GET_VARIABLE(name), see {@link LocalVariableTests}) and table-valued functions -- both
+ * temporary ({@code CREATE TEMPORARY FUNCTION}) and permanent ({@code CREATE FUNCTION}).
+ */
+public class LocalVariableTemporaryFunctionTests {
+
+    @RegisterExtension
+    @Order(0)
+    public final EmbeddedRelationalExtension relationalExtension = new EmbeddedRelationalExtension();
+
+    public LocalVariableTemporaryFunctionTests() {
+        Utils.enableCascadesDebugger();
+    }
+
+    @Test
+    void schemaTemplateFunctionWithVariableInBody() throws Exception {
+        // The TVF takes an explicit parameter and is called with GET_VARIABLE(var) as the argument.
+        // This tests the interaction between local variables and schema-template TVFs.
+        // Note: using GET_VARIABLE(var) directly inside a TVF body requires lazy compilation support
+        // (separate work item); passing GET_VARIABLE(var) at the call site works today.
+        final String schemaTemplate =
+                "create table schfoo(pk bigint, name string, primary key(pk)) " +
+                "create function find_names(in target string) as select pk, name from schfoo where name = target";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/LV")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            try (var stmt = ddl.setSchemaAndGetConnection().createStatement()) {
+                stmt.executeUpdate("insert into schfoo values (1, 'alice'), (2, 'bob'), (3, 'carol')");
+            }
+            final var conn = ddl.getConnection();
+
+            // Without setting GET_VARIABLE(varname): call fails with UNDEFINED_PARAMETER
+            conn.setAutoCommit(false);
+            try (var stmt = conn.createStatement()) {
+                RelationalAssertions.assertThrowsSqlException(
+                        () -> stmt.executeQuery("select pk, name from find_names(target => GET_VARIABLE(varname))"))
+                        .hasErrorCode(ErrorCode.UNDEFINED_PARAMETER);
+            }
+            conn.rollback();
+
+            // Set GET_VARIABLE(varname) = 'alice' → only alice is returned
+            conn.unwrap(EmbeddedRelationalConnection.class).createNewTransaction();
+            conn.setAutoCommit(false);
+            try (var stmt = conn.createStatement()) {
+                stmt.execute("set transaction variable varname = 'alice'");
+                try (var rs = stmt.executeQuery("select pk, name from find_names(target => GET_VARIABLE(varname))")) {
+                    ResultSetAssert.assertThat(rs).hasNextRow().isRowExactly(1L, "alice").hasNoNextRow();
+                }
+            }
+            conn.commit();
+
+            // Set GET_VARIABLE(varname) = 'bob' → only bob is returned (different value, same function call site)
+            conn.unwrap(EmbeddedRelationalConnection.class).createNewTransaction();
+            conn.setAutoCommit(false);
+            try (var stmt = conn.createStatement()) {
+                stmt.execute("set transaction variable varname = 'bob'");
+                try (var rs = stmt.executeQuery("select pk, name from find_names(target => GET_VARIABLE(varname))")) {
+                    ResultSetAssert.assertThat(rs).hasNextRow().isRowExactly(2L, "bob").hasNoNextRow();
+                }
+            }
+            conn.rollback();
+        }
+    }
+
+    @Test
+    void filteredIndexSelectedByVariableWithPlanCacheConstraints() throws Exception {
+        // Schema: table with a boolean column, a filtered index covering only active=true rows,
+        // and a schema-template TVF that accepts the filter as a parameter.
+        // The TVF is called with GET_VARIABLE(filter) as the argument so the Cascades planner generates a
+        // constraint-based plan bundle:
+        //   - when GET_VARIABLE(filter)=true  → filtered-index plan variant is used
+        //   - when GET_VARIABLE(filter)=false → full-scan plan variant is used
+        // Verified via plan-cache hit/miss log messages.
+        final String schemaTemplate =
+                "create table schbar(pk bigint, active boolean, val bigint, primary key(pk)) " +
+                "create index idx_active as select pk, val from schbar where active = true order by pk " +
+                "create function active_items(in active_filter boolean) as select pk, val from schbar where active = active_filter";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/LV")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            try (var stmt = ddl.setSchemaAndGetConnection().createStatement()) {
+                stmt.executeUpdate("insert into schbar values (1, true, 10), (2, false, 20), (3, true, 30)");
+            }
+            final var conn = ddl.getConnection();
+
+            try (var logAppender = LogAppenderRule.of("LocalVariableTests_idx", PlanGenerator.class, Level.INFO)) {
+
+                // --- first call: GET_VARIABLE(filter) = true ---
+                // active_filter = true satisfies the filtered index predicate active = true
+                // → filtered-index plan is selected; first time seeing this query → cache miss.
+                conn.setAutoCommit(false);
+                try (var stmt = conn.createStatement()) {
+                    stmt.execute("set transaction variable filter = true");
+                    try (var rs = stmt.executeQuery("select pk, val from active_items(active_filter => GET_VARIABLE(filter)) options (log query)")) {
+                        ResultSetAssert.assertThat(rs)
+                                .hasNextRow().isRowExactly(1L, 10L)
+                                .hasNextRow().isRowExactly(3L, 30L)
+                                .hasNoNextRow();
+                    }
+                }
+                conn.commit();
+                Assertions.assertTrue(logAppender.lastMessageIsCacheMiss(), "first call (filter=true) should be a cache miss");
+
+                // --- second call: GET_VARIABLE(filter) = true again ---
+                // Same constraint satisfied → same plan variant → cache hit.
+                conn.unwrap(EmbeddedRelationalConnection.class).createNewTransaction();
+                conn.setAutoCommit(false);
+                try (var stmt = conn.createStatement()) {
+                    stmt.execute("set transaction variable filter = true");
+                    try (var rs = stmt.executeQuery("select pk, val from active_items(active_filter => GET_VARIABLE(filter)) options (log query)")) {
+                        ResultSetAssert.assertThat(rs)
+                                .hasNextRow().isRowExactly(1L, 10L)
+                                .hasNextRow().isRowExactly(3L, 30L)
+                                .hasNoNextRow();
+                    }
+                }
+                conn.commit();
+                Assertions.assertTrue(logAppender.lastMessageIsCacheHit(), "second call (filter=true) should be a cache hit");
+
+                // --- third call: GET_VARIABLE(filter) = false ---
+                // active_filter = false does NOT satisfy the filtered index predicate active = true
+                // → full-scan plan variant required; constraint violated → cache miss (new plan stored).
+                conn.unwrap(EmbeddedRelationalConnection.class).createNewTransaction();
+                conn.setAutoCommit(false);
+                try (var stmt = conn.createStatement()) {
+                    stmt.execute("set transaction variable filter = false");
+                    try (var rs = stmt.executeQuery("select pk, val from active_items(active_filter => GET_VARIABLE(filter)) options (log query)")) {
+                        ResultSetAssert.assertThat(rs)
+                                .hasNextRow().isRowExactly(2L, 20L)
+                                .hasNoNextRow();
+                    }
+                }
+                conn.commit();
+                Assertions.assertTrue(logAppender.lastMessageIsCacheMiss(), "call with filter=false should be a cache miss (different plan variant)");
+
+                // --- fourth call: GET_VARIABLE(filter) = false again ---
+                // Same full-scan plan variant → cache hit.
+                conn.unwrap(EmbeddedRelationalConnection.class).createNewTransaction();
+                conn.setAutoCommit(false);
+                try (var stmt = conn.createStatement()) {
+                    stmt.execute("set transaction variable filter = false");
+                    try (var rs = stmt.executeQuery("select pk, val from active_items(active_filter => GET_VARIABLE(filter)) options (log query)")) {
+                        ResultSetAssert.assertThat(rs)
+                                .hasNextRow().isRowExactly(2L, 20L)
+                                .hasNoNextRow();
+                    }
+                }
+                conn.rollback();
+                Assertions.assertTrue(logAppender.lastMessageIsCacheHit(), "fourth call (filter=false again) should be a cache hit");
+            }
+        }
+    }
+
+    @Test
+    void variableInTempFunctionBodyResolvesAtCallTime() throws Exception {
+        // GET_VARIABLE(body_var) directly inside a temp TVF body is resolved at invocation time, not at CREATE
+        // TEMPORARY FUNCTION time. The function can be created before the variable exists; the error
+        // surfaces only if GET_VARIABLE(body_var) is still absent when the function is actually called.
+        final String schemaTemplate = "create table tvfbody(pk bigint, name string, primary key(pk))";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/LV")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            try (var stmt = ddl.setSchemaAndGetConnection().createStatement()) {
+                stmt.executeUpdate("insert into tvfbody values (1, 'alice'), (2, 'bob'), (3, 'carol')");
+            }
+            final var conn = ddl.getConnection();
+            conn.setAutoCommit(false);
+            try (var stmt = conn.createStatement()) {
+                // CREATE succeeds even though GET_VARIABLE(body_var) is not set yet
+                stmt.execute("create temporary function find_by_body_var() on commit drop function " +
+                        "as select pk, name from tvfbody where name = GET_VARIABLE(body_var)");
+
+                // calling before GET_VARIABLE(body_var) is set → UNDEFINED_PARAMETER at invocation time
+                RelationalAssertions.assertThrowsSqlException(
+                        () -> stmt.executeQuery("select pk, name from find_by_body_var()"))
+                        .hasErrorCode(ErrorCode.UNDEFINED_PARAMETER);
+
+                // set GET_VARIABLE(body_var) = 'alice' → first call returns alice
+                stmt.execute("set transaction variable body_var = 'alice'");
+                try (var rs = stmt.executeQuery("select pk, name from find_by_body_var()")) {
+                    ResultSetAssert.assertThat(rs).hasNextRow().isRowExactly(1L, "alice").hasNoNextRow();
+                }
+
+                // overwrite GET_VARIABLE(body_var) to 'bob' → same function now returns bob (live reference)
+                stmt.execute("set transaction variable body_var = 'bob'");
+                try (var rs = stmt.executeQuery("select pk, name from find_by_body_var()")) {
+                    ResultSetAssert.assertThat(rs).hasNextRow().isRowExactly(2L, "bob").hasNoNextRow();
+                }
+            }
+            conn.rollback();
+        }
+    }
+
+    @Test
+    void tempFunctionAndLocalVariableCoexist() throws Exception {
+        // Verifies that SET TRANSACTION VARIABLE and CREATE TEMPORARY FUNCTION are independent:
+        // - the temp function survives a SET TRANSACTION VARIABLE in the same transaction
+        // - the local variable survives a CREATE TEMPORARY FUNCTION in the same transaction
+        // - both can be used together in the same query (variable passed as a function argument)
+        final String schemaTemplate = "create table coexist(pk bigint, val bigint, primary key(pk))";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/LV")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            try (var stmt = ddl.setSchemaAndGetConnection().createStatement()) {
+                stmt.executeUpdate("insert into coexist values (1, 10), (2, 20), (3, 30)");
+            }
+            final var conn = ddl.getConnection();
+            conn.setAutoCommit(false);
+            try (var stmt = conn.createStatement()) {
+                // Create a temp function, then set a variable — function must still work
+                stmt.execute("create temporary function find_val(in threshold bigint) on commit drop function as select pk from coexist where val > threshold");
+                stmt.execute("set transaction variable limit_val = 15");
+
+                // Temp function still works after SET TRANSACTION VARIABLE
+                try (var rs = stmt.executeQuery("select pk from find_val(threshold => 15)")) {
+                    ResultSetAssert.assertThat(rs)
+                            .hasNextRow().isRowExactly(2L)
+                            .hasNextRow().isRowExactly(3L)
+                            .hasNoNextRow();
+                }
+
+                // Local variable still works after CREATE TEMPORARY FUNCTION
+                try (var rs = stmt.executeQuery("select pk from coexist where val > GET_VARIABLE(limit_val)")) {
+                    ResultSetAssert.assertThat(rs)
+                            .hasNextRow().isRowExactly(2L)
+                            .hasNextRow().isRowExactly(3L)
+                            .hasNoNextRow();
+                }
+
+                // Both together: variable as argument to the temp function
+                try (var rs = stmt.executeQuery("select pk from find_val(threshold => GET_VARIABLE(limit_val))")) {
+                    ResultSetAssert.assertThat(rs)
+                            .hasNextRow().isRowExactly(2L)
+                            .hasNextRow().isRowExactly(3L)
+                            .hasNoNextRow();
+                }
+            }
+            conn.rollback();
+        }
+    }
+
+    @Test
+    void nullLocalVariableDoesNotBreakFunctionInvocation() throws Exception {
+        // Regression: a local variable bound to NULL must not crash a query that invokes a
+        // user-defined/table function. The function-compilation memoize cache previously keyed on
+        // ImmutableMap.copyOf(localVars), which throws NullPointerException on null values, so
+        // merely having a null-valued local variable in scope while resolving any function crashed.
+        final String schemaTemplate =
+                "create table nulltvf(pk bigint, name string, primary key(pk)) " +
+                "create function names_like(in target string) as select pk, name from nulltvf where name = target";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/LV")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            try (var stmt = ddl.setSchemaAndGetConnection().createStatement()) {
+                stmt.executeUpdate("insert into nulltvf values (1, 'alice'), (2, 'bob')");
+            }
+            final var conn = ddl.getConnection();
+            conn.setAutoCommit(false);
+            try (var stmt = conn.createStatement()) {
+                // A null-valued local variable is in scope (unrelated to the function argument).
+                stmt.execute("set transaction variable unused = null");
+                try (var rs = stmt.executeQuery("select pk, name from names_like(target => 'alice')")) {
+                    ResultSetAssert.assertThat(rs).hasNextRow().isRowExactly(1L, "alice").hasNoNextRow();
+                }
+            }
+            conn.rollback();
+        }
+    }
+
+    @Test
+    void permanentFunctionBodyCannotReferenceLocalVariable() throws Exception {
+        // Sanity check for the review concern about GET_VARIABLE(var) inside static/permanent function bodies.
+        // Unlike temporary functions (see variableInTempFunctionBodyResolvesAtCallTime), a permanent
+        // (schema-template) function body is compiled against an EMPTY local-variable scope:
+        //  - DdlVisitor.getInvokedRoutineMetadata compiles non-temporary bodies eagerly at CREATE
+        //    time (only table-valued TEMPORARY functions defer and thread the vars in), and
+        //  - the deserialization path (RecordMetadataDeserializer.getSqlFunctionCompiler ->
+        //    RoutineParser.parse) builds a fresh MutablePlanGenerationContext with no local
+        //    variables and ignores the localVars argument entirely.
+        // So a GET_VARIABLE(var) reference in a permanent function body is never resolved from the calling
+        // transaction and surfaces as UNDEFINED_PARAMETER. Here it fails when the schema template
+        // (which eagerly compiles the body) is created; the whole flow is wrapped so the assertion
+        // still holds if compilation is ever deferred to invocation time.
+        final String schemaTemplate =
+                "create table permfoo(pk bigint, name string, primary key(pk)) " +
+                "create function names_matching() as select pk, name from permfoo where name = GET_VARIABLE(body_var)";
+        RelationalAssertions.assertThrowsSqlException(() -> {
+            try (var ddl = Ddl.builder().database(URI.create("/TEST/LVPERM")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+                final var conn = ddl.setSchemaAndGetConnection();
+                conn.setAutoCommit(false);
+                try (var stmt = conn.createStatement()) {
+                    stmt.executeUpdate("insert into permfoo values (1, 'alice')");
+                    stmt.execute("set transaction variable body_var = 'alice'");
+                    try (var rs = stmt.executeQuery("select pk, name from names_matching()")) {
+                        rs.next();
+                    }
+                }
+            }
+        }).hasErrorCode(ErrorCode.UNDEFINED_PARAMETER);
+    }
+}

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/LocalVariableTemporaryFunctionTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/LocalVariableTemporaryFunctionTests.java
@@ -53,10 +53,8 @@ public class LocalVariableTemporaryFunctionTests {
 
     @Test
     void schemaTemplateFunctionWithVariableInBody() throws Exception {
-        // The TVF takes an explicit parameter and is called with GET_VARIABLE(var) as the argument.
-        // This tests the interaction between local variables and schema-template TVFs.
-        // Note: using GET_VARIABLE(var) directly inside a TVF body requires lazy compilation support
-        // (separate work item); passing GET_VARIABLE(var) at the call site works today.
+        // Passing GET_VARIABLE(var) at the call site works today; using it directly inside a TVF
+        // body requires lazy compilation support, which is a separate work item.
         final String schemaTemplate =
                 "create table schfoo(pk bigint, name string, primary key(pk)) " +
                 "create function find_names(in target string) as select pk, name from schfoo where name = target";
@@ -66,7 +64,6 @@ public class LocalVariableTemporaryFunctionTests {
             }
             final var conn = ddl.getConnection();
 
-            // Without setting GET_VARIABLE(varname): call fails with UNDEFINED_PARAMETER
             conn.setAutoCommit(false);
             try (var stmt = conn.createStatement()) {
                 RelationalAssertions.assertThrowsSqlException(
@@ -75,7 +72,6 @@ public class LocalVariableTemporaryFunctionTests {
             }
             conn.rollback();
 
-            // Set GET_VARIABLE(varname) = 'alice' → only alice is returned
             conn.unwrap(EmbeddedRelationalConnection.class).createNewTransaction();
             conn.setAutoCommit(false);
             try (var stmt = conn.createStatement()) {
@@ -86,7 +82,7 @@ public class LocalVariableTemporaryFunctionTests {
             }
             conn.commit();
 
-            // Set GET_VARIABLE(varname) = 'bob' → only bob is returned (different value, same function call site)
+            // Different value, same function call site
             conn.unwrap(EmbeddedRelationalConnection.class).createNewTransaction();
             conn.setAutoCommit(false);
             try (var stmt = conn.createStatement()) {
@@ -101,13 +97,9 @@ public class LocalVariableTemporaryFunctionTests {
 
     @Test
     void filteredIndexSelectedByVariableWithPlanCacheConstraints() throws Exception {
-        // Schema: table with a boolean column, a filtered index covering only active=true rows,
-        // and a schema-template TVF that accepts the filter as a parameter.
-        // The TVF is called with GET_VARIABLE(filter) as the argument so the Cascades planner generates a
-        // constraint-based plan bundle:
-        //   - when GET_VARIABLE(filter)=true  → filtered-index plan variant is used
-        //   - when GET_VARIABLE(filter)=false → full-scan plan variant is used
-        // Verified via plan-cache hit/miss log messages.
+        // A filtered index covers only active=true rows. The TVF is called with GET_VARIABLE(filter)
+        // as its argument, so the Cascades planner picks a different plan variant (filtered-index vs.
+        // full-scan) depending on the variable's value -- verified via plan-cache hit/miss log messages.
         final String schemaTemplate =
                 "create table schbar(pk bigint, active boolean, val bigint, primary key(pk)) " +
                 "create index idx_active as select pk, val from schbar where active = true order by pk " +
@@ -120,9 +112,7 @@ public class LocalVariableTemporaryFunctionTests {
 
             try (var logAppender = LogAppenderRule.of("LocalVariableTests_idx", PlanGenerator.class, Level.INFO)) {
 
-                // --- first call: GET_VARIABLE(filter) = true ---
-                // active_filter = true satisfies the filtered index predicate active = true
-                // → filtered-index plan is selected; first time seeing this query → cache miss.
+                // filter=true satisfies the filtered index's predicate -> filtered-index plan, first seen -> miss
                 conn.setAutoCommit(false);
                 try (var stmt = conn.createStatement()) {
                     stmt.execute("set transaction variable filter = true");
@@ -136,8 +126,6 @@ public class LocalVariableTemporaryFunctionTests {
                 conn.commit();
                 Assertions.assertTrue(logAppender.lastMessageIsCacheMiss(), "first call (filter=true) should be a cache miss");
 
-                // --- second call: GET_VARIABLE(filter) = true again ---
-                // Same constraint satisfied → same plan variant → cache hit.
                 conn.unwrap(EmbeddedRelationalConnection.class).createNewTransaction();
                 conn.setAutoCommit(false);
                 try (var stmt = conn.createStatement()) {
@@ -152,9 +140,7 @@ public class LocalVariableTemporaryFunctionTests {
                 conn.commit();
                 Assertions.assertTrue(logAppender.lastMessageIsCacheHit(), "second call (filter=true) should be a cache hit");
 
-                // --- third call: GET_VARIABLE(filter) = false ---
-                // active_filter = false does NOT satisfy the filtered index predicate active = true
-                // → full-scan plan variant required; constraint violated → cache miss (new plan stored).
+                // filter=false violates the filtered index's predicate -> full-scan plan, a different variant -> miss
                 conn.unwrap(EmbeddedRelationalConnection.class).createNewTransaction();
                 conn.setAutoCommit(false);
                 try (var stmt = conn.createStatement()) {
@@ -168,8 +154,6 @@ public class LocalVariableTemporaryFunctionTests {
                 conn.commit();
                 Assertions.assertTrue(logAppender.lastMessageIsCacheMiss(), "call with filter=false should be a cache miss (different plan variant)");
 
-                // --- fourth call: GET_VARIABLE(filter) = false again ---
-                // Same full-scan plan variant → cache hit.
                 conn.unwrap(EmbeddedRelationalConnection.class).createNewTransaction();
                 conn.setAutoCommit(false);
                 try (var stmt = conn.createStatement()) {
@@ -203,18 +187,16 @@ public class LocalVariableTemporaryFunctionTests {
                 stmt.execute("create temporary function find_by_body_var() on commit drop function " +
                         "as select pk, name from tvfbody where name = GET_VARIABLE(body_var)");
 
-                // calling before GET_VARIABLE(body_var) is set → UNDEFINED_PARAMETER at invocation time
                 RelationalAssertions.assertThrowsSqlException(
                         () -> stmt.executeQuery("select pk, name from find_by_body_var()"))
                         .hasErrorCode(ErrorCode.UNDEFINED_PARAMETER);
 
-                // set GET_VARIABLE(body_var) = 'alice' → first call returns alice
                 stmt.execute("set transaction variable body_var = 'alice'");
                 try (var rs = stmt.executeQuery("select pk, name from find_by_body_var()")) {
                     ResultSetAssert.assertThat(rs).hasNextRow().isRowExactly(1L, "alice").hasNoNextRow();
                 }
 
-                // overwrite GET_VARIABLE(body_var) to 'bob' → same function now returns bob (live reference)
+                // Overwriting the variable updates what the same compiled function resolves to
                 stmt.execute("set transaction variable body_var = 'bob'");
                 try (var rs = stmt.executeQuery("select pk, name from find_by_body_var()")) {
                     ResultSetAssert.assertThat(rs).hasNextRow().isRowExactly(2L, "bob").hasNoNextRow();
@@ -238,11 +220,9 @@ public class LocalVariableTemporaryFunctionTests {
             final var conn = ddl.getConnection();
             conn.setAutoCommit(false);
             try (var stmt = conn.createStatement()) {
-                // Create a temp function, then set a variable — function must still work
                 stmt.execute("create temporary function find_val(in threshold bigint) on commit drop function as select pk from coexist where val > threshold");
                 stmt.execute("set transaction variable limit_val = 15");
 
-                // Temp function still works after SET TRANSACTION VARIABLE
                 try (var rs = stmt.executeQuery("select pk from find_val(threshold => 15)")) {
                     ResultSetAssert.assertThat(rs)
                             .hasNextRow().isRowExactly(2L)
@@ -250,7 +230,6 @@ public class LocalVariableTemporaryFunctionTests {
                             .hasNoNextRow();
                 }
 
-                // Local variable still works after CREATE TEMPORARY FUNCTION
                 try (var rs = stmt.executeQuery("select pk from coexist where val > GET_VARIABLE(limit_val)")) {
                     ResultSetAssert.assertThat(rs)
                             .hasNextRow().isRowExactly(2L)
@@ -258,7 +237,6 @@ public class LocalVariableTemporaryFunctionTests {
                             .hasNoNextRow();
                 }
 
-                // Both together: variable as argument to the temp function
                 try (var rs = stmt.executeQuery("select pk from find_val(threshold => GET_VARIABLE(limit_val))")) {
                     ResultSetAssert.assertThat(rs)
                             .hasNextRow().isRowExactly(2L)
@@ -298,7 +276,6 @@ public class LocalVariableTemporaryFunctionTests {
 
     @Test
     void permanentFunctionBodyCannotReferenceLocalVariable() throws Exception {
-        // Sanity check for the review concern about GET_VARIABLE(var) inside static/permanent function bodies.
         // Unlike temporary functions (see variableInTempFunctionBodyResolvesAtCallTime), a permanent
         // (schema-template) function body is compiled against an EMPTY local-variable scope:
         //  - DdlVisitor.getInvokedRoutineMetadata compiles non-temporary bodies eagerly at CREATE

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/TemporaryFunctionTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/TemporaryFunctionTests.java
@@ -65,6 +65,7 @@ import org.mockito.Mockito;
 import javax.annotation.Nonnull;
 import java.net.URI;
 import java.sql.SQLException;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -271,7 +272,7 @@ public class TemporaryFunctionTests {
         Assertions.assertTrue(invokedRoutineMaybe.isPresent());
         Assertions.assertTrue(invokedRoutineMaybe.get().isTemporary());
         Assertions.assertInstanceOf(RecordLayerInvokedRoutine.class, invokedRoutineMaybe.get());
-        return ((RecordLayerInvokedRoutine) invokedRoutineMaybe.get()).getUserDefinedFunctionProvider().apply(true);
+        return ((RecordLayerInvokedRoutine) invokedRoutineMaybe.get()).getUserDefinedFunctionProvider().apply(true, Map.of());
     }
 
     @Test


### PR DESCRIPTION
Two changes that only make sense together: without both, a temp
function referencing GET_VARIABLE(x) would either never see the
calling transaction's variables, or would see them but reuse a stale
compiled function when they change.

- Thread local variables from BaseVisitor down through
  SqlFunctionCatalog/UserDefinedFunctionCatalog to where a
  user-defined function actually gets (lazily) compiled.
- RecordLayerInvokedRoutine's function-provider memoization key grows
  from just isCaseSensitive to (isCaseSensitive, snapshot of local
  variables), so a temp function body gets recompiled when the
  variables it references change, rather than reusing whatever it
  first compiled to. Uses a LinkedHashMap snapshot rather than an
  ImmutableMap because local-variable values are legitimately
  nullable.
- AstNormalizer defers a missing GET_VARIABLE reference inside a
  CREATE TEMPORARY FUNCTION body (the function may be called, with
  the variable set, long after it's created) but still hard-fails at
  actual invocation time if the variable is still unset.
- Permanent (schema-template) function bodies are unaffected: they
  compile eagerly at CREATE time against an empty variable scope, so
  a GET_VARIABLE reference in one always raises UNDEFINED_PARAMETER.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>