### PR TITLE
Add yamsql integration coverage for transaction-scoped local variables

### DIFF
--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryCommand.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryCommand.java
@@ -69,6 +69,10 @@ import java.util.stream.Collectors;
 public final class QueryCommand extends Command {
     private static final Logger logger = LogManager.getLogger(QueryCommand.class);
 
+    // Statements allowed for inline/referenced transaction setups: both are transaction-local (never committed,
+    // never visible outside the transaction), so they cannot introduce cross-test conflicts under parallel execution.
+    private static final List<String> ALLOWED_SETUP_STATEMENTS = List.of("CREATE TEMPORARY FUNCTION", "SET TRANSACTION VARIABLE");
+
     @Nonnull
     private final List<QueryConfig> queryConfigs;
     @Nonnull
@@ -266,13 +270,14 @@ public final class QueryCommand extends Command {
                 Assert.that(!queryIsRunning, "Transaction setup should not be intermingled with query results");
                 final String setupStatement = Matchers.notNull(Matchers.string(Matchers.notNull(queryConfig.getVal(),
                                 "Setup Config Val"), "Transaction setup"), "Transaction setup");
-                // we restrict transaction setups to CREATE TEMPORARY FUNCTION, because other mutations could be hard
-                // to reason about when running in a parallel world. It's possible the right answer is that we shouldn't
+                // we restrict transaction setups to statements that only affect transaction-local state (never
+                // committed, never visible outside the transaction), because other mutations could be hard to reason
+                // about when running in a parallel world. It's possible the right answer is that we shouldn't
                 // commit after the query, or that we shouldn't allow things that modify state in the database. This will
                 // become clearer as we have more related tests, and for now, just try to stop people from being confused.
-                final String allowedStatement = "CREATE TEMPORARY FUNCTION";
-                Assert.that(setupStatement.regionMatches(true, 0, allowedStatement, 0, allowedStatement.length()),
-                        "Only \"CREATE TEMPORARY FUNCTION\" is allowed for transaction setups");
+                Assert.that(ALLOWED_SETUP_STATEMENTS.stream().anyMatch(allowedStatement ->
+                                setupStatement.regionMatches(true, 0, allowedStatement, 0, allowedStatement.length())),
+                        "Only " + ALLOWED_SETUP_STATEMENTS + " are allowed for transaction setups");
                 executor.addSetup(setupStatement);
             } else if (!QueryConfig.QUERY_CONFIG_SUPPORTED_VERSION.equals(queryConfig.getConfigName()) &&
                     !QueryConfig.QUERY_CONFIG_DEBUGGER.equals(queryConfig.getConfigName())) {

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryConfig.java
@@ -71,7 +71,8 @@ import static com.apple.foundationdb.relational.yamltests.command.QueryCommand.r
  *   <tr><td>{@code planHash}</td><td>Validate the query plan hash (integer).</td></tr>
  *   <tr><td>{@code maxRows}</td><td>Limit rows fetched per result set (enables pagination testing with multiple
  *       {@code result} directives).</td></tr>
- *   <tr><td>{@code setup}</td><td>Inline transaction-scoped setup SQL (only {@code CREATE TEMPORARY FUNCTION}).</td></tr>
+ *   <tr><td>{@code setup}</td><td>Inline transaction-scoped setup SQL (only {@code CREATE TEMPORARY FUNCTION} or
+ *       {@code SET TRANSACTION VARIABLE}).</td></tr>
  *   <tr><td>{@code setupReference}</td><td>Reference a named setup from a {@code transaction_setups} block.</td></tr>
  *   <tr><td>{@code supported_version}</td><td>Minimum version for this query. Must be the first directive if
  *       present.</td></tr>

--- a/yaml-tests/src/test/java/YamlIntegrationTests.java
+++ b/yaml-tests/src/test/java/YamlIntegrationTests.java
@@ -268,6 +268,11 @@ public class YamlIntegrationTests {
     }
 
     @TestTemplate
+    public void localVariables(YamlTest.Runner runner) throws Exception {
+        runner.runYamsql("local-variables.yamsql");
+    }
+
+    @TestTemplate
     public void maxRows(YamlTest.Runner runner) throws Exception {
         runner.runYamsql("maxRows.yamsql");
     }

--- a/yaml-tests/src/test/resources/local-variables.yamsql
+++ b/yaml-tests/src/test/resources/local-variables.yamsql
@@ -1,0 +1,103 @@
+#
+# local-variables.yamsql
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2021-2026 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Integration coverage for transaction-scoped local variables: `SET TRANSACTION VARIABLE name =
+# constant` and `GET_VARIABLE(name)`. See docs/sphinx/source/reference/sql_commands/DDL/SET_TRANSACTION_VARIABLE.rst
+# and docs/sphinx/source/reference/Functions/scalar_functions/get_variable.rst.
+#
+# Every test below relies on the inline `setup:` directive to run `SET TRANSACTION VARIABLE`
+# statements in the same transaction as the query that follows (the same mechanism already used
+# for `CREATE TEMPORARY FUNCTION`), since a local variable is only visible within the transaction
+# that set it.
+---
+options:
+    supported_version: !current_version
+---
+schema_template:
+    create table employees(id bigint, name string, department string, salary bigint, primary key(id))
+    create function high_earners(in dept string) as
+        select id, name, salary from employees where department = dept and salary >= 100000
+---
+setup:
+  connect: 1
+  steps:
+    - query: INSERT INTO employees VALUES
+               (1, 'Alice', 'Engineering', 100000),
+               (2, 'Bob', 'Engineering', 110000),
+               (3, 'Carol', 'Engineering', 150000),
+               (4, 'Dave', 'Sales', 80000),
+               (5, 'Eve', 'Sales', 120000)
+---
+test_block:
+  name: local-variables
+  preset: single_repetition_ordered
+  tests:
+    -
+      # Basic round trip: a variable set in the transaction is visible to GET_VARIABLE(name) in a
+      # query executed in that same transaction.
+      - query: select id, name from employees where department = GET_VARIABLE(dept) order by id
+      - setup: set transaction variable dept = 'Engineering'
+      - result: [{ID: !l 1, NAME: 'Alice'}, {ID: !l 2, NAME: 'Bob'}, {ID: !l 3, NAME: 'Carol'}]
+
+    -
+      # Setting the same variable twice in one transaction: the last SET wins.
+      - query: select GET_VARIABLE(x) as val
+      - setup: set transaction variable x = 1
+      - setup: set transaction variable x = 42
+      - result: [{VAL: 42}]
+
+    -
+      # A variable explicitly set to NULL is defined (successfully readable, unlike a variable that
+      # was never set -- see the UNDEFINED_PARAMETER test below). GET_VARIABLE(name) cannot be
+      # selected bare when its value is NULL (a NULL-typed value has no declared result-set column
+      # type), so it is exercised here in a WHERE comparison instead: per three-valued logic,
+      # `department = NULL` matches no rows, without error.
+      - query: select id from employees where department = GET_VARIABLE(deptOrNull)
+      - setup: set transaction variable deptOrNull = null
+      - result: []
+
+    -
+      # Referencing a variable that was never set in the current transaction is a hard error,
+      # distinct from a variable explicitly set to NULL.
+      - query: select GET_VARIABLE(neverSet) from employees
+      - error: UNDEFINED_PARAMETER
+
+    -
+      # Re-setting a variable to a value of a different type (including NULL) is allowed; the
+      # new value's type governs how it behaves in the query that follows.
+      - query: select GET_VARIABLE(y) as val
+      - setup: set transaction variable y = 10
+      - setup: set transaction variable y = 'ten'
+      - result: [{VAL: 'ten'}]
+
+    -
+      # GET_VARIABLE(name) can be passed as an argument at a table-valued function call site.
+      - query: select id, name from high_earners(dept => GET_VARIABLE(minDept)) order by id
+      - setup: set transaction variable minDept = 'Engineering'
+      - result: [{ID: !l 1, NAME: 'Alice'}, {ID: !l 2, NAME: 'Bob'}, {ID: !l 3, NAME: 'Carol'}]
+
+    -
+      # SET TRANSACTION VARIABLE and CREATE TEMPORARY FUNCTION coexist in the same transaction:
+      # the temporary function call site uses a local variable as an argument.
+      - query: select id from find_high_salary(threshold => GET_VARIABLE(limitVal)) order by id
+      - setup: set transaction variable limitVal = 100000
+      - setup: create temporary function find_high_salary(in threshold bigint) on commit drop function as
+               select id from employees where salary > threshold
+      - result: [{ID: !l 2}, {ID: !l 3}, {ID: !l 5}]
+...

--- a/yaml-tests/src/test/resources/showcasing-tests.yamsql
+++ b/yaml-tests/src/test/resources/showcasing-tests.yamsql
@@ -455,7 +455,8 @@ setup:
 # TRANSACTION SETUPS AND SETUP REFERENCES
 # ============================================================================
 # Define named transaction-scoped setup commands that can be referenced from
-# individual tests. Currently only CREATE TEMPORARY FUNCTION is supported.
+# individual tests. Currently only CREATE TEMPORARY FUNCTION and SET TRANSACTION VARIABLE are
+# supported.
 #
 #   ---
 #   transaction_setups:


### PR DESCRIPTION
Add local-variables.yamsql exercising SET TRANSACTION VARIABLE / GET_VARIABLE
end-to-end through the real SQL planner/executor path: basic round trips,
overwriting and retyping a variable within one transaction, the NULL-vs-never-set
distinction, UNDEFINED_PARAMETER on an unset reference, use as a table-valued
function argument, and coexistence with CREATE TEMPORARY FUNCTION.

The inline `setup:`/`setupReference:` transaction-setup mechanism previously only
allowed CREATE TEMPORARY FUNCTION statements; extend the allow-list to also
accept SET TRANSACTION VARIABLE, since it has the same transaction-local,
never-committed safety property that motivated the original restriction. This is
required to exercise SET and GET_VARIABLE together within a single transaction
from a yamsql test.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>