### PR TITLE
Adopt jspecify + NullAway null-checking on fdb-java-annotations

### DIFF
--- a/fdb-java-annotations/fdb-java-annotations.gradle
+++ b/fdb-java-annotations/fdb-java-annotations.gradle
@@ -18,6 +18,10 @@
  * limitations under the License.
  */
 
+plugins {
+    alias(libs.plugins.errorprone)
+}
+
 apply from: rootProject.file('gradle/publishing.gradle')
 
 dependencies {
@@ -28,7 +32,23 @@ dependencies {
     // barring that, we can exclude it as a transitive dependency when importing
     implementation(libs.javaPoet)
     compileOnly(libs.autoService)
+    compileOnly(libs.jspecify)
     annotationProcessor(libs.autoService)
+
+    errorprone(libs.errorprone.core)
+    errorprone(libs.nullaway)
+}
+
+// jspecify + NullAway, scoped to this module only. See @NullMarked package-info.java in
+// com.apple.foundationdb.annotation.
+tasks.withType(JavaCompile).configureEach {
+    options.errorprone {
+        disableAllChecks = true
+        error("NullAway")
+        option("NullAway:AnnotatedPackages", "com.apple.foundationdb.annotation")
+        option("NullAway:JSpecifyMode", "true")
+        option("NullAway:AcknowledgeRestrictiveAnnotations", "true")
+    }
 }
 
 publishing {

--- a/fdb-java-annotations/src/main/java/com/apple/foundationdb/annotation/GenerateVisitorAnnotationHelper.java
+++ b/fdb-java-annotations/src/main/java/com/apple/foundationdb/annotation/GenerateVisitorAnnotationHelper.java
@@ -121,12 +121,12 @@ class GenerateVisitorAnnotationHelper {
         return true;
     }
 
-    private static void generateCode(@Nonnull final Types typeUtils,
-                                     @Nonnull final Filer filer,
-                                     @Nonnull GenerateVisitor generateVisitor,
-                                     @Nonnull final PackageElement packageElement,
-                                     @Nonnull final TypeElement rootTypeElement,
-                                     @Nonnull final List<TypeMirror> subClassTypeMirrors) throws IOException {
+    private static void generateCode(final Types typeUtils,
+                                     final Filer filer,
+                                     GenerateVisitor generateVisitor,
+                                     final PackageElement packageElement,
+                                     final TypeElement rootTypeElement,
+                                     final List<TypeMirror> subClassTypeMirrors) throws IOException {
         final var rootTypeMirror = rootTypeElement.asType();
         final var interfaceName = rootTypeElement.getSimpleName() + generateVisitor.classSuffix();
         final var typeVariableName = TypeVariableName.get("T");
@@ -138,15 +138,15 @@ class GenerateVisitorAnnotationHelper {
         generateImplementationWithDefaults(typeUtils, filer, generateVisitor, packageElement, subClassTypeMirrors, className, interfaceName, typeVariableName, defaultMethodName);
     }
 
-    private static void generateInterface(@Nonnull final Types typeUtils,
-                                          @Nonnull final Filer filer,
-                                          @Nonnull final GenerateVisitor generateVisitor,
-                                          @Nonnull final PackageElement packageElement,
-                                          @Nonnull final List<TypeMirror> subClassTypeMirrors,
-                                          @Nonnull final TypeMirror rootTypeMirror,
-                                          @Nonnull final String interfaceName,
-                                          @Nonnull final TypeVariableName typeVariableName,
-                                          @Nonnull final String defaultMethodName) throws IOException {
+    private static void generateInterface(final Types typeUtils,
+                                          final Filer filer,
+                                          final GenerateVisitor generateVisitor,
+                                          final PackageElement packageElement,
+                                          final List<TypeMirror> subClassTypeMirrors,
+                                          final TypeMirror rootTypeMirror,
+                                          final String interfaceName,
+                                          final TypeVariableName typeVariableName,
+                                          final String defaultMethodName) throws IOException {
         final TypeSpec.Builder typeBuilder =
                 TypeSpec.interfaceBuilder(interfaceName)
                         .addModifiers(Modifier.PUBLIC)
@@ -216,15 +216,15 @@ class GenerateVisitorAnnotationHelper {
                 .writeTo(Objects.requireNonNull(filer));
     }
 
-    private static void generateImplementationWithDefaults(@Nonnull final Types typeUtils,
-                                                           @Nonnull final Filer filer,
-                                                           @Nonnull final GenerateVisitor generateVisitor,
-                                                           @Nonnull final PackageElement packageElement,
-                                                           @Nonnull final List<TypeMirror> subClassTypeMirrors,
-                                                           @Nonnull final String className,
-                                                           @Nonnull final String interfaceName,
-                                                           @Nonnull final TypeVariableName typeVariableName,
-                                                           @Nonnull final String defaultMethodName) throws IOException {
+    private static void generateImplementationWithDefaults(final Types typeUtils,
+                                                           final Filer filer,
+                                                           final GenerateVisitor generateVisitor,
+                                                           final PackageElement packageElement,
+                                                           final List<TypeMirror> subClassTypeMirrors,
+                                                           final String className,
+                                                           final String interfaceName,
+                                                           final TypeVariableName typeVariableName,
+                                                           final String defaultMethodName) throws IOException {
         final TypeSpec.Builder typeBuilder =
                 TypeSpec.interfaceBuilder(className)
                         .addModifiers(Modifier.PUBLIC)
@@ -254,7 +254,7 @@ class GenerateVisitorAnnotationHelper {
                 .writeTo(Objects.requireNonNull(filer));
     }
 
-    private static String methodNameOfVisitMethod(@Nonnull final GenerateVisitor generateVisitor, @Nonnull TypeElement typeElement) {
+    private static String methodNameOfVisitMethod(final GenerateVisitor generateVisitor, TypeElement typeElement) {
         return generateVisitor.methodPrefix() + typeElement.getSimpleName().toString().replace(generateVisitor.stripPrefix(), "");
     }
 

--- a/fdb-java-annotations/src/main/java/com/apple/foundationdb/annotation/GenerateVisitorAnnotationProcessor.java
+++ b/fdb-java-annotations/src/main/java/com/apple/foundationdb/annotation/GenerateVisitorAnnotationProcessor.java
@@ -22,7 +22,6 @@ package com.apple.foundationdb.annotation;
 
 import com.google.auto.service.AutoService;
 
-import javax.annotation.Nonnull;
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.Processor;
@@ -78,11 +77,10 @@ import java.util.Set;
 @AutoService(Processor.class)
 public class GenerateVisitorAnnotationProcessor extends AbstractProcessor {
     @Override
-    public synchronized void init(@Nonnull final ProcessingEnvironment processingEnv) {
+    public synchronized void init(final ProcessingEnvironment processingEnv) {
         super.init(processingEnv);
     }
 
-    @Nonnull
     @Override
     public SourceVersion getSupportedSourceVersion() {
         return SourceVersion.latestSupported();

--- a/fdb-java-annotations/src/main/java/com/apple/foundationdb/annotation/package-info.java
+++ b/fdb-java-annotations/src/main/java/com/apple/foundationdb/annotation/package-info.java
@@ -33,4 +33,7 @@
  * None of the annotations have dependencies on
  * </p>
  */
+@NullMarked
 package com.apple.foundationdb.annotation;
+
+import org.jspecify.annotations.NullMarked;


### PR DESCRIPTION
3rd of a 14-PR stack adopting jspecify + NullAway null-checking, stacked on #4533 (`fdb-relational-jdbc`). Same treatment applied to `fdb-java-annotations`. See inline comments for specific findings.