### PR TITLE
Adopt jspecify + NullAway null-checking on fdb-record-layer-icu

### DIFF
--- a/fdb-record-layer-icu/fdb-record-layer-icu.gradle
+++ b/fdb-record-layer-icu/fdb-record-layer-icu.gradle
@@ -18,15 +18,22 @@
  * limitations under the License.
  */
 
+plugins {
+    alias(libs.plugins.errorprone)
+}
+
 def coreProject = ":${ext.coreProjectName}"
 dependencies {
     api project(coreProject)
     implementation(libs.icu)
     implementation(libs.protobuf)
     implementation(libs.slf4j.api)
-    compileOnly(libs.jsr305)
+    compileOnly(libs.jspecify)
     compileOnly(libs.autoService)
     annotationProcessor(libs.autoService)
+
+    errorprone(libs.errorprone.core)
+    errorprone(libs.nullaway)
 
     testImplementation project(':fdb-test-utils')
     testImplementation(testFixtures(project(coreProject)))
@@ -34,6 +41,19 @@ dependencies {
     testRuntimeOnly(libs.bundles.test.runtime)
     testCompileOnly(libs.bundles.test.compileOnly)
     testImplementation(libs.snakeyaml)
+}
+
+// jspecify + NullAway, scoped to this module only. See the @NullMarked package-info.java in
+// com.apple.foundationdb.record.icu. Part of a module-by-module null-checking rollout that started
+// with fdb-relational-grpc and fdb-relational-jdbc.
+tasks.withType(JavaCompile).configureEach {
+    options.errorprone {
+        disableAllChecks = true
+        error("NullAway")
+        option("NullAway:AnnotatedPackages", "com.apple.foundationdb.record.icu")
+        option("NullAway:JSpecifyMode", "true")
+        option("NullAway:AcknowledgeRestrictiveAnnotations", "true")
+    }
 }
 
 apply from: rootProject.file('gradle/publishing.gradle')

--- a/fdb-record-layer-icu/src/main/java/com/apple/foundationdb/record/icu/CollateFunctionKeyExpressionFactoryICU.java
+++ b/fdb-record-layer-icu/src/main/java/com/apple/foundationdb/record/icu/CollateFunctionKeyExpressionFactoryICU.java
@@ -26,7 +26,6 @@ import com.apple.foundationdb.record.metadata.expressions.FunctionKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
 import com.google.auto.service.AutoService;
 
-import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.List;
 
@@ -40,7 +39,6 @@ import java.util.List;
 public class CollateFunctionKeyExpressionFactoryICU implements FunctionKeyExpression.Factory {
     public static final String FUNCTION_NAME = "collate_icu";
 
-    @Nonnull
     @Override
     public List<FunctionKeyExpression.Builder> getBuilders() {
         return Collections.singletonList(
@@ -48,7 +46,7 @@ public class CollateFunctionKeyExpressionFactoryICU implements FunctionKeyExpres
     }
 
     protected static class CollateFunctionKeyExpressionICU extends CollateFunctionKeyExpression {
-        protected CollateFunctionKeyExpressionICU(@Nonnull String name, @Nonnull KeyExpression arguments) {
+        protected CollateFunctionKeyExpressionICU(String name, KeyExpression arguments) {
             super(TextCollatorRegistryICU.instance(), name, arguments);
         }
     }

--- a/fdb-record-layer-icu/src/main/java/com/apple/foundationdb/record/icu/TextCollatorRegistryICU.java
+++ b/fdb-record-layer-icu/src/main/java/com/apple/foundationdb/record/icu/TextCollatorRegistryICU.java
@@ -30,7 +30,6 @@ import com.google.protobuf.ZeroCopyByteString;
 import com.ibm.icu.text.Collator;
 import com.ibm.icu.util.ULocale;
 
-import javax.annotation.Nonnull;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -59,21 +58,18 @@ public class TextCollatorRegistryICU implements TextCollatorRegistry {
     private TextCollatorRegistryICU() {
     }
 
-    @Nonnull
     @Override
     public String getName() {
         return "icu";
     }
 
     @Override
-    @Nonnull
     public TextCollator getTextCollator(int strength) {
         return getTextCollator(DEFAULT_LOCALE, strength);
     }
 
     @Override
-    @Nonnull
-    public TextCollator getTextCollator(@Nonnull String locale, int strength) {
+    public TextCollator getTextCollator(String locale, int strength) {
         return MapUtils.computeIfAbsent(collators, NonnullPair.of(locale, strength), key -> {
             final Collator collator = DEFAULT_LOCALE.equals(locale) ?
                                       Collator.getInstance(ULocale.forLocale(Locale.ROOT)) :
@@ -84,21 +80,19 @@ public class TextCollatorRegistryICU implements TextCollatorRegistry {
     }
 
     protected static class TextCollatorICU implements TextCollator {
-        @Nonnull
         private final Collator collator;
-        
-        protected TextCollatorICU(@Nonnull Collator collator) {
+
+        protected TextCollatorICU(Collator collator) {
             this.collator = collator;
         }
 
         @Override
-        public int compare(@Nonnull String str1, @Nonnull String str2) {
+        public int compare(String str1, String str2) {
             return collator.compare(str1, str2);
         }
 
-        @Nonnull
         @Override
-        public ByteString getKey(@Nonnull String str) {
+        public ByteString getKey(String str) {
             return ZeroCopyByteString.wrap(collator.getCollationKey(str).toByteArray());
         }
     }

--- a/fdb-record-layer-icu/src/main/java/com/apple/foundationdb/record/icu/package-info.java
+++ b/fdb-record-layer-icu/src/main/java/com/apple/foundationdb/record/icu/package-info.java
@@ -21,4 +21,7 @@
 /**
  * Use ICU4J instead of JRE {@code Collator} classes.
  */
+@NullMarked
 package com.apple.foundationdb.record.icu;
+
+import org.jspecify.annotations.NullMarked;


### PR DESCRIPTION
5th of a 14-PR stack adopting jspecify + NullAway null-checking, stacked on #4577 (`fdb-test-utils`). Same treatment applied to `fdb-record-layer-icu`. See inline comments for specific findings.