### PR TITLE
Adopt jspecify + NullAway null-checking on fdb-extensions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -217,6 +217,14 @@ subprojects {
         targetCompatibility = JavaVersion.VERSION_17
     }
 
+    // jspecify annotations are being adopted module-by-module (see AGENTS.md). Declare the
+    // dependency for every module, not just migrated ones, so that SpotBugs (and javac) can
+    // always resolve org.jspecify.annotations.* references found on the compiled classpath of
+    // an already-migrated dependency, even before a given module has done its own migration.
+    dependencies {
+        compileOnly rootProject.libs.jspecify
+    }
+
     def publishBuild = Boolean.parseBoolean(findProperty('publishBuild') ?: 'false')
     def autoServiceVersion = publishBuild ? rootProject.libs.versions.autoService.asProvider().get() : rootProject.libs.versions.autoService.development.get()
 

--- a/fdb-extensions/fdb-extensions.gradle
+++ b/fdb-extensions/fdb-extensions.gradle
@@ -21,6 +21,10 @@
 import de.undercouch.gradle.tasks.download.Download
 import de.undercouch.gradle.tasks.download.Verify
 
+plugins {
+    alias(libs.plugins.errorprone)
+}
+
 apply plugin: 'java-test-fixtures'
 apply from: rootProject.file('gradle/publishing.gradle')
 
@@ -31,8 +35,10 @@ dependencies {
     api(libs.fdbJava)
     implementation(libs.guava)
     implementation(libs.slf4j.api)
-    compileOnly(libs.jsr305)
     compileOnly(libs.jspecify)
+
+    errorprone(libs.errorprone.core)
+    errorprone(libs.nullaway)
 
     testImplementation project(':fdb-test-utils')
     testImplementation(libs.bundles.test.impl)
@@ -48,6 +54,26 @@ dependencies {
     testFixturesCompileOnly(libs.jsr305)
     testFixturesImplementation(libs.slf4j.api)
     testFixturesAnnotationProcessor(libs.autoService)
+}
+
+// jspecify + NullAway null-checking, scoped to this module only. See @NullMarked
+// package-info.java files across fdb-extensions' packages (com.apple.foundationdb.async,
+// .linear, .tuple, .util, .map, .kmeans, .rabitq, .clientlog, .system, .synchronizedsession,
+// and their sub-packages). The shared "com.apple.foundationdb" prefix covers all of them in one
+// go; NullAway only analyzes this module's own compiled sources regardless of prefix breadth,
+// and any package lacking @NullMarked (e.g. the vendored com.apple.foundationdb.half datatype,
+// copied from an external library) is treated leniently rather than strictly checked, so the
+// broad prefix cannot cause false positives there. There is no generated/vendored code under
+// src/main that needs an UnannotatedSubPackages carve-out.
+tasks.withType(JavaCompile).configureEach {
+    options.compilerArgs += ['-Xmaxerrs', '5000']
+    options.errorprone {
+        disableAllChecks = true
+        error("NullAway")
+        option("NullAway:AnnotatedPackages", "com.apple.foundationdb")
+        option("NullAway:JSpecifyMode", "true")
+        option("NullAway:AcknowledgeRestrictiveAnnotations", "true")
+    }
 }
 
 // Describe all SIFT datasets here. Each is downloaded once into project.ext.downloadsDirectory

--- a/fdb-extensions/fdb-extensions.gradle
+++ b/fdb-extensions/fdb-extensions.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation(libs.guava)
     implementation(libs.slf4j.api)
     compileOnly(libs.jsr305)
+    compileOnly(libs.jspecify)
 
     testImplementation project(':fdb-test-utils')
     testImplementation(libs.bundles.test.impl)

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/FDBError.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/FDBError.java
@@ -23,7 +23,6 @@ package com.apple.foundationdb;
 import com.apple.foundationdb.annotation.API;
 import com.google.common.collect.ImmutableMap;
 
-import javax.annotation.Nonnull;
 import java.util.Map;
 
 /**
@@ -124,7 +123,6 @@ public enum FDBError {
         return code;
     }
 
-    @Nonnull
     public static FDBError fromCode(int code) {
         final FDBError error = ERROR_BY_CODE.get(code);
         if (error == null) {
@@ -133,7 +131,6 @@ public enum FDBError {
         return error;
     }
 
-    @Nonnull
     public static String toString(int errorCode) {
         final FDBError error = ERROR_BY_CODE.get(errorCode);
         if (error == null) {

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/AsyncPeekCallbackIterator.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/AsyncPeekCallbackIterator.java
@@ -20,7 +20,6 @@
 
 package com.apple.foundationdb.async;
 
-import javax.annotation.Nonnull;
 import java.util.function.Consumer;
 
 /**
@@ -46,7 +45,7 @@ public interface AsyncPeekCallbackIterator<T> extends AsyncPeekIterator<T> {
      * @param callback a callback to call when {@link #next()} produces a result
      * @return an iterator over the same values as <code>iterator</code> that supports peek and callback semantics
      */
-    static <T> AsyncPeekCallbackIterator<T> wrap(@Nonnull AsyncIterator<T> iterator, @Nonnull Consumer<T> callback) {
+    static <T> AsyncPeekCallbackIterator<T> wrap(AsyncIterator<T> iterator, Consumer<T> callback) {
         if (iterator instanceof AsyncPeekCallbackIterator) {
             final Consumer<T> originalCallback = ((AsyncPeekCallbackIterator<T>)iterator).getCallback();
             ((AsyncPeekCallbackIterator<T>)iterator).setCallback(t -> {
@@ -62,12 +61,11 @@ public interface AsyncPeekCallbackIterator<T> extends AsyncPeekIterator<T> {
      * Set the callback to the provided {@link Consumer}.
      * @param callback a consumer to call when a new result is produced by {@link #next()}
      */
-    void setCallback(@Nonnull Consumer<T> callback);
+    void setCallback(Consumer<T> callback);
 
     /**
      * Return the callback that this iterator calls before a new result is returned by {@link #next()}.
      * @return the callback that this iterator calls before a new result is returned by {@link #next()};W
      */
-    @Nonnull
     Consumer<T> getCallback();
 }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/AsyncPeekIterator.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/AsyncPeekIterator.java
@@ -22,7 +22,6 @@ package com.apple.foundationdb.async;
 
 import com.apple.foundationdb.annotation.API;
 
-import javax.annotation.Nonnull;
 import java.util.NoSuchElementException;
 
 /**
@@ -69,7 +68,7 @@ public interface AsyncPeekIterator<T> extends AsyncIterator<T> {
      * @return an scan over the same values as <code>scan</code> that
      *         supports peek semantics
      */
-    static <T> AsyncPeekIterator<T> wrap(@Nonnull AsyncIterator<T> iterator) {
+    static <T> AsyncPeekIterator<T> wrap(AsyncIterator<T> iterator) {
         if (iterator instanceof AsyncPeekIterator) {
             // Don't actually wrap the iterator if it is already
             // a peek iterator.

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/MoreAsyncUtil.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/MoreAsyncUtil.java
@@ -131,7 +131,11 @@ public class MoreAsyncUtil {
      */
     public static <T> CompletableFuture<Void> consumeRemaining(final AsyncIterator<T> iterator,
                                                                final Executor executor) {
-        return tag(AsyncUtil.forEachRemaining(iterator, t -> { }, executor), null);
+        // tag() is from the unannotated fdb-java client library, so its generic value parameter is treated as
+        // @NonNull by NullAway's defaults; Void's only inhabitant is null, so this is the correct call.
+        @SuppressWarnings("NullAway")
+        final CompletableFuture<Void> result = tag(AsyncUtil.forEachRemaining(iterator, t -> { }, executor), null);
+        return result;
     }
 
     public static <T> AsyncIterable<T> limitIterable(final AsyncIterable<T> iterable,
@@ -223,6 +227,7 @@ public class MoreAsyncUtil {
             boolean done = false;
             @Nullable
             CompletableFuture<Boolean> nextFuture = null;
+            @Nullable
             T next = null;
 
             @Override
@@ -265,7 +270,8 @@ public class MoreAsyncUtil {
                 if (!hasNext()) {
                     throw new NoSuchElementException();
                 }
-                final T result = next;
+                // hasNext() (via advanceIfMatches) is guaranteed to have set next when it returns true.
+                final T result = Objects.requireNonNull(next);
                 nextFuture = null;
                 next = null;
                 return result;
@@ -305,6 +311,7 @@ public class MoreAsyncUtil {
                                                                 final AsyncIterator<T> iterator,
                                                                 final Function<T, Boolean> filter) {
         return new CloseableAsyncIterator<T>() {
+            @Nullable
             T next;
             boolean haveNext;
             @Nullable
@@ -350,7 +357,8 @@ public class MoreAsyncUtil {
                     throw new NoSuchElementException();
                 }
                 haveNext = false;
-                return next;
+                // hasNext() is guaranteed to have set next when it returns true.
+                return Objects.requireNonNull(next);
             }
 
             @Override
@@ -384,6 +392,7 @@ public class MoreAsyncUtil {
                                                      final AsyncIterable<T> iterable) {
         return filterIterable(executor, iterable,
                 new Function<>() {
+                    @Nullable
                     private Object lastObj;
 
                     @Override
@@ -419,6 +428,7 @@ public class MoreAsyncUtil {
                     int index = 0;
                     @Nullable
                     AsyncIterator<T> current;
+                    @Nullable
                     AsyncIterator<T> removeFrom;
                     @Nullable
                     CompletableFuture<Boolean> nextFuture;
@@ -472,8 +482,10 @@ public class MoreAsyncUtil {
                         if (!hasNext()) {
                             throw new NoSuchElementException();
                         }
-                        removeFrom = current;
-                        return current.next();
+                        // hasNext() is guaranteed to have set current when it returns true.
+                        final AsyncIterator<T> currentIterator = Objects.requireNonNull(current);
+                        removeFrom = currentIterator;
+                        return currentIterator.next();
                     }
 
                     @Override
@@ -688,7 +700,6 @@ public class MoreAsyncUtil {
     public static <T> AsyncIterable<T> filterToIterable(final T item,
                                                         final Function<T, CompletableFuture<Boolean>> filter) {
         return new AsyncIterable<T>() {
-            @Nullable
             @Override
             public CloseableAsyncIterator<T> iterator() {
                 return new CloseableAsyncIterator<T>() {
@@ -696,7 +707,6 @@ public class MoreAsyncUtil {
                     @Nullable
                     CompletableFuture<Boolean> nextFuture;
 
-                    @Nullable
                     @Override
                     public CompletableFuture<Boolean> onHasNext() {
                         if (used) {
@@ -772,16 +782,15 @@ public class MoreAsyncUtil {
     public static <T1, T2> AsyncIterable<T2> mapToIterable(final T1 item,
                                                            final Function<T1, CompletableFuture<T2>> func) {
         return new AsyncIterable<T2>() {
-            @Nullable
             @Override
             public CloseableAsyncIterator<T2> iterator() {
                 return new CloseableAsyncIterator<T2>() {
+                    @Nullable
                     T2 result;
                     boolean used = false;
                     @Nullable
                     CompletableFuture<Boolean> nextFuture;
 
-                    @Nullable
                     @Override
                     public CompletableFuture<Boolean> onHasNext() {
                         if (used) {
@@ -813,7 +822,8 @@ public class MoreAsyncUtil {
                             result = func.apply(item).join();
                         }
                         used = true;
-                        return result;
+                        // If nextFuture completed normally, or the direct func.apply(item) branch ran, result is set.
+                        return Objects.requireNonNull(result);
                     }
 
                     @Override
@@ -1021,7 +1031,7 @@ public class MoreAsyncUtil {
      * @param iterator iterator to close
      */
     @API(API.Status.UNSTABLE)
-    public static void closeIterator(Iterator<?> iterator) {
+    public static void closeIterator(@Nullable Iterator<?> iterator) {
         if (iterator instanceof CloseableAsyncIterator) {
             ((CloseableAsyncIterator<?>)iterator).close();
         } else if (iterator instanceof AsyncIterator) {

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/MoreAsyncUtil.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/MoreAsyncUtil.java
@@ -908,13 +908,15 @@ public class MoreAsyncUtil {
      * @param <T> the element type of the iterator
      * @return the reduced result
      */
-    @Nullable
     public static <U, T> CompletableFuture<U> reduce(AsyncIterator<T> iterator, U identity,
                                                      BiFunction<U, ? super T, U> accumulator) {
         return reduce(ForkJoinPool.commonPool(), iterator, identity, accumulator);
     }
 
-    @Nullable
+    // The returned CompletableFuture reference is never itself null (it is always a fresh future constructed
+    // below); a pre-existing @Nullable annotation here predating this migration incorrectly described the
+    // future's resolved value (which may be null if U is nullable-instantiated) rather than the future
+    // reference. Corrected rather than propagated by the mechanical jspecify swap.
     public static <U, T> CompletableFuture<U> reduce(Executor executor,
                                                      AsyncIterator<T> iterator, U identity,
                                                      BiFunction<U, ? super T, U> accumulator) {

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/MoreAsyncUtil.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/MoreAsyncUtil.java
@@ -26,8 +26,7 @@ import com.google.common.base.Suppliers;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -85,11 +84,9 @@ public class MoreAsyncUtil {
         return alreadyCancelled;
     }
 
-    @Nonnull
-    public static <T> AsyncIterable<T> iterableOf(@Nonnull final Supplier<AsyncIterator<T>> iteratorSupplier,
-                                                  @Nonnull final Executor executor) {
+    public static <T> AsyncIterable<T> iterableOf(final Supplier<AsyncIterator<T>> iteratorSupplier,
+                                                  final Executor executor) {
         return new AsyncIterable<>() {
-            @Nonnull
             @Override
             public AsyncIterator<T> iterator() {
                 return iteratorSupplier.get();
@@ -115,9 +112,8 @@ public class MoreAsyncUtil {
      * @return a future that completes with {@code null} once the iterable is exhausted, or exceptionally if advancing
      *         it fails
      */
-    @Nonnull
-    public static <T> CompletableFuture<Void> consume(@Nonnull final AsyncIterable<T> iterable,
-                                                      @Nonnull final Executor executor) {
+    public static <T> CompletableFuture<Void> consume(final AsyncIterable<T> iterable,
+                                                      final Executor executor) {
         return consumeRemaining(iterable.iterator(), executor);
     }
 
@@ -133,20 +129,17 @@ public class MoreAsyncUtil {
      * @return a future that completes with {@code null} once the iterator is exhausted, or exceptionally if advancing
      *         it fails
      */
-    @Nonnull
-    public static <T> CompletableFuture<Void> consumeRemaining(@Nonnull final AsyncIterator<T> iterator,
-                                                               @Nonnull final Executor executor) {
+    public static <T> CompletableFuture<Void> consumeRemaining(final AsyncIterator<T> iterator,
+                                                               final Executor executor) {
         return tag(AsyncUtil.forEachRemaining(iterator, t -> { }, executor), null);
     }
 
-    @Nonnull
-    public static <T> AsyncIterable<T> limitIterable(@Nonnull final AsyncIterable<T> iterable,
-                                                     final int limit, @Nonnull final Executor executor) {
+    public static <T> AsyncIterable<T> limitIterable(final AsyncIterable<T> iterable,
+                                                     final int limit, final Executor executor) {
         return iterableOf(() -> limitRemaining(iterable.iterator(), limit), executor);
     }
 
-    @Nonnull
-    public static <T> CloseableAsyncIterator<T> limitRemaining(@Nonnull final AsyncIterator<T> iterator,
+    public static <T> CloseableAsyncIterator<T> limitRemaining(final AsyncIterator<T> iterator,
                                                                final int limit) {
         return new CloseableAsyncIterator<T>() {
             int count = 0;
@@ -198,10 +191,9 @@ public class MoreAsyncUtil {
      *
      * @return an {@link AsyncIterable} over the leading run of matching elements
      */
-    @Nonnull
-    public static <T> AsyncIterable<T> takeWhileIterable(@Nonnull final AsyncIterable<T> iterable,
-                                                         @Nonnull final Predicate<T> whilePredicate,
-                                                         @Nonnull final Executor executor) {
+    public static <T> AsyncIterable<T> takeWhileIterable(final AsyncIterable<T> iterable,
+                                                         final Predicate<T> whilePredicate,
+                                                         final Executor executor) {
         return iterableOf(() -> takeWhileRemaining(iterable.iterator(), whilePredicate), executor);
     }
 
@@ -225,9 +217,8 @@ public class MoreAsyncUtil {
      *
      * @return a {@link CloseableAsyncIterator} over the leading run of matching elements
      */
-    @Nonnull
-    public static <T> CloseableAsyncIterator<T> takeWhileRemaining(@Nonnull final AsyncIterator<T> iterator,
-                                                                   @Nonnull final Predicate<T> whilePredicate) {
+    public static <T> CloseableAsyncIterator<T> takeWhileRemaining(final AsyncIterator<T> iterator,
+                                                                   final Predicate<T> whilePredicate) {
         return new CloseableAsyncIterator<>() {
             boolean done = false;
             @Nullable
@@ -299,30 +290,26 @@ public class MoreAsyncUtil {
      * @param <T> the source type
      * @return a new {@code AsyncIterable} that only contains those items in iterable for which filter returns {@code true}
      */
-    @Nonnull
-    public static <T> AsyncIterable<T> filterIterable(@Nonnull final AsyncIterable<T> iterable,
-                                                      @Nonnull final Function<T, Boolean> filter) {
+    public static <T> AsyncIterable<T> filterIterable(final AsyncIterable<T> iterable,
+                                                      final Function<T, Boolean> filter) {
         return filterIterable(ForkJoinPool.commonPool(), iterable, filter);
     }
 
-    @Nonnull
-    public static <T> AsyncIterable<T> filterIterable(@Nonnull final Executor executor,
-                                                      @Nonnull final AsyncIterable<T> iterable,
-                                                      @Nonnull final Function<T, Boolean> filter) {
+    public static <T> AsyncIterable<T> filterIterable(final Executor executor,
+                                                      final AsyncIterable<T> iterable,
+                                                      final Function<T, Boolean> filter) {
         return iterableOf(() -> filterRemaining(executor, iterable.iterator(), filter), executor);
     }
 
-    @Nonnull
-    public static <T> CloseableAsyncIterator<T> filterRemaining(@Nonnull Executor executor,
-                                                                @Nonnull final AsyncIterator<T> iterator,
-                                                                @Nonnull final Function<T, Boolean> filter) {
+    public static <T> CloseableAsyncIterator<T> filterRemaining(Executor executor,
+                                                                final AsyncIterator<T> iterator,
+                                                                final Function<T, Boolean> filter) {
         return new CloseableAsyncIterator<T>() {
             T next;
             boolean haveNext;
             @Nullable
             CompletableFuture<Boolean> nextFuture;
 
-            @Nonnull
             @Override
             public CompletableFuture<Boolean> onHasNext() {
                 if (nextFuture != null) {
@@ -389,19 +376,16 @@ public class MoreAsyncUtil {
      * @param <T> the source type
      * @return a new {@code AsyncIterable} that only contains those items in iterable for which the previous item was different
      */
-    @Nonnull
-    public static <T> AsyncIterable<T> dedupIterable(@Nonnull final AsyncIterable<T> iterable) {
+    public static <T> AsyncIterable<T> dedupIterable(final AsyncIterable<T> iterable) {
         return dedupIterable(ForkJoinPool.commonPool(), iterable);
     }
 
-    @Nonnull
-    public static <T> AsyncIterable<T> dedupIterable(@Nonnull Executor executor,
-                                                     @Nonnull final AsyncIterable<T> iterable) {
+    public static <T> AsyncIterable<T> dedupIterable(Executor executor,
+                                                     final AsyncIterable<T> iterable) {
         return filterIterable(executor, iterable,
                 new Function<>() {
                     private Object lastObj;
 
-                    @Nonnull
                     @Override
                     public Boolean apply(T obj) {
                         if ((lastObj != null) && lastObj.equals(obj)) {
@@ -421,17 +405,14 @@ public class MoreAsyncUtil {
      * @return a new {@code AsyncIterable} that starts with all the elements of the first iterable provided,
      * then all the elements of the second iterable and so on
      */
-    @Nonnull
     @SuppressWarnings("unchecked") // parameterized vararg
-    public static <T> AsyncIterable<T> concatIterables(@Nonnull final AsyncIterable<T>... iterables) {
+    public static <T> AsyncIterable<T> concatIterables(final AsyncIterable<T>... iterables) {
         return concatIterables(ForkJoinPool.commonPool(), iterables);
     }
 
-    @Nonnull
     @SuppressWarnings("unchecked") // parameterized vararg
-    public static <T> AsyncIterable<T> concatIterables(@Nonnull Executor executor, @Nonnull final AsyncIterable<T>... iterables) {
+    public static <T> AsyncIterable<T> concatIterables(Executor executor, final AsyncIterable<T>... iterables) {
         return new AsyncIterable<T>() {
-            @Nonnull
             @Override
             public CloseableAsyncIterator<T> iterator() {
                 return new CloseableAsyncIterator<T>() {
@@ -442,7 +423,6 @@ public class MoreAsyncUtil {
                     @Nullable
                     CompletableFuture<Boolean> nextFuture;
 
-                    @Nonnull
                     @Override
                     public CompletableFuture<Boolean> onHasNext() {
                         if (nextFuture != null) {
@@ -557,13 +537,11 @@ public class MoreAsyncUtil {
      * @param <T2> the type of the destination iterables
      * @return the results of all the {@code AsyncIterable}s returned by func for each value of iterable, concatenated
      */
-    @Nonnull
-    public static <T1, T2> AsyncIterable<T2> mapConcatIterable(@Nonnull Executor executor,
-                                                               @Nonnull final AsyncIterable<T1> iterable,
-                                                               @Nonnull final Function<T1, AsyncIterable<T2>> func,
+    public static <T1, T2> AsyncIterable<T2> mapConcatIterable(Executor executor,
+                                                               final AsyncIterable<T1> iterable,
+                                                               final Function<T1, AsyncIterable<T2>> func,
                                                                final int pipelineSize) {
         return new AsyncIterable<>() {
-            @Nonnull
             @Override
             public CloseableAsyncIterator<T2> iterator() {
                 CloseableAsyncIterator<T2> it = new CloseableAsyncIterator<T2>() {
@@ -574,7 +552,6 @@ public class MoreAsyncUtil {
                     @Nullable
                     CompletableFuture<Boolean> nextFuture;
 
-                    @Nonnull
                     @Override
                     public CompletableFuture<Boolean> onHasNext() {
                         if (nextFuture != null) {
@@ -708,9 +685,8 @@ public class MoreAsyncUtil {
      * @return an {@code AsyncIterable} that will either contain item or nothing, depending on the result
      * of filter
      */
-    @Nonnull
     public static <T> AsyncIterable<T> filterToIterable(final T item,
-                                                        @Nonnull final Function<T, CompletableFuture<Boolean>> filter) {
+                                                        final Function<T, CompletableFuture<Boolean>> filter) {
         return new AsyncIterable<T>() {
             @Nullable
             @Override
@@ -776,10 +752,9 @@ public class MoreAsyncUtil {
         };
     }
 
-    @Nonnull
-    public static <T> AsyncIterable<T> filterIterablePipelined(@Nonnull Executor executor,
-                                                               @Nonnull AsyncIterable<T> iterable,
-                                                               @Nonnull final Function<T, CompletableFuture<Boolean>> filter,
+    public static <T> AsyncIterable<T> filterIterablePipelined(Executor executor,
+                                                               AsyncIterable<T> iterable,
+                                                               final Function<T, CompletableFuture<Boolean>> filter,
                                                                int pipelineSize) {
         return mapConcatIterable(executor, iterable,
                 item -> filterToIterable(item, filter),
@@ -794,9 +769,8 @@ public class MoreAsyncUtil {
      * @param <T2> the destination type
      * @return a new {@code AsyncIterable} containing the result of func(item)
      */
-    @Nonnull
     public static <T1, T2> AsyncIterable<T2> mapToIterable(final T1 item,
-                                                           @Nonnull final Function<T1, CompletableFuture<T2>> func) {
+                                                           final Function<T1, CompletableFuture<T2>> func) {
         return new AsyncIterable<T2>() {
             @Nullable
             @Override
@@ -876,9 +850,8 @@ public class MoreAsyncUtil {
      * @param <T2> the destination type
      * @return a new {@code AsyncIterable} with the results of applying func to each of the elements of iterable
      */
-    @Nonnull
-    public static <T1, T2> AsyncIterable<T2> mapIterablePipelined(@Nonnull AsyncIterable<T1> iterable,
-                                                                  @Nonnull final Function<T1, CompletableFuture<T2>> func,
+    public static <T1, T2> AsyncIterable<T2> mapIterablePipelined(AsyncIterable<T1> iterable,
+                                                                  final Function<T1, CompletableFuture<T2>> func,
                                                                   int pipelineSize) {
         return mapIterablePipelined(ForkJoinPool.commonPool(), iterable, func, pipelineSize);
     }
@@ -895,10 +868,9 @@ public class MoreAsyncUtil {
      * @param <T2> the destination type
      * @return a new {@code AsyncIterable} with the results of applying func to each of the elements of iterable
      */
-    @Nonnull
-    public static <T1, T2> AsyncIterable<T2> mapIterablePipelined(@Nonnull final Executor executor,
-                                                                  @Nonnull final AsyncIterable<T1> iterable,
-                                                                  @Nonnull final Function<T1, CompletableFuture<T2>> func,
+    public static <T1, T2> AsyncIterable<T2> mapIterablePipelined(final Executor executor,
+                                                                  final AsyncIterable<T1> iterable,
+                                                                  final Function<T1, CompletableFuture<T2>> func,
                                                                   int pipelineSize) {
         return mapConcatIterable(executor, iterable,
                 item -> mapToIterable(item, func),
@@ -927,14 +899,14 @@ public class MoreAsyncUtil {
      * @return the reduced result
      */
     @Nullable
-    public static <U, T> CompletableFuture<U> reduce(@Nonnull AsyncIterator<T> iterator, U identity,
+    public static <U, T> CompletableFuture<U> reduce(AsyncIterator<T> iterator, U identity,
                                                      BiFunction<U, ? super T, U> accumulator) {
         return reduce(ForkJoinPool.commonPool(), iterator, identity, accumulator);
     }
 
     @Nullable
-    public static <U, T> CompletableFuture<U> reduce(@Nonnull Executor executor,
-                                                     @Nonnull AsyncIterator<T> iterator, U identity,
+    public static <U, T> CompletableFuture<U> reduce(Executor executor,
+                                                     AsyncIterator<T> iterator, U identity,
                                                      BiFunction<U, ? super T, U> accumulator) {
         Holder<U> holder = new Holder<>(identity);
         return whileTrue(() -> iterator.onHasNext().thenApply(hasNext -> {
@@ -953,7 +925,7 @@ public class MoreAsyncUtil {
      * @return whether the future has completed without exception
      */
     @API(API.Status.UNSTABLE)
-    public static boolean isCompletedNormally(@Nonnull CompletableFuture<?> future) {
+    public static boolean isCompletedNormally(CompletableFuture<?> future) {
         return future.isDone() && !future.isCompletedExceptionally();
     }
 
@@ -972,7 +944,6 @@ public class MoreAsyncUtil {
      * @return an executor service that allows for tasks to be efficiently scheduled for later
      * @see #delayedFuture(long, TimeUnit, ScheduledExecutorService)
      */
-    @Nonnull
     public static ScheduledExecutorService getDefaultScheduledExecutor() {
         return scheduledExecutorSupplier.get();
     }
@@ -988,8 +959,7 @@ public class MoreAsyncUtil {
      * @see #delayedFuture(long, TimeUnit, ScheduledExecutorService)
      */
     @API(API.Status.UNSTABLE)
-    @Nonnull
-    public static CompletableFuture<Void> delayedFuture(long delay, @Nonnull TimeUnit unit) {
+    public static CompletableFuture<Void> delayedFuture(long delay, TimeUnit unit) {
         return delayedFuture(delay, unit, getDefaultScheduledExecutor());
     }
 
@@ -1007,8 +977,7 @@ public class MoreAsyncUtil {
      * @return a {@link CompletableFuture} that will fire after the given delay
      */
     @API(API.Status.UNSTABLE)
-    @Nonnull
-    public static CompletableFuture<Void> delayedFuture(long delay, @Nonnull TimeUnit unit, @Nonnull ScheduledExecutorService scheduledExecutor) {
+    public static CompletableFuture<Void> delayedFuture(long delay, TimeUnit unit, ScheduledExecutorService scheduledExecutor) {
         if (delay <= 0) {
             return AsyncUtil.DONE;
         }
@@ -1031,8 +1000,8 @@ public class MoreAsyncUtil {
      */
     @API(API.Status.EXPERIMENTAL)
     public static <T> CompletableFuture<T> getWithDeadline(long deadlineTimeMillis,
-                                                           @Nonnull Supplier<CompletableFuture<T>> supplier,
-                                                           @Nonnull ScheduledExecutorService scheduledExecutor) {
+                                                           Supplier<CompletableFuture<T>> supplier,
+                                                           ScheduledExecutorService scheduledExecutor) {
         final CompletableFuture<T> valueFuture = supplier.get();
         if (deadlineTimeMillis == Long.MAX_VALUE) {
             return valueFuture;
@@ -1052,7 +1021,7 @@ public class MoreAsyncUtil {
      * @param iterator iterator to close
      */
     @API(API.Status.UNSTABLE)
-    public static void closeIterator(@Nonnull Iterator<?> iterator) {
+    public static void closeIterator(Iterator<?> iterator) {
         if (iterator instanceof CloseableAsyncIterator) {
             ((CloseableAsyncIterator<?>)iterator).close();
         } else if (iterator instanceof AsyncIterator) {
@@ -1079,8 +1048,8 @@ public class MoreAsyncUtil {
      * @see #composeWhenCompleteAndHandle(CompletableFuture, BiFunction, Function)
      */
     public static <V> CompletableFuture<V> composeWhenComplete(
-            @Nonnull CompletableFuture<V> future,
-            @Nonnull BiFunction<V, Throwable, CompletableFuture<Void>> handler,
+            CompletableFuture<V> future,
+            BiFunction<V, Throwable, CompletableFuture<Void>> handler,
             @Nullable Function<Throwable, RuntimeException> exceptionMapper) {
         return composeWhenCompleteAndHandle(
                 future,
@@ -1102,8 +1071,8 @@ public class MoreAsyncUtil {
      * @see AsyncUtil#composeHandle(CompletableFuture, BiFunction)
      */
     public static <V, T> CompletableFuture<T> composeWhenCompleteAndHandle(
-            @Nonnull CompletableFuture<V> future,
-            @Nonnull BiFunction<V, Throwable, ? extends CompletableFuture<T>> handler,
+            CompletableFuture<V> future,
+            BiFunction<V, Throwable, ? extends CompletableFuture<T>> handler,
             @Nullable Function<Throwable, RuntimeException> exceptionMapper) {
         return AsyncUtil.composeHandle(future, (futureResult, futureException) -> {
             try {
@@ -1150,7 +1119,7 @@ public class MoreAsyncUtil {
         }
     }
 
-    private static RuntimeException getRuntimeException(@Nonnull Throwable exception,
+    private static RuntimeException getRuntimeException(Throwable exception,
                                                         @Nullable Function<Throwable, RuntimeException> exceptionMapper) {
         return exceptionMapper == null ? new RuntimeException(exception) : exceptionMapper.apply(exception);
     }
@@ -1193,8 +1162,8 @@ public class MoreAsyncUtil {
      * @return a future that will complete successfully if  {@code future} completed successfully, <em>or</em> the
      * {@code shouldSwallow} predicate returned {@code true} for the error that {@code future} threw
      */
-    public static CompletableFuture<Void> swallowException(@Nonnull CompletableFuture<Void> future,
-                                                           @Nonnull Predicate<Throwable> shouldSwallow) {
+    public static CompletableFuture<Void> swallowException(CompletableFuture<Void> future,
+                                                           Predicate<Throwable> shouldSwallow) {
         CompletableFuture<Void> result = new CompletableFuture<>();
         future.whenComplete((vignore, err) -> {
             if (err == null || shouldSwallow.test(err) ||
@@ -1224,12 +1193,11 @@ public class MoreAsyncUtil {
      * @param <U> the type of the result of the body {@link BiFunction}
      * @return a {@link CompletableFuture} containing the result of the last iteration's body invocation.
      */
-    @Nonnull
     public static <U> CompletableFuture<U> forLoop(final int startI, @Nullable final U startU,
-                                                   @Nonnull final IntPredicate conditionPredicate,
-                                                   @Nonnull final IntUnaryOperator stepFunction,
-                                                   @Nonnull final BiFunction<Integer, U, CompletableFuture<U>> body,
-                                                   @Nonnull final Executor executor) {
+                                                   final IntPredicate conditionPredicate,
+                                                   final IntUnaryOperator stepFunction,
+                                                   final BiFunction<Integer, U, CompletableFuture<U>> body,
+                                                   final Executor executor) {
         return forLoop(startI, startU,
                 (i, ignored) -> conditionPredicate.test(i),
                 stepFunction, body, executor);
@@ -1252,12 +1220,11 @@ public class MoreAsyncUtil {
      * @param <U> the type of the result of the body {@link BiFunction}
      * @return a {@link CompletableFuture} containing the result of the last iteration's body invocation.
      */
-    @Nonnull
     public static <U> CompletableFuture<U> forLoop(final int startI, @Nullable final U startU,
-                                                   @Nonnull final BiPredicate<Integer, U> conditionPredicate,
-                                                   @Nonnull final IntUnaryOperator stepFunction,
-                                                   @Nonnull final BiFunction<Integer, U, CompletableFuture<U>> body,
-                                                   @Nonnull final Executor executor) {
+                                                   final BiPredicate<Integer, U> conditionPredicate,
+                                                   final IntUnaryOperator stepFunction,
+                                                   final BiFunction<Integer, U, CompletableFuture<U>> body,
+                                                   final Executor executor) {
         final AtomicInteger loopVariableAtomic = new AtomicInteger(startI);
         final AtomicReference<U> lastResultAtomic = new AtomicReference<>(startU);
         return whileTrue(() -> {
@@ -1285,12 +1252,11 @@ public class MoreAsyncUtil {
      * @param <U> the type of the result
      * @return a {@link CompletableFuture} containing a list of results collected from the individual body invocations
      */
-    @Nonnull
     @SuppressWarnings({"unchecked", "PMD.CompareObjectsWithEquals"}) // identity check against a null stand-in sentinel
-    public static <T, U> CompletableFuture<List<U>> forEach(@Nonnull final Iterable<T> items,
-                                                            @Nonnull final Function<T, CompletableFuture<U>> body,
+    public static <T, U> CompletableFuture<List<U>> forEach(final Iterable<T> items,
+                                                            final Function<T, CompletableFuture<U>> body,
                                                             final int parallelism,
-                                                            @Nonnull final Executor executor) {
+                                                            final Executor executor) {
         if (parallelism < 1) {
             throw new IllegalArgumentException("parallelism must be at least 1, got " + parallelism);
         }
@@ -1330,14 +1296,12 @@ public class MoreAsyncUtil {
         }, executor).thenApply(ignored -> Arrays.asList((U[])resultArray));
     }
 
-    @Nonnull
-    public static <T> AsyncIterable<T> iterableFromCollection(@Nonnull final CompletableFuture<Collection<T>> collectionFuture,
-                                                              @Nonnull final Executor executor) {
+    public static <T> AsyncIterable<T> iterableFromCollection(final CompletableFuture<Collection<T>> collectionFuture,
+                                                              final Executor executor) {
         return iterableOf(() -> iteratorFromCollection(collectionFuture), executor);
     }
 
-    @Nonnull
-    public static <T> AsyncIterator<T> iteratorFromCollection(@Nonnull final CompletableFuture<Collection<T>> collectionFuture) {
+    public static <T> AsyncIterator<T> iteratorFromCollection(final CompletableFuture<Collection<T>> collectionFuture) {
         return new CloseableAsyncIterator<>() {
             @Nullable
             Iterator<T> iterator = null;
@@ -1379,7 +1343,6 @@ public class MoreAsyncUtil {
      */
     public static class AlwaysTrue<T> implements Function<T, Boolean> {
 
-        @Nonnull
         @Override
         public Boolean apply(T t) {
             return true;

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/MoreAsyncUtil.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/MoreAsyncUtil.java
@@ -296,18 +296,18 @@ public class MoreAsyncUtil {
      * @param <T> the source type
      * @return a new {@code AsyncIterable} that only contains those items in iterable for which filter returns {@code true}
      */
-    public static <T> AsyncIterable<T> filterIterable(final AsyncIterable<T> iterable,
+    public static <T extends @Nullable Object> AsyncIterable<T> filterIterable(final AsyncIterable<T> iterable,
                                                       final Function<T, Boolean> filter) {
         return filterIterable(ForkJoinPool.commonPool(), iterable, filter);
     }
 
-    public static <T> AsyncIterable<T> filterIterable(final Executor executor,
+    public static <T extends @Nullable Object> AsyncIterable<T> filterIterable(final Executor executor,
                                                       final AsyncIterable<T> iterable,
                                                       final Function<T, Boolean> filter) {
         return iterableOf(() -> filterRemaining(executor, iterable.iterator(), filter), executor);
     }
 
-    public static <T> CloseableAsyncIterator<T> filterRemaining(Executor executor,
+    public static <T extends @Nullable Object> CloseableAsyncIterator<T> filterRemaining(Executor executor,
                                                                 final AsyncIterator<T> iterator,
                                                                 final Function<T, Boolean> filter) {
         return new CloseableAsyncIterator<T>() {
@@ -352,13 +352,19 @@ public class MoreAsyncUtil {
             }
 
             @Override
+            // hasNext() is guaranteed to have set next when it returns true. Unlike a "missing value" sentinel,
+            // next may itself legitimately be null when T is instantiated with a nullable type (e.g.
+            // dedupIterable() below is used over streams that can contain null elements). AsyncIterator.next()
+            // is unannotated external code that NullAway infers as @NonNull, so this override can't be
+            // re-declared @Nullable; Objects.requireNonNull() would be wrong too, since it would incorrectly
+            // reject that legitimate null case, so the method is suppressed instead.
+            @SuppressWarnings("NullAway")
             public T next() {
                 if (!hasNext()) {
                     throw new NoSuchElementException();
                 }
                 haveNext = false;
-                // hasNext() is guaranteed to have set next when it returns true.
-                return Objects.requireNonNull(next);
+                return next;
             }
 
             @Override
@@ -384,11 +390,11 @@ public class MoreAsyncUtil {
      * @param <T> the source type
      * @return a new {@code AsyncIterable} that only contains those items in iterable for which the previous item was different
      */
-    public static <T> AsyncIterable<T> dedupIterable(final AsyncIterable<T> iterable) {
+    public static <T extends @Nullable Object> AsyncIterable<T> dedupIterable(final AsyncIterable<T> iterable) {
         return dedupIterable(ForkJoinPool.commonPool(), iterable);
     }
 
-    public static <T> AsyncIterable<T> dedupIterable(Executor executor,
+    public static <T extends @Nullable Object> AsyncIterable<T> dedupIterable(Executor executor,
                                                      final AsyncIterable<T> iterable) {
         return filterIterable(executor, iterable,
                 new Function<>() {

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/RangeSet.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/RangeSet.java
@@ -30,8 +30,7 @@ import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.subspace.Subspace;
 import com.apple.foundationdb.tuple.ByteArrayUtil;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.Arrays;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -52,9 +51,9 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 @API(API.Status.UNSTABLE)
 public class RangeSet {
-    @Nonnull private Subspace subspace;
-    @Nonnull private static final byte[] FIRST_KEY = { (byte)0x00 };
-    @Nonnull private static final byte[] FINAL_KEY = { (byte)0xff };
+    private Subspace subspace;
+    private static final byte[] FIRST_KEY = { (byte)0x00 };
+    private static final byte[] FINAL_KEY = { (byte)0xff };
 
     private static final Range COMPLETE_RANGE = new Range(FIRST_KEY, FINAL_KEY);
 
@@ -71,43 +70,42 @@ public class RangeSet {
      * used by another RangeSet object.
      * @param subspace the subspace in which to write data
      */
-    public RangeSet(@Nonnull Subspace subspace) {
+    public RangeSet(Subspace subspace) {
         this.subspace = subspace;
     }
 
-    private static void checkKey(@Nonnull byte[] key) {
+    private static void checkKey(byte[] key) {
         if (key.length == 0 || ByteArrayUtil.compareUnsigned(key, FINAL_KEY) >= 0) {
             // NOTE: Perhaps this should instead return a completable future completed in exceptional state...
             throw new IllegalArgumentException("Key " + ByteArrayUtil.printable(key) + " outside of accepted key range of [\\x00,\\xff)");
         }
     }
 
-    private static void checkRange(@Nonnull byte[] begin, @Nonnull byte[] end) {
+    private static void checkRange(byte[] begin, byte[] end) {
         if (ByteArrayUtil.compareUnsigned(begin, end) > 0) {
             throw new IllegalArgumentException("Inverted range; " + ByteArrayUtil.printable(begin) + " is greater than " + ByteArrayUtil.printable(end));
         }
     }
 
-    public static boolean isFirstKey(@Nonnull byte[] key) {
+    public static boolean isFirstKey(byte[] key) {
         return Arrays.equals(key, FIRST_KEY);
     }
 
-    public static boolean isFinalKey(@Nonnull byte[] key) {
+    public static boolean isFinalKey(byte[] key) {
         return Arrays.equals(key, FINAL_KEY);
     }
 
-    public static byte[] nullIfFirst(@Nonnull byte[] key) {
+    public static byte[] nullIfFirst(byte[] key) {
         return isFirstKey(key) ? null : key;
     }
 
-    public static byte[] nullIfFinal(@Nonnull byte[] key) {
+    public static byte[] nullIfFinal(byte[] key) {
         return isFinalKey(key) ? null : key;
     }
 
     // This returns the next possible key after another key (i.e., a key that is greater than current key but
     // every key greater than this key will be greater than or equal to the returned key).
-    @Nonnull
-    private byte[] keyAfter(@Nonnull byte[] key) {
+    private byte[] keyAfter(byte[] key) {
         byte[] ret = new byte[key.length + 1];
         System.arraycopy(key, 0, ret, 0, key.length);
         ret[key.length] = (byte)0;
@@ -125,8 +123,7 @@ public class RangeSet {
      * @param key the key to check presence in set
      * @return a future that contains whether some range in the set contains the key
      */
-    @Nonnull
-    public CompletableFuture<Boolean> contains(@Nonnull TransactionContext tc, @Nonnull byte[] key) {
+    public CompletableFuture<Boolean> contains(TransactionContext tc, byte[] key) {
         checkKey(key);
         return tc.runAsync(tr -> {
             // Add a read conflict to only the key being checked so that if this gets
@@ -156,8 +153,7 @@ public class RangeSet {
      * @param r the range to add to the set
      * @return a future that is <code>true</code> if there were any modifications to the database and <code>false</code> otherwise
      */
-    @Nonnull
-    public CompletableFuture<Boolean> insertRange(@Nonnull TransactionContext tc, @Nonnull Range r) {
+    public CompletableFuture<Boolean> insertRange(TransactionContext tc, Range r) {
         return insertRange(tc, r.begin, r.end);
     }
 
@@ -171,8 +167,7 @@ public class RangeSet {
      * @param requireEmpty whether this should only be added if this range is initally empty
      * @return a future that is <code>true</code> if there were any modifications to the database and <code>false</code> otherwise
      */
-    @Nonnull
-    public CompletableFuture<Boolean> insertRange(@Nonnull TransactionContext tc, @Nonnull Range r, boolean requireEmpty) {
+    public CompletableFuture<Boolean> insertRange(TransactionContext tc, Range r, boolean requireEmpty) {
         return insertRange(tc, r.begin, r.end, requireEmpty);
     }
 
@@ -187,8 +182,7 @@ public class RangeSet {
      * @param end the (exclusive) end of the range to add
      * @return a future that is <code>true</code> if there were any modifications to the database and <code>false</code> otherwise
      */
-    @Nonnull
-    public CompletableFuture<Boolean> insertRange(@Nonnull TransactionContext tc, @Nullable byte[] begin, @Nullable byte[] end) {
+    public CompletableFuture<Boolean> insertRange(TransactionContext tc, @Nullable byte[] begin, @Nullable byte[] end) {
         return insertRange(tc, begin, end, false);
     }
 
@@ -224,8 +218,7 @@ public class RangeSet {
      * @param requireEmpty whether this should only be added if this range is initially empty
      * @return a future that is <code>true</code> if there were any modifications to the database and <code>false</code> otherwise
      */
-    @Nonnull
-    public CompletableFuture<Boolean> insertRange(@Nonnull TransactionContext tc, @Nullable byte[] begin, @Nullable byte[] end, boolean requireEmpty) {
+    public CompletableFuture<Boolean> insertRange(TransactionContext tc, @Nullable byte[] begin, @Nullable byte[] end, boolean requireEmpty) {
         byte[] beginNonNull = (begin == null) ? FIRST_KEY : begin;
         byte[] endNonNull = (end == null) ? FINAL_KEY : end;
         checkKey(beginNonNull);
@@ -324,8 +317,7 @@ public class RangeSet {
      * @param tc transaction that will be used to access the database
      * @return an iterable that will produce all of the missing ranges
      */
-    @Nonnull
-    public CompletableFuture<List<Range>> missingRanges(@Nonnull ReadTransactionContext tc) {
+    public CompletableFuture<List<Range>> missingRanges(ReadTransactionContext tc) {
         return tc.readAsync(tr -> {
             AsyncIterable<Range> ranges = missingRanges(tr);
             return ranges.asList();
@@ -341,8 +333,7 @@ public class RangeSet {
      * @param tr transaction that will be used to access the database
      * @return an iterable that will produce all of the missing ranges
      */
-    @Nonnull
-    public AsyncIterable<Range> missingRanges(@Nonnull ReadTransaction tr) {
+    public AsyncIterable<Range> missingRanges(ReadTransaction tr) {
         return missingRanges(tr, null, null);
     }
 
@@ -355,8 +346,7 @@ public class RangeSet {
      * @param superRange the range within to search for additional ranges
      * @return an iterable that will produce all of the missing ranges
      */
-    @Nonnull
-    public CompletableFuture<List<Range>> missingRanges(@Nonnull ReadTransactionContext tc, @Nonnull Range superRange) {
+    public CompletableFuture<List<Range>> missingRanges(ReadTransactionContext tc, Range superRange) {
         return tc.readAsync(tr -> {
             AsyncIterable<Range> ranges = missingRanges(tr, superRange);
             return ranges.asList();
@@ -372,8 +362,7 @@ public class RangeSet {
      * @param superRange the range within to search for additional ranges
      * @return an iterable that will produce all of the missing ranges
      */
-    @Nonnull
-    public AsyncIterable<Range> missingRanges(@Nonnull ReadTransaction tr, @Nonnull Range superRange) {
+    public AsyncIterable<Range> missingRanges(ReadTransaction tr, Range superRange) {
         return missingRanges(tr, superRange.begin, superRange.end);
     }
 
@@ -387,8 +376,7 @@ public class RangeSet {
      * @param end the end (inclusive) of the range to look for gaps
      * @return an iterable that will produce all of the missing ranges
      */
-    @Nonnull
-    public CompletableFuture<List<Range>> missingRanges(@Nonnull ReadTransactionContext tc, @Nullable byte[] begin, @Nullable byte[] end) {
+    public CompletableFuture<List<Range>> missingRanges(ReadTransactionContext tc, @Nullable byte[] begin, @Nullable byte[] end) {
         return tc.readAsync(tr -> {
             AsyncIterable<Range> ranges = missingRanges(tr, begin, end);
             return ranges.asList();
@@ -406,8 +394,7 @@ public class RangeSet {
      * @param end the end (inclusive) of the range to look for gaps
      * @return an iterable that will produce all of the missing ranges
      */
-    @Nonnull
-    public AsyncIterable<Range> missingRanges(@Nonnull ReadTransaction tr, @Nullable byte[] begin, @Nullable byte[] end) {
+    public AsyncIterable<Range> missingRanges(ReadTransaction tr, @Nullable byte[] begin, @Nullable byte[] end) {
         return missingRanges(tr, begin, end, Integer.MAX_VALUE);
     }
 
@@ -423,8 +410,7 @@ public class RangeSet {
      * @param limit the maximum number of results to return
      * @return an iterable that will produce all of the missing ranges
      */
-    @Nonnull
-    public CompletableFuture<List<Range>> missingRanges(@Nonnull ReadTransactionContext tc, @Nullable byte[] begin, @Nullable byte[] end, int limit) {
+    public CompletableFuture<List<Range>> missingRanges(ReadTransactionContext tc, @Nullable byte[] begin, @Nullable byte[] end, int limit) {
         return tc.readAsync(tr -> {
             AsyncIterable<Range> ranges = missingRanges(tr, begin, end, limit);
             return ranges.asList();
@@ -444,8 +430,7 @@ public class RangeSet {
      * @param limit the maximum number of results to return
      * @return an iterable that will produce all of the missing ranges
      */
-    @Nonnull
-    public AsyncIterable<Range> missingRanges(@Nonnull ReadTransaction tr, @Nullable byte[] begin, @Nullable byte[] end, int limit) {
+    public AsyncIterable<Range> missingRanges(ReadTransaction tr, @Nullable byte[] begin, @Nullable byte[] end, int limit) {
         byte[] beginNonNull = (begin == null) ? FIRST_KEY : begin;
         byte[] endNonNull = (end == null) ? FINAL_KEY : end;
         checkKey(beginNonNull);
@@ -474,7 +459,7 @@ public class RangeSet {
      * @return a future that will contain {@code true} if there are no ranges in this set or {@code false} otherwise
      * @see #isEmpty(ReadTransaction)
      */
-    public CompletableFuture<Boolean> isEmpty(@Nonnull ReadTransactionContext rtc) {
+    public CompletableFuture<Boolean> isEmpty(ReadTransactionContext rtc) {
         return rtc.readAsync(this::isEmpty);
     }
 
@@ -485,7 +470,7 @@ public class RangeSet {
      * @param rtr transaction that will be used to read from the database
      * @return a future that will contain {@code true} if there are no ranges in this set or {@code false} otherwise
      */
-    public CompletableFuture<Boolean> isEmpty(@Nonnull ReadTransaction rtr) {
+    public CompletableFuture<Boolean> isEmpty(ReadTransaction rtr) {
         final AsyncIterator<Range> missing = missingRanges(rtr, null, null, 1).iterator();
         return missing.onHasNext().thenApply(doesHaveNext -> {
             if (doesHaveNext) {
@@ -502,19 +487,19 @@ public class RangeSet {
     // range. It will stop after the limit has been acheived unless the limit is set
     // to UNLIMITED.
     private class MissingRangeIterator implements CloseableAsyncIterator<Range> {
-        @Nonnull private final byte[] endNonNull;
-        @Nonnull private AsyncIterator<KeyValue> before;
-        @Nonnull private AsyncIterator<KeyValue> after;
+        private final byte[] endNonNull;
+        private AsyncIterator<KeyValue> before;
+        private AsyncIterator<KeyValue> after;
 
-        @Nonnull private byte[] currBegin;
+        private byte[] currBegin;
         @Nullable private Range next;
         private boolean found;
         private int limit;
         private int numFound;
         private final Executor executor;
-        @Nonnull private CompletableFuture<Boolean> nextFuture;
+        private CompletableFuture<Boolean> nextFuture;
 
-        public MissingRangeIterator(@Nonnull ReadTransaction tr, @Nonnull byte[] beginNonNull, @Nonnull byte[] endNonNull, int limit) {
+        public MissingRangeIterator(ReadTransaction tr, byte[] beginNonNull, byte[] endNonNull, int limit) {
             this.endNonNull = endNonNull;
             this.numFound = 0;
             this.limit = limit;
@@ -616,7 +601,7 @@ public class RangeSet {
      * Clears the subspace used by this RangeSet instance. This will remove all ranges from this set.
      * @param tr transaction with which to run the operation
      */
-    public void clear(@Nonnull Transaction tr) {
+    public void clear(Transaction tr) {
         tr.clear(subspace.range());
     }
 
@@ -625,16 +610,14 @@ public class RangeSet {
      * @param tc transaction or database in which to run operation
      * @return a future that is completed when the range has been cleared
      */
-    @Nonnull
-    public CompletableFuture<Void> clear(@Nonnull TransactionContext tc) {
+    public CompletableFuture<Void> clear(TransactionContext tc) {
         return tc.runAsync(tr -> {
             clear(tr);
             return AsyncUtil.DONE;
         });
     }
 
-    @Nonnull
-    public CompletableFuture<String> rep(@Nonnull ReadTransactionContext tc) {
+    public CompletableFuture<String> rep(ReadTransactionContext tc) {
         return tc.readAsync(tr -> {
             StringBuilder sb = new StringBuilder();
             AsyncIterable<KeyValue> iterable = tr.getRange(subspace.range());

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/RangeSet.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/RangeSet.java
@@ -34,6 +34,7 @@ import org.jspecify.annotations.Nullable;
 import java.util.Arrays;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -95,10 +96,16 @@ public class RangeSet {
         return Arrays.equals(key, FINAL_KEY);
     }
 
+    // NullAway does not reliably recognize @Nullable on array-typed return values, so the `null` branches
+    // below are misflagged as returning @Nullable from a @NonNull-returning method despite the annotation.
+    @Nullable
+    @SuppressWarnings("NullAway")
     public static byte[] nullIfFirst(byte[] key) {
         return isFirstKey(key) ? null : key;
     }
 
+    @Nullable
+    @SuppressWarnings("NullAway")
     public static byte[] nullIfFinal(byte[] key) {
         return isFinalKey(key) ? null : key;
     }
@@ -219,8 +226,12 @@ public class RangeSet {
      * @return a future that is <code>true</code> if there were any modifications to the database and <code>false</code> otherwise
      */
     public CompletableFuture<Boolean> insertRange(TransactionContext tc, @Nullable byte[] begin, @Nullable byte[] end, boolean requireEmpty) {
-        byte[] beginNonNull = (begin == null) ? FIRST_KEY : begin;
-        byte[] endNonNull = (end == null) ? FINAL_KEY : end;
+        // NullAway does not reliably narrow @Nullable byte[] locals inside a ternary, even though begin/end
+        // are provably non-null in the branch where they are used below.
+        @SuppressWarnings("NullAway")
+        final byte[] beginNonNull = (begin == null) ? FIRST_KEY : begin;
+        @SuppressWarnings("NullAway")
+        final byte[] endNonNull = (end == null) ? FINAL_KEY : end;
         checkKey(beginNonNull);
         checkRange(beginNonNull, endNonNull);
 
@@ -249,7 +260,9 @@ public class RangeSet {
 
                 // If the before key is in some range, we don't have to update from before to the
                 // end of that range.
-                if (hasBefore) {
+                // hasBefore implies before != null (both are derived together just above), but NullAway
+                // cannot correlate the nullness of two different variables, so it is checked explicitly.
+                if (hasBefore && before != null) {
                     byte[] beforeEnd = before.getValue();
                     if (ByteArrayUtil.compareUnsigned(beginNonNull, beforeEnd) < 0) {
                         if (requireEmpty) {
@@ -282,7 +295,10 @@ public class RangeSet {
                     AtomicBoolean changed = new AtomicBoolean(false);
                     // If we are allowing non-empty ranges, then we just need to fill in the gaps.
                     return AsyncUtil.whileTrue(() -> {
-                        byte[] lastSeenBytes = lastSeen.get();
+                        // lastSeen is only ever set to a non-null value (see the AtomicReference construction
+                        // above and the .set() calls below), but NullAway models AtomicReference#get() as
+                        // always @Nullable, so the non-null-ness is re-asserted here.
+                        byte[] lastSeenBytes = Objects.requireNonNull(lastSeen.get());
                         if (MoreAsyncUtil.isCompletedNormally(afterIterator.onHasNext()) && afterIterator.hasNext()) {
                             KeyValue kv = afterIterator.next();
                             if (ByteArrayUtil.compareUnsigned(lastSeenBytes, kv.getKey()) < 0) {
@@ -294,7 +310,7 @@ public class RangeSet {
                         }
                         return afterIterator.onHasNext();
                     }, tc.getExecutor()).thenApply(vignore -> {
-                        byte[] lastSeenBytes = lastSeen.get();
+                        byte[] lastSeenBytes = Objects.requireNonNull(lastSeen.get());
                         // Get from lastSeen to the end (the last gap).
                         if (ByteArrayUtil.compareUnsigned(lastSeenBytes, frobnicatedEnd) < 0) {
                             tr.set(lastSeenBytes, endNonNull);
@@ -334,7 +350,11 @@ public class RangeSet {
      * @return an iterable that will produce all of the missing ranges
      */
     public AsyncIterable<Range> missingRanges(ReadTransaction tr) {
-        return missingRanges(tr, null, null);
+        // NullAway does not reliably honor @Nullable on byte[]-typed parameters, so the null literals below
+        // are misflagged as NonNull violations even though missingRanges()'s begin/end are @Nullable byte[].
+        @SuppressWarnings("NullAway")
+        final AsyncIterable<Range> result = missingRanges(tr, null, null);
+        return result;
     }
 
     /**
@@ -431,8 +451,12 @@ public class RangeSet {
      * @return an iterable that will produce all of the missing ranges
      */
     public AsyncIterable<Range> missingRanges(ReadTransaction tr, @Nullable byte[] begin, @Nullable byte[] end, int limit) {
-        byte[] beginNonNull = (begin == null) ? FIRST_KEY : begin;
-        byte[] endNonNull = (end == null) ? FINAL_KEY : end;
+        // NullAway does not reliably narrow @Nullable byte[] locals inside a ternary, even though begin/end
+        // are provably non-null in the branch where they are used below.
+        @SuppressWarnings("NullAway")
+        final byte[] beginNonNull = (begin == null) ? FIRST_KEY : begin;
+        @SuppressWarnings("NullAway")
+        final byte[] endNonNull = (end == null) ? FINAL_KEY : end;
         checkKey(beginNonNull);
         checkRange(beginNonNull, endNonNull);
 
@@ -471,6 +495,9 @@ public class RangeSet {
      * @return a future that will contain {@code true} if there are no ranges in this set or {@code false} otherwise
      */
     public CompletableFuture<Boolean> isEmpty(ReadTransaction rtr) {
+        // NullAway does not reliably honor @Nullable on byte[]-typed parameters, so the null literals below
+        // are misflagged as NonNull violations even though missingRanges()'s begin/end are @Nullable byte[].
+        @SuppressWarnings("NullAway")
         final AsyncIterator<Range> missing = missingRanges(rtr, null, null, 1).iterator();
         return missing.onHasNext().thenApply(doesHaveNext -> {
             if (doesHaveNext) {
@@ -579,7 +606,8 @@ public class RangeSet {
             if (!hasNext()) {
                 throw new NoSuchElementException("Attempted to get next missing range when none were present");
             }
-            Range ret = next;
+            // hasNext() is guaranteed to have set next when it returns true.
+            Range ret = Objects.requireNonNull(next);
             found = false;
             if (limit == UNLIMITED || numFound < limit) {
                 nextFuture = getNext();

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/RankedSet.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/RankedSet.java
@@ -35,6 +35,8 @@ import com.apple.foundationdb.tuple.ByteArrayUtil;
 import com.apple.foundationdb.tuple.ByteArrayUtil2;
 import com.apple.foundationdb.tuple.Tuple;
 
+import org.jspecify.annotations.Nullable;
+
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
@@ -555,15 +557,19 @@ public class RankedSet {
 
     class NthLookup implements Lookup {
         private long rank;
+        @Nullable
         private byte[] key = EMPTY_ARRAY;
         private int level = config.getNLevels();
+        @Nullable
         private Subspace levelSubspace;
-        private AsyncIterator<KeyValue> asyncIterator = null;
+        @Nullable
+        private AsyncIterator<KeyValue> asyncIterator;
 
         public NthLookup(long rank) {
             this.rank = rank;
         }
 
+        @Nullable
         public byte[] getKey() {
             return key;
         }
@@ -576,7 +582,11 @@ public class RankedSet {
                 if (level < 0) {
                     // Down to finest level without finding enough.
                     if (!config.isCountDuplicates()) {
-                        key = null;
+                        // NullAway does not reliably honor @Nullable on byte[]-typed fields, so the null literal
+                        // below is misflagged as a NonNull violation even though key is declared @Nullable byte[].
+                        @SuppressWarnings("NullAway")
+                        final Runnable clearKey = () -> key = null;
+                        clearKey.run();
                     }
                     return READY_FALSE;
                 }
@@ -586,8 +596,13 @@ public class RankedSet {
                         false,
                         StreamingMode.WANT_ALL));
             }
+            // Either newIterator just assigned levelSubspace/asyncIterator above, or this is a continuation of an
+            // already-started lookup where a previous call did so; either way both are non-null from here on, but
+            // that invariant does not survive the lambda boundary below, so it is re-asserted with local captures.
+            final Subspace currentLevelSubspace = Objects.requireNonNull(levelSubspace);
+            final AsyncIterator<KeyValue> currentAsyncIterator = Objects.requireNonNull(asyncIterator);
             final long startTime = System.nanoTime();
-            final CompletableFuture<Boolean> onHasNext = asyncIterator.onHasNext();
+            final CompletableFuture<Boolean> onHasNext = currentAsyncIterator.onHasNext();
             final boolean wasDone = onHasNext.isDone();
             return onHasNext.thenApply(hasNext -> {
                 if (!wasDone) {
@@ -595,12 +610,17 @@ public class RankedSet {
                 }
                 if (!hasNext) {
                     // Not enough on this level.
-                    key = null;
+                    // NullAway does not reliably honor @Nullable on byte[]-typed fields, so the null literal
+                    // below is misflagged as a NonNull violation even though key is declared @Nullable byte[].
+                    @SuppressWarnings("NullAway")
+                    final Runnable clearKey = () -> key = null;
+                    clearKey.run();
                     return false;
                 }
-                KeyValue kv = asyncIterator.next();
-                key = levelSubspace.unpack(kv.getKey()).getBytes(0);
-                if (rank == 0 && key.length > 0) {
+                KeyValue kv = currentAsyncIterator.next();
+                final byte[] newKey = currentLevelSubspace.unpack(kv.getKey()).getBytes(0);
+                key = newKey;
+                if (rank == 0 && newKey.length > 0) {
                     // Moved along correct rank, this is the key.
                     return false;
                 }
@@ -685,9 +705,11 @@ public class RankedSet {
         private final boolean keyShouldBePresent;
         private byte[] rankKey = EMPTY_ARRAY;
         private long rank = 0;
+        @Nullable
         private Subspace levelSubspace;
         private int level = config.getNLevels();
-        private AsyncIterator<KeyValue> asyncIterator = null;
+        @Nullable
+        private AsyncIterator<KeyValue> asyncIterator;
         private long lastCount;
 
         public RankLookup(byte[] key, boolean keyShouldBePresent) {
@@ -717,8 +739,13 @@ public class RankedSet {
                         StreamingMode.WANT_ALL));
                 lastCount = 0;
             }
+            // Either newIterator just assigned levelSubspace/asyncIterator above, or this is a continuation of an
+            // already-started lookup where a previous call did so; either way both are non-null from here on, but
+            // that invariant does not survive the lambda boundary below, so it is re-asserted with local captures.
+            final Subspace currentLevelSubspace = Objects.requireNonNull(levelSubspace);
+            final AsyncIterator<KeyValue> currentAsyncIterator = Objects.requireNonNull(asyncIterator);
             final long startTime = System.nanoTime();
-            final CompletableFuture<Boolean> onHasNext = asyncIterator.onHasNext();
+            final CompletableFuture<Boolean> onHasNext = currentAsyncIterator.onHasNext();
             final boolean wasDone = onHasNext.isDone();
             return onHasNext.thenApply(hasNext -> {
                 if (!wasDone) {
@@ -742,8 +769,8 @@ public class RankedSet {
                     }
                     return true;
                 }
-                KeyValue kv = asyncIterator.next();
-                rankKey = levelSubspace.unpack(kv.getKey()).getBytes(0);
+                KeyValue kv = currentAsyncIterator.next();
+                rankKey = currentLevelSubspace.unpack(kv.getKey()).getBytes(0);
                 lastCount = decodeLong(kv.getValue());
                 rank += lastCount;
                 return true;
@@ -817,7 +844,11 @@ public class RankedSet {
                     KeyValue kv = more ? it.next() : null;
                     byte[] nextKey = kv == null ? null : subspace.unpack(kv.getKey()).getBytes(1);
                     if (prevKey != null) {
-                        long count = countRange(tr, level - 1, prevKey, nextKey).join();
+                        // NullAway does not reliably honor @Nullable on byte[]-typed parameters, so forwarding
+                        // the @Nullable-tracked nextKey local is misflagged as a NonNull violation even though
+                        // countRange()'s endKey parameter is declared @Nullable byte[].
+                        @SuppressWarnings("NullAway")
+                        final long count = countRange(tr, level - 1, prevKey, nextKey).join();
                         if (prevCount != count) {
                             return new Consistency(level, prevCount, count, toDebugString(tc));
                         }
@@ -826,7 +857,10 @@ public class RankedSet {
                         break;
                     }
                     prevKey = nextKey;
-                    prevCount = decodeLong(kv.getValue());
+                    // more is true here (we would have broken out above otherwise), so kv is non-null (it is
+                    // set together with more just above), but NullAway cannot correlate the nullness of two
+                    // different variables, so it is checked explicitly.
+                    prevCount = decodeLong(Objects.requireNonNull(kv).getValue());
                 }
             }
             return new Consistency();
@@ -863,7 +897,7 @@ public class RankedSet {
         }
     }
 
-    private CompletableFuture<Long> countRange(ReadTransactionContext tc, int level, byte[] beginKey, byte[] endKey) {
+    private CompletableFuture<Long> countRange(ReadTransactionContext tc, int level, @Nullable byte[] beginKey, @Nullable byte[] endKey) {
         return tc.readAsync(tr ->
                 AsyncUtil.mapIterable(tr.getRange(beginKey == null ?
                                 subspace.range(Tuple.from(level)).begin :
@@ -930,6 +964,7 @@ public class RankedSet {
         private final int level;
         private final long prevCount;
         private final long count;
+        @Nullable
         private String structure;
 
         public Consistency(int level, long prevCount, long count, String structure) {

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/TaskNotifyingExecutor.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/TaskNotifyingExecutor.java
@@ -22,7 +22,6 @@ package com.apple.foundationdb.async;
 
 import com.apple.foundationdb.annotation.API;
 
-import javax.annotation.Nonnull;
 import java.util.concurrent.Executor;
 
 /**
@@ -32,10 +31,9 @@ import java.util.concurrent.Executor;
  */
 @API(API.Status.EXPERIMENTAL)
 public abstract class TaskNotifyingExecutor implements Executor {
-    @Nonnull
     protected final Executor delegate;
 
-    public TaskNotifyingExecutor(@Nonnull Executor executor) {
+    public TaskNotifyingExecutor(Executor executor) {
         this.delegate = executor;
     }
 
@@ -63,10 +61,9 @@ public abstract class TaskNotifyingExecutor implements Executor {
     public abstract void afterTask();
 
     private class Notifier implements Runnable {
-        @Nonnull
         private final Runnable delegate;
 
-        public Notifier(@Nonnull Runnable delegate) {
+        public Notifier(Runnable delegate) {
             this.delegate = delegate;
         }
 

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/WrappingAsyncPeekIterator.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/WrappingAsyncPeekIterator.java
@@ -23,8 +23,7 @@ package com.apple.foundationdb.async;
 import java.util.NoSuchElementException;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * An implementation of the {@link AsyncPeekIterator} interface that wraps a regular
@@ -36,7 +35,6 @@ import javax.annotation.Nullable;
  * @param <T> type of elements returned by this iterator
  */
 class WrappingAsyncPeekIterator<T> implements AsyncPeekCallbackIterator<T> {
-    @Nonnull
     private AsyncIterator<T> underlying;
     @Nullable
     private CompletableFuture<Boolean> hasNextFuture;
@@ -44,14 +42,13 @@ class WrappingAsyncPeekIterator<T> implements AsyncPeekCallbackIterator<T> {
     private boolean hasCurrent;
     @Nullable
     private T nextItem;
-    @Nonnull
     private Consumer<T> callback;
 
-    WrappingAsyncPeekIterator(@Nonnull AsyncIterator<T> underlying) {
+    WrappingAsyncPeekIterator(AsyncIterator<T> underlying) {
         this(underlying, t -> { });
     }
 
-    WrappingAsyncPeekIterator(@Nonnull AsyncIterator<T> underlying, @Nonnull Consumer<T> callback) {
+    WrappingAsyncPeekIterator(AsyncIterator<T> underlying, Consumer<T> callback) {
         this.underlying = underlying;
         this.callback = callback;
         this.done = false;
@@ -110,12 +107,11 @@ class WrappingAsyncPeekIterator<T> implements AsyncPeekCallbackIterator<T> {
     }
 
     @Override
-    public void setCallback(@Nonnull Consumer<T> callback) {
+    public void setCallback(Consumer<T> callback) {
         this.callback = callback;
     }
 
     @Override
-    @Nonnull
     public Consumer<T> getCallback() {
         return callback;
     }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/WrappingAsyncPeekIterator.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/WrappingAsyncPeekIterator.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.async;
 
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import org.jspecify.annotations.Nullable;
@@ -87,7 +88,8 @@ class WrappingAsyncPeekIterator<T> implements AsyncPeekCallbackIterator<T> {
         if (done) {
             throw new NoSuchElementException();
         } else if (hasCurrent || hasNext()) {
-            return nextItem;
+            // hasCurrent (or hasNext() having just made it so) guarantees nextItem was set below.
+            return Objects.requireNonNull(nextItem);
         } else {
             throw new NoSuchElementException();
         }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/common/AggregatedVector.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/common/AggregatedVector.java
@@ -23,7 +23,6 @@ package com.apple.foundationdb.async.common;
 import com.apple.foundationdb.linear.RealVector;
 import com.apple.foundationdb.linear.Transformed;
 
-import javax.annotation.Nonnull;
 
 /**
  * A record-like class wrapping a {@link RealVector} and a count. This data structure is used to keep a running sum
@@ -31,8 +30,7 @@ import javax.annotation.Nonnull;
  * @param partialCount count aggregate to indicate how many vectors have been aggregated to form {@code partialVector}
  * @param partialVector the vector aggregate (mostly the sum of all individual vectors)
  */
-public record AggregatedVector(int partialCount, @Nonnull Transformed<RealVector> partialVector) {
-    @Nonnull
+public record AggregatedVector(int partialCount, Transformed<RealVector> partialVector) {
     @Override
     public String toString() {
         return "AggregatedVector[" + partialCount + ", " + partialVector + "]";

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/common/DistinctTopK.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/common/DistinctTopK.java
@@ -26,7 +26,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 
-import javax.annotation.Nonnull;
 import java.util.Comparator;
 import java.util.List;
 import java.util.NavigableSet;
@@ -46,12 +45,11 @@ import static com.apple.foundationdb.async.AsyncUtil.forEachRemaining;
  * @param <T> the type of element collected
  */
 public class DistinctTopK<T> {
-    @Nonnull
     private final NavigableSet<T> set;
     @SuppressWarnings("checkstyle:MemberName")
     private final int k;
 
-    private DistinctTopK(@Nonnull final Comparator<T> comparator, final int k) {
+    private DistinctTopK(final Comparator<T> comparator, final int k) {
         Preconditions.checkArgument(k > 0, "k must be positive");
         this.set = Sets.newTreeSet(comparator);
         this.k = k;
@@ -67,7 +65,7 @@ public class DistinctTopK<T> {
      *
      * @return {@code true} if the element was retained, {@code false} if it was a duplicate or was rejected
      */
-    public boolean add(@Nonnull T item) {
+    public boolean add(T item) {
         if (set.contains(item)) {
             return false;
         }
@@ -101,7 +99,6 @@ public class DistinctTopK<T> {
      *
      * @return the worst retained element, or {@link Optional#empty()} if the collector is empty
      */
-    @Nonnull
     public Optional<T> worstElement() {
         if (set.isEmpty()) {
             return Optional.empty();
@@ -118,7 +115,6 @@ public class DistinctTopK<T> {
      *
      * @return a future completing with the retained distinct top-K elements, sorted from best to worst
      */
-    @Nonnull
     public CompletableFuture<List<T>> collect(final AsyncIterable<T> iterable,
                                               final Executor executor) {
         return collectRemaining(iterable.iterator(), executor);
@@ -150,8 +146,7 @@ public class DistinctTopK<T> {
      *
      * @throws IllegalArgumentException if {@code k} is not positive
      */
-    @Nonnull
-    public static <T> DistinctTopK<T> min(@Nonnull final Comparator<T> comparator, final int k) {
+    public static <T> DistinctTopK<T> min(final Comparator<T> comparator, final int k) {
         return new DistinctTopK<>(comparator.reversed(), k);
     }
 
@@ -167,8 +162,7 @@ public class DistinctTopK<T> {
      *
      * @throws IllegalArgumentException if {@code k} is not positive
      */
-    @Nonnull
-    public static <T> DistinctTopK<T> max(@Nonnull final Comparator<T> comparator, final int k) {
+    public static <T> DistinctTopK<T> max(final Comparator<T> comparator, final int k) {
         return new DistinctTopK<>(comparator, k);
     }
 }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/common/OnKeyValueReadListener.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/common/OnKeyValueReadListener.java
@@ -20,8 +20,7 @@
 
 package com.apple.foundationdb.async.common;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Interface for call backs whenever we read data from the database.
@@ -36,7 +35,7 @@ public interface OnKeyValueReadListener {
      * @param value the value associated with the key, can be null if the key was not found
      */
     @SuppressWarnings("unused")
-    default void onKeyValueRead(@Nonnull byte[] key,
+    default void onKeyValueRead(byte[] key,
                                 @Nullable byte[] value) {
         // nothing
     }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/common/OnKeyValueWriteListener.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/common/OnKeyValueWriteListener.java
@@ -22,7 +22,6 @@ package com.apple.foundationdb.async.common;
 
 import com.apple.foundationdb.Range;
 
-import javax.annotation.Nonnull;
 
 /**
  * Interface for call backs whenever we write data to the database.
@@ -37,7 +36,7 @@ public interface OnKeyValueWriteListener {
      * @param value the value.
      */
     @SuppressWarnings("unused")
-    default void onKeyValueWritten(@Nonnull final byte[] key, @Nonnull final byte[] value) {
+    default void onKeyValueWritten(final byte[] key, final byte[] value) {
         // nothing
     }
 
@@ -49,7 +48,7 @@ public interface OnKeyValueWriteListener {
      * @param key the key that was deleted
      */
     @SuppressWarnings("unused")
-    default void onKeyDeleted(@Nonnull final byte[] key) {
+    default void onKeyDeleted(final byte[] key) {
         // nothing
     }
 
@@ -61,7 +60,7 @@ public interface OnKeyValueWriteListener {
      * @param range the {@link Range} that was deleted
      */
     @SuppressWarnings("unused")
-    default void onRangeDeleted(@Nonnull final Range range) {
+    default void onRangeDeleted(final Range range) {
         // nothing
     }
 }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/common/RandomHelpers.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/common/RandomHelpers.java
@@ -24,7 +24,6 @@ import com.apple.foundationdb.async.MoreAsyncUtil;
 import com.apple.foundationdb.tuple.Tuple;
 import com.google.common.collect.Iterables;
 
-import javax.annotation.Nonnull;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.SplittableRandom;
@@ -47,8 +46,7 @@ public final class RandomHelpers {
      *
      * @return a new {@link SplittableRandom}
      */
-    @Nonnull
-    public static SplittableRandom random(@Nonnull final Tuple primaryKey) {
+    public static SplittableRandom random(final Tuple primaryKey) {
         return new SplittableRandom(seedFromBytes(primaryKey.pack()));
     }
 
@@ -60,8 +58,7 @@ public final class RandomHelpers {
      *
      * @return a new {@link SplittableRandom}
      */
-    @Nonnull
-    public static SplittableRandom random(@Nonnull final UUID identity) {
+    public static SplittableRandom random(final UUID identity) {
         return new SplittableRandom(seedFromBytes(bytesOf(identity)));
     }
 
@@ -98,7 +95,7 @@ public final class RandomHelpers {
      *
      * @return a 64-bit seed
      */
-    private static long seedFromBytes(@Nonnull final byte[] bytes) {
+    private static long seedFromBytes(final byte[] bytes) {
         long seed = 0L;
         for (final byte b : bytes) {
             seed = splitMixLong(seed ^ (b & 0xffL));
@@ -113,8 +110,7 @@ public final class RandomHelpers {
      *
      * @return its 16-byte representation
      */
-    @Nonnull
-    private static byte[] bytesOf(@Nonnull final UUID uuid) {
+    private static byte[] bytesOf(final UUID uuid) {
         return ByteBuffer.allocate(Long.BYTES * 2)
                 .putLong(uuid.getMostSignificantBits())
                 .putLong(uuid.getLeastSignificantBits())
@@ -130,8 +126,7 @@ public final class RandomHelpers {
      *
      * @return a new UUID
      */
-    @Nonnull
-    public static UUID randomUuid(@Nonnull final SplittableRandom random, final boolean deterministicRandomness) {
+    public static UUID randomUuid(final SplittableRandom random, final boolean deterministicRandomness) {
         return deterministicRandomness ? randomUuid(random) : UUID.randomUUID();
     }
 
@@ -143,8 +138,7 @@ public final class RandomHelpers {
      *
      * @return a type-4 UUID derived from {@code random}
      */
-    @Nonnull
-    public static UUID randomUuid(@Nonnull final SplittableRandom random) {
+    public static UUID randomUuid(final SplittableRandom random) {
         long msb = random.nextLong();
         long lsb = random.nextLong();
 
@@ -170,8 +164,7 @@ public final class RandomHelpers {
      *
      * @return a new UUID
      */
-    @Nonnull
-    public static UUID randomUuid(@Nonnull final Tuple primaryKey, final boolean deterministicRandomness) {
+    public static UUID randomUuid(final Tuple primaryKey, final boolean deterministicRandomness) {
         return deterministicRandomness ? UUID.nameUUIDFromBytes(primaryKey.pack()) : UUID.randomUUID();
     }
 
@@ -185,8 +178,7 @@ public final class RandomHelpers {
      *
      * @return a new UUID
      */
-    @Nonnull
-    public static UUID randomUuid(@Nonnull final UUID identity, final boolean deterministicRandomness) {
+    public static UUID randomUuid(final UUID identity, final boolean deterministicRandomness) {
         return deterministicRandomness ? UUID.nameUUIDFromBytes(bytesOf(identity)) : UUID.randomUUID();
     }
 
@@ -204,12 +196,11 @@ public final class RandomHelpers {
      *
      * @return a future completing with the per-item results
      */
-    @Nonnull
-    public static <T, U> CompletableFuture<List<U>> forEach(@Nonnull final SplittableRandom splittableRandom,
-                                                            @Nonnull final Iterable<T> items,
-                                                            @Nonnull final BiFunction<T, SplittableRandom, CompletableFuture<U>> body,
+    public static <T, U> CompletableFuture<List<U>> forEach(final SplittableRandom splittableRandom,
+                                                            final Iterable<T> items,
+                                                            final BiFunction<T, SplittableRandom, CompletableFuture<U>> body,
                                                             final int parallelism,
-                                                            @Nonnull final Executor executor) {
+                                                            final Executor executor) {
         final Iterable<ItemRandomPair<T>> itemWithRandoms =
                 Iterables.transform(items, item -> new ItemRandomPair<>(item, splittableRandom.split()));
 
@@ -225,22 +216,18 @@ public final class RandomHelpers {
      * @param <T> the type of the paired item
      */
     private static class ItemRandomPair<T> {
-        @Nonnull
         private final T item;
-        @Nonnull
         private final SplittableRandom random;
 
-        public ItemRandomPair(@Nonnull final T item, @Nonnull final SplittableRandom random) {
+        public ItemRandomPair(final T item, final SplittableRandom random) {
             this.item = item;
             this.random = random;
         }
 
-        @Nonnull
         public T getItem() {
             return item;
         }
 
-        @Nonnull
         public SplittableRandom getRandom() {
             return random;
         }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/common/ResultEntry.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/common/ResultEntry.java
@@ -28,8 +28,7 @@ import com.apple.foundationdb.linear.RealVector;
 import com.apple.foundationdb.tuple.Tuple;
 import com.google.common.base.Preconditions;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Record class that wraps the results of a kNN-search.
@@ -47,7 +46,7 @@ import javax.annotation.Nullable;
  * @param distance The distance of item's vector to the query vector.
  * @param rankOrRowNumber The row number of the item. TODO support rank.
  */
-public record ResultEntry(@Nonnull Tuple primaryKey, @Nullable RealVector vector, @Nullable Tuple additionalValues,
+public record ResultEntry(Tuple primaryKey, @Nullable RealVector vector, @Nullable Tuple additionalValues,
                           double distance, int rankOrRowNumber) {
     public ResultEntry {
         if (vector != null) {
@@ -59,7 +58,6 @@ public record ResultEntry(@Nonnull Tuple primaryKey, @Nullable RealVector vector
         }
     }
 
-    @Nonnull
     @Override
     public String toString() {
         return "[" +

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/common/StorageHelpers.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/common/StorageHelpers.java
@@ -36,8 +36,7 @@ import com.apple.foundationdb.tuple.Tuple;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.List;
 import java.util.SplittableRandom;
 import java.util.concurrent.CompletableFuture;
@@ -65,11 +64,10 @@ public final class StorageHelpers {
      *
      * @return a future completing with the consumed sampled vectors
      */
-    @Nonnull
-    public static CompletableFuture<List<AggregatedVector>> consumeSampledVectors(@Nonnull final Transaction transaction,
-                                                                                  @Nonnull final Subspace prefixSubspace,
+    public static CompletableFuture<List<AggregatedVector>> consumeSampledVectors(final Transaction transaction,
+                                                                                  final Subspace prefixSubspace,
                                                                                   final int numMaxVectors,
-                                                                                  @Nonnull final OnKeyValueReadListener onReadListener) {
+                                                                                  final OnKeyValueReadListener onReadListener) {
         final byte[] prefixKey = prefixSubspace.pack();
         final ReadTransaction snapshot = transaction.snapshot();
         final Range range = Range.startsWith(prefixKey);
@@ -104,7 +102,7 @@ public final class StorageHelpers {
      * @return the combined aggregate, or {@code null} if {@code vectors} contributes no elements
      */
     @Nullable
-    public static AggregatedVector aggregateVectors(@Nonnull final Iterable<AggregatedVector> vectors) {
+    public static AggregatedVector aggregateVectors(final Iterable<AggregatedVector> vectors) {
         Transformed<RealVector> partialVector = null;
         int partialCount = 0;
         for (final AggregatedVector vector : vectors) {
@@ -127,13 +125,13 @@ public final class StorageHelpers {
      * @param vector the sampled (partial) vector to store
      * @param onWriteListener the listener notified of the written key/value
      */
-    public static void appendSampledVector(@Nonnull final Transaction transaction,
-                                           @Nonnull final SplittableRandom random,
+    public static void appendSampledVector(final Transaction transaction,
+                                           final SplittableRandom random,
                                            final boolean deterministicRandomness,
-                                           @Nonnull final Subspace prefixSubspace,
+                                           final Subspace prefixSubspace,
                                            final int partialCount,
-                                           @Nonnull final Transformed<RealVector> vector,
-                                           @Nonnull final OnKeyValueWriteListener onWriteListener) {
+                                           final Transformed<RealVector> vector,
+                                           final OnKeyValueWriteListener onWriteListener) {
         final Subspace keySubspace = prefixSubspace.subspace(Tuple.from(partialCount,
                 RandomHelpers.randomUuid(random, deterministicRandomness)));
         final byte[] prefixKey = keySubspace.pack();
@@ -150,18 +148,17 @@ public final class StorageHelpers {
      * @param prefixSubspace the subspace holding the sampled vectors
      * @param onWriteListener the listener notified of the cleared range
      */
-    public static void deleteAllSampledVectors(@Nonnull final Transaction transaction, @Nonnull final Subspace prefixSubspace,
-                                               @Nonnull final OnKeyValueWriteListener onWriteListener) {
+    public static void deleteAllSampledVectors(final Transaction transaction, final Subspace prefixSubspace,
+                                               final OnKeyValueWriteListener onWriteListener) {
         final byte[] prefixKey = prefixSubspace.pack();
         final Range range = Range.startsWith(prefixKey);
         transaction.clear(range);
         onWriteListener.onRangeDeleted(range);
     }
 
-    @Nonnull
-    private static AggregatedVector aggregatedVectorFromRaw(@Nonnull final Subspace prefixSubspace,
-                                                            @Nonnull final byte[] key,
-                                                            @Nonnull final byte[] value) {
+    private static AggregatedVector aggregatedVectorFromRaw(final Subspace prefixSubspace,
+                                                            final byte[] key,
+                                                            final byte[] value) {
         final Tuple keyTuple = prefixSubspace.unpack(key);
         final int partialCount = Math.toIntExact(keyTuple.getLong(0));
         final RealVector vector = DoubleRealVector.fromBytes(Tuple.fromBytes(value).getBytes(0));
@@ -174,8 +171,7 @@ public final class StorageHelpers {
      * @param vector a transformed vector
      * @return a new, non-null {@code Tuple} instance representing the contents of the underlying vector.
      */
-    @Nonnull
-    public static Tuple tupleFromVector(@Nonnull final Transformed<RealVector> vector) {
+    public static Tuple tupleFromVector(final Transformed<RealVector> vector) {
         return tupleFromVector(vector.getUnderlyingVector());
     }
 
@@ -187,9 +183,8 @@ public final class StorageHelpers {
      * @param vector the {@link RealVector} to convert. Cannot be null.
      * @return a new, non-null {@code Tuple} instance representing the contents of the vector.
      */
-    @Nonnull
     @SuppressWarnings("PrimitiveArrayArgumentToVarargsMethod")
-    public static Tuple tupleFromVector(@Nonnull final RealVector vector) {
+    public static Tuple tupleFromVector(final RealVector vector) {
         return Tuple.from(vector.getRawData());
     }
 
@@ -200,8 +195,7 @@ public final class StorageHelpers {
      *
      * @return the raw bytes of the underlying vector
      */
-    @Nonnull
-    public static byte[] bytesFromVector(@Nonnull final Transformed<RealVector> transformedVector) {
+    public static byte[] bytesFromVector(final Transformed<RealVector> transformedVector) {
         return transformedVector.getUnderlyingVector().getRawData();
     }
 
@@ -216,8 +210,7 @@ public final class StorageHelpers {
      * @return a new {@link RealVector} instance created from the tuple's data.
      *         This method never returns {@code null}.
      */
-    @Nonnull
-    public static RealVector vectorFromTuple(@Nonnull final VectorEncodingConfig config, @Nonnull final Tuple vectorTuple) {
+    public static RealVector vectorFromTuple(final VectorEncodingConfig config, final Tuple vectorTuple) {
         return vectorFromBytes(config, vectorTuple.getBytes(0));
     }
 
@@ -230,8 +223,7 @@ public final class StorageHelpers {
      * @param vectorBytes the non-null byte array to convert.
      * @return a new {@link RealVector} instance created from the byte array.
      */
-    @Nonnull
-    public static RealVector vectorFromBytes(@Nonnull final VectorEncodingConfig config, @Nonnull final byte[] vectorBytes) {
+    public static RealVector vectorFromBytes(final VectorEncodingConfig config, final byte[] vectorBytes) {
         final byte vectorTypeOrdinal = vectorBytes[0];
         return switch (RealVector.fromVectorTypeOrdinal(vectorTypeOrdinal)) {
             case RABITQ -> {

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/common/StorageHelpers.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/common/StorageHelpers.java
@@ -38,6 +38,7 @@ import com.google.common.collect.ImmutableList;
 
 import org.jspecify.annotations.Nullable;
 import java.util.List;
+import java.util.Objects;
 import java.util.SplittableRandom;
 import java.util.concurrent.CompletableFuture;
 
@@ -110,7 +111,10 @@ public final class StorageHelpers {
                             ? vector.partialVector() : partialVector.add(vector.partialVector());
             partialCount += vector.partialCount();
         }
-        return partialCount == 0 ? null : new AggregatedVector(partialCount, partialVector);
+        // partialCount != 0 implies the loop ran at least once (it starts at 0 and is only ever increased by
+        // vector.partialCount()), which in turn means partialVector was assigned a non-null value; NullAway
+        // cannot correlate the nullness of two different locals like this.
+        return partialCount == 0 ? null : new AggregatedVector(partialCount, Objects.requireNonNull(partialVector));
     }
 
     /**

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/common/StorageTransform.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/common/StorageTransform.java
@@ -27,8 +27,7 @@ import com.apple.foundationdb.linear.RealVector;
 import com.apple.foundationdb.linear.VectorOperator;
 import com.apple.foundationdb.rabitq.EncodedRealVector;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A special operator that is used to rotate, translate, and potentially normalize vectors. This operator is used
@@ -40,7 +39,6 @@ public class StorageTransform implements VectorOperator {
     private static final StorageTransform IDENTITY_STORAGE_TRANSFORM =
             new StorageTransform(null, null, false);
 
-    @Nonnull
     private final AffineOperator affineOperator;
     private final boolean normalizeVectors;
 
@@ -56,9 +54,8 @@ public class StorageTransform implements VectorOperator {
         return affineOperator.getNumDimensions();
     }
 
-    @Nonnull
     @Override
-    public RealVector apply(@Nonnull final RealVector vector) {
+    public RealVector apply(final RealVector vector) {
         //
         // Only transform the vector if it is needed. We make the decision based on whether the vector is encoded or
         // not. When we switch on encoding, we apply the new coordinate system from that point onwards meaning that all
@@ -73,9 +70,8 @@ public class StorageTransform implements VectorOperator {
         return affineOperator.apply(normalizeVectors ? vector.normalize() : vector);
     }
 
-    @Nonnull
     @Override
-    public RealVector invertedApply(@Nonnull final RealVector vector) {
+    public RealVector invertedApply(final RealVector vector) {
         //
         // Only invertApply(.) the vector, do not also un-normalize (which is impossible to do as we don't have the
         // original L2-norm stored anywhere) using the following reasoning:
@@ -89,7 +85,6 @@ public class StorageTransform implements VectorOperator {
         return affineOperator.invertedApply(vector);
     }
 
-    @Nonnull
     public static StorageTransform identity() {
         return IDENTITY_STORAGE_TRANSFORM;
     }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/common/TimedAsyncIterable.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/common/TimedAsyncIterable.java
@@ -23,7 +23,6 @@ package com.apple.foundationdb.async.common;
 import com.apple.foundationdb.async.AsyncIterable;
 import com.apple.foundationdb.async.AsyncIterator;
 
-import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -63,22 +62,19 @@ public final class TimedAsyncIterable {
      *
      * @return a timing wrapper around {@code iterable}
      */
-    @Nonnull
-    public static <T> AsyncIterable<T> wrap(@Nonnull final AsyncIterable<T> iterable,
-                                            @Nonnull final LongConsumer elapsedNanosConsumer) {
+    public static <T> AsyncIterable<T> wrap(final AsyncIterable<T> iterable,
+                                            final LongConsumer elapsedNanosConsumer) {
         return new TimedIterable<>(iterable, elapsedNanosConsumer);
     }
 
-    private record TimedIterable<T>(@Nonnull AsyncIterable<T> delegate, @Nonnull LongConsumer elapsedNanosConsumer)
+    private record TimedIterable<T>(AsyncIterable<T> delegate, LongConsumer elapsedNanosConsumer)
             implements AsyncIterable<T> {
 
-        @Nonnull
         @Override
         public AsyncIterator<T> iterator() {
             return new TimedAsyncIterator<>(delegate.iterator(), elapsedNanosConsumer);
         }
 
-        @Nonnull
         @Override
         public CompletableFuture<List<T>> asList() {
             final long startNanos = System.nanoTime();
@@ -88,17 +84,13 @@ public final class TimedAsyncIterable {
     }
 
     private static final class TimedAsyncIterator<T> implements AsyncIterator<T> {
-        @Nonnull
         private final AsyncIterator<T> delegate;
-        @Nonnull
         private final LongConsumer elapsedNanosConsumer;
-        @Nonnull
         private final AtomicLong elapsedNanos = new AtomicLong();
-        @Nonnull
         private final AtomicBoolean reported = new AtomicBoolean();
 
-        private TimedAsyncIterator(@Nonnull final AsyncIterator<T> delegate,
-                                   @Nonnull final LongConsumer elapsedNanosConsumer) {
+        private TimedAsyncIterator(final AsyncIterator<T> delegate,
+                                   final LongConsumer elapsedNanosConsumer) {
             this.delegate = delegate;
             this.elapsedNanosConsumer = elapsedNanosConsumer;
         }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/common/TopK.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/common/TopK.java
@@ -24,7 +24,6 @@ import com.apple.foundationdb.async.AsyncIterable;
 import com.apple.foundationdb.async.AsyncIterator;
 import com.google.common.collect.ImmutableList;
 
-import javax.annotation.Nonnull;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -44,12 +43,11 @@ import static com.apple.foundationdb.async.AsyncUtil.forEachRemaining;
  * @param <T> the type of element collected
  */
 public class TopK<T> {
-    @Nonnull
     private final PriorityQueue<T> queue;
     @SuppressWarnings("checkstyle:MemberName")
     private final int k;
 
-    private TopK(@Nonnull final Comparator<T> comparator, final int k) {
+    private TopK(final Comparator<T> comparator, final int k) {
         this.queue = new PriorityQueue<>(comparator);
         this.k = k;
     }
@@ -62,7 +60,7 @@ public class TopK<T> {
      *
      * @return {@code true} if the element was retained, {@code false} if it was rejected
      */
-    public boolean add(@Nonnull T item) {
+    public boolean add(T item) {
         if (queue.size() < k) {
             return queue.add(item);
         }
@@ -83,7 +81,6 @@ public class TopK<T> {
      *
      * @return the retained elements, unordered
      */
-    @Nonnull
     public List<T> toUnsortedList() {
         return ImmutableList.copyOf(queue);
     }
@@ -109,7 +106,6 @@ public class TopK<T> {
      *
      * @return the worst retained element, or {@link Optional#empty()} if the collector is empty
      */
-    @Nonnull
     public Optional<T> worstElement() {
         if (queue.isEmpty()) {
             return Optional.empty();
@@ -126,7 +122,6 @@ public class TopK<T> {
      *
      * @return a future completing with the retained top-K elements, sorted from best to worst
      */
-    @Nonnull
     public CompletableFuture<List<T>> collect(final AsyncIterable<T> iterable,
                                               final Executor executor) {
         return collectRemaining(iterable.iterator(), executor);
@@ -156,8 +151,7 @@ public class TopK<T> {
      *
      * @return a new collector retaining the k smallest elements
      */
-    @Nonnull
-    public static <T> TopK<T> min(@Nonnull final Comparator<T> comparator, final int k) {
+    public static <T> TopK<T> min(final Comparator<T> comparator, final int k) {
         return new TopK<>(comparator.reversed(), k);
     }
 
@@ -171,8 +165,7 @@ public class TopK<T> {
      *
      * @return a new collector retaining the k largest elements
      */
-    @Nonnull
-    public static <T> TopK<T> max(@Nonnull final Comparator<T> comparator, final int k) {
+    public static <T> TopK<T> max(final Comparator<T> comparator, final int k) {
         return new TopK<>(comparator, k);
     }
 }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/common/VectorEncodingConfig.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/common/VectorEncodingConfig.java
@@ -22,7 +22,6 @@ package com.apple.foundationdb.async.common;
 
 import com.apple.foundationdb.linear.Metric;
 
-import javax.annotation.Nonnull;
 
 /**
  * The minimal vector-encoding configuration shared by the HNSW and Guardiann configs: the metric, the number of
@@ -33,7 +32,6 @@ public interface VectorEncodingConfig {
     /**
      * The metric that is used to determine distances between vectors.
      */
-    @Nonnull
     Metric metric();
 
     /**

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/common/package-info.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/common/package-info.java
@@ -21,4 +21,7 @@
 /**
  * Common logic for all kinds of structures for effectively searching, retrieving and managing vectors.
  */
+@NullMarked
 package com.apple.foundationdb.async.common;
+
+import org.jspecify.annotations.NullMarked;

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/AbstractDeferredTask.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/AbstractDeferredTask.java
@@ -35,8 +35,7 @@ import com.google.common.collect.Maps;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import org.slf4j.Logger;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
@@ -63,13 +62,9 @@ import java.util.concurrent.CompletableFuture;
  * actual maintenance work.
  */
 abstract class AbstractDeferredTask {
-    @Nonnull
     private final Locator locator;
-    @Nonnull
     private final AccessInfo accessInfo;
-    @Nonnull
     private final UUID taskId;
-    @Nonnull
     private final Set<UUID> targetClusterIds;
 
     /**
@@ -83,10 +78,10 @@ abstract class AbstractDeferredTask {
      * @param taskId the id under which this task is stored in the queue; its high bit encodes scheduling priority
      * @param targetClusterId the cluster ids this task operates on (defensively copied)
      */
-    AbstractDeferredTask(@Nonnull final Locator locator,
-                         @Nonnull final AccessInfo accessInfo,
-                         @Nonnull final UUID taskId,
-                         @Nonnull final Set<UUID> targetClusterId) {
+    AbstractDeferredTask(final Locator locator,
+                         final AccessInfo accessInfo,
+                         final UUID taskId,
+                         final Set<UUID> targetClusterId) {
         this.locator = locator;
         this.accessInfo = accessInfo;
         this.taskId = taskId;
@@ -98,7 +93,6 @@ abstract class AbstractDeferredTask {
      *
      * @return the locator
      */
-    @Nonnull
     public Locator getLocator() {
         return locator;
     }
@@ -108,7 +102,6 @@ abstract class AbstractDeferredTask {
      *
      * @return the primitives for the underlying structure
      */
-    @Nonnull
     Primitives primitives() {
         return getLocator().primitives();
     }
@@ -118,7 +111,6 @@ abstract class AbstractDeferredTask {
      *
      * @return the on-write listener
      */
-    @Nonnull
     OnWriteListener getOnWriteListener() {
         return getLocator().getOnWriteListener();
     }
@@ -128,7 +120,6 @@ abstract class AbstractDeferredTask {
      *
      * @return the on-read listener
      */
-    @Nonnull
     OnReadListener getOnReadListener() {
         return getLocator().getOnReadListener();
     }
@@ -140,7 +131,6 @@ abstract class AbstractDeferredTask {
      *
      * @return the access context
      */
-    @Nonnull
     AccessInfo getAccessInfo() {
         return accessInfo;
     }
@@ -151,7 +141,6 @@ abstract class AbstractDeferredTask {
      *
      * @return the task id
      */
-    @Nonnull
     public UUID getTaskId() {
         return taskId;
     }
@@ -161,7 +150,6 @@ abstract class AbstractDeferredTask {
      *
      * @return the immutable set of target cluster ids
      */
-    @Nonnull
     public Set<UUID> getTargetClusterIds() {
         return targetClusterIds;
     }
@@ -171,7 +159,6 @@ abstract class AbstractDeferredTask {
      *
      * @return the configuration
      */
-    @Nonnull
     public Config getConfig() {
         return getLocator().getConfig();
     }
@@ -183,7 +170,6 @@ abstract class AbstractDeferredTask {
      *
      * @return the value tuple to persist for this task
      */
-    @Nonnull
     public abstract Tuple valueTuple();
 
     /**
@@ -193,8 +179,7 @@ abstract class AbstractDeferredTask {
      *
      * @return a future that completes when the task has finished
      */
-    @Nonnull
-    public abstract CompletableFuture<Void> runTask(@Nonnull Transaction transaction);
+    public abstract CompletableFuture<Void> runTask(Transaction transaction);
 
     /**
      * Emits a debug log line marking the start of this task's execution (kind, id, targets). A no-op unless debug
@@ -202,7 +187,7 @@ abstract class AbstractDeferredTask {
      *
      * @param logger the subclass logger to emit through
      */
-    protected void logStart(@Nonnull final Logger logger) {
+    protected void logStart(final Logger logger) {
         if (logger.isDebugEnabled()) {
             logger.debug("executing task kind={}, taskId={}, targetClusterIds={}", getKind(), taskIdToString(getTaskId()),
                     getTargetClusterIds());
@@ -214,7 +199,7 @@ abstract class AbstractDeferredTask {
      *
      * @param logger the subclass logger to emit through
      */
-    protected void logSuccessful(@Nonnull final Logger logger) {
+    protected void logSuccessful(final Logger logger) {
         if (logger.isDebugEnabled()) {
             logger.debug("successfully finished executing task kind={}, taskId={}", getKind(),
                     taskIdToString(getTaskId()));
@@ -226,7 +211,7 @@ abstract class AbstractDeferredTask {
      *
      * @param transaction the transaction to write the task within
      */
-    protected void writeDeferredTask(@Nonnull final Transaction transaction) {
+    protected void writeDeferredTask(final Transaction transaction) {
         primitives().writeDeferredTask(transaction, this.getTaskId(), valueTuple());
         getOnWriteListener().onTaskEnqueued(this.getKind(), this.getTaskId(), this.getTargetClusterIds());
     }
@@ -237,7 +222,6 @@ abstract class AbstractDeferredTask {
      *
      * @return this task's kind
      */
-    @Nonnull
     public abstract TaskKind getKind();
 
     /**
@@ -261,11 +245,11 @@ abstract class AbstractDeferredTask {
      * @param centroid the target cluster's centroid, carried to the collapse task
      * @return {@code true} if a collapse (and bounce) were enqueued, {@code false} if the cluster was below threshold
      */
-    boolean enqueueCollapseIfNecessary(@Nonnull final Transaction transaction,
-                                       @Nonnull final SplittableRandom random,
-                                       @Nonnull final List<VectorReference> primaryVectorReferences,
-                                       @Nonnull final UUID targetClusterId,
-                                       @Nonnull final Transformed<RealVector> centroid) {
+    boolean enqueueCollapseIfNecessary(final Transaction transaction,
+                                       final SplittableRandom random,
+                                       final List<VectorReference> primaryVectorReferences,
+                                       final UUID targetClusterId,
+                                       final Transformed<RealVector> centroid) {
         final Config config = getConfig();
         final Map<UUID, Integer> collapsibleVectorsCountersMap =
                 CollapseTask.collapsibleVectorsCountersMap(primaryVectorReferences);
@@ -301,10 +285,9 @@ abstract class AbstractDeferredTask {
      * @param valueTuple the task's stored value tuple (its kind plus payload)
      * @return the reconstructed task
      */
-    @Nonnull
-    static AbstractDeferredTask newFromTuples(@Nonnull final Locator locator,
-                                              @Nonnull final AccessInfo accessInfo,
-                                              @Nonnull final Tuple keyTuple, @Nonnull final Tuple valueTuple) {
+    static AbstractDeferredTask newFromTuples(final Locator locator,
+                                              final AccessInfo accessInfo,
+                                              final Tuple keyTuple, final Tuple valueTuple) {
         final TaskKind kind = TaskKind.fromValueTuple(valueTuple);
         return kind.create(locator, accessInfo, keyTuple, valueTuple);
     }
@@ -318,8 +301,7 @@ abstract class AbstractDeferredTask {
      *
      * @return a high-priority task id
      */
-    @Nonnull
-    protected static UUID randomHighPriorityTaskId(@Nonnull final SplittableRandom random, final boolean isDeterministic) {
+    protected static UUID randomHighPriorityTaskId(final SplittableRandom random, final boolean isDeterministic) {
         return uuidToHighPriorityTaskId(isDeterministic ? RandomHelpers.randomUuid(random) : UUID.randomUUID());
     }
 
@@ -330,8 +312,7 @@ abstract class AbstractDeferredTask {
      * @param uuid the base uuid
      * @return the high-priority task id
      */
-    @Nonnull
-    private static UUID uuidToHighPriorityTaskId(@Nonnull final UUID uuid) {
+    private static UUID uuidToHighPriorityTaskId(final UUID uuid) {
         return new UUID(uuid.getMostSignificantBits() & 0x7fffffffffffffffL,
                 uuid.getLeastSignificantBits());
     }
@@ -345,8 +326,7 @@ abstract class AbstractDeferredTask {
      *
      * @return a normal-priority task id
      */
-    @Nonnull
-    protected static UUID randomNormalPriorityTaskId(@Nonnull final SplittableRandom random, final boolean isDeterministic) {
+    protected static UUID randomNormalPriorityTaskId(final SplittableRandom random, final boolean isDeterministic) {
         return uuidToNormalPriorityTaskId(isDeterministic ? RandomHelpers.randomUuid(random) : UUID.randomUUID());
     }
 
@@ -357,8 +337,7 @@ abstract class AbstractDeferredTask {
      * @param uuid the base uuid
      * @return the normal-priority task id
      */
-    @Nonnull
-    private static UUID uuidToNormalPriorityTaskId(@Nonnull final UUID uuid) {
+    private static UUID uuidToNormalPriorityTaskId(final UUID uuid) {
         return new UUID(uuid.getMostSignificantBits() | 0x8000000000000000L,
                 uuid.getLeastSignificantBits());
     }
@@ -370,8 +349,7 @@ abstract class AbstractDeferredTask {
      * @param taskId the task id
      * @return a human-readable, priority-prefixed rendering
      */
-    @Nonnull
-    static String taskIdToString(@Nonnull final UUID taskId) {
+    static String taskIdToString(final UUID taskId) {
         return (isNormalPriority(taskId) ? "NORMAL" : "HIGH") + ":" + taskId;
     }
 
@@ -382,7 +360,7 @@ abstract class AbstractDeferredTask {
      * @param taskId the task id to test
      * @return {@code true} if the id is normal priority, {@code false} if high priority
      */
-    static boolean isNormalPriority(@Nonnull final UUID taskId) {
+    static boolean isNormalPriority(final UUID taskId) {
         return (taskId.getMostSignificantBits() & 0x8000000000000000L) != 0;
     }
 
@@ -396,7 +374,7 @@ abstract class AbstractDeferredTask {
      * @return the incremented counter value
      */
     @CanIgnoreReturnValue
-    static <T> int incrementCounter(@Nonnull final Map<T, Integer> countersMap, @Nonnull final T key) {
+    static <T> int incrementCounter(final Map<T, Integer> countersMap, final T key) {
         return  countersMap.compute(key, (ignoredKey, oldCounter) -> {
             if (oldCounter == null) {
                 return 1;
@@ -417,8 +395,8 @@ abstract class AbstractDeferredTask {
      */
     @CanIgnoreReturnValue
     static <T> RunningStats
-               updateRunningStatsMap(@Nonnull final Map<T, RunningStats> map,
-                                     @Nonnull final T key, final double distance) {
+               updateRunningStatsMap(final Map<T, RunningStats> map,
+                                     final T key, final double distance) {
         return map.compute(key, (ignoredKey, old) -> {
             if (old == null) {
                 return RunningStats.of(distance);
@@ -437,9 +415,8 @@ abstract class AbstractDeferredTask {
      * @param newAssignments the new vector references that should be in the cluster
      * @return the delta of writes and deletes
      */
-    @Nonnull
-    static TargetClusterDelta computeTargetClusterDelta(@Nonnull final Cluster targetCluster,
-                                                        @Nonnull final List<VectorReference> newAssignments) {
+    static TargetClusterDelta computeTargetClusterDelta(final Cluster targetCluster,
+                                                        final List<VectorReference> newAssignments) {
         final ImmutableMap.Builder<Tuple, VectorReference> assignedByPrimaryKeyBuilder = ImmutableMap.builder();
         for (final VectorReference assignedVector : newAssignments) {
             assignedByPrimaryKeyBuilder.put(assignedVector.id().primaryKey(), assignedVector);
@@ -491,8 +468,8 @@ abstract class AbstractDeferredTask {
      * @param toWrite the vector references to write to the cluster
      * @param toDelete the primary keys of vectors to delete from the cluster
      */
-    record TargetClusterDelta(@Nonnull List<VectorReference> toWrite,
-                              @Nonnull List<Tuple> toDelete) {
+    record TargetClusterDelta(List<VectorReference> toWrite,
+                              List<Tuple> toDelete) {
     }
 
     /**
@@ -512,10 +489,9 @@ abstract class AbstractDeferredTask {
      * @param candidateClusters all clusters (new + outer) that vectors may be assigned to
      * @return the nearest cluster assignments and accumulated standard deviation updates
      */
-    @Nonnull
-    static NearestClustersResult computeNearestClusters(@Nonnull final DistanceEstimator estimator,
-                                                        @Nonnull final List<VectorReference> vectorReferences,
-                                                        @Nonnull final Collection<ClusterMetadataWithDistance> candidateClusters) {
+    static NearestClustersResult computeNearestClusters(final DistanceEstimator estimator,
+                                                        final List<VectorReference> vectorReferences,
+                                                        final Collection<ClusterMetadataWithDistance> candidateClusters) {
         final ImmutableListMultimap.Builder<VectorId, ClusterMetadataWithDistance> invertedAssignmentsMapBuilder =
                 ImmutableListMultimap.builder();
         final Map<UUID, RunningStats> standardDeviationUpdates = Maps.newHashMap();
@@ -556,8 +532,8 @@ abstract class AbstractDeferredTask {
      * @param target the mutable map to merge into
      * @param updates the updates to merge (as returned by {@link #computeNearestClusters})
      */
-    static void mergeStandardDeviationUpdates(@Nonnull final Map<UUID, RunningStats> target,
-                                              @Nonnull final Map<UUID, RunningStats> updates) {
+    static void mergeStandardDeviationUpdates(final Map<UUID, RunningStats> target,
+                                              final Map<UUID, RunningStats> updates) {
         for (final Map.Entry<UUID, RunningStats> entry : updates.entrySet()) {
             target.merge(entry.getKey(), entry.getValue(), RunningStats::combine);
         }
@@ -587,9 +563,9 @@ abstract class AbstractDeferredTask {
      *         target) never get {@code null} and should {@link java.util.Objects#requireNonNull(Object) requireNonNull}.
      */
     @Nullable
-    static ClusterClassification classifyClusters(@Nonnull final List<ClusterMetadataWithDistance> clusterMetadataWithDistances,
-                                                  @Nonnull final ClusterMetadata targetClusterMetadata,
-                                                  @Nonnull final Transformed<RealVector> targetClusterCentroid,
+    static ClusterClassification classifyClusters(final List<ClusterMetadataWithDistance> clusterMetadataWithDistances,
+                                                  final ClusterMetadata targetClusterMetadata,
+                                                  final Transformed<RealVector> targetClusterCentroid,
                                                   final int numCoreClusters,
                                                   final int numNeighboringClusters) {
         Verify.verify(numCoreClusters >= 1, "numCoreClusters must be >= 1, got %s", numCoreClusters);
@@ -643,8 +619,8 @@ abstract class AbstractDeferredTask {
      * @param invertedAssignments a multimap from vector id to its nearest clusters, in ascending distance order
      * @param standardDeviationUpdates a map from cluster id to the running statistics update for that cluster
      */
-    record NearestClustersResult(@Nonnull ImmutableListMultimap<VectorId, ClusterMetadataWithDistance> invertedAssignments,
-                                 @Nonnull Map<UUID, RunningStats> standardDeviationUpdates) {
+    record NearestClustersResult(ImmutableListMultimap<VectorId, ClusterMetadataWithDistance> invertedAssignments,
+                                 Map<UUID, RunningStats> standardDeviationUpdates) {
     }
 
     /**
@@ -655,7 +631,7 @@ abstract class AbstractDeferredTask {
      * @param coreClusters the closest clusters, to be dissolved or repartitioned
      * @param neighboringClusters the surrounding clusters that may receive overflow vectors
      */
-    record ClusterClassification(@Nonnull List<ClusterMetadataWithDistance> coreClusters,
-                                 @Nonnull List<ClusterMetadataWithDistance> neighboringClusters) {
+    record ClusterClassification(List<ClusterMetadataWithDistance> coreClusters,
+                                 List<ClusterMetadataWithDistance> neighboringClusters) {
     }
 }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/AccessInfo.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/AccessInfo.java
@@ -25,8 +25,7 @@ import com.apple.foundationdb.linear.AffineOperator;
 import com.apple.foundationdb.linear.FhtKacRotator;
 import com.apple.foundationdb.linear.RealVector;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.Objects;
 
 /**
@@ -69,7 +68,6 @@ record AccessInfo(long rotatorSeed, @Nullable RealVector negatedCentroid) {
      * before accessing this field.
      * @return a vector which is the negated centroid used for translation
      */
-    @Nonnull
     public RealVector negatedCentroid() {
         return Objects.requireNonNull(negatedCentroid);
     }
@@ -85,7 +83,6 @@ record AccessInfo(long rotatorSeed, @Nullable RealVector negatedCentroid) {
         return negatedCentroid != null;
     }
 
-    @Nonnull
     @Override
     public String toString() {
         return "AccessInfo[" +

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/AlmostSortedAsyncIterator.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/AlmostSortedAsyncIterator.java
@@ -25,7 +25,6 @@ import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.async.CloseableAsyncIterator;
 import com.apple.foundationdb.async.MoreAsyncUtil;
 
-import javax.annotation.Nonnull;
 import java.util.Comparator;
 import java.util.NoSuchElementException;
 import java.util.Objects;
@@ -51,22 +50,19 @@ import java.util.concurrent.Executor;
  * @param <T> the type of element produced
  */
 class AlmostSortedAsyncIterator<T> implements CloseableAsyncIterator<T> {
-    @Nonnull
     private final AsyncIterator<T> in;
     private final int maxQueueSize;
-    @Nonnull
     private final PriorityQueue<T> out;
 
-    @Nonnull
     private final Executor executor;
 
     private CompletableFuture<T> nextFuture;
     private boolean inDone;
 
-    public AlmostSortedAsyncIterator(@Nonnull final AsyncIterator<T> in,
-                                     @Nonnull Comparator<T> comparator,
+    public AlmostSortedAsyncIterator(final AsyncIterator<T> in,
+                                     Comparator<T> comparator,
                                      final int maxQueueSize,
-                                     @Nonnull final Executor executor) {
+                                     final Executor executor) {
         this.in = in;
         this.maxQueueSize = maxQueueSize;
         this.out = new PriorityQueue<>(comparator);
@@ -83,7 +79,6 @@ class AlmostSortedAsyncIterator<T> implements CloseableAsyncIterator<T> {
         return nextFuture.thenApply(Objects::nonNull);
     }
 
-    @Nonnull
     private CompletableFuture<T> computeNextRecord() {
         return AsyncUtil.whileTrue(() -> {
             if (inDone || out.size() >= maxQueueSize) {

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/AlmostSortedAsyncIterator.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/AlmostSortedAsyncIterator.java
@@ -25,6 +25,8 @@ import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.async.CloseableAsyncIterator;
 import com.apple.foundationdb.async.MoreAsyncUtil;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.Comparator;
 import java.util.NoSuchElementException;
 import java.util.Objects;
@@ -56,6 +58,7 @@ class AlmostSortedAsyncIterator<T> implements CloseableAsyncIterator<T> {
 
     private final Executor executor;
 
+    @Nullable
     private CompletableFuture<T> nextFuture;
     private boolean inDone;
 

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/BounceTask.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/BounceTask.java
@@ -36,8 +36,7 @@ import com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
@@ -68,33 +67,27 @@ import java.util.concurrent.Executor;
  * remain, the bounce enqueues its follow-up work (see {@link #enqueueFollowUpTasks}).
  */
 class BounceTask extends AbstractDeferredTask {
-    @Nonnull
     private static final Logger logger = LoggerFactory.getLogger(BounceTask.class);
 
-    @Nonnull
     private final Set<UUID> dependentTaskIds;
-    @Nonnull
     private final TaskKind finalTaskKind;
 
-    private BounceTask(@Nonnull final Locator locator, @Nonnull final AccessInfo accessInfo,
-                       @Nonnull final UUID taskId, @Nonnull final Set<UUID> targetClusterIds,
-                       @Nonnull final Set<UUID> dependentTaskIds, @Nonnull final TaskKind finalTaskKind) {
+    private BounceTask(final Locator locator, final AccessInfo accessInfo,
+                       final UUID taskId, final Set<UUID> targetClusterIds,
+                       final Set<UUID> dependentTaskIds, final TaskKind finalTaskKind) {
         super(locator, accessInfo, taskId, targetClusterIds);
         this.dependentTaskIds = ImmutableSet.copyOf(dependentTaskIds);
         this.finalTaskKind = finalTaskKind;
     }
 
-    @Nonnull
     Set<UUID> getDependentTaskIds() {
         return dependentTaskIds;
     }
 
-    @Nonnull
     TaskKind getFinalTaskKind() {
         return finalTaskKind;
     }
 
-    @Nonnull
     @Override
     public Tuple valueTuple() {
         return Tuple.from(getKind().getCode(), StorageAdapter.tupleFromClusterIds(getTargetClusterIds()),
@@ -102,7 +95,7 @@ class BounceTask extends AbstractDeferredTask {
     }
 
     @Override
-    protected void writeDeferredTask(@Nonnull final Transaction transaction) {
+    protected void writeDeferredTask(final Transaction transaction) {
         super.writeDeferredTask(transaction);
         if (logger.isDebugEnabled()) {
             logger.debug("enqueuing BOUNCE; taskId={}; targetClusterIds={}; newDependentTaskIds={}",
@@ -110,15 +103,13 @@ class BounceTask extends AbstractDeferredTask {
         }
     }
 
-    @Nonnull
     @Override
     public TaskKind getKind() {
         return TaskKind.BOUNCE;
     }
 
-    @Nonnull
     @Override
-    public CompletableFuture<Void> runTask(@Nonnull final Transaction transaction) {
+    public CompletableFuture<Void> runTask(final Transaction transaction) {
         logStart(logger);
         final SplittableRandom splittableRandom = RandomHelpers.random(getTaskId());
 
@@ -216,9 +207,8 @@ class BounceTask extends AbstractDeferredTask {
      * @return a future that completes once the follow-up tasks have been enqueued
      */
     @SuppressWarnings("checkstyle:Indentation")
-    @Nonnull
-    private CompletableFuture<Void> enqueueFollowUpTasks(@Nonnull final Transaction transaction,
-                                                         @Nonnull final SplittableRandom random) {
+    private CompletableFuture<Void> enqueueFollowUpTasks(final Transaction transaction,
+                                                         final SplittableRandom random) {
         final Primitives primitives = getLocator().primitives();
         final Executor executor = getLocator().getExecutor();
         final HNSW centroidsHnsw = primitives.getClusterCentroidsHnsw();
@@ -262,12 +252,12 @@ class BounceTask extends AbstractDeferredTask {
      * @param resultEntry the cluster's centroid entry fetched from the centroid HNSW, or {@code null} if it is gone
      * @param targetClusterMetadata the cluster's current metadata
      */
-    private void enqueueFollowUpTaskForCluster(@Nonnull final Transaction transaction,
-                                               @Nonnull final UUID targetClusterId,
-                                               @Nonnull final SplittableRandom random,
-                                               @Nonnull final StorageTransform storageTransform,
+    private void enqueueFollowUpTaskForCluster(final Transaction transaction,
+                                               final UUID targetClusterId,
+                                               final SplittableRandom random,
+                                               final StorageTransform storageTransform,
                                                @Nullable final ResultEntry resultEntry,
-                                               @Nonnull final ClusterMetadata targetClusterMetadata) {
+                                               final ClusterMetadata targetClusterMetadata) {
         if (resultEntry == null) {
             // Centroid gone: the target cluster was deleted before this bounce ran its follow-up (see javadoc).
             if (logger.isDebugEnabled()) {
@@ -312,9 +302,8 @@ class BounceTask extends AbstractDeferredTask {
         }
     }
 
-    @Nonnull
-    static BounceTask fromTuples(@Nonnull final Locator locator, @Nonnull final AccessInfo accessInfo,
-                                 @Nonnull final Tuple keyTuple, @Nonnull final Tuple valueTuple) {
+    static BounceTask fromTuples(final Locator locator, final AccessInfo accessInfo,
+                                 final Tuple keyTuple, final Tuple valueTuple) {
         Verify.verify(TaskKind.fromValueTuple(valueTuple) == TaskKind.BOUNCE);
 
         final Set<UUID> targetClusterIds = StorageAdapter.clusterIdsFromTuple(valueTuple.getNestedTuple(1));
@@ -324,10 +313,9 @@ class BounceTask extends AbstractDeferredTask {
                 targetClusterIds, dependentTaskIds, finalTaskKind);
     }
 
-    @Nonnull
-    static BounceTask of(@Nonnull final Locator locator, @Nonnull final AccessInfo accessInfo,
-                         @Nonnull final UUID taskId, @Nonnull final Set<UUID> targetClusterIds,
-                         @Nonnull final Set<UUID> dependentTaskIds, @Nonnull final TaskKind finalTaskKind) {
+    static BounceTask of(final Locator locator, final AccessInfo accessInfo,
+                         final UUID taskId, final Set<UUID> targetClusterIds,
+                         final Set<UUID> dependentTaskIds, final TaskKind finalTaskKind) {
         return new BounceTask(locator, accessInfo, taskId, targetClusterIds, dependentTaskIds, finalTaskKind);
     }
 }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/Cluster.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/Cluster.java
@@ -23,7 +23,6 @@ package com.apple.foundationdb.async.guardiann;
 import com.apple.foundationdb.linear.RealVector;
 import com.apple.foundationdb.linear.Transformed;
 
-import javax.annotation.Nonnull;
 import java.util.List;
 
 /**
@@ -36,11 +35,10 @@ import java.util.List;
  * @param centroid the cluster's centroid in the transformed coordinate space
  * @param vectorReferences all vector references stored in this cluster (primary and replicated)
  */
-record Cluster(@Nonnull ClusterMetadata clusterMetadata,
-               @Nonnull Transformed<RealVector> centroid,
-               @Nonnull List<VectorReference> vectorReferences) {
+record Cluster(ClusterMetadata clusterMetadata,
+               Transformed<RealVector> centroid,
+               List<VectorReference> vectorReferences) {
     @Override
-    @Nonnull
     public String toString() {
         return "C[" + clusterMetadata + "]";
     }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/ClusterCapacityExceededException.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/ClusterCapacityExceededException.java
@@ -22,7 +22,6 @@ package com.apple.foundationdb.async.guardiann;
 
 import com.apple.foundationdb.util.LoggableException;
 
-import javax.annotation.Nonnull;
 import java.util.UUID;
 
 /**
@@ -36,7 +35,7 @@ import java.util.UUID;
  */
 @SuppressWarnings("serial")
 public class ClusterCapacityExceededException extends LoggableException {
-    public ClusterCapacityExceededException(@Nonnull final UUID clusterId, final int numPrimaryVectors,
+    public ClusterCapacityExceededException(final UUID clusterId, final int numPrimaryVectors,
                                             final int primaryClusterHardMax) {
         super("primary cluster reached its hard cap while the deferred split backlog is not being drained",
                 "clusterId", clusterId,

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/ClusterMetadata.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/ClusterMetadata.java
@@ -22,7 +22,6 @@ package com.apple.foundationdb.async.guardiann;
 
 import com.google.common.base.Preconditions;
 
-import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.Map;
@@ -44,11 +43,11 @@ import java.util.stream.Collectors;
  *        number of primary vectors
  * @param states the set of maintenance operations currently in flight for this cluster
  */
-record ClusterMetadata(@Nonnull UUID id, int numPrimaryUnderreplicatedVectors, int numReplicatedVectors,
-                       @Nonnull RunningStats runningStandardDeviation, @Nonnull EnumSet<State> states) {
-    public ClusterMetadata(@Nonnull final UUID id, final int numPrimaryUnderreplicatedVectors,
+record ClusterMetadata(UUID id, int numPrimaryUnderreplicatedVectors, int numReplicatedVectors,
+                       RunningStats runningStandardDeviation, EnumSet<State> states) {
+    public ClusterMetadata(final UUID id, final int numPrimaryUnderreplicatedVectors,
                            final int numReplicatedVectors,
-                           @Nonnull final RunningStats runningStandardDeviation, final int stateCode) {
+                           final RunningStats runningStandardDeviation, final int stateCode) {
         this(id, numPrimaryUnderreplicatedVectors, numReplicatedVectors, runningStandardDeviation,
                 State.ofCode(stateCode));
     }
@@ -77,35 +76,31 @@ record ClusterMetadata(@Nonnull UUID id, int numPrimaryUnderreplicatedVectors, i
         return result;
     }
 
-    @Nonnull
     public ClusterMetadata withNewVectors(final int numPrimaryUnderreplicatedVectors,
                                           final int numReplicatedVectors,
-                                          @Nonnull final RunningStats newStandardDeviation,
-                                          @Nonnull final EnumSet<State> states) {
+                                          final RunningStats newStandardDeviation,
+                                          final EnumSet<State> states) {
         final EnumSet<State> newStates = EnumSet.copyOf(states);
         return new ClusterMetadata(id(), numPrimaryUnderreplicatedVectors, numReplicatedVectors,
                 newStandardDeviation, newStates);
     }
 
-    @Nonnull
     public ClusterMetadata withAdditionalVectors(final int numPrimaryUnderreplicatedVectorsAdded,
                                                  final int numReplicatedVectorsAdded,
-                                                 @Nonnull final RunningStats newStandardDeviation) {
+                                                 final RunningStats newStandardDeviation) {
         return withAdditionalVectorsAndStates(numPrimaryUnderreplicatedVectorsAdded,
                 numReplicatedVectorsAdded, newStandardDeviation, EnumSet.noneOf(State.class));
     }
 
-    @Nonnull
-    public ClusterMetadata withNewStates(@Nonnull final EnumSet<State> newStates) {
+    public ClusterMetadata withNewStates(final EnumSet<State> newStates) {
         return new ClusterMetadata(id(), numPrimaryUnderreplicatedVectors(), numReplicatedVectors(),
                 runningStandardDeviation(), newStates);
     }
 
-    @Nonnull
     public ClusterMetadata withAdditionalVectorsAndStates(final int numPrimaryUnderreplicatedVectorsAdded,
                                                           final int numReplicatedVectorsAdded,
-                                                          @Nonnull final RunningStats newStandardDeviation,
-                                                          @Nonnull final EnumSet<State> additionalStates) {
+                                                          final RunningStats newStandardDeviation,
+                                                          final EnumSet<State> additionalStates) {
         final EnumSet<State> newStates = EnumSet.copyOf(states());
         newStates.addAll(additionalStates);
         return new ClusterMetadata(id(),
@@ -115,7 +110,6 @@ record ClusterMetadata(@Nonnull UUID id, int numPrimaryUnderreplicatedVectors, i
     }
 
     @Override
-    @Nonnull
     public String toString() {
         return "CM[id=" + id() +
                 ", numPrimaryVectors=" + getNumPrimaryVectors() +

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/ClusterMetadataWithDistance.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/ClusterMetadataWithDistance.java
@@ -23,7 +23,6 @@ package com.apple.foundationdb.async.guardiann;
 import com.apple.foundationdb.linear.RealVector;
 import com.apple.foundationdb.linear.Transformed;
 
-import javax.annotation.Nonnull;
 
 /**
  * A {@link ClusterMetadata} paired with its centroid and the distance from a reference point (typically the query
@@ -34,10 +33,9 @@ import javax.annotation.Nonnull;
  * @param centroid the transformed centroid of the cluster
  * @param distance the distance from the reference point to {@code centroid}
  */
-record ClusterMetadataWithDistance(@Nonnull ClusterMetadata clusterMetadata,
-                                   @Nonnull Transformed<RealVector> centroid,
+record ClusterMetadataWithDistance(ClusterMetadata clusterMetadata,
+                                   Transformed<RealVector> centroid,
                                    double distance) {
-    @Nonnull
     public ClusterMetadataWithDistance withNewDistance(final double newDistance) {
         return new ClusterMetadataWithDistance(clusterMetadata(), centroid(), newDistance);
     }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/ClusterReference.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/ClusterReference.java
@@ -24,8 +24,7 @@ import com.apple.foundationdb.linear.RealVector;
 import com.apple.foundationdb.linear.Transformed;
 import com.apple.foundationdb.util.Lens;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.List;
 import java.util.UUID;
 
@@ -37,17 +36,16 @@ import java.util.UUID;
  * @param clusterId the id of the referenced cluster
  * @param centroid the transformed centroid of the referenced cluster
  */
-record ClusterReference(@Nonnull UUID clusterId, @Nonnull Transformed<RealVector> centroid) {
+record ClusterReference(UUID clusterId, Transformed<RealVector> centroid) {
 
     static final Lens<ClusterMetadataWithDistance, ClusterReference> FROM_CLUSTER_METADATA_AND_DISTANCE =
             new Lens<>() {
                 @Override
-                public ClusterReference get(@Nonnull final ClusterMetadataWithDistance clusterMetadataWithDistance) {
+                public ClusterReference get(final ClusterMetadataWithDistance clusterMetadataWithDistance) {
                     return new ClusterReference(clusterMetadataWithDistance.clusterMetadata().id(),
                             clusterMetadataWithDistance.centroid());
                 }
 
-                @Nonnull
                 @Override
                 public ClusterMetadataWithDistance set(@Nullable final ClusterMetadataWithDistance clusterMetadataWithDistance,
                                                        @Nullable final ClusterReference clusterReference) {
@@ -64,8 +62,7 @@ record ClusterReference(@Nonnull UUID clusterId, @Nonnull Transformed<RealVector
      *
      * @return the projected references, one per input, in the same order
      */
-    @Nonnull
-    static List<ClusterReference> fromClusterMetadataAndDistances(@Nonnull List<ClusterMetadataWithDistance> clusterMetadataWithDistances) {
+    static List<ClusterReference> fromClusterMetadataAndDistances(List<ClusterMetadataWithDistance> clusterMetadataWithDistances) {
         return Lens.extract(FROM_CLUSTER_METADATA_AND_DISTANCE, clusterMetadataWithDistances);
     }
 }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/ClusterView.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/ClusterView.java
@@ -23,7 +23,6 @@ package com.apple.foundationdb.async.guardiann;
 import com.apple.foundationdb.linear.RealVector;
 import com.apple.foundationdb.linear.Transformed;
 
-import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -46,12 +45,12 @@ import java.util.UUID;
  * @param references every vector reference stored in the cluster (primaries, replicas and collapsed), retaining
  *        each reference's flags and stored {@code replicationPriority}
  */
-record ClusterView(@Nonnull UUID clusterId,
-                   @Nonnull RealVector centroid,
-                   @Nonnull Transformed<RealVector> transformedCentroid,
-                   @Nonnull ClusterMetadata metadata,
-                   @Nonnull Set<VectorId> primaries,
-                   @Nonnull Set<VectorId> replicas,
-                   @Nonnull Set<VectorId> collapsedRefs,
-                   @Nonnull List<VectorReference> references) {
+record ClusterView(UUID clusterId,
+                   RealVector centroid,
+                   Transformed<RealVector> transformedCentroid,
+                   ClusterMetadata metadata,
+                   Set<VectorId> primaries,
+                   Set<VectorId> replicas,
+                   Set<VectorId> collapsedRefs,
+                   List<VectorReference> references) {
 }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/CollapseTask.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/CollapseTask.java
@@ -42,7 +42,6 @@ import com.google.common.collect.Maps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
 import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.List;
@@ -83,30 +82,25 @@ import java.util.concurrent.CompletableFuture;
  * occur naturally when the cluster was merged away or otherwise re-tasked between this task being enqueued and run.
  */
 class CollapseTask extends AbstractDeferredTask {
-    @Nonnull
     private static final Logger logger = LoggerFactory.getLogger(CollapseTask.class);
 
-    @Nonnull
     private final Transformed<RealVector> centroid;
 
-    private CollapseTask(@Nonnull final Locator locator, @Nonnull final AccessInfo accessInfo,
-                         @Nonnull final UUID taskId, @Nonnull final UUID targetClusterId,
-                         @Nonnull final Transformed<RealVector> centroid) {
+    private CollapseTask(final Locator locator, final AccessInfo accessInfo,
+                         final UUID taskId, final UUID targetClusterId,
+                         final Transformed<RealVector> centroid) {
         super(locator, accessInfo, taskId, ImmutableSet.of(targetClusterId));
         this.centroid = centroid;
     }
 
-    @Nonnull
     public Transformed<RealVector> getCentroid() {
         return centroid;
     }
 
-    @Nonnull
     public UUID getTargetClusterId() {
         return Iterables.getOnlyElement(getTargetClusterIds());
     }
 
-    @Nonnull
     @Override
     public Tuple valueTuple() {
         final Quantizer quantizer = getLocator().primitives().quantizer(getAccessInfo());
@@ -117,7 +111,7 @@ class CollapseTask extends AbstractDeferredTask {
     }
 
     @Override
-    protected void writeDeferredTask(@Nonnull final Transaction transaction) {
+    protected void writeDeferredTask(final Transaction transaction) {
         super.writeDeferredTask(transaction);
         if (logger.isDebugEnabled()) {
             logger.debug("enqueuing COLLAPSE; taskId={}; targetClusterIds={}",
@@ -125,15 +119,13 @@ class CollapseTask extends AbstractDeferredTask {
         }
     }
 
-    @Nonnull
     @Override
     public TaskKind getKind() {
         return TaskKind.COLLAPSE;
     }
 
-    @Nonnull
     @Override
-    public CompletableFuture<Void> runTask(@Nonnull final Transaction transaction) {
+    public CompletableFuture<Void> runTask(final Transaction transaction) {
         logStart(logger);
 
         final Primitives primitives = getLocator().primitives();
@@ -161,10 +153,9 @@ class CollapseTask extends AbstractDeferredTask {
                 }).thenAccept(ignored -> logSuccessful(logger));
     }
 
-    @Nonnull
-    private CompletableFuture<Void> collapse(@Nonnull final Transaction transaction,
-                                             @Nonnull final ClusterMetadata targetClusterMetadata,
-                                             @Nonnull final RealVector targetClusterCentroid) {
+    private CompletableFuture<Void> collapse(final Transaction transaction,
+                                             final ClusterMetadata targetClusterMetadata,
+                                             final RealVector targetClusterCentroid) {
         final Primitives primitives = getLocator().primitives();
         final AccessInfo accessInfo = getAccessInfo();
         final StorageTransform storageTransform = primitives.storageTransform(accessInfo);
@@ -193,11 +184,10 @@ class CollapseTask extends AbstractDeferredTask {
                 });
     }
 
-    @Nonnull
-    private CollapseAssignments computeCollapseAssignments(@Nonnull final SplittableRandom random,
-                                                           @Nonnull final DistanceEstimator estimator,
-                                                           @Nonnull final ClusterMetadataWithDistance targetClusterMetadataWithDistance,
-                                                           @Nonnull final List<VectorReference> vectorReferences) {
+    private CollapseAssignments computeCollapseAssignments(final SplittableRandom random,
+                                                           final DistanceEstimator estimator,
+                                                           final ClusterMetadataWithDistance targetClusterMetadataWithDistance,
+                                                           final List<VectorReference> vectorReferences) {
         final Config config = getConfig();
         final Transformed<RealVector> targetClusterCentroid = targetClusterMetadataWithDistance.centroid();
 
@@ -315,11 +305,11 @@ class CollapseTask extends AbstractDeferredTask {
      * @param delta the vectors to write to and delete from the target cluster
      * @param quantizer the quantizer used to encode vectors before persisting
      */
-    private void persistCollapse(@Nonnull final Transaction transaction,
-                                 @Nonnull final ClusterMetadataWithDistance targetClusterMetadataWithDistance,
-                                 @Nonnull final CollapseAssignments collapseAssignments,
-                                 @Nonnull final TargetClusterDelta delta,
-                                 @Nonnull final Quantizer quantizer) {
+    private void persistCollapse(final Transaction transaction,
+                                 final ClusterMetadataWithDistance targetClusterMetadataWithDistance,
+                                 final CollapseAssignments collapseAssignments,
+                                 final TargetClusterDelta delta,
+                                 final Quantizer quantizer) {
         final CollapseCounters counters = countAssignments(collapseAssignments);
         persistTargetClusterDelta(transaction, quantizer, targetClusterMetadataWithDistance.clusterMetadata().id(), delta);
         writeCollapsedVectorIds(transaction, collapseAssignments);
@@ -334,8 +324,7 @@ class CollapseTask extends AbstractDeferredTask {
      *
      * @return the primary-underreplicated and replicated vector counts for the assignments
      */
-    @Nonnull
-    private CollapseCounters countAssignments(@Nonnull final CollapseAssignments collapseAssignments) {
+    private CollapseCounters countAssignments(final CollapseAssignments collapseAssignments) {
         int numPrimaryUnderreplicatedVectors = 0;
         int numReplicatedVectors = 0;
 
@@ -360,10 +349,10 @@ class CollapseTask extends AbstractDeferredTask {
      * @param targetClusterId the id of the cluster the delta is applied to
      * @param delta the vectors to delete from and write to the target cluster
      */
-    private void persistTargetClusterDelta(@Nonnull final Transaction transaction,
-                                           @Nonnull final Quantizer quantizer,
-                                           @Nonnull final UUID targetClusterId,
-                                           @Nonnull final TargetClusterDelta delta) {
+    private void persistTargetClusterDelta(final Transaction transaction,
+                                           final Quantizer quantizer,
+                                           final UUID targetClusterId,
+                                           final TargetClusterDelta delta) {
         final Primitives primitives = getLocator().primitives();
 
         for (final Tuple primaryKey : delta.toDelete()) {
@@ -382,8 +371,8 @@ class CollapseTask extends AbstractDeferredTask {
      * @param transaction the transaction to write into
      * @param collapseAssignments the assignments holding the collapsed vector-id mappings to persist
      */
-    private void writeCollapsedVectorIds(@Nonnull final Transaction transaction,
-                                         @Nonnull final CollapseAssignments collapseAssignments) {
+    private void writeCollapsedVectorIds(final Transaction transaction,
+                                         final CollapseAssignments collapseAssignments) {
         final Primitives primitives = getLocator().primitives();
         final ListMultimap<UUID, VectorId> collapsedAssignmentsMap = collapseAssignments.collapsedAssignmentsMap();
         for (final Map.Entry<UUID, VectorId> entry : collapsedAssignmentsMap.entries()) {
@@ -401,11 +390,11 @@ class CollapseTask extends AbstractDeferredTask {
      * @param counters the primary-underreplicated and replicated vector counts to store
      * @param delta the applied delta, used only for trace logging of deleted/written counts
      */
-    private void writeClusterMetadata(@Nonnull final Transaction transaction,
-                                      @Nonnull final ClusterMetadataWithDistance targetClusterMetadataWithDistance,
-                                      @Nonnull final CollapseAssignments collapseAssignments,
-                                      @Nonnull final CollapseCounters counters,
-                                      @Nonnull final TargetClusterDelta delta) {
+    private void writeClusterMetadata(final Transaction transaction,
+                                      final ClusterMetadataWithDistance targetClusterMetadataWithDistance,
+                                      final CollapseAssignments collapseAssignments,
+                                      final CollapseCounters counters,
+                                      final TargetClusterDelta delta) {
         final Primitives primitives = getLocator().primitives();
         final ClusterMetadata targetClusterMetadata = targetClusterMetadataWithDistance.clusterMetadata();
 
@@ -442,9 +431,8 @@ class CollapseTask extends AbstractDeferredTask {
                                     int numReplicatedVectors) {
     }
 
-    @Nonnull
-    static CollapseTask fromTuples(@Nonnull final Locator locator, @Nonnull final AccessInfo accessInfo,
-                                   @Nonnull final Tuple keyTuple, @Nonnull final Tuple valueTuple) {
+    static CollapseTask fromTuples(final Locator locator, final AccessInfo accessInfo,
+                                   final Tuple keyTuple, final Tuple valueTuple) {
         Verify.verify(TaskKind.fromValueTuple(valueTuple) == TaskKind.COLLAPSE);
         final StorageTransform storageTransform = locator.primitives().storageTransform(accessInfo);
 
@@ -455,10 +443,9 @@ class CollapseTask extends AbstractDeferredTask {
         return new CollapseTask(locator, accessInfo, keyTuple.getUUID(0), targetClusterId, centroid);
     }
 
-    @Nonnull
-    static CollapseTask of(@Nonnull final Locator locator, @Nonnull final AccessInfo accessInfo,
-                           @Nonnull final UUID taskId, @Nonnull final UUID clusterId,
-                           @Nonnull final Transformed<RealVector> centroid) {
+    static CollapseTask of(final Locator locator, final AccessInfo accessInfo,
+                           final UUID taskId, final UUID clusterId,
+                           final Transformed<RealVector> centroid) {
         return new CollapseTask(locator, accessInfo, taskId, clusterId, centroid);
     }
 
@@ -473,8 +460,7 @@ class CollapseTask extends AbstractDeferredTask {
         return maximumCollapsiblePerDuplicate;
     }
 
-    @Nonnull
-    static Map<UUID, Integer> collapsibleVectorsCountersMap(@Nonnull final List<VectorReference> vectorReferences) {
+    static Map<UUID, Integer> collapsibleVectorsCountersMap(final List<VectorReference> vectorReferences) {
         final Map<UUID, Integer> countersMap = Maps.newHashMapWithExpectedSize(vectorReferences.size());
         for (final VectorReference vectorReference : vectorReferences) {
             if (vectorReference.isPrimaryCopy()) {
@@ -485,8 +471,7 @@ class CollapseTask extends AbstractDeferredTask {
         return countersMap;
     }
 
-    @Nonnull
-    static ImmutableSetMultimap<VectorId, UUID> vectorReferenceToSignatureMap(@Nonnull final List<VectorReference> vectorReferences) {
+    static ImmutableSetMultimap<VectorId, UUID> vectorReferenceToSignatureMap(final List<VectorReference> vectorReferences) {
         final ImmutableSetMultimap.Builder<VectorId, UUID> resultMapBuilder = ImmutableSetMultimap.builder();
         for (final VectorReference vectorReference : vectorReferences) {
             if (vectorReference.isPrimaryCopy()) {
@@ -505,8 +490,8 @@ class CollapseTask extends AbstractDeferredTask {
      * @param updatedStandardDeviation the recomputed running statistics of member distances to the centroid
      * @param collapsedAssignmentsMap a multimap from a collapsed reference's id to the {@link VectorId}s absorbed into it
      */
-    private record CollapseAssignments(@Nonnull List<VectorReference> assignments,
-                                       @Nonnull RunningStats updatedStandardDeviation,
-                                       @Nonnull ListMultimap<UUID, VectorId> collapsedAssignmentsMap) {
+    private record CollapseAssignments(List<VectorReference> assignments,
+                                       RunningStats updatedStandardDeviation,
+                                       ListMultimap<UUID, VectorId> collapsedAssignmentsMap) {
     }
 }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/Config.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/Config.java
@@ -25,7 +25,6 @@ import com.apple.foundationdb.linear.Metric;
 import com.google.common.base.Preconditions;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 
-import javax.annotation.Nonnull;
 
 /**
  * Configuration for the Guardiann vector structure.
@@ -76,7 +75,7 @@ import javax.annotation.Nonnull;
  *        knobs are consulted there
  */
 @SuppressWarnings("checkstyle:MemberName")
-public record Config(@Nonnull Metric metric,
+public record Config(Metric metric,
                      int numDimensions,
                      int primaryClusterMin,
                      int primaryClusterMax,
@@ -115,9 +114,9 @@ public record Config(@Nonnull Metric metric,
                      int collapseConcurrency,
                      int bounceConcurrency,
                      // construction (centroid-walk tuning for the non-search insert/delete/maintenance paths)
-                     @Nonnull SearchConfig constructionSearchConfig) implements VectorEncodingConfig {
+                     SearchConfig constructionSearchConfig) implements VectorEncodingConfig {
 
-    @Nonnull public static final Metric DEFAULT_METRIC = Metric.EUCLIDEAN_METRIC;
+    public static final Metric DEFAULT_METRIC = Metric.EUCLIDEAN_METRIC;
     public static final int DEFAULT_PRIMARY_CLUSTER_MIN = 100;
     public static final int DEFAULT_PRIMARY_CLUSTER_MAX = 1000;
     public static final int DEFAULT_PRIMARY_CLUSTER_HARD_MAX = 2 * DEFAULT_PRIMARY_CLUSTER_MAX;
@@ -160,7 +159,6 @@ public record Config(@Nonnull Metric metric,
     public static final int DEFAULT_REASSIGN_CONCURRENCY = 10;
     public static final int DEFAULT_COLLAPSE_CONCURRENCY = 10;
     public static final int DEFAULT_BOUNCE_CONCURRENCY = 10;
-    @Nonnull
     public static final SearchConfig DEFAULT_CONSTRUCTION_SEARCH_CONFIG = new SearchConfig.SearchConfigBuilder().build();
 
     public Config {
@@ -171,7 +169,6 @@ public record Config(@Nonnull Metric metric,
                 "primaryClusterHardMax must be > primaryClusterMax");
     }
 
-    @Nonnull
     public ConfigBuilder toBuilder() {
         return new ConfigBuilder(metric(), primaryClusterMin(), primaryClusterMax(), primaryClusterHardMax(),
                 underreplicatedPrimaryClusterMax(), replicatedClusterMaxWrites(), replicatedClusterTarget(),
@@ -189,7 +186,6 @@ public record Config(@Nonnull Metric metric,
     }
 
     @Override
-    @Nonnull
     public String toString() {
         return "Config[metric=" + metric() + ", numDimensions=" + numDimensions() +
                 ", primaryClusterMin=" + primaryClusterMin() + ", primaryClusterMax=" + primaryClusterMax() +
@@ -231,7 +227,6 @@ public record Config(@Nonnull Metric metric,
     @CanIgnoreReturnValue
     @SuppressWarnings("checkstyle:MemberName")
     public static class ConfigBuilder {
-        @Nonnull
         private Metric metric = DEFAULT_METRIC;
         private int primaryClusterMin = DEFAULT_PRIMARY_CLUSTER_MIN;
         private int primaryClusterMax = DEFAULT_PRIMARY_CLUSTER_MAX;
@@ -274,13 +269,12 @@ public record Config(@Nonnull Metric metric,
         private int collapseConcurrency = DEFAULT_COLLAPSE_CONCURRENCY;
         private int bounceConcurrency = DEFAULT_BOUNCE_CONCURRENCY;
         // construction (centroid-walk tuning for the non-search insert/delete/maintenance paths)
-        @Nonnull
         private SearchConfig constructionSearchConfig = DEFAULT_CONSTRUCTION_SEARCH_CONFIG;
 
         public ConfigBuilder() {
         }
 
-        public ConfigBuilder(@Nonnull final Metric metric, final int primaryClusterMin, final int primaryClusterMax,
+        public ConfigBuilder(final Metric metric, final int primaryClusterMin, final int primaryClusterMax,
                              final int primaryClusterHardMax,
                              final int underreplicatedPrimaryClusterMax, final int replicatedClusterMaxWrites,
                              final int replicatedClusterTarget, final double replicationPriorityMin,
@@ -300,7 +294,7 @@ public record Config(@Nonnull Metric metric,
                              final int splitMergeConcurrency, final int reassignConcurrency,
                              final int collapseConcurrency,
                              final int bounceConcurrency,
-                             @Nonnull final SearchConfig constructionSearchConfig) {
+                             final SearchConfig constructionSearchConfig) {
             this.metric = metric;
             this.primaryClusterMin = primaryClusterMin;
             this.primaryClusterMax = primaryClusterMax;
@@ -335,14 +329,12 @@ public record Config(@Nonnull Metric metric,
             this.constructionSearchConfig = constructionSearchConfig;
         }
 
-        @Nonnull
         public Metric getMetric() {
             return metric;
         }
 
         @CanIgnoreReturnValue
-        @Nonnull
-        public ConfigBuilder setMetric(@Nonnull final Metric metric) {
+        public ConfigBuilder setMetric(final Metric metric) {
             this.metric = metric;
             return this;
         }
@@ -352,7 +344,6 @@ public record Config(@Nonnull Metric metric,
         }
 
         @CanIgnoreReturnValue
-        @Nonnull
         public ConfigBuilder setPrimaryClusterMin(final int primaryClusterMin) {
             this.primaryClusterMin = primaryClusterMin;
             return this;
@@ -363,7 +354,6 @@ public record Config(@Nonnull Metric metric,
         }
 
         @CanIgnoreReturnValue
-        @Nonnull
         public ConfigBuilder setPrimaryClusterMax(final int primaryClusterMax) {
             this.primaryClusterMax = primaryClusterMax;
             return this;
@@ -374,7 +364,6 @@ public record Config(@Nonnull Metric metric,
         }
 
         @CanIgnoreReturnValue
-        @Nonnull
         public ConfigBuilder setPrimaryClusterHardMax(final int primaryClusterHardMax) {
             this.primaryClusterHardMax = primaryClusterHardMax;
             return this;
@@ -385,7 +374,6 @@ public record Config(@Nonnull Metric metric,
         }
 
         @CanIgnoreReturnValue
-        @Nonnull
         public ConfigBuilder setUnderreplicatedPrimaryClusterMax(final int underreplicatedPrimaryClusterMax) {
             this.underreplicatedPrimaryClusterMax = underreplicatedPrimaryClusterMax;
             return this;
@@ -396,7 +384,6 @@ public record Config(@Nonnull Metric metric,
         }
 
         @CanIgnoreReturnValue
-        @Nonnull
         public ConfigBuilder setReplicatedClusterMaxWrites(final int replicatedClusterMaxWrites) {
             this.replicatedClusterMaxWrites = replicatedClusterMaxWrites;
             return this;
@@ -407,7 +394,6 @@ public record Config(@Nonnull Metric metric,
         }
 
         @CanIgnoreReturnValue
-        @Nonnull
         public ConfigBuilder setReplicatedClusterTarget(final int replicatedClusterTarget) {
             this.replicatedClusterTarget = replicatedClusterTarget;
             return this;
@@ -418,7 +404,6 @@ public record Config(@Nonnull Metric metric,
         }
 
         @CanIgnoreReturnValue
-        @Nonnull
         public ConfigBuilder setReplicationPriorityMin(final double replicationPriorityMin) {
             this.replicationPriorityMin = replicationPriorityMin;
             return this;
@@ -429,7 +414,6 @@ public record Config(@Nonnull Metric metric,
         }
 
         @CanIgnoreReturnValue
-        @Nonnull
         public ConfigBuilder setReplicationDistanceRatioWeight(final double replicationDistanceRatioWeight) {
             this.replicationDistanceRatioWeight = replicationDistanceRatioWeight;
             return this;
@@ -440,7 +424,6 @@ public record Config(@Nonnull Metric metric,
         }
 
         @CanIgnoreReturnValue
-        @Nonnull
         public ConfigBuilder setReplicationZScoreWeight(final double replicationZScoreWeight) {
             this.replicationZScoreWeight = replicationZScoreWeight;
             return this;
@@ -451,7 +434,6 @@ public record Config(@Nonnull Metric metric,
         }
 
         @CanIgnoreReturnValue
-        @Nonnull
         public ConfigBuilder setReplicationStatsMinSampleSize(final int replicationStatsMinSampleSize) {
             this.replicationStatsMinSampleSize = replicationStatsMinSampleSize;
             return this;
@@ -462,7 +444,6 @@ public record Config(@Nonnull Metric metric,
         }
 
         @CanIgnoreReturnValue
-        @Nonnull
         public ConfigBuilder setSampleVectorStatsProbability(final double sampleVectorStatsProbability) {
             this.sampleVectorStatsProbability = sampleVectorStatsProbability;
             return this;
@@ -473,7 +454,6 @@ public record Config(@Nonnull Metric metric,
         }
 
         @CanIgnoreReturnValue
-        @Nonnull
         public ConfigBuilder setMaintainStatsProbability(final double maintainStatsProbability) {
             this.maintainStatsProbability = maintainStatsProbability;
             return this;
@@ -484,7 +464,6 @@ public record Config(@Nonnull Metric metric,
         }
 
         @CanIgnoreReturnValue
-        @Nonnull
         public ConfigBuilder setStatsThreshold(final int statsThreshold) {
             this.statsThreshold = statsThreshold;
             return this;
@@ -495,7 +474,6 @@ public record Config(@Nonnull Metric metric,
         }
 
         @CanIgnoreReturnValue
-        @Nonnull
         public ConfigBuilder setUseRaBitQ(final boolean useRaBitQ) {
             this.useRaBitQ = useRaBitQ;
             return this;
@@ -506,7 +484,6 @@ public record Config(@Nonnull Metric metric,
         }
 
         @CanIgnoreReturnValue
-        @Nonnull
         public ConfigBuilder setRaBitQNumExBits(final int raBitQNumExBits) {
             this.raBitQNumExBits = raBitQNumExBits;
             return this;
@@ -517,7 +494,6 @@ public record Config(@Nonnull Metric metric,
         }
 
         @CanIgnoreReturnValue
-        @Nonnull
         public ConfigBuilder setDeterministicRandomness(final boolean deterministicRandomness) {
             this.deterministicRandomness = deterministicRandomness;
             return this;
@@ -528,7 +504,6 @@ public record Config(@Nonnull Metric metric,
         }
 
         @CanIgnoreReturnValue
-        @Nonnull
         public ConfigBuilder setSampleBatchSize(final int sampleBatchSize) {
             this.sampleBatchSize = sampleBatchSize;
             return this;
@@ -539,7 +514,6 @@ public record Config(@Nonnull Metric metric,
         }
 
         @CanIgnoreReturnValue
-        @Nonnull
         public ConfigBuilder setInsertMaxCandidateClusters(final int insertMaxCandidateClusters) {
             this.insertMaxCandidateClusters = insertMaxCandidateClusters;
             return this;
@@ -550,7 +524,6 @@ public record Config(@Nonnull Metric metric,
         }
 
         @CanIgnoreReturnValue
-        @Nonnull
         public ConfigBuilder setDeleteMaxCandidateClusters(final int deleteMaxCandidateClusters) {
             this.deleteMaxCandidateClusters = deleteMaxCandidateClusters;
             return this;
@@ -561,7 +534,6 @@ public record Config(@Nonnull Metric metric,
         }
 
         @CanIgnoreReturnValue
-        @Nonnull
         public ConfigBuilder setDeleteConcurrency(final int deleteConcurrency) {
             this.deleteConcurrency = deleteConcurrency;
             return this;
@@ -572,7 +544,6 @@ public record Config(@Nonnull Metric metric,
         }
 
         @CanIgnoreReturnValue
-        @Nonnull
         public ConfigBuilder setSplitNumNearestClusters(final int splitNumNearestClusters) {
             this.splitNumNearestClusters = splitNumNearestClusters;
             return this;
@@ -583,7 +554,6 @@ public record Config(@Nonnull Metric metric,
         }
 
         @CanIgnoreReturnValue
-        @Nonnull
         public ConfigBuilder setMergeNumNearestClusters(final int mergeNumNearestClusters) {
             this.mergeNumNearestClusters = mergeNumNearestClusters;
             return this;
@@ -594,7 +564,6 @@ public record Config(@Nonnull Metric metric,
         }
 
         @CanIgnoreReturnValue
-        @Nonnull
         public ConfigBuilder setKMeansMaxIterations(final int kMeansMaxIterations) {
             this.kMeansMaxIterations = kMeansMaxIterations;
             return this;
@@ -605,7 +574,6 @@ public record Config(@Nonnull Metric metric,
         }
 
         @CanIgnoreReturnValue
-        @Nonnull
         public ConfigBuilder setKMeansMaxRestarts(final int kMeansMaxRestarts) {
             this.kMeansMaxRestarts = kMeansMaxRestarts;
             return this;
@@ -616,7 +584,6 @@ public record Config(@Nonnull Metric metric,
         }
 
         @CanIgnoreReturnValue
-        @Nonnull
         public ConfigBuilder setReassignNumNeighboringClusters(final int reassignNumNeighboringClusters) {
             this.reassignNumNeighboringClusters = reassignNumNeighboringClusters;
             return this;
@@ -627,7 +594,6 @@ public record Config(@Nonnull Metric metric,
         }
 
         @CanIgnoreReturnValue
-        @Nonnull
         public ConfigBuilder setCollapseMinDuplicates(final int collapseMinDuplicates) {
             this.collapseMinDuplicates = collapseMinDuplicates;
             return this;
@@ -638,7 +604,6 @@ public record Config(@Nonnull Metric metric,
         }
 
         @CanIgnoreReturnValue
-        @Nonnull
         public ConfigBuilder setSplitMergeConcurrency(final int splitMergeConcurrency) {
             this.splitMergeConcurrency = splitMergeConcurrency;
             return this;
@@ -649,7 +614,6 @@ public record Config(@Nonnull Metric metric,
         }
 
         @CanIgnoreReturnValue
-        @Nonnull
         public ConfigBuilder setReassignConcurrency(final int reassignConcurrency) {
             this.reassignConcurrency = reassignConcurrency;
             return this;
@@ -660,7 +624,6 @@ public record Config(@Nonnull Metric metric,
         }
 
         @CanIgnoreReturnValue
-        @Nonnull
         public ConfigBuilder setCollapseConcurrency(final int collapseConcurrency) {
             this.collapseConcurrency = collapseConcurrency;
             return this;
@@ -671,20 +634,17 @@ public record Config(@Nonnull Metric metric,
         }
 
         @CanIgnoreReturnValue
-        @Nonnull
         public ConfigBuilder setBounceConcurrency(final int bounceConcurrency) {
             this.bounceConcurrency = bounceConcurrency;
             return this;
         }
 
-        @Nonnull
         public SearchConfig getConstructionSearchConfig() {
             return constructionSearchConfig;
         }
 
         @CanIgnoreReturnValue
-        @Nonnull
-        public ConfigBuilder setConstructionSearchConfig(@Nonnull final SearchConfig constructionSearchConfig) {
+        public ConfigBuilder setConstructionSearchConfig(final SearchConfig constructionSearchConfig) {
             this.constructionSearchConfig = constructionSearchConfig;
             return this;
         }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/Delete.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/Delete.java
@@ -32,7 +32,6 @@ import com.google.common.collect.ImmutableSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
 import java.util.Objects;
 import java.util.SplittableRandom;
 import java.util.UUID;
@@ -48,37 +47,30 @@ import static com.apple.foundationdb.async.MoreAsyncUtil.mapIterablePipelined;
  * if a cluster drops below its minimum size threshold.
  */
 class Delete {
-    @Nonnull
     private static final Logger logger = LoggerFactory.getLogger(Delete.class);
 
-    @Nonnull
     private final Locator locator;
 
-    public Delete(@Nonnull final Locator locator) {
+    public Delete(final Locator locator) {
         this.locator = locator;
     }
 
-    @Nonnull
     public Locator getLocator() {
         return locator;
     }
 
-    @Nonnull
     public Subspace getSubspace() {
         return getLocator().getSubspace();
     }
 
-    @Nonnull
     public Executor getExecutor() {
         return getLocator().getExecutor();
     }
 
-    @Nonnull
     public Config getConfig() {
         return getLocator().getConfig();
     }
 
-    @Nonnull
     private Primitives primitives() {
         return getLocator().primitives();
     }
@@ -99,10 +91,9 @@ class Delete {
      * @return a {@link CompletableFuture} that completes when the deletion is finished, or completes
      *         immediately if the vector does not exist
      */
-    @Nonnull
-    public CompletableFuture<Void> delete(@Nonnull final Transaction transaction,
-                                          @Nonnull final Tuple primaryKey,
-                                          @Nonnull final RealVector vector,
+    public CompletableFuture<Void> delete(final Transaction transaction,
+                                          final Tuple primaryKey,
+                                          final RealVector vector,
                                           final boolean maintainInTransaction) {
         final SplittableRandom random = RandomHelpers.random(primaryKey);
         final Primitives primitives = primitives();
@@ -135,12 +126,11 @@ class Delete {
                 });
     }
 
-    @Nonnull
-    private CompletableFuture<Void> deleteFromClusters(@Nonnull final Transaction transaction,
-                                                       @Nonnull final SplittableRandom random,
-                                                       @Nonnull final AccessInfo accessInfo,
-                                                       @Nonnull final Tuple primaryKey,
-                                                       @Nonnull final RealVector vector) {
+    private CompletableFuture<Void> deleteFromClusters(final Transaction transaction,
+                                                       final SplittableRandom random,
+                                                       final AccessInfo accessInfo,
+                                                       final Tuple primaryKey,
+                                                       final RealVector vector) {
         final Config config = getConfig();
         final Primitives primitives = primitives();
         final StorageTransform storageTransform = primitives.storageTransform(accessInfo);

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/Guardiann.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/Guardiann.java
@@ -28,8 +28,7 @@ import com.apple.foundationdb.linear.RealVector;
 import com.apple.foundationdb.subspace.Subspace;
 import com.apple.foundationdb.tuple.Tuple;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -92,7 +91,6 @@ import java.util.concurrent.Executor;
  */
 @API(API.Status.EXPERIMENTAL)
 public class Guardiann {
-    @Nonnull
     private final Locator locator;
 
     /**
@@ -110,7 +108,6 @@ public class Guardiann {
      * @return a new default {@code Config}.
      * @see Config.ConfigBuilder#build
      */
-    @Nonnull
     public static Config defaultConfig(int numDimensions) {
         return new Config.ConfigBuilder().build(numDimensions);
     }
@@ -127,15 +124,14 @@ public class Guardiann {
      * @param onWriteListener a listener to be notified of write events
      * @param onReadListener a listener to be notified of read events
      */
-    public Guardiann(@Nonnull final Subspace subspace,
-                     @Nonnull final Executor executor,
-                     @Nonnull final Config config,
-                     @Nonnull final OnWriteListener onWriteListener,
-                     @Nonnull final OnReadListener onReadListener) {
+    public Guardiann(final Subspace subspace,
+                     final Executor executor,
+                     final Config config,
+                     final OnWriteListener onWriteListener,
+                     final OnReadListener onReadListener) {
         this.locator = new Locator(subspace, executor, config, onWriteListener, onReadListener);
     }
 
-    @Nonnull
     public Locator getLocator() {
         return locator;
     }
@@ -145,7 +141,6 @@ public class Guardiann {
      *
      * @return the non-null subspace
      */
-    @Nonnull
     public Subspace getSubspace() {
         return getLocator().getSubspace();
     }
@@ -154,7 +149,6 @@ public class Guardiann {
      * Get the executor used by this object.
      * @return executor used when running asynchronous tasks
      */
-    @Nonnull
     public Executor getExecutor() {
         return getLocator().getExecutor();
     }
@@ -163,7 +157,6 @@ public class Guardiann {
      * Get this object's configuration.
      * @return the configuration
      */
-    @Nonnull
     public Config getConfig() {
         return getLocator().getConfig();
     }
@@ -172,7 +165,6 @@ public class Guardiann {
      * Get the on-write listener.
      * @return the on-write listener
      */
-    @Nonnull
     public OnWriteListener getOnWriteListener() {
         return getLocator().getOnWriteListener();
     }
@@ -181,22 +173,18 @@ public class Guardiann {
      * Get the on-read listener.
      * @return the on-read listener
      */
-    @Nonnull
     public OnReadListener getOnReadListener() {
         return getLocator().getOnReadListener();
     }
 
-    @Nonnull
     private Search search() {
         return getLocator().search();
     }
 
-    @Nonnull
     private Insert insert() {
         return getLocator().insert();
     }
 
-    @Nonnull
     private Delete delete() {
         return getLocator().delete();
     }
@@ -214,13 +202,12 @@ public class Guardiann {
      *         sorted by distance in ascending order.
      */
     @SuppressWarnings("checkstyle:MethodName") // method name normally used in literature
-    @Nonnull
     public CompletableFuture<List<? extends ResultEntry>>
-            kNearestNeighborsSearch(@Nonnull final ReadTransaction readTransaction,
+            kNearestNeighborsSearch(final ReadTransaction readTransaction,
                                     final int k,
-                                    @Nonnull final SearchConfig searchConfig,
+                                    final SearchConfig searchConfig,
                                     final boolean includeVectors,
-                                    @Nonnull final RealVector queryVector) {
+                                    final RealVector queryVector) {
         return search().kNearestNeighborsSearch(readTransaction, k, searchConfig, includeVectors, queryVector);
     }
 
@@ -246,16 +233,15 @@ public class Guardiann {
      *
      * @return a {@link CompletableFuture} completing with up to {@code k} results in ascending distance order
      */
-    @Nonnull
     CompletableFuture<List<? extends ResultEntry>>
-            searchOrderedByDistance(@Nonnull final ReadTransaction readTransaction,
+            searchOrderedByDistance(final ReadTransaction readTransaction,
                                     final int k,
-                                    @Nonnull final SearchConfig searchConfig,
+                                    final SearchConfig searchConfig,
                                     final double minimumRadiusCluster,
                                     final double minimumRadius,
                                     @Nullable final Tuple minimumPrimaryKey,
                                     final boolean includeVectors,
-                                    @Nonnull final RealVector queryVector) {
+                                    final RealVector queryVector) {
         return search().searchOrderedByDistanceResults(readTransaction, k, searchConfig,
                 queryVector, minimumRadiusCluster, minimumRadius, minimumPrimaryKey, includeVectors);
     }
@@ -276,9 +262,8 @@ public class Guardiann {
      *        transaction (and skip hard-cap back-pressure); when {@code false} tasks accumulate for a background merge
      * @return a {@link CompletableFuture} that completes when the insertion operation is finished
      */
-    @Nonnull
-    public CompletableFuture<Void> insert(@Nonnull final Transaction transaction, @Nonnull final Tuple newPrimaryKey,
-                                          @Nonnull final RealVector newVector, @Nullable final Tuple additionalValues,
+    public CompletableFuture<Void> insert(final Transaction transaction, final Tuple newPrimaryKey,
+                                          final RealVector newVector, @Nullable final Tuple additionalValues,
                                           final boolean maintainInTransaction) {
         return insert().insert(transaction, newPrimaryKey, newVector, additionalValues, maintainInTransaction);
     }
@@ -297,9 +282,8 @@ public class Guardiann {
      *        transaction; when {@code false} tasks accumulate for a background merge
      * @return a {@link CompletableFuture} that completes when the deletion is finished
      */
-    @Nonnull
-    public CompletableFuture<Void> delete(@Nonnull final Transaction transaction, @Nonnull final Tuple primaryKey,
-                                          @Nonnull final RealVector vector, final boolean maintainInTransaction) {
+    public CompletableFuture<Void> delete(final Transaction transaction, final Tuple primaryKey,
+                                          final RealVector vector, final boolean maintainInTransaction) {
         return delete().delete(transaction, primaryKey, vector, maintainInTransaction);
     }
 
@@ -316,8 +300,7 @@ public class Guardiann {
      * @return a {@link CompletableFuture} of the number of tasks actually executed ({@code 0} if the structure holds
      *         none, or has never been initialized)
      */
-    @Nonnull
-    public CompletableFuture<Integer> executeDeferredTasks(@Nonnull final Transaction transaction, final int numTasks,
+    public CompletableFuture<Integer> executeDeferredTasks(final Transaction transaction, final int numTasks,
                                                            final long deadlineMillis) {
         final Primitives primitives = getLocator().primitives();
         return primitives.fetchAccessInfo(transaction)

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/Insert.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/Insert.java
@@ -44,8 +44,7 @@ import com.google.common.util.concurrent.AtomicDouble;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
@@ -71,10 +70,8 @@ import static com.apple.foundationdb.async.common.StorageHelpers.deleteAllSample
  */
 @SuppressWarnings("PMD.TooManyStaticImports")
 class Insert {
-    @Nonnull
     private static final Logger logger = LoggerFactory.getLogger(Insert.class);
 
-    @Nonnull
     private final Locator locator;
 
     /**
@@ -84,11 +81,10 @@ class Insert {
      * @param locator the {@link Locator} where the graph data is stored, which config to use, which executor to use,
      *        etc.
      */
-    public Insert(@Nonnull final Locator locator) {
+    public Insert(final Locator locator) {
         this.locator = locator;
     }
 
-    @Nonnull
     public Locator getLocator() {
         return locator;
     }
@@ -98,7 +94,6 @@ class Insert {
      *
      * @return the non-null subspace
      */
-    @Nonnull
     public Subspace getSubspace() {
         return getLocator().getSubspace();
     }
@@ -107,7 +102,6 @@ class Insert {
      * Get the executor used by this Guardiann structure.
      * @return executor used when running asynchronous tasks
      */
-    @Nonnull
     public Executor getExecutor() {
         return getLocator().getExecutor();
     }
@@ -116,7 +110,6 @@ class Insert {
      * Get the configuration of this Guardiann structure.
      * @return the configuration
      */
-    @Nonnull
     public Config getConfig() {
         return getLocator().getConfig();
     }
@@ -125,7 +118,6 @@ class Insert {
      * Get the on-write listener.
      * @return the on-write listener
      */
-    @Nonnull
     public OnWriteListener getOnWriteListener() {
         return getLocator().getOnWriteListener();
     }
@@ -134,22 +126,18 @@ class Insert {
      * Get the on-read listener.
      * @return the on-read listener
      */
-    @Nonnull
     public OnReadListener getOnReadListener() {
         return getLocator().getOnReadListener();
     }
 
-    @Nonnull
     private Primitives primitives() {
         return getLocator().primitives();
     }
 
-    @Nonnull
     private StorageAdapter getStorageAdapter() {
         return getLocator().getStorageAdapter();
     }
 
-    @Nonnull
     private Subspace getSamplesSubspace() {
         return getStorageAdapter().getSamplesSubspace();
     }
@@ -177,9 +165,8 @@ class Insert {
      *
      * @return a {@link CompletableFuture} that completes when the insertion operation is finished
      */
-    @Nonnull
-    public CompletableFuture<Void> insert(@Nonnull final Transaction transaction, @Nonnull final Tuple newPrimaryKey,
-                                          @Nonnull final RealVector newVector,
+    public CompletableFuture<Void> insert(final Transaction transaction, final Tuple newPrimaryKey,
+                                          final RealVector newVector,
                                           @Nullable final Tuple newAdditionalValues,
                                           final boolean maintainInTransaction) {
         final SplittableRandom random = RandomHelpers.random(newPrimaryKey);
@@ -215,12 +202,11 @@ class Insert {
                                 newPrimaryKey, newVector, newAdditionalValues, maintainInTransaction));
     }
 
-    @Nonnull
-    private CompletableFuture<Void> insertIntoClusters(@Nonnull final Transaction transaction,
-                                                       @Nonnull final SplittableRandom random,
-                                                       @Nonnull final AccessInfoAndNodeExistence accessInfoAndNodeExistence,
-                                                       @Nonnull final Tuple newPrimaryKey,
-                                                       @Nonnull final RealVector newVector,
+    private CompletableFuture<Void> insertIntoClusters(final Transaction transaction,
+                                                       final SplittableRandom random,
+                                                       final AccessInfoAndNodeExistence accessInfoAndNodeExistence,
+                                                       final Tuple newPrimaryKey,
+                                                       final RealVector newVector,
                                                        @Nullable final Tuple newAdditionalValues,
                                                        final boolean maintainInTransaction) {
         if (accessInfoAndNodeExistence.nodeExists()) {
@@ -302,16 +288,16 @@ class Insert {
                         addToStatsIfNecessary(transaction, random, accessInfo, transformedNewVector));
     }
 
-    private void writeNeighboringClusterReferences(@Nonnull final Transaction transaction,
-                                                   @Nonnull final SplittableRandom random,
-                                                   @Nonnull final AccessInfo accessInfo,
-                                                   @Nonnull final Quantizer quantizer,
-                                                   @Nonnull final DistanceEstimator estimator,
+    private void writeNeighboringClusterReferences(final Transaction transaction,
+                                                   final SplittableRandom random,
+                                                   final AccessInfo accessInfo,
+                                                   final Quantizer quantizer,
+                                                   final DistanceEstimator estimator,
                                                    @Nullable final UUID primaryClusterId,
                                                    final double distanceToPrimaryCentroid,
-                                                   @Nonnull final VectorMetadata newVectorMetadata,
-                                                   @Nonnull final Transformed<RealVector> transformedNewVector,
-                                                   @Nonnull final List<ClusterMetadataWithDistance> replicationCandidates,
+                                                   final VectorMetadata newVectorMetadata,
+                                                   final Transformed<RealVector> transformedNewVector,
+                                                   final List<ClusterMetadataWithDistance> replicationCandidates,
                                                    final boolean maintainInTransaction) {
         final Config config = getConfig();
         final Primitives primitives = primitives();
@@ -392,10 +378,9 @@ class Insert {
      *
      * @return a future of the {@link AccessInfo} established for the structure
      */
-    @Nonnull
-    private CompletableFuture<AccessInfo> initialAccessInfoAndFirstCluster(@Nonnull final Transaction transaction,
-                                                                           @Nonnull final SplittableRandom random,
-                                                                           @Nonnull final RealVector newVector) {
+    private CompletableFuture<AccessInfo> initialAccessInfoAndFirstCluster(final Transaction transaction,
+                                                                           final SplittableRandom random,
+                                                                           final RealVector newVector) {
         final Config config = getConfig();
         final Primitives primitives = primitives();
         final long rotatorSeed;
@@ -451,11 +436,10 @@ class Insert {
      *
      * @return a future that returns {@code null} when completed
      */
-    @Nonnull
-    private CompletableFuture<Void> addToStatsIfNecessary(@Nonnull final Transaction transaction,
-                                                          @Nonnull final SplittableRandom random,
-                                                          @Nonnull final AccessInfo currentAccessInfo,
-                                                          @Nonnull final Transformed<RealVector> transformedNewVector) {
+    private CompletableFuture<Void> addToStatsIfNecessary(final Transaction transaction,
+                                                          final SplittableRandom random,
+                                                          final AccessInfo currentAccessInfo,
+                                                          final Transformed<RealVector> transformedNewVector) {
         final Config config = getConfig();
         final Subspace samplesSubspace = getSamplesSubspace();
         if (config.useRaBitQ() &&
@@ -509,11 +493,11 @@ class Insert {
         return AsyncUtil.DONE;
     }
 
-    private boolean shouldSampleVector(@Nonnull final SplittableRandom random) {
+    private boolean shouldSampleVector(final SplittableRandom random) {
         return random.nextDouble() < getConfig().sampleVectorStatsProbability();
     }
 
-    private boolean shouldMaintainStats(@Nonnull final SplittableRandom random) {
+    private boolean shouldMaintainStats(final SplittableRandom random) {
         return random.nextDouble() < getConfig().maintainStatsProbability();
     }
 }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/Locator.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/Locator.java
@@ -24,7 +24,6 @@ import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.subspace.Subspace;
 import com.google.common.base.Suppliers;
 
-import javax.annotation.Nonnull;
 import java.util.concurrent.Executor;
 import java.util.function.Supplier;
 
@@ -36,18 +35,12 @@ import java.util.function.Supplier;
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 public final class Locator {
-    @Nonnull
     private final Executor executor;
-    @Nonnull
     private final StorageAdapter storageAdapter;
 
-    @Nonnull
     private final Supplier<Primitives> primitivesSupplier = Suppliers.memoize(() -> new Primitives(this));
-    @Nonnull
     private final Supplier<Search> searchSupplier = Suppliers.memoize(() -> new Search(this));
-    @Nonnull
     private final Supplier<Insert> insertSupplier = Suppliers.memoize(() -> new Insert(this));
-    @Nonnull
     private final Supplier<Delete> deleteSupplier = Suppliers.memoize(() -> new Delete(this));
 
     /**
@@ -65,16 +58,15 @@ public final class Locator {
      *
      * @throws NullPointerException if any of the parameters are {@code null}.
      */
-    public Locator(@Nonnull final Subspace subspace,
-                   @Nonnull final Executor executor,
-                   @Nonnull final Config config,
-                   @Nonnull final OnWriteListener onWriteListener,
-                   @Nonnull final OnReadListener onReadListener) {
+    public Locator(final Subspace subspace,
+                   final Executor executor,
+                   final Config config,
+                   final OnWriteListener onWriteListener,
+                   final OnReadListener onReadListener) {
         this.executor = executor;
         this.storageAdapter = new StorageAdapter(config, subspace, onWriteListener, onReadListener);
     }
 
-    @Nonnull
     StorageAdapter getStorageAdapter() {
         return storageAdapter;
     }
@@ -84,7 +76,6 @@ public final class Locator {
      *
      * @return the non-null subspace
      */
-    @Nonnull
     public Subspace getSubspace() {
         return getStorageAdapter().getSubspace();
     }
@@ -93,7 +84,6 @@ public final class Locator {
      * Get the executor used by this hnsw.
      * @return executor used when running asynchronous tasks
      */
-    @Nonnull
     public Executor getExecutor() {
         return executor;
     }
@@ -102,7 +92,6 @@ public final class Locator {
      * Get this hnsw's configuration.
      * @return hnsw configuration
      */
-    @Nonnull
     public Config getConfig() {
         return getStorageAdapter().getConfig();
     }
@@ -111,7 +100,6 @@ public final class Locator {
      * Get the on-write listener.
      * @return the on-write listener
      */
-    @Nonnull
     public OnWriteListener getOnWriteListener() {
         return getStorageAdapter().getOnWriteListener();
     }
@@ -120,27 +108,22 @@ public final class Locator {
      * Get the on-read listener.
      * @return the on-read listener
      */
-    @Nonnull
     public OnReadListener getOnReadListener() {
         return getStorageAdapter().getOnReadListener();
     }
 
-    @Nonnull
     Primitives primitives() {
         return primitivesSupplier.get();
     }
 
-    @Nonnull
     Search search() {
         return searchSupplier.get();
     }
 
-    @Nonnull
     Insert insert() {
         return insertSupplier.get();
     }
 
-    @Nonnull
     Delete delete() {
         return deleteSupplier.get();
     }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/OnReadListener.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/OnReadListener.java
@@ -28,7 +28,6 @@ import com.apple.foundationdb.linear.RealVector;
 import com.apple.foundationdb.linear.Transformed;
 import com.apple.foundationdb.tuple.Tuple;
 
-import javax.annotation.Nonnull;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
@@ -53,7 +52,7 @@ public interface OnReadListener extends OnKeyValueReadListener {
      * @return the future to await; by default the same instance
      */
     @SuppressWarnings("unused")
-    default <T> CompletableFuture<T> onAsyncRead(@Nonnull final CompletableFuture<T> future) {
+    default <T> CompletableFuture<T> onAsyncRead(final CompletableFuture<T> future) {
         return future;
     }
 
@@ -68,8 +67,7 @@ public interface OnReadListener extends OnKeyValueReadListener {
      * @return the iterable to consume; by default the same instance
      */
     @SuppressWarnings("unused")
-    @Nonnull
-    default AsyncIterable<KeyValue> onAsyncReadRange(@Nonnull final AsyncIterable<KeyValue> iterable) {
+    default AsyncIterable<KeyValue> onAsyncReadRange(final AsyncIterable<KeyValue> iterable) {
         return iterable;
     }
 
@@ -86,8 +84,8 @@ public interface OnReadListener extends OnKeyValueReadListener {
      *        vector
      */
     @SuppressWarnings("unused")
-    default void onVectorRead(@Nonnull final UUID clusterId, @Nonnull final Tuple primaryKey,
-                              @Nonnull final UUID vectorUuid, @Nonnull final Transformed<RealVector> vector) {
+    default void onVectorRead(final UUID clusterId, final Tuple primaryKey,
+                              final UUID vectorUuid, final Transformed<RealVector> vector) {
         // nothing
     }
 }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/OnWriteListener.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/OnWriteListener.java
@@ -25,7 +25,6 @@ import com.apple.foundationdb.async.hnsw.Node;
 import com.apple.foundationdb.async.hnsw.NodeReference;
 import com.apple.foundationdb.tuple.Tuple;
 
-import javax.annotation.Nonnull;
 import java.util.Set;
 import java.util.UUID;
 
@@ -47,8 +46,8 @@ public interface OnWriteListener extends OnKeyValueWriteListener {
      * @param targetClusterIds the cluster ids the task targets
      */
     @SuppressWarnings("unused")
-    default void onTaskEnqueued(@Nonnull final TaskKind kind, @Nonnull UUID taskId,
-                                @Nonnull final Set<UUID> targetClusterIds) {
+    default void onTaskEnqueued(final TaskKind kind, UUID taskId,
+                                final Set<UUID> targetClusterIds) {
         // nothing
     }
 
@@ -62,8 +61,8 @@ public interface OnWriteListener extends OnKeyValueWriteListener {
      * @param targetClusterIds target cluster ids of the task
      */
     @SuppressWarnings("unused")
-    default void onTaskExecuted(@Nonnull final TaskKind taskKind, @Nonnull final UUID taskId,
-                                @Nonnull final Set<UUID> targetClusterIds) {
+    default void onTaskExecuted(final TaskKind taskKind, final UUID taskId,
+                                final Set<UUID> targetClusterIds) {
         // nothing
     }
 
@@ -81,8 +80,8 @@ public interface OnWriteListener extends OnKeyValueWriteListener {
      * @param neighbor the {@link NodeReference} of the neighbor that was written; must not be null
      */
     @SuppressWarnings("unused")
-    default void onNeighborWritten(final int layer, @Nonnull final Node<? extends NodeReference> node,
-                                   @Nonnull final NodeReference neighbor) {
+    default void onNeighborWritten(final int layer, final Node<? extends NodeReference> node,
+                                   final NodeReference neighbor) {
         // nothing
     }
 
@@ -95,7 +94,7 @@ public interface OnWriteListener extends OnKeyValueWriteListener {
      * @param primaryKey the {@link Tuple} used as key to identify the node that was deleted; guaranteed to be non-null.
      */
     @SuppressWarnings("unused")
-    default void onNodeDeleted(final int layer, @Nonnull final Tuple primaryKey) {
+    default void onNodeDeleted(final int layer, final Tuple primaryKey) {
         // nothing
     }
 
@@ -110,8 +109,8 @@ public interface OnWriteListener extends OnKeyValueWriteListener {
      * @param neighborPrimaryKey the primary key (as a {@link Tuple}) of the neighbor that was deleted
      */
     @SuppressWarnings("unused")
-    default void onNeighborDeleted(final int layer, @Nonnull final Node<? extends NodeReference> node,
-                                   @Nonnull final Tuple neighborPrimaryKey) {
+    default void onNeighborDeleted(final int layer, final Node<? extends NodeReference> node,
+                                   final Tuple neighborPrimaryKey) {
         // nothing
     }
 }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/PrimaryCopy.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/PrimaryCopy.java
@@ -24,7 +24,6 @@ import com.apple.foundationdb.linear.RealVector;
 import com.apple.foundationdb.linear.Transformed;
 import com.apple.foundationdb.tuple.Tuple;
 
-import javax.annotation.Nonnull;
 import java.util.UUID;
 
 /**
@@ -36,46 +35,39 @@ import java.util.UUID;
  * @param isUnderreplicated whether this primary's replicas have not yet been propagated
  * @param isCollapsed whether this reference represents a collapsed set of identical vectors
  */
-record PrimaryCopy(@Nonnull VectorId id, @Nonnull Transformed<RealVector> vector,
+record PrimaryCopy(VectorId id, Transformed<RealVector> vector,
                    boolean isUnderreplicated, boolean isCollapsed) implements VectorReference {
-    @Nonnull
     @Override
-    public VectorReference withVectorId(@Nonnull final VectorId newVectorId) {
+    public VectorReference withVectorId(final VectorId newVectorId) {
         return id.equals(newVectorId) ? this : new PrimaryCopy(newVectorId, vector, isUnderreplicated, isCollapsed);
     }
 
-    @Nonnull
     @Override
     @SuppressWarnings("PMD.CompareObjectsWithEquals")
-    public VectorReference withVector(@Nonnull final Transformed<RealVector> newVector) {
+    public VectorReference withVector(final Transformed<RealVector> newVector) {
         return vector == newVector ? this : new PrimaryCopy(id, newVector, isUnderreplicated, isCollapsed);
     }
 
-    @Nonnull
     @Override
     public VectorReference toPrimaryCopy() {
         return isUnderreplicated ? new PrimaryCopy(id, vector, false, isCollapsed) : this;
     }
 
-    @Nonnull
     @Override
     public VectorReference toPrimaryUnderreplicatedCopy() {
         return isUnderreplicated ? this : new PrimaryCopy(id, vector, true, isCollapsed);
     }
 
-    @Nonnull
     @Override
     public VectorReference toReplicatedCopy(final double newReplicationScore) {
         return new ReplicatedCopy(id, vector, newReplicationScore, isCollapsed);
     }
 
-    @Nonnull
     @Override
-    public VectorReference toCollapsed(@Nonnull final UUID signature, @Nonnull final UUID vectorUuid) {
+    public VectorReference toCollapsed(final UUID signature, final UUID vectorUuid) {
         return new PrimaryCopy(new VectorId(Tuple.from(signature), vectorUuid), vector, isUnderreplicated, true);
     }
 
-    @Nonnull
     @Override
     public String toString() {
         return "VR[" + id + ", PRIMARY, isUnderreplicated=" + isUnderreplicated

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/Primitives.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/Primitives.java
@@ -51,8 +51,7 @@ import com.google.common.collect.Maps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
@@ -74,13 +73,10 @@ import static com.apple.foundationdb.async.MoreAsyncUtil.forLoop;
  */
 @API(API.Status.EXPERIMENTAL)
 class Primitives {
-    @Nonnull
     private static final Logger logger = LoggerFactory.getLogger(Primitives.class);
 
-    @Nonnull
     private final Locator locator;
 
-    @Nonnull
     private final Supplier<HNSW> clusterCentroidsHnswSupplier;
 
     // Traversal flags for the centroid-HNSW walk that ranks clusters around a point. includeVectors must be true
@@ -97,7 +93,7 @@ class Primitives {
      * @param locator the {@link Locator} where the graph data is stored, which config to use, which executor to use,
      *        etc.
      */
-    public Primitives(@Nonnull final Locator locator) {
+    public Primitives(final Locator locator) {
         this.locator = locator;
 
         this.clusterCentroidsHnswSupplier = Suppliers.memoize(this::computeClusterCentroidsHnsw);
@@ -108,7 +104,6 @@ class Primitives {
      *
      * @return the locator
      */
-    @Nonnull
     public Locator getLocator() {
         return locator;
     }
@@ -118,7 +113,6 @@ class Primitives {
      *
      * @return the storage adapter
      */
-    @Nonnull
     StorageAdapter getStorageAdapter() {
         return locator.getStorageAdapter();
     }
@@ -127,7 +121,6 @@ class Primitives {
      * Get the executor used by this guardiann.
      * @return executor used when running asynchronous tasks
      */
-    @Nonnull
     private Executor getExecutor() {
         return getLocator().getExecutor();
     }
@@ -136,7 +129,6 @@ class Primitives {
      * Get the configuration.
      * @return the configuration
      */
-    @Nonnull
     private Config getConfig() {
         return getLocator().getConfig();
     }
@@ -145,7 +137,6 @@ class Primitives {
      * Get the on-write listener.
      * @return the on-write listener
      */
-    @Nonnull
     private OnWriteListener getOnWriteListener() {
         return getLocator().getOnWriteListener();
     }
@@ -154,7 +145,6 @@ class Primitives {
      * Get the on-read listener.
      * @return the on-read listener
      */
-    @Nonnull
     private OnReadListener getOnReadListener() {
         return getLocator().getOnReadListener();
     }
@@ -164,7 +154,6 @@ class Primitives {
      *
      * @return the access-info subspace
      */
-    @Nonnull
     Subspace getAccessInfoSubspace() {
         return getStorageAdapter().getAccessInfoSubspace();
     }
@@ -174,7 +163,6 @@ class Primitives {
      *
      * @return the cluster-centroids subspace
      */
-    @Nonnull
     Subspace getClusterCentroidsSubspace() {
         return getStorageAdapter().getClusterCentroidsSubspace();
     }
@@ -184,7 +172,6 @@ class Primitives {
      *
      * @return the cluster-metadata subspace
      */
-    @Nonnull
     Subspace getClusterMetadataSubspace() {
         return getStorageAdapter().getClusterMetadataSubspace();
     }
@@ -194,7 +181,6 @@ class Primitives {
      *
      * @return the vector-references subspace
      */
-    @Nonnull
     Subspace getVectorReferencesSubspace() {
         return getStorageAdapter().getVectorReferencesSubspace();
     }
@@ -204,7 +190,6 @@ class Primitives {
      *
      * @return the collapsed-vector-ids subspace
      */
-    @Nonnull
     Subspace getCollapsedVectorIdsSubspace() {
         return getStorageAdapter().getCollapsedVectorIdsSubspace();
     }
@@ -214,7 +199,6 @@ class Primitives {
      *
      * @return the vector-metadata subspace
      */
-    @Nonnull
     Subspace getVectorMetadataSubspace() {
         return getStorageAdapter().getVectorMetadataSubspace();
     }
@@ -225,7 +209,6 @@ class Primitives {
      *
      * @return the samples subspace
      */
-    @Nonnull
     Subspace getSamplesSubspace() {
         return getStorageAdapter().getSamplesSubspace();
     }
@@ -235,7 +218,6 @@ class Primitives {
      *
      * @return the tasks subspace
      */
-    @Nonnull
     Subspace getTasksSubspace() {
         return getStorageAdapter().getTasksSubspace();
     }
@@ -245,7 +227,6 @@ class Primitives {
      *
      * @return the cluster-centroids HNSW
      */
-    @Nonnull
     HNSW getClusterCentroidsHnsw() {
         return clusterCentroidsHnswSupplier.get();
     }
@@ -257,22 +238,21 @@ class Primitives {
      *
      * @return a newly constructed cluster-centroids HNSW
      */
-    @Nonnull
     private HNSW computeClusterCentroidsHnsw() {
         final com.apple.foundationdb.async.hnsw.OnWriteListener onWriteListener =
                 new com.apple.foundationdb.async.hnsw.OnWriteListener() {
                     @Override
-                    public void onKeyValueWritten(final int layer, @Nonnull final byte[] key, @Nonnull final byte[] value) {
+                    public void onKeyValueWritten(final int layer, final byte[] key, final byte[] value) {
                         getOnWriteListener().onKeyValueWritten(key, value);
                     }
 
                     @Override
-                    public void onKeyDeleted(final int layer, @Nonnull final byte[] key) {
+                    public void onKeyDeleted(final int layer, final byte[] key) {
                         getOnWriteListener().onKeyDeleted(key);
                     }
 
                     @Override
-                    public void onRangeDeleted(final int layer, @Nonnull final Range range) {
+                    public void onRangeDeleted(final int layer, final Range range) {
                         getOnWriteListener().onRangeDeleted(range);
                     }
                 };
@@ -280,7 +260,7 @@ class Primitives {
         final com.apple.foundationdb.async.hnsw.OnReadListener onReadListener =
                 new com.apple.foundationdb.async.hnsw.OnReadListener() {
                     @Override
-                    public void onKeyValueRead(final int layer, @Nonnull final byte[] key, @Nullable final byte[] value) {
+                    public void onKeyValueRead(final int layer, final byte[] key, @Nullable final byte[] value) {
                         getOnReadListener().onKeyValueRead(key, value);
                     }
                 };
@@ -308,7 +288,6 @@ class Primitives {
      * @param accessInfo the trained access context, or {@code null} if none has been established yet
      * @return the transform mapping vectors to and from their stored representation
      */
-    @Nonnull
     StorageTransform storageTransform(@Nullable final AccessInfo accessInfo) {
         if (accessInfo == null || !accessInfo.canUseRaBitQ()) {
             return StorageTransform.identity();
@@ -329,7 +308,6 @@ class Primitives {
      * @param normalizeVectors whether to normalize vectors as part of the transform
      * @return the assembled storage transform
      */
-    @Nonnull
     private StorageTransform storageTransform(@Nullable final Long rotatorSeed,
                                               @Nullable final RealVector negatedCentroid,
                                               final boolean normalizeVectors) {
@@ -348,7 +326,6 @@ class Primitives {
      * @param accessInfo the trained access context, or {@code null} if none has been established yet
      * @return the quantizer used to encode and decode stored vectors
      */
-    @Nonnull
     Quantizer quantizer(@Nullable final AccessInfo accessInfo) {
         if (accessInfo == null || !accessInfo.canUseRaBitQ()) {
             return Quantizer.noOpQuantizer(getConfig().metric());
@@ -368,8 +345,7 @@ class Primitives {
      * @param readTransaction the read transaction
      * @return a future of the access info, or {@code null} if the structure has not been initialized yet
      */
-    @Nonnull
-    CompletableFuture<AccessInfo> fetchAccessInfo(@Nonnull final ReadTransaction readTransaction) {
+    CompletableFuture<AccessInfo> fetchAccessInfo(final ReadTransaction readTransaction) {
         final Subspace accessInfoSubspace = getAccessInfoSubspace();
         final byte[] key = accessInfoSubspace.pack();
 
@@ -390,8 +366,8 @@ class Primitives {
      * @param transaction the transaction to write within
      * @param accessInfo the access info to persist
      */
-    void writeAccessInfo(@Nonnull final Transaction transaction,
-                         @Nonnull final AccessInfo accessInfo) {
+    void writeAccessInfo(final Transaction transaction,
+                         final AccessInfo accessInfo) {
         final Subspace accessInfoSubspace = getAccessInfoSubspace();
         final byte[] key = accessInfoSubspace.pack();
         final byte[] value = StorageAdapter.tupleFromAccessInfo(accessInfo).pack();
@@ -408,8 +384,7 @@ class Primitives {
      * @param primaryKey the primary key to test
      * @return a future completing {@code true} iff a metadata entry exists for the primary key
      */
-    @Nonnull
-    CompletableFuture<Boolean> primaryKeyExists(@Nonnull final ReadTransaction readTransaction, final Tuple primaryKey) {
+    CompletableFuture<Boolean> primaryKeyExists(final ReadTransaction readTransaction, final Tuple primaryKey) {
         return fetchVectorMetadata(readTransaction, primaryKey).thenApply(Objects::nonNull);
     }
 
@@ -422,9 +397,8 @@ class Primitives {
      * @param primaryKey the primary key of the vector
      * @return a future of the metadata, or {@code null} if no such vector exists
      */
-    @Nonnull
-    CompletableFuture<VectorMetadata> fetchVectorMetadata(@Nonnull final ReadTransaction readTransaction,
-                                                          @Nonnull final Tuple primaryKey) {
+    CompletableFuture<VectorMetadata> fetchVectorMetadata(final ReadTransaction readTransaction,
+                                                          final Tuple primaryKey) {
         final Subspace vectorMetadataSubspace = getVectorMetadataSubspace();
         final byte[] key = vectorMetadataSubspace.pack(primaryKey);
 
@@ -445,8 +419,8 @@ class Primitives {
      * @param transaction the transaction to write within
      * @param vectorMetadata the metadata to persist
      */
-    void writeVectorMetadata(@Nonnull final Transaction transaction,
-                             @Nonnull final VectorMetadata vectorMetadata) {
+    void writeVectorMetadata(final Transaction transaction,
+                             final VectorMetadata vectorMetadata) {
         final Subspace vectorMetadataSubspace = getVectorMetadataSubspace();
         final byte[] key = vectorMetadataSubspace.pack(vectorMetadata.vectorId().primaryKey());
         final byte[] value = StorageAdapter.valueTupleFromVectorMetadata(vectorMetadata).pack();
@@ -463,8 +437,8 @@ class Primitives {
      * @param transaction the transaction to write within
      * @param primaryKey the primary key whose metadata is removed
      */
-    void deleteVectorMetadata(@Nonnull final Transaction transaction,
-                              @Nonnull final Tuple primaryKey) {
+    void deleteVectorMetadata(final Transaction transaction,
+                              final Tuple primaryKey) {
         final Subspace vectorMetadataSubspace = getVectorMetadataSubspace();
         final byte[] key = vectorMetadataSubspace.pack(primaryKey);
         getLocator().getOnWriteListener().onKeyDeleted(key);
@@ -485,9 +459,8 @@ class Primitives {
      * @param efOutwardSearch the outward-search exploration factor (candidate-queue size) for the centroid HNSW walk
      * @return an iterator of centroids (as {@link ResultEntry}s), nearest first
      */
-    @Nonnull
-    AsyncIterator<ResultEntry> centroidsOrderedByDistance(@Nonnull final ReadTransaction readTransaction,
-                                                          @Nonnull final RealVector centerVector,
+    AsyncIterator<ResultEntry> centroidsOrderedByDistance(final ReadTransaction readTransaction,
+                                                          final RealVector centerVector,
                                                           final double minimumRadius,
                                                           @Nullable final Tuple minimumPrimaryKey,
                                                           final int efRingSearch,
@@ -513,10 +486,9 @@ class Primitives {
      * @param distance the already-computed distance to attach
      * @return a future of the metadata bundled with its centroid and distance, or {@code null} if the cluster does not exist
      */
-    @Nonnull
-    CompletableFuture<ClusterMetadataWithDistance> fetchClusterMetadataWithDistance(@Nonnull final ReadTransaction readTransaction,
-                                                                                    @Nonnull final UUID clusterId,
-                                                                                    @Nonnull final Transformed<RealVector> centroid,
+    CompletableFuture<ClusterMetadataWithDistance> fetchClusterMetadataWithDistance(final ReadTransaction readTransaction,
+                                                                                    final UUID clusterId,
+                                                                                    final Transformed<RealVector> centroid,
                                                                                     final double distance) {
         return fetchClusterMetadata(readTransaction, clusterId)
                 .thenApply(clusterMetadata -> clusterMetadata == null
@@ -537,10 +509,9 @@ class Primitives {
      * @param concurrency the fan-out width for the per-cluster metadata reads
      * @return a future of the surviving clusters' metadata-with-distance, with vanished clusters filtered out
      */
-    @Nonnull
     CompletableFuture<List<ClusterMetadataWithDistance>>
-            fetchClusterMetadataForReferences(@Nonnull final ReadTransaction readTransaction,
-                                              @Nonnull final List<ClusterReference> nearestClusters,
+            fetchClusterMetadataForReferences(final ReadTransaction readTransaction,
+                                              final List<ClusterReference> nearestClusters,
                                               final int concurrency) {
         return forEach(nearestClusters,
                 clusterReference -> fetchClusterMetadataWithDistance(readTransaction,
@@ -562,11 +533,10 @@ class Primitives {
      * @param centroid the cluster centroid in the untransformed (client) coordinate space
      * @return a future of the fetched cluster
      */
-    @Nonnull
-    CompletableFuture<Cluster> fetchCluster(@Nonnull final ReadTransaction readTransaction,
-                                            @Nonnull final StorageTransform storageTransform,
-                                            @Nonnull final UUID clusterId,
-                                            @Nonnull final RealVector centroid) {
+    CompletableFuture<Cluster> fetchCluster(final ReadTransaction readTransaction,
+                                            final StorageTransform storageTransform,
+                                            final UUID clusterId,
+                                            final RealVector centroid) {
         final Transformed<RealVector> transformedCentroid = storageTransform.transform(centroid);
         return fetchCluster(readTransaction, storageTransform, clusterId, transformedCentroid);
     }
@@ -582,11 +552,10 @@ class Primitives {
      * @param centroid the cluster centroid in the transformed (stored) coordinate space
      * @return a future of the fetched cluster
      */
-    @Nonnull
-    CompletableFuture<Cluster> fetchCluster(@Nonnull final ReadTransaction readTransaction,
-                                            @Nonnull final StorageTransform storageTransform,
-                                            @Nonnull final UUID clusterId,
-                                            @Nonnull final Transformed<RealVector> centroid) {
+    CompletableFuture<Cluster> fetchCluster(final ReadTransaction readTransaction,
+                                            final StorageTransform storageTransform,
+                                            final UUID clusterId,
+                                            final Transformed<RealVector> centroid) {
         return StorageAdapter.requireNonNull(fetchClusterMetadata(readTransaction, clusterId))
                 .thenCombine(fetchVectorReferences(readTransaction, storageTransform, clusterId),
                         (clusterMetadata, vectorReferences) -> {
@@ -605,9 +574,8 @@ class Primitives {
      * @param clusterId the id of the cluster
      * @return a future of the metadata, or {@code null} if the cluster does not exist
      */
-    @Nonnull
-    CompletableFuture<ClusterMetadata> fetchClusterMetadata(@Nonnull final ReadTransaction readTransaction,
-                                                            @Nonnull final UUID clusterId) {
+    CompletableFuture<ClusterMetadata> fetchClusterMetadata(final ReadTransaction readTransaction,
+                                                            final UUID clusterId) {
         final byte[] key = getClusterMetadataSubspace().pack(Tuple.from(clusterId));
         return getOnReadListener().onAsyncRead(readTransaction.get(key))
                 .thenApply(valueBytes -> {
@@ -626,8 +594,8 @@ class Primitives {
      * @param transaction the transaction to write within
      * @param clusterMetadata the metadata to persist
      */
-    void writeClusterMetadata(@Nonnull final Transaction transaction,
-                              @Nonnull final ClusterMetadata clusterMetadata) {
+    void writeClusterMetadata(final Transaction transaction,
+                              final ClusterMetadata clusterMetadata) {
         final Subspace clusterMetadataSubspace = getClusterMetadataSubspace();
         final byte[] key = clusterMetadataSubspace.pack(Tuple.from(clusterMetadata.id()));
         final byte[] value = StorageAdapter.valueTupleFromClusterMetadata(clusterMetadata).pack();
@@ -644,8 +612,8 @@ class Primitives {
      * @param transaction the transaction to write within
      * @param clusterId the id of the dissolved cluster
      */
-    void deleteClusterMetadata(@Nonnull final Transaction transaction,
-                               @Nonnull final UUID clusterId) {
+    void deleteClusterMetadata(final Transaction transaction,
+                               final UUID clusterId) {
         final Subspace clusterMetadataSubspace = getClusterMetadataSubspace();
         final byte[] key = clusterMetadataSubspace.pack(Tuple.from(clusterId));
 
@@ -662,10 +630,9 @@ class Primitives {
      * @param clusterId the id of the cluster
      * @return a future of the cluster's vector references
      */
-    @Nonnull
-    CompletableFuture<List<VectorReference>> fetchVectorReferences(@Nonnull final ReadTransaction readTransaction,
-                                                                   @Nonnull final StorageTransform storageTransform,
-                                                                   @Nonnull final UUID clusterId) {
+    CompletableFuture<List<VectorReference>> fetchVectorReferences(final ReadTransaction readTransaction,
+                                                                   final StorageTransform storageTransform,
+                                                                   final UUID clusterId) {
         return AsyncUtil.collect(fetchVectorReferencesIterable(readTransaction, storageTransform, clusterId),
                 getExecutor());
     }
@@ -680,10 +647,9 @@ class Primitives {
      * @param clusterId the id of the cluster
      * @return an iterable over the cluster's vector references
      */
-    @Nonnull
-    AsyncIterable<VectorReference> fetchVectorReferencesIterable(@Nonnull final ReadTransaction readTransaction,
-                                                                 @Nonnull final StorageTransform storageTransform,
-                                                                 @Nonnull final UUID clusterId) {
+    AsyncIterable<VectorReference> fetchVectorReferencesIterable(final ReadTransaction readTransaction,
+                                                                 final StorageTransform storageTransform,
+                                                                 final UUID clusterId) {
         final Subspace vectorReferencesSubspace = getVectorReferencesSubspace();
         final byte[] rangeKey = vectorReferencesSubspace.pack(Tuple.from(clusterId));
 
@@ -715,11 +681,10 @@ class Primitives {
      * @param primaryKey the primary key of the reference within the cluster
      * @return a future of the reference, or {@code null} if absent from this cluster
      */
-    @Nonnull
-    CompletableFuture<VectorReference> fetchVectorReference(@Nonnull final ReadTransaction readTransaction,
-                                                            @Nonnull final StorageTransform storageTransform,
-                                                            @Nonnull final UUID clusterId,
-                                                            @Nonnull final Tuple primaryKey) {
+    CompletableFuture<VectorReference> fetchVectorReference(final ReadTransaction readTransaction,
+                                                            final StorageTransform storageTransform,
+                                                            final UUID clusterId,
+                                                            final Tuple primaryKey) {
         final Subspace vectorReferencesSubspace = getVectorReferencesSubspace();
         final byte[] key = vectorReferencesSubspace.pack(Tuple.from(clusterId, primaryKey));
 
@@ -747,10 +712,10 @@ class Primitives {
      * @param clusterId the id of the cluster to write the reference into
      * @param vectorReference the reference to persist
      */
-    void writeVectorReference(@Nonnull final Transaction transaction,
-                              @Nonnull final Quantizer quantizer,
-                              @Nonnull final UUID clusterId,
-                              @Nonnull final VectorReference vectorReference) {
+    void writeVectorReference(final Transaction transaction,
+                              final Quantizer quantizer,
+                              final UUID clusterId,
+                              final VectorReference vectorReference) {
         final Subspace vectorReferencesSubspace = getVectorReferencesSubspace();
         final byte[] key = vectorReferencesSubspace.pack(Tuple.from(clusterId, vectorReference.id().primaryKey()));
         final byte[] value = StorageAdapter.valueTupleFromVectorReference(quantizer, vectorReference).pack();
@@ -767,9 +732,9 @@ class Primitives {
      * @param clusterId the id of the cluster
      * @param primaryKey the primary key of the reference to remove
      */
-    void deleteVectorReference(@Nonnull final Transaction transaction,
-                               @Nonnull final UUID clusterId,
-                               @Nonnull final Tuple primaryKey) {
+    void deleteVectorReference(final Transaction transaction,
+                               final UUID clusterId,
+                               final Tuple primaryKey) {
         final Subspace vectorReferencesSubspace = getVectorReferencesSubspace();
         final byte[] key = vectorReferencesSubspace.pack(Tuple.from(clusterId, primaryKey));
 
@@ -784,8 +749,8 @@ class Primitives {
      * @param transaction the transaction to write within
      * @param clusterId the id of the cluster being dissolved
      */
-    void deleteVectorReferencesForCluster(@Nonnull final Transaction transaction,
-                                          @Nonnull final UUID clusterId) {
+    void deleteVectorReferencesForCluster(final Transaction transaction,
+                                          final UUID clusterId) {
         final Subspace vectorReferencesSubspace = getVectorReferencesSubspace();
         final byte[] rangeKey = vectorReferencesSubspace.pack(Tuple.from(clusterId));
         final Range range = Range.startsWith(rangeKey);
@@ -802,9 +767,8 @@ class Primitives {
      * @param signature the content signature identifying the collapsed set
      * @return a future of the collapsed members' vector ids
      */
-    @Nonnull
-    CompletableFuture<List<VectorId>> fetchCollapsedVectorIds(@Nonnull final ReadTransaction readTransaction,
-                                                              @Nonnull final UUID signature) {
+    CompletableFuture<List<VectorId>> fetchCollapsedVectorIds(final ReadTransaction readTransaction,
+                                                              final UUID signature) {
         return AsyncUtil.collect(fetchCollapsedVectorIdsIterable(readTransaction, signature),
                 getExecutor());
     }
@@ -818,9 +782,8 @@ class Primitives {
      * @param signature the content signature identifying the collapsed set
      * @return an iterable over the collapsed members' vector ids
      */
-    @Nonnull
-    AsyncIterable<VectorId> fetchCollapsedVectorIdsIterable(@Nonnull final ReadTransaction readTransaction,
-                                                            @Nonnull final UUID signature) {
+    AsyncIterable<VectorId> fetchCollapsedVectorIdsIterable(final ReadTransaction readTransaction,
+                                                            final UUID signature) {
         final Subspace collapsedVectorIdsSubspace = getCollapsedVectorIdsSubspace();
         final byte[] rangeKey = collapsedVectorIdsSubspace.pack(Tuple.from(signature));
 
@@ -847,10 +810,9 @@ class Primitives {
      * @param primaryKey the primary key whose membership is being checked
      * @return a future of the stored {@link VectorId}, or {@code null} if there is no such collapsed entry
      */
-    @Nonnull
-    CompletableFuture<VectorId> fetchCollapsedVectorId(@Nonnull final ReadTransaction readTransaction,
-                                                       @Nonnull final UUID signature,
-                                                       @Nonnull final Tuple primaryKey) {
+    CompletableFuture<VectorId> fetchCollapsedVectorId(final ReadTransaction readTransaction,
+                                                       final UUID signature,
+                                                       final Tuple primaryKey) {
         final Subspace collapsedVectorIdsSubspace = getCollapsedVectorIdsSubspace();
         final byte[] key = collapsedVectorIdsSubspace.pack(Tuple.from(signature, primaryKey));
 
@@ -872,9 +834,8 @@ class Primitives {
      * @param readTransaction the read transaction
      * @return an iterable over all collapsed vector ids in the structure
      */
-    @Nonnull
     @VisibleForTesting
-    AsyncIterable<VectorId> scanCollapsedVectorIdsIterable(@Nonnull final ReadTransaction readTransaction) {
+    AsyncIterable<VectorId> scanCollapsedVectorIdsIterable(final ReadTransaction readTransaction) {
         final Subspace collapsedVectorIdsSubspace = getCollapsedVectorIdsSubspace();
         final byte[] rangeKey = collapsedVectorIdsSubspace.pack();
 
@@ -898,9 +859,9 @@ class Primitives {
      * @param signature the content signature of the collapsed set
      * @param vectorId the vector recorded as a collapsed member
      */
-    void writeCollapsedVectorId(@Nonnull final Transaction transaction,
-                                @Nonnull final UUID signature,
-                                @Nonnull final VectorId vectorId) {
+    void writeCollapsedVectorId(final Transaction transaction,
+                                final UUID signature,
+                                final VectorId vectorId) {
         final Subspace collapsedVectorIdsSubspace = getCollapsedVectorIdsSubspace();
         final byte[] key = collapsedVectorIdsSubspace.pack(Tuple.from(signature, vectorId.primaryKey()));
         final byte[] value = StorageAdapter.valueTupleFromCollapsedVectorId(vectorId).pack();
@@ -917,9 +878,9 @@ class Primitives {
      * @param signature the content signature of the collapsed set
      * @param primaryKey the primary key of the member to remove
      */
-    void deleteCollapsedVectorId(@Nonnull final Transaction transaction,
-                                 @Nonnull final UUID signature,
-                                 @Nonnull final Tuple primaryKey) {
+    void deleteCollapsedVectorId(final Transaction transaction,
+                                 final UUID signature,
+                                 final Tuple primaryKey) {
         final Subspace collapsedVectorIdsSubspace = getCollapsedVectorIdsSubspace();
         final byte[] key = collapsedVectorIdsSubspace.pack(Tuple.from(signature, primaryKey));
 
@@ -942,9 +903,8 @@ class Primitives {
      * @return a future of the number of tasks this method ran directly (fewer than {@code numTasks} when the queue held
      *         fewer, or when a fetched task had already been run by another task in this transaction and was skipped)
      */
-    @Nonnull
-    CompletableFuture<Integer> executeDeferredTasks(@Nonnull final Transaction transaction,
-                                                    @Nonnull final AccessInfo accessInfo,
+    CompletableFuture<Integer> executeDeferredTasks(final Transaction transaction,
+                                                    final AccessInfo accessInfo,
                                                     final int numTasks) {
         return executeDeferredTasks(transaction, accessInfo, numTasks, Long.MAX_VALUE);
     }
@@ -966,9 +926,8 @@ class Primitives {
      * @return a future of the number of tasks this method ran directly (fewer than {@code numTasks} when the queue held
      *         fewer, the deadline was reached, or a fetched task had already been run by another task and was skipped)
      */
-    @Nonnull
-    CompletableFuture<Integer> executeDeferredTasks(@Nonnull final Transaction transaction,
-                                                    @Nonnull final AccessInfo accessInfo,
+    CompletableFuture<Integer> executeDeferredTasks(final Transaction transaction,
+                                                    final AccessInfo accessInfo,
                                                     final int numTasks,
                                                     final long deadlineMillis) {
         return fetchSomeDeferredTasks(transaction, accessInfo, numTasks)
@@ -1002,9 +961,8 @@ class Primitives {
      * @return a future of whether the task actually ran ({@code true}), or was skipped because its queue entry had
      *         already been removed in this transaction ({@code false})
      */
-    @Nonnull
-    CompletableFuture<Boolean> executeSingleDeferredTask(@Nonnull final Transaction transaction,
-                                                         @Nonnull final AbstractDeferredTask deferredTask) {
+    CompletableFuture<Boolean> executeSingleDeferredTask(final Transaction transaction,
+                                                         final AbstractDeferredTask deferredTask) {
         final byte[] taskKey = getTasksSubspace().pack(Tuple.from(deferredTask.getTaskId()));
         return transaction.get(taskKey).thenCompose(existing -> {
             if (existing == null) {
@@ -1032,9 +990,8 @@ class Primitives {
      * @param numTasks the maximum number of tasks to fetch
      * @return a future of the fetched tasks, in queue (priority) order
      */
-    @Nonnull
-    CompletableFuture<List<AbstractDeferredTask>> fetchSomeDeferredTasks(@Nonnull final ReadTransaction readTransaction,
-                                                                         @Nonnull final AccessInfo accessInfo,
+    CompletableFuture<List<AbstractDeferredTask>> fetchSomeDeferredTasks(final ReadTransaction readTransaction,
+                                                                         final AccessInfo accessInfo,
                                                                          final int numTasks) {
         final Subspace tasksSubspace = getTasksSubspace();
         final byte[] rangeKey = tasksSubspace.pack();
@@ -1067,10 +1024,9 @@ class Primitives {
      * @param taskId the id of the task
      * @return a future of the task, or {@code null} if it is not currently enqueued
      */
-    @Nonnull
-    CompletableFuture<AbstractDeferredTask> fetchDeferredTask(@Nonnull final ReadTransaction readTransaction,
-                                                              @Nonnull final AccessInfo accessInfo,
-                                                              @Nonnull final UUID taskId) {
+    CompletableFuture<AbstractDeferredTask> fetchDeferredTask(final ReadTransaction readTransaction,
+                                                              final AccessInfo accessInfo,
+                                                              final UUID taskId) {
         final Subspace tasksSubspace = getTasksSubspace();
         final Tuple keyTuple = Tuple.from(taskId);
         final byte[] keyBytes = tasksSubspace.pack(keyTuple);
@@ -1096,9 +1052,9 @@ class Primitives {
      * @param taskId the task id the task is stored under
      * @param valueTuple the task's serialized value
      */
-    void writeDeferredTask(@Nonnull final Transaction transaction,
-                           @Nonnull final UUID taskId,
-                           @Nonnull final Tuple valueTuple) {
+    void writeDeferredTask(final Transaction transaction,
+                           final UUID taskId,
+                           final Tuple valueTuple) {
         final Subspace tasksSubspace = getTasksSubspace();
         final byte[] key = tasksSubspace.pack(Tuple.from(taskId));
         final byte[] value = valueTuple.pack();
@@ -1132,17 +1088,16 @@ class Primitives {
      *
      * @return the id of an enqueued task, or {@link Optional#empty()} if none was enqueued
      */
-    @Nonnull
-    Optional<UUID> updateClusterMetadataAndEnqueueSplitOrReassignTaskMaybe(@Nonnull final Transaction transaction,
-                                                                           @Nonnull final SplittableRandom random,
-                                                                           @Nonnull final ClusterMetadata clusterMetadata,
-                                                                           @Nonnull final Transformed<RealVector> clusterCentroid,
-                                                                           @Nonnull final AccessInfo accessInfo,
+    Optional<UUID> updateClusterMetadataAndEnqueueSplitOrReassignTaskMaybe(final Transaction transaction,
+                                                                           final SplittableRandom random,
+                                                                           final ClusterMetadata clusterMetadata,
+                                                                           final Transformed<RealVector> clusterCentroid,
+                                                                           final AccessInfo accessInfo,
                                                                            final int numPrimaryVectorsAdded,
                                                                            final int numPrimaryUnderreplicatedVectorsAdded,
                                                                            final int numReplicatedVectorsAdded,
-                                                                           @Nonnull final RunningStats updatedStandardDeviation,
-                                                                           @Nonnull final Set<UUID> causeClusterIds) {
+                                                                           final RunningStats updatedStandardDeviation,
+                                                                           final Set<UUID> causeClusterIds) {
         Verify.verify(numPrimaryVectorsAdded >= 0,
                 "updateClusterMetadataAndEnqueueSplitOrReassignTaskMaybe only handles added primary vectors");
         final Config config = getConfig();
@@ -1191,17 +1146,16 @@ class Primitives {
      *
      * @return the id of an enqueued reassign task, or {@link Optional#empty()} if none was enqueued
      */
-    @Nonnull
-    private Optional<UUID> updateClusterMetadataAndEnqueueReassignTaskMaybe(@Nonnull final Transaction transaction,
-                                                                            @Nonnull final SplittableRandom random,
-                                                                            @Nonnull final ClusterMetadata clusterMetadata,
-                                                                            @Nonnull final Transformed<RealVector> clusterCentroid,
-                                                                            @Nonnull final AccessInfo accessInfo,
+    private Optional<UUID> updateClusterMetadataAndEnqueueReassignTaskMaybe(final Transaction transaction,
+                                                                            final SplittableRandom random,
+                                                                            final ClusterMetadata clusterMetadata,
+                                                                            final Transformed<RealVector> clusterCentroid,
+                                                                            final AccessInfo accessInfo,
                                                                             final int numPrimaryVectorsAdded,
                                                                             final int numPrimaryUnderreplicatedVectorsAdded,
                                                                             final int numReplicatedVectorsAdded,
-                                                                            @Nonnull final RunningStats updatedStandardDeviation,
-                                                                            @Nonnull final Set<UUID> causeClusterIds) {
+                                                                            final RunningStats updatedStandardDeviation,
+                                                                            final Set<UUID> causeClusterIds) {
         final Config config = getConfig();
         final UUID clusterId = clusterMetadata.id();
 
@@ -1277,13 +1231,12 @@ class Primitives {
      *
      * @return a future that completes once the metadata has been written and any task enqueued
      */
-    @Nonnull
-    CompletableFuture<Void> updateClusterMetadataAndEnqueueMergeTaskMaybe(@Nonnull final Transaction transaction,
-                                                                         @Nonnull final SplittableRandom random,
-                                                                         @Nonnull final ClusterMetadata clusterMetadata,
-                                                                         @Nonnull final Transformed<RealVector> clusterCentroid,
-                                                                         @Nonnull final AccessInfo accessInfo,
-                                                                         @Nonnull final RunningStats updatedStandardDeviation) {
+    CompletableFuture<Void> updateClusterMetadataAndEnqueueMergeTaskMaybe(final Transaction transaction,
+                                                                         final SplittableRandom random,
+                                                                         final ClusterMetadata clusterMetadata,
+                                                                         final Transformed<RealVector> clusterCentroid,
+                                                                         final AccessInfo accessInfo,
+                                                                         final RunningStats updatedStandardDeviation) {
         final Config config = getConfig();
 
         // A single primary vector was just deleted, i.e. numPrimaryVectorsAdded == -1.
@@ -1341,15 +1294,14 @@ class Primitives {
      *
      * @return the id of the enqueued task
      */
-    @Nonnull
-    UUID updateClusterMetadataAndEnqueueSplitMergeTask(@Nonnull final Transaction transaction,
-                                                       @Nonnull final SplittableRandom random,
-                                                       @Nonnull final ClusterMetadata clusterMetadata,
-                                                       @Nonnull final Transformed<RealVector> clusterCentroid,
-                                                       @Nonnull final AccessInfo accessInfo,
+    UUID updateClusterMetadataAndEnqueueSplitMergeTask(final Transaction transaction,
+                                                       final SplittableRandom random,
+                                                       final ClusterMetadata clusterMetadata,
+                                                       final Transformed<RealVector> clusterCentroid,
+                                                       final AccessInfo accessInfo,
                                                        final int numPrimaryUnderreplicatedVectorsAdded,
                                                        final int numReplicatedVectorsAdded,
-                                                       @Nonnull final RunningStats updatedStandardDeviation) {
+                                                       final RunningStats updatedStandardDeviation) {
         final Config config = getConfig();
         final UUID newTaskId =
                 AbstractDeferredTask.randomNormalPriorityTaskId(random, config.deterministicRandomness());
@@ -1372,8 +1324,8 @@ class Primitives {
      * @param transaction the transaction to write within
      * @param deferredTask the task whose queue entry is cleared
      */
-    void deleteDeferredTask(@Nonnull final Transaction transaction,
-                            @Nonnull final AbstractDeferredTask deferredTask) {
+    void deleteDeferredTask(final Transaction transaction,
+                            final AbstractDeferredTask deferredTask) {
         final Subspace tasksSubspace = getTasksSubspace();
         final byte[] key = tasksSubspace.pack(Tuple.from(deferredTask.getTaskId()));
 
@@ -1398,12 +1350,11 @@ class Primitives {
      * @param concurrency the fan-out width for the per-cluster metadata reads
      * @return a future of the nearest clusters, nearest first
      */
-    @Nonnull
     CompletableFuture<List<ClusterMetadataWithDistance>>
-            findNearestClustersMetadata(@Nonnull final ReadTransaction transaction,
-                                        @Nonnull final ClusterMetadata targetClusterMetadata,
-                                        @Nonnull final RealVector targetClusterCentroid,
-                                        @Nonnull final StorageTransform storageTransform,
+            findNearestClustersMetadata(final ReadTransaction transaction,
+                                        final ClusterMetadata targetClusterMetadata,
+                                        final RealVector targetClusterCentroid,
+                                        final StorageTransform storageTransform,
                                         final int numClusters,
                                         final int concurrency) {
         final Executor executor = getLocator().getExecutor();
@@ -1445,10 +1396,9 @@ class Primitives {
      * @param concurrency the fan-out width for the per-cluster loads
      * @return a future of the fully-loaded clusters
      */
-    @Nonnull
-    CompletableFuture<List<Cluster>> fetchCoreClusters(@Nonnull final Transaction transaction,
-                                                        @Nonnull final List<ClusterMetadataWithDistance> coreClusters,
-                                                        @Nonnull final StorageTransform storageTransform,
+    CompletableFuture<List<Cluster>> fetchCoreClusters(final Transaction transaction,
+                                                        final List<ClusterMetadataWithDistance> coreClusters,
+                                                        final StorageTransform storageTransform,
                                                         final int concurrency) {
         final Executor executor = getLocator().getExecutor();
 
@@ -1474,9 +1424,8 @@ class Primitives {
      * @param concurrency the fan-out width for the per-vector metadata re-reads
      * @return a future of the surviving, de-duplicated, still-current references
      */
-    @Nonnull
-    CompletableFuture<List<VectorReference>> cleanUpVectorReferences(@Nonnull final Transaction transaction,
-                                                                     @Nonnull final List<Cluster> clusters,
+    CompletableFuture<List<VectorReference>> cleanUpVectorReferences(final Transaction transaction,
+                                                                     final List<Cluster> clusters,
                                                                      final boolean discardReplicatedVectorReferences,
                                                                      final int concurrency) {
         final Executor executor = getLocator().getExecutor();
@@ -1518,9 +1467,8 @@ class Primitives {
      * Resolves which of two {@link VectorReference}s sharing the same vector UUID to keep when de-duplicating:
      * prefer a primary over a replica, warn on a duplicate primary, otherwise keep the higher replication priority.
      */
-    @Nonnull
     private static VectorReference mergeVectorReference(@Nullable final VectorReference oldVectorReference,
-                                                        @Nonnull final VectorReference vectorReference) {
+                                                        final VectorReference vectorReference) {
         if (oldVectorReference == null) {
             return vectorReference;
         }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/ReassignTask.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/ReassignTask.java
@@ -45,8 +45,7 @@ import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.List;
@@ -110,49 +109,40 @@ import java.util.concurrent.Executor;
  *
  */
 class ReassignTask extends AbstractDeferredTask {
-    @Nonnull
     private static final Logger logger = LoggerFactory.getLogger(ReassignTask.class);
 
-    @Nonnull
     private final Transformed<RealVector> centroid;
 
-    @Nonnull
     private final Set<UUID> causeClusterIds;
-    @Nonnull
     private final List<ClusterReference> nearestClusters;
 
-    private ReassignTask(@Nonnull final Locator locator, @Nonnull final AccessInfo accessInfo,
-                         @Nonnull final UUID taskId, @Nonnull final UUID targetClusterId,
-                         @Nonnull final Transformed<RealVector> centroid,
-                         @Nonnull final Set<UUID> causeClusterIds,
-                         @Nonnull final List<ClusterReference> nearestClusters) {
+    private ReassignTask(final Locator locator, final AccessInfo accessInfo,
+                         final UUID taskId, final UUID targetClusterId,
+                         final Transformed<RealVector> centroid,
+                         final Set<UUID> causeClusterIds,
+                         final List<ClusterReference> nearestClusters) {
         super(locator, accessInfo, taskId, ImmutableSet.of(targetClusterId));
         this.centroid = centroid;
         this.causeClusterIds = ImmutableSet.copyOf(causeClusterIds);
         this.nearestClusters = ImmutableList.copyOf(nearestClusters);
     }
 
-    @Nonnull
     public Transformed<RealVector> getCentroid() {
         return centroid;
     }
 
-    @Nonnull
     public Set<UUID> getCauseClusterIds() {
         return causeClusterIds;
     }
 
-    @Nonnull
     private List<ClusterReference> getNearestClusters() {
         return nearestClusters;
     }
 
-    @Nonnull
     public UUID getTargetClusterId() {
         return Iterables.getOnlyElement(getTargetClusterIds());
     }
 
-    @Nonnull
     @Override
     public Tuple valueTuple() {
         final Quantizer quantizer = getLocator().primitives().quantizer(getAccessInfo());
@@ -172,7 +162,7 @@ class ReassignTask extends AbstractDeferredTask {
     }
 
     @Override
-    protected void writeDeferredTask(@Nonnull final Transaction transaction) {
+    protected void writeDeferredTask(final Transaction transaction) {
         super.writeDeferredTask(transaction);
         if (logger.isDebugEnabled()) {
             logger.debug("enqueuing REASSIGN; taskId={}; clusterId={}",
@@ -180,15 +170,13 @@ class ReassignTask extends AbstractDeferredTask {
         }
     }
 
-    @Nonnull
     @Override
     public TaskKind getKind() {
         return TaskKind.REASSIGN;
     }
 
-    @Nonnull
     @Override
-    public CompletableFuture<Void> runTask(@Nonnull final Transaction transaction) {
+    public CompletableFuture<Void> runTask(final Transaction transaction) {
         logStart(logger);
 
         final Primitives primitives = getLocator().primitives();
@@ -228,10 +216,9 @@ class ReassignTask extends AbstractDeferredTask {
      *
      * @return a future that completes when the reassignment has been persisted
      */
-    @Nonnull
-    CompletableFuture<Void> reassign(@Nonnull final Transaction transaction,
-                                     @Nonnull final ClusterMetadata targetClusterMetadata,
-                                     @Nonnull final RealVector targetClusterCentroid,
+    CompletableFuture<Void> reassign(final Transaction transaction,
+                                     final ClusterMetadata targetClusterMetadata,
+                                     final RealVector targetClusterCentroid,
                                      final boolean enqueueFollowUpTasks) {
         final SplittableRandom random = RandomHelpers.random(getTaskId());
         final Config config = getConfig();
@@ -303,11 +290,11 @@ class ReassignTask extends AbstractDeferredTask {
      * precomputed nearest clusters rather than re-enqueue.
      */
     @Nullable
-    private CompletableFuture<Void> reenqueueWithFetchedNearestClustersIfEmpty(@Nonnull final Transaction transaction,
-                                                                               @Nonnull final ClusterMetadata targetClusterMetadata,
-                                                                               @Nonnull final RealVector targetClusterCentroid,
-                                                                               @Nonnull final SplittableRandom random,
-                                                                               @Nonnull final StorageTransform storageTransform,
+    private CompletableFuture<Void> reenqueueWithFetchedNearestClustersIfEmpty(final Transaction transaction,
+                                                                               final ClusterMetadata targetClusterMetadata,
+                                                                               final RealVector targetClusterCentroid,
+                                                                               final SplittableRandom random,
+                                                                               final StorageTransform storageTransform,
                                                                                final int numNearestClusters,
                                                                                final boolean enqueueFollowUpTasks) {
         if (!getNearestClusters().isEmpty()) {
@@ -333,11 +320,10 @@ class ReassignTask extends AbstractDeferredTask {
                 });
     }
 
-    @Nonnull
-    private Reassignment reassignVectorReferences(@Nonnull final DistanceEstimator estimator,
-                                                  @Nonnull final ClusterMetadataWithDistance targetClusterMetadataWithDistance,
-                                                  @Nonnull final List<ClusterMetadataWithDistance> neighboringClusters,
-                                                  @Nonnull final List<VectorReference> vectorReferences) {
+    private Reassignment reassignVectorReferences(final DistanceEstimator estimator,
+                                                  final ClusterMetadataWithDistance targetClusterMetadataWithDistance,
+                                                  final List<ClusterMetadataWithDistance> neighboringClusters,
+                                                  final List<VectorReference> vectorReferences) {
         final ImmutableMap.Builder<UUID, ClusterMetadataWithDistance> clusterIdMetadataMapBuilder =
                 ImmutableMap.builder();
 
@@ -467,10 +453,9 @@ class ReassignTask extends AbstractDeferredTask {
      * @param k the maximum number of references to keep
      * @return a future of the finalized reassignment
      */
-    @Nonnull
-    private CompletableFuture<Reassignment> foldCollapsedReplicas(@Nonnull final ReadTransaction readTransaction,
-                                                                  @Nonnull final Reassignment reassignment,
-                                                                  @Nonnull final UUID targetClusterId,
+    private CompletableFuture<Reassignment> foldCollapsedReplicas(final ReadTransaction readTransaction,
+                                                                  final Reassignment reassignment,
+                                                                  final UUID targetClusterId,
                                                                   final int k) {
         final Primitives primitives = getLocator().primitives();
         final Executor executor = getLocator().getExecutor();
@@ -537,14 +522,13 @@ class ReassignTask extends AbstractDeferredTask {
      * cluster that should hold a replica, records a replicated copy keyed by that cluster. Pure — returns the
      * replicas to place together with this primary's contribution to the replication trace counters.
      */
-    @Nonnull
-    private ReplicaSelection selectReplicationAssignments(@Nonnull final DistanceEstimator estimator,
-                                                          @Nonnull final VectorReference vectorReference,
+    private ReplicaSelection selectReplicationAssignments(final DistanceEstimator estimator,
+                                                          final VectorReference vectorReference,
                                                           final double distanceToPrimaryCentroid,
-                                                          @Nonnull final List<ClusterMetadataWithDistance> replicationCandidates,
-                                                          @Nonnull final Set<UUID> causeClusterIds,
-                                                          @Nonnull final UUID targetClusterId,
-                                                          @Nonnull final Map<UUID, RunningStats> standardDeviationsMap) {
+                                                          final List<ClusterMetadataWithDistance> replicationCandidates,
+                                                          final Set<UUID> causeClusterIds,
+                                                          final UUID targetClusterId,
+                                                          final Map<UUID, RunningStats> standardDeviationsMap) {
         final Config config = getConfig();
         final List<ClusterMetadataWithDistance> selectedReplicationClusters =
                 Lists.newArrayListWithExpectedSize(replicationCandidates.size());
@@ -607,21 +591,20 @@ class ReassignTask extends AbstractDeferredTask {
                 new ReplicationStats(replicationPriorityStandardDeviation, numReplicated, numOccluded));
     }
 
-    @Nonnull
-    private TargetClusterDelta computeTargetClusterDelta(@Nonnull final Cluster targetCluster,
-                                                         @Nonnull final Reassignment reassignment,
-                                                         @Nonnull final UUID targetClusterId) {
+    private TargetClusterDelta computeTargetClusterDelta(final Cluster targetCluster,
+                                                         final Reassignment reassignment,
+                                                         final UUID targetClusterId) {
         final List<VectorReference> targetClusterAssignedVectors =
                 reassignment.assignmentMultimap().get(targetClusterId);
         return AbstractDeferredTask.computeTargetClusterDelta(targetCluster, targetClusterAssignedVectors);
     }
 
-    private void persistReassignment(@Nonnull final Transaction transaction,
-                                     @Nonnull final SplittableRandom random,
-                                     @Nonnull final ClusterMetadata targetClusterMetadata,
-                                     @Nonnull final Reassignment reassignment,
-                                     @Nonnull final TargetClusterDelta delta,
-                                     @Nonnull final Quantizer quantizer,
+    private void persistReassignment(final Transaction transaction,
+                                     final SplittableRandom random,
+                                     final ClusterMetadata targetClusterMetadata,
+                                     final Reassignment reassignment,
+                                     final TargetClusterDelta delta,
+                                     final Quantizer quantizer,
                                      final boolean enqueueFollowUpTasks) {
         final WriteCounters counters = countAssignments(targetClusterMetadata, reassignment);
         writeOuterClusterVectors(transaction, quantizer, targetClusterMetadata, reassignment);
@@ -630,9 +613,8 @@ class ReassignTask extends AbstractDeferredTask {
                 enqueueFollowUpTasks);
     }
 
-    @Nonnull
-    private WriteCounters countAssignments(@Nonnull final ClusterMetadata targetClusterMetadata,
-                                           @Nonnull final Reassignment reassignment) {
+    private WriteCounters countAssignments(final ClusterMetadata targetClusterMetadata,
+                                           final Reassignment reassignment) {
         final ListMultimap<UUID, VectorReference> assignmentMultiMap = reassignment.assignmentMultimap();
 
         final Map<UUID, Integer> clusterIdToNumPrimaryVectorsAdded = Maps.newHashMap();
@@ -668,10 +650,10 @@ class ReassignTask extends AbstractDeferredTask {
                 numPrimaryPushedOut, numReplicatedPushedOut);
     }
 
-    private void writeOuterClusterVectors(@Nonnull final Transaction transaction,
-                                          @Nonnull final Quantizer quantizer,
-                                          @Nonnull final ClusterMetadata targetClusterMetadata,
-                                          @Nonnull final Reassignment reassignment) {
+    private void writeOuterClusterVectors(final Transaction transaction,
+                                          final Quantizer quantizer,
+                                          final ClusterMetadata targetClusterMetadata,
+                                          final Reassignment reassignment) {
         final Primitives primitives = getLocator().primitives();
         final ListMultimap<UUID, VectorReference> assignmentMultiMap = reassignment.assignmentMultimap();
 
@@ -687,10 +669,10 @@ class ReassignTask extends AbstractDeferredTask {
         }
     }
 
-    private void persistTargetClusterDelta(@Nonnull final Transaction transaction,
-                                           @Nonnull final Quantizer quantizer,
-                                           @Nonnull final UUID targetClusterId,
-                                           @Nonnull final TargetClusterDelta delta) {
+    private void persistTargetClusterDelta(final Transaction transaction,
+                                           final Quantizer quantizer,
+                                           final UUID targetClusterId,
+                                           final TargetClusterDelta delta) {
         final Primitives primitives = getLocator().primitives();
 
         for (final Tuple primaryKey : delta.toDelete()) {
@@ -702,12 +684,12 @@ class ReassignTask extends AbstractDeferredTask {
         }
     }
 
-    private void writeClusterMetadata(@Nonnull final Transaction transaction,
-                                      @Nonnull final SplittableRandom random,
-                                      @Nonnull final ClusterMetadata targetClusterMetadata,
-                                      @Nonnull final Reassignment reassignment,
-                                      @Nonnull final WriteCounters counters,
-                                      @Nonnull final TargetClusterDelta delta,
+    private void writeClusterMetadata(final Transaction transaction,
+                                      final SplittableRandom random,
+                                      final ClusterMetadata targetClusterMetadata,
+                                      final Reassignment reassignment,
+                                      final WriteCounters counters,
+                                      final TargetClusterDelta delta,
                                       final boolean enqueueFollowUpTasks) {
         final Primitives primitives = getLocator().primitives();
         final Map<UUID, ClusterMetadataWithDistance> clusterIdMetadataMap =
@@ -768,17 +750,15 @@ class ReassignTask extends AbstractDeferredTask {
         }
     }
 
-    @Nonnull
-    private ReassignTask withHighPriorityAndNearestClusters(@Nonnull final SplittableRandom random,
-                                                         @Nonnull final List<ClusterReference> nearestClusters) {
+    private ReassignTask withHighPriorityAndNearestClusters(final SplittableRandom random,
+                                                         final List<ClusterReference> nearestClusters) {
         return ReassignTask.of(getLocator(), getAccessInfo(),
                 randomHighPriorityTaskId(random, getConfig().deterministicRandomness()), getTargetClusterId(),
                 getCentroid(), getCauseClusterIds(), nearestClusters);
     }
 
-    @Nonnull
-    static ReassignTask fromTuples(@Nonnull final Locator locator, @Nonnull final AccessInfo accessInfo,
-                                   @Nonnull final Tuple keyTuple, @Nonnull final Tuple valueTuple) {
+    static ReassignTask fromTuples(final Locator locator, final AccessInfo accessInfo,
+                                   final Tuple keyTuple, final Tuple valueTuple) {
         Verify.verify(TaskKind.fromValueTuple(valueTuple) == TaskKind.REASSIGN);
         final StorageTransform storageTransform = locator.primitives().storageTransform(accessInfo);
 
@@ -798,20 +778,18 @@ class ReassignTask extends AbstractDeferredTask {
                 causeClusterIds, nearestClustersBuilder.build());
     }
 
-    @Nonnull
-    static ReassignTask of(@Nonnull final Locator locator, @Nonnull final AccessInfo accessInfo,
-                           @Nonnull final UUID taskId, @Nonnull final UUID clusterId,
-                           @Nonnull final Transformed<RealVector> centroid,
-                           @Nonnull final Set<UUID> causeClusterIds) {
+    static ReassignTask of(final Locator locator, final AccessInfo accessInfo,
+                           final UUID taskId, final UUID clusterId,
+                           final Transformed<RealVector> centroid,
+                           final Set<UUID> causeClusterIds) {
         return of(locator, accessInfo, taskId, clusterId, centroid, causeClusterIds, ImmutableList.of());
     }
 
-    @Nonnull
-    static ReassignTask of(@Nonnull final Locator locator, @Nonnull final AccessInfo accessInfo,
-                           @Nonnull final UUID taskId, @Nonnull final UUID clusterId,
-                           @Nonnull final Transformed<RealVector> centroid,
-                           @Nonnull final Set<UUID> causeClusterIds,
-                           @Nonnull final List<ClusterReference> nearestClusters) {
+    static ReassignTask of(final Locator locator, final AccessInfo accessInfo,
+                           final UUID taskId, final UUID clusterId,
+                           final Transformed<RealVector> centroid,
+                           final Set<UUID> causeClusterIds,
+                           final List<ClusterReference> nearestClusters) {
         return new ReassignTask(locator, accessInfo, taskId, clusterId, centroid, causeClusterIds, nearestClusters);
     }
 
@@ -826,10 +804,10 @@ class ReassignTask extends AbstractDeferredTask {
      *        replication priority but not yet top-k-truncated, deduplicated, or collapse-folded; consumed by
      *        {@link #foldCollapsedReplicas}
      */
-    private record Reassignment(@Nonnull Map<UUID, ClusterMetadataWithDistance> clusterIdMetadataMap,
-                                @Nonnull ListMultimap<UUID, VectorReference> assignmentMultimap,
-                                @Nonnull Map<UUID, RunningStats> updatedStandardDeviationsMap,
-                                @Nonnull List<VectorReference> orderedReplicatedReferences) {
+    private record Reassignment(Map<UUID, ClusterMetadataWithDistance> clusterIdMetadataMap,
+                                ListMultimap<UUID, VectorReference> assignmentMultimap,
+                                Map<UUID, RunningStats> updatedStandardDeviationsMap,
+                                List<VectorReference> orderedReplicatedReferences) {
     }
 
     /**
@@ -842,9 +820,9 @@ class ReassignTask extends AbstractDeferredTask {
      * @param numPrimaryPushedOut the number of primary vectors moved out of the target cluster
      * @param numReplicatedPushedOut the number of replicated vectors moved out of the target cluster
      */
-    private record WriteCounters(@Nonnull Map<UUID, Integer> numPrimaryVectorsAdded,
-                                 @Nonnull Map<UUID, Integer> numPrimaryUnderreplicatedVectorsAdded,
-                                 @Nonnull Map<UUID, Integer> numReplicatedVectorsAdded,
+    private record WriteCounters(Map<UUID, Integer> numPrimaryVectorsAdded,
+                                 Map<UUID, Integer> numPrimaryUnderreplicatedVectorsAdded,
+                                 Map<UUID, Integer> numReplicatedVectorsAdded,
                                  int numPrimaryPushedOut,
                                  int numReplicatedPushedOut) {
     }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/ReplicaSelection.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/ReplicaSelection.java
@@ -22,7 +22,6 @@ package com.apple.foundationdb.async.guardiann;
 
 import com.google.common.collect.ImmutableListMultimap;
 
-import javax.annotation.Nonnull;
 import java.util.UUID;
 
 /**
@@ -34,6 +33,6 @@ import java.util.UUID;
  * @param replicasByCluster the replicas to place, keyed by destination cluster id
  * @param stats this primary's contribution to the replication trace counters
  */
-record ReplicaSelection(@Nonnull ImmutableListMultimap<UUID, VectorReference> replicasByCluster,
-                        @Nonnull ReplicationStats stats) {
+record ReplicaSelection(ImmutableListMultimap<UUID, VectorReference> replicasByCluster,
+                        ReplicationStats stats) {
 }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/ReplicatedCopy.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/ReplicatedCopy.java
@@ -24,7 +24,6 @@ import com.apple.foundationdb.linear.RealVector;
 import com.apple.foundationdb.linear.Transformed;
 import com.apple.foundationdb.tuple.Tuple;
 
-import javax.annotation.Nonnull;
 import java.util.UUID;
 
 /**
@@ -37,47 +36,40 @@ import java.util.UUID;
  * @param replicationPriority the replication-priority score
  * @param isCollapsed whether this reference represents a collapsed set of identical vectors
  */
-record ReplicatedCopy(@Nonnull VectorId id, @Nonnull Transformed<RealVector> vector,
+record ReplicatedCopy(VectorId id, Transformed<RealVector> vector,
                       double replicationPriority, boolean isCollapsed) implements VectorReference {
-    @Nonnull
     @Override
-    public VectorReference withVectorId(@Nonnull final VectorId newVectorId) {
+    public VectorReference withVectorId(final VectorId newVectorId) {
         return id.equals(newVectorId) ? this : new ReplicatedCopy(newVectorId, vector, replicationPriority, isCollapsed);
     }
 
-    @Nonnull
     @Override
     @SuppressWarnings("PMD.CompareObjectsWithEquals")
-    public VectorReference withVector(@Nonnull final Transformed<RealVector> newVector) {
+    public VectorReference withVector(final Transformed<RealVector> newVector) {
         return vector == newVector ? this : new ReplicatedCopy(id, newVector, replicationPriority, isCollapsed);
     }
 
-    @Nonnull
     @Override
     public VectorReference toPrimaryCopy() {
         return new PrimaryCopy(id, vector, false, isCollapsed);
     }
 
-    @Nonnull
     @Override
     public VectorReference toPrimaryUnderreplicatedCopy() {
         return new PrimaryCopy(id, vector, true, isCollapsed);
     }
 
-    @Nonnull
     @Override
     public VectorReference toReplicatedCopy(final double newReplicationScore) {
         return replicationPriority == newReplicationScore
                ? this : new ReplicatedCopy(id, vector, newReplicationScore, isCollapsed);
     }
 
-    @Nonnull
     @Override
-    public VectorReference toCollapsed(@Nonnull final UUID signature, @Nonnull final UUID vectorUuid) {
+    public VectorReference toCollapsed(final UUID signature, final UUID vectorUuid) {
         return new ReplicatedCopy(new VectorId(Tuple.from(signature), vectorUuid), vector, replicationPriority, true);
     }
 
-    @Nonnull
     @Override
     public String toString() {
         return "VR[" + id + ", REPLICATED, replicationPriority=" + replicationPriority

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/ReplicationStats.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/ReplicationStats.java
@@ -20,7 +20,6 @@
 
 package com.apple.foundationdb.async.guardiann;
 
-import javax.annotation.Nonnull;
 
 /**
  * The running trace counters accumulated across the per-primary replication passes (used only for logging): the
@@ -32,10 +31,9 @@ import javax.annotation.Nonnull;
  * @param numReplicated the number of replicas written
  * @param numOccluded the number of candidates skipped because they were occluded
  */
-record ReplicationStats(@Nonnull RunningStats replicationPriorityStandardDeviation,
+record ReplicationStats(RunningStats replicationPriorityStandardDeviation,
                         int numReplicated, int numOccluded) {
     /** Returns the empty accumulator (no replicas, no occlusions, empty priority stats). */
-    @Nonnull
     static ReplicationStats identity() {
         return new ReplicationStats(RunningStats.identity(), 0, 0);
     }
@@ -47,8 +45,7 @@ record ReplicationStats(@Nonnull RunningStats replicationPriorityStandardDeviati
      * @param other the accumulator to combine with
      * @return a new accumulator representing the combined counters
      */
-    @Nonnull
-    ReplicationStats combine(@Nonnull final ReplicationStats other) {
+    ReplicationStats combine(final ReplicationStats other) {
         return new ReplicationStats(
                 replicationPriorityStandardDeviation.combine(other.replicationPriorityStandardDeviation()),
                 numReplicated + other.numReplicated(),

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/RunningStats.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/RunningStats.java
@@ -20,7 +20,6 @@
 
 package com.apple.foundationdb.async.guardiann;
 
-import javax.annotation.Nonnull;
 
 /**
  * Incrementally maintained statistics for a set of distance values, using Welford's online algorithm
@@ -51,7 +50,6 @@ record RunningStats(long numElements, double runningMean, double runningSumSquar
      * @param newValue the value to add
      * @return a new accumulator reflecting the added value
      */
-    @Nonnull
     public RunningStats add(final double newValue) {
         long newN = numElements() + 1;
         double delta = newValue - runningMean();
@@ -70,7 +68,6 @@ record RunningStats(long numElements, double runningMean, double runningSumSquar
      * @return a new accumulator reflecting the removal
      * @throws IllegalStateException if the accumulator is empty
      */
-    @Nonnull
     public RunningStats remove(double x) {
         if (numElements() == 0) {
             throw new IllegalStateException("Cannot remove from an empty set");
@@ -103,8 +100,7 @@ record RunningStats(long numElements, double runningMean, double runningSumSquar
      * @param other the accumulator to combine with
      * @return a new accumulator representing the combined statistics
      */
-    @Nonnull
-    public RunningStats combine(@Nonnull final RunningStats other) {
+    public RunningStats combine(final RunningStats other) {
         if (other.numElements() == 0) {
             return this;
         }
@@ -133,8 +129,7 @@ record RunningStats(long numElements, double runningMean, double runningSumSquar
      * @throws IllegalArgumentException if the other accumulator has more elements
      * @throws IllegalStateException if the subtraction produces an invalid M2 (negative beyond roundoff)
      */
-    @Nonnull
-    public RunningStats subtract(@Nonnull final RunningStats other) {
+    public RunningStats subtract(final RunningStats other) {
         if (other.numElements() == 0) {
             return this;
         }
@@ -212,7 +207,6 @@ record RunningStats(long numElements, double runningMean, double runningSumSquar
         return Double.isInfinite(runningMaxEver) && runningMaxEver < 0 ? Double.NaN : runningMaxEver;
     }
 
-    @Nonnull
     @Override
     public String toString() {
         return "RunningStats[" + numElements() + ", " + runningMean() + ", " +
@@ -220,7 +214,6 @@ record RunningStats(long numElements, double runningMean, double runningSumSquar
     }
 
     /** Returns the empty accumulator (zero elements). */
-    @Nonnull
     public static RunningStats identity() {
         return IDENTITY;
     }
@@ -231,7 +224,6 @@ record RunningStats(long numElements, double runningMean, double runningSumSquar
      * @param newValue the initial value
      * @return a new accumulator with one element
      */
-    @Nonnull
     public static RunningStats of(final double newValue) {
         return identity().add(newValue);
     }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/Search.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/Search.java
@@ -40,8 +40,7 @@ import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -76,10 +75,8 @@ import static com.apple.foundationdb.async.MoreAsyncUtil.mapIterablePipelined;
  * </ol>
  */
 class Search {
-    @Nonnull
     private static final Logger logger = LoggerFactory.getLogger(Search.class);
 
-    @Nonnull
     private final Locator locator;
 
     /**
@@ -87,11 +84,10 @@ class Search {
      *
      * @param locator the {@link Locator} providing access to storage, configuration, and execution context
      */
-    public Search(@Nonnull final Locator locator) {
+    public Search(final Locator locator) {
         this.locator = locator;
     }
 
-    @Nonnull
     public Locator getLocator() {
         return locator;
     }
@@ -101,7 +97,6 @@ class Search {
      *
      * @return the non-null subspace
      */
-    @Nonnull
     public Subspace getSubspace() {
         return getLocator().getSubspace();
     }
@@ -110,7 +105,6 @@ class Search {
      * Get the executor used by this hnsw.
      * @return executor used when running asynchronous tasks
      */
-    @Nonnull
     public Executor getExecutor() {
         return getLocator().getExecutor();
     }
@@ -119,7 +113,6 @@ class Search {
      * Get the configuration of this hnsw.
      * @return hnsw configuration
      */
-    @Nonnull
     public Config getConfig() {
         return getLocator().getConfig();
     }
@@ -128,7 +121,6 @@ class Search {
      * Get the on-write listener.
      * @return the on-write listener
      */
-    @Nonnull
     public OnWriteListener getOnWriteListener() {
         return getLocator().getOnWriteListener();
     }
@@ -137,12 +129,10 @@ class Search {
      * Get the on-read listener.
      * @return the on-read listener
      */
-    @Nonnull
     public OnReadListener getOnReadListener() {
         return getLocator().getOnReadListener();
     }
 
-    @Nonnull
     private Primitives primitives() {
         return getLocator().primitives();
     }
@@ -158,14 +148,13 @@ class Search {
      * @param queryVector the query vector to search for
      * @return a future completing with up to {@code k} nearest neighbors sorted by distance
      */
-    @Nonnull
     @SuppressWarnings("checkstyle:MethodName")
     public CompletableFuture<List<? extends ResultEntry>>
-            kNearestNeighborsSearch(@Nonnull final ReadTransaction readTransaction,
+            kNearestNeighborsSearch(final ReadTransaction readTransaction,
                                     final int k,
-                                    @Nonnull final SearchConfig searchConfig,
+                                    final SearchConfig searchConfig,
                                     final boolean includeVectors,
-                                    @Nonnull final RealVector queryVector) {
+                                    final RealVector queryVector) {
         return search(readTransaction, k, searchConfig, queryVector)
                 .thenApply(searchResult ->
                         searchResult == null
@@ -185,11 +174,10 @@ class Search {
      * @param queryVector the query vector
      * @return a future completing with the search result, or {@code null} if no vectors exist yet
      */
-    @Nonnull
-    CompletableFuture<SearchResult> search(@Nonnull final ReadTransaction readTransaction,
+    CompletableFuture<SearchResult> search(final ReadTransaction readTransaction,
                                            final int k,
-                                           @Nonnull final SearchConfig searchConfig,
-                                           @Nonnull final RealVector queryVector) {
+                                           final SearchConfig searchConfig,
+                                           final RealVector queryVector) {
         final Primitives primitives = primitives();
 
         return primitives.fetchAccessInfo(readTransaction)
@@ -226,13 +214,12 @@ class Search {
      * @param searchConfig the search tuning knobs (probed-cluster cap and centroid-walk exploration factors)
      * @return a future completing with the candidate clusters sorted by centroid distance (ascending)
      */
-    @Nonnull
     private CompletableFuture<List<ClusterMetadataWithDistance>>
-            fetchCandidateClusters(@Nonnull final ReadTransaction readTransaction,
-                                   @Nonnull final Primitives primitives,
-                                   @Nonnull final StorageTransform storageTransform,
-                                   @Nonnull final RealVector queryVector,
-                                   @Nonnull final SearchConfig searchConfig) {
+            fetchCandidateClusters(final ReadTransaction readTransaction,
+                                   final Primitives primitives,
+                                   final StorageTransform storageTransform,
+                                   final RealVector queryVector,
+                                   final SearchConfig searchConfig) {
         final AsyncIterable<ResultEntry> clusterCentroidEntriesByDistanceIterable =
                 MoreAsyncUtil.limitIterable(MoreAsyncUtil.iterableOf(() ->
                         primitives.centroidsOrderedByDistance(readTransaction, queryVector, 0.0d, null,
@@ -266,10 +253,9 @@ class Search {
      * @param searchConfig the search tuning knobs (the min-clusters floor and distance-ratio cutoff)
      * @return the pruned sublist
      */
-    @Nonnull
     private List<ClusterMetadataWithDistance>
-            pruneClusters(@Nonnull final List<ClusterMetadataWithDistance> clusterMetadataWithDistances,
-                          @Nonnull final SearchConfig searchConfig) {
+            pruneClusters(final List<ClusterMetadataWithDistance> clusterMetadataWithDistances,
+                          final SearchConfig searchConfig) {
         final int searchMinClustersBeforePruning = searchConfig.searchMinClustersBeforePruning();
         final double searchDistanceRatioCutoff = searchConfig.searchDistanceRatioCutoff();
         if (clusterMetadataWithDistances.size() <= searchMinClustersBeforePruning) {
@@ -308,16 +294,15 @@ class Search {
      * @param searchConfig the search tuning knobs (candidate-pool factor and fan-out concurrency)
      * @return a future completing with the top candidates sorted by distance (best first)
      */
-    @Nonnull
     private CompletableFuture<List<VectorReferenceAndDistance>>
-            retrieveVectorReferencesFromClusters(@Nonnull final ReadTransaction readTransaction,
-                                                 @Nonnull final Primitives primitives,
-                                                 @Nonnull final StorageTransform storageTransform,
-                                                 @Nonnull final DistanceEstimator estimator,
-                                                 @Nonnull final Transformed<RealVector> transformedQueryVector,
-                                                 @Nonnull final List<ClusterMetadataWithDistance> clusters,
+            retrieveVectorReferencesFromClusters(final ReadTransaction readTransaction,
+                                                 final Primitives primitives,
+                                                 final StorageTransform storageTransform,
+                                                 final DistanceEstimator estimator,
+                                                 final Transformed<RealVector> transformedQueryVector,
+                                                 final List<ClusterMetadataWithDistance> clusters,
                                                  final int k,
-                                                 @Nonnull final SearchConfig searchConfig) {
+                                                 final SearchConfig searchConfig) {
         final AsyncIterable<ClusterMetadataWithDistance> boundedClusterMetadataIterable =
                 MoreAsyncUtil.iterableFromCollection(
                         CompletableFuture.completedFuture(clusters), getExecutor());
@@ -354,13 +339,12 @@ class Search {
      * @param searchConfig the search tuning knobs (candidate-pool factor for the expanded top-K and concurrency)
      * @return a future completing with the expanded top candidates
      */
-    @Nonnull
     private CompletableFuture<List<VectorReferenceAndDistance>>
-            expandCollapsedReferencesIfNecessary(@Nonnull final ReadTransaction readTransaction,
-                                                 @Nonnull final Primitives primitives,
-                                                 @Nonnull final List<VectorReferenceAndDistance> topReferences,
+            expandCollapsedReferencesIfNecessary(final ReadTransaction readTransaction,
+                                                 final Primitives primitives,
+                                                 final List<VectorReferenceAndDistance> topReferences,
                                                  final int k,
-                                                 @Nonnull final SearchConfig searchConfig) {
+                                                 final SearchConfig searchConfig) {
         boolean foundCollapsedReferences = false;
         for (final VectorReferenceAndDistance referenceAndDistance : topReferences) {
             if (referenceAndDistance.vectorReference().isCollapsed()) {
@@ -411,13 +395,12 @@ class Search {
      * @param searchConfig the search tuning knobs (fan-out concurrency)
      * @return a future completing with the filtered and enriched results
      */
-    @Nonnull
     private CompletableFuture<List<VectorRecord>>
-            enrichResults(@Nonnull final ReadTransaction readTransaction,
-                          @Nonnull final Primitives primitives,
-                          @Nonnull final List<VectorReferenceAndDistance> topReferences,
+            enrichResults(final ReadTransaction readTransaction,
+                          final Primitives primitives,
+                          final List<VectorReferenceAndDistance> topReferences,
                           final int k,
-                          @Nonnull final SearchConfig searchConfig) {
+                          final SearchConfig searchConfig) {
         final Map<Tuple, CompletableFuture<VectorMetadata>> primaryKeyToVectorMetadataFutureMap =
                 Maps.newConcurrentMap();
 
@@ -464,11 +447,10 @@ class Search {
                 });
     }
 
-    @Nonnull
-    CompletableFuture<SearchResult> searchOrderedByDistance(@Nonnull final ReadTransaction readTransaction,
+    CompletableFuture<SearchResult> searchOrderedByDistance(final ReadTransaction readTransaction,
                                                             final int k,
-                                                            @Nonnull final SearchConfig searchConfig,
-                                                            @Nonnull final RealVector queryVector,
+                                                            final SearchConfig searchConfig,
+                                                            final RealVector queryVector,
                                                             final double minimumRadiusCluster,
                                                             final double minimumRadius,
                                                             @Nullable final Tuple minimumPrimaryKey) {
@@ -540,12 +522,11 @@ class Search {
      * @param includeVectors whether to include reconstructed vector data in the results
      * @return a future completing with up to {@code k} results in ascending distance order
      */
-    @Nonnull
     CompletableFuture<List<? extends ResultEntry>>
-            searchOrderedByDistanceResults(@Nonnull final ReadTransaction readTransaction,
+            searchOrderedByDistanceResults(final ReadTransaction readTransaction,
                                            final int k,
-                                           @Nonnull final SearchConfig searchConfig,
-                                           @Nonnull final RealVector queryVector,
+                                           final SearchConfig searchConfig,
+                                           final RealVector queryVector,
                                            final double minimumRadiusCluster,
                                            final double minimumRadius,
                                            @Nullable final Tuple minimumPrimaryKey,
@@ -565,13 +546,12 @@ class Search {
      * (approximate) distance order, drops references whose metadata is stale, de-duplicates by primary key, then
      * takes the nearest {@code k} and enriches each with its full metadata.
      */
-    @Nonnull
     private CompletableFuture<List<VectorRecord>> collectNearestKOrderedByDistance(
-            @Nonnull final ReadTransaction readTransaction,
-            @Nonnull final Primitives primitives,
-            @Nonnull final AsyncIterable<VectorReferenceAndDistance> vectorReferenceAndDistancesIterable,
+            final ReadTransaction readTransaction,
+            final Primitives primitives,
+            final AsyncIterable<VectorReferenceAndDistance> vectorReferenceAndDistancesIterable,
             final int k,
-            @Nonnull final SearchConfig searchConfig,
+            final SearchConfig searchConfig,
             final double minimumRadius,
             @Nullable final Tuple minimumPrimaryKey) {
         // Expand collapsed references inline: a collapsed reference becomes one entry
@@ -654,9 +634,8 @@ class Search {
      * @param includeVectors whether to include the reconstructed vector data in each result entry
      * @return the search results as a list of {@link ResultEntry} instances
      */
-    @Nonnull
-    private ImmutableList<ResultEntry> postProcessSearchResult(@Nonnull final StorageTransform storageTransform,
-                                                               @Nonnull final List<VectorRecord> nearestRecords,
+    private ImmutableList<ResultEntry> postProcessSearchResult(final StorageTransform storageTransform,
+                                                               final List<VectorRecord> nearestRecords,
                                                                final boolean includeVectors) {
         final ImmutableList.Builder<ResultEntry> resultBuilder = ImmutableList.builder();
 
@@ -688,11 +667,10 @@ class Search {
      * @param searchConfig the search tuning knobs (fan-out concurrency)
      * @return a future completing with a list of overlap counts (one per query vector)
      */
-    @Nonnull
-    CompletableFuture<List<Integer>> clusterOverlapDiagnostics(@Nonnull final ReadTransaction readTransaction,
-                                                               @Nonnull final List<RealVector> queryVectors,
-                                                               @Nonnull final List<ResultEntry> centroids,
-                                                               @Nonnull final SearchConfig searchConfig) {
+    CompletableFuture<List<Integer>> clusterOverlapDiagnostics(final ReadTransaction readTransaction,
+                                                               final List<RealVector> queryVectors,
+                                                               final List<ResultEntry> centroids,
+                                                               final SearchConfig searchConfig) {
         final Primitives primitives = primitives();
 
         return primitives.fetchAccessInfo(readTransaction)
@@ -771,10 +749,9 @@ class Search {
      * @return a future completing with the topology snapshot (an empty snapshot if the structure has no access
      *         info yet)
      */
-    @Nonnull
-    CompletableFuture<StructureSnapshot> snapshotStructure(@Nonnull final ReadTransaction readTransaction,
-                                                           @Nonnull final List<ResultEntry> centroids,
-                                                           @Nonnull final SearchConfig searchConfig) {
+    CompletableFuture<StructureSnapshot> snapshotStructure(final ReadTransaction readTransaction,
+                                                           final List<ResultEntry> centroids,
+                                                           final SearchConfig searchConfig) {
         final Primitives primitives = primitives();
 
         return primitives.fetchAccessInfo(readTransaction)
@@ -812,10 +789,9 @@ class Search {
      * Builds a single {@link ClusterView} from a fetched {@link Cluster}, bucketing its references into primaries,
      * replicas and collapsed (a reference is collapsed first, then primary, else a replica).
      */
-    @Nonnull
-    private static ClusterView buildClusterView(@Nonnull final UUID clusterId,
-                                                @Nonnull final RealVector untransformedCentroid,
-                                                @Nonnull final Cluster cluster) {
+    private static ClusterView buildClusterView(final UUID clusterId,
+                                                final RealVector untransformedCentroid,
+                                                final Cluster cluster) {
         final ImmutableSet.Builder<VectorId> primariesBuilder = ImmutableSet.builder();
         final ImmutableSet.Builder<VectorId> replicasBuilder = ImmutableSet.builder();
         final ImmutableSet.Builder<VectorId> collapsedBuilder = ImmutableSet.builder();
@@ -833,10 +809,9 @@ class Search {
                 ImmutableList.copyOf(cluster.vectorReferences()));
     }
 
-    @Nonnull
     private static AsyncIterable<VectorReferenceAndDistance>
-            almostSortedVectorReferencesIterable(@Nonnull final AsyncIterable<VectorReferenceAndDistance> iterable,
-                                                 final int maxQueueSize, @Nonnull final Executor executor) {
+            almostSortedVectorReferencesIterable(final AsyncIterable<VectorReferenceAndDistance> iterable,
+                                                 final int maxQueueSize, final Executor executor) {
         return MoreAsyncUtil.iterableOf(() -> new AlmostSortedAsyncIterator<>(iterable.iterator(),
                         Comparator.comparing(VectorReferenceAndDistance::distance)
                                 .thenComparing(d -> d.vectorReference().id()), maxQueueSize, executor),
@@ -853,9 +828,8 @@ class Search {
      * @param distance the computed distance between this vector and the query vector
      * @return the enriched record carrying the metadata, the stored vector, and the distance
      */
-    @Nonnull
-    private static VectorRecord enrichVectorReference(@Nonnull final Map<Tuple, CompletableFuture<VectorMetadata>> primaryKeyToVectorMetadataUuidFutureMap,
-                                                      @Nonnull final VectorReference vectorReference,
+    private static VectorRecord enrichVectorReference(final Map<Tuple, CompletableFuture<VectorMetadata>> primaryKeyToVectorMetadataUuidFutureMap,
+                                                      final VectorReference vectorReference,
                                                       final double distance) {
         // Every metadata future was already awaited by the enclosing forEach(...).thenApply(...), so it is complete.
         final CompletableFuture<VectorMetadata> metadataFuture =
@@ -875,11 +849,11 @@ class Search {
      * @param nearestRecords the enriched search results sorted by distance (best first), defensively copied
      */
     record SearchResult(@Nullable AccessInfo accessInfo,
-                        @Nonnull StorageTransform storageTransform,
-                        @Nonnull List<VectorRecord> nearestRecords) {
+                        StorageTransform storageTransform,
+                        List<VectorRecord> nearestRecords) {
         SearchResult(@Nullable final AccessInfo accessInfo,
-                     @Nonnull final StorageTransform storageTransform,
-                     @Nonnull final List<VectorRecord> nearestRecords) {
+                     final StorageTransform storageTransform,
+                     final List<VectorRecord> nearestRecords) {
             this.accessInfo = accessInfo;
             this.storageTransform = storageTransform;
             this.nearestRecords = ImmutableList.copyOf(nearestRecords);

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/SearchConfig.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/SearchConfig.java
@@ -23,7 +23,6 @@ package com.apple.foundationdb.async.guardiann;
 import com.google.common.base.Preconditions;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 
-import javax.annotation.Nonnull;
 
 /**
  * The performance/recall tuning knobs for a single Guardiann search. These are the parameters that change how hard the
@@ -99,14 +98,12 @@ public record SearchConfig(double candidatePoolFactor,
         return Math.max(k, (int) Math.ceil(candidatePoolFactor() * k));
     }
 
-    @Nonnull
     public SearchConfigBuilder toBuilder() {
         return new SearchConfigBuilder(candidatePoolFactor(), searchMaxClusters(), searchMinClustersBeforePruning(),
                 searchDistanceRatioCutoff(), centroidEfRingSearch(), centroidEfOutwardSearch(), searchConcurrency());
     }
 
     @Override
-    @Nonnull
     public String toString() {
         return "SearchConfig[candidatePoolFactor=" + candidatePoolFactor() +
                 ", searchMaxClusters=" + searchMaxClusters() +
@@ -152,7 +149,6 @@ public record SearchConfig(double candidatePoolFactor,
             return candidatePoolFactor;
         }
 
-        @Nonnull
         public SearchConfigBuilder setCandidatePoolFactor(final double candidatePoolFactor) {
             this.candidatePoolFactor = candidatePoolFactor;
             return this;
@@ -162,7 +158,6 @@ public record SearchConfig(double candidatePoolFactor,
             return searchMaxClusters;
         }
 
-        @Nonnull
         public SearchConfigBuilder setSearchMaxClusters(final int searchMaxClusters) {
             this.searchMaxClusters = searchMaxClusters;
             return this;
@@ -172,7 +167,6 @@ public record SearchConfig(double candidatePoolFactor,
             return searchMinClustersBeforePruning;
         }
 
-        @Nonnull
         public SearchConfigBuilder setSearchMinClustersBeforePruning(final int searchMinClustersBeforePruning) {
             this.searchMinClustersBeforePruning = searchMinClustersBeforePruning;
             return this;
@@ -182,7 +176,6 @@ public record SearchConfig(double candidatePoolFactor,
             return searchDistanceRatioCutoff;
         }
 
-        @Nonnull
         public SearchConfigBuilder setSearchDistanceRatioCutoff(final double searchDistanceRatioCutoff) {
             this.searchDistanceRatioCutoff = searchDistanceRatioCutoff;
             return this;
@@ -192,7 +185,6 @@ public record SearchConfig(double candidatePoolFactor,
             return centroidEfRingSearch;
         }
 
-        @Nonnull
         public SearchConfigBuilder setCentroidEfRingSearch(final int centroidEfRingSearch) {
             this.centroidEfRingSearch = centroidEfRingSearch;
             return this;
@@ -202,7 +194,6 @@ public record SearchConfig(double candidatePoolFactor,
             return centroidEfOutwardSearch;
         }
 
-        @Nonnull
         public SearchConfigBuilder setCentroidEfOutwardSearch(final int centroidEfOutwardSearch) {
             this.centroidEfOutwardSearch = centroidEfOutwardSearch;
             return this;
@@ -212,13 +203,11 @@ public record SearchConfig(double candidatePoolFactor,
             return searchConcurrency;
         }
 
-        @Nonnull
         public SearchConfigBuilder setSearchConcurrency(final int searchConcurrency) {
             this.searchConcurrency = searchConcurrency;
             return this;
         }
 
-        @Nonnull
         public SearchConfig build() {
             return new SearchConfig(getCandidatePoolFactor(), getSearchMaxClusters(),
                     getSearchMinClustersBeforePruning(), getSearchDistanceRatioCutoff(), getCentroidEfRingSearch(),

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/SplitMergeTask.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/SplitMergeTask.java
@@ -48,8 +48,7 @@ import com.google.common.collect.Maps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.List;
@@ -77,35 +76,30 @@ import java.util.concurrent.Executor;
  * </p>
  */
 class SplitMergeTask extends AbstractDeferredTask {
-    @Nonnull
     private static final Logger logger = LoggerFactory.getLogger(SplitMergeTask.class);
 
-    @Nonnull
     private final Transformed<RealVector> centroid;
-    @Nonnull
     private final List<ClusterReference> nearestClusters;
 
-    private SplitMergeTask(@Nonnull final Locator locator, @Nonnull final AccessInfo accessInfo,
-                           @Nonnull final UUID taskId, @Nonnull final UUID targetClusterId,
-                           @Nonnull final Transformed<RealVector> centroid,
-                           @Nonnull final List<ClusterReference> nearestClusters) {
+    private SplitMergeTask(final Locator locator, final AccessInfo accessInfo,
+                           final UUID taskId, final UUID targetClusterId,
+                           final Transformed<RealVector> centroid,
+                           final List<ClusterReference> nearestClusters) {
         super(locator, accessInfo, taskId, ImmutableSet.of(targetClusterId));
         this.centroid = centroid;
         this.nearestClusters = ImmutableList.copyOf(nearestClusters);
     }
 
-    @Nonnull
     public Transformed<RealVector> getCentroid() {
         return centroid;
     }
 
-    @Nonnull
     private List<ClusterReference> getNearestClusters() {
         return nearestClusters;
     }
 
     @Override
-    protected void writeDeferredTask(@Nonnull final Transaction transaction) {
+    protected void writeDeferredTask(final Transaction transaction) {
         super.writeDeferredTask(transaction);
         if (logger.isDebugEnabled()) {
             logger.debug("enqueuing SPLIT_MERGE; taskId={}; clusterId={}",
@@ -113,13 +107,11 @@ class SplitMergeTask extends AbstractDeferredTask {
         }
     }
 
-    @Nonnull
     @Override
     public TaskKind getKind() {
         return TaskKind.SPLIT_MERGE;
     }
 
-    @Nonnull
     private UUID getTargetClusterId() {
         return Iterables.getOnlyElement(getTargetClusterIds());
     }
@@ -129,7 +121,6 @@ class SplitMergeTask extends AbstractDeferredTask {
      * Encodes the centroid and the precomputed nearest clusters so the task can be resumed without
      * re-fetching from the HNSW index.
      */
-    @Nonnull
     @Override
     public Tuple valueTuple() {
         final Quantizer quantizer = primitives().quantizer(getAccessInfo());
@@ -155,9 +146,8 @@ class SplitMergeTask extends AbstractDeferredTask {
      * @param transaction the FDB transaction to operate within
      * @return a future that completes when the task has finished
      */
-    @Nonnull
     @Override
-    public CompletableFuture<Void> runTask(@Nonnull final Transaction transaction) {
+    public CompletableFuture<Void> runTask(final Transaction transaction) {
         logStart(logger);
 
         final Config config = getConfig();
@@ -212,10 +202,9 @@ class SplitMergeTask extends AbstractDeferredTask {
      * @param targetClusterCentroid untransformed centroid of the target cluster
      * @return a future that completes when the split is done
      */
-    @Nonnull
-    private CompletableFuture<Void> split(@Nonnull final Transaction transaction,
-                                          @Nonnull final ClusterMetadata targetClusterMetadata,
-                                          @Nonnull final RealVector targetClusterCentroid) {
+    private CompletableFuture<Void> split(final Transaction transaction,
+                                          final ClusterMetadata targetClusterMetadata,
+                                          final RealVector targetClusterCentroid) {
         final Config config = getConfig();
         final SplittableRandom random = RandomHelpers.random(getTaskId());
         final Primitives primitives = primitives();
@@ -249,11 +238,11 @@ class SplitMergeTask extends AbstractDeferredTask {
      * early-out. If precomputed nearest clusters are already present, returns {@code null} and the caller proceeds.
      */
     @Nullable
-    private CompletableFuture<Void> reenqueueWithFetchedNearestClustersIfEmpty(@Nonnull final Transaction transaction,
-                                                                               @Nonnull final ClusterMetadata targetClusterMetadata,
-                                                                               @Nonnull final RealVector targetClusterCentroid,
-                                                                               @Nonnull final SplittableRandom random,
-                                                                               @Nonnull final StorageTransform storageTransform,
+    private CompletableFuture<Void> reenqueueWithFetchedNearestClustersIfEmpty(final Transaction transaction,
+                                                                               final ClusterMetadata targetClusterMetadata,
+                                                                               final RealVector targetClusterCentroid,
+                                                                               final SplittableRandom random,
+                                                                               final StorageTransform storageTransform,
                                                                                final int numNearestClusters) {
         if (!getNearestClusters().isEmpty()) {
             if (logger.isTraceEnabled()) {
@@ -283,12 +272,11 @@ class SplitMergeTask extends AbstractDeferredTask {
      * centroids in the HNSW index, and persists the result. A {@code null} candidate (split chose to collapse, or
      * merge found no mergeable neighbor) is a no-op.
      */
-    @Nonnull
-    private CompletableFuture<Void> applyRepartitioning(@Nonnull final Transaction transaction,
-                                                        @Nonnull final SplittableRandom random,
-                                                        @Nonnull final StorageTransform storageTransform,
-                                                        @Nonnull final Quantizer quantizer,
-                                                        @Nonnull final DistanceEstimator estimator,
+    private CompletableFuture<Void> applyRepartitioning(final Transaction transaction,
+                                                        final SplittableRandom random,
+                                                        final StorageTransform storageTransform,
+                                                        final Quantizer quantizer,
+                                                        final DistanceEstimator estimator,
                                                         @Nullable final RepartitioningCandidate repartitioningCandidate) {
         if (repartitioningCandidate == null) {
             return AsyncUtil.DONE;
@@ -313,14 +301,13 @@ class SplitMergeTask extends AbstractDeferredTask {
      * scores them, and returns the best; returns a future of {@code null} (after enqueueing a collapse when
      * warranted) when neither candidate is viable.
      */
-    @Nonnull
-    private CompletableFuture<RepartitioningCandidate> selectSplitCandidate(@Nonnull final Transaction transaction,
-                                                                            @Nonnull final SplittableRandom random,
-                                                                            @Nonnull final StorageTransform storageTransform,
-                                                                            @Nonnull final DistanceEstimator estimator,
+    private CompletableFuture<RepartitioningCandidate> selectSplitCandidate(final Transaction transaction,
+                                                                            final SplittableRandom random,
+                                                                            final StorageTransform storageTransform,
+                                                                            final DistanceEstimator estimator,
                                                                             final int numNearestClusters,
-                                                                            @Nonnull final ClusterMetadata targetClusterMetadata,
-                                                                            @Nonnull final List<ClusterMetadataWithDistance> nearestClusterMetadataWithDistances) {
+                                                                            final ClusterMetadata targetClusterMetadata,
+                                                                            final List<ClusterMetadataWithDistance> nearestClusterMetadataWithDistances) {
         final Config config = getConfig();
         final Executor executor = getLocator().getExecutor();
         final Primitives primitives = primitives();
@@ -415,10 +402,9 @@ class SplitMergeTask extends AbstractDeferredTask {
      * @param targetClusterCentroid untransformed centroid of the target cluster
      * @return a future that completes when the merge is done
      */
-    @Nonnull
-    private CompletableFuture<Void> merge(@Nonnull final Transaction transaction,
-                                          @Nonnull final ClusterMetadata targetClusterMetadata,
-                                          @Nonnull final RealVector targetClusterCentroid) {
+    private CompletableFuture<Void> merge(final Transaction transaction,
+                                          final ClusterMetadata targetClusterMetadata,
+                                          final RealVector targetClusterCentroid) {
         final Config config = getConfig();
         final SplittableRandom random = RandomHelpers.random(getTaskId());
         final Primitives primitives = primitives();
@@ -451,14 +437,13 @@ class SplitMergeTask extends AbstractDeferredTask {
      * scores them, and returns the best (falling back to the 2&#8594;1 merge); returns a future of {@code null}
      * (after clearing {@code SPLIT_MERGE}) when there is no mergeable neighbor at all.
      */
-    @Nonnull
-    private CompletableFuture<RepartitioningCandidate> selectMergeCandidate(@Nonnull final Transaction transaction,
-                                                                            @Nonnull final SplittableRandom random,
-                                                                            @Nonnull final StorageTransform storageTransform,
-                                                                            @Nonnull final DistanceEstimator estimator,
+    private CompletableFuture<RepartitioningCandidate> selectMergeCandidate(final Transaction transaction,
+                                                                            final SplittableRandom random,
+                                                                            final StorageTransform storageTransform,
+                                                                            final DistanceEstimator estimator,
                                                                             final int numNearestClusters,
-                                                                            @Nonnull final ClusterMetadata targetClusterMetadata,
-                                                                            @Nonnull final List<ClusterMetadataWithDistance> nearestClusterMetadataWithDistances) {
+                                                                            final ClusterMetadata targetClusterMetadata,
+                                                                            final List<ClusterMetadataWithDistance> nearestClusterMetadataWithDistances) {
         final Config config = getConfig();
         final Executor executor = getLocator().getExecutor();
         final Primitives primitives = primitives();
@@ -563,12 +548,11 @@ class SplitMergeTask extends AbstractDeferredTask {
      * @param targetNumPartitions number of new clusters being created
      * @return an assignment result containing the vector-to-cluster mapping and updated statistics
      */
-    @Nonnull
-    private Repartitioning assignPrimaryVectorReferences(@Nonnull final SplittableRandom random,
-                                                         @Nonnull final DistanceEstimator estimator,
-                                                         @Nonnull final List<ClusterMetadataWithDistance> neighboringClusters,
-                                                         @Nonnull final List<VectorReference> primaryVectorReferences,
-                                                         @Nonnull final KMeans.Result<Transformed<RealVector>> kMeansResult,
+    private Repartitioning assignPrimaryVectorReferences(final SplittableRandom random,
+                                                         final DistanceEstimator estimator,
+                                                         final List<ClusterMetadataWithDistance> neighboringClusters,
+                                                         final List<VectorReference> primaryVectorReferences,
+                                                         final KMeans.Result<Transformed<RealVector>> kMeansResult,
                                                          final int targetNumPartitions) {
         final Config config = getConfig();
 
@@ -688,12 +672,11 @@ class SplitMergeTask extends AbstractDeferredTask {
      * cluster that should hold a replica, records a replicated copy keyed by that cluster. Pure — returns the
      * replicas to place together with this primary's contribution to the replication trace counters.
      */
-    @Nonnull
-    private ReplicaSelection selectReplicationAssignments(@Nonnull final DistanceEstimator estimator,
-                                                          @Nonnull final VectorReference vectorReference,
+    private ReplicaSelection selectReplicationAssignments(final DistanceEstimator estimator,
+                                                          final VectorReference vectorReference,
                                                           final double distanceToPrimaryCentroid,
-                                                          @Nonnull final List<ClusterMetadataWithDistance> replicationCandidates,
-                                                          @Nonnull final Map<UUID, RunningStats> standardDeviationsMap) {
+                                                          final List<ClusterMetadataWithDistance> replicationCandidates,
+                                                          final Map<UUID, RunningStats> standardDeviationsMap) {
         final Config config = getConfig();
         final List<ClusterMetadataWithDistance> selectedReplicationClusters =
                 Lists.newArrayListWithExpectedSize(replicationCandidates.size());
@@ -747,11 +730,10 @@ class SplitMergeTask extends AbstractDeferredTask {
      * @param repartitioning the result containing the new cluster IDs and their centroids
      * @return a future completing with the assignment result (passed through for chaining)
      */
-    @Nonnull
-    private CompletableFuture<Repartitioning> replaceCentroidsInHnsw(@Nonnull final Transaction transaction,
-                                                                     @Nonnull final StorageTransform storageTransform,
-                                                                     @Nonnull final List<ClusterMetadataWithDistance> coreClusters,
-                                                                     @Nonnull final Repartitioning repartitioning) {
+    private CompletableFuture<Repartitioning> replaceCentroidsInHnsw(final Transaction transaction,
+                                                                     final StorageTransform storageTransform,
+                                                                     final List<ClusterMetadataWithDistance> coreClusters,
+                                                                     final Repartitioning repartitioning) {
         final Primitives primitives = primitives();
         final HNSW centroidsHnsw = primitives.getClusterCentroidsHnsw();
         final Map<UUID, ClusterMetadataWithDistance> clusterIdMetadataMap = repartitioning.clusterIdMetadataMap();
@@ -807,11 +789,11 @@ class SplitMergeTask extends AbstractDeferredTask {
      * @param repartitioning the computed vector-to-cluster mapping
      * @param quantizer quantizer used to encode vectors for storage
      */
-    private void persistRepartitioning(@Nonnull final Transaction transaction,
-                                       @Nonnull final SplittableRandom random,
-                                       @Nonnull final List<ClusterMetadataWithDistance> coreClusters,
-                                       @Nonnull final Repartitioning repartitioning,
-                                       @Nonnull final Quantizer quantizer) {
+    private void persistRepartitioning(final Transaction transaction,
+                                       final SplittableRandom random,
+                                       final List<ClusterMetadataWithDistance> coreClusters,
+                                       final Repartitioning repartitioning,
+                                       final Quantizer quantizer) {
         deleteDissolvedClusters(transaction, coreClusters);
         final VectorWriteCounters counters = writeVectorReferences(transaction, quantizer, repartitioning);
         final Set<UUID> dependentTaskIds = writeClusterMetadataAndEnqueueTasks(transaction, random, repartitioning, counters);
@@ -825,8 +807,8 @@ class SplitMergeTask extends AbstractDeferredTask {
      * @param transaction the transaction to delete from
      * @param coreClusters the clusters being dissolved, whose vector references and metadata are removed
      */
-    private void deleteDissolvedClusters(@Nonnull final Transaction transaction,
-                                         @Nonnull final List<ClusterMetadataWithDistance> coreClusters) {
+    private void deleteDissolvedClusters(final Transaction transaction,
+                                         final List<ClusterMetadataWithDistance> coreClusters) {
         final Primitives primitives = primitives();
         for (final ClusterMetadataWithDistance clusterMetadata : coreClusters) {
             final UUID toBeDeleted = clusterMetadata.clusterMetadata().id();
@@ -844,10 +826,9 @@ class SplitMergeTask extends AbstractDeferredTask {
      * @param repartitioning the computed vector-to-cluster assignments
      * @return counters broken down by cluster ID and vector type
      */
-    @Nonnull
-    private VectorWriteCounters writeVectorReferences(@Nonnull final Transaction transaction,
-                                                      @Nonnull final Quantizer quantizer,
-                                                      @Nonnull final Repartitioning repartitioning) {
+    private VectorWriteCounters writeVectorReferences(final Transaction transaction,
+                                                      final Quantizer quantizer,
+                                                      final Repartitioning repartitioning) {
         final Primitives primitives = primitives();
         final ListMultimap<UUID, VectorReference> assignmentMultiMap = repartitioning.assignmentMultimap();
         final Map<UUID, Integer> clusterIdToNumPrimaryVectorsAdded = Maps.newHashMap();
@@ -881,11 +862,10 @@ class SplitMergeTask extends AbstractDeferredTask {
      * @param counters per-cluster write counts from the preceding vector write phase
      * @return the set of task IDs for any newly enqueued dependent tasks
      */
-    @Nonnull
-    private Set<UUID> writeClusterMetadataAndEnqueueTasks(@Nonnull final Transaction transaction,
-                                                          @Nonnull final SplittableRandom random,
-                                                          @Nonnull final Repartitioning repartitioning,
-                                                          @Nonnull final VectorWriteCounters counters) {
+    private Set<UUID> writeClusterMetadataAndEnqueueTasks(final Transaction transaction,
+                                                          final SplittableRandom random,
+                                                          final Repartitioning repartitioning,
+                                                          final VectorWriteCounters counters) {
         final Map<UUID, ClusterMetadataWithDistance> clusterIdMetadataMap = repartitioning.clusterIdMetadataMap();
         final Set<UUID> newClusterIds = repartitioning.newClusterIds();
         final Map<UUID, RunningStats> updatedStandardDeviationsMap =
@@ -932,10 +912,10 @@ class SplitMergeTask extends AbstractDeferredTask {
      * @param newClusterIds the ids of the clusters created by this split/merge that the bounce will reassign
      * @param dependentTaskIds the ids of the tasks the bounce must wait for; no task is enqueued if this is empty
      */
-    private void enqueueBounceIfNeeded(@Nonnull final Transaction transaction,
-                                       @Nonnull final SplittableRandom random,
-                                       @Nonnull final Set<UUID> newClusterIds,
-                                       @Nonnull final Set<UUID> dependentTaskIds) {
+    private void enqueueBounceIfNeeded(final Transaction transaction,
+                                       final SplittableRandom random,
+                                       final Set<UUID> newClusterIds,
+                                       final Set<UUID> dependentTaskIds) {
         if (!dependentTaskIds.isEmpty()) {
             final Config config = getConfig();
             final BounceTask newBounceTask =
@@ -956,9 +936,8 @@ class SplitMergeTask extends AbstractDeferredTask {
      *
      * @return a high-priority copy of this task carrying the given nearest clusters
      */
-    @Nonnull
-    private SplitMergeTask withHighPriorityAndNearestClusters(@Nonnull final SplittableRandom random,
-                                                           @Nonnull final List<ClusterReference> nearestClusters) {
+    private SplitMergeTask withHighPriorityAndNearestClusters(final SplittableRandom random,
+                                                           final List<ClusterReference> nearestClusters) {
         return SplitMergeTask.of(getLocator(), getAccessInfo(),
                 randomHighPriorityTaskId(random, getConfig().deterministicRandomness()), getTargetClusterId(),
                 getCentroid(), nearestClusters);
@@ -974,9 +953,8 @@ class SplitMergeTask extends AbstractDeferredTask {
      * @param valueTuple the value tuple containing the serialized task data
      * @return the deserialized task
      */
-    @Nonnull
-    static SplitMergeTask fromTuples(@Nonnull final Locator locator, @Nonnull final AccessInfo accessInfo,
-                                     @Nonnull final Tuple keyTuple, @Nonnull final Tuple valueTuple) {
+    static SplitMergeTask fromTuples(final Locator locator, final AccessInfo accessInfo,
+                                     final Tuple keyTuple, final Tuple valueTuple) {
         Verify.verify(TaskKind.fromValueTuple(valueTuple) == TaskKind.SPLIT_MERGE);
         final StorageTransform storageTransform = locator.primitives().storageTransform(accessInfo);
         final Transformed<RealVector> centroid = storageTransform.transform(
@@ -1005,10 +983,9 @@ class SplitMergeTask extends AbstractDeferredTask {
      *
      * @return a new task without precomputed nearest clusters
      */
-    @Nonnull
-    static SplitMergeTask of(@Nonnull final Locator locator, @Nonnull final AccessInfo accessInfo,
-                             @Nonnull final UUID taskId, @Nonnull final UUID clusterId,
-                             @Nonnull final Transformed<RealVector> centroid) {
+    static SplitMergeTask of(final Locator locator, final AccessInfo accessInfo,
+                             final UUID taskId, final UUID clusterId,
+                             final Transformed<RealVector> centroid) {
         return of(locator, accessInfo, taskId, clusterId, centroid, ImmutableList.of());
     }
 
@@ -1025,11 +1002,10 @@ class SplitMergeTask extends AbstractDeferredTask {
      *
      * @return a new task carrying the given precomputed nearest clusters
      */
-    @Nonnull
-    static SplitMergeTask of(@Nonnull final Locator locator, @Nonnull final AccessInfo accessInfo,
-                             @Nonnull final UUID taskId, @Nonnull final UUID clusterId,
-                             @Nonnull final Transformed<RealVector> centroid,
-                             @Nonnull final List<ClusterReference> nearestClusters) {
+    static SplitMergeTask of(final Locator locator, final AccessInfo accessInfo,
+                             final UUID taskId, final UUID clusterId,
+                             final Transformed<RealVector> centroid,
+                             final List<ClusterReference> nearestClusters) {
         return new SplitMergeTask(locator, accessInfo, taskId, clusterId, centroid, nearestClusters);
     }
 
@@ -1043,7 +1019,6 @@ class SplitMergeTask extends AbstractDeferredTask {
      *
      * @return the larger of the two core-cluster lists
      */
-    @Nonnull
     private static List<ClusterMetadataWithDistance> largestCoreClusters(@Nullable final ClusterClassification classification1,
                                                                               @Nullable final ClusterClassification classification2) {
         if (classification1 == null) {
@@ -1081,12 +1056,11 @@ class SplitMergeTask extends AbstractDeferredTask {
      * @param maxRestarts maximum number of random restarts
      * @return an assignment candidate wrapping the k-means result and primary vectors
      */
-    @Nonnull
     @SuppressWarnings("checkstyle:MethodName")
-    private static RepartitioningCandidate kMeans(@Nonnull final ClusterClassification classification,
-                                                  @Nonnull final List<VectorReference> vectorReferences,
-                                                  @Nonnull final SplittableRandom random,
-                                                  @Nonnull final DistanceEstimator estimator,
+    private static RepartitioningCandidate kMeans(final ClusterClassification classification,
+                                                  final List<VectorReference> vectorReferences,
+                                                  final SplittableRandom random,
+                                                  final DistanceEstimator estimator,
                                                   final int targetNumPartitions,
                                                   final int maxIterations,
                                                   final int maxRestarts) {
@@ -1117,11 +1091,10 @@ class SplitMergeTask extends AbstractDeferredTask {
      * @param repartitioningCandidate the proposed new partition from k-means
      * @return the evaluation result containing the decision and score gain
      */
-    @Nonnull
     private static EvaluationResult
-            scoreCandidate(@Nonnull final DistanceEstimator estimator,
-                           @Nonnull final List<Cluster> currentClusters,
-                           @Nonnull final RepartitioningCandidate repartitioningCandidate) {
+            scoreCandidate(final DistanceEstimator estimator,
+                           final List<Cluster> currentClusters,
+                           final RepartitioningCandidate repartitioningCandidate) {
         int vectorCount = 0;
         final ImmutableList.Builder<Transformed<RealVector>> clusterCentroidsBuilder =
                 ImmutableList.builder();
@@ -1178,8 +1151,7 @@ class SplitMergeTask extends AbstractDeferredTask {
      *
      * @return the evaluator parameters tuned for the {@code currentK → candidateK} transition
      */
-    @Nonnull
-    private static PartitionEvaluator.Parameters parametersFor(@Nonnull final DistanceEstimator estimator,
+    private static PartitionEvaluator.Parameters parametersFor(final DistanceEstimator estimator,
                                                                final int currentK,
                                                                final int candidateK) {
         final PartitionEvaluator.Parameters defaults = new PartitionEvaluator.Parameters(estimator);
@@ -1212,8 +1184,7 @@ class SplitMergeTask extends AbstractDeferredTask {
      * @param candidateToEvaluationResultMap map of candidates to their evaluation results
      * @return the best valid candidate, or empty if no valid candidate exists
      */
-    @Nonnull
-    private Optional<RepartitioningCandidate> selectBestCandidateMaybe(@Nonnull final Map<RepartitioningCandidate, EvaluationResult> candidateToEvaluationResultMap) {
+    private Optional<RepartitioningCandidate> selectBestCandidateMaybe(final Map<RepartitioningCandidate, EvaluationResult> candidateToEvaluationResultMap) {
         RepartitioningCandidate bestCandidate = null;
         EvaluationResult bestEvaluationResult = null;
         for (final Map.Entry<RepartitioningCandidate, EvaluationResult> entry : candidateToEvaluationResultMap.entrySet()) {
@@ -1242,9 +1213,9 @@ class SplitMergeTask extends AbstractDeferredTask {
      * @param primaryVectorReferences the primary vectors participating in the split
      * @param kMeansResult the k-means result defining the proposed new cluster boundaries
      */
-    private record RepartitioningCandidate(@Nonnull ClusterClassification classification,
-                                           @Nonnull List<VectorReference> primaryVectorReferences,
-                                           @Nonnull @SuppressWarnings("checkstyle:MemberName") KMeans.Result<Transformed<RealVector>> kMeansResult) {
+    private record RepartitioningCandidate(ClusterClassification classification,
+                                           List<VectorReference> primaryVectorReferences,
+                                           @SuppressWarnings("checkstyle:MemberName") KMeans.Result<Transformed<RealVector>> kMeansResult) {
     }
 
     /**
@@ -1257,10 +1228,10 @@ class SplitMergeTask extends AbstractDeferredTask {
      * @param assignmentMultimap the assignments of vectors to clusters
      * @param updatedStandardDeviationsMap a map from cluster id to its updated running distance statistics
      */
-    private record Repartitioning(@Nonnull Set<UUID> newClusterIds,
-                                  @Nonnull Map<UUID, ClusterMetadataWithDistance> clusterIdMetadataMap,
-                                  @Nonnull ListMultimap<UUID, VectorReference> assignmentMultimap,
-                                  @Nonnull Map<UUID, RunningStats> updatedStandardDeviationsMap) {
+    private record Repartitioning(Set<UUID> newClusterIds,
+                                  Map<UUID, ClusterMetadataWithDistance> clusterIdMetadataMap,
+                                  ListMultimap<UUID, VectorReference> assignmentMultimap,
+                                  Map<UUID, RunningStats> updatedStandardDeviationsMap) {
     }
 
     /**
@@ -1271,8 +1242,8 @@ class SplitMergeTask extends AbstractDeferredTask {
      * @param numPrimaryUnderreplicatedVectorsAdded a map from cluster id to the number of primary underreplicated vectors written to it
      * @param numReplicatedVectorsAdded a map from cluster id to the number of replicated vectors written to it
      */
-    private record VectorWriteCounters(@Nonnull Map<UUID, Integer> numPrimaryVectorsAdded,
-                                       @Nonnull Map<UUID, Integer> numPrimaryUnderreplicatedVectorsAdded,
-                                       @Nonnull Map<UUID, Integer> numReplicatedVectorsAdded) {
+    private record VectorWriteCounters(Map<UUID, Integer> numPrimaryVectorsAdded,
+                                       Map<UUID, Integer> numPrimaryUnderreplicatedVectorsAdded,
+                                       Map<UUID, Integer> numReplicatedVectorsAdded) {
     }
 }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/SplitMergeTask.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/SplitMergeTask.java
@@ -327,6 +327,10 @@ class SplitMergeTask extends AbstractDeferredTask {
                         targetClusterMetadata, getCentroid(),
                         2, numNearestClusters - 2);
 
+        // Lists.newArrayList(E...) is from Guava, which is not jspecify-annotated, so its varargs parameter is
+        // treated as @NonNull by NullAway's defaults; a null classification2To3 is intentional here (see above)
+        // and is explicitly handled by the null check below.
+        @SuppressWarnings("NullAway")
         final List<ClusterClassification> allClassifications =
                 Lists.newArrayList(classification1To2, classification2To3);
 
@@ -481,6 +485,10 @@ class SplitMergeTask extends AbstractDeferredTask {
                         targetClusterMetadata, getCentroid(),
                         3, numNearestClusters - 3);
 
+        // Lists.newArrayList(E...) is from Guava, which is not jspecify-annotated, so its varargs parameter is
+        // treated as @NonNull by NullAway's defaults; a null classification3To2 is intentional (an unviable
+        // split drops out of the candidate set) and is explicitly handled downstream.
+        @SuppressWarnings("NullAway")
         final List<ClusterClassification> allClassifications =
                 Lists.newArrayList(classification2To1, classification3To2);
 

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/StorageAdapter.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/StorageAdapter.java
@@ -220,8 +220,13 @@ class StorageAdapter {
     }
 
     static Tuple tupleFromAccessInfo(final AccessInfo accessInfo) {
-        return Tuple.from(accessInfo.rotatorSeed(),
+        // Tuple.from(Object...) is from the unannotated fdb-java client library and genuinely supports null
+        // elements (a null centroid tuple represents "RaBitQ not in use"), but its varargs parameter is
+        // treated as @NonNull by NullAway's defaults.
+        @SuppressWarnings("NullAway")
+        final Tuple result = Tuple.from(accessInfo.rotatorSeed(),
                 accessInfo.canUseRaBitQ() ? StorageHelpers.tupleFromVector(accessInfo.negatedCentroid()) : null);
+        return result;
     }
 
     static VectorMetadata vectorMetadataFromTuple(final Tuple primaryKey, final Tuple valueTuple) {
@@ -229,7 +234,12 @@ class StorageAdapter {
     }
 
     static Tuple valueTupleFromVectorMetadata(final VectorMetadata vectorMetadata) {
-        return Tuple.from(vectorMetadata.vectorId().uuid(), vectorMetadata.additionalValues());
+        // Tuple.from(Object...) is from the unannotated fdb-java client library and genuinely supports null
+        // elements, but its varargs parameter is treated as @NonNull by NullAway's defaults;
+        // additionalValues() may legitimately be absent.
+        @SuppressWarnings("NullAway")
+        final Tuple result = Tuple.from(vectorMetadata.vectorId().uuid(), vectorMetadata.additionalValues());
+        return result;
     }
 
     static UUID clusterIdFromTuple(final Tuple tuple) {

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/StorageAdapter.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/StorageAdapter.java
@@ -32,7 +32,6 @@ import com.apple.foundationdb.tuple.Tuple;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableSet;
 
-import javax.annotation.Nonnull;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
@@ -91,33 +90,20 @@ class StorageAdapter {
      */
     private static final long SUBSPACE_PREFIX_TASKS = 0x07;
 
-    @Nonnull
     private final Config config;
-    @Nonnull
     private final Subspace subspace;
-    @Nonnull
     private final OnWriteListener onWriteListener;
-    @Nonnull
     private final OnReadListener onReadListener;
 
-    @Nonnull
     private final Supplier<Subspace> accessInfoSubspaceSupplier;
-    @Nonnull
     private final Supplier<Subspace> clusterCentroidsSubspaceSupplier;
-    @Nonnull
     private final Supplier<Subspace> clusterMetadataSubspaceSupplier;
-    @Nonnull
     private final Supplier<Subspace> vectorReferencesSubspaceSupplier;
-    @Nonnull
     private final Supplier<Subspace> collapsedVectorIdsSubspaceSupplier;
-    @Nonnull
     private final Supplier<Subspace> vectorMetadataSubspaceSupplier;
-    @Nonnull
     private final Supplier<Subspace> samplesSubspaceSupplier;
-    @Nonnull
     private final Supplier<Subspace> tasksSubspaceSupplier;
 
-    @Nonnull
     private final Supplier<com.apple.foundationdb.async.hnsw.Config> clusterCentroidsHnswConfigSupplier;
 
     /**
@@ -131,10 +117,10 @@ class StorageAdapter {
      * @param onWriteListener the listener to be called on write operations
      * @param onReadListener the listener to be called on read operations
      */
-    StorageAdapter(@Nonnull final Config config,
-                   @Nonnull final Subspace subspace,
-                   @Nonnull final OnWriteListener onWriteListener,
-                   @Nonnull final OnReadListener onReadListener) {
+    StorageAdapter(final Config config,
+                   final Subspace subspace,
+                   final OnWriteListener onWriteListener,
+                   final OnReadListener onReadListener) {
         this.config = config;
         this.subspace = subspace;
         this.onWriteListener = onWriteListener;
@@ -159,72 +145,58 @@ class StorageAdapter {
         this.clusterCentroidsHnswConfigSupplier = Suppliers.memoize(this::computeClusterCentroidHnswConfig);
     }
 
-    @Nonnull
     Config getConfig() {
         return config;
     }
 
-    @Nonnull
     Subspace getSubspace() {
         return subspace;
     }
 
-    @Nonnull
     public Subspace getAccessInfoSubspace() {
         return accessInfoSubspaceSupplier.get();
     }
 
-    @Nonnull
     Subspace getClusterCentroidsSubspace() {
         return clusterCentroidsSubspaceSupplier.get();
     }
 
-    @Nonnull
     public Subspace getClusterMetadataSubspace() {
         return clusterMetadataSubspaceSupplier.get();
     }
 
-    @Nonnull
     public Subspace getVectorReferencesSubspace() {
         return vectorReferencesSubspaceSupplier.get();
     }
 
-    @Nonnull
     public Subspace getCollapsedVectorIdsSubspace() {
         return collapsedVectorIdsSubspaceSupplier.get();
     }
 
-    @Nonnull
     public Subspace getVectorMetadataSubspace() {
         return vectorMetadataSubspaceSupplier.get();
     }
 
-    @Nonnull
     public Subspace getSamplesSubspace() {
         return samplesSubspaceSupplier.get();
     }
 
-    @Nonnull
     public Subspace getTasksSubspace() {
         return tasksSubspaceSupplier.get();
     }
 
-    @Nonnull
     OnWriteListener getOnWriteListener() {
         return onWriteListener;
     }
 
-    @Nonnull
     OnReadListener getOnReadListener() {
         return onReadListener;
     }
 
-    @Nonnull
     com.apple.foundationdb.async.hnsw.Config getClusterCentroidsHnswConfig() {
         return clusterCentroidsHnswConfigSupplier.get();
     }
 
-    @Nonnull
     private com.apple.foundationdb.async.hnsw.Config computeClusterCentroidHnswConfig() {
         final Config config = getConfig();
         return HNSW.newConfigBuilder()
@@ -240,37 +212,31 @@ class StorageAdapter {
                 .build(config.numDimensions());
     }
 
-    @Nonnull
-    static AccessInfo accessInfoFromTuple(@Nonnull final Config config, @Nonnull final Tuple valueTuple) {
+    static AccessInfo accessInfoFromTuple(final Config config, final Tuple valueTuple) {
         final long rotatorSeed = valueTuple.getLong(0);
         final Tuple centroidVectorTuple = valueTuple.getNestedTuple(1);
         return new AccessInfo(rotatorSeed,
                 centroidVectorTuple == null ? null : StorageHelpers.vectorFromTuple(config, centroidVectorTuple));
     }
 
-    @Nonnull
-    static Tuple tupleFromAccessInfo(@Nonnull final AccessInfo accessInfo) {
+    static Tuple tupleFromAccessInfo(final AccessInfo accessInfo) {
         return Tuple.from(accessInfo.rotatorSeed(),
                 accessInfo.canUseRaBitQ() ? StorageHelpers.tupleFromVector(accessInfo.negatedCentroid()) : null);
     }
 
-    @Nonnull
-    static VectorMetadata vectorMetadataFromTuple(@Nonnull final Tuple primaryKey, @Nonnull final Tuple valueTuple) {
+    static VectorMetadata vectorMetadataFromTuple(final Tuple primaryKey, final Tuple valueTuple) {
         return new VectorMetadata(primaryKey, valueTuple.getUUID(0), valueTuple.getNestedTuple(1));
     }
 
-    @Nonnull
-    static Tuple valueTupleFromVectorMetadata(@Nonnull final VectorMetadata vectorMetadata) {
+    static Tuple valueTupleFromVectorMetadata(final VectorMetadata vectorMetadata) {
         return Tuple.from(vectorMetadata.vectorId().uuid(), vectorMetadata.additionalValues());
     }
 
-    @Nonnull
-    static UUID clusterIdFromTuple(@Nonnull final Tuple tuple) {
+    static UUID clusterIdFromTuple(final Tuple tuple) {
         return tuple.getUUID(0);
     }
 
-    @Nonnull
-    static Tuple tupleFromClusterId(@Nonnull final UUID clusterId) {
+    static Tuple tupleFromClusterId(final UUID clusterId) {
         return Tuple.from(clusterId);
     }
 
@@ -281,8 +247,7 @@ class StorageAdapter {
      *
      * @return a tuple encoding the cluster ids
      */
-    @Nonnull
-    public static Tuple tupleFromClusterIds(@Nonnull final Set<UUID> clusterIds) {
+    public static Tuple tupleFromClusterIds(final Set<UUID> clusterIds) {
         return tupleFromUuids(clusterIds);
     }
 
@@ -293,8 +258,7 @@ class StorageAdapter {
      *
      * @return the decoded set of cluster ids
      */
-    @Nonnull
-    public static Set<UUID> clusterIdsFromTuple(@Nonnull final Tuple clusterIdsAsTuple) {
+    public static Set<UUID> clusterIdsFromTuple(final Tuple clusterIdsAsTuple) {
         return uuidsFromTuple(clusterIdsAsTuple);
     }
 
@@ -305,8 +269,7 @@ class StorageAdapter {
      *
      * @return a tuple encoding the task ids
      */
-    @Nonnull
-    public static Tuple tupleFromTaskIds(@Nonnull final Set<UUID> taskIds) {
+    public static Tuple tupleFromTaskIds(final Set<UUID> taskIds) {
         return tupleFromUuids(taskIds);
     }
 
@@ -317,18 +280,15 @@ class StorageAdapter {
      *
      * @return the decoded set of task ids
      */
-    @Nonnull
-    public static Set<UUID> taskIdsFromTuple(@Nonnull final Tuple taskIdsAsTuple) {
+    public static Set<UUID> taskIdsFromTuple(final Tuple taskIdsAsTuple) {
         return uuidsFromTuple(taskIdsAsTuple);
     }
 
-    @Nonnull
-    private static Tuple tupleFromUuids(@Nonnull final Set<UUID> uuids) {
+    private static Tuple tupleFromUuids(final Set<UUID> uuids) {
         return Tuple.fromItems(uuids);
     }
 
-    @Nonnull
-    private static Set<UUID> uuidsFromTuple(@Nonnull final Tuple uuidsAsTuple) {
+    private static Set<UUID> uuidsFromTuple(final Tuple uuidsAsTuple) {
         final ImmutableSet.Builder<UUID> resultBuilder = ImmutableSet.builder();
         for (int i = 0; i < uuidsAsTuple.size(); i ++) {
             resultBuilder.add(uuidsAsTuple.getUUID(i));
@@ -336,8 +296,7 @@ class StorageAdapter {
         return resultBuilder.build();
     }
 
-    @Nonnull
-    static ClusterMetadata clusterMetadataFromTuple(@Nonnull final Tuple valueTuple) {
+    static ClusterMetadata clusterMetadataFromTuple(final Tuple valueTuple) {
         return new ClusterMetadata(valueTuple.getUUID(0),
                 Math.toIntExact(valueTuple.getLong(1)),
                 Math.toIntExact(valueTuple.getLong(2)),
@@ -345,47 +304,41 @@ class StorageAdapter {
                 Math.toIntExact(valueTuple.getLong(4)));
     }
 
-    @Nonnull
-    static Tuple valueTupleFromClusterMetadata(@Nonnull final ClusterMetadata clusterMetadata) {
+    static Tuple valueTupleFromClusterMetadata(final ClusterMetadata clusterMetadata) {
         return Tuple.from(clusterMetadata.id(),
                 clusterMetadata.numPrimaryUnderreplicatedVectors(), clusterMetadata.numReplicatedVectors(),
                 valueTupleFromRunningStats(clusterMetadata.runningStandardDeviation()),
                 clusterMetadata.getStatesCode());
     }
 
-    @Nonnull
-    static RunningStats runningStandardDeviationFromTuple(@Nonnull final Tuple valueTuple) {
+    static RunningStats runningStandardDeviationFromTuple(final Tuple valueTuple) {
         return new RunningStats(valueTuple.getLong(0), valueTuple.getDouble(1),
                 valueTuple.getDouble(2), valueTuple.getDouble(3));
     }
 
-    @Nonnull
-    static Tuple valueTupleFromRunningStats(@Nonnull final RunningStats runningStandardDeviation) {
+    static Tuple valueTupleFromRunningStats(final RunningStats runningStandardDeviation) {
         return Tuple.from(runningStandardDeviation.numElements(), runningStandardDeviation.runningMean(),
                 runningStandardDeviation.runningSumSquaredDeviations(),
                 runningStandardDeviation.runningMaxEver());
     }
 
-    @Nonnull
-    static ClusterReference clusterReferenceFromTuple(@Nonnull final Config config,
-                                                      @Nonnull final StorageTransform storageTransform,
-                                                      @Nonnull final Tuple valueTuple) {
+    static ClusterReference clusterReferenceFromTuple(final Config config,
+                                                      final StorageTransform storageTransform,
+                                                      final Tuple valueTuple) {
         return new ClusterReference(valueTuple.getUUID(0),
                 storageTransform.transform(StorageHelpers.vectorFromBytes(config, valueTuple.getBytes(1))));
     }
 
-    @Nonnull
-    static Tuple valueTupleFromClusterReference(@Nonnull final Quantizer quantizer,
-                                                @Nonnull final ClusterReference clusterReference) {
+    static Tuple valueTupleFromClusterReference(final Quantizer quantizer,
+                                                final ClusterReference clusterReference) {
         return Tuple.from(clusterReference.clusterId(),
                 StorageHelpers.bytesFromVector(quantizer.encode(clusterReference.centroid())));
     }
 
-    @Nonnull
-    static VectorReference vectorReferenceFromTuples(@Nonnull final Config config,
-                                                     @Nonnull final StorageTransform storageTransform,
-                                                     @Nonnull final Tuple primaryKey,
-                                                     @Nonnull final Tuple valueTuple) {
+    static VectorReference vectorReferenceFromTuples(final Config config,
+                                                     final StorageTransform storageTransform,
+                                                     final Tuple primaryKey,
+                                                     final Tuple valueTuple) {
         final VectorId vectorId = new VectorId(primaryKey, valueTuple.getUUID(0));
         final VectorReference.Role role = VectorReference.Role.ofCode((int)valueTuple.getLong(1));
         final boolean isCollapsed = valueTuple.getBoolean(2);
@@ -398,9 +351,8 @@ class StorageAdapter {
         };
     }
 
-    @Nonnull
-    static Tuple valueTupleFromVectorReference(@Nonnull final Quantizer quantizer,
-                                               @Nonnull final VectorReference vectorReference) {
+    static Tuple valueTupleFromVectorReference(final Quantizer quantizer,
+                                               final VectorReference vectorReference) {
         final UUID uuid = vectorReference.id().uuid();
         final byte[] rawData = quantizer.encode(vectorReference.vector()).getUnderlyingVector().getRawData();
         final boolean isCollapsed = vectorReference.isCollapsed();
@@ -416,14 +368,12 @@ class StorageAdapter {
         return Tuple.from(uuid, role.getCode(), isCollapsed, rawData);
     }
 
-    @Nonnull
-    static VectorId collapsedVectorIdFromValueTuple(@Nonnull final Tuple primaryKey,
-                                                    @Nonnull final Tuple valueTuple) {
+    static VectorId collapsedVectorIdFromValueTuple(final Tuple primaryKey,
+                                                    final Tuple valueTuple) {
         return new VectorId(primaryKey, valueTuple.getUUID(0));
     }
 
-    @Nonnull
-    static Tuple valueTupleFromCollapsedVectorId(@Nonnull final VectorId vectorId) {
+    static Tuple valueTupleFromCollapsedVectorId(final VectorId vectorId) {
         return Tuple.from(vectorId.uuid());
     }
 
@@ -471,7 +421,7 @@ class StorageAdapter {
      * @return the replication priority score; larger values argue more strongly for replicating the vector into the
      *         candidate cluster
      */
-    static double replicationPriority(@Nonnull final Config config,
+    static double replicationPriority(final Config config,
                                       final double distance, final double distanceToPrimaryCentroid,
                                       final int num, final double mean, final double standardDeviation) {
         final double zWeight = config.replicationZScoreWeight();
@@ -510,9 +460,9 @@ class StorageAdapter {
      * @return {@code true} if the candidate is occluded by an already-selected cluster (and should be skipped),
      *         {@code false} otherwise
      */
-    static boolean isOccluded(@Nonnull final DistanceEstimator estimator,
-                              @Nonnull final ClusterMetadataWithDistance replicationCandidate,
-                              @Nonnull final List<ClusterMetadataWithDistance> selectedReplicationClusters) {
+    static boolean isOccluded(final DistanceEstimator estimator,
+                              final ClusterMetadataWithDistance replicationCandidate,
+                              final List<ClusterMetadataWithDistance> selectedReplicationClusters) {
         final double vectorToCentroidDistance = replicationCandidate.distance();
         if (!selectedReplicationClusters.isEmpty()) {
             final Transformed<RealVector> replicationCandidateCentroid =
@@ -533,8 +483,7 @@ class StorageAdapter {
         return false;
     }
 
-    @Nonnull
-    static UUID signatureUuid(@Nonnull final Transformed<RealVector> vector) {
+    static UUID signatureUuid(final Transformed<RealVector> vector) {
         return uuidFromBytes(signatureOf(vector));
     }
 
@@ -550,8 +499,7 @@ class StorageAdapter {
      * @param keyAsBytes exactly 16 bytes of hash payload
      * @return the version-8 UUID carrying those bytes
      */
-    @Nonnull
-    private static UUID uuidFromBytes(@Nonnull final byte[] keyAsBytes) {
+    private static UUID uuidFromBytes(final byte[] keyAsBytes) {
         if (keyAsBytes.length != 16) {
             throw new IllegalArgumentException("Expected 16 bytes, got " + keyAsBytes.length);
         }
@@ -571,19 +519,16 @@ class StorageAdapter {
                 ((long) (b[off + 7] & 0xff));
     }
 
-    @Nonnull
-    static byte[] signatureOf(@Nonnull final Transformed<RealVector> vector) {
+    static byte[] signatureOf(final Transformed<RealVector> vector) {
         return signatureOf(vector.getUnderlyingVector());
     }
 
-    @Nonnull
-    static byte[] signatureOf(@Nonnull final RealVector vector) {
+    static byte[] signatureOf(final RealVector vector) {
         byte[] full = sha256(vector);
         return Arrays.copyOf(full, 16);
     }
 
-    @Nonnull
-    static byte[] sha256(@Nonnull final RealVector vector) {
+    static byte[] sha256(final RealVector vector) {
         try {
             MessageDigest md = MessageDigest.getInstance("SHA-256");
             md.update(vector.getRawData());
@@ -593,8 +538,7 @@ class StorageAdapter {
         }
     }
 
-    @Nonnull
-    static <T> CompletableFuture<T> requireNonNull(@Nonnull final CompletableFuture<T> future) {
+    static <T> CompletableFuture<T> requireNonNull(final CompletableFuture<T> future) {
         return future.thenApply(Objects::requireNonNull);
     }
 }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/StructureSnapshot.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/StructureSnapshot.java
@@ -24,8 +24,7 @@ import com.apple.foundationdb.linear.DistanceEstimator;
 import com.google.common.base.Verify;
 import com.google.common.collect.Maps;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.Map;
 import java.util.UUID;
 
@@ -41,7 +40,7 @@ import java.util.UUID;
  *        {@link ClusterView#transformedCentroid()} by {@link #computeAssignmentRanking}; {@code null} only when
  *        the structure is empty (no clusters)
  */
-record StructureSnapshot(@Nonnull Map<UUID, ClusterView> clusters,
+record StructureSnapshot(Map<UUID, ClusterView> clusters,
                          @Nullable DistanceEstimator estimator) {
     /** Returns the number of clusters in this snapshot. */
     public int numClusters() {
@@ -68,7 +67,6 @@ record StructureSnapshot(@Nonnull Map<UUID, ClusterView> clusters,
      * {@link Verify} if a primary appears in more than one cluster, so the returned map is guaranteed unique by
      * construction.
      */
-    @Nonnull
     public Map<VectorId, UUID> primaryOwners() {
         final Map<VectorId, UUID> owners = Maps.newHashMapWithExpectedSize(totalPrimaries());
         for (final ClusterView cv : clusters.values()) {
@@ -99,7 +97,6 @@ record StructureSnapshot(@Nonnull Map<UUID, ClusterView> clusters,
      *
      * @return the ranking-derived statistics
      */
-    @Nonnull
     public AssignmentRanking computeAssignmentRanking() {
         if (estimator == null) {
             return new AssignmentRanking(0, 0);

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/TaskKind.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/TaskKind.java
@@ -22,7 +22,6 @@ package com.apple.foundationdb.async.guardiann;
 
 import com.apple.foundationdb.tuple.Tuple;
 
-import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
@@ -51,7 +50,7 @@ public enum TaskKind {
     private final int code;
     private final TaskCreationFunction taskCreationFunction;
 
-    TaskKind(final int code, @Nonnull final TaskCreationFunction taskCreationFunction) {
+    TaskKind(final int code, final TaskCreationFunction taskCreationFunction) {
         this.code = code;
         this.taskCreationFunction = taskCreationFunction;
     }
@@ -65,11 +64,10 @@ public enum TaskKind {
         return code;
     }
 
-    @Nonnull
-    AbstractDeferredTask create(@Nonnull final Locator locator,
-                                @Nonnull final AccessInfo accessInfo,
-                                @Nonnull final Tuple keyTuple,
-                                @Nonnull final Tuple valueTuple) {
+    AbstractDeferredTask create(final Locator locator,
+                                final AccessInfo accessInfo,
+                                final Tuple keyTuple,
+                                final Tuple valueTuple) {
         return taskCreationFunction.create(locator, accessInfo, keyTuple, valueTuple);
     }
 
@@ -79,8 +77,7 @@ public enum TaskKind {
      * @param valueTuple the task's stored value tuple
      * @return the decoded kind
      */
-    @Nonnull
-    static TaskKind fromValueTuple(@Nonnull final Tuple valueTuple) {
+    static TaskKind fromValueTuple(final Tuple valueTuple) {
         return TaskKind.ofCode(Math.toIntExact(valueTuple.getLong(0)));
     }
 
@@ -91,7 +88,6 @@ public enum TaskKind {
      * @return the matching kind
      * @throws NullPointerException if the code does not correspond to any kind
      */
-    @Nonnull
     static TaskKind ofCode(final int code) {
         return Objects.requireNonNull(BY_CODE.getOrDefault(code, null));
     }
@@ -101,9 +97,9 @@ public enum TaskKind {
      */
     @FunctionalInterface
     private interface TaskCreationFunction {
-        AbstractDeferredTask create(@Nonnull Locator locator,
-                                    @Nonnull AccessInfo accessInfo,
-                                    @Nonnull Tuple keyTuple,
-                                    @Nonnull Tuple valueTuple);
+        AbstractDeferredTask create(Locator locator,
+                                    AccessInfo accessInfo,
+                                    Tuple keyTuple,
+                                    Tuple valueTuple);
     }
 }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/VectorId.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/VectorId.java
@@ -22,7 +22,6 @@ package com.apple.foundationdb.async.guardiann;
 
 import com.apple.foundationdb.tuple.Tuple;
 
-import javax.annotation.Nonnull;
 import java.util.UUID;
 
 /**
@@ -61,15 +60,14 @@ import java.util.UUID;
  *        maintenance write, and replaced only when the record is re-inserted (updated); shared by every copy of that
  *        generation, so stale copies from an earlier generation can be filtered by UUID mismatch
  */
-record VectorId(@Nonnull Tuple primaryKey, @Nonnull UUID uuid) implements Comparable<VectorId> {
-    @Nonnull
+record VectorId(Tuple primaryKey, UUID uuid) implements Comparable<VectorId> {
     @Override
     public String toString() {
         return "VId[" + primaryKey + ";" + uuid + "]";
     }
 
     @Override
-    public int compareTo(@Nonnull final VectorId o) {
+    public int compareTo(final VectorId o) {
         final int cmp = primaryKey.compareTo(o.primaryKey());
         if (cmp != 0) {
             return cmp;

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/VectorMetadata.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/VectorMetadata.java
@@ -22,8 +22,7 @@ package com.apple.foundationdb.async.guardiann;
 
 import com.apple.foundationdb.tuple.Tuple;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.UUID;
 
 /**
@@ -37,7 +36,7 @@ import java.util.UUID;
  * @param vectorId the identity (primary key plus UUID) of the vector this metadata describes
  * @param additionalValues the extra covering values stored with the vector, or {@code null} if there are none
  */
-record VectorMetadata(@Nonnull VectorId vectorId, @Nullable Tuple additionalValues) {
+record VectorMetadata(VectorId vectorId, @Nullable Tuple additionalValues) {
     /**
      * Convenience constructor that assembles the {@link VectorId} from its primary key and UUID components.
      *
@@ -45,7 +44,7 @@ record VectorMetadata(@Nonnull VectorId vectorId, @Nullable Tuple additionalValu
      * @param uuid the UUID disambiguating copies of the same vector
      * @param additionalValues the extra covering values stored with the vector, or {@code null} if there are none
      */
-    VectorMetadata(@Nonnull final Tuple primaryKey, @Nonnull final UUID uuid, @Nullable final Tuple additionalValues) {
+    VectorMetadata(final Tuple primaryKey, final UUID uuid, @Nullable final Tuple additionalValues) {
         this(new VectorId(primaryKey, uuid), additionalValues);
     }
 }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/VectorRecord.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/VectorRecord.java
@@ -23,7 +23,6 @@ package com.apple.foundationdb.async.guardiann;
 import com.apple.foundationdb.linear.RealVector;
 import com.apple.foundationdb.linear.Transformed;
 
-import javax.annotation.Nonnull;
 
 /**
  * A fully enriched search result: a vector's {@link VectorMetadata} together with its stored vector data and the
@@ -41,5 +40,5 @@ import javax.annotation.Nonnull;
  *        coordinate space during result post-processing
  * @param distance the computed distance between this vector and the query vector
  */
-record VectorRecord(@Nonnull VectorMetadata vectorMetadata, @Nonnull Transformed<RealVector> vector, double distance) {
+record VectorRecord(VectorMetadata vectorMetadata, Transformed<RealVector> vector, double distance) {
 }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/VectorReference.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/VectorReference.java
@@ -25,7 +25,6 @@ import com.apple.foundationdb.linear.Transformed;
 import com.apple.foundationdb.util.Lens;
 import com.google.common.collect.ImmutableMap;
 
-import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
@@ -64,7 +63,6 @@ sealed interface VectorReference permits PrimaryCopy, ReplicatedCopy {
      *
      * @return the vector id
      */
-    @Nonnull
     VectorId id();
 
     /**
@@ -72,7 +70,6 @@ sealed interface VectorReference permits PrimaryCopy, ReplicatedCopy {
      *
      * @return the transformed vector
      */
-    @Nonnull
     Transformed<RealVector> vector();
 
     /**
@@ -126,7 +123,7 @@ sealed interface VectorReference permits PrimaryCopy, ReplicatedCopy {
      * @param other the reference to compare against (e.g. a freshly recomputed assignment of the same vector)
      * @return {@code true} if the two priorities differ by more than the floating-point-noise floor
      */
-    default boolean replicationPriorityChanged(@Nonnull final VectorReference other) {
+    default boolean replicationPriorityChanged(final VectorReference other) {
         return Math.abs(other.replicationPriority() - replicationPriority())
                 > RealVector.EPS * (1.0d + Math.abs(replicationPriority()));
     }
@@ -137,8 +134,7 @@ sealed interface VectorReference permits PrimaryCopy, ReplicatedCopy {
      * @param newVectorId the new vector id
      * @return the updated reference (or {@code this} if the id is unchanged)
      */
-    @Nonnull
-    VectorReference withVectorId(@Nonnull VectorId newVectorId);
+    VectorReference withVectorId(VectorId newVectorId);
 
     /**
      * Returns a copy of this reference with the vector data replaced, preserving role and all other state.
@@ -146,8 +142,7 @@ sealed interface VectorReference permits PrimaryCopy, ReplicatedCopy {
      * @param newVector the new vector data in the transformed coordinate space
      * @return the updated reference (or {@code this} if the vector is unchanged)
      */
-    @Nonnull
-    VectorReference withVector(@Nonnull Transformed<RealVector> newVector);
+    VectorReference withVector(Transformed<RealVector> newVector);
 
     /**
      * Returns this reference as a non-underreplicated primary copy. A replica is promoted to a primary (dropping its
@@ -155,7 +150,6 @@ sealed interface VectorReference permits PrimaryCopy, ReplicatedCopy {
      *
      * @return the primary-copy reference
      */
-    @Nonnull
     VectorReference toPrimaryCopy();
 
     /**
@@ -164,7 +158,6 @@ sealed interface VectorReference permits PrimaryCopy, ReplicatedCopy {
      *
      * @return the underreplicated primary-copy reference
      */
-    @Nonnull
     VectorReference toPrimaryUnderreplicatedCopy();
 
     /**
@@ -174,7 +167,6 @@ sealed interface VectorReference permits PrimaryCopy, ReplicatedCopy {
      * @param newReplicationScore the replication priority for the replica
      * @return the replicated-copy reference
      */
-    @Nonnull
     VectorReference toReplicatedCopy(double newReplicationScore);
 
     /**
@@ -186,8 +178,7 @@ sealed interface VectorReference permits PrimaryCopy, ReplicatedCopy {
      * @param vectorUuid the UUID assigned to the collapsed representative
      * @return the collapsed reference
      */
-    @Nonnull
-    VectorReference toCollapsed(@Nonnull UUID signature, @Nonnull UUID vectorUuid);
+    VectorReference toCollapsed(UUID signature, UUID vectorUuid);
 
     /**
      * Creates a primary-copy reference (this cluster owns the vector).
@@ -198,8 +189,7 @@ sealed interface VectorReference permits PrimaryCopy, ReplicatedCopy {
      * @param isCollapsed whether this reference represents a collapsed set of identical vectors
      * @return the primary-copy reference
      */
-    @Nonnull
-    static VectorReference primaryCopy(@Nonnull final VectorId id, @Nonnull final Transformed<RealVector> vector,
+    static VectorReference primaryCopy(final VectorId id, final Transformed<RealVector> vector,
                                        final boolean isUnderreplicated, final boolean isCollapsed) {
         return new PrimaryCopy(id, vector, isUnderreplicated, isCollapsed);
     }
@@ -213,8 +203,7 @@ sealed interface VectorReference permits PrimaryCopy, ReplicatedCopy {
      * @param isCollapsed whether this reference represents a collapsed set of identical vectors
      * @return the replicated-copy reference
      */
-    @Nonnull
-    static VectorReference replicatedCopy(@Nonnull final VectorId id, @Nonnull final Transformed<RealVector> vector,
+    static VectorReference replicatedCopy(final VectorId id, final Transformed<RealVector> vector,
                                           final double replicationPriority, final boolean isCollapsed) {
         return new ReplicatedCopy(id, vector, replicationPriority, isCollapsed);
     }
@@ -225,7 +214,6 @@ sealed interface VectorReference permits PrimaryCopy, ReplicatedCopy {
      *
      * @return the composed lens
      */
-    @Nonnull
     static Lens<VectorReference, RealVector> vectorLens() {
         return VectorReferenceVectorLens.VECTOR_LENS;
     }
@@ -266,7 +254,6 @@ sealed interface VectorReference permits PrimaryCopy, ReplicatedCopy {
          * @return the matching role
          * @throws NullPointerException if the code does not correspond to any role
          */
-        @Nonnull
         public static Role ofCode(final int code) {
             return Objects.requireNonNull(BY_CODE.get(code),
                     () -> "unknown vector reference role code: " + code);

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/VectorReferenceAndDistance.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/VectorReferenceAndDistance.java
@@ -20,7 +20,6 @@
 
 package com.apple.foundationdb.async.guardiann;
 
-import javax.annotation.Nonnull;
 
 /**
  * Pairs a {@link VectorReference} with its computed distance to a query vector. Used during search
@@ -29,7 +28,7 @@ import javax.annotation.Nonnull;
  * @param vectorReference the vector reference from a cluster
  * @param distance the computed distance between this vector and the query vector
  */
-record VectorReferenceAndDistance(@Nonnull VectorReference vectorReference, double distance) {
+record VectorReferenceAndDistance(VectorReference vectorReference, double distance) {
 
     /**
      * Returns a copy of this pair with a different vector reference, preserving the same distance.
@@ -39,8 +38,7 @@ record VectorReferenceAndDistance(@Nonnull VectorReference vectorReference, doub
      * @param vectorReference the replacement vector reference
      * @return a new pair with the given reference and the original distance
      */
-    @Nonnull
-    public VectorReferenceAndDistance withVectorReference(@Nonnull final VectorReference vectorReference) {
+    public VectorReferenceAndDistance withVectorReference(final VectorReference vectorReference) {
         return new VectorReferenceAndDistance(vectorReference, distance());
     }
 }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/VectorReferenceVectorLens.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/VectorReferenceVectorLens.java
@@ -25,8 +25,7 @@ import com.apple.foundationdb.linear.RealVector;
 import com.apple.foundationdb.linear.Transformed;
 import com.apple.foundationdb.util.Lens;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.Objects;
 
 /**
@@ -39,7 +38,7 @@ class VectorReferenceVectorLens implements Lens<VectorReference, Transformed<Rea
 
     @Nullable
     @Override
-    public Transformed<RealVector> get(@Nonnull final VectorReference vectorReference) {
+    public Transformed<RealVector> get(final VectorReference vectorReference) {
         return vectorReference.vector();
     }
 
@@ -55,7 +54,6 @@ class VectorReferenceVectorLens implements Lens<VectorReference, Transformed<Rea
      *
      * @return the reference carrying {@code transformed}
      */
-    @Nonnull
     @Override
     @SpotBugsSuppressWarnings("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
     public VectorReference set(@Nullable final VectorReference vectorReference,

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/package-info.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/guardiann/package-info.java
@@ -23,4 +23,7 @@
  * Guided Updatable cluster Assignment and Routing via Distance-based Indexing for ANN searches.
  * See {@link com.apple.foundationdb.async.guardiann.Guardiann} for an introduction.
  */
+@NullMarked
 package com.apple.foundationdb.async.guardiann;
+
+import org.jspecify.annotations.NullMarked;

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/AbstractNode.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/AbstractNode.java
@@ -23,7 +23,6 @@ package com.apple.foundationdb.async.hnsw;
 import com.apple.foundationdb.tuple.Tuple;
 import com.google.common.collect.ImmutableList;
 
-import javax.annotation.Nonnull;
 import java.util.List;
 
 /**
@@ -37,10 +36,8 @@ import java.util.List;
  * @param <N> the type of the node reference used for neighbors, which must extend {@link NodeReference}
  */
 abstract class AbstractNode<N extends NodeReference> implements Node<N> {
-    @Nonnull
     private final Tuple primaryKey;
 
-    @Nonnull
     private final List<N> neighbors;
 
     /**
@@ -49,8 +46,8 @@ abstract class AbstractNode<N extends NodeReference> implements Node<N> {
      * @param primaryKey the unique identifier for this node; must not be {@code null}
      * @param neighbors the list of nodes connected to this node; must not be {@code null}
      */
-    protected AbstractNode(@Nonnull final Tuple primaryKey,
-                           @Nonnull final List<N> neighbors) {
+    protected AbstractNode(final Tuple primaryKey,
+                           final List<N> neighbors) {
         this.primaryKey = primaryKey;
         this.neighbors = ImmutableList.copyOf(neighbors);
     }
@@ -59,7 +56,6 @@ abstract class AbstractNode<N extends NodeReference> implements Node<N> {
      * Gets the primary key that uniquely identifies this object.
      * @return the primary key {@link Tuple}, which will never be {@code null}.
      */
-    @Nonnull
     @Override
     public Tuple getPrimaryKey() {
         return primaryKey;
@@ -72,7 +68,6 @@ abstract class AbstractNode<N extends NodeReference> implements Node<N> {
      * immutable.
      * @return a non-null, possibly empty, list of neighbors.
      */
-    @Nonnull
     @Override
     public List<N> getNeighbors() {
         return neighbors;
@@ -92,7 +87,6 @@ abstract class AbstractNode<N extends NodeReference> implements Node<N> {
      *
      * @return a non-null {@link CompactNode} representing the current node.
      */
-    @Nonnull
     public abstract CompactNode asCompactNode();
 
     /**
@@ -107,6 +101,5 @@ abstract class AbstractNode<N extends NodeReference> implements Node<N> {
      * @throws ClassCastException if this object is not actually an instance of
      * {@link InliningNode}.
      */
-    @Nonnull
     public abstract InliningNode asInliningNode();
 }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/AbstractStorageAdapter.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/AbstractStorageAdapter.java
@@ -30,8 +30,7 @@ import com.google.common.base.Verify;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -45,21 +44,14 @@ import java.util.concurrent.CompletableFuture;
  * @param <N> the type of {@link NodeReference} used to reference nodes in the graph
  */
 abstract class AbstractStorageAdapter<N extends NodeReference> implements StorageAdapter<N> {
-    @Nonnull
     private static final Logger logger = LoggerFactory.getLogger(AbstractStorageAdapter.class);
 
-    @Nonnull
     private final Config config;
-    @Nonnull
     private final NodeFactory<N> nodeFactory;
-    @Nonnull
     private final Subspace subspace;
-    @Nonnull
     private final OnWriteListener onWriteListener;
-    @Nonnull
     private final OnReadListener onReadListener;
 
-    @Nonnull
     private final Subspace dataSubspace;
 
     /**
@@ -75,10 +67,10 @@ abstract class AbstractStorageAdapter<N extends NodeReference> implements Storag
      * @param onWriteListener the listener to be called on write operations
      * @param onReadListener the listener to be called on read operations
      */
-    protected AbstractStorageAdapter(@Nonnull final Config config, @Nonnull final NodeFactory<N> nodeFactory,
-                                     @Nonnull final Subspace subspace,
-                                     @Nonnull final OnWriteListener onWriteListener,
-                                     @Nonnull final OnReadListener onReadListener) {
+    protected AbstractStorageAdapter(final Config config, final NodeFactory<N> nodeFactory,
+                                     final Subspace subspace,
+                                     final OnWriteListener onWriteListener,
+                                     final OnReadListener onReadListener) {
         this.config = config;
         this.nodeFactory = nodeFactory;
         this.subspace = subspace;
@@ -88,12 +80,10 @@ abstract class AbstractStorageAdapter<N extends NodeReference> implements Storag
     }
 
     @Override
-    @Nonnull
     public Config getConfig() {
         return config;
     }
 
-    @Nonnull
     @Override
     public NodeFactory<N> getNodeFactory() {
         return nodeFactory;
@@ -106,7 +96,6 @@ abstract class AbstractStorageAdapter<N extends NodeReference> implements Storag
         return isInliningStorageAdapter;
     }
 
-    @Nonnull
     @Override
     public InliningStorageAdapter asInliningStorageAdapter() {
         Verify.verify(isInliningStorageAdapter());
@@ -120,7 +109,6 @@ abstract class AbstractStorageAdapter<N extends NodeReference> implements Storag
         return isCompactStorageAdapter;
     }
 
-    @Nonnull
     @Override
     public CompactStorageAdapter asCompactStorageAdapter() {
         Verify.verify(isCompactStorageAdapter());
@@ -128,7 +116,6 @@ abstract class AbstractStorageAdapter<N extends NodeReference> implements Storag
     }
 
     @Override
-    @Nonnull
     public Subspace getSubspace() {
         return subspace;
     }
@@ -142,28 +129,24 @@ abstract class AbstractStorageAdapter<N extends NodeReference> implements Storag
      * @return the non-null {@link Subspace} for the data
      */
     @Override
-    @Nonnull
     public Subspace getDataSubspace() {
         return dataSubspace;
     }
 
     @Override
-    @Nonnull
     public OnWriteListener getOnWriteListener() {
         return onWriteListener;
     }
 
     @Override
-    @Nonnull
     public OnReadListener getOnReadListener() {
         return onReadListener;
     }
 
-    @Nonnull
     @Override
-    public CompletableFuture<AbstractNode<N>> fetchNode(@Nonnull final ReadTransaction readTransaction,
-                                                        @Nonnull final StorageTransform storageTransform,
-                                                        final int layer, @Nonnull Tuple primaryKey) {
+    public CompletableFuture<AbstractNode<N>> fetchNode(final ReadTransaction readTransaction,
+                                                        final StorageTransform storageTransform,
+                                                        final int layer, Tuple primaryKey) {
         return fetchNodeInternal(readTransaction, storageTransform, layer, primaryKey).thenApply(this::checkNode);
     }
 
@@ -183,10 +166,9 @@ abstract class AbstractStorageAdapter<N extends NodeReference> implements Storag
      * @return a {@link CompletableFuture} that will be completed with the fetched {@link AbstractNode}.
      *         The future will complete with {@code null} if no node is found for the given key and layer.
      */
-    @Nonnull
-    protected abstract CompletableFuture<AbstractNode<N>> fetchNodeInternal(@Nonnull ReadTransaction readTransaction,
-                                                                            @Nonnull StorageTransform storageTransform,
-                                                                            int layer, @Nonnull Tuple primaryKey);
+    protected abstract CompletableFuture<AbstractNode<N>> fetchNodeInternal(ReadTransaction readTransaction,
+                                                                            StorageTransform storageTransform,
+                                                                            int layer, Tuple primaryKey);
 
     /**
      * Method to perform basic invariant check(s) on a newly-fetched node.
@@ -218,9 +200,9 @@ abstract class AbstractStorageAdapter<N extends NodeReference> implements Storag
      * to the node's neighbors
      */
     @Override
-    public void writeNode(@Nonnull final Transaction transaction, @Nonnull final Quantizer quantizer,
-                          final int layer, @Nonnull final AbstractNode<N> node,
-                          @Nonnull final NeighborsChangeSet<N> changeSet) {
+    public void writeNode(final Transaction transaction, final Quantizer quantizer,
+                          final int layer, final AbstractNode<N> node,
+                          final NeighborsChangeSet<N> changeSet) {
         writeNodeInternal(transaction, quantizer, layer, node, changeSet);
         if (logger.isTraceEnabled()) {
             logger.trace("written node with key={} at layer={}", node.getPrimaryKey(), layer);
@@ -242,12 +224,12 @@ abstract class AbstractStorageAdapter<N extends NodeReference> implements Storag
      * @param changeSet the non-null {@link NeighborsChangeSet} detailing additions or
      * removals of neighbor links
      */
-    protected abstract void writeNodeInternal(@Nonnull Transaction transaction, @Nonnull Quantizer quantizer,
-                                              int layer, @Nonnull AbstractNode<N> node,
-                                              @Nonnull NeighborsChangeSet<N> changeSet);
+    protected abstract void writeNodeInternal(Transaction transaction, Quantizer quantizer,
+                                              int layer, AbstractNode<N> node,
+                                              NeighborsChangeSet<N> changeSet);
 
     @Override
-    public void deleteNode(@Nonnull final Transaction transaction, final int layer, @Nonnull final Tuple primaryKey) {
+    public void deleteNode(final Transaction transaction, final int layer, final Tuple primaryKey) {
         deleteNodeInternal(transaction, layer, primaryKey);
         if (logger.isTraceEnabled()) {
             logger.trace("deleted node with key={} at layer={}", primaryKey, layer);
@@ -260,5 +242,5 @@ abstract class AbstractStorageAdapter<N extends NodeReference> implements Storag
      * @param layer the layer
      * @param primaryKey the primary key of the node
      */
-    protected abstract void deleteNodeInternal(@Nonnull Transaction transaction, int layer, @Nonnull Tuple primaryKey);
+    protected abstract void deleteNodeInternal(Transaction transaction, int layer, Tuple primaryKey);
 }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/AccessInfo.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/AccessInfo.java
@@ -23,8 +23,7 @@ package com.apple.foundationdb.async.hnsw;
 import com.apple.foundationdb.async.common.StorageTransform;
 import com.apple.foundationdb.linear.RealVector;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.Objects;
 
 /**
@@ -37,7 +36,6 @@ class AccessInfo {
     /**
      * The current entry point. All searches start here.
      */
-    @Nonnull
     private final EntryNodeReference entryNodeReference;
 
     /**
@@ -55,14 +53,13 @@ class AccessInfo {
     @Nullable
     private final RealVector negatedCentroid;
 
-    public AccessInfo(@Nonnull final EntryNodeReference entryNodeReference, final long rotatorSeed,
+    public AccessInfo(final EntryNodeReference entryNodeReference, final long rotatorSeed,
                       @Nullable final RealVector negatedCentroid) {
         this.entryNodeReference = entryNodeReference;
         this.rotatorSeed = rotatorSeed;
         this.negatedCentroid = negatedCentroid;
     }
 
-    @Nonnull
     public EntryNodeReference getEntryNodeReference() {
         return entryNodeReference;
     }
@@ -80,8 +77,7 @@ class AccessInfo {
         return negatedCentroid;
     }
 
-    @Nonnull
-    public AccessInfo withNewEntryNodeReference(@Nonnull final EntryNodeReference entryNodeReference) {
+    public AccessInfo withNewEntryNodeReference(final EntryNodeReference entryNodeReference) {
         return new AccessInfo(entryNodeReference, getRotatorSeed(), getNegatedCentroid());
     }
 
@@ -101,7 +97,6 @@ class AccessInfo {
         return Objects.hash(entryNodeReference, rotatorSeed, negatedCentroid);
     }
 
-    @Nonnull
     @Override
     public String toString() {
         return "AccessInfo[" +

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/BaseNeighborsChangeSet.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/BaseNeighborsChangeSet.java
@@ -25,8 +25,7 @@ import com.apple.foundationdb.linear.Quantizer;
 import com.apple.foundationdb.tuple.Tuple;
 import com.google.common.collect.ImmutableList;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.List;
 import java.util.function.Predicate;
 
@@ -39,7 +38,6 @@ import java.util.function.Predicate;
  * @param <N> the type of the node reference, which must extend {@link NodeReference}
  */
 class BaseNeighborsChangeSet<N extends NodeReference> implements NeighborsChangeSet<N> {
-    @Nonnull
     private final List<N> neighbors;
 
     /**
@@ -49,7 +47,7 @@ class BaseNeighborsChangeSet<N extends NodeReference> implements NeighborsChange
      *
      * @param neighbors the list of neighbors for this change set; must not be null.
      */
-    public BaseNeighborsChangeSet(@Nonnull final List<N> neighbors) {
+    public BaseNeighborsChangeSet(final List<N> neighbors) {
         this.neighbors = ImmutableList.copyOf(neighbors);
     }
 
@@ -84,7 +82,6 @@ class BaseNeighborsChangeSet<N extends NodeReference> implements NeighborsChange
      * @return a non-null list of neighbors. The generic type {@code N} represents
      *         the type of the neighboring elements.
      */
-    @Nonnull
     @Override
     public List<N> merge() {
         return neighbors;
@@ -97,9 +94,9 @@ class BaseNeighborsChangeSet<N extends NodeReference> implements NeighborsChange
      * as indicated by the empty method body.
      */
     @Override
-    public void writeDelta(@Nonnull final InliningStorageAdapter storageAdapter, @Nonnull final Transaction transaction,
-                           @Nonnull final Quantizer quantizer, final int layer, @Nonnull final AbstractNode<N> node,
-                           @Nonnull final Predicate<Tuple> primaryKeyPredicate) {
+    public void writeDelta(final InliningStorageAdapter storageAdapter, final Transaction transaction,
+                           final Quantizer quantizer, final int layer, final AbstractNode<N> node,
+                           final Predicate<Tuple> primaryKeyPredicate) {
         // nothing to be written
     }
 }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/Cardinality.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/Cardinality.java
@@ -22,7 +22,6 @@ package com.apple.foundationdb.async.hnsw;
 
 import com.apple.foundationdb.ReadTransaction;
 
-import javax.annotation.Nonnull;
 
 /**
  * A coarse classification of how many nodes live on a layer of the graph. It is deliberately coarse — only the
@@ -47,7 +46,6 @@ public enum Cardinality {
      *
      * @return the matching {@link Cardinality}
      */
-    @Nonnull
     static Cardinality fromCount(final int count) {
         if (count <= 0) {
             return EMPTY;

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/CompactNode.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/CompactNode.java
@@ -26,8 +26,7 @@ import com.apple.foundationdb.linear.RealVector;
 import com.apple.foundationdb.linear.Transformed;
 import com.apple.foundationdb.tuple.Tuple;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.List;
 import java.util.Objects;
 
@@ -42,28 +41,24 @@ import java.util.Objects;
  * @see NodeReference
  */
 class CompactNode extends AbstractNode<NodeReference> {
-    @Nonnull
     private static final NodeFactory<NodeReference> FACTORY = new NodeFactory<>() {
         @SuppressWarnings("unchecked")
-        @Nonnull
         @Override
         @SpotBugsSuppressWarnings("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
-        public AbstractNode<NodeReference> create(@Nonnull final Tuple primaryKey,
+        public AbstractNode<NodeReference> create(final Tuple primaryKey,
                                                   @Nullable final Transformed<RealVector> vector,
                                                   @Nullable final Tuple additionalValues,
-                                                  @Nonnull final List<? extends NodeReference> neighbors) {
+                                                  final List<? extends NodeReference> neighbors) {
             return new CompactNode(primaryKey, (List<NodeReference>)neighbors, Objects.requireNonNull(vector),
                     additionalValues);
         }
 
-        @Nonnull
         @Override
         public NodeKind getNodeKind() {
             return NodeKind.COMPACT;
         }
     };
 
-    @Nonnull
     private final Transformed<RealVector> vector;
 
     @Nullable
@@ -82,9 +77,9 @@ class CompactNode extends AbstractNode<NodeReference> {
      * @param vector the data vector of type {@code RealVector} associated with this node; must not be {@code null}.
      * @param additionalValues additional values to be stored with the node
      */
-    public CompactNode(@Nonnull final Tuple primaryKey,
-                       @Nonnull final List<NodeReference> neighbors,
-                       @Nonnull final Transformed<RealVector> vector,
+    public CompactNode(final Tuple primaryKey,
+                       final List<NodeReference> neighbors,
+                       final Transformed<RealVector> vector,
                        @Nullable final Tuple additionalValues) {
         super(primaryKey, neighbors);
         this.vector = vector;
@@ -102,7 +97,6 @@ class CompactNode extends AbstractNode<NodeReference> {
      *
      * @return a non-null {@link NodeReference} to this node.
      */
-    @Nonnull
     @Override
     public NodeReference getSelfReference(@Nullable final Transformed<RealVector> vector) {
         return new NodeReference(getPrimaryKey());
@@ -113,7 +107,6 @@ class CompactNode extends AbstractNode<NodeReference> {
      * This implementation always returns {@link NodeKind#COMPACT}.
      * @return the node kind, which is guaranteed to be {@link NodeKind#COMPACT}.
      */
-    @Nonnull
     @Override
     public NodeKind getKind() {
         return NodeKind.COMPACT;
@@ -123,7 +116,6 @@ class CompactNode extends AbstractNode<NodeReference> {
      * Gets the vector of {@code Half} objects.
      * @return the non-null vector of {@link Half} objects.
      */
-    @Nonnull
     public Transformed<RealVector> getVector() {
         return vector;
     }
@@ -143,7 +135,6 @@ class CompactNode extends AbstractNode<NodeReference> {
      * {@code this}.
      * @return this object cast as a {@code CompactNode}, which is guaranteed to be non-null.
      */
-    @Nonnull
     @Override
     public CompactNode asCompactNode() {
         return this;
@@ -162,7 +153,6 @@ class CompactNode extends AbstractNode<NodeReference> {
      * @return this node as a non-null {@link InliningNode}
      * @throws IllegalStateException always, as this is not an inlining node
      */
-    @Nonnull
     @Override
     public InliningNode asInliningNode() {
         throw new IllegalStateException("this is not an inlining node");
@@ -176,7 +166,6 @@ class CompactNode extends AbstractNode<NodeReference> {
      *
      * @return a shared, non-null instance of {@code NodeFactory<NodeReference>}
      */
-    @Nonnull
     public static NodeFactory<NodeReference> factory() {
         return FACTORY;
     }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/CompactStorageAdapter.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/CompactStorageAdapter.java
@@ -40,8 +40,7 @@ import com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -54,7 +53,6 @@ import java.util.concurrent.CompletableFuture;
  * just neighbor primary keys. It extends {@link AbstractStorageAdapter} to inherit common storage logic.
  */
 class CompactStorageAdapter extends AbstractStorageAdapter<NodeReference> implements StorageAdapter<NodeReference> {
-    @Nonnull
     private static final Logger logger = LoggerFactory.getLogger(CompactStorageAdapter.class);
 
     /**
@@ -66,17 +64,16 @@ class CompactStorageAdapter extends AbstractStorageAdapter<NodeReference> implem
      * @param onWriteListener the listener to be notified of write events, must not be null.
      * @param onReadListener the listener to be notified of read events, must not be null.
      */
-    public CompactStorageAdapter(@Nonnull final Config config,
-                                 @Nonnull final NodeFactory<NodeReference> nodeFactory,
-                                 @Nonnull final Subspace subspace,
-                                 @Nonnull final OnWriteListener onWriteListener,
-                                 @Nonnull final OnReadListener onReadListener) {
+    public CompactStorageAdapter(final Config config,
+                                 final NodeFactory<NodeReference> nodeFactory,
+                                 final Subspace subspace,
+                                 final OnWriteListener onWriteListener,
+                                 final OnReadListener onReadListener) {
         super(config, nodeFactory, subspace, onWriteListener, onReadListener);
     }
 
-    @Nonnull
     @Override
-    public Transformed<RealVector> getVector(@Nonnull final NodeReference nodeReference, @Nonnull final AbstractNode<NodeReference> node) {
+    public Transformed<RealVector> getVector(final NodeReference nodeReference, final AbstractNode<NodeReference> node) {
         return node.asCompactNode().getVector();
     }
 
@@ -96,12 +93,11 @@ class CompactStorageAdapter extends AbstractStorageAdapter<NodeReference> implem
      * @return a future that will complete with the fetched {@link AbstractNode} or {@code null} if the node cannot
      *         be fetched
      */
-    @Nonnull
     @Override
-    protected CompletableFuture<AbstractNode<NodeReference>> fetchNodeInternal(@Nonnull final ReadTransaction readTransaction,
-                                                                               @Nonnull final StorageTransform storageTransform,
+    protected CompletableFuture<AbstractNode<NodeReference>> fetchNodeInternal(final ReadTransaction readTransaction,
+                                                                               final StorageTransform storageTransform,
                                                                                final int layer,
-                                                                               @Nonnull final Tuple primaryKey) {
+                                                                               final Tuple primaryKey) {
         final byte[] keyBytes = getNodeKey(layer, primaryKey);
         return readTransaction.get(keyBytes)
                 .thenApply(valueBytes -> {
@@ -129,10 +125,9 @@ class CompactStorageAdapter extends AbstractStorageAdapter<NodeReference> implem
      *
      * @return a non-null, deserialized {@link AbstractNode} object
      */
-    @Nonnull
-    private AbstractNode<NodeReference> nodeFromRaw(@Nonnull final StorageTransform storageTransform, final int layer,
-                                                    final @Nonnull Tuple primaryKey,
-                                                    @Nonnull final byte[] keyBytes, @Nonnull final byte[] valueBytes) {
+    private AbstractNode<NodeReference> nodeFromRaw(final StorageTransform storageTransform, final int layer,
+                                                    final Tuple primaryKey,
+                                                    final byte[] keyBytes, final byte[] valueBytes) {
         final Tuple nodeTuple = Tuple.fromBytes(valueBytes);
         final AbstractNode<NodeReference> node = nodeFromKeyValuesTuples(storageTransform, primaryKey, nodeTuple);
         final OnReadListener onReadListener = getOnReadListener();
@@ -160,10 +155,9 @@ class CompactStorageAdapter extends AbstractStorageAdapter<NodeReference> implem
      * @throws com.google.common.base.VerifyException if the node kind encoded in {@code valueTuple} is not
      *         {@link NodeKind#COMPACT}
      */
-    @Nonnull
-    private AbstractNode<NodeReference> nodeFromKeyValuesTuples(@Nonnull final StorageTransform storageTransform,
-                                                                @Nonnull final Tuple primaryKey,
-                                                                @Nonnull final Tuple valueTuple) {
+    private AbstractNode<NodeReference> nodeFromKeyValuesTuples(final StorageTransform storageTransform,
+                                                                final Tuple primaryKey,
+                                                                final Tuple valueTuple) {
         final NodeKind nodeKind = NodeKind.fromSerializedNodeKind((byte)valueTuple.getLong(0));
         Verify.verify(nodeKind == NodeKind.COMPACT);
 
@@ -191,12 +185,11 @@ class CompactStorageAdapter extends AbstractStorageAdapter<NodeReference> implem
      *
      * @return a new {@code Node} instance containing the deserialized data from the input tuples
      */
-    @Nonnull
-    private AbstractNode<NodeReference> compactNodeFromTuples(@Nonnull final StorageTransform storageTransform,
-                                                              @Nonnull final Tuple primaryKey,
-                                                              @Nonnull final Tuple vectorTuple,
+    private AbstractNode<NodeReference> compactNodeFromTuples(final StorageTransform storageTransform,
+                                                              final Tuple primaryKey,
+                                                              final Tuple vectorTuple,
                                                               @Nullable final Tuple additionalValuesTuple,
-                                                              @Nonnull final Tuple neighborsTuple) {
+                                                              final Tuple neighborsTuple) {
         final Transformed<RealVector> vector =
                 storageTransform.transform(StorageHelpers.vectorFromTuple(getConfig(), vectorTuple));
         final List<NodeReference> nodeReferences = Lists.newArrayListWithExpectedSize(neighborsTuple.size());
@@ -226,9 +219,9 @@ class CompactStorageAdapter extends AbstractStorageAdapter<NodeReference> implem
      * merged to determine the final set of neighbors to be written.
      */
     @Override
-    public void writeNodeInternal(@Nonnull final Transaction transaction, @Nonnull final Quantizer quantizer,
-                                  final int layer, @Nonnull final AbstractNode<NodeReference> node,
-                                  @Nonnull final NeighborsChangeSet<NodeReference> neighborsChangeSet) {
+    public void writeNodeInternal(final Transaction transaction, final Quantizer quantizer,
+                                  final int layer, final AbstractNode<NodeReference> node,
+                                  final NeighborsChangeSet<NodeReference> neighborsChangeSet) {
         final byte[] key = getNodeKey(layer, node.getPrimaryKey());
 
         final CompactNode compactNode = node.asCompactNode();
@@ -263,8 +256,8 @@ class CompactStorageAdapter extends AbstractStorageAdapter<NodeReference> implem
     }
 
     @Override
-    protected void deleteNodeInternal(@Nonnull final Transaction transaction, final int layer,
-                                      @Nonnull final Tuple primaryKey) {
+    protected void deleteNodeInternal(final Transaction transaction, final int layer,
+                                      final Tuple primaryKey) {
         final byte[] key = getNodeKey(layer, primaryKey);
         transaction.clear(key);
         getOnWriteListener().onNodeDeleted(layer, primaryKey);
@@ -284,8 +277,7 @@ class CompactStorageAdapter extends AbstractStorageAdapter<NodeReference> implem
      *
      * @return a byte array representing the packed key for the specified node
      */
-    @Nonnull
-    private byte[] getNodeKey(final int layer, @Nonnull final Tuple primaryKey) {
+    private byte[] getNodeKey(final int layer, final Tuple primaryKey) {
         return getDataSubspace().pack(Tuple.from(layer, primaryKey));
     }
 
@@ -305,9 +297,8 @@ class CompactStorageAdapter extends AbstractStorageAdapter<NodeReference> implem
      * @return an {@link Iterable} of {@link AbstractNode} objects found in the specified layer,
      * limited by {@code maxNumRead}
      */
-    @Nonnull
     @Override
-    public AsyncIterable<AbstractNode<NodeReference>> scanLayer(@Nonnull final ReadTransaction readTransaction, int layer,
+    public AsyncIterable<AbstractNode<NodeReference>> scanLayer(final ReadTransaction readTransaction, int layer,
                                                                 @Nullable final Tuple lastPrimaryKey, int maxNumRead) {
         final byte[] layerPrefix = getDataSubspace().pack(Tuple.from(layer));
         final Range range =

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/Config.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/Config.java
@@ -25,7 +25,6 @@ import com.apple.foundationdb.linear.Metric;
 import com.google.common.base.Preconditions;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 
-import javax.annotation.Nonnull;
 
 /**
  * Configuration settings for an {@link HNSW}.
@@ -50,7 +49,7 @@ import javax.annotation.Nonnull;
  * @param maxNumConcurrentDeleteFromLayer maximum concurrent delete operations per layer
  */
 @SuppressWarnings("checkstyle:MemberName")
-public record Config(@Nonnull Metric metric,
+public record Config(Metric metric,
                      int numDimensions,
                      boolean useInlining,
                      int m,
@@ -69,7 +68,7 @@ public record Config(@Nonnull Metric metric,
                      int maxNumConcurrentNeighborhoodFetches,
                      int maxNumConcurrentDeleteFromLayer) implements VectorEncodingConfig {
 
-    @Nonnull public static final Metric DEFAULT_METRIC = Metric.EUCLIDEAN_METRIC;
+    public static final Metric DEFAULT_METRIC = Metric.EUCLIDEAN_METRIC;
     public static final boolean DEFAULT_USE_INLINING = false;
     public static final int DEFAULT_M = 16;
     public static final int DEFAULT_M_MAX_0 = 2 * DEFAULT_M;
@@ -120,7 +119,6 @@ public record Config(@Nonnull Metric metric,
                 "maxNumConcurrentDeleteFromLayer must be (0, 10]");
     }
 
-    @Nonnull
     public ConfigBuilder toBuilder() {
         return new ConfigBuilder(metric(), useInlining(), m(), mMax(), mMax0(),
                 efConstruction(), efRepair(), extendCandidates(), keepPrunedConnections(),
@@ -130,7 +128,6 @@ public record Config(@Nonnull Metric metric,
     }
 
     @Override
-    @Nonnull
     public String toString() {
         return "Config[metric=" + metric() + ", numDimensions=" + numDimensions() +
                 ", useInlining=" + useInlining() + ", m=" + m() + ", mMax=" + mMax() +
@@ -155,7 +152,6 @@ public record Config(@Nonnull Metric metric,
     @CanIgnoreReturnValue
     @SuppressWarnings("checkstyle:MemberName")
     public static class ConfigBuilder {
-        @Nonnull
         private Metric metric = DEFAULT_METRIC;
         private boolean useInlining = DEFAULT_USE_INLINING;
         private int m = DEFAULT_M;
@@ -180,7 +176,7 @@ public record Config(@Nonnull Metric metric,
         public ConfigBuilder() {
         }
 
-        public ConfigBuilder(@Nonnull final Metric metric, final boolean useInlining, final int m, final int mMax,
+        public ConfigBuilder(final Metric metric, final boolean useInlining, final int m, final int mMax,
                              final int mMax0, final int efConstruction, final int efRepair,
                              final boolean extendCandidates, final boolean keepPrunedConnections,
                              final double sampleVectorStatsProbability, final double maintainStatsProbability,
@@ -206,13 +202,11 @@ public record Config(@Nonnull Metric metric,
             this.maxNumConcurrentDeleteFromLayer = maxNumConcurrentDeleteFromLayer;
         }
 
-        @Nonnull
         public Metric getMetric() {
             return metric;
         }
 
-        @Nonnull
-        public ConfigBuilder setMetric(@Nonnull final Metric metric) {
+        public ConfigBuilder setMetric(final Metric metric) {
             this.metric = metric;
             return this;
         }
@@ -221,7 +215,6 @@ public record Config(@Nonnull Metric metric,
             return useInlining;
         }
 
-        @Nonnull
         public ConfigBuilder setUseInlining(final boolean useInlining) {
             this.useInlining = useInlining;
             return this;
@@ -231,7 +224,6 @@ public record Config(@Nonnull Metric metric,
             return m;
         }
 
-        @Nonnull
         public ConfigBuilder setM(final int m) {
             this.m = m;
             return this;
@@ -241,7 +233,6 @@ public record Config(@Nonnull Metric metric,
             return mMax;
         }
 
-        @Nonnull
         public ConfigBuilder setMMax(final int mMax) {
             this.mMax = mMax;
             return this;
@@ -251,7 +242,6 @@ public record Config(@Nonnull Metric metric,
             return mMax0;
         }
 
-        @Nonnull
         public ConfigBuilder setMMax0(final int mMax0) {
             this.mMax0 = mMax0;
             return this;
@@ -261,7 +251,6 @@ public record Config(@Nonnull Metric metric,
             return efConstruction;
         }
 
-        @Nonnull
         public ConfigBuilder setEfConstruction(final int efConstruction) {
             this.efConstruction = efConstruction;
             return this;
@@ -271,7 +260,6 @@ public record Config(@Nonnull Metric metric,
             return efRepair;
         }
 
-        @Nonnull
         public ConfigBuilder setEfRepair(final int efRepair) {
             this.efRepair = efRepair;
             return this;
@@ -281,7 +269,6 @@ public record Config(@Nonnull Metric metric,
             return extendCandidates;
         }
 
-        @Nonnull
         public ConfigBuilder setExtendCandidates(final boolean extendCandidates) {
             this.extendCandidates = extendCandidates;
             return this;
@@ -291,7 +278,6 @@ public record Config(@Nonnull Metric metric,
             return keepPrunedConnections;
         }
 
-        @Nonnull
         public ConfigBuilder setKeepPrunedConnections(final boolean keepPrunedConnections) {
             this.keepPrunedConnections = keepPrunedConnections;
             return this;
@@ -301,7 +287,6 @@ public record Config(@Nonnull Metric metric,
             return sampleVectorStatsProbability;
         }
 
-        @Nonnull
         public ConfigBuilder setSampleVectorStatsProbability(final double sampleVectorStatsProbability) {
             this.sampleVectorStatsProbability = sampleVectorStatsProbability;
             return this;
@@ -311,7 +296,6 @@ public record Config(@Nonnull Metric metric,
             return maintainStatsProbability;
         }
 
-        @Nonnull
         public ConfigBuilder setMaintainStatsProbability(final double maintainStatsProbability) {
             this.maintainStatsProbability = maintainStatsProbability;
             return this;
@@ -321,7 +305,6 @@ public record Config(@Nonnull Metric metric,
             return statsThreshold;
         }
 
-        @Nonnull
         public ConfigBuilder setStatsThreshold(final int statsThreshold) {
             this.statsThreshold = statsThreshold;
             return this;
@@ -331,7 +314,6 @@ public record Config(@Nonnull Metric metric,
             return useRaBitQ;
         }
 
-        @Nonnull
         public ConfigBuilder setUseRaBitQ(final boolean useRaBitQ) {
             this.useRaBitQ = useRaBitQ;
             return this;
@@ -341,7 +323,6 @@ public record Config(@Nonnull Metric metric,
             return raBitQNumExBits;
         }
 
-        @Nonnull
         public ConfigBuilder setRaBitQNumExBits(final int raBitQNumExBits) {
             this.raBitQNumExBits = raBitQNumExBits;
             return this;

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/Delete.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/Delete.java
@@ -203,7 +203,11 @@ class Delete {
 
                     return deleteFromLayers(transaction, storageTransform, quantizer, random, primaryKey, topLayer)
                             .thenCompose(potentialEntryNodeReferences -> {
-                                if (entryNodeReference != null && primaryKey.equals(entryNodeReference.getPrimaryKey())) {
+                                // entryNodeReference != null implies accessInfo != null (entryNodeReference is
+                                // derived from it just above), and accessInfo is used (not just entryNodeReference)
+                                // below, so it is checked explicitly; NullAway also does not carry a null check on
+                                // accessInfo across this lambda boundary even if it were checked outside.
+                                if (entryNodeReference != null && accessInfo != null && primaryKey.equals(entryNodeReference.getPrimaryKey())) {
                                     // find (and store) a new entry reference
                                     for (int i = potentialEntryNodeReferences.size() - 1; i >= 0; i --) {
                                         final EntryNodeReference potentialEntyNodeReference =
@@ -375,6 +379,10 @@ class Delete {
                                 // entry node reference in order to avoid a costly search for a new global entry point.
                                 // This reference is guaranteed to exist.
                                 //
+                                // Iterables.getFirst is from Guava, which is not jspecify-annotated, so its generic
+                                // default-value parameter is treated as @NonNull by NullAway's defaults; null is
+                                // the correct default here (there may be no candidates).
+                                @SuppressWarnings("NullAway")
                                 final Tuple firstPrimaryKey =
                                         Iterables.getFirst(candidateReferencesMap.keySet(), null);
                                 return firstPrimaryKey == null

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/Delete.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/Delete.java
@@ -38,8 +38,7 @@ import com.google.common.collect.Maps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -66,10 +65,8 @@ import static com.apple.foundationdb.async.MoreAsyncUtil.forEach;
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 class Delete {
-    @Nonnull
     private static final Logger logger = LoggerFactory.getLogger(Delete.class);
 
-    @Nonnull
     private final Locator locator;
 
     /**
@@ -79,11 +76,10 @@ class Delete {
      * @param locator the {@link Locator} where the graph data is stored, which config to use, which executor to use,
      *        etc.
      */
-    public Delete(@Nonnull final Locator locator) {
+    public Delete(final Locator locator) {
         this.locator = locator;
     }
 
-    @Nonnull
     public Locator getLocator() {
         return locator;
     }
@@ -93,7 +89,6 @@ class Delete {
      *
      * @return the non-null subspace
      */
-    @Nonnull
     public Subspace getSubspace() {
         return getLocator().getSubspace();
     }
@@ -102,7 +97,6 @@ class Delete {
      * Get the executor used by this hnsw.
      * @return executor used when running asynchronous tasks
      */
-    @Nonnull
     private Executor getExecutor() {
         return getLocator().getExecutor();
     }
@@ -111,7 +105,6 @@ class Delete {
      * Get the configuration of this hnsw.
      * @return hnsw configuration
      */
-    @Nonnull
     private Config getConfig() {
         return getLocator().getConfig();
     }
@@ -120,7 +113,6 @@ class Delete {
      * Get the on-write listener.
      * @return the on-write listener
      */
-    @Nonnull
     private OnWriteListener getOnWriteListener() {
         return getLocator().getOnWriteListener();
     }
@@ -129,12 +121,10 @@ class Delete {
      * Get the on-read listener.
      * @return the on-read listener
      */
-    @Nonnull
     private OnReadListener getOnReadListener() {
         return getLocator().getOnReadListener();
     }
 
-    @Nonnull
     private Primitives primitives() {
         return getLocator().primitives();
     }
@@ -181,8 +171,7 @@ class Delete {
      *         including all graph repairs and entry point updates. The future completes with {@code null}
      *         on successful deletion.
      */
-    @Nonnull
-    public CompletableFuture<Void> delete(@Nonnull final Transaction transaction, @Nonnull final Tuple primaryKey) {
+    public CompletableFuture<Void> delete(final Transaction transaction, final Tuple primaryKey) {
         final Primitives primitives = primitives();
         final SplittableRandom random = RandomHelpers.random(primaryKey);
         final int topLayer = primitives.topLayer(primaryKey);
@@ -249,12 +238,11 @@ class Delete {
      * @return a {@link CompletableFuture} that completes when the new node has been successfully inserted into all
      *         its designated layers and contains an existing neighboring entry node reference on that layer.
      */
-    @Nonnull
-    private CompletableFuture<List<EntryNodeReference>> deleteFromLayers(@Nonnull final Transaction transaction,
-                                                                         @Nonnull final StorageTransform storageTransform,
-                                                                         @Nonnull final Quantizer quantizer,
-                                                                         @Nonnull final SplittableRandom random,
-                                                                         @Nonnull final Tuple primaryKey,
+    private CompletableFuture<List<EntryNodeReference>> deleteFromLayers(final Transaction transaction,
+                                                                         final StorageTransform storageTransform,
+                                                                         final Quantizer quantizer,
+                                                                         final SplittableRandom random,
+                                                                         final Tuple primaryKey,
                                                                          final int topLayer) {
         // delete the node from all layers in parallel (inside layer in [0, topLayer])
         return RandomHelpers.forEach(random, () -> IntStream.rangeClosed(0, topLayer).iterator(),
@@ -280,15 +268,14 @@ class Delete {
      *
      * @return a {@code CompletableFuture} that completes with a {@code null}
      */
-    @Nonnull
     private <N extends NodeReference> CompletableFuture<EntryNodeReference>
-            deleteFromLayer(@Nonnull final StorageAdapter<N> storageAdapter,
-                            @Nonnull final Transaction transaction,
-                            @Nonnull final StorageTransform storageTransform,
-                            @Nonnull final Quantizer quantizer,
-                            @Nonnull final SplittableRandom random,
+            deleteFromLayer(final StorageAdapter<N> storageAdapter,
+                            final Transaction transaction,
+                            final StorageTransform storageTransform,
+                            final Quantizer quantizer,
+                            final SplittableRandom random,
                             final int layer,
-                            @Nonnull final Tuple toBeDeletedPrimaryKey) {
+                            final Tuple toBeDeletedPrimaryKey) {
         if (logger.isTraceEnabled()) {
             logger.trace("begin delete key={} at layer={}", toBeDeletedPrimaryKey, layer);
         }
@@ -404,10 +391,10 @@ class Delete {
                 });
     }
 
-    private <N extends NodeReference> void initializeCandidateChangeSetMap(@Nonnull final Tuple toBeDeletedPrimaryKey,
-                                                                           @Nonnull final AbstractNode<N> toBeDeletedNode,
-                                                                           @Nonnull final List<NodeReferenceAndNode<NodeReferenceWithVector, N>> candidates,
-                                                                           @Nonnull final Map<Tuple, NeighborsChangeSet<N>> candidateChangeSetMap) {
+    private <N extends NodeReference> void initializeCandidateChangeSetMap(final Tuple toBeDeletedPrimaryKey,
+                                                                           final AbstractNode<N> toBeDeletedNode,
+                                                                           final List<NodeReferenceAndNode<NodeReferenceWithVector, N>> candidates,
+                                                                           final Map<Tuple, NeighborsChangeSet<N>> candidateChangeSetMap) {
         for (final NodeReferenceAndNode<NodeReferenceWithVector, N> candidate : candidates) {
             final AbstractNode<N> candidateNode = candidate.getNode();
             boolean foundToBeDeleted = false;
@@ -450,12 +437,11 @@ class Delete {
      * @param nodeCache the node cache to avoid repeated fetches
      * @return a future that if successful completes with {@code null}
      */
-    @Nonnull
     private <N extends NodeReference> CompletableFuture<List<NodeReferenceAndNode<NodeReferenceWithVector, N>>>
-             findDeletionRepairCandidates(final @Nonnull StorageAdapter<N> storageAdapter,
-                                          final @Nonnull Transaction transaction,
-                                          final @Nonnull StorageTransform storageTransform,
-                                          final @Nonnull SplittableRandom random,
+             findDeletionRepairCandidates(final StorageAdapter<N> storageAdapter,
+                                          final Transaction transaction,
+                                          final StorageTransform storageTransform,
+                                          final SplittableRandom random,
                                           final int layer,
                                           final NodeReferenceAndNode<NodeReference, N> toBeDeletedNodeReferenceAndNode,
                                           final Map<Tuple, AbstractNode<N>> nodeCache) {
@@ -503,16 +489,16 @@ class Delete {
      * @param nodeCache the node cache to avoid repeated fetches
      * @return a future that if successful completes with {@code null}
      */
-    private <N extends NodeReference> @Nonnull CompletableFuture<Void>
-            repairNeighbor(@Nonnull final StorageAdapter<N> storageAdapter,
-                           @Nonnull final Transaction transaction,
-                           @Nonnull final StorageTransform storageTransform,
-                           @Nonnull final DistanceEstimator distanceEstimator,
+    private <N extends NodeReference> CompletableFuture<Void>
+            repairNeighbor(final StorageAdapter<N> storageAdapter,
+                           final Transaction transaction,
+                           final StorageTransform storageTransform,
+                           final DistanceEstimator distanceEstimator,
                            final int layer,
-                           @Nonnull final N neighborReference,
-                           @Nonnull final Collection<NodeReferenceAndNode<NodeReferenceWithVector, N>> candidates,
-                           @Nonnull final Map<Tuple /* primaryKey */, NeighborsChangeSet<N>> neighborChangeSetMap,
-                           @Nonnull final Map<Tuple, AbstractNode<N>> nodeCache) {
+                           final N neighborReference,
+                           final Collection<NodeReferenceAndNode<NodeReferenceWithVector, N>> candidates,
+                           final Map<Tuple /* primaryKey */, NeighborsChangeSet<N>> neighborChangeSetMap,
+                           final Map<Tuple, AbstractNode<N>> nodeCache) {
 
         return primitives().fetchNodeIfNotCached(storageAdapter, transaction,
                 storageTransform, layer, neighborReference, nodeCache)
@@ -559,14 +545,14 @@ class Delete {
      * @return a future that if successful completes with {@code null}
      */
     private <N extends NodeReference> CompletableFuture<Void>
-            repairInsForNeighborNode(@Nonnull final StorageAdapter<N> storageAdapter,
-                                     @Nonnull final Transaction transaction,
-                                     @Nonnull final StorageTransform storageTransform,
-                                     @Nonnull final DistanceEstimator distanceEstimator,
+            repairInsForNeighborNode(final StorageAdapter<N> storageAdapter,
+                                     final Transaction transaction,
+                                     final StorageTransform storageTransform,
+                                     final DistanceEstimator distanceEstimator,
                                      final int layer,
-                                     @Nonnull final N neighborReference,
-                                     @Nonnull final Iterable<NodeReferenceWithDistance> candidates,
-                                     @Nonnull final Map<Tuple /* primaryKey */, NeighborsChangeSet<N>> neighborChangeSetMap,
+                                     final N neighborReference,
+                                     final Iterable<NodeReferenceWithDistance> candidates,
+                                     final Map<Tuple /* primaryKey */, NeighborsChangeSet<N>> neighborChangeSetMap,
                                      final Map<Tuple, AbstractNode<N>> nodeCache) {
         return primitives().selectCandidates(storageAdapter, transaction, storageTransform, distanceEstimator, candidates,
                 layer, getConfig().m(), nodeCache)
@@ -604,8 +590,8 @@ class Delete {
      * @param toBeDeletedPrimaryKey the {@link Tuple} representing the node that is being deleted
      * @return {@code true} iff {@code candidateReference} is accepted as an actual candidate for repair.
      */
-    private boolean shouldUsePrimaryCandidateForRepair(@Nonnull final NodeReference candidateReference,
-                                                       @Nonnull final Tuple toBeDeletedPrimaryKey) {
+    private boolean shouldUsePrimaryCandidateForRepair(final NodeReference candidateReference,
+                                                       final Tuple toBeDeletedPrimaryKey) {
         final Tuple candidatePrimaryKey = candidateReference.getPrimaryKey();
 
         //
@@ -631,10 +617,10 @@ class Delete {
      * @return {@code true} iff {@code candidateReference} is accepted as an actual candidate for repair.
      */
     private boolean shouldUseSecondaryCandidateForRepair(@Nullable final SplittableRandom random,
-                                                         @Nonnull final Set<Tuple> initialNodeKeys,
+                                                         final Set<Tuple> initialNodeKeys,
                                                          final int numberOfCandidates,
-                                                         @Nonnull final NodeReference candidateReference,
-                                                         @Nonnull final Tuple toBeDeletedPrimaryKey) {
+                                                         final NodeReference candidateReference,
+                                                         final Tuple toBeDeletedPrimaryKey) {
         final Tuple candidatePrimaryKey = candidateReference.getPrimaryKey();
 
         //

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/DeleteNeighborsChangeSet.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/DeleteNeighborsChangeSet.java
@@ -29,7 +29,6 @@ import com.google.common.collect.Iterables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.Set;
@@ -44,13 +43,10 @@ import java.util.function.Predicate;
  * @param <N> the type of the node reference, which must extend {@link NodeReference}
  */
 class DeleteNeighborsChangeSet<N extends NodeReference> implements NeighborsChangeSet<N> {
-    @Nonnull
     private static final Logger logger = LoggerFactory.getLogger(DeleteNeighborsChangeSet.class);
 
-    @Nonnull
     private final NeighborsChangeSet<N> parent;
 
-    @Nonnull
     private final Set<Tuple /* primary key */> deletedNeighborsPrimaryKeys;
 
     /**
@@ -64,8 +60,8 @@ class DeleteNeighborsChangeSet<N extends NodeReference> implements NeighborsChan
      * @param deletedNeighborsPrimaryKeys a {@link Collection} of primary keys, represented as {@link Tuple}s,
      * identifying the neighbors to be deleted. Must not be null.
      */
-    public DeleteNeighborsChangeSet(@Nonnull final NeighborsChangeSet<N> parent,
-                                    @Nonnull final Collection<Tuple> deletedNeighborsPrimaryKeys) {
+    public DeleteNeighborsChangeSet(final NeighborsChangeSet<N> parent,
+                                    final Collection<Tuple> deletedNeighborsPrimaryKeys) {
         this.parent = parent;
         this.deletedNeighborsPrimaryKeys = ImmutableSet.copyOf(deletedNeighborsPrimaryKeys);
     }
@@ -78,7 +74,6 @@ class DeleteNeighborsChangeSet<N extends NodeReference> implements NeighborsChan
      *
      * @return the parent {@link NeighborsChangeSet}
      */
-    @Nonnull
     @Override
     public NeighborsChangeSet<N> getParent() {
         return parent;
@@ -107,7 +102,6 @@ class DeleteNeighborsChangeSet<N extends NodeReference> implements NeighborsChan
      * @return an {@link Iterable} of the merged neighbors, excluding those marked as deleted. This method never returns
      * {@code null}.
      */
-    @Nonnull
     @Override
     public Iterable<N> merge() {
         return Iterables.filter(getParent().merge(),
@@ -133,9 +127,9 @@ class DeleteNeighborsChangeSet<N extends NodeReference> implements NeighborsChan
      *        only deletions matching this predicate will be written
      */
     @Override
-    public void writeDelta(@Nonnull final InliningStorageAdapter storageAdapter, @Nonnull final Transaction transaction,
-                           @Nonnull final Quantizer quantizer, final int layer, @Nonnull final AbstractNode<N> node,
-                           @Nonnull final Predicate<Tuple> tuplePredicate) {
+    public void writeDelta(final InliningStorageAdapter storageAdapter, final Transaction transaction,
+                           final Quantizer quantizer, final int layer, final AbstractNode<N> node,
+                           final Predicate<Tuple> tuplePredicate) {
         Verify.verify(node.isInliningNode());
         getParent().writeDelta(storageAdapter, transaction, quantizer, layer, node,
                 tuplePredicate.and(tuple -> !deletedNeighborsPrimaryKeys.contains(tuple)));

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/DeleteNeighborsChangeSet.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/DeleteNeighborsChangeSet.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.async.hnsw;
 
 import com.apple.foundationdb.Transaction;
+import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.linear.Quantizer;
 import com.apple.foundationdb.tuple.Tuple;
 import com.google.common.base.Verify;
@@ -103,6 +104,10 @@ class DeleteNeighborsChangeSet<N extends NodeReference> implements NeighborsChan
      * {@code null}.
      */
     @Override
+    // getParent() is overridden below to always return this.parent, which is non-null by construction (see the
+    // constructor's contract); SpotBugs's NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE analysis appears to fall back to
+    // the wider @Nullable contract declared by NeighborsChangeSet.getParent() rather than this narrowed override.
+    @SpotBugsSuppressWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     public Iterable<N> merge() {
         return Iterables.filter(getParent().merge(),
                 current -> !deletedNeighborsPrimaryKeys.contains(Objects.requireNonNull(current).getPrimaryKey()));
@@ -127,6 +132,8 @@ class DeleteNeighborsChangeSet<N extends NodeReference> implements NeighborsChan
      *        only deletions matching this predicate will be written
      */
     @Override
+    // See the comment on merge() above: getParent() always returns this.parent (non-null) in this class.
+    @SpotBugsSuppressWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     public void writeDelta(final InliningStorageAdapter storageAdapter, final Transaction transaction,
                            final Quantizer quantizer, final int layer, final AbstractNode<N> node,
                            final Predicate<Tuple> tuplePredicate) {

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/EntryNodeReference.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/EntryNodeReference.java
@@ -24,7 +24,6 @@ import com.apple.foundationdb.linear.RealVector;
 import com.apple.foundationdb.linear.Transformed;
 import com.apple.foundationdb.tuple.Tuple;
 
-import javax.annotation.Nonnull;
 import java.util.Objects;
 
 /**
@@ -49,7 +48,7 @@ class EntryNodeReference extends NodeReferenceWithVector {
      * @param vector the vector data associated with the node. Must not be {@code null}.
      * @param layer the layer number where this entry node is located.
      */
-    public EntryNodeReference(@Nonnull final Tuple primaryKey, @Nonnull final Transformed<RealVector> vector,
+    public EntryNodeReference(final Tuple primaryKey, final Transformed<RealVector> vector,
                               final int layer) {
         super(primaryKey, vector);
         this.layer = layer;
@@ -63,8 +62,7 @@ class EntryNodeReference extends NodeReferenceWithVector {
         return layer;
     }
 
-    @Nonnull
-    public EntryNodeReference withVector(@Nonnull final Transformed<RealVector> newVector) {
+    public EntryNodeReference withVector(final Transformed<RealVector> newVector) {
         return new EntryNodeReference(getPrimaryKey(), newVector, getLayer());
     }
 

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/HNSW.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/HNSW.java
@@ -31,8 +31,7 @@ import com.apple.foundationdb.subspace.Subspace;
 import com.apple.foundationdb.tuple.Tuple;
 import com.google.common.annotations.VisibleForTesting;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -58,7 +57,6 @@ import java.util.function.Consumer;
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 public class HNSW {
-    @Nonnull
     private final Locator locator;
 
     /**
@@ -76,7 +74,6 @@ public class HNSW {
      * @return a new default {@code Config}.
      * @see Config.ConfigBuilder#build
      */
-    @Nonnull
     public static Config defaultConfig(int numDimensions) {
         return new Config.ConfigBuilder().build(numDimensions);
     }
@@ -95,15 +92,14 @@ public class HNSW {
      *
      * @throws NullPointerException if any of the parameters are {@code null}.
      */
-    public HNSW(@Nonnull final Subspace subspace,
-                @Nonnull final Executor executor,
-                @Nonnull final Config config,
-                @Nonnull final OnWriteListener onWriteListener,
-                @Nonnull final OnReadListener onReadListener) {
+    public HNSW(final Subspace subspace,
+                final Executor executor,
+                final Config config,
+                final OnWriteListener onWriteListener,
+                final OnReadListener onReadListener) {
         this.locator = new Locator(subspace, executor, config, onWriteListener, onReadListener);
     }
 
-    @Nonnull
     public Locator getLocator() {
         return locator;
     }
@@ -113,7 +109,6 @@ public class HNSW {
      *
      * @return the non-null subspace
      */
-    @Nonnull
     public Subspace getSubspace() {
         return getLocator().getSubspace();
     }
@@ -122,7 +117,6 @@ public class HNSW {
      * Get the executor used by this hnsw.
      * @return executor used when running asynchronous tasks
      */
-    @Nonnull
     public Executor getExecutor() {
         return getLocator().getExecutor();
     }
@@ -131,7 +125,6 @@ public class HNSW {
      * Get this hnsw's configuration.
      * @return hnsw configuration
      */
-    @Nonnull
     public Config getConfig() {
         return getLocator().getConfig();
     }
@@ -140,7 +133,6 @@ public class HNSW {
      * Get the on-write listener.
      * @return the on-write listener
      */
-    @Nonnull
     public OnWriteListener getOnWriteListener() {
         return getLocator().getOnWriteListener();
     }
@@ -149,27 +141,22 @@ public class HNSW {
      * Get the on-read listener.
      * @return the on-read listener
      */
-    @Nonnull
     public OnReadListener getOnReadListener() {
         return getLocator().getOnReadListener();
     }
 
-    @Nonnull
     private Primitives primitives() {
         return getLocator().primitives();
     }
 
-    @Nonnull
     private Search search() {
         return getLocator().search();
     }
 
-    @Nonnull
     private Insert insert() {
         return getLocator().insert();
     }
 
-    @Nonnull
     private Delete delete() {
         return getLocator().delete();
     }
@@ -181,9 +168,8 @@ public class HNSW {
      * @return a new {@link ResultEntry} where {@link ResultEntry#distance()} returns {@code 0.0d} and
      *         {@link ResultEntry#rankOrRowNumber()} returns {@code -1}
      */
-    @Nonnull
-    public CompletableFuture<ResultEntry> fetch(@Nonnull final ReadTransaction readTransaction,
-                                                @Nonnull final Tuple primaryKey) {
+    public CompletableFuture<ResultEntry> fetch(final ReadTransaction readTransaction,
+                                                final Tuple primaryKey) {
         return primitives().fetch(readTransaction, primaryKey);
     }
 
@@ -201,8 +187,7 @@ public class HNSW {
      *
      * @return a {@link CompletableFuture} that completes with the {@link Cardinality} of layer 0
      */
-    @Nonnull
-    public CompletableFuture<Cardinality> cardinality(@Nonnull final ReadTransaction readTransaction) {
+    public CompletableFuture<Cardinality> cardinality(final ReadTransaction readTransaction) {
         return primitives().cardinality(readTransaction);
     }
 
@@ -220,13 +205,12 @@ public class HNSW {
      *         sorted by distance in ascending order.
      */
     @SuppressWarnings("checkstyle:MethodName") // method name introduced by paper
-    @Nonnull
     public CompletableFuture<List<? extends ResultEntry>>
-            kNearestNeighborsSearch(@Nonnull final ReadTransaction readTransaction,
+            kNearestNeighborsSearch(final ReadTransaction readTransaction,
                                     final int k,
                                     final int efSearch,
                                     final boolean includeVectors,
-                                    @Nonnull final RealVector queryVector) {
+                                    final RealVector queryVector) {
         return search().kNearestNeighborsSearch(readTransaction, k, efSearch, includeVectors, queryVector);
     }
 
@@ -244,13 +228,12 @@ public class HNSW {
      *         sorted by distance in ascending order.
      */
     @SuppressWarnings("checkstyle:MethodName") // method name introduced by paper
-    @Nonnull
     public CompletableFuture<List<? extends ResultEntry>>
-            kNearestNeighborsRingSearch(@Nonnull final ReadTransaction readTransaction,
+            kNearestNeighborsRingSearch(final ReadTransaction readTransaction,
                                         final int k,
                                         final int efSearch,
                                         final boolean includeVectors,
-                                        @Nonnull final RealVector queryVector,
+                                        final RealVector queryVector,
                                         final double radius) {
         return search().kNearestNeighborsRingSearch(readTransaction, k, efSearch, includeVectors, queryVector, radius);
     }
@@ -275,9 +258,8 @@ public class HNSW {
      *
      * @return a {@link CompletableFuture} that completes when the insertion operation is finished
      */
-    @Nonnull
-    public CompletableFuture<Void> insert(@Nonnull final Transaction transaction, @Nonnull final Tuple newPrimaryKey,
-                                          @Nonnull final RealVector newVector, @Nullable final Tuple additionalValues) {
+    public CompletableFuture<Void> insert(final Transaction transaction, final Tuple newPrimaryKey,
+                                          final RealVector newVector, @Nullable final Tuple additionalValues) {
         return insert().insert(transaction, newPrimaryKey, newVector, additionalValues);
     }
 
@@ -323,8 +305,7 @@ public class HNSW {
      *         including all graph repairs and entry point updates. The future completes with {@code null}
      *         on successful deletion.
      */
-    @Nonnull
-    public CompletableFuture<Void> delete(@Nonnull final Transaction transaction, @Nonnull final Tuple primaryKey) {
+    public CompletableFuture<Void> delete(final Transaction transaction, final Tuple primaryKey) {
         return delete().delete(transaction, primaryKey);
     }
 
@@ -358,12 +339,11 @@ public class HNSW {
      * @return an {@link AsyncIterator} of {@link ResultEntry} objects, ordered by increasing distance from the
      *         {@code centerVector}
      */
-    @Nonnull
-    public AsyncIterator<ResultEntry> orderByDistance(@Nonnull final ReadTransaction readTransaction,
+    public AsyncIterator<ResultEntry> orderByDistance(final ReadTransaction readTransaction,
                                                       final int efRingSearch,
                                                       final int efOutwardSearch,
                                                       final boolean includeVectors,
-                                                      @Nonnull final RealVector centerVector,
+                                                      final RealVector centerVector,
                                                       final double minimumRadius,
                                                       @Nullable final Tuple minimumPrimaryKey,
                                                       final boolean shouldQuickStart) {
@@ -372,12 +352,12 @@ public class HNSW {
     }
 
     @VisibleForTesting
-    public static void scanLayer(@Nonnull final Config config,
-                                 @Nonnull final Subspace subspace,
-                                 @Nonnull final Database db,
+    public static void scanLayer(final Config config,
+                                 final Subspace subspace,
+                                 final Database db,
                                  final int layer,
                                  final int batchSize,
-                                 @Nonnull final Consumer<ResultEntry> consumer) {
+                                 final Consumer<ResultEntry> consumer) {
         Primitives.scanLayer(config, subspace, db, layer, batchSize, consumer);
     }
 
@@ -395,12 +375,12 @@ public class HNSW {
      * found in the layer.
      */
     @VisibleForTesting
-    static void scanLayerInternal(@Nonnull final Config config,
-                                  @Nonnull final Subspace subspace,
-                                  @Nonnull final Database db,
+    static void scanLayerInternal(final Config config,
+                                  final Subspace subspace,
+                                  final Database db,
                                   final int layer,
                                   final int batchSize,
-                                  @Nonnull final Consumer<AbstractNode<? extends NodeReference>> nodeConsumer) {
+                                  final Consumer<AbstractNode<? extends NodeReference>> nodeConsumer) {
         Primitives.scanLayerInternal(config, subspace, db, layer, batchSize, nodeConsumer);
     }
 
@@ -418,13 +398,12 @@ public class HNSW {
      * @param layer the layer number for which to get the storage adapter
      * @return a non-null {@link StorageAdapter} instance
      */
-    @Nonnull
     @VisibleForTesting
     static StorageAdapter<? extends NodeReference>
-            storageAdapterForLayer(@Nonnull final Config config,
-                                   @Nonnull final Subspace subspace,
-                                   @Nonnull final OnWriteListener onWriteListener,
-                                   @Nonnull final OnReadListener onReadListener,
+            storageAdapterForLayer(final Config config,
+                                   final Subspace subspace,
+                                   final OnWriteListener onWriteListener,
+                                   final OnReadListener onReadListener,
                                    final int layer) {
         return Primitives.storageAdapterForLayer(config, subspace, onWriteListener, onReadListener, layer);
     }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/InliningNode.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/InliningNode.java
@@ -26,8 +26,7 @@ import com.apple.foundationdb.linear.Transformed;
 import com.apple.foundationdb.tuple.Tuple;
 import com.google.common.base.Verify;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.List;
 import java.util.Objects;
 
@@ -40,20 +39,17 @@ import java.util.Objects;
  * {@link CompactNode}.
  */
 class InliningNode extends AbstractNode<NodeReferenceWithVector> {
-    @Nonnull
     private static final NodeFactory<NodeReferenceWithVector> FACTORY = new NodeFactory<>() {
         @SuppressWarnings("unchecked")
-        @Nonnull
         @Override
-        public AbstractNode<NodeReferenceWithVector> create(@Nonnull final Tuple primaryKey,
+        public AbstractNode<NodeReferenceWithVector> create(final Tuple primaryKey,
                                                             @Nullable final Transformed<RealVector> vector,
                                                             @Nullable final Tuple additionalValues,
-                                                            @Nonnull final List<? extends NodeReference> neighbors) {
+                                                            final List<? extends NodeReference> neighbors) {
             Verify.verify(additionalValues == null, "inlining nodes do not carry additional values");
             return new InliningNode(primaryKey, (List<NodeReferenceWithVector>)neighbors);
         }
 
-        @Nonnull
         @Override
         public NodeKind getNodeKind() {
             return NodeKind.INLINING;
@@ -70,8 +66,8 @@ class InliningNode extends AbstractNode<NodeReferenceWithVector> {
      * @param neighbors the non-null list of neighbors for this node, where each neighbor
      * is a {@link NodeReferenceWithVector}.
      */
-    public InliningNode(@Nonnull final Tuple primaryKey,
-                        @Nonnull final List<NodeReferenceWithVector> neighbors) {
+    public InliningNode(final Tuple primaryKey,
+                        final List<NodeReferenceWithVector> neighbors) {
         super(primaryKey, neighbors);
     }
 
@@ -86,7 +82,6 @@ class InliningNode extends AbstractNode<NodeReferenceWithVector> {
      *
      * @throws NullPointerException if the provided {@code vector} is null.
      */
-    @Nonnull
     @Override
     @SpotBugsSuppressWarnings("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
     public NodeReferenceWithVector getSelfReference(@Nullable final Transformed<RealVector> vector) {
@@ -98,7 +93,6 @@ class InliningNode extends AbstractNode<NodeReferenceWithVector> {
      * @return the non-null {@link NodeKind} of this node, which is always
      * {@code NodeKind.INLINING}.
      */
-    @Nonnull
     @Override
     public NodeKind getKind() {
         return NodeKind.INLINING;
@@ -117,7 +111,6 @@ class InliningNode extends AbstractNode<NodeReferenceWithVector> {
      * @return this node as a {@link CompactNode}, never {@code null}
      * @throws IllegalStateException always, as this node is not a compact node
      */
-    @Nonnull
     @Override
     public CompactNode asCompactNode() {
         throw new IllegalStateException("this is not a compact node");
@@ -134,7 +127,6 @@ class InliningNode extends AbstractNode<NodeReferenceWithVector> {
      * As this class is already an instance of {@code InliningNode}, this method simply returns {@code this}.
      * @return this object, which is guaranteed to be an {@code InliningNode} and never {@code null}.
      */
-    @Nonnull
     @Override
     public InliningNode asInliningNode() {
         return this;
@@ -148,7 +140,6 @@ class InliningNode extends AbstractNode<NodeReferenceWithVector> {
      *
      * @return the singleton {@link NodeFactory} instance, never {@code null}.
      */
-    @Nonnull
     public static NodeFactory<NodeReferenceWithVector> factory() {
         return FACTORY;
     }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/InliningStorageAdapter.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/InliningStorageAdapter.java
@@ -40,6 +40,7 @@ import com.google.common.collect.ImmutableList;
 
 import org.jspecify.annotations.Nullable;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -371,13 +372,16 @@ class InliningStorageAdapter extends AbstractStorageAdapter<NodeReferenceWithVec
             final Tuple nodePrimaryKeyFromNeighbor = neighborKeyTuple.getNestedTuple(1);
             if (nodePrimaryKey == null || !nodePrimaryKey.equals(nodePrimaryKeyFromNeighbor)) {
                 if (nodePrimaryKey != null) {
+                    // A prior iteration must have run (nodePrimaryKey starts null) and set neighborsBuilder then;
+                    // NullAway cannot verify non-nullness carried across loop iterations like this.
                     nodeBuilder.add(getNodeFactory().create(nodePrimaryKey, null, null,
-                            neighborsBuilder.build()));
+                            Objects.requireNonNull(neighborsBuilder).build()));
                 }
                 nodePrimaryKey = nodePrimaryKeyFromNeighbor;
                 neighborsBuilder = ImmutableList.builder();
             }
-            neighborsBuilder.add(neighbor);
+            // Always set just above, either on this iteration or an earlier one.
+            Objects.requireNonNull(neighborsBuilder).add(neighbor);
             numRead ++;
         }
 
@@ -388,8 +392,9 @@ class InliningStorageAdapter extends AbstractStorageAdapter<NodeReferenceWithVec
         // a node can have.
         //
         if (numRead < maxNumRead && nodePrimaryKey != null) {
+            // nodePrimaryKey != null implies the loop ran at least once and set neighborsBuilder.
             nodeBuilder.add(getNodeFactory().create(nodePrimaryKey, null, null,
-                    neighborsBuilder.build()));
+                    Objects.requireNonNull(neighborsBuilder).build()));
         }
 
         return nodeBuilder.build();

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/InliningStorageAdapter.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/InliningStorageAdapter.java
@@ -38,8 +38,7 @@ import com.apple.foundationdb.tuple.Tuple;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -69,18 +68,17 @@ class InliningStorageAdapter extends AbstractStorageAdapter<NodeReferenceWithVec
      * @param onWriteListener the listener to be notified on write operations
      * @param onReadListener the listener to be notified on read operations
      */
-    public InliningStorageAdapter(@Nonnull final Config config,
-                                  @Nonnull final NodeFactory<NodeReferenceWithVector> nodeFactory,
-                                  @Nonnull final Subspace subspace,
-                                  @Nonnull final OnWriteListener onWriteListener,
-                                  @Nonnull final OnReadListener onReadListener) {
+    public InliningStorageAdapter(final Config config,
+                                  final NodeFactory<NodeReferenceWithVector> nodeFactory,
+                                  final Subspace subspace,
+                                  final OnWriteListener onWriteListener,
+                                  final OnReadListener onReadListener) {
         super(config, nodeFactory, subspace, onWriteListener, onReadListener);
     }
 
-    @Nonnull
     @Override
-    public Transformed<RealVector> getVector(@Nonnull final NodeReferenceWithVector nodeReference,
-                                             @Nonnull final AbstractNode<NodeReferenceWithVector> node) {
+    public Transformed<RealVector> getVector(final NodeReferenceWithVector nodeReference,
+                                             final AbstractNode<NodeReferenceWithVector> node) {
         Verify.verify(nodeReference.isNodeReferenceWithVector());
         return nodeReference.asNodeReferenceWithVector().getVector();
     }
@@ -105,13 +103,12 @@ class InliningStorageAdapter extends AbstractStorageAdapter<NodeReferenceWithVec
      * @return a {@link CompletableFuture} that will complete with the fetched {@link AbstractNode} containing
      *         {@link NodeReferenceWithVector}s
      */
-    @Nonnull
     @Override
     protected CompletableFuture<AbstractNode<NodeReferenceWithVector>>
-              fetchNodeInternal(@Nonnull final ReadTransaction readTransaction,
-                                @Nonnull final StorageTransform storageTransform,
+              fetchNodeInternal(final ReadTransaction readTransaction,
+                                final StorageTransform storageTransform,
                                 final int layer,
-                                @Nonnull final Tuple primaryKey) {
+                                final Tuple primaryKey) {
         final byte[] rangeKey = getNodeKey(layer, primaryKey);
 
         return AsyncUtil.collect(readTransaction.getRange(Range.startsWith(rangeKey),
@@ -138,11 +135,10 @@ class InliningStorageAdapter extends AbstractStorageAdapter<NodeReferenceWithVec
      *
      * @return a non-null, fully constructed {@link AbstractNode} object with its neighbors
      */
-    @Nonnull
-    private AbstractNode<NodeReferenceWithVector> nodeFromRaw(@Nonnull final StorageTransform storageTransform,
+    private AbstractNode<NodeReferenceWithVector> nodeFromRaw(final StorageTransform storageTransform,
                                                               final int layer,
-                                                              @Nonnull final Tuple primaryKey,
-                                                              @Nonnull final List<KeyValue> keyValues) {
+                                                              final Tuple primaryKey,
+                                                              final List<KeyValue> keyValues) {
         final OnReadListener onReadListener = getOnReadListener();
 
         final ImmutableList.Builder<NodeReferenceWithVector> nodeReferencesWithVectorBuilder = ImmutableList.builder();
@@ -173,9 +169,8 @@ class InliningStorageAdapter extends AbstractStorageAdapter<NodeReferenceWithVec
      * @return a new {@link NodeReferenceWithVector} instance representing the deserialized neighbor.
      * @throws IllegalArgumentException if the key or value byte arrays are malformed and cannot be unpacked.
      */
-    @Nonnull
-    private NodeReferenceWithVector neighborFromRaw(@Nonnull final StorageTransform storageTransform, final int layer,
-                                                    @Nonnull final byte[] key, @Nonnull final byte[] value) {
+    private NodeReferenceWithVector neighborFromRaw(final StorageTransform storageTransform, final int layer,
+                                                    final byte[] key, final byte[] value) {
         final OnReadListener onReadListener = getOnReadListener();
         onReadListener.onKeyValueRead(layer, key, value);
 
@@ -195,9 +190,8 @@ class InliningStorageAdapter extends AbstractStorageAdapter<NodeReferenceWithVec
      * @return a new {@link NodeReferenceWithVector} instance representing the deserialized neighbor.
      * @throws IllegalArgumentException if the key or value byte arrays are malformed and cannot be unpacked.
      */
-    @Nonnull
-    private NodeReferenceWithVector neighborFromTuples(@Nonnull final StorageTransform storageTransform,
-                                                       @Nonnull final Tuple keyTuple, @Nonnull final Tuple valueTuple) {
+    private NodeReferenceWithVector neighborFromTuples(final StorageTransform storageTransform,
+                                                       final Tuple keyTuple, final Tuple valueTuple) {
         final Tuple neighborPrimaryKey = keyTuple.getNestedTuple(2); // neighbor primary key
         //
         // Transform the raw vector that was just fetched into the internal coordinate system. If we do not have
@@ -229,9 +223,9 @@ class InliningStorageAdapter extends AbstractStorageAdapter<NodeReferenceWithVec
      * persisted; must not be null
      */
     @Override
-    public void writeNodeInternal(@Nonnull final Transaction transaction, @Nonnull final Quantizer quantizer,
-                                  final int layer, @Nonnull final AbstractNode<NodeReferenceWithVector> node,
-                                  @Nonnull final NeighborsChangeSet<NodeReferenceWithVector> neighborsChangeSet) {
+    public void writeNodeInternal(final Transaction transaction, final Quantizer quantizer,
+                                  final int layer, final AbstractNode<NodeReferenceWithVector> node,
+                                  final NeighborsChangeSet<NodeReferenceWithVector> neighborsChangeSet) {
         Verify.verify(node.isInliningNode());
         final InliningNode inliningNode = node.asInliningNode();
 
@@ -240,8 +234,8 @@ class InliningStorageAdapter extends AbstractStorageAdapter<NodeReferenceWithVec
     }
 
     @Override
-    protected void deleteNodeInternal(@Nonnull final Transaction transaction, final int layer,
-                                      @Nonnull final Tuple primaryKey) {
+    protected void deleteNodeInternal(final Transaction transaction, final int layer,
+                                      final Tuple primaryKey) {
         final byte[] key = getNodeKey(layer, primaryKey);
         final Range range = Range.startsWith(key);
         transaction.clear(range);
@@ -262,8 +256,7 @@ class InliningStorageAdapter extends AbstractStorageAdapter<NodeReferenceWithVec
      *
      * @return a byte array representing the packed key for the specified node
      */
-    @Nonnull
-    private byte[] getNodeKey(final int layer, @Nonnull final Tuple primaryKey) {
+    private byte[] getNodeKey(final int layer, final Tuple primaryKey) {
         return getDataSubspace().pack(Tuple.from(layer, primaryKey));
     }
 
@@ -280,9 +273,9 @@ class InliningStorageAdapter extends AbstractStorageAdapter<NodeReferenceWithVec
      * @param node the source {@link AbstractNode} for which the neighbor is being written
      * @param neighbor the {@link NodeReferenceWithVector} representing the neighbor to persist
      */
-    public void writeNeighbor(@Nonnull final Transaction transaction, @Nonnull final Quantizer quantizer,
-                              final int layer, @Nonnull final AbstractNode<NodeReferenceWithVector> node,
-                              @Nonnull final NodeReferenceWithVector neighbor) {
+    public void writeNeighbor(final Transaction transaction, final Quantizer quantizer,
+                              final int layer, final AbstractNode<NodeReferenceWithVector> node,
+                              final NodeReferenceWithVector neighbor) {
         final byte[] neighborKey = getNeighborKey(layer, node, neighbor.getPrimaryKey());
         // getting underlying vector is okay as it is only written to the database
         final byte[] value =
@@ -304,9 +297,9 @@ class InliningStorageAdapter extends AbstractStorageAdapter<NodeReferenceWithVec
      * @param node the node from which the neighbor edge is removed
      * @param neighborPrimaryKey the primary key of the neighbor node to be deleted
      */
-    public void deleteNeighbor(@Nonnull final Transaction transaction, final int layer,
-                               @Nonnull final AbstractNode<NodeReferenceWithVector> node,
-                               @Nonnull final Tuple neighborPrimaryKey) {
+    public void deleteNeighbor(final Transaction transaction, final int layer,
+                               final AbstractNode<NodeReferenceWithVector> node,
+                               final Tuple neighborPrimaryKey) {
         transaction.clear(getNeighborKey(layer, node, neighborPrimaryKey));
         getOnWriteListener().onNeighborDeleted(layer, node, neighborPrimaryKey);
     }
@@ -323,10 +316,9 @@ class InliningStorageAdapter extends AbstractStorageAdapter<NodeReferenceWithVec
      * @param neighborPrimaryKey the non-null primary key of the neighbor node
      * @return a non-null byte array representing the packed key for the neighbor relationship
      */
-    @Nonnull
     private byte[] getNeighborKey(final int layer,
-                                  @Nonnull final AbstractNode<NodeReferenceWithVector> node,
-                                  @Nonnull final Tuple neighborPrimaryKey) {
+                                  final AbstractNode<NodeReferenceWithVector> node,
+                                  final Tuple neighborPrimaryKey) {
         return getDataSubspace().pack(Tuple.from(layer, node.getPrimaryKey(), neighborPrimaryKey));
     }
 
@@ -347,9 +339,8 @@ class InliningStorageAdapter extends AbstractStorageAdapter<NodeReferenceWithVec
      * @return an {@code Iterable} of {@link AbstractNode} objects reconstructed from the scanned layer. Each node
      *         contains its neighbors within that layer.
      */
-    @Nonnull
     @Override
-    public Iterable<AbstractNode<NodeReferenceWithVector>> scanLayer(@Nonnull final ReadTransaction readTransaction,
+    public Iterable<AbstractNode<NodeReferenceWithVector>> scanLayer(final ReadTransaction readTransaction,
                                                                      int layer,
                                                                      @Nullable final Tuple lastPrimaryKey,
                                                                      int maxNumRead) {

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/Insert.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/Insert.java
@@ -41,8 +41,7 @@ import com.google.common.collect.Maps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -72,10 +71,8 @@ import static com.apple.foundationdb.async.common.StorageHelpers.deleteAllSample
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("PMD.TooManyStaticImports")
 public class Insert {
-    @Nonnull
     private static final Logger logger = LoggerFactory.getLogger(Insert.class);
 
-    @Nonnull
     private final Locator locator;
 
     /**
@@ -85,11 +82,10 @@ public class Insert {
      * @param locator the {@link Locator} where the graph data is stored, which config to use, which executor to use,
      *        etc.
      */
-    public Insert(@Nonnull final Locator locator) {
+    public Insert(final Locator locator) {
         this.locator = locator;
     }
 
-    @Nonnull
     public Locator getLocator() {
         return locator;
     }
@@ -99,7 +95,6 @@ public class Insert {
      *
      * @return the non-null subspace
      */
-    @Nonnull
     public Subspace getSubspace() {
         return getLocator().getSubspace();
     }
@@ -108,7 +103,6 @@ public class Insert {
      * Get the executor used by this hnsw.
      * @return executor used when running asynchronous tasks
      */
-    @Nonnull
     public Executor getExecutor() {
         return getLocator().getExecutor();
     }
@@ -117,7 +111,6 @@ public class Insert {
      * Get the configuration of this hnsw.
      * @return hnsw configuration
      */
-    @Nonnull
     public Config getConfig() {
         return getLocator().getConfig();
     }
@@ -126,7 +119,6 @@ public class Insert {
      * Get the on-write listener.
      * @return the on-write listener
      */
-    @Nonnull
     public OnWriteListener getOnWriteListener() {
         return getLocator().getOnWriteListener();
     }
@@ -135,17 +127,14 @@ public class Insert {
      * Get the on-read listener.
      * @return the on-read listener
      */
-    @Nonnull
     public OnReadListener getOnReadListener() {
         return getLocator().getOnReadListener();
     }
 
-    @Nonnull
     private Primitives primitives() {
         return getLocator().primitives();
     }
 
-    @Nonnull
     private Search searcher() {
         return getLocator().search();
     }
@@ -170,9 +159,8 @@ public class Insert {
      *
      * @return a {@link CompletableFuture} that completes when the insertion operation is finished
      */
-    @Nonnull
-    public CompletableFuture<Void> insert(@Nonnull final Transaction transaction, @Nonnull final Tuple newPrimaryKey,
-                                          @Nonnull final RealVector newVector,
+    public CompletableFuture<Void> insert(final Transaction transaction, final Tuple newPrimaryKey,
+                                          final RealVector newVector,
                                           @Nullable final Tuple newAdditionalValues) {
         final Primitives primitives = primitives();
         final SplittableRandom random = RandomHelpers.random(newPrimaryKey);
@@ -259,12 +247,12 @@ public class Insert {
                 }).thenCompose(ignored -> AsyncUtil.DONE);
     }
 
-    private void firstInsert(@Nonnull final Transaction transaction,
-                             @Nonnull final Tuple newPrimaryKey,
-                             @Nonnull final RealVector newVector,
+    private void firstInsert(final Transaction transaction,
+                             final Tuple newPrimaryKey,
+                             final RealVector newVector,
                              @Nullable final Tuple additionalValues,
-                             @Nonnull final SplittableRandom random,
-                             @Nonnull final Primitives primitives,
+                             final SplittableRandom random,
+                             final Primitives primitives,
                              final int insertionLayer) {
         final Config config = getConfig();
         final long rotatorSeed;
@@ -324,11 +312,10 @@ public class Insert {
      *
      * @return a future that returns {@code null} when completed
      */
-    @Nonnull
-    private CompletableFuture<Void> addToStatsIfNecessary(@Nonnull final Transaction transaction,
-                                                          @Nonnull final SplittableRandom random,
-                                                          @Nonnull final AccessInfo currentAccessInfo,
-                                                          @Nonnull final Transformed<RealVector> transformedNewVector) {
+    private CompletableFuture<Void> addToStatsIfNecessary(final Transaction transaction,
+                                                          final SplittableRandom random,
+                                                          final AccessInfo currentAccessInfo,
+                                                          final Transformed<RealVector> transformedNewVector) {
         if (getConfig().useRaBitQ() &&
                 !currentAccessInfo.canUseRaBitQ()) {
             if (shouldSampleVector(random)) {
@@ -423,14 +410,13 @@ public class Insert {
      * @return a {@link CompletableFuture} that completes when the new node has been successfully inserted into all
      * its designated layers
      */
-    @Nonnull
-    private CompletableFuture<Void> insertIntoLayers(@Nonnull final Transaction transaction,
-                                                     @Nonnull final StorageTransform storageTransform,
-                                                     @Nonnull final Quantizer quantizer,
-                                                     @Nonnull final Tuple newPrimaryKey,
-                                                     @Nonnull final Transformed<RealVector> newVector,
+    private CompletableFuture<Void> insertIntoLayers(final Transaction transaction,
+                                                     final StorageTransform storageTransform,
+                                                     final Quantizer quantizer,
+                                                     final Tuple newPrimaryKey,
+                                                     final Transformed<RealVector> newVector,
                                                      @Nullable final Tuple newAdditionalValues,
-                                                     @Nonnull final NodeReferenceWithDistance nodeReference,
+                                                     final NodeReferenceWithDistance nodeReference,
                                                      final int lMax,
                                                      final int insertionLayer) {
         if (logger.isTraceEnabled()) {
@@ -485,16 +471,15 @@ public class Insert {
      *         initial search phase. This list serves as the entry point for insertion into the next lower layer
      *         (i.e., {@code layer - 1}).
      */
-    @Nonnull
     private <N extends NodeReference> CompletableFuture<List<NodeReferenceAndNode<NodeReferenceWithDistance, N>>>
-            insertIntoLayer(@Nonnull final StorageAdapter<N> storageAdapter,
-                            @Nonnull final Transaction transaction,
-                            @Nonnull final StorageTransform storageTransform,
-                            @Nonnull final Quantizer quantizer,
-                            @Nonnull final List<NodeReferenceWithDistance> nearestNeighbors,
+            insertIntoLayer(final StorageAdapter<N> storageAdapter,
+                            final Transaction transaction,
+                            final StorageTransform storageTransform,
+                            final Quantizer quantizer,
+                            final List<NodeReferenceWithDistance> nearestNeighbors,
                             final int layer,
-                            @Nonnull final Tuple newPrimaryKey,
-                            @Nonnull final Transformed<RealVector> newVector,
+                            final Tuple newPrimaryKey,
+                            final Transformed<RealVector> newVector,
                             @Nullable final Tuple newAdditionalValues) {
         if (logger.isTraceEnabled()) {
             logger.trace("begin insert key={} at layer={}", newPrimaryKey, layer);
@@ -583,16 +568,15 @@ public class Insert {
                 });
     }
 
-    @Nonnull
     private Subspace getSamplesSubspace() {
         return StorageAdapter.samplesSubspace(getSubspace());
     }
 
-    private boolean shouldSampleVector(@Nonnull final SplittableRandom random) {
+    private boolean shouldSampleVector(final SplittableRandom random) {
         return random.nextDouble() < getConfig().sampleVectorStatsProbability();
     }
 
-    private boolean shouldMaintainStats(@Nonnull final SplittableRandom random) {
+    private boolean shouldMaintainStats(final SplittableRandom random) {
         return random.nextDouble() < getConfig().maintainStatsProbability();
     }
 }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/InsertNeighborsChangeSet.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/InsertNeighborsChangeSet.java
@@ -28,7 +28,6 @@ import com.google.common.collect.Iterables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -45,13 +44,10 @@ import java.util.function.Predicate;
  * @param <N> the type of the node reference, which must extend {@link NodeReference}
  */
 class InsertNeighborsChangeSet<N extends NodeReference> implements NeighborsChangeSet<N> {
-    @Nonnull
     private static final Logger logger = LoggerFactory.getLogger(InsertNeighborsChangeSet.class);
 
-    @Nonnull
     private final NeighborsChangeSet<N> parent;
 
-    @Nonnull
     private final Map<Tuple, N> insertedNeighborsMap;
 
     /**
@@ -64,8 +60,8 @@ class InsertNeighborsChangeSet<N extends NodeReference> implements NeighborsChan
      * @param parent the parent {@link NeighborsChangeSet} on which this insertion is based.
      * @param insertedNeighbors the list of neighbors to be inserted.
      */
-    public InsertNeighborsChangeSet(@Nonnull final NeighborsChangeSet<N> parent,
-                                    @Nonnull final List<N> insertedNeighbors) {
+    public InsertNeighborsChangeSet(final NeighborsChangeSet<N> parent,
+                                    final List<N> insertedNeighbors) {
         this.parent = parent;
         final ImmutableMap.Builder<Tuple, N> insertedNeighborsMapBuilder = ImmutableMap.builder();
         for (final N insertedNeighbor : insertedNeighbors) {
@@ -79,7 +75,6 @@ class InsertNeighborsChangeSet<N extends NodeReference> implements NeighborsChan
      * Gets the parent {@code NeighborsChangeSet} from which this change set was derived.
      * @return the parent {@link NeighborsChangeSet}, which is never {@code null}.
      */
-    @Nonnull
     @Override
     public NeighborsChangeSet<N> getParent() {
         return parent;
@@ -98,7 +93,6 @@ class InsertNeighborsChangeSet<N extends NodeReference> implements NeighborsChan
      * set of neighbors from this node and all its ancestors.
      * @return a non-null {@code Iterable} containing all neighbors from this node and its ancestors.
      */
-    @Nonnull
     @Override
     public Iterable<N> merge() {
         return Iterables.concat(Iterables.filter(getParent().merge(),
@@ -121,9 +115,9 @@ class InsertNeighborsChangeSet<N extends NodeReference> implements NeighborsChan
      * @param tuplePredicate a predicate to filter which neighbor tuples should be written; must not be null
      */
     @Override
-    public void writeDelta(@Nonnull final InliningStorageAdapter storageAdapter, @Nonnull final Transaction transaction,
-                           @Nonnull final Quantizer quantizer, final int layer, @Nonnull final AbstractNode<N> node,
-                           @Nonnull final Predicate<Tuple> tuplePredicate) {
+    public void writeDelta(final InliningStorageAdapter storageAdapter, final Transaction transaction,
+                           final Quantizer quantizer, final int layer, final AbstractNode<N> node,
+                           final Predicate<Tuple> tuplePredicate) {
         getParent().writeDelta(storageAdapter, transaction, quantizer, layer, node,
                 tuplePredicate.and(tuple -> !insertedNeighborsMap.containsKey(tuple)));
 

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/InsertNeighborsChangeSet.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/InsertNeighborsChangeSet.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.async.hnsw;
 
 import com.apple.foundationdb.Transaction;
+import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.linear.Quantizer;
 import com.apple.foundationdb.tuple.Tuple;
 import com.google.common.collect.ImmutableMap;
@@ -94,6 +95,11 @@ class InsertNeighborsChangeSet<N extends NodeReference> implements NeighborsChan
      * @return a non-null {@code Iterable} containing all neighbors from this node and its ancestors.
      */
     @Override
+    // getParent() is overridden below to always return this.parent, which is non-null by construction (see the
+    // constructor's contract, documented as "never null" on the override's Javadoc); SpotBugs's
+    // NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE analysis appears to fall back to the wider @Nullable contract
+    // declared by NeighborsChangeSet.getParent() rather than this narrowed override.
+    @SpotBugsSuppressWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     public Iterable<N> merge() {
         return Iterables.concat(Iterables.filter(getParent().merge(),
                 current -> !insertedNeighborsMap.containsKey(Objects.requireNonNull(current).getPrimaryKey())),
@@ -115,6 +121,8 @@ class InsertNeighborsChangeSet<N extends NodeReference> implements NeighborsChan
      * @param tuplePredicate a predicate to filter which neighbor tuples should be written; must not be null
      */
     @Override
+    // See the comment on merge() above: getParent() always returns this.parent (non-null) in this class.
+    @SpotBugsSuppressWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     public void writeDelta(final InliningStorageAdapter storageAdapter, final Transaction transaction,
                            final Quantizer quantizer, final int layer, final AbstractNode<N> node,
                            final Predicate<Tuple> tuplePredicate) {

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/Locator.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/Locator.java
@@ -24,7 +24,6 @@ import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.subspace.Subspace;
 import com.google.common.base.Suppliers;
 
-import javax.annotation.Nonnull;
 import java.util.concurrent.Executor;
 import java.util.function.Supplier;
 
@@ -34,27 +33,18 @@ import java.util.function.Supplier;
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 public class Locator {
-    @Nonnull
     private final Subspace subspace;
-    @Nonnull
     private final Executor executor;
-    @Nonnull
     private final Config config;
-    @Nonnull
     private final OnWriteListener onWriteListener;
-    @Nonnull
     private final OnReadListener onReadListener;
 
-    @Nonnull
     @SuppressWarnings("this-escape")
     private final Supplier<Primitives> primitivesSupplier = Suppliers.memoize(() -> new Primitives(this));
-    @Nonnull
     @SuppressWarnings("this-escape")
     private final Supplier<Search> searchSupplier = Suppliers.memoize(() -> new Search(this));
-    @Nonnull
     @SuppressWarnings("this-escape")
     private final Supplier<Insert> insertSupplier = Suppliers.memoize(() -> new Insert(this));
-    @Nonnull
     @SuppressWarnings("this-escape")
     private final Supplier<Delete> deleteSupplier = Suppliers.memoize(() -> new Delete(this));
 
@@ -72,11 +62,11 @@ public class Locator {
      *
      * @throws NullPointerException if any of the parameters are {@code null}.
      */
-    public Locator(@Nonnull final Subspace subspace,
-                   @Nonnull final Executor executor,
-                   @Nonnull final Config config,
-                   @Nonnull final OnWriteListener onWriteListener,
-                   @Nonnull final OnReadListener onReadListener) {
+    public Locator(final Subspace subspace,
+                   final Executor executor,
+                   final Config config,
+                   final OnWriteListener onWriteListener,
+                   final OnReadListener onReadListener) {
         this.subspace = subspace;
         this.executor = executor;
         this.config = config;
@@ -90,7 +80,6 @@ public class Locator {
      *
      * @return the non-null subspace
      */
-    @Nonnull
     public Subspace getSubspace() {
         return subspace;
     }
@@ -99,7 +88,6 @@ public class Locator {
      * Get the executor used by this hnsw.
      * @return executor used when running asynchronous tasks
      */
-    @Nonnull
     public Executor getExecutor() {
         return executor;
     }
@@ -108,7 +96,6 @@ public class Locator {
      * Get this hnsw's configuration.
      * @return hnsw configuration
      */
-    @Nonnull
     public Config getConfig() {
         return config;
     }
@@ -117,7 +104,6 @@ public class Locator {
      * Get the on-write listener.
      * @return the on-write listener
      */
-    @Nonnull
     public OnWriteListener getOnWriteListener() {
         return onWriteListener;
     }
@@ -126,27 +112,22 @@ public class Locator {
      * Get the on-read listener.
      * @return the on-read listener
      */
-    @Nonnull
     public OnReadListener getOnReadListener() {
         return onReadListener;
     }
 
-    @Nonnull
     Primitives primitives() {
         return primitivesSupplier.get();
     }
 
-    @Nonnull
     Search search() {
         return searchSupplier.get();
     }
 
-    @Nonnull
     Insert insert() {
         return insertSupplier.get();
     }
 
-    @Nonnull
     Delete delete() {
         return deleteSupplier.get();
     }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/NeighborsChangeSet.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/NeighborsChangeSet.java
@@ -24,8 +24,7 @@ import com.apple.foundationdb.Transaction;
 import com.apple.foundationdb.linear.Quantizer;
 import com.apple.foundationdb.tuple.Tuple;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.function.Predicate;
 
 /**
@@ -65,7 +64,6 @@ interface NeighborsChangeSet<N extends NodeReference> {
      *
      * @return a non-null {@code Iterable} containing the merged sequence of elements.
      */
-    @Nonnull
     Iterable<N> merge();
 
     /**
@@ -83,7 +81,7 @@ interface NeighborsChangeSet<N extends NodeReference> {
      * @param primaryKeyPredicate a predicate to filter records by their primary key. Only records
      *        for which the predicate returns {@code true} will be written. Must not be null.
      */
-    void writeDelta(@Nonnull InliningStorageAdapter storageAdapter, @Nonnull Transaction transaction,
-                    @Nonnull Quantizer quantizer, int layer, @Nonnull AbstractNode<N> node,
-                    @Nonnull Predicate<Tuple /* primary key */> primaryKeyPredicate);
+    void writeDelta(InliningStorageAdapter storageAdapter, Transaction transaction,
+                    Quantizer quantizer, int layer, AbstractNode<N> node,
+                    Predicate<Tuple /* primary key */> primaryKeyPredicate);
 }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/Node.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/Node.java
@@ -24,8 +24,7 @@ import com.apple.foundationdb.linear.RealVector;
 import com.apple.foundationdb.linear.Transformed;
 import com.apple.foundationdb.tuple.Tuple;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.List;
 
 /**
@@ -48,7 +47,6 @@ public interface Node<N extends NodeReference> {
      *
      * @return the primary key as a {@code Tuple}, which is never {@code null}
      */
-    @Nonnull
     Tuple getPrimaryKey();
 
     /**
@@ -60,7 +58,6 @@ public interface Node<N extends NodeReference> {
      * @return a non-null reference to this object ({@code this}) for further
      * method calls.
      */
-    @Nonnull
     N getSelfReference(@Nullable Transformed<RealVector> vector);
 
     /**
@@ -70,13 +67,11 @@ public interface Node<N extends NodeReference> {
      *
      * @return a non-null list of neighboring nodes.
      */
-    @Nonnull
     List<N> getNeighbors();
 
     /**
      * Return the kind of the node, i.e. {@link NodeKind#COMPACT} or {@link NodeKind#INLINING}.
      * @return the kind of this node as a {@link NodeKind}
      */
-    @Nonnull
     NodeKind getKind();
 }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/NodeFactory.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/NodeFactory.java
@@ -24,8 +24,7 @@ import com.apple.foundationdb.linear.RealVector;
 import com.apple.foundationdb.linear.Transformed;
 import com.apple.foundationdb.tuple.Tuple;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.List;
 
 /**
@@ -54,14 +53,12 @@ interface NodeFactory<N extends NodeReference> {
      *        node does not carry additional values (see {@link CompactNode} versus {@link InliningNode}).
      * @return a new, non-null {@link AbstractNode} instance configured with the provided parameters.
      */
-    @Nonnull
-    AbstractNode<N> create(@Nonnull Tuple primaryKey, @Nullable Transformed<RealVector> vector,
-                           @Nullable Tuple additionalValues, @Nonnull List<? extends NodeReference> neighbors);
+    AbstractNode<N> create(Tuple primaryKey, @Nullable Transformed<RealVector> vector,
+                           @Nullable Tuple additionalValues, List<? extends NodeReference> neighbors);
 
     /**
      * Gets the kind of this node.
      * @return the kind of this node, never {@code null}.
      */
-    @Nonnull
     NodeKind getNodeKind();
 }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/NodeKind.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/NodeKind.java
@@ -22,7 +22,6 @@ package com.apple.foundationdb.async.hnsw;
 
 import com.google.common.base.Verify;
 
-import javax.annotation.Nonnull;
 
 /**
  * Represents the different kinds of nodes, each associated with a unique byte value for serialization and
@@ -69,7 +68,6 @@ public enum NodeKind {
      * @throws IllegalArgumentException if the {@code serializedNodeKind} does not
      * correspond to a known node kind.
      */
-    @Nonnull
     static NodeKind fromSerializedNodeKind(byte serializedNodeKind) {
         final NodeKind nodeKind;
         switch (serializedNodeKind) {

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/NodeReference.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/NodeReference.java
@@ -23,7 +23,6 @@ package com.apple.foundationdb.async.hnsw;
 import com.apple.foundationdb.tuple.Tuple;
 import com.google.common.collect.Streams;
 
-import javax.annotation.Nonnull;
 import java.util.Objects;
 
 /**
@@ -32,14 +31,13 @@ import java.util.Objects;
  * specialized node references.
  */
 public class NodeReference {
-    @Nonnull
     private final Tuple primaryKey;
 
     /**
      * Constructs a new {@code NodeReference} with the specified primary key.
      * @param primaryKey the primary key of the node to reference; must not be {@code null}.
      */
-    public NodeReference(@Nonnull final Tuple primaryKey) {
+    public NodeReference(final Tuple primaryKey) {
         this.primaryKey = primaryKey;
     }
 
@@ -47,7 +45,6 @@ public class NodeReference {
      * Gets the primary key for this object.
      * @return the primary key as a {@code Tuple} object, which is guaranteed to be non-null.
      */
-    @Nonnull
     public Tuple getPrimaryKey() {
         return primaryKey;
     }
@@ -69,7 +66,6 @@ public class NodeReference {
      * @throws IllegalStateException always, to indicate that this object cannot be
      *         represented as a {@link NodeReferenceWithVector}.
      */
-    @Nonnull
     public NodeReferenceWithVector asNodeReferenceWithVector() {
         throw new IllegalStateException("method should not be called");
     }
@@ -122,8 +118,7 @@ public class NodeReference {
      * @param neighbors an iterable of {@link NodeReference} objects from which to extract primary keys.
      * @return a lazily-evaluated {@code Iterable} of {@link Tuple}s, representing the primary keys of the input nodes.
      */
-    @Nonnull
-    public static Iterable<Tuple> primaryKeys(@Nonnull Iterable<? extends NodeReference> neighbors) {
+    public static Iterable<Tuple> primaryKeys(Iterable<? extends NodeReference> neighbors) {
         return () -> Streams.stream(neighbors)
                 .map(nodeReference ->
                         Objects.requireNonNull(nodeReference).getPrimaryKey())

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/NodeReferenceAndNode.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/NodeReferenceAndNode.java
@@ -23,7 +23,6 @@ package com.apple.foundationdb.async.hnsw;
 import com.apple.foundationdb.tuple.Tuple;
 import com.google.common.collect.ImmutableList;
 
-import javax.annotation.Nonnull;
 import java.util.List;
 
 /**
@@ -37,9 +36,7 @@ import java.util.List;
  *        references
  */
 class NodeReferenceAndNode<T extends NodeReference, N extends NodeReference> {
-    @Nonnull
     private final T nodeReference;
-    @Nonnull
     private final AbstractNode<N> node;
 
     /**
@@ -49,8 +46,8 @@ class NodeReferenceAndNode<T extends NodeReference, N extends NodeReference> {
      *        {@code null}.
      * @param node the actual {@link AbstractNode} object that the reference points to. Must not be {@code null}.
      */
-    public NodeReferenceAndNode(@Nonnull final T nodeReference,
-                                @Nonnull final AbstractNode<N> node) {
+    public NodeReferenceAndNode(final T nodeReference,
+                                final AbstractNode<N> node) {
         this.nodeReference = nodeReference;
         this.node = node;
     }
@@ -59,7 +56,6 @@ class NodeReferenceAndNode<T extends NodeReference, N extends NodeReference> {
      * Gets the node reference and its associated distance.
      * @return the non-null {@link NodeReferenceWithDistance} object.
      */
-    @Nonnull
     public T getNodeReference() {
         return nodeReference;
     }
@@ -68,7 +64,6 @@ class NodeReferenceAndNode<T extends NodeReference, N extends NodeReference> {
      * Gets the underlying node represented by this object.
      * @return the associated {@link Node} instance, never {@code null}.
      */
-    @Nonnull
     public AbstractNode<N> getNode() {
         return node;
     }
@@ -84,8 +79,7 @@ class NodeReferenceAndNode<T extends NodeReference, N extends NodeReference> {
      *        references.
      * @return a {@link List} of {@link NodeReferenceAndNode}s
      */
-    @Nonnull
-    public static <T extends NodeReferenceWithVector> List<T> references(@Nonnull List<? extends NodeReferenceAndNode<T, ?>> referencesAndNodes) {
+    public static <T extends NodeReferenceWithVector> List<T> references(List<? extends NodeReferenceAndNode<T, ?>> referencesAndNodes) {
         final ImmutableList.Builder<T> referencesBuilder = ImmutableList.builder();
         for (final NodeReferenceAndNode<T, ?> referenceWithNode : referencesAndNodes) {
             referencesBuilder.add(referenceWithNode.getNodeReference());
@@ -99,8 +93,7 @@ class NodeReferenceAndNode<T extends NodeReference, N extends NodeReference> {
      *        primary keys.
      * @return a {@link List} of {@link Tuple}s
      */
-    @Nonnull
-    public static List<Tuple> primaryKeys(@Nonnull List<? extends NodeReferenceAndNode<?, ?>> referencesAndNodes) {
+    public static List<Tuple> primaryKeys(List<? extends NodeReferenceAndNode<?, ?>> referencesAndNodes) {
         final ImmutableList.Builder<Tuple> referencesBuilder = ImmutableList.builder();
         for (final NodeReferenceAndNode<?, ?> referenceWithNode : referencesAndNodes) {
             referencesBuilder.add(referenceWithNode.getNodeReference().getPrimaryKey());

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/NodeReferenceWithDistance.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/NodeReferenceWithDistance.java
@@ -24,7 +24,6 @@ import com.apple.foundationdb.linear.RealVector;
 import com.apple.foundationdb.linear.Transformed;
 import com.apple.foundationdb.tuple.Tuple;
 
-import javax.annotation.Nonnull;
 import java.util.Comparator;
 import java.util.Objects;
 
@@ -52,7 +51,7 @@ public class NodeReferenceWithDistance extends NodeReferenceWithVector {
      * @param vector the vector associated with the referenced node. Must not be null.
      * @param distance the calculated distance of this node reference to some query vector or similar.
      */
-    public NodeReferenceWithDistance(@Nonnull final Tuple primaryKey, @Nonnull final Transformed<RealVector> vector,
+    public NodeReferenceWithDistance(final Tuple primaryKey, final Transformed<RealVector> vector,
                                      final double distance) {
         super(primaryKey, vector);
         this.distance = distance;
@@ -95,12 +94,10 @@ public class NodeReferenceWithDistance extends NodeReferenceWithVector {
         return Objects.hash(super.hashCode(), distance);
     }
 
-    @Nonnull
     public static Comparator<NodeReferenceWithDistance> comparator() {
         return COMPARATOR;
     }
 
-    @Nonnull
     public static Comparator<NodeReferenceWithDistance> reversedComparator() {
         return REVERSED_COMPARATOR;
     }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/NodeReferenceWithVector.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/NodeReferenceWithVector.java
@@ -24,7 +24,6 @@ import com.apple.foundationdb.linear.RealVector;
 import com.apple.foundationdb.linear.Transformed;
 import com.apple.foundationdb.tuple.Tuple;
 
-import javax.annotation.Nonnull;
 import java.util.Objects;
 
 /**
@@ -37,7 +36,6 @@ import java.util.Objects;
  * may not.
  */
 public class NodeReferenceWithVector extends NodeReference {
-    @Nonnull
     private final Transformed<RealVector> vector;
 
     /**
@@ -50,7 +48,7 @@ public class NodeReferenceWithVector extends NodeReference {
      * @param primaryKey the primary key of the node, must not be null
      * @param vector the vector associated with the node, must not be null
      */
-    public NodeReferenceWithVector(@Nonnull final Tuple primaryKey, @Nonnull final Transformed<RealVector> vector) {
+    public NodeReferenceWithVector(final Tuple primaryKey, final Transformed<RealVector> vector) {
         super(primaryKey);
         this.vector = vector;
     }
@@ -63,7 +61,6 @@ public class NodeReferenceWithVector extends NodeReference {
      *
      * @return the vector of {@code Half} objects; will never be {@code null}.
      */
-    @Nonnull
     public Transformed<RealVector> getVector() {
         return vector;
     }
@@ -81,7 +78,6 @@ public class NodeReferenceWithVector extends NodeReference {
      * Returns this instance cast as a {@code NodeReferenceWithVector}.
      * @return this instance as a {@code NodeReferenceWithVector}, which is never {@code null}.
      */
-    @Nonnull
     @Override
     public NodeReferenceWithVector asNodeReferenceWithVector() {
         return this;

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/NodeReferenceWithVectorAndAdditionalValues.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/NodeReferenceWithVectorAndAdditionalValues.java
@@ -24,8 +24,7 @@ import com.apple.foundationdb.linear.RealVector;
 import com.apple.foundationdb.linear.Transformed;
 import com.apple.foundationdb.tuple.Tuple;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.Objects;
 
 /**
@@ -46,7 +45,7 @@ class NodeReferenceWithVectorAndAdditionalValues extends NodeReferenceWithVector
      * @param additionalValues additional values that are stored with and associated with the node this reference
      *        refers to.
      */
-    public NodeReferenceWithVectorAndAdditionalValues(@Nonnull final Tuple primaryKey, @Nonnull final Transformed<RealVector> vector,
+    public NodeReferenceWithVectorAndAdditionalValues(final Tuple primaryKey, final Transformed<RealVector> vector,
                                                       @Nullable final Tuple additionalValues) {
         super(primaryKey, vector);
         this.additionalValues = additionalValues;

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/OnReadListener.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/OnReadListener.java
@@ -22,8 +22,7 @@ package com.apple.foundationdb.async.hnsw;
 
 import com.apple.foundationdb.async.common.OnKeyValueReadListener;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -43,7 +42,7 @@ public interface OnReadListener extends OnKeyValueReadListener {
      * @param value the value associated with the key, can be null if the key was not found
      */
     @SuppressWarnings("unused")
-    default void onKeyValueRead(final int layer, @Nonnull final byte[] key, @Nullable final byte[] value) {
+    default void onKeyValueRead(final int layer, final byte[] key, @Nullable final byte[] value) {
         onKeyValueRead(key, value);
     }
 
@@ -60,7 +59,7 @@ public interface OnReadListener extends OnKeyValueReadListener {
      *         By default, this is the same future that was passed as an argument.
      */
     @SuppressWarnings("unused")
-    default <N extends NodeReference, T extends Node<N>> CompletableFuture<T> onAsyncRead(@Nonnull CompletableFuture<T> future) {
+    default <N extends NodeReference, T extends Node<N>> CompletableFuture<T> onAsyncRead(CompletableFuture<T> future) {
         return future;
     }
 
@@ -73,7 +72,7 @@ public interface OnReadListener extends OnKeyValueReadListener {
      * @param node the {@link Node} that was just read (guaranteed to be non-null).
      */
     @SuppressWarnings("unused")
-    default void onNodeRead(int layer, @Nonnull Node<? extends NodeReference> node) {
+    default void onNodeRead(int layer, Node<? extends NodeReference> node) {
         // nothing
     }
 }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/OnWriteListener.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/OnWriteListener.java
@@ -24,7 +24,6 @@ import com.apple.foundationdb.Range;
 import com.apple.foundationdb.async.common.OnKeyValueWriteListener;
 import com.apple.foundationdb.tuple.Tuple;
 
-import javax.annotation.Nonnull;
 
 /**
  * Interface for call backs whenever we write data to the database.
@@ -44,7 +43,7 @@ public interface OnWriteListener extends OnKeyValueWriteListener {
      * @param value the value.
      */
     @SuppressWarnings("unused")
-    default void onKeyValueWritten(final int layer, @Nonnull final byte[] key, @Nonnull final byte[] value) {
+    default void onKeyValueWritten(final int layer, final byte[] key, final byte[] value) {
         onKeyValueWritten(key, value);
     }
 
@@ -58,7 +57,7 @@ public interface OnWriteListener extends OnKeyValueWriteListener {
      * @param key the key that was deleted
      */
     @SuppressWarnings("unused")
-    default void onKeyDeleted(final int layer, @Nonnull final byte[] key) {
+    default void onKeyDeleted(final int layer, final byte[] key) {
         onKeyDeleted(key);
     }
 
@@ -72,7 +71,7 @@ public interface OnWriteListener extends OnKeyValueWriteListener {
      * @param range the {@link Range} that was deleted
      */
     @SuppressWarnings("unused")
-    default void onRangeDeleted(final int layer, @Nonnull final Range range) {
+    default void onRangeDeleted(final int layer, final Range range) {
         onRangeDeleted(range);
     }
 
@@ -85,7 +84,7 @@ public interface OnWriteListener extends OnKeyValueWriteListener {
      * @param node the {@link Node} that was written; guaranteed to be non-null.
      */
     @SuppressWarnings("unused")
-    default void onNodeWritten(final int layer, @Nonnull final Node<? extends NodeReference> node) {
+    default void onNodeWritten(final int layer, final Node<? extends NodeReference> node) {
         // nothing
     }
 
@@ -103,8 +102,8 @@ public interface OnWriteListener extends OnKeyValueWriteListener {
      * @param neighbor the {@link NodeReference} of the neighbor that was written; must not be null
      */
     @SuppressWarnings("unused")
-    default void onNeighborWritten(final int layer, @Nonnull final Node<? extends NodeReference> node,
-                                   @Nonnull final NodeReference neighbor) {
+    default void onNeighborWritten(final int layer, final Node<? extends NodeReference> node,
+                                   final NodeReference neighbor) {
         // nothing
     }
 
@@ -117,7 +116,7 @@ public interface OnWriteListener extends OnKeyValueWriteListener {
      * @param primaryKey the {@link Tuple} used as key to identify the node that was deleted; guaranteed to be non-null.
      */
     @SuppressWarnings("unused")
-    default void onNodeDeleted(final int layer, @Nonnull final Tuple primaryKey) {
+    default void onNodeDeleted(final int layer, final Tuple primaryKey) {
         // nothing
     }
 
@@ -132,8 +131,8 @@ public interface OnWriteListener extends OnKeyValueWriteListener {
      * @param neighborPrimaryKey the primary key (as a {@link Tuple}) of the neighbor that was deleted
      */
     @SuppressWarnings("unused")
-    default void onNeighborDeleted(final int layer, @Nonnull final Node<? extends NodeReference> node,
-                                   @Nonnull final Tuple neighborPrimaryKey) {
+    default void onNeighborDeleted(final int layer, final Node<? extends NodeReference> node,
+                                   final Tuple neighborPrimaryKey) {
         // nothing
     }
 }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/OutwardTraversalIterator.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/OutwardTraversalIterator.java
@@ -33,8 +33,7 @@ import com.google.common.collect.ImmutableSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
@@ -48,18 +47,12 @@ import java.util.concurrent.CompletableFuture;
  * where {@code minimumRadius} is measured as the distance of a vector to the given {@code centerVector}.
  */
 class OutwardTraversalIterator implements AsyncIterator<NodeReferenceAndNode<NodeReferenceWithDistance, NodeReference>> {
-    @Nonnull
     private static final Logger logger = LoggerFactory.getLogger(OutwardTraversalIterator.class);
 
-    @Nonnull
     private final Locator locator;
-    @Nonnull
     private final StorageAdapter<NodeReference> storageAdapter;
-    @Nonnull
     private final ReadTransaction readTransaction;
-    @Nonnull
     private final CompletableFuture<Search.SearchResult> zoomInResultFuture;
-    @Nonnull
     private final RealVector centerVector;
     private final double minimumRadius;
     @Nullable
@@ -78,11 +71,11 @@ class OutwardTraversalIterator implements AsyncIterator<NodeReferenceAndNode<Nod
     @Nullable
     private CompletableFuture<NodeReferenceAndNode<NodeReferenceWithDistance, NodeReference>> nextFuture;
 
-    public OutwardTraversalIterator(@Nonnull final Locator locator,
-                                    @Nonnull final StorageAdapter<NodeReference> storageAdapter,
-                                    @Nonnull final ReadTransaction readTransaction,
-                                    @Nonnull final CompletableFuture<Search.SearchResult> zoomInResultFuture,
-                                    @Nonnull final RealVector centerVector,
+    public OutwardTraversalIterator(final Locator locator,
+                                    final StorageAdapter<NodeReference> storageAdapter,
+                                    final ReadTransaction readTransaction,
+                                    final CompletableFuture<Search.SearchResult> zoomInResultFuture,
+                                    final RealVector centerVector,
                                     final double minimumRadius,
                                     @Nullable final Tuple minimumPrimaryKey,
                                     final int efOutwardSearch,
@@ -101,17 +94,14 @@ class OutwardTraversalIterator implements AsyncIterator<NodeReferenceAndNode<Nod
         this.nextFuture = null;
     }
 
-    @Nonnull
     public OutwardTraversalState getTraversalState() {
         return Objects.requireNonNull(traversalState);
     }
 
-    @Nonnull
     private Config getConfig() {
         return locator.getConfig();
     }
 
-    @Nonnull
     private Primitives primitives() {
         return locator.primitives();
     }
@@ -132,8 +122,7 @@ class OutwardTraversalIterator implements AsyncIterator<NodeReferenceAndNode<Nod
         return nextFuture.thenApply(Objects::nonNull);
     }
 
-    @Nonnull
-    private OutwardTraversalState initialTravelState(@Nonnull final Search.SearchResult zoomInResult) {
+    private OutwardTraversalState initialTravelState(final Search.SearchResult zoomInResult) {
         final StorageTransform storageTransform = zoomInResult.getStorageTransform();
         final Transformed<RealVector> transformedCenterVector = storageTransform.transform(centerVector);
         final PriorityQueue<NodeReferenceWithDistance> candidates =
@@ -169,7 +158,6 @@ class OutwardTraversalIterator implements AsyncIterator<NodeReferenceAndNode<Nod
                 transformedCenterVector, candidates, visited, out, quickStart, zoomInResult.getNodeCache());
     }
 
-    @Nonnull
     private CompletableFuture<NodeReferenceAndNode<NodeReferenceWithDistance, NodeReference>> computeNextRecord() {
         final Primitives primitives = primitives();
         final OutwardTraversalState localTraversalState = getTraversalState();
@@ -270,33 +258,24 @@ class OutwardTraversalIterator implements AsyncIterator<NodeReferenceAndNode<Nod
     }
 
     static class OutwardTraversalState {
-        @Nonnull
         private final StorageTransform storageTransform;
-        @Nonnull
         private final DistanceEstimator distanceEstimator;
-        @Nonnull
         private final Transformed<RealVector> transformedCenterVector;
-        @Nonnull
         private final Queue<NodeReferenceWithDistance> candidates;
-        @Nonnull
         private final SpatialRestrictions spatialRestrictions;
-        @Nonnull
         private final Queue<NodeReferenceWithDistance> out;
-        @Nonnull
         private final Queue<NodeReferenceWithDistance> quickStart;
-        @Nonnull
         private final Set<Tuple> quickStartPrimaryKeys;
-        @Nonnull
         private final Map<Tuple, AbstractNode<NodeReference>> nodeCache;
 
-        public OutwardTraversalState(@Nonnull final StorageTransform storageTransform,
-                                     @Nonnull final DistanceEstimator distanceEstimator,
-                                     @Nonnull final Transformed<RealVector> transformedCenterVector,
-                                     @Nonnull final Queue<NodeReferenceWithDistance> candidates,
-                                     @Nonnull final SpatialRestrictions spatialRestrictions,
-                                     @Nonnull final Queue<NodeReferenceWithDistance> out,
-                                     @Nonnull final Queue<NodeReferenceWithDistance> quickStart,
-                                     @Nonnull final Map<Tuple, AbstractNode<NodeReference>> nodeCache) {
+        public OutwardTraversalState(final StorageTransform storageTransform,
+                                     final DistanceEstimator distanceEstimator,
+                                     final Transformed<RealVector> transformedCenterVector,
+                                     final Queue<NodeReferenceWithDistance> candidates,
+                                     final SpatialRestrictions spatialRestrictions,
+                                     final Queue<NodeReferenceWithDistance> out,
+                                     final Queue<NodeReferenceWithDistance> quickStart,
+                                     final Map<Tuple, AbstractNode<NodeReference>> nodeCache) {
             this.storageTransform = storageTransform;
             this.distanceEstimator = distanceEstimator;
             this.transformedCenterVector = transformedCenterVector;
@@ -312,47 +291,38 @@ class OutwardTraversalIterator implements AsyncIterator<NodeReferenceAndNode<Nod
             this.nodeCache = nodeCache;
         }
 
-        @Nonnull
         public StorageTransform getStorageTransform() {
             return storageTransform;
         }
 
-        @Nonnull
         public DistanceEstimator getEstimator() {
             return distanceEstimator;
         }
 
-        @Nonnull
         public Transformed<RealVector> getTransformedCenterVector() {
             return transformedCenterVector;
         }
 
-        @Nonnull
         public Queue<NodeReferenceWithDistance> getCandidates() {
             return candidates;
         }
 
-        @Nonnull
         public SpatialRestrictions getSpatialRestrictions() {
             return spatialRestrictions;
         }
 
-        @Nonnull
         public Queue<NodeReferenceWithDistance> getOut() {
             return out;
         }
 
-        @Nonnull
         public Queue<NodeReferenceWithDistance> getQuickStart() {
             return quickStart;
         }
 
-        @Nonnull
         public Set<Tuple> getQuickStartPrimaryKeys() {
             return quickStartPrimaryKeys;
         }
 
-        @Nonnull
         public Map<Tuple, AbstractNode<NodeReference>> getNodeCache() {
             return nodeCache;
         }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/Primitives.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/Primitives.java
@@ -52,8 +52,7 @@ import com.google.common.collect.Streams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -78,10 +77,8 @@ import static com.apple.foundationdb.async.MoreAsyncUtil.forEach;
  */
 @API(API.Status.EXPERIMENTAL)
 public class Primitives {
-    @Nonnull
     private static final Logger logger = LoggerFactory.getLogger(Primitives.class);
 
-    @Nonnull
     private final Locator locator;
 
     /**
@@ -93,11 +90,10 @@ public class Primitives {
      * @param locator the {@link Locator} where the graph data is stored, which config to use, which executor to use,
      *        etc.
      */
-    public Primitives(@Nonnull final Locator locator) {
+    public Primitives(final Locator locator) {
         this.locator = locator;
     }
 
-    @Nonnull
     public Locator getLocator() {
         return locator;
     }
@@ -107,7 +103,6 @@ public class Primitives {
      *
      * @return the non-null subspace
      */
-    @Nonnull
     private Subspace getSubspace() {
         return getLocator().getSubspace();
     }
@@ -116,7 +111,6 @@ public class Primitives {
      * Get the executor used by this hnsw.
      * @return executor used when running asynchronous tasks
      */
-    @Nonnull
     private Executor getExecutor() {
         return getLocator().getExecutor();
     }
@@ -125,7 +119,6 @@ public class Primitives {
      * Get this hnsw's configuration.
      * @return hnsw configuration
      */
-    @Nonnull
     private Config getConfig() {
         return getLocator().getConfig();
     }
@@ -134,7 +127,6 @@ public class Primitives {
      * Get the on-write listener.
      * @return the on-write listener
      */
-    @Nonnull
     private OnWriteListener getOnWriteListener() {
         return getLocator().getOnWriteListener();
     }
@@ -143,7 +135,6 @@ public class Primitives {
      * Get the on-read listener.
      * @return the on-read listener
      */
-    @Nonnull
     private OnReadListener getOnReadListener() {
         return getLocator().getOnReadListener();
     }
@@ -152,7 +143,6 @@ public class Primitives {
         return getConfig().metric() == Metric.COSINE_METRIC;
     }
 
-    @Nonnull
     StorageTransform storageTransform(@Nullable final AccessInfo accessInfo) {
         if (accessInfo == null || !accessInfo.canUseRaBitQ()) {
             return StorageTransform.identity();
@@ -163,14 +153,12 @@ public class Primitives {
                 isMetricNeedsNormalizedVectors());
     }
 
-    @Nonnull
     StorageTransform storageTransform(@Nullable final Long rotatorSeed,
                                       @Nullable final RealVector negatedCentroid,
                                       final boolean normalizeVectors) {
         return storageTransform(rotatorSeed, negatedCentroid, normalizeVectors, getConfig().numDimensions());
     }
 
-    @Nonnull
     Quantizer quantizer(@Nullable final AccessInfo accessInfo) {
         if (accessInfo == null || !accessInfo.canUseRaBitQ()) {
             return Quantizer.noOpQuantizer(getConfig().metric());
@@ -192,9 +180,8 @@ public class Primitives {
      * @return a {@link CompletableFuture} that will be completed with the cached {@link AbstractNode}
      * @throws IllegalArgumentException if the node is not already present in the cache
      */
-    @Nonnull
-    <N extends NodeReference> AbstractNode<N> nodeFromCache(@Nonnull final Tuple primaryKey,
-                                                            @Nonnull final Map<Tuple, AbstractNode<N>> nodeCache) {
+    <N extends NodeReference> AbstractNode<N> nodeFromCache(final Tuple primaryKey,
+                                                            final Map<Tuple, AbstractNode<N>> nodeCache) {
         final AbstractNode<N> nodeFromCache = nodeCache.get(primaryKey);
         if (nodeFromCache == null) {
             throw new IllegalStateException("node should already have been fetched: " + primaryKey);
@@ -223,14 +210,13 @@ public class Primitives {
      *
      * @return a {@link CompletableFuture} that will be completed with the fetched or cached {@link AbstractNode}
      */
-    @Nonnull
     <N extends NodeReference> CompletableFuture<AbstractNode<N>>
-            fetchNodeIfNotCached(@Nonnull final StorageAdapter<N> storageAdapter,
-                                 @Nonnull final ReadTransaction readTransaction,
-                                 @Nonnull final StorageTransform storageTransform,
+            fetchNodeIfNotCached(final StorageAdapter<N> storageAdapter,
+                                 final ReadTransaction readTransaction,
+                                 final StorageTransform storageTransform,
                                  final int layer,
-                                 @Nonnull final NodeReference nodeReference,
-                                 @Nonnull final Map<Tuple, AbstractNode<N>> nodeCache) {
+                                 final NodeReference nodeReference,
+                                 final Map<Tuple, AbstractNode<N>> nodeCache) {
         return fetchNodeIfNecessaryAndApply(storageAdapter, readTransaction, storageTransform, layer, nodeReference,
                 nR -> nodeCache.get(nR.getPrimaryKey()),
                 (nR, node) -> {
@@ -272,15 +258,14 @@ public class Primitives {
      * @return A {@link CompletableFuture} that will complete with the result from either the
      * {@code fetchBypassFunction} or the {@code biMapFunction}.
      */
-    @Nonnull
     private <R extends NodeReference, N extends NodeReference, U> CompletableFuture<U>
-            fetchNodeIfNecessaryAndApply(@Nonnull final StorageAdapter<N> storageAdapter,
-                                         @Nonnull final ReadTransaction readTransaction,
-                                         @Nonnull final StorageTransform storageTransform,
+            fetchNodeIfNecessaryAndApply(final StorageAdapter<N> storageAdapter,
+                                         final ReadTransaction readTransaction,
+                                         final StorageTransform storageTransform,
                                          final int layer,
-                                         @Nonnull final R nodeReference,
-                                         @Nonnull final Function<R, U> fetchBypassFunction,
-                                         @Nonnull final BiFunction<R, AbstractNode<N>, U> biMapFunction) {
+                                         final R nodeReference,
+                                         final Function<R, U> fetchBypassFunction,
+                                         final BiFunction<R, AbstractNode<N>, U> biMapFunction) {
         final U bypass = fetchBypassFunction.apply(nodeReference);
         if (bypass != null) {
             return CompletableFuture.completedFuture(bypass);
@@ -314,14 +299,13 @@ public class Primitives {
      * @return a {@link CompletableFuture} that, upon completion, will contain a list of
      *         {@link NodeReferenceWithVectorAndAdditionalValues} objects for the specified neighbors
      */
-    @Nonnull
     <N extends NodeReference> CompletableFuture<List<NodeReferenceWithVectorAndAdditionalValues>>
-            fetchNeighborhoodReferences(@Nonnull final StorageAdapter<N> storageAdapter,
-                                        @Nonnull final ReadTransaction readTransaction,
-                                        @Nonnull final StorageTransform storageTransform,
+            fetchNeighborhoodReferences(final StorageAdapter<N> storageAdapter,
+                                        final ReadTransaction readTransaction,
+                                        final StorageTransform storageTransform,
                                         final int layer,
-                                        @Nonnull final Iterable<? extends NodeReference> neighborReferences,
-                                        @Nonnull final Map<Tuple, AbstractNode<N>> nodeCache) {
+                                        final Iterable<? extends NodeReference> neighborReferences,
+                                        final Map<Tuple, AbstractNode<N>> nodeCache) {
         return fetchSomeNodesAndApply(storageAdapter, readTransaction, storageTransform, layer, neighborReferences,
                 neighborReference -> {
                     if (storageAdapter.isInliningStorageAdapter() && neighborReference.isNodeReferenceWithVector()) {
@@ -378,14 +362,13 @@ public class Primitives {
      * @return A {@link CompletableFuture} which will complete with a {@link List} of {@link NodeReferenceAndNode}
      *         objects, pairing each requested reference with its corresponding node.
      */
-    @Nonnull
     <T extends NodeReferenceWithVector, N extends NodeReference> CompletableFuture<List<NodeReferenceAndNode<T, N>>>
-            fetchSomeNodesIfNotCached(@Nonnull final StorageAdapter<N> storageAdapter,
-                                      @Nonnull final ReadTransaction readTransaction,
-                                      @Nonnull final StorageTransform storageTransform,
+            fetchSomeNodesIfNotCached(final StorageAdapter<N> storageAdapter,
+                                      final ReadTransaction readTransaction,
+                                      final StorageTransform storageTransform,
                                       final int layer,
-                                      @Nonnull final Iterable<T> nodeReferences,
-                                      @Nonnull final Map<Tuple, AbstractNode<N>> nodeCache) {
+                                      final Iterable<T> nodeReferences,
+                                      final Map<Tuple, AbstractNode<N>> nodeCache) {
         return fetchSomeNodesAndApply(storageAdapter, readTransaction, storageTransform, layer, nodeReferences,
                 nodeReference -> {
                     final AbstractNode<N> node = nodeCache.get(nodeReference.getPrimaryKey());
@@ -430,15 +413,14 @@ public class Primitives {
      * @return A {@link CompletableFuture} that, upon completion, will hold a {@link List} of non-null results
      * of type {@code U}
      */
-    @Nonnull
     private <R extends NodeReference, N extends NodeReference, U> CompletableFuture<List<U>>
-            fetchSomeNodesAndApply(@Nonnull final StorageAdapter<N> storageAdapter,
-                                   @Nonnull final ReadTransaction readTransaction,
-                                   @Nonnull final StorageTransform storageTransform,
+            fetchSomeNodesAndApply(final StorageAdapter<N> storageAdapter,
+                                   final ReadTransaction readTransaction,
+                                   final StorageTransform storageTransform,
                                    final int layer,
-                                   @Nonnull final Iterable<R> nodeReferences,
-                                   @Nonnull final Function<R, U> fetchBypassFunction,
-                                   @Nonnull final BiFunction<R, AbstractNode<N>, U> biMapFunction) {
+                                   final Iterable<R> nodeReferences,
+                                   final Function<R, U> fetchBypassFunction,
+                                   final BiFunction<R, AbstractNode<N>, U> biMapFunction) {
         return forEach(nodeReferences,
                 currentNeighborReference -> fetchNodeIfNecessaryAndApply(storageAdapter, readTransaction,
                         storageTransform, layer, currentNeighborReference, fetchBypassFunction, biMapFunction),
@@ -455,12 +437,11 @@ public class Primitives {
                 });
     }
 
-    @Nonnull
     <N extends NodeReference> CompletableFuture<List<NodeReferenceAndNode<NodeReferenceWithVector, N>>>
-            filterExisting(@Nonnull final StorageAdapter<N> storageAdapter,
-                           @Nonnull final ReadTransaction readTransaction,
-                           @Nonnull final StorageTransform storageTransform,
-                           @Nonnull final Iterable<? extends NodeReferenceAndNode<? extends NodeReferenceWithVector, N>> nodeReferenceAndNodes) {
+            filterExisting(final StorageAdapter<N> storageAdapter,
+                           final ReadTransaction readTransaction,
+                           final StorageTransform storageTransform,
+                           final Iterable<? extends NodeReferenceAndNode<? extends NodeReferenceWithVector, N>> nodeReferenceAndNodes) {
         if (!storageAdapter.isInliningStorageAdapter()) {
             final ImmutableList.Builder<NodeReferenceAndNode<NodeReferenceWithVector, N>> resultBuilder =
                     ImmutableList.builder();
@@ -505,9 +486,8 @@ public class Primitives {
                 });
     }
 
-    @Nonnull
-    CompletableFuture<Boolean> exists(@Nonnull final ReadTransaction readTransaction,
-                                      @Nonnull final Tuple primaryKey) {
+    CompletableFuture<Boolean> exists(final ReadTransaction readTransaction,
+                                      final Tuple primaryKey) {
         //
         // Call fetchBaseNode() to check for the node's existence; we are handing in the identity operator,
         // since we do not care about the vector itself at all.
@@ -516,9 +496,8 @@ public class Primitives {
                 .thenApply(Objects::nonNull);
     }
 
-    @Nonnull
-    CompletableFuture<ResultEntry> fetch(@Nonnull final ReadTransaction readTransaction,
-                                         @Nonnull final Tuple primaryKey) {
+    CompletableFuture<ResultEntry> fetch(final ReadTransaction readTransaction,
+                                         final Tuple primaryKey) {
         return StorageAdapter.fetchAccessInfo(getConfig(), readTransaction, getSubspace(), getOnReadListener())
                 .thenCompose(accessInfo -> {
                     if (accessInfo == null) {
@@ -537,10 +516,9 @@ public class Primitives {
                 });
     }
 
-    @Nonnull
-    CompletableFuture<CompactNode> fetchBaseNode(@Nonnull final ReadTransaction readTransaction,
-                                                 @Nonnull final StorageTransform storageTransform,
-                                                 @Nonnull final Tuple primaryKey) {
+    CompletableFuture<CompactNode> fetchBaseNode(final ReadTransaction readTransaction,
+                                                 final StorageTransform storageTransform,
+                                                 final Tuple primaryKey) {
         final StorageAdapter<? extends NodeReference> storageAdapter = storageAdapterForLayer(0);
 
         return storageAdapter.fetchNode(readTransaction, storageTransform, 0, primaryKey)
@@ -562,15 +540,13 @@ public class Primitives {
      *
      * @return a {@link CompletableFuture} that completes with the {@link Cardinality} of layer 0
      */
-    @Nonnull
-    CompletableFuture<Cardinality> cardinality(@Nonnull final ReadTransaction readTransaction) {
+    CompletableFuture<Cardinality> cardinality(final ReadTransaction readTransaction) {
         return cardinality(readTransaction, storageAdapterForLayer(0));
     }
 
-    @Nonnull
     private <N extends NodeReference> CompletableFuture<Cardinality>
-            cardinality(@Nonnull final ReadTransaction readTransaction,
-                        @Nonnull final StorageAdapter<N> storageAdapter) {
+            cardinality(final ReadTransaction readTransaction,
+                        final StorageAdapter<N> storageAdapter) {
         // Reading just two nodes is enough to tell empty / single / multiple apart; passing maxNumRead == 2
         // bounds the underlying range read to (at most) two key/value pairs, so the cost does not grow with the
         // size of the graph. Layer 0 is always backed by a CompactStorageAdapter (inlining is only used for
@@ -605,17 +581,16 @@ public class Primitives {
      * @return a {@link CompletableFuture} which completes with a list of the newly selected neighbors for the pruned node.
      * If no pruning was necessary, it completes with {@code null}.
      */
-    @Nonnull
     <N extends NodeReference> CompletableFuture<List<NodeReferenceAndNode<NodeReferenceWithDistance, N>>>
-            pruneNeighborsIfNecessary(@Nonnull final StorageAdapter<N> storageAdapter,
-                                      @Nonnull final Transaction transaction,
-                                      @Nonnull final StorageTransform storageTransform,
-                                      @Nonnull final DistanceEstimator distanceEstimator,
+            pruneNeighborsIfNecessary(final StorageAdapter<N> storageAdapter,
+                                      final Transaction transaction,
+                                      final StorageTransform storageTransform,
+                                      final DistanceEstimator distanceEstimator,
                                       final int layer,
-                                      @Nonnull final NodeReferenceWithVector nodeReferenceWithVector,
+                                      final NodeReferenceWithVector nodeReferenceWithVector,
                                       final int mMax,
-                                      @Nonnull final NeighborsChangeSet<N> neighborChangeSet,
-                                      @Nonnull final Map<Tuple, AbstractNode<N>> nodeCache) {
+                                      final NeighborsChangeSet<N> neighborChangeSet,
+                                      final Map<Tuple, AbstractNode<N>> nodeCache) {
         final int numNeighbors =
                 Iterables.size(neighborChangeSet.merge()); // this is a view over the iterable neighbors in the set
         if (numNeighbors < mMax) {
@@ -677,14 +652,14 @@ public class Primitives {
      * each represented as a {@link NodeReferenceAndNode}
      */
     <N extends NodeReference> CompletableFuture<List<NodeReferenceAndNode<NodeReferenceWithDistance, N>>>
-            selectCandidates(@Nonnull final StorageAdapter<N> storageAdapter,
-                             @Nonnull final ReadTransaction readTransaction,
-                             @Nonnull final StorageTransform storageTransform,
-                             @Nonnull final DistanceEstimator distanceEstimator,
-                             @Nonnull final Iterable<NodeReferenceWithDistance> initialCandidates,
+            selectCandidates(final StorageAdapter<N> storageAdapter,
+                             final ReadTransaction readTransaction,
+                             final StorageTransform storageTransform,
+                             final DistanceEstimator distanceEstimator,
+                             final Iterable<NodeReferenceWithDistance> initialCandidates,
                              final int layer,
                              final int m,
-                             @Nonnull final Map<Tuple, AbstractNode<N>> nodeCache) {
+                             final Map<Tuple, AbstractNode<N>> nodeCache) {
         final Metric metric = getConfig().metric();
 
         final List<NodeReferenceWithDistance> selected = Lists.newArrayListWithExpectedSize(m);
@@ -763,15 +738,15 @@ public class Primitives {
      * containing the original candidates and potentially their neighbors
      */
     <N extends NodeReference> CompletableFuture<List<NodeReferenceWithDistance>>
-            extendCandidatesIfNecessary(@Nonnull final StorageAdapter<N> storageAdapter,
-                                        @Nonnull final ReadTransaction readTransaction,
-                                        @Nonnull final StorageTransform storageTransform,
-                                        @Nonnull final DistanceEstimator distanceEstimator,
-                                        @Nonnull final Collection<NodeReferenceAndNode<NodeReferenceWithDistance, N>> candidates,
+            extendCandidatesIfNecessary(final StorageAdapter<N> storageAdapter,
+                                        final ReadTransaction readTransaction,
+                                        final StorageTransform storageTransform,
+                                        final DistanceEstimator distanceEstimator,
+                                        final Collection<NodeReferenceAndNode<NodeReferenceWithDistance, N>> candidates,
                                         final int layer,
                                         final boolean isExtendCandidates,
-                                        @Nonnull final Map<Tuple, AbstractNode<N>> nodeCache,
-                                        @Nonnull final Transformed<RealVector> vector) {
+                                        final Map<Tuple, AbstractNode<N>> nodeCache,
+                                        final Transformed<RealVector> vector) {
         final ImmutableList.Builder<NodeReferenceWithDistance> resultBuilder = ImmutableList.builder();
 
         if (isExtendCandidates) {
@@ -815,14 +790,14 @@ public class Primitives {
      * @return a {@link CompletableFuture} which will complete with a list of fetched nodes
      */
     <T extends NodeReference, N extends NodeReference> CompletableFuture<List<NodeReferenceAndNode<NodeReferenceWithVector, N>>>
-            neighbors(@Nonnull final StorageAdapter<N> storageAdapter,
-                      @Nonnull final ReadTransaction readTransaction,
-                      @Nonnull final StorageTransform storageTransform,
-                      @Nonnull final SplittableRandom random,
-                      @Nonnull final Collection<NodeReferenceAndNode<T, N>> initialNodeReferenceAndNodes,
-                      @Nonnull final CandidatePredicate samplingPredicate,
+            neighbors(final StorageAdapter<N> storageAdapter,
+                      final ReadTransaction readTransaction,
+                      final StorageTransform storageTransform,
+                      final SplittableRandom random,
+                      final Collection<NodeReferenceAndNode<T, N>> initialNodeReferenceAndNodes,
+                      final CandidatePredicate samplingPredicate,
                       final int layer,
-                      @Nonnull final Map<Tuple, AbstractNode<N>> nodeCache) {
+                      final Map<Tuple, AbstractNode<N>> nodeCache) {
         return neighborReferences(storageAdapter, readTransaction, storageTransform, random,
                 initialNodeReferenceAndNodes, samplingPredicate, layer, nodeCache)
                 .thenCompose(neighbors ->
@@ -852,14 +827,14 @@ public class Primitives {
      * @return a {@link CompletableFuture} which will complete with a list of {@link NodeReferenceWithVector}
      */
     private <T extends NodeReference, N extends NodeReference> CompletableFuture<? extends List<? extends NodeReferenceWithVector>>
-            neighborReferences(@Nonnull final StorageAdapter<N> storageAdapter,
-                               @Nonnull final ReadTransaction readTransaction,
-                               @Nonnull final StorageTransform storageTransform,
+            neighborReferences(final StorageAdapter<N> storageAdapter,
+                               final ReadTransaction readTransaction,
+                               final StorageTransform storageTransform,
                                @Nullable final SplittableRandom random,
-                               @Nonnull final Collection<NodeReferenceAndNode<T, N>> initialNodeReferenceAndNodes,
-                               @Nonnull final CandidatePredicate samplingPredicate,
+                               final Collection<NodeReferenceAndNode<T, N>> initialNodeReferenceAndNodes,
+                               final CandidatePredicate samplingPredicate,
                                final int layer,
-                               @Nonnull final Map<Tuple, AbstractNode<N>> nodeCache) {
+                               final Map<Tuple, AbstractNode<N>> nodeCache) {
         final Iterable<NodeReference> toBeFetched =
                 findNeighborReferences(initialNodeReferenceAndNodes, random, samplingPredicate);
         return fetchNeighborhoodReferences(storageAdapter, readTransaction, storageTransform, layer, toBeFetched,
@@ -875,9 +850,9 @@ public class Primitives {
      * @return a {@link CompletableFuture} which will complete with a set of {@link NodeReference}s
      */
     private <T extends NodeReference, N extends NodeReference> Set<NodeReference>
-            findNeighborReferences(@Nonnull final Collection<NodeReferenceAndNode<T, N>> initialNodeReferenceAndNodes,
+            findNeighborReferences(final Collection<NodeReferenceAndNode<T, N>> initialNodeReferenceAndNodes,
                                    @Nullable final SplittableRandom random,
-                                   @Nonnull final CandidatePredicate candidatePredicate) {
+                                   final CandidatePredicate candidatePredicate) {
         final Set<NodeReference> neighborReferences = Sets.newLinkedHashSet();
         final ImmutableMap.Builder<Tuple, NodeReferenceAndNode<T, N>> initialNodesMapBuilder = ImmutableMap.builder();
         for (final NodeReferenceAndNode<T, N> nodeReferenceAndNode : initialNodeReferenceAndNodes) {
@@ -941,10 +916,10 @@ public class Primitives {
      * @param highestLayerInclusive the highest layer (inclusive) to begin writing lonely nodes on
      * @param lowestLayerExclusive the lowest layer (exclusive) at which to stop writing lonely nodes
      */
-    void writeLonelyNodes(@Nonnull final Quantizer quantizer,
-                          @Nonnull final Transaction transaction,
-                          @Nonnull final Tuple primaryKey,
-                          @Nonnull final Transformed<RealVector> vector,
+    void writeLonelyNodes(final Quantizer quantizer,
+                          final Transaction transaction,
+                          final Tuple primaryKey,
+                          final Transformed<RealVector> vector,
                           @Nullable final Tuple additionalValues,
                           final int highestLayerInclusive,
                           final int lowestLayerExclusive) {
@@ -971,12 +946,12 @@ public class Primitives {
      * @param vector the vector data for the new node; must not be null
      * @param additionalValues additional values associated with the vector that is written
      */
-    <N extends NodeReference> void writeLonelyNodeOnLayer(@Nonnull final Quantizer quantizer,
-                                                          @Nonnull final StorageAdapter<N> storageAdapter,
-                                                          @Nonnull final Transaction transaction,
+    <N extends NodeReference> void writeLonelyNodeOnLayer(final Quantizer quantizer,
+                                                          final StorageAdapter<N> storageAdapter,
+                                                          final Transaction transaction,
                                                           final int layer,
-                                                          @Nonnull final Tuple primaryKey,
-                                                          @Nonnull final Transformed<RealVector> vector,
+                                                          final Tuple primaryKey,
+                                                          final Transformed<RealVector> vector,
                                                           @Nullable final Tuple additionalValues) {
         final AbstractNode<N> node =
                 storageAdapter.getNodeFactory()
@@ -1002,10 +977,9 @@ public class Primitives {
      * @param candidateChangeSetMap the initialized candidate change set map.
      * @return a list of existing primary neighbors
      */
-    @Nonnull
     <N extends NodeReference> ImmutableList<N>
-            primaryNeighbors(@Nonnull final AbstractNode<N> toBeDeletedNode,
-                             @Nonnull final Map<Tuple, NeighborsChangeSet<N>> candidateChangeSetMap) {
+            primaryNeighbors(final AbstractNode<N> toBeDeletedNode,
+                             final Map<Tuple, NeighborsChangeSet<N>> candidateChangeSetMap) {
         //
         // All entries in the change set map definitely exist and the candidate change set map hold all keys for all
         // existing primary candidates.
@@ -1040,8 +1014,8 @@ public class Primitives {
      * operations to transform the neighbors from the "before" state to the "after" state.
      */
     <N extends NodeReference> NeighborsChangeSet<N>
-            resolveChangeSetFromNewNeighbors(@Nonnull final NeighborsChangeSet<N> beforeChangeSet,
-                                             @Nonnull final Iterable<NodeReferenceAndNode<NodeReferenceWithDistance, N>> afterNeighbors) {
+            resolveChangeSetFromNewNeighbors(final NeighborsChangeSet<N> beforeChangeSet,
+                                             final Iterable<NodeReferenceAndNode<NodeReferenceWithDistance, N>> afterNeighbors) {
         final Map<Tuple, N> beforeNeighborsMap = Maps.newLinkedHashMap();
         for (final N n : beforeChangeSet.merge()) {
             beforeNeighborsMap.put(n.getPrimaryKey(), n);
@@ -1092,7 +1066,6 @@ public class Primitives {
      * @param layer the layer number for which to get the storage adapter
      * @return a non-null {@link StorageAdapter} instance
      */
-    @Nonnull
     StorageAdapter<? extends NodeReference> storageAdapterForLayer(final int layer) {
         return storageAdapterForLayer(getConfig(), getSubspace(), getOnWriteListener(), getOnReadListener(), layer);
     }
@@ -1107,13 +1080,12 @@ public class Primitives {
      * @param primaryKey the primary key of the record to be inserted/updated/deleted
      * @return a non-negative integer representing the randomly selected layer
      */
-    int topLayer(@Nonnull final Tuple primaryKey) {
+    int topLayer(final Tuple primaryKey) {
         double lambda = 1.0 / Math.log(getConfig().m());
         double u = 1.0 - RandomHelpers.splitMixDouble(primaryKey.hashCode());  // Avoid log(0)
         return (int) Math.floor(-Math.log(u) * lambda);
     }
 
-    @Nonnull
     static StorageTransform storageTransform(@Nullable final Long rotatorSeed,
                                              @Nullable final RealVector negatedCentroid,
                                              final boolean normalizeVectors,
@@ -1126,12 +1098,12 @@ public class Primitives {
     }
 
     @VisibleForTesting
-    static void scanLayer(@Nonnull final Config config,
-                          @Nonnull final Subspace subspace,
-                          @Nonnull final Database db,
+    static void scanLayer(final Config config,
+                          final Subspace subspace,
+                          final Database db,
                           final int layer,
                           final int batchSize,
-                          @Nonnull final Consumer<ResultEntry> nodeConsumer) {
+                          final Consumer<ResultEntry> nodeConsumer) {
         final AccessInfo accessInfo = db.run(readTransaction ->
                 StorageAdapter.fetchAccessInfo(config, readTransaction, subspace, OnReadListener.NOOP).join());
         final StorageTransform storageTransform =
@@ -1163,12 +1135,12 @@ public class Primitives {
      * found in the layer.
      */
     @VisibleForTesting
-    static void scanLayerInternal(@Nonnull final Config config,
-                                  @Nonnull final Subspace subspace,
-                                  @Nonnull final Database db,
+    static void scanLayerInternal(final Config config,
+                                  final Subspace subspace,
+                                  final Database db,
                                   final int layer,
                                   final int batchSize,
-                                  @Nonnull final Consumer<AbstractNode<? extends NodeReference>> nodeConsumer) {
+                                  final Consumer<AbstractNode<? extends NodeReference>> nodeConsumer) {
         final StorageAdapter<? extends NodeReference> storageAdapter =
                 storageAdapterForLayer(config, subspace, OnWriteListener.NOOP, OnReadListener.NOOP, layer);
         final AtomicReference<Tuple> lastPrimaryKeyAtomic = new AtomicReference<>();
@@ -1201,21 +1173,19 @@ public class Primitives {
      * @param layer the layer number for which to get the storage adapter
      * @return a non-null {@link StorageAdapter} instance
      */
-    @Nonnull
     @VisibleForTesting
     static StorageAdapter<? extends NodeReference>
-            storageAdapterForLayer(@Nonnull final Config config,
-                                   @Nonnull final Subspace subspace,
-                                   @Nonnull final OnWriteListener onWriteListener,
-                                   @Nonnull final OnReadListener onReadListener,
+            storageAdapterForLayer(final Config config,
+                                   final Subspace subspace,
+                                   final OnWriteListener onWriteListener,
+                                   final OnReadListener onReadListener,
                                    final int layer) {
         return config.useInlining() && layer > 0
                ? new InliningStorageAdapter(config, InliningNode.factory(), subspace, onWriteListener, onReadListener)
                : new CompactStorageAdapter(config, CompactNode.factory(), subspace, onWriteListener, onReadListener);
     }
 
-    @Nonnull
-    static <T> List<T> drain(@Nonnull Queue<T> queue) {
+    static <T> List<T> drain(Queue<T> queue) {
         final ImmutableList.Builder<T> resultBuilder = ImmutableList.builder();
         while (!queue.isEmpty()) {
             resultBuilder.add(queue.poll());
@@ -1231,12 +1201,11 @@ public class Primitives {
 
     @FunctionalInterface
     interface CandidatePredicate {
-        @Nonnull
         static CandidatePredicate tautology() {
             return (random, initialNodeKeys, size, nodeReference) -> true;
         }
 
-        boolean test(@Nullable SplittableRandom random, @Nonnull Set<Tuple> initialNodeKeys, int size, NodeReference nodeReference);
+        boolean test(@Nullable SplittableRandom random, Set<Tuple> initialNodeKeys, int size, NodeReference nodeReference);
     }
 
     static class AccessInfoAndNodeExistence {

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/Search.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/Search.java
@@ -40,8 +40,7 @@ import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -66,10 +65,8 @@ import static com.apple.foundationdb.async.MoreAsyncUtil.forLoop;
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 public class Search {
-    @Nonnull
     private static final Logger logger = LoggerFactory.getLogger(Search.class);
 
-    @Nonnull
     private final Locator locator;
 
     /**
@@ -79,11 +76,10 @@ public class Search {
      * @param locator the {@link Locator} where the graph data is stored, which config to use, which executor to use,
      *        etc.
      */
-    public Search(@Nonnull final Locator locator) {
+    public Search(final Locator locator) {
         this.locator = locator;
     }
 
-    @Nonnull
     public Locator getLocator() {
         return locator;
     }
@@ -93,7 +89,6 @@ public class Search {
      *
      * @return the non-null subspace
      */
-    @Nonnull
     public Subspace getSubspace() {
         return getLocator().getSubspace();
     }
@@ -102,7 +97,6 @@ public class Search {
      * Get the executor used by this hnsw.
      * @return executor used when running asynchronous tasks
      */
-    @Nonnull
     private Executor getExecutor() {
         return getLocator().getExecutor();
     }
@@ -111,7 +105,6 @@ public class Search {
      * Get the configuration of this hnsw.
      * @return hnsw configuration
      */
-    @Nonnull
     private Config getConfig() {
         return getLocator().getConfig();
     }
@@ -120,12 +113,10 @@ public class Search {
      * Get the on-read listener.
      * @return the on-read listener
      */
-    @Nonnull
     private OnReadListener getOnReadListener() {
         return getLocator().getOnReadListener();
     }
 
-    @Nonnull
     private Primitives primitives() {
         return locator.primitives();
     }
@@ -144,13 +135,12 @@ public class Search {
      *         sorted by distance in ascending order.
      */
     @SuppressWarnings("checkstyle:MethodName") // method name introduced by paper
-    @Nonnull
     public CompletableFuture<List<? extends ResultEntry>>
-            kNearestNeighborsSearch(@Nonnull final ReadTransaction readTransaction,
+            kNearestNeighborsSearch(final ReadTransaction readTransaction,
                                     final int k,
                                     final int efSearch,
                                     final boolean includeVectors,
-                                    @Nonnull final RealVector queryVector) {
+                                    final RealVector queryVector) {
         return search(readTransaction, queryVector,
                 layer -> layer > 0 ? 1 : efSearch,
                 Search::distanceToTargetVector)
@@ -174,13 +164,12 @@ public class Search {
      *         sorted by distance in ascending order.
      */
     @SuppressWarnings("checkstyle:MethodName") // method name introduced by paper
-    @Nonnull
     public CompletableFuture<List<? extends ResultEntry>>
-            kNearestNeighborsRingSearch(@Nonnull final ReadTransaction readTransaction,
+            kNearestNeighborsRingSearch(final ReadTransaction readTransaction,
                                         final int k,
                                         final int efSearch,
                                         final boolean includeVectors,
-                                        @Nonnull final RealVector queryVector,
+                                        final RealVector queryVector,
                                         final double radius) {
         return search(readTransaction, queryVector,
                 layer ->
@@ -216,11 +205,10 @@ public class Search {
      *         sorted by distance in ascending order.
      */
     @SuppressWarnings("checkstyle:MethodName") // method name introduced by paper
-    @Nonnull
-    CompletableFuture<SearchResult> search(@Nonnull final ReadTransaction readTransaction,
-                                           @Nonnull final RealVector queryVector,
-                                           @Nonnull final IntUnaryOperator efSearchFunction,
-                                           @Nonnull final ObjectiveFunctionCreator objectiveFunctionCreator) {
+    CompletableFuture<SearchResult> search(final ReadTransaction readTransaction,
+                                           final RealVector queryVector,
+                                           final IntUnaryOperator efSearchFunction,
+                                           final ObjectiveFunctionCreator objectiveFunctionCreator) {
         return StorageAdapter.fetchAccessInfo(getConfig(), readTransaction, getSubspace(), getOnReadListener())
                 .thenCompose(accessInfo -> {
                     if (accessInfo == null) {
@@ -267,15 +255,14 @@ public class Search {
                 });
     }
 
-    @Nonnull
     private <N extends NodeReference> CompletableFuture<List<NodeReferenceWithDistance>>
-            searchLayer(@Nonnull final StorageAdapter<N> storageAdapter,
-                        @Nonnull final ReadTransaction readTransaction,
-                        @Nonnull final StorageTransform storageTransform,
-                        @Nonnull final List<NodeReferenceWithDistance> nodeReferenceWithDistances,
+            searchLayer(final StorageAdapter<N> storageAdapter,
+                        final ReadTransaction readTransaction,
+                        final StorageTransform storageTransform,
+                        final List<NodeReferenceWithDistance> nodeReferenceWithDistances,
                         final int layer,
                         final int efSearch,
-                        @Nonnull final ToDoubleFunction<Transformed<RealVector>> objectiveFunction) {
+                        final ToDoubleFunction<Transformed<RealVector>> objectiveFunction) {
         if (efSearch == 1 && nodeReferenceWithDistances.size() == 1) {
             return greedySearchLayer(storageAdapter, readTransaction, storageTransform,
                     Iterables.getOnlyElement(nodeReferenceWithDistances),
@@ -288,10 +275,9 @@ public class Search {
         }
     }
 
-    @Nonnull
-    private ImmutableList<ResultEntry> postProcessSearchResult(@Nonnull final StorageTransform storageTransform,
+    private ImmutableList<ResultEntry> postProcessSearchResult(final StorageTransform storageTransform,
                                                                final int k,
-                                                               @Nonnull List<NodeReferenceAndNode<NodeReferenceWithDistance, NodeReference>> nearestReferencesAndNodes,
+                                                               List<NodeReferenceAndNode<NodeReferenceWithDistance, NodeReference>> nearestReferencesAndNodes,
                                                                final boolean includeVectors) {
         final int lastIndex = Math.max(nearestReferencesAndNodes.size() - k, 0);
 
@@ -335,14 +321,13 @@ public class Search {
      * @return a {@link CompletableFuture} that, upon completion, will contain the closest node found on the layer,
      *         represented as a {@link NodeReferenceWithDistance}
      */
-    @Nonnull
     <N extends NodeReference> CompletableFuture<NodeReferenceWithDistance>
-            greedySearchLayer(@Nonnull final StorageAdapter<N> storageAdapter,
-                              @Nonnull final ReadTransaction readTransaction,
-                              @Nonnull final StorageTransform storageTransform,
-                              @Nonnull final NodeReferenceWithDistance nodeReferenceWithDistance,
+            greedySearchLayer(final StorageAdapter<N> storageAdapter,
+                              final ReadTransaction readTransaction,
+                              final StorageTransform storageTransform,
+                              final NodeReferenceWithDistance nodeReferenceWithDistance,
                               final int layer,
-                              @Nonnull final ToDoubleFunction<Transformed<RealVector>> objectiveFunction) {
+                              final ToDoubleFunction<Transformed<RealVector>> objectiveFunction) {
         if (storageAdapter.isInliningStorageAdapter()) {
             return greedySearchInliningLayer(storageAdapter.asInliningStorageAdapter(), readTransaction,
                     storageTransform, nodeReferenceWithDistance, layer, objectiveFunction);
@@ -370,14 +355,13 @@ public class Search {
      * @return a {@link CompletableFuture} that, upon completion, will contain the closest node found on the layer,
      *         represented as a {@link NodeReferenceWithDistance}
      */
-    @Nonnull
     private CompletableFuture<NodeReferenceWithDistance>
-            greedySearchInliningLayer(@Nonnull final InliningStorageAdapter storageAdapter,
-                                      @Nonnull final ReadTransaction readTransaction,
-                                      @Nonnull final StorageTransform storageTransform,
-                                      @Nonnull final NodeReferenceWithDistance nodeReferenceWithDistance,
+            greedySearchInliningLayer(final InliningStorageAdapter storageAdapter,
+                                      final ReadTransaction readTransaction,
+                                      final StorageTransform storageTransform,
+                                      final NodeReferenceWithDistance nodeReferenceWithDistance,
                                       final int layer,
-                                      @Nonnull final ToDoubleFunction<Transformed<RealVector>> objectiveFunction) {
+                                      final ToDoubleFunction<Transformed<RealVector>> objectiveFunction) {
         final Primitives primitives = primitives();
         final NodeFactory<NodeReferenceWithVector> nodeFactory = storageAdapter.getNodeFactory();
         final Map<Tuple, AbstractNode<NodeReferenceWithVector>> nodeCache = Maps.newHashMap();
@@ -496,16 +480,15 @@ public class Search {
      * @return A {@link CompletableFuture} that, upon completion, will contain a list of the
      * best candidate nodes found in this layer, paired with their full node data.
      */
-    @Nonnull
     <N extends NodeReference> CompletableFuture<List<NodeReferenceAndNode<NodeReferenceWithDistance, N>>>
-            beamSearchLayer(@Nonnull final StorageAdapter<N> storageAdapter,
-                            @Nonnull final ReadTransaction readTransaction,
-                            @Nonnull final StorageTransform storageTransform,
-                            @Nonnull final Collection<NodeReferenceWithDistance> nodeReferences,
+            beamSearchLayer(final StorageAdapter<N> storageAdapter,
+                            final ReadTransaction readTransaction,
+                            final StorageTransform storageTransform,
+                            final Collection<NodeReferenceWithDistance> nodeReferences,
                             final int layer,
                             final int efSearch,
-                            @Nonnull final ToDoubleFunction<Transformed<RealVector>> objectiveFunction,
-                            @Nonnull final Map<Tuple, AbstractNode<N>> nodeCache) {
+                            final ToDoubleFunction<Transformed<RealVector>> objectiveFunction,
+                            final Map<Tuple, AbstractNode<N>> nodeCache) {
         final Primitives primitives = primitives();
 
         //
@@ -628,11 +611,11 @@ public class Search {
      * @return an {@link AsyncIterator} of {@link ResultEntry} objects, ordered by increasing distance from the
      *         {@code centerVector}
      */
-    AsyncIterator<ResultEntry> orderByDistance(@Nonnull final ReadTransaction readTransaction,
+    AsyncIterator<ResultEntry> orderByDistance(final ReadTransaction readTransaction,
                                                final int efRingSearch,
                                                final int efOutwardSearch,
                                                final boolean includeVectors,
-                                               @Nonnull final RealVector centerVector,
+                                               final RealVector centerVector,
                                                final double minimumRadius,
                                                @Nullable final Tuple minimumPrimaryKey,
                                                final boolean shouldQuickStart) {
@@ -659,11 +642,10 @@ public class Search {
                 });
     }
 
-    @Nonnull
-    private OutwardTraversalIterator searchAndIterateOutward(@Nonnull final ReadTransaction readTransaction,
+    private OutwardTraversalIterator searchAndIterateOutward(final ReadTransaction readTransaction,
                                                              final int efRingSearch,
                                                              final int efOutwardSearch,
-                                                             @Nonnull final RealVector centerVector,
+                                                             final RealVector centerVector,
                                                              final double minimumRadius,
                                                              @Nullable final Tuple minimumPrimaryKey,
                                                              final boolean shouldQuickStart) {
@@ -680,15 +662,13 @@ public class Search {
                 minimumRadius, minimumPrimaryKey, efOutwardSearch, shouldQuickStart);
     }
 
-    @Nonnull
-    static ToDoubleFunction<Transformed<RealVector>> distanceToTargetVector(@Nonnull final DistanceEstimator distanceEstimator,
-                                                                            @Nonnull final Transformed<RealVector> targetVector) {
+    static ToDoubleFunction<Transformed<RealVector>> distanceToTargetVector(final DistanceEstimator distanceEstimator,
+                                                                            final Transformed<RealVector> targetVector) {
         return vector -> distanceEstimator.distance(targetVector, vector);
     }
 
-    @Nonnull
-    static ToDoubleFunction<Transformed<RealVector>> distanceToSphericalSurface(@Nonnull final DistanceEstimator distanceEstimator,
-                                                                                @Nonnull final Transformed<RealVector> targetVector,
+    static ToDoubleFunction<Transformed<RealVector>> distanceToSphericalSurface(final DistanceEstimator distanceEstimator,
+                                                                                final Transformed<RealVector> targetVector,
                                                                                 final double radius) {
         return vector -> Math.abs(distanceEstimator.distance(targetVector, vector) - radius);
     }
@@ -696,17 +676,14 @@ public class Search {
     static class SearchResult {
         @Nullable
         private final AccessInfo accessInfo;
-        @Nonnull
         private final StorageTransform storageTransform;
-        @Nonnull
         private final List<NodeReferenceAndNode<NodeReferenceWithDistance, NodeReference>> nearestReferenceAndNodes;
-        @Nonnull
         private final Map<Tuple, AbstractNode<NodeReference>> nodeCache;
 
         public SearchResult(@Nullable final AccessInfo accessInfo,
-                            @Nonnull final StorageTransform storageTransform,
-                            @Nonnull final List<NodeReferenceAndNode<NodeReferenceWithDistance, NodeReference>> nearestReferenceWithNodes,
-                            @Nonnull final Map<Tuple, AbstractNode<NodeReference>> nodeCache) {
+                            final StorageTransform storageTransform,
+                            final List<NodeReferenceAndNode<NodeReferenceWithDistance, NodeReference>> nearestReferenceWithNodes,
+                            final Map<Tuple, AbstractNode<NodeReference>> nodeCache) {
             this.accessInfo = accessInfo;
             this.storageTransform = storageTransform;
             this.nearestReferenceAndNodes = nearestReferenceWithNodes;
@@ -718,17 +695,14 @@ public class Search {
             return accessInfo;
         }
 
-        @Nonnull
         public StorageTransform getStorageTransform() {
             return storageTransform;
         }
 
-        @Nonnull
         public List<NodeReferenceAndNode<NodeReferenceWithDistance, NodeReference>> getNearestReferenceAndNodes() {
             return nearestReferenceAndNodes;
         }
 
-        @Nonnull
         public Map<Tuple, AbstractNode<NodeReference>> getNodeCache() {
             return nodeCache;
         }
@@ -736,7 +710,6 @@ public class Search {
 
     @FunctionalInterface
     private interface ObjectiveFunctionCreator {
-        @Nonnull
-        ToDoubleFunction<Transformed<RealVector>> create(@Nonnull DistanceEstimator distanceEstimator, @Nonnull Transformed<RealVector> targetVector);
+        ToDoubleFunction<Transformed<RealVector>> create(DistanceEstimator distanceEstimator, Transformed<RealVector> targetVector);
     }
 }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/SpatialRestrictions.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/SpatialRestrictions.java
@@ -24,8 +24,7 @@ import com.apple.foundationdb.tuple.Tuple;
 import com.google.common.base.Verify;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.Comparator;
 import java.util.NavigableSet;
 import java.util.TreeSet;
@@ -41,9 +40,7 @@ class SpatialRestrictions {
     @Nullable
     private final Tuple minimumPrimaryKey;
 
-    @Nonnull
     private final NavigableSet<NodeReferenceWithDistance> insideRadius; // inclusive
-    @Nonnull
     private final NavigableSet<NodeReferenceWithDistance> outsideRadius; // exclusive
 
     public SpatialRestrictions(final int insideLimit,
@@ -56,11 +53,11 @@ class SpatialRestrictions {
         this.outsideRadius = new TreeSet<>(COMPARATOR);
     }
 
-    boolean isGreaterThanMinimum(@Nonnull final NodeReferenceWithDistance nodeReferenceWithDistance) {
+    boolean isGreaterThanMinimum(final NodeReferenceWithDistance nodeReferenceWithDistance) {
         return compareAgainstMinimum(nodeReferenceWithDistance) < 0;
     }
 
-    boolean isGreaterThanOrEqualMinimum(@Nonnull final NodeReferenceWithDistance nodeReferenceWithDistance) {
+    boolean isGreaterThanOrEqualMinimum(final NodeReferenceWithDistance nodeReferenceWithDistance) {
         return compareAgainstMinimum(nodeReferenceWithDistance) <= 0;
     }
 
@@ -73,7 +70,7 @@ class SpatialRestrictions {
      * @return a negative integer, zero, or a positive integer when {@code lastEmitted} is
      * less than, equal, or greater than the parameter {@code t}.
      */
-    int compareAgainstMinimum(@Nonnull final NodeReferenceWithDistance nodeReferenceWithDistance) {
+    int compareAgainstMinimum(final NodeReferenceWithDistance nodeReferenceWithDistance) {
         if (minimumRadius == 0.0d || minimumPrimaryKey == null) {
             return -1;
         }
@@ -85,7 +82,7 @@ class SpatialRestrictions {
         return minimumPrimaryKey.compareTo(nodeReferenceWithDistance.getPrimaryKey());
     }
 
-    boolean shouldBeAdded(@Nonnull final NodeReferenceWithDistance nodeReferenceWithDistance) {
+    boolean shouldBeAdded(final NodeReferenceWithDistance nodeReferenceWithDistance) {
         if (insideRadius.size() >= insideLimit) {
             final NodeReferenceWithDistance least = insideRadius.first();
             if (COMPARATOR.compare(nodeReferenceWithDistance, least) <= 0) {
@@ -102,7 +99,7 @@ class SpatialRestrictions {
     }
 
     @CanIgnoreReturnValue
-    boolean add(@Nonnull final NodeReferenceWithDistance nodeReferenceWithDistance) {
+    boolean add(final NodeReferenceWithDistance nodeReferenceWithDistance) {
         if (isGreaterThanOrEqualMinimum(nodeReferenceWithDistance)) {
             return outsideRadius.add(nodeReferenceWithDistance);
         }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/StorageAdapter.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/StorageAdapter.java
@@ -266,6 +266,10 @@ interface StorageAdapter<N extends NodeReference> {
         final EntryNodeReference entryNodeReference = accessInfo.getEntryNodeReference();
         final RealVector centroid = accessInfo.getNegatedCentroid();
         final byte[] key = entryNodeSubspace.pack();
+        // Tuple.from(Object...) is from the unannotated fdb-java client library and genuinely supports null
+        // elements (a null centroid tuple represents "no centroid"), but its varargs parameter is treated as
+        // @NonNull by NullAway's defaults.
+        @SuppressWarnings("NullAway")
         final byte[] value = Tuple.from(entryNodeReference.getLayer(),
                 entryNodeReference.getPrimaryKey(),
                 // getting underlying is okay as it is only written to the database

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/StorageAdapter.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/StorageAdapter.java
@@ -33,8 +33,7 @@ import com.apple.foundationdb.subspace.Subspace;
 import com.apple.foundationdb.tuple.Tuple;
 import com.google.common.annotations.VisibleForTesting;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -72,7 +71,6 @@ interface StorageAdapter<N extends NodeReference> {
      * construction (efConstruction), and the beam width for searching (ef).
      * @return the {@code HNSW.Config} for this graph, never {@code null}.
      */
-    @Nonnull
     Config getConfig();
 
     /**
@@ -81,7 +79,6 @@ interface StorageAdapter<N extends NodeReference> {
      * This factory is responsible for instantiating new nodes of type {@code N}.
      * @return the non-null factory for creating nodes.
      */
-    @Nonnull
     NodeFactory<N> getNodeFactory();
 
     /**
@@ -98,7 +95,6 @@ interface StorageAdapter<N extends NodeReference> {
      * method that the storage adapter actually is of the right kind (by calling{@link #isInliningStorageAdapter()}.
      * @return {@code this} as an {@link InliningStorageAdapter}
      */
-    @Nonnull
     InliningStorageAdapter asInliningStorageAdapter();
 
     /**
@@ -115,14 +111,12 @@ interface StorageAdapter<N extends NodeReference> {
      * actually is of the right kind (by calling{@link #isCompactStorageAdapter()}.
      * @return {@code this} as a {@link CompactStorageAdapter}
      */
-    @Nonnull
     CompactStorageAdapter asCompactStorageAdapter();
 
     /**
      * Get the subspace used to store this HNSW structure.
      * @return the subspace
      */
-    @Nonnull
     Subspace getSubspace();
 
     /**
@@ -132,21 +126,18 @@ interface StorageAdapter<N extends NodeReference> {
      * or other system-level information.
      * @return the subspace containing the data, which is guaranteed to be non-null
      */
-    @Nonnull
     Subspace getDataSubspace();
 
     /**
      * Get the on-write listener.
      * @return the on-write listener.
      */
-    @Nonnull
     OnWriteListener getOnWriteListener();
 
     /**
      * Get the on-read listener.
      * @return the on-read listener.
      */
-    @Nonnull
     OnReadListener getOnReadListener();
 
     /**
@@ -159,8 +150,7 @@ interface StorageAdapter<N extends NodeReference> {
      * @param node the accompanying node to {@code nodeReference}
      * @return the associated vector as {@link Transformed} of {@link RealVector}
      */
-    @Nonnull
-    Transformed<RealVector> getVector(@Nonnull N nodeReference, @Nonnull AbstractNode<N> node);
+    Transformed<RealVector> getVector(N nodeReference, AbstractNode<N> node);
 
     /**
      * Asynchronously fetches a node from a specific layer, identified by its primary key.
@@ -175,11 +165,10 @@ interface StorageAdapter<N extends NodeReference> {
      * @param primaryKey the {@link Tuple} representing the primary key of the node to retrieve
      * @return a non-null {@link CompletableFuture} which will complete with the fetched {@link AbstractNode}.
      */
-    @Nonnull
-    CompletableFuture<AbstractNode<N>> fetchNode(@Nonnull ReadTransaction readTransaction,
-                                                 @Nonnull StorageTransform storageTransform,
+    CompletableFuture<AbstractNode<N>> fetchNode(ReadTransaction readTransaction,
+                                                 StorageTransform storageTransform,
                                                  int layer,
-                                                 @Nonnull Tuple primaryKey);
+                                                 Tuple primaryKey);
 
     /**
      * Writes a node and its neighbor changes to the data store within a given transaction.
@@ -196,8 +185,8 @@ interface StorageAdapter<N extends NodeReference> {
      * @param changeSet the non-null set of changes describing additions or removals of
      *        neighbors for the given {@link AbstractNode}.
      */
-    void writeNode(@Nonnull Transaction transaction, @Nonnull Quantizer quantizer, int layer,
-                   @Nonnull AbstractNode<N> node, @Nonnull NeighborsChangeSet<N> changeSet);
+    void writeNode(Transaction transaction, Quantizer quantizer, int layer,
+                   AbstractNode<N> node, NeighborsChangeSet<N> changeSet);
 
     /**
      * Deletes a node from a particular layer in the database.
@@ -205,7 +194,7 @@ interface StorageAdapter<N extends NodeReference> {
      * @param layer the layer the node should be deleted from
      * @param primaryKey the primary key of the node
      */
-    void deleteNode(@Nonnull Transaction transaction, int layer, @Nonnull Tuple primaryKey);
+    void deleteNode(Transaction transaction, int layer, Tuple primaryKey);
 
     /**
      * Scans a specified layer of the structure, returning an iterable sequence of nodes.
@@ -222,14 +211,13 @@ interface StorageAdapter<N extends NodeReference> {
      * @return an {@link AsyncIterable} that provides the nodes found in the specified layer range
      */
     @VisibleForTesting
-    Iterable<AbstractNode<N>> scanLayer(@Nonnull ReadTransaction readTransaction, int layer,
+    Iterable<AbstractNode<N>> scanLayer(ReadTransaction readTransaction, int layer,
                                         @Nullable Tuple lastPrimaryKey, int maxNumRead);
 
-    @Nonnull
-    static CompletableFuture<AccessInfo> fetchAccessInfo(@Nonnull final Config config,
-                                                         @Nonnull final ReadTransaction readTransaction,
-                                                         @Nonnull final Subspace subspace,
-                                                         @Nonnull final OnReadListener onReadListener) {
+    static CompletableFuture<AccessInfo> fetchAccessInfo(final Config config,
+                                                         final ReadTransaction readTransaction,
+                                                         final Subspace subspace,
+                                                         final OnReadListener onReadListener) {
         final Subspace entryNodeSubspace = accessInfoSubspace(subspace);
         final byte[] key = entryNodeSubspace.pack();
 
@@ -270,10 +258,10 @@ interface StorageAdapter<N extends NodeReference> {
      * @param accessInfo the {@link AccessInfo} object to write
      * @param onWriteListener the listener to be notified after the key-value pair is written
      */
-    static void writeAccessInfo(@Nonnull final Transaction transaction,
-                                @Nonnull final Subspace subspace,
-                                @Nonnull final AccessInfo accessInfo,
-                                @Nonnull final OnWriteListener onWriteListener) {
+    static void writeAccessInfo(final Transaction transaction,
+                                final Subspace subspace,
+                                final AccessInfo accessInfo,
+                                final OnWriteListener onWriteListener) {
         final Subspace entryNodeSubspace = accessInfoSubspace(subspace);
         final EntryNodeReference entryNodeReference = accessInfo.getEntryNodeReference();
         final RealVector centroid = accessInfo.getNegatedCentroid();
@@ -294,22 +282,20 @@ interface StorageAdapter<N extends NodeReference> {
      * @param subspace the subspace where the entry node reference will be stored
      * @param onWriteListener the listener to be notified after the key-value pair is written
      */
-    static void deleteAccessInfo(@Nonnull final Transaction transaction,
-                                 @Nonnull final Subspace subspace,
-                                 @Nonnull final OnWriteListener onWriteListener) {
+    static void deleteAccessInfo(final Transaction transaction,
+                                 final Subspace subspace,
+                                 final OnWriteListener onWriteListener) {
         final Subspace entryNodeSubspace = accessInfoSubspace(subspace);
         final byte[] key = entryNodeSubspace.pack();
         transaction.clear(key);
         onWriteListener.onKeyDeleted(-1, key);
     }
 
-    @Nonnull
-    static Subspace accessInfoSubspace(@Nonnull final Subspace rootSubspace) {
+    static Subspace accessInfoSubspace(final Subspace rootSubspace) {
         return rootSubspace.subspace(Tuple.from(SUBSPACE_PREFIX_ACCESS_INFO));
     }
 
-    @Nonnull
-    static Subspace samplesSubspace(@Nonnull final Subspace rootSubspace) {
+    static Subspace samplesSubspace(final Subspace rootSubspace) {
         return rootSubspace.subspace(Tuple.from(SUBSPACE_PREFIX_SAMPLES));
     }
 }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/package-info.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/hnsw/package-info.java
@@ -21,4 +21,7 @@
 /**
  * Classes and interfaces related to the HNSW implementation as used for vector indexes.
  */
+@NullMarked
 package com.apple.foundationdb.async.hnsw;
+
+import org.jspecify.annotations.NullMarked;

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/package-info.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/package-info.java
@@ -35,4 +35,7 @@
  * {@link java.util.concurrent.CompletableFuture} class.
  * </p>
  */
+@NullMarked
 package com.apple.foundationdb.async;
+
+import org.jspecify.annotations.NullMarked;

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/AbstractChangeSet.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/AbstractChangeSet.java
@@ -23,8 +23,7 @@ package com.apple.foundationdb.async.rtree;
 import com.apple.foundationdb.Transaction;
 import com.apple.foundationdb.async.rtree.Node.ChangeSet;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Abstract base implementations for all {@link ChangeSet}s.
@@ -35,19 +34,18 @@ public abstract class AbstractChangeSet<S extends NodeSlot, N extends AbstractNo
     @Nullable
     private final ChangeSet previousChangeSet;
 
-    @Nonnull
     private final N node;
 
     private final int level;
 
-    AbstractChangeSet(@Nullable final ChangeSet previousChangeSet, @Nonnull final N node, final int level) {
+    AbstractChangeSet(@Nullable final ChangeSet previousChangeSet, final N node, final int level) {
         this.previousChangeSet = previousChangeSet;
         this.node = node;
         this.level = level;
     }
 
     @Override
-    public void apply(@Nonnull final Transaction transaction) {
+    public void apply(final Transaction transaction) {
         if (previousChangeSet != null) {
             previousChangeSet.apply(transaction);
         }
@@ -66,7 +64,6 @@ public abstract class AbstractChangeSet<S extends NodeSlot, N extends AbstractNo
      * The node this change set applies to.
      * @return the node this change set applies to
      */
-    @Nonnull
     public N getNode() {
         return node;
     }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/AbstractNode.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/AbstractNode.java
@@ -208,8 +208,11 @@ abstract class AbstractNode<S extends NodeSlot, N extends AbstractNode<S, N>> im
 
     @Override
     public String toString() {
+        // Captured once rather than calling getParentNode() twice (once to check for null, once to dereference);
+        // SpotBugs (NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE) cannot tell that two separate calls would agree.
+        final IntermediateNode parent = getParentNode();
         return "[" + getKind().name() + ": id = " + NodeHelpers.bytesToHex(getId()) + "; parent = " +
-               (getParentNode() == null ? "null" : NodeHelpers.bytesToHex(getParentNode().getId())) + "; slotInParent = " +
+               (parent == null ? "null" : NodeHelpers.bytesToHex(parent.getId())) + "; slotInParent = " +
                getSlotInParent() + "]";
     }
 }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/AbstractNode.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/AbstractNode.java
@@ -24,8 +24,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Streams;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -36,10 +35,8 @@ import java.util.stream.Stream;
  * @param <N> node type class. This is also called the self type.
  */
 abstract class AbstractNode<S extends NodeSlot, N extends AbstractNode<S, N>> implements Node {
-    @Nonnull
     private final byte[] id;
 
-    @Nonnull
     private List<S> nodeSlots;
 
     @Nullable
@@ -49,7 +46,7 @@ abstract class AbstractNode<S extends NodeSlot, N extends AbstractNode<S, N>> im
     @Nullable
     private AbstractChangeSet<S, N> changeSet;
 
-    protected AbstractNode(@Nonnull final byte[] id, @Nonnull final List<S> nodeSlots,
+    protected AbstractNode(final byte[] id, final List<S> nodeSlots,
                            @Nullable final IntermediateNode parentNode, final int slotIndexInParent) {
         this.id = id;
         this.nodeSlots = nodeSlots;
@@ -66,7 +63,6 @@ abstract class AbstractNode<S extends NodeSlot, N extends AbstractNode<S, N>> im
      */
     protected abstract N getThis();
 
-    @Nonnull
     @Override
     public byte[] getId() {
         return id;
@@ -76,7 +72,6 @@ abstract class AbstractNode<S extends NodeSlot, N extends AbstractNode<S, N>> im
      * Return the slots of this node as a list. Note that the result type is covariant.
      * @return a list of node slots
      */
-    @Nonnull
     @Override
     public List<S> getSlots() {
         return nodeSlots;
@@ -86,7 +81,6 @@ abstract class AbstractNode<S extends NodeSlot, N extends AbstractNode<S, N>> im
      * Return a sub range of the slots of this node as a list. Note that the result type is covariant.
      * @return a list of node slots
      */
-    @Nonnull
     @Override
     public List<S> getSlots(final int startIndexInclusive, final int endIndexExclusive) {
         return nodeSlots.subList(startIndexInclusive, endIndexExclusive);
@@ -102,13 +96,11 @@ abstract class AbstractNode<S extends NodeSlot, N extends AbstractNode<S, N>> im
         return nodeSlots.isEmpty();
     }
 
-    @Nonnull
     @Override
     public S getSlot(final int index) {
         return getSlots().get(index);
     }
 
-    @Nonnull
     @Override
     public Stream<? extends NodeSlot> slotsStream() {
         return nodeSlots.stream();
@@ -130,12 +122,10 @@ abstract class AbstractNode<S extends NodeSlot, N extends AbstractNode<S, N>> im
      * @param slot a slot
      * @return the same slot that was passed in, but of type {@code S}
      */
-    @Nonnull
-    public abstract S narrowSlot(@Nonnull NodeSlot slot);
+    public abstract S narrowSlot(NodeSlot slot);
 
-    @Nonnull
     @Override
-    public N moveInSlots(@Nonnull final StorageAdapter storageAdapter, @Nonnull final Iterable<? extends NodeSlot> slots) {
+    public N moveInSlots(final StorageAdapter storageAdapter, final Iterable<? extends NodeSlot> slots) {
         final AbstractStorageAdapter abstractStorageAdapter = (AbstractStorageAdapter)storageAdapter;
         final N self = getThis();
         final List<S> narrowedSlots = Streams.stream(slots).map(this::narrowSlot).collect(ImmutableList.toImmutableList());
@@ -144,16 +134,14 @@ abstract class AbstractNode<S extends NodeSlot, N extends AbstractNode<S, N>> im
         return self;
     }
 
-    @Nonnull
     @Override
-    public N moveOutAllSlots(@Nonnull final StorageAdapter storageAdapter) {
+    public N moveOutAllSlots(final StorageAdapter storageAdapter) {
         return deleteAllSlots(storageAdapter, -1);
     }
 
-    @Nonnull
     @Override
-    public N insertSlot(@Nonnull final StorageAdapter storageAdapter, final int level, final int slotIndex,
-                        @Nonnull final NodeSlot slot) {
+    public N insertSlot(final StorageAdapter storageAdapter, final int level, final int slotIndex,
+                        final NodeSlot slot) {
         final AbstractStorageAdapter abstractStorageAdapter = (AbstractStorageAdapter)storageAdapter;
         final N self = getThis();
         final S narrowedSlot = narrowSlot(slot);
@@ -162,10 +150,9 @@ abstract class AbstractNode<S extends NodeSlot, N extends AbstractNode<S, N>> im
         return self;
     }
 
-    @Nonnull
     @Override
-    public Node updateSlot(@Nonnull final StorageAdapter storageAdapter, final int level, final int slotIndex,
-                           @Nonnull final NodeSlot updatedSlot) {
+    public Node updateSlot(final StorageAdapter storageAdapter, final int level, final int slotIndex,
+                           final NodeSlot updatedSlot) {
         final AbstractStorageAdapter abstractStorageAdapter = (AbstractStorageAdapter)storageAdapter;
         final N self = getThis();
         final S narrowedSlot = narrowSlot(updatedSlot);
@@ -174,9 +161,8 @@ abstract class AbstractNode<S extends NodeSlot, N extends AbstractNode<S, N>> im
         return self;
     }
 
-    @Nonnull
     @Override
-    public Node deleteSlot(@Nonnull final StorageAdapter storageAdapter, final int level, final int slotIndex) {
+    public Node deleteSlot(final StorageAdapter storageAdapter, final int level, final int slotIndex) {
         final AbstractStorageAdapter abstractStorageAdapter = (AbstractStorageAdapter)storageAdapter;
         final N self = getThis();
         final S narrowedSlot = nodeSlots.get(slotIndex);
@@ -185,9 +171,8 @@ abstract class AbstractNode<S extends NodeSlot, N extends AbstractNode<S, N>> im
         return self;
     }
 
-    @Nonnull
     @Override
-    public N deleteAllSlots(@Nonnull final StorageAdapter storageAdapter, final int level) {
+    public N deleteAllSlots(final StorageAdapter storageAdapter, final int level) {
         final AbstractStorageAdapter abstractStorageAdapter = (AbstractStorageAdapter)storageAdapter;
         final N self = getThis();
         this.changeSet = abstractStorageAdapter.newDeleteChangeSet(self, level, this.nodeSlots);
@@ -207,7 +192,7 @@ abstract class AbstractNode<S extends NodeSlot, N extends AbstractNode<S, N>> im
     }
 
     @Override
-    public void linkToParent(@Nonnull final IntermediateNode parentNode, final int slotInParent) {
+    public void linkToParent(final IntermediateNode parentNode, final int slotInParent) {
         this.parentNode = parentNode;
         this.slotIndexInParent = slotInParent;
     }
@@ -218,12 +203,10 @@ abstract class AbstractNode<S extends NodeSlot, N extends AbstractNode<S, N>> im
      * @param nodeId node id for the new node
      * @return a new node of type {@code N}
      */
-    @Nonnull
     @Override
-    public abstract N newOfSameKind(@Nonnull byte[] nodeId);
+    public abstract N newOfSameKind(byte[] nodeId);
 
     @Override
-    @Nonnull
     public String toString() {
         return "[" + getKind().name() + ": id = " + NodeHelpers.bytesToHex(getId()) + "; parent = " +
                (getParentNode() == null ? "null" : NodeHelpers.bytesToHex(getParentNode().getId())) + "; slotInParent = " +

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/AbstractStorageAdapter.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/AbstractStorageAdapter.java
@@ -25,8 +25,7 @@ import com.apple.foundationdb.Transaction;
 import com.apple.foundationdb.subspace.Subspace;
 import com.apple.foundationdb.tuple.Tuple;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.math.BigInteger;
 import java.util.List;
 import java.util.Objects;
@@ -37,24 +36,19 @@ import java.util.function.Function;
  * Implementations and attributes common to all concrete implementations of {@link StorageAdapter}.
  */
 abstract class AbstractStorageAdapter implements StorageAdapter {
-    @Nonnull
     private final RTree.Config config;
-    @Nonnull
     private final Subspace subspace;
     @Nullable
     private final NodeSlotIndexAdapter nodeSlotIndexAdapter;
-    @Nonnull
     private final Function<RTree.Point, BigInteger> hilbertValueFunction;
-    @Nonnull
     private final OnWriteListener onWriteListener;
-    @Nonnull
     private final OnReadListener onReadListener;
 
-    protected AbstractStorageAdapter(@Nonnull final RTree.Config config, @Nonnull final Subspace subspace,
-                                     @Nonnull final Subspace nodeSlotIndexSubspace,
-                                     @Nonnull final Function<RTree.Point, BigInteger> hilbertValueFunction,
-                                     @Nonnull final OnWriteListener onWriteListener,
-                                     @Nonnull final OnReadListener onReadListener) {
+    protected AbstractStorageAdapter(final RTree.Config config, final Subspace subspace,
+                                     final Subspace nodeSlotIndexSubspace,
+                                     final Function<RTree.Point, BigInteger> hilbertValueFunction,
+                                     final OnWriteListener onWriteListener,
+                                     final OnReadListener onReadListener) {
         this.config = config;
         this.subspace = subspace;
         this.nodeSlotIndexAdapter = config.isUseNodeSlotIndex()
@@ -66,13 +60,11 @@ abstract class AbstractStorageAdapter implements StorageAdapter {
     }
 
     @Override
-    @Nonnull
     public RTree.Config getConfig() {
         return config;
     }
 
     @Override
-    @Nonnull
     public Subspace getSubspace() {
         return subspace;
     }
@@ -83,31 +75,28 @@ abstract class AbstractStorageAdapter implements StorageAdapter {
         return nodeSlotIndexAdapter == null ? null : nodeSlotIndexAdapter.getNodeSlotIndexSubspace();
     }
 
-    @Nonnull
     protected Function<RTree.Point, BigInteger> getHilbertValueFunction() {
         return hilbertValueFunction;
     }
 
     @Override
-    @Nonnull
     public OnWriteListener getOnWriteListener() {
         return onWriteListener;
     }
 
     @Override
-    @Nonnull
     public OnReadListener getOnReadListener() {
         return onReadListener;
     }
 
     @Override
-    public void writeNodes(@Nonnull final Transaction transaction, @Nonnull final List<? extends Node> nodes) {
+    public void writeNodes(final Transaction transaction, final List<? extends Node> nodes) {
         for (final Node node : nodes) {
             writeNode(transaction, node);
         }
     }
 
-    protected void writeNode(@Nonnull final Transaction transaction, @Nonnull final Node node) {
+    protected void writeNode(final Transaction transaction, final Node node) {
         final Node.ChangeSet changeSet = node.getChangeSet();
         if (changeSet == null) {
             return;
@@ -117,17 +106,15 @@ abstract class AbstractStorageAdapter implements StorageAdapter {
         getOnWriteListener().onNodeWritten(node);
     }
 
-    @Nonnull
     public byte[] packWithSubspace(final byte[] key) {
         return getSubspace().pack(key);
     }
 
-    @Nonnull
     @Override
-    public CompletableFuture<Node> scanNodeIndexAndFetchNode(@Nonnull final ReadTransaction transaction,
+    public CompletableFuture<Node> scanNodeIndexAndFetchNode(final ReadTransaction transaction,
                                                              final int level,
-                                                             @Nonnull final BigInteger hilbertValue,
-                                                             @Nonnull final Tuple key,
+                                                             final BigInteger hilbertValue,
+                                                             final Tuple key,
                                                              final boolean isInsertUpdate) {
         Objects.requireNonNull(nodeSlotIndexAdapter);
         return nodeSlotIndexAdapter.scanIndexForNodeId(transaction, level, hilbertValue, key, isInsertUpdate)
@@ -137,8 +124,8 @@ abstract class AbstractStorageAdapter implements StorageAdapter {
     }
 
     @Override
-    public void insertIntoNodeIndexIfNecessary(@Nonnull final Transaction transaction, final int level,
-                                               @Nonnull final NodeSlot nodeSlot) {
+    public void insertIntoNodeIndexIfNecessary(final Transaction transaction, final int level,
+                                               final NodeSlot nodeSlot) {
         if (!getConfig().isUseNodeSlotIndex() || !(nodeSlot instanceof ChildSlot)) {
             return;
         }
@@ -148,8 +135,8 @@ abstract class AbstractStorageAdapter implements StorageAdapter {
     }
 
     @Override
-    public void deleteFromNodeIndexIfNecessary(@Nonnull final Transaction transaction, final int level,
-                                               @Nonnull final NodeSlot nodeSlot) {
+    public void deleteFromNodeIndexIfNecessary(final Transaction transaction, final int level,
+                                               final NodeSlot nodeSlot) {
         if (!getConfig().isUseNodeSlotIndex() || !(nodeSlot instanceof ChildSlot)) {
             return;
         }
@@ -158,14 +145,12 @@ abstract class AbstractStorageAdapter implements StorageAdapter {
         nodeSlotIndexAdapter.clearChildSlot(transaction, level, (ChildSlot)nodeSlot);
     }
 
-    @Nonnull
     @Override
-    public CompletableFuture<Node> fetchNode(@Nonnull final ReadTransaction transaction, @Nonnull final byte[] nodeId) {
+    public CompletableFuture<Node> fetchNode(final ReadTransaction transaction, final byte[] nodeId) {
         return getOnWriteListener().onAsyncReadForWrite(fetchNodeInternal(transaction, nodeId).thenApply(this::checkNode));
     }
 
-    @Nonnull
-    protected abstract CompletableFuture<Node> fetchNodeInternal(@Nonnull ReadTransaction transaction, @Nonnull byte[] nodeId);
+    protected abstract CompletableFuture<Node> fetchNodeInternal(ReadTransaction transaction, byte[] nodeId);
 
     /**
      * Method to perform basic invariant check(s) on a newly-fetched node.
@@ -186,15 +171,12 @@ abstract class AbstractStorageAdapter implements StorageAdapter {
         return node;
     }
 
-    @Nonnull
     abstract <S extends NodeSlot, N extends AbstractNode<S, N>> AbstractChangeSet<S, N>
-            newInsertChangeSet(@Nonnull N node, int level, @Nonnull List<S> insertedSlots);
+            newInsertChangeSet(N node, int level, List<S> insertedSlots);
 
-    @Nonnull
     abstract <S extends NodeSlot, N extends AbstractNode<S, N>> AbstractChangeSet<S, N>
-            newUpdateChangeSet(@Nonnull N node, int level, @Nonnull S originalSlot, @Nonnull S updatedSlot);
+            newUpdateChangeSet(N node, int level, S originalSlot, S updatedSlot);
 
-    @Nonnull
     abstract <S extends NodeSlot, N extends AbstractNode<S, N>> AbstractChangeSet<S, N>
-            newDeleteChangeSet(@Nonnull N node, int level, @Nonnull List<S> deletedSlots);
+            newDeleteChangeSet(N node, int level, List<S> deletedSlots);
 }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/ByNodeStorageAdapter.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/ByNodeStorageAdapter.java
@@ -31,6 +31,7 @@ import com.google.common.collect.Streams;
 
 import java.math.BigInteger;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
@@ -167,9 +168,13 @@ class ByNodeStorageAdapter extends AbstractStorageAdapter implements StorageAdap
         Verify.verify((nodeKind == NodeKind.LEAF && itemSlots != null) ||
                       (nodeKind == NodeKind.INTERMEDIATE && childSlots != null));
 
-        return nodeKind == NodeKind.LEAF
-               ? new LeafNode(nodeId, itemSlots)
-               : new IntermediateNode(nodeId, childSlots);
+        // Verified above, but NullAway does not treat Verify.verify() as a null-check, so the invariant is
+        // re-asserted here.
+        if (nodeKind == NodeKind.LEAF) {
+            return new LeafNode(nodeId, Objects.requireNonNull(itemSlots));
+        } else {
+            return new IntermediateNode(nodeId, Objects.requireNonNull(childSlots));
+        }
     }
 
     @Override

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/ByNodeStorageAdapter.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/ByNodeStorageAdapter.java
@@ -29,7 +29,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Streams;
 
-import javax.annotation.Nonnull;
 import java.math.BigInteger;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -65,27 +64,27 @@ import java.util.function.Function;
  * </pre>
  */
 class ByNodeStorageAdapter extends AbstractStorageAdapter implements StorageAdapter {
-    public ByNodeStorageAdapter(@Nonnull final RTree.Config config, @Nonnull final Subspace subspace,
-                                @Nonnull final Subspace nodeSlotIndexSubspace,
-                                @Nonnull final Function<RTree.Point, BigInteger> hilbertValueFunction,
-                                @Nonnull final OnWriteListener onWriteListener,
-                                @Nonnull final OnReadListener onReadListener) {
+    public ByNodeStorageAdapter(final RTree.Config config, final Subspace subspace,
+                                final Subspace nodeSlotIndexSubspace,
+                                final Function<RTree.Point, BigInteger> hilbertValueFunction,
+                                final OnWriteListener onWriteListener,
+                                final OnReadListener onReadListener) {
         super(config, subspace, nodeSlotIndexSubspace, hilbertValueFunction, onWriteListener, onReadListener);
     }
 
     @Override
-    public void writeLeafNodeSlot(@Nonnull final Transaction transaction, @Nonnull final LeafNode node,
-                                  @Nonnull final ItemSlot itemSlot) {
+    public void writeLeafNodeSlot(final Transaction transaction, final LeafNode node,
+                                  final ItemSlot itemSlot) {
         persistNode(transaction, node);
     }
 
     @Override
-    public void clearLeafNodeSlot(@Nonnull final Transaction transaction, @Nonnull final LeafNode node,
-                                  @Nonnull final ItemSlot itemSlot) {
+    public void clearLeafNodeSlot(final Transaction transaction, final LeafNode node,
+                                  final ItemSlot itemSlot) {
         persistNode(transaction, node);
     }
 
-    private void persistNode(@Nonnull final Transaction transaction, @Nonnull final Node node) {
+    private void persistNode(final Transaction transaction, final Node node) {
         final byte[] packedKey = packWithSubspace(node.getId());
 
         if (node.isEmpty()) {
@@ -100,8 +99,7 @@ class ByNodeStorageAdapter extends AbstractStorageAdapter implements StorageAdap
         }
     }
 
-    @Nonnull
-    private Tuple toTuple(@Nonnull final Node node) {
+    private Tuple toTuple(final Node node) {
         final RTree.Config config = getConfig();
         final List<Tuple> slotTuples = Lists.newArrayListWithExpectedSize(node.size());
         for (final NodeSlot nodeSlot : node.getSlots()) {
@@ -113,10 +111,9 @@ class ByNodeStorageAdapter extends AbstractStorageAdapter implements StorageAdap
         return Tuple.from(node.getKind().getSerialized(), slotTuples);
     }
 
-    @Nonnull
     @Override
-    public CompletableFuture<Node> fetchNodeInternal(@Nonnull final ReadTransaction transaction,
-                                                     @Nonnull final byte[] nodeId) {
+    public CompletableFuture<Node> fetchNodeInternal(final ReadTransaction transaction,
+                                                     final byte[] nodeId) {
         final byte[] key = packWithSubspace(nodeId);
         return transaction.get(key)
                 .thenApply(valueBytes -> {
@@ -132,8 +129,7 @@ class ByNodeStorageAdapter extends AbstractStorageAdapter implements StorageAdap
     }
 
     @SuppressWarnings("unchecked")
-    @Nonnull
-    private Node fromTuple(@Nonnull final byte[] nodeId, @Nonnull final Tuple tuple) {
+    private Node fromTuple(final byte[] nodeId, final Tuple tuple) {
         final NodeKind nodeKind = NodeKind.fromSerializedNodeKind((byte)tuple.getLong(0));
         final List<Object> nodeSlotObjects = tuple.getNestedList(1);
 
@@ -176,39 +172,35 @@ class ByNodeStorageAdapter extends AbstractStorageAdapter implements StorageAdap
                : new IntermediateNode(nodeId, childSlots);
     }
 
-    @Nonnull
     @Override
     public <S extends NodeSlot, N extends AbstractNode<S, N>> AbstractChangeSet<S, N>
-            newInsertChangeSet(@Nonnull final N node, final int level, @Nonnull final List<S> insertedSlots) {
+            newInsertChangeSet(final N node, final int level, final List<S> insertedSlots) {
         return new InsertChangeSet<>(node, level, insertedSlots);
     }
 
-    @Nonnull
     @Override
     public <S extends NodeSlot, N extends AbstractNode<S, N>> AbstractChangeSet<S, N>
-            newUpdateChangeSet(@Nonnull final N node, final int level,
-                               @Nonnull final S originalSlot, @Nonnull final S updatedSlot) {
+            newUpdateChangeSet(final N node, final int level,
+                               final S originalSlot, final S updatedSlot) {
         return new UpdateChangeSet<>(node, level, originalSlot, updatedSlot);
     }
 
-    @Nonnull
     @Override
     public <S extends NodeSlot, N extends AbstractNode<S, N>> AbstractChangeSet<S, N>
-            newDeleteChangeSet(@Nonnull final N node, final int level, @Nonnull final List<S> deletedSlots) {
+            newDeleteChangeSet(final N node, final int level, final List<S> deletedSlots) {
         return new DeleteChangeSet<>(node, level, deletedSlots);
     }
 
     private class InsertChangeSet<S extends NodeSlot, N extends AbstractNode<S, N>> extends AbstractChangeSet<S, N> {
-        @Nonnull
         private final List<S> insertedSlots;
 
-        public InsertChangeSet(@Nonnull final N node, final int level, @Nonnull final List<S> insertedSlots) {
+        public InsertChangeSet(final N node, final int level, final List<S> insertedSlots) {
             super(node.getChangeSet(), node, level);
             this.insertedSlots = ImmutableList.copyOf(insertedSlots);
         }
 
         @Override
-        public void apply(@Nonnull final Transaction transaction) {
+        public void apply(final Transaction transaction) {
             super.apply(transaction);
 
             //
@@ -228,20 +220,18 @@ class ByNodeStorageAdapter extends AbstractStorageAdapter implements StorageAdap
     }
 
     private class UpdateChangeSet<S extends NodeSlot, N extends AbstractNode<S, N>> extends AbstractChangeSet<S, N> {
-        @Nonnull
         private final S originalSlot;
-        @Nonnull
         private final S updatedSlot;
 
-        public UpdateChangeSet(@Nonnull final N node, final int level, @Nonnull final S originalSlot,
-                               @Nonnull final S updatedSlot) {
+        public UpdateChangeSet(final N node, final int level, final S originalSlot,
+                               final S updatedSlot) {
             super(node.getChangeSet(), node, level);
             this.originalSlot = originalSlot;
             this.updatedSlot = updatedSlot;
         }
 
         @Override
-        public void apply(@Nonnull final Transaction transaction) {
+        public void apply(final Transaction transaction) {
             super.apply(transaction);
 
             //
@@ -260,16 +250,15 @@ class ByNodeStorageAdapter extends AbstractStorageAdapter implements StorageAdap
     }
 
     private class DeleteChangeSet<S extends NodeSlot, N extends AbstractNode<S, N>> extends AbstractChangeSet<S, N> {
-        @Nonnull
         private final List<S> deletedSlots;
 
-        public DeleteChangeSet(@Nonnull final N node, final int level, @Nonnull final List<S> deletedSlots) {
+        public DeleteChangeSet(final N node, final int level, final List<S> deletedSlots) {
             super(node.getChangeSet(), node, level);
             this.deletedSlots = ImmutableList.copyOf(deletedSlots);
         }
 
         @Override
-        public void apply(@Nonnull final Transaction transaction) {
+        public void apply(final Transaction transaction) {
             super.apply(transaction);
 
             //

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/BySlotStorageAdapter.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/BySlotStorageAdapter.java
@@ -32,7 +32,6 @@ import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
-import javax.annotation.Nonnull;
 import java.math.BigInteger;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -42,20 +41,20 @@ import java.util.function.Function;
  * Storage adapter that normalizes internal nodes such that each node slot is a key/value pair in the database.
  */
 class BySlotStorageAdapter extends AbstractStorageAdapter implements StorageAdapter {
-    public BySlotStorageAdapter(@Nonnull final RTree.Config config, @Nonnull final Subspace subspace,
-                                @Nonnull final Subspace nodeSlotIndexSubspace,
-                                @Nonnull final Function<RTree.Point, BigInteger> hilbertValueFunction,
-                                @Nonnull final OnWriteListener onWriteListener,
-                                @Nonnull final OnReadListener onReadListener) {
+    public BySlotStorageAdapter(final RTree.Config config, final Subspace subspace,
+                                final Subspace nodeSlotIndexSubspace,
+                                final Function<RTree.Point, BigInteger> hilbertValueFunction,
+                                final OnWriteListener onWriteListener,
+                                final OnReadListener onReadListener) {
         super(config, subspace, nodeSlotIndexSubspace, hilbertValueFunction, onWriteListener, onReadListener);
     }
 
     @Override
-    public void writeLeafNodeSlot(@Nonnull final Transaction transaction, @Nonnull final LeafNode node, @Nonnull final ItemSlot itemSlot) {
+    public void writeLeafNodeSlot(final Transaction transaction, final LeafNode node, final ItemSlot itemSlot) {
         writeNodeSlot(transaction, node, itemSlot);
     }
 
-    private void writeNodeSlot(@Nonnull final Transaction transaction, @Nonnull final Node node, @Nonnull final NodeSlot nodeSlot) {
+    private void writeNodeSlot(final Transaction transaction, final Node node, final NodeSlot nodeSlot) {
         Tuple keyTuple = Tuple.from(node.getKind().getSerialized());
         keyTuple = keyTuple.addAll(nodeSlot.getSlotKey(getConfig().isStoreHilbertValues()));
         final byte[] packedKey = keyTuple.pack(packWithSubspace(node.getId()));
@@ -65,11 +64,11 @@ class BySlotStorageAdapter extends AbstractStorageAdapter implements StorageAdap
     }
 
     @Override
-    public void clearLeafNodeSlot(@Nonnull final Transaction transaction, @Nonnull final LeafNode node, @Nonnull final ItemSlot itemSlot) {
+    public void clearLeafNodeSlot(final Transaction transaction, final LeafNode node, final ItemSlot itemSlot) {
         clearNodeSlot(transaction, node, itemSlot);
     }
 
-    private void clearNodeSlot(@Nonnull final Transaction transaction, @Nonnull final Node node, @Nonnull final NodeSlot nodeSlot) {
+    private void clearNodeSlot(final Transaction transaction, final Node node, final NodeSlot nodeSlot) {
         Tuple keyTuple = Tuple.from(node.getKind().getSerialized());
         keyTuple = keyTuple.addAll(nodeSlot.getSlotKey(getConfig().isStoreHilbertValues()));
         final byte[] packedKey = keyTuple.pack(packWithSubspace(node.getId()));
@@ -77,10 +76,9 @@ class BySlotStorageAdapter extends AbstractStorageAdapter implements StorageAdap
         getOnWriteListener().onKeyCleared(node, packedKey);
     }
 
-    @Nonnull
     @Override
-    public CompletableFuture<Node> fetchNodeInternal(@Nonnull final ReadTransaction transaction,
-                                                     @Nonnull final byte[] nodeId) {
+    public CompletableFuture<Node> fetchNodeInternal(final ReadTransaction transaction,
+                                                     final byte[] nodeId) {
         return AsyncUtil.collect(transaction.getRange(Range.startsWith(packWithSubspace(nodeId)),
                         ReadTransaction.ROW_LIMIT_UNLIMITED, false, StreamingMode.WANT_ALL), transaction.getExecutor())
                 .thenApply(keyValues -> {
@@ -105,8 +103,7 @@ class BySlotStorageAdapter extends AbstractStorageAdapter implements StorageAdap
      * @return an instance of a subclass of {@link Node} specific to the node kind as read from the database.
      */
     @SuppressWarnings("ConstantValue")
-    @Nonnull
-    private Node fromKeyValues(@Nonnull final byte[] nodeId, final List<KeyValue> keyValues) {
+    private Node fromKeyValues(final byte[] nodeId, final List<KeyValue> keyValues) {
         List<ItemSlot> itemSlots = null;
         List<ChildSlot> childSlots = null;
         NodeKind nodeKind = null;
@@ -157,38 +154,34 @@ class BySlotStorageAdapter extends AbstractStorageAdapter implements StorageAdap
                : new IntermediateNode(nodeId, childSlots);
     }
 
-    @Nonnull
     @Override
     public <S extends NodeSlot, N extends AbstractNode<S, N>> AbstractChangeSet<S, N>
-            newInsertChangeSet(@Nonnull final N node, final int level, @Nonnull final List<S> insertedSlots) {
+            newInsertChangeSet(final N node, final int level, final List<S> insertedSlots) {
         return new InsertChangeSet<>(node, level, insertedSlots);
     }
 
-    @Nonnull
     @Override
     public <S extends NodeSlot, N extends AbstractNode<S, N>> AbstractChangeSet<S, N>
-            newUpdateChangeSet(@Nonnull final N node, final int level, @Nonnull final S originalSlot, @Nonnull final S updatedSlot) {
+            newUpdateChangeSet(final N node, final int level, final S originalSlot, final S updatedSlot) {
         return new UpdateChangeSet<>(node, level, originalSlot, updatedSlot);
     }
 
-    @Nonnull
     @Override
     public <S extends NodeSlot, N extends AbstractNode<S, N>> AbstractChangeSet<S, N>
-            newDeleteChangeSet(@Nonnull final N node, final int level, @Nonnull final List<S> deletedSlots) {
+            newDeleteChangeSet(final N node, final int level, final List<S> deletedSlots) {
         return new DeleteChangeSet<>(node, level, deletedSlots);
     }
 
     private class InsertChangeSet<S extends NodeSlot, N extends AbstractNode<S, N>> extends AbstractChangeSet<S, N> {
-        @Nonnull
         private final List<S> insertedSlots;
 
-        public InsertChangeSet(@Nonnull final N node, final int level, @Nonnull final List<S> insertedSlots) {
+        public InsertChangeSet(final N node, final int level, final List<S> insertedSlots) {
             super(node.getChangeSet(), node, level);
             this.insertedSlots = ImmutableList.copyOf(insertedSlots);
         }
 
         @Override
-        public void apply(@Nonnull final Transaction transaction) {
+        public void apply(final Transaction transaction) {
             super.apply(transaction);
             for (final S insertedSlot : insertedSlots) {
                 writeNodeSlot(transaction, getNode(), insertedSlot);
@@ -200,20 +193,18 @@ class BySlotStorageAdapter extends AbstractStorageAdapter implements StorageAdap
     }
 
     private class UpdateChangeSet<S extends NodeSlot, N extends AbstractNode<S, N>> extends AbstractChangeSet<S, N> {
-        @Nonnull
         private final S originalSlot;
-        @Nonnull
         private final S updatedSlot;
 
-        public UpdateChangeSet(@Nonnull final N node, final int level, @Nonnull final S originalSlot,
-                               @Nonnull final S updatedSlot) {
+        public UpdateChangeSet(final N node, final int level, final S originalSlot,
+                               final S updatedSlot) {
             super(node.getChangeSet(), node, level);
             this.originalSlot = originalSlot;
             this.updatedSlot = updatedSlot;
         }
 
         @Override
-        public void apply(@Nonnull final Transaction transaction) {
+        public void apply(final Transaction transaction) {
             super.apply(transaction);
             clearNodeSlot(transaction, getNode(), originalSlot);
             writeNodeSlot(transaction, getNode(), updatedSlot);
@@ -225,16 +216,15 @@ class BySlotStorageAdapter extends AbstractStorageAdapter implements StorageAdap
     }
 
     private class DeleteChangeSet<S extends NodeSlot, N extends AbstractNode<S, N>> extends AbstractChangeSet<S, N> {
-        @Nonnull
         private final List<S> deletedSlots;
 
-        public DeleteChangeSet(@Nonnull final N node, final int level, @Nonnull final List<S> deletedSlots) {
+        public DeleteChangeSet(final N node, final int level, final List<S> deletedSlots) {
             super(node.getChangeSet(), node, level);
             this.deletedSlots = ImmutableList.copyOf(deletedSlots);
         }
 
         @Override
-        public void apply(@Nonnull final Transaction transaction) {
+        public void apply(final Transaction transaction) {
             super.apply(transaction);
             for (final S deletedSlot : deletedSlots) {
                 clearNodeSlot(transaction, getNode(), deletedSlot);

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/BySlotStorageAdapter.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/BySlotStorageAdapter.java
@@ -34,6 +34,7 @@ import com.google.common.collect.Lists;
 
 import java.math.BigInteger;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
@@ -140,18 +141,22 @@ class BySlotStorageAdapter extends AbstractStorageAdapter implements StorageAdap
         Verify.verify((nodeKind == NodeKind.LEAF && itemSlots != null && childSlots == null) ||
                       (nodeKind == NodeKind.INTERMEDIATE && itemSlots == null && childSlots != null));
 
-        if (nodeKind == NodeKind.LEAF &&
-                !getConfig().isStoreHilbertValues()) {
-            //
-            // We need to sort the slots by the computed Hilbert value/key. This is not necessary when we store
-            // the Hilbert value as fdb does the sorting for us.
-            //
-            itemSlots.sort(ItemSlot.comparator);
+        if (nodeKind == NodeKind.LEAF) {
+            // Verified above: nodeKind == LEAF implies itemSlots != null, but NullAway does not treat
+            // Verify.verify() as a null-check, so the invariant is re-asserted here.
+            final List<ItemSlot> nonNullItemSlots = Objects.requireNonNull(itemSlots);
+            if (!getConfig().isStoreHilbertValues()) {
+                //
+                // We need to sort the slots by the computed Hilbert value/key. This is not necessary when we store
+                // the Hilbert value as fdb does the sorting for us.
+                //
+                nonNullItemSlots.sort(ItemSlot.comparator);
+            }
+            return new LeafNode(nodeId, nonNullItemSlots);
+        } else {
+            // Verified above: nodeKind == INTERMEDIATE implies childSlots != null.
+            return new IntermediateNode(nodeId, Objects.requireNonNull(childSlots));
         }
-
-        return nodeKind == NodeKind.LEAF
-               ? new LeafNode(nodeId, itemSlots)
-               : new IntermediateNode(nodeId, childSlots);
     }
 
     @Override

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/ChildSlot.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/ChildSlot.java
@@ -25,7 +25,6 @@ import com.apple.foundationdb.tuple.Tuple;
 import com.apple.foundationdb.tuple.TupleHelpers;
 import com.google.common.base.Verify;
 
-import javax.annotation.Nonnull;
 import java.math.BigInteger;
 
 /**
@@ -37,23 +36,17 @@ public class ChildSlot implements NodeSlot {
     static final int SLOT_KEY_TUPLE_SIZE = 4;
     static final int SLOT_VALUE_TUPLE_SIZE = 2;
 
-    @Nonnull
     private final byte[] childId;
-    @Nonnull
     private final RTree.Rectangle mbr;
 
-    @Nonnull
     private final BigInteger smallestHilbertValue;
-    @Nonnull
     private final Tuple smallestKey;
-    @Nonnull
     private final BigInteger largestHilbertValue;
-    @Nonnull
     private final Tuple largestKey;
 
-    ChildSlot(@Nonnull final BigInteger smallestHilbertValue, @Nonnull final Tuple smallestKey,
-              @Nonnull final BigInteger largestHilbertValue, @Nonnull final Tuple largestKey,
-              @Nonnull final byte[] childId, @Nonnull final RTree.Rectangle mbr) {
+    ChildSlot(final BigInteger smallestHilbertValue, final Tuple smallestKey,
+              final BigInteger largestHilbertValue, final Tuple largestKey,
+              final byte[] childId, final RTree.Rectangle mbr) {
         this.smallestHilbertValue = smallestHilbertValue;
         this.smallestKey = smallestKey;
         this.largestHilbertValue = largestHilbertValue;
@@ -62,48 +55,40 @@ public class ChildSlot implements NodeSlot {
         this.mbr = mbr;
     }
 
-    @Nonnull
     @SpotBugsSuppressWarnings("EI_EXPOSE_REP")
     public byte[] getChildId() {
         return childId;
     }
 
-    @Nonnull
     @Override
     public BigInteger getSmallestHilbertValue() {
         return smallestHilbertValue;
     }
 
-    @Nonnull
     @Override
     public Tuple getSmallestKey() {
         return smallestKey;
     }
 
-    @Nonnull
     @Override
     public BigInteger getLargestHilbertValue() {
         return largestHilbertValue;
     }
 
-    @Nonnull
     @Override
     public Tuple getLargestKey() {
         return largestKey;
     }
 
-    @Nonnull
     public RTree.Rectangle getMbr() {
         return mbr;
     }
 
-    @Nonnull
     @Override
     public Tuple getSlotKey(final boolean storeHilbertValue) {
         return Tuple.from(getSmallestHilbertValue(), getSmallestKey(), getLargestHilbertValue(), getLargestKey());
     }
 
-    @Nonnull
     @Override
     public Tuple getSlotValue() {
         return Tuple.from(getChildId(), getMbr().getRanges());
@@ -128,14 +113,12 @@ public class ChildSlot implements NodeSlot {
         return positionTupleCompare == 0;
     }
 
-    @Nonnull
     @Override
     public String toString() {
         return "[" + getMbr() + ";" + getSmallestHilbertValue() + "; " + getLargestHilbertValue() + "]";
     }
 
-    @Nonnull
-    static ChildSlot fromKeyAndValue(@Nonnull final Tuple keyTuple, @Nonnull final Tuple valueTuple) {
+    static ChildSlot fromKeyAndValue(final Tuple keyTuple, final Tuple valueTuple) {
         Verify.verify(keyTuple.size() == SLOT_KEY_TUPLE_SIZE);
         Verify.verify(valueTuple.size() == SLOT_VALUE_TUPLE_SIZE);
         return new ChildSlot(keyTuple.getBigInteger(0), keyTuple.getNestedTuple(1),

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/IntermediateNode.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/IntermediateNode.java
@@ -22,8 +22,7 @@ package com.apple.foundationdb.async.rtree;
 
 import com.google.common.collect.Lists;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.List;
 
 /**
@@ -32,17 +31,17 @@ import java.util.List;
  * {@code largestKey} can be derived (and recomputed) if the children of this node are available to be introspected.
  */
 class IntermediateNode extends AbstractNode<ChildSlot, IntermediateNode> {
-    public IntermediateNode(@Nonnull final byte[] id) {
+    public IntermediateNode(final byte[] id) {
         this(id, Lists.newArrayList());
     }
 
-    public IntermediateNode(@Nonnull final byte[] id,
-                            @Nonnull final List<ChildSlot> childSlots) {
+    public IntermediateNode(final byte[] id,
+                            final List<ChildSlot> childSlots) {
         this(id, childSlots, null, -1);
     }
 
-    public IntermediateNode(@Nonnull final byte[] id,
-                            @Nonnull final List<ChildSlot> childSlots,
+    public IntermediateNode(final byte[] id,
+                            final List<ChildSlot> childSlots,
                             @Nullable final IntermediateNode parentNode,
                             final int slotIndexInParent) {
         super(id, childSlots, parentNode, slotIndexInParent);
@@ -53,21 +52,18 @@ class IntermediateNode extends AbstractNode<ChildSlot, IntermediateNode> {
         return this;
     }
 
-    @Nonnull
     @Override
-    public ChildSlot narrowSlot(@Nonnull final NodeSlot slot) {
+    public ChildSlot narrowSlot(final NodeSlot slot) {
         return (ChildSlot)slot;
     }
 
-    @Nonnull
     @Override
     public NodeKind getKind() {
         return NodeKind.INTERMEDIATE;
     }
 
-    @Nonnull
     @Override
-    public IntermediateNode newOfSameKind(@Nonnull final byte[] nodeId) {
+    public IntermediateNode newOfSameKind(final byte[] nodeId) {
         return new IntermediateNode(nodeId, Lists.newArrayList());
     }
 }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/ItemSlot.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/ItemSlot.java
@@ -24,7 +24,6 @@ import com.apple.foundationdb.tuple.Tuple;
 import com.apple.foundationdb.tuple.TupleHelpers;
 import com.google.common.base.Verify;
 
-import javax.annotation.Nonnull;
 import java.math.BigInteger;
 import java.util.Comparator;
 import java.util.function.Function;
@@ -40,80 +39,65 @@ public class ItemSlot implements NodeSlot {
     public static final int SLOT_KEY_TUPLE_SIZE = 2;
     public static final int SLOT_VALUE_TUPLE_SIZE = 1;
 
-    @Nonnull
     private final BigInteger hilbertValue;
-    @Nonnull
     private final Tuple key;
 
-    @Nonnull
     private final Tuple value;
-    @Nonnull
     private final RTree.Point position;
 
-    public ItemSlot(@Nonnull final BigInteger hilbertValue, @Nonnull final RTree.Point position, @Nonnull final Tuple key,
-                    @Nonnull final Tuple value) {
+    public ItemSlot(final BigInteger hilbertValue, final RTree.Point position, final Tuple key,
+                    final Tuple value) {
         this.hilbertValue = hilbertValue;
         this.key = key;
         this.value = value;
         this.position = position;
     }
 
-    @Nonnull
     public BigInteger getHilbertValue() {
         return hilbertValue;
     }
 
-    @Nonnull
     public Tuple getKey() {
         return key;
     }
 
-    @Nonnull
     public Tuple getKeySuffix() {
         return key.getNestedTuple(1);
     }
 
-    @Nonnull
     public Tuple getValue() {
         return value;
     }
 
-    @Nonnull
     public RTree.Point getPosition() {
         return position;
     }
 
-    @Nonnull
     @Override
     public BigInteger getSmallestHilbertValue() {
         return hilbertValue;
     }
 
-    @Nonnull
     @Override
     public BigInteger getLargestHilbertValue() {
         return hilbertValue;
     }
 
-    @Nonnull
     @Override
     public Tuple getSmallestKey() {
         return key;
     }
 
-    @Nonnull
     @Override
     public Tuple getLargestKey() {
         return key;
     }
 
-    @Nonnull
     @Override
     public Tuple getSlotKey(final boolean storeHilbertValues) {
         return Tuple.from(storeHilbertValues ? getHilbertValue() : null, getKey());
     }
 
-    @Nonnull
     @Override
     public Tuple getSlotValue() {
         return Tuple.from(getValue());
@@ -128,8 +112,8 @@ public class ItemSlot implements NodeSlot {
      *
      * @return {@code -1, 0, 1} if this node slot's pair is less/equal/greater than the pair passed in
      */
-    public int compareHilbertValueAndKey(@Nonnull final BigInteger hilbertValue,
-                                         @Nonnull final Tuple key) {
+    public int compareHilbertValueAndKey(final BigInteger hilbertValue,
+                                         final Tuple key) {
         final int hilbertValueCompare = getHilbertValue().compareTo(hilbertValue);
         if (hilbertValueCompare != 0) {
             return hilbertValueCompare;
@@ -142,9 +126,8 @@ public class ItemSlot implements NodeSlot {
         return "[" + getPosition() + ";" + getHilbertValue() + "; " + getKey() + "]";
     }
 
-    @Nonnull
-    static ItemSlot fromKeyAndValue(@Nonnull final Tuple keyTuple, @Nonnull final Tuple valueTuple,
-                                    @Nonnull final Function<RTree.Point, BigInteger> hilbertValueFunction) {
+    static ItemSlot fromKeyAndValue(final Tuple keyTuple, final Tuple valueTuple,
+                                    final Function<RTree.Point, BigInteger> hilbertValueFunction) {
         Verify.verify(keyTuple.size() == SLOT_KEY_TUPLE_SIZE);
         Verify.verify(valueTuple.size() == SLOT_VALUE_TUPLE_SIZE);
         final Tuple itemKey = keyTuple.getNestedTuple(1);

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/ItemSlot.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/ItemSlot.java
@@ -95,7 +95,12 @@ public class ItemSlot implements NodeSlot {
 
     @Override
     public Tuple getSlotKey(final boolean storeHilbertValues) {
-        return Tuple.from(storeHilbertValues ? getHilbertValue() : null, getKey());
+        // Tuple.from(Object...) is from the unannotated fdb-java client library and genuinely supports null
+        // elements (omitting the Hilbert value when it is not stored), but its varargs parameter is treated
+        // as @NonNull by NullAway's defaults.
+        @SuppressWarnings("NullAway")
+        final Tuple result = Tuple.from(storeHilbertValues ? getHilbertValue() : null, getKey());
+        return result;
     }
 
     @Override

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/LeafNode.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/LeafNode.java
@@ -22,21 +22,20 @@ package com.apple.foundationdb.async.rtree;
 
 import com.google.common.collect.Lists;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.List;
 
 /**
  * A leaf node of the R-tree. A leaf node holds the actual data in {@link ItemSlot}s.
  */
 class LeafNode extends AbstractNode<ItemSlot, LeafNode> {
-    public LeafNode(@Nonnull final byte[] id,
-                    @Nonnull final List<ItemSlot> itemSlots) {
+    public LeafNode(final byte[] id,
+                    final List<ItemSlot> itemSlots) {
         this(id, itemSlots, null, -1);
     }
 
-    public LeafNode(@Nonnull final byte[] id,
-                    @Nonnull final List<ItemSlot> itemSlots,
+    public LeafNode(final byte[] id,
+                    final List<ItemSlot> itemSlots,
                     @Nullable final IntermediateNode parentNode,
                     final int slotIndexInParent) {
         super(id, itemSlots, parentNode, slotIndexInParent);
@@ -47,21 +46,18 @@ class LeafNode extends AbstractNode<ItemSlot, LeafNode> {
         return this;
     }
 
-    @Nonnull
     @Override
-    public ItemSlot narrowSlot(@Nonnull final NodeSlot slot) {
+    public ItemSlot narrowSlot(final NodeSlot slot) {
         return (ItemSlot)slot;
     }
 
-    @Nonnull
     @Override
     public NodeKind getKind() {
         return NodeKind.LEAF;
     }
 
-    @Nonnull
     @Override
-    public LeafNode newOfSameKind(@Nonnull final byte[] nodeId) {
+    public LeafNode newOfSameKind(final byte[] nodeId) {
         return new LeafNode(nodeId, Lists.newArrayList());
     }
 }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/Node.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/Node.java
@@ -26,8 +26,7 @@ import com.apple.foundationdb.tuple.TupleHelpers;
 import com.google.common.base.Verify;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Objects;
@@ -50,7 +49,6 @@ public interface Node {
      * Return the id of this node.
      * @return a byte array that represents the unique identifier of this node
      */
-    @Nonnull
     byte[] getId();
 
     /**
@@ -72,7 +70,6 @@ public interface Node {
      * {@code ? extends NodeSlot} rather than the particular actual node slot type.
      * @return an {@link Iterable} of node slots.
      */
-    @Nonnull
     Iterable<? extends NodeSlot> getSlots();
 
     /**
@@ -82,7 +79,6 @@ public interface Node {
      * @param endIndexExclusive end index (exclusive)
      * @return an {@link Iterable} of node slots.
      */
-    @Nonnull
     Iterable<? extends NodeSlot> getSlots(int startIndexInclusive, int endIndexExclusive);
 
     /**
@@ -90,7 +86,6 @@ public interface Node {
      * @param index the index
      * @return a {@link NodeSlot} at position {@code index}
      */
-    @Nonnull
     NodeSlot getSlot(int index);
 
     /**
@@ -98,7 +93,6 @@ public interface Node {
      * {@code ? extends NodeSlot} rather than the particular actual node slot type.
      * @return a {@link Stream} of node slots
      */
-    @Nonnull
     Stream<? extends NodeSlot> slotsStream();
 
     /**
@@ -118,8 +112,7 @@ public interface Node {
      * @return this node
      */
     @CanIgnoreReturnValue
-    @Nonnull
-    Node moveInSlots(@Nonnull StorageAdapter storageAdapter, @Nonnull Iterable<? extends NodeSlot> slots);
+    Node moveInSlots(StorageAdapter storageAdapter, Iterable<? extends NodeSlot> slots);
 
     /**
      * Move all slots out of this node. This operation differs from the semantics of
@@ -129,8 +122,7 @@ public interface Node {
      * @return this node
      */
     @CanIgnoreReturnValue
-    @Nonnull
-    Node moveOutAllSlots(@Nonnull StorageAdapter storageAdapter);
+    Node moveOutAllSlots(StorageAdapter storageAdapter);
 
     /**
      * Insert a new slot into the node.
@@ -141,8 +133,7 @@ public interface Node {
      * @return this node
      */
     @CanIgnoreReturnValue
-    @Nonnull
-    Node insertSlot(@Nonnull StorageAdapter storageAdapter, int level, int slotIndex, @Nonnull NodeSlot slot);
+    Node insertSlot(StorageAdapter storageAdapter, int level, int slotIndex, NodeSlot slot);
 
     /**
      * Update an existing slot of this node.
@@ -153,8 +144,7 @@ public interface Node {
      * @return this node
      */
     @CanIgnoreReturnValue
-    @Nonnull
-    Node updateSlot(@Nonnull StorageAdapter storageAdapter, int level, int slotIndex, @Nonnull NodeSlot updatedSlot);
+    Node updateSlot(StorageAdapter storageAdapter, int level, int slotIndex, NodeSlot updatedSlot);
 
     /**
      * Delete a slot from the node.
@@ -164,8 +154,7 @@ public interface Node {
      * @return this node
      */
     @CanIgnoreReturnValue
-    @Nonnull
-    Node deleteSlot(@Nonnull StorageAdapter storageAdapter, int level, int slotIndex);
+    Node deleteSlot(StorageAdapter storageAdapter, int level, int slotIndex);
 
     /**
      * Delete all slots from the node.
@@ -174,8 +163,7 @@ public interface Node {
      * @return this node
      */
     @CanIgnoreReturnValue
-    @Nonnull
-    Node deleteAllSlots(@Nonnull StorageAdapter storageAdapter, int level);
+    Node deleteAllSlots(StorageAdapter storageAdapter, int level);
 
     /**
      * Returns if this node is the root node. Note that a node is considered the root node if its node id is
@@ -190,7 +178,6 @@ public interface Node {
      * Return the kind of the node, i.e. {@link NodeKind#LEAF} or {@link NodeKind#INTERMEDIATE}.
      * @return the kind of this node as a {@link NodeKind}
      */
-    @Nonnull
     NodeKind getKind();
 
     /**
@@ -229,15 +216,14 @@ public interface Node {
      * @param slotInParent the slot index indicating the {@link ChildSlot} in the parent node that corresponds to this
      *        node
      */
-    void linkToParent(@Nonnull IntermediateNode parentNode, int slotInParent);
+    void linkToParent(IntermediateNode parentNode, int slotInParent);
 
     /**
      * Create a new node that is of the same {@link NodeKind} as this node.
      * @param nodeId node id for the new node
      * @return a new empty node using the unique node id passed in
      */
-    @Nonnull
-    Node newOfSameKind(@Nonnull byte[] nodeId);
+    Node newOfSameKind(byte[] nodeId);
 
     /**
      * Method to validate the invariants of this node.
@@ -324,6 +310,6 @@ public interface Node {
          * provided.
          * @param transaction transaction to use when making all modifications
          */
-        void apply(@Nonnull Transaction transaction);
+        void apply(Transaction transaction);
     }
 }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/Node.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/Node.java
@@ -239,7 +239,9 @@ public interface Node {
                 Verify.verify(hilbertValueCompare >= 0,
                         "smallest (hilbertValue, key) pairs are not monotonically increasing (hilbertValueCheck)");
                 if (hilbertValueCompare == 0) {
-                    Verify.verify(TupleHelpers.compare(nodeSlot.getSmallestKey(), lastKey) >= 0,
+                    // lastHilbertValue != null implies lastKey != null (both are set together at the end of
+                    // each iteration below), but NullAway cannot correlate the nullness of two different locals.
+                    Verify.verify(TupleHelpers.compare(nodeSlot.getSmallestKey(), Objects.requireNonNull(lastKey)) >= 0,
                             "smallest (hilbertValue, key) pairs are not monotonically increasing (keyCheck)");
                 }
             }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/NodeHelpers.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/NodeHelpers.java
@@ -22,8 +22,7 @@ package com.apple.foundationdb.async.rtree;
 
 import com.google.common.collect.Lists;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Collections;
@@ -53,7 +52,6 @@ public class NodeHelpers {
      * production to avoid conflicts.
      * @return a new 16-byte byte array containing a new unique node identifier
      */
-    @Nonnull
     public static byte[] newRandomNodeId() {
         final UUID uuid = UUID.randomUUID();
         final byte[] uuidBytes = new byte[nodeIdLength];
@@ -70,7 +68,6 @@ public class NodeHelpers {
      * or logged. This way of creating node identifiers should only be used for testing and debugging purposes.
      * @return a new 16-byte byte array containing a new unique node identifier
      */
-    @Nonnull
     static byte[] newSequentialNodeId() {
         final long nodeIdAsLong = nodeIdState.getAndIncrement();
         final byte[] uuidBytes = new byte[nodeIdLength];
@@ -86,7 +83,6 @@ public class NodeHelpers {
      * @param bytes an array of bytes
      * @return a {@link String} containing the hexadecimal representation of the byte array passed in
      */
-    @Nonnull
     static String bytesToHex(byte[] bytes) {
         char[] hexChars = new char[bytes.length * 2];
         for (int j = 0; j < bytes.length; j++) {
@@ -102,7 +98,6 @@ public class NodeHelpers {
      * @param node a node that is usually linked up to its parents to form an insert/update path
      * @return a {@link String} containing the string presentation of the insert/update path starting at {@code node}
      */
-    @Nonnull
     static String nodeIdPath(@Nullable Node node) {
         final List<String> nodeIds = Lists.newArrayList();
         do {
@@ -123,8 +118,7 @@ public class NodeHelpers {
      * @param slots an {@link Iterable} of slots
      * @return a {@link RTree.Rectangle} representing the mbr of the {@link RTree.Point}s of the given slots.
      */
-    @Nonnull
-    static RTree.Rectangle computeMbr(@Nonnull final Iterable<? extends NodeSlot> slots) {
+    static RTree.Rectangle computeMbr(final Iterable<? extends NodeSlot> slots) {
         RTree.Rectangle mbr = null;
         for (final NodeSlot slot : slots) {
             if (slot instanceof ItemSlot) {

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/NodeKind.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/NodeKind.java
@@ -22,7 +22,6 @@ package com.apple.foundationdb.async.rtree;
 
 import com.google.common.base.Verify;
 
-import javax.annotation.Nonnull;
 
 /**
  * Enum to capture the kind of node.
@@ -41,7 +40,6 @@ public enum NodeKind {
         return serialized;
     }
 
-    @Nonnull
     static NodeKind fromSerializedNodeKind(byte serializedNodeKind) {
         final NodeKind nodeKind;
         switch (serializedNodeKind) {

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/NodeSlot.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/NodeSlot.java
@@ -23,7 +23,6 @@ package com.apple.foundationdb.async.rtree;
 import com.apple.foundationdb.tuple.Tuple;
 import com.apple.foundationdb.tuple.TupleHelpers;
 
-import javax.annotation.Nonnull;
 import java.math.BigInteger;
 
 /**
@@ -31,8 +30,8 @@ import java.math.BigInteger;
  * is refined in the subclasses {@link ItemSlot} and {@link ChildSlot}.
  */
 public interface NodeSlot {
-    static int compareHilbertValueKeyPair(@Nonnull final BigInteger hilbertValue1, @Nonnull final Tuple key1,
-                                          @Nonnull final BigInteger hilbertValue2, @Nonnull final Tuple key2) {
+    static int compareHilbertValueKeyPair(final BigInteger hilbertValue1, final Tuple key1,
+                                          final BigInteger hilbertValue2, final Tuple key2) {
         final int hilbertValueCompare = hilbertValue1.compareTo(hilbertValue2);
         if (hilbertValueCompare != 0) {
             return hilbertValueCompare;
@@ -40,24 +39,18 @@ public interface NodeSlot {
         return TupleHelpers.compare(key1, key2);
     }
 
-    @Nonnull
     BigInteger getSmallestHilbertValue();
 
-    @Nonnull
     BigInteger getLargestHilbertValue();
 
-    @Nonnull
     Tuple getSmallestKey();
 
-    @Nonnull
     default Tuple getSmallestKeySuffix() {
         return getSmallestKey().getNestedTuple(1);
     }
 
-    @Nonnull
     Tuple getLargestKey();
 
-    @Nonnull
     default Tuple getLargestKeySuffix() {
         return getLargestKey().getNestedTuple(1);
     }
@@ -70,7 +63,6 @@ public interface NodeSlot {
      *
      * @return a new tuple
      */
-    @Nonnull
     Tuple getSlotKey(boolean storeHilbertValues);
 
     /**
@@ -79,7 +71,6 @@ public interface NodeSlot {
      *
      * @return a new tuple
      */
-    @Nonnull
     Tuple getSlotValue();
 
     /**
@@ -91,8 +82,8 @@ public interface NodeSlot {
      *
      * @return {@code -1, 0, 1} if this node slot's pair is less/equal/greater than the pair passed in
      */
-    default int compareSmallestHilbertValueAndKey(@Nonnull final BigInteger hilbertValue,
-                                                  @Nonnull final Tuple key) {
+    default int compareSmallestHilbertValueAndKey(final BigInteger hilbertValue,
+                                                  final Tuple key) {
         return compareHilbertValueKeyPair(getSmallestHilbertValue(), getSmallestKey(), hilbertValue, key);
     }
 
@@ -105,8 +96,8 @@ public interface NodeSlot {
      *
      * @return {@code -1, 0, 1} if this node slot's pair is less/equal/greater than the pair passed in
      */
-    default int compareLargestHilbertValueAndKey(@Nonnull final BigInteger hilbertValue,
-                                                 @Nonnull final Tuple key) {
+    default int compareLargestHilbertValueAndKey(final BigInteger hilbertValue,
+                                                 final Tuple key) {
         return compareHilbertValueKeyPair(getLargestHilbertValue(), getLargestKey(), hilbertValue, key);
     }
 }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/NodeSlotIndexAdapter.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/NodeSlotIndexAdapter.java
@@ -31,7 +31,6 @@ import com.apple.foundationdb.tuple.Tuple;
 import com.google.common.base.Verify;
 import com.google.common.collect.Lists;
 
-import javax.annotation.Nonnull;
 import java.math.BigInteger;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -82,31 +81,26 @@ class NodeSlotIndexAdapter {
 
     private static final byte[] emptyArray = { };
 
-    @Nonnull
     private final Subspace nodeSlotIndexSubspace;
 
-    @Nonnull
     private final OnWriteListener onWriteListener;
-    @Nonnull
     private final OnReadListener onReadListener;
 
-    NodeSlotIndexAdapter(@Nonnull final Subspace nodeSlotIndexSubspace, @Nonnull final OnWriteListener onWriteListener,
-                         @Nonnull final OnReadListener onReadListener) {
+    NodeSlotIndexAdapter(final Subspace nodeSlotIndexSubspace, final OnWriteListener onWriteListener,
+                         final OnReadListener onReadListener) {
         this.nodeSlotIndexSubspace = nodeSlotIndexSubspace;
         this.onWriteListener = onWriteListener;
         this.onReadListener = onReadListener;
     }
 
-    @Nonnull
     public Subspace getNodeSlotIndexSubspace() {
         return nodeSlotIndexSubspace;
     }
 
-    @Nonnull
-    CompletableFuture<byte[]> scanIndexForNodeId(@Nonnull final ReadTransaction transaction,
+    CompletableFuture<byte[]> scanIndexForNodeId(final ReadTransaction transaction,
                                                  final int level,
-                                                 @Nonnull final BigInteger hilbertValue,
-                                                 @Nonnull final Tuple key,
+                                                 final BigInteger hilbertValue,
+                                                 final Tuple key,
                                                  final boolean isInsertUpdate) {
         final List<Object> keys = Lists.newArrayList();
         keys.add(level);
@@ -175,29 +169,27 @@ class NodeSlotIndexAdapter {
                 });
     }
 
-    void writeChildSlot(@Nonnull final Transaction transaction, final int level,
-                        @Nonnull final ChildSlot childSlot) {
+    void writeChildSlot(final Transaction transaction, final int level,
+                        final ChildSlot childSlot) {
         final Tuple indexKeyTuple = createIndexKeyTuple(level, childSlot);
         final byte[] packedKey = nodeSlotIndexSubspace.pack(indexKeyTuple);
         transaction.set(packedKey, emptyArray);
         onWriteListener.onSlotIndexEntryWritten(packedKey);
     }
 
-    void clearChildSlot(@Nonnull final Transaction transaction, final int level, @Nonnull final ChildSlot childSlot) {
+    void clearChildSlot(final Transaction transaction, final int level, final ChildSlot childSlot) {
         final Tuple indexKeyTuple = createIndexKeyTuple(level, childSlot);
         final byte[] packedKey = nodeSlotIndexSubspace.pack(indexKeyTuple);
         transaction.clear(packedKey);
         onWriteListener.onSlotIndexEntryCleared(packedKey);
     }
 
-    @Nonnull
-    private Tuple createIndexKeyTuple(final int level, @Nonnull final ChildSlot childSlot) {
+    private Tuple createIndexKeyTuple(final int level, final ChildSlot childSlot) {
         return createIndexKeyTuple(level, childSlot.getLargestHilbertValue(), childSlot.getLargestKey(), childSlot.getChildId());
     }
 
-    @Nonnull
-    private Tuple createIndexKeyTuple(final int level, @Nonnull final BigInteger largestHilbertValue,
-                                      @Nonnull final Tuple largestKey, @Nonnull final byte[] nodeId) {
+    private Tuple createIndexKeyTuple(final int level, final BigInteger largestHilbertValue,
+                                      final Tuple largestKey, final byte[] nodeId) {
         final List<Object> keys = Lists.newArrayList();
         keys.add(level);
         keys.add(largestHilbertValue);
@@ -206,7 +198,6 @@ class NodeSlotIndexAdapter {
         return Tuple.fromList(keys);
     }
 
-    @Nonnull
     private byte[] getNodeIdFromIndexKeyTuple(final Tuple tuple) {
         return tuple.getBytes(tuple.size() - 1);
     }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/OnReadListener.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/OnReadListener.java
@@ -20,7 +20,6 @@
 
 package com.apple.foundationdb.async.rtree;
 
-import javax.annotation.Nonnull;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -30,25 +29,25 @@ public interface OnReadListener {
     OnReadListener NOOP = new OnReadListener() {
     };
 
-    default void onSlotIndexEntryRead(@Nonnull final byte[] key) {
+    default void onSlotIndexEntryRead(final byte[] key) {
         // nothing
     }
 
-    default <T extends Node> CompletableFuture<T> onAsyncRead(@Nonnull CompletableFuture<T> future) {
+    default <T extends Node> CompletableFuture<T> onAsyncRead(CompletableFuture<T> future) {
         return future;
     }
 
-    default void onNodeRead(@Nonnull Node node) {
+    default void onNodeRead(Node node) {
         // nothing
     }
 
-    default void onKeyValueRead(@Nonnull Node node,
-                                @Nonnull byte[] key,
-                                @Nonnull byte[] value) {
+    default void onKeyValueRead(Node node,
+                                byte[] key,
+                                byte[] value) {
         // nothing
     }
 
-    default void onChildNodeDiscard(@Nonnull final ChildSlot childSlot) {
+    default void onChildNodeDiscard(final ChildSlot childSlot) {
         // nothing
     }
 }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/OnWriteListener.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/OnWriteListener.java
@@ -20,7 +20,6 @@
 
 package com.apple.foundationdb.async.rtree;
 
-import javax.annotation.Nonnull;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -30,34 +29,34 @@ public interface OnWriteListener {
     OnWriteListener NOOP = new OnWriteListener() {
     };
 
-    default void onSlotIndexEntryWritten(@Nonnull final byte[] key) {
+    default void onSlotIndexEntryWritten(final byte[] key) {
         // nothing
     }
 
-    default void onSlotIndexEntryCleared(@Nonnull final byte[] key) {
+    default void onSlotIndexEntryCleared(final byte[] key) {
         // nothing
     }
 
-    default <T extends Node> CompletableFuture<T> onAsyncReadForWrite(@Nonnull CompletableFuture<T> future) {
+    default <T extends Node> CompletableFuture<T> onAsyncReadForWrite(CompletableFuture<T> future) {
         return future;
     }
 
-    default void onNodeWritten(@Nonnull Node node) {
+    default void onNodeWritten(Node node) {
         // nothing
     }
 
-    default void onKeyValueWritten(@Nonnull Node node,
-                                   @Nonnull byte[] key,
-                                   @Nonnull byte[] value) {
+    default void onKeyValueWritten(Node node,
+                                   byte[] key,
+                                   byte[] value) {
         // nothing
     }
 
-    default void onNodeCleared(@Nonnull Node node) {
+    default void onNodeCleared(Node node) {
         // nothing
     }
 
-    default void onKeyCleared(@Nonnull Node node,
-                              @Nonnull byte[] key) {
+    default void onKeyCleared(Node node,
+                              byte[] key) {
         // nothing
     }
 }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/RTree.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/RTree.java
@@ -39,8 +39,7 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.math.BigInteger;
 import java.util.ArrayDeque;
 import java.util.Arrays;
@@ -183,7 +182,6 @@ public class RTree {
      * inlines slot information into the node leading to a more size-efficient layout of the data. That advantage is
      * offset by a higher likelihood of conflicts.
      */
-    @Nonnull
     public static final Storage DEFAULT_STORAGE = Storage.BY_NODE;
 
     /**
@@ -192,22 +190,14 @@ public class RTree {
      */
     public static final boolean DEFAULT_STORE_HILBERT_VALUES = true;
 
-    @Nonnull
     public static final Config DEFAULT_CONFIG = new Config();
 
-    @Nonnull
     private final StorageAdapter storageAdapter;
-    @Nonnull
     private final Executor executor;
-    @Nonnull
     private final Config config;
-    @Nonnull
     private final Function<Point, BigInteger> hilbertValueFunction;
-    @Nonnull
     private final Supplier<byte[]> nodeIdSupplier;
-    @Nonnull
     private final OnWriteListener onWriteListener;
-    @Nonnull
     private final OnReadListener onReadListener;
 
     /**
@@ -223,19 +213,17 @@ public class RTree {
          */
         BY_NODE(ByNodeStorageAdapter::new);
 
-        @Nonnull
         private final StorageAdapterCreator storageAdapterCreator;
 
-        Storage(@Nonnull final StorageAdapterCreator storageAdapterCreator) {
+        Storage(final StorageAdapterCreator storageAdapterCreator) {
             this.storageAdapterCreator = storageAdapterCreator;
         }
 
-        @Nonnull
-        private StorageAdapter newStorageAdapter(@Nonnull final Config config, @Nonnull final Subspace subspace,
-                                                 @Nonnull final Subspace nodeSlotIndexSubspace,
-                                                 @Nonnull final Function<Point, BigInteger> hilbertValueFunction,
-                                                 @Nonnull final OnWriteListener onWriteListener,
-                                                 @Nonnull final OnReadListener onReadListener) {
+        private StorageAdapter newStorageAdapter(final Config config, final Subspace subspace,
+                                                 final Subspace nodeSlotIndexSubspace,
+                                                 final Function<Point, BigInteger> hilbertValueFunction,
+                                                 final OnWriteListener onWriteListener,
+                                                 final OnReadListener onReadListener) {
             return storageAdapterCreator.create(config, subspace, nodeSlotIndexSubspace,
                     hilbertValueFunction, onWriteListener, onReadListener);
         }
@@ -245,10 +233,10 @@ public class RTree {
      * Functional interface to create a {@link StorageAdapter}.
      */
     private interface StorageAdapterCreator {
-        StorageAdapter create(@Nonnull Config config, @Nonnull Subspace subspace, @Nonnull Subspace nodeSlotIndexSubspace,
-                              @Nonnull Function<Point, BigInteger> hilbertValueFunction,
-                              @Nonnull OnWriteListener onWriteListener,
-                              @Nonnull OnReadListener onReadListener);
+        StorageAdapter create(Config config, Subspace subspace, Subspace nodeSlotIndexSubspace,
+                              Function<Point, BigInteger> hilbertValueFunction,
+                              OnWriteListener onWriteListener,
+                              OnReadListener onReadListener);
     }
 
     /**
@@ -259,7 +247,6 @@ public class RTree {
         private final int minM;
         private final int maxM;
         private final int splitS;
-        @Nonnull
         private final Storage storage;
 
         private final boolean storeHilbertValues;
@@ -274,7 +261,7 @@ public class RTree {
         }
 
         protected Config(final boolean useNodeSlotIndex, final int minM, final int maxM, final int splitS,
-                         @Nonnull final Storage storage, final boolean storeHilbertValues) {
+                         final Storage storage, final boolean storeHilbertValues) {
             this.useNodeSlotIndex = useNodeSlotIndex;
             this.minM = minM;
             this.maxM = maxM;
@@ -299,7 +286,6 @@ public class RTree {
             return splitS;
         }
 
-        @Nonnull
         public Storage getStorage() {
             return storage;
         }
@@ -331,7 +317,6 @@ public class RTree {
         private int minM = DEFAULT_MIN_M;
         private int maxM = DEFAULT_MAX_M;
         private int splitS = DEFAULT_S;
-        @Nonnull
         private Storage storage = DEFAULT_STORAGE;
         private boolean storeHilbertValues = DEFAULT_STORE_HILBERT_VALUES;
 
@@ -339,7 +324,7 @@ public class RTree {
         }
 
         public ConfigBuilder(final boolean useNodeSlotIndex, final int minM, final int maxM, final int splitS,
-                             @Nonnull final Storage storage, final boolean storeHilbertValues) {
+                             final Storage storage, final boolean storeHilbertValues) {
             this.useNodeSlotIndex = useNodeSlotIndex;
             this.minM = minM;
             this.maxM = maxM;
@@ -375,12 +360,11 @@ public class RTree {
             return this;
         }
 
-        @Nonnull
         public Storage getStorage() {
             return storage;
         }
 
-        public ConfigBuilder setStorage(@Nonnull final Storage storage) {
+        public ConfigBuilder setStorage(final Storage storage) {
             this.storage = storage;
             return this;
         }
@@ -424,8 +408,8 @@ public class RTree {
      * @param executor an executor to use when running asynchronous tasks
      * @param hilbertValueFunction function to compute the Hilbert value from a {@link Point}
      */
-    public RTree(@Nonnull final Subspace subspace, @Nonnull final Subspace secondarySubspace,
-                 @Nonnull final Executor executor, @Nonnull final Function<Point, BigInteger> hilbertValueFunction) {
+    public RTree(final Subspace subspace, final Subspace secondarySubspace,
+                 final Executor executor, final Function<Point, BigInteger> hilbertValueFunction) {
         this(subspace, secondarySubspace, executor, DEFAULT_CONFIG, hilbertValueFunction, NodeHelpers::newRandomNodeId,
                 OnWriteListener.NOOP, OnReadListener.NOOP);
     }
@@ -441,12 +425,12 @@ public class RTree {
      * @param onWriteListener an on-write listener to be called after writes take place
      * @param onReadListener an on-read listener to be called after reads take place
      */
-    public RTree(@Nonnull final Subspace subspace, @Nonnull final Subspace nodeSlotIndexSubspace,
-                 @Nonnull final Executor executor, @Nonnull final Config config,
-                 @Nonnull final Function<Point, BigInteger> hilbertValueFunction,
-                 @Nonnull final Supplier<byte[]> nodeIdSupplier,
-                 @Nonnull final OnWriteListener onWriteListener,
-                 @Nonnull final OnReadListener onReadListener) {
+    public RTree(final Subspace subspace, final Subspace nodeSlotIndexSubspace,
+                 final Executor executor, final Config config,
+                 final Function<Point, BigInteger> hilbertValueFunction,
+                 final Supplier<byte[]> nodeIdSupplier,
+                 final OnWriteListener onWriteListener,
+                 final OnReadListener onReadListener) {
         this.storageAdapter = config.getStorage()
                 .newStorageAdapter(config, subspace, nodeSlotIndexSubspace, hilbertValueFunction, onWriteListener,
                         onReadListener);
@@ -462,7 +446,6 @@ public class RTree {
      * Get the {@link StorageAdapter} used to manage this r-tree.
      * @return r-tree subspace
      */
-    @Nonnull
     StorageAdapter getStorageAdapter() {
         return storageAdapter;
     }
@@ -471,7 +454,6 @@ public class RTree {
      * Get the executer used by this r-tree.
      * @return executor used when running asynchronous tasks
      */
-    @Nonnull
     public Executor getExecutor() {
         return executor;
     }
@@ -480,7 +462,6 @@ public class RTree {
      * Get this r-tree's configuration.
      * @return r-tree configuration
      */
-    @Nonnull
     public Config getConfig() {
         return config;
     }
@@ -489,7 +470,6 @@ public class RTree {
      * Get the on-write listener.
      * @return the on-write listener
      */
-    @Nonnull
     public OnWriteListener getOnWriteListener() {
         return onWriteListener;
     }
@@ -498,7 +478,6 @@ public class RTree {
      * Get the on-read listener.
      * @return the on-read listener
      */
-    @Nonnull
     public OnReadListener getOnReadListener() {
         return onReadListener;
     }
@@ -523,10 +502,9 @@ public class RTree {
      * @param suffixKeyPredicate a predicate on the suffix key
      * @return an {@link AsyncIterator} of {@link ItemSlot}s.
      */
-    @Nonnull
-    public AsyncIterator<ItemSlot> scan(@Nonnull final ReadTransaction readTransaction,
-                                        @Nonnull final Predicate<Rectangle> mbrPredicate,
-                                        @Nonnull final BiPredicate<Tuple, Tuple> suffixKeyPredicate) {
+    public AsyncIterator<ItemSlot> scan(final ReadTransaction readTransaction,
+                                        final Predicate<Rectangle> mbrPredicate,
+                                        final BiPredicate<Tuple, Tuple> suffixKeyPredicate) {
         return scan(readTransaction, null, null, mbrPredicate, suffixKeyPredicate);
     }
 
@@ -548,12 +526,11 @@ public class RTree {
      * @param suffixKeyPredicate a predicate on the suffix key
      * @return an {@link AsyncIterator} of {@link ItemSlot}s.
      */
-    @Nonnull
-    public AsyncIterator<ItemSlot> scan(@Nonnull final ReadTransaction readTransaction,
+    public AsyncIterator<ItemSlot> scan(final ReadTransaction readTransaction,
                                         @Nullable final BigInteger lastHilbertValue,
                                         @Nullable final Tuple lastKey,
-                                        @Nonnull final Predicate<Rectangle> mbrPredicate,
-                                        @Nonnull final BiPredicate<Tuple, Tuple> suffixKeyPredicate) {
+                                        final Predicate<Rectangle> mbrPredicate,
+                                        final BiPredicate<Tuple, Tuple> suffixKeyPredicate) {
         Preconditions.checkArgument((lastHilbertValue == null && lastKey == null) ||
                                     (lastHilbertValue != null && lastKey != null));
         AsyncIterator<LeafNode> leafIterator =
@@ -577,13 +554,12 @@ public class RTree {
      * @return a {@link TraversalState} of the left-most path from {@code nodeId} to a {@link LeafNode} whose
      *         {@link Node}s all pass the mbr predicate test.
      */
-    @Nonnull
-    private CompletableFuture<TraversalState> fetchLeftmostPathToLeaf(@Nonnull final ReadTransaction readTransaction,
-                                                                      @Nonnull final byte[] nodeId,
+    private CompletableFuture<TraversalState> fetchLeftmostPathToLeaf(final ReadTransaction readTransaction,
+                                                                      final byte[] nodeId,
                                                                       @Nullable final BigInteger lastHilbertValue,
                                                                       @Nullable final Tuple lastKey,
-                                                                      @Nonnull final Predicate<Rectangle> mbrPredicate,
-                                                                      @Nonnull final BiPredicate<Tuple, Tuple> suffixPredicate) {
+                                                                      final Predicate<Rectangle> mbrPredicate,
+                                                                      final BiPredicate<Tuple, Tuple> suffixPredicate) {
         final AtomicReference<byte[]> currentId = new AtomicReference<>(nodeId);
         final List<Deque<ChildSlot>> toBeProcessed = Lists.newArrayList();
         final AtomicReference<LeafNode> leafNode = new AtomicReference<>(null);
@@ -663,13 +639,12 @@ public class RTree {
      * @return a {@link TraversalState} of the left-most path from {@code nodeId} to a {@link LeafNode} whose
      *         {@link Node}s all pass the mbr predicate test.
      */
-    @Nonnull
-    private CompletableFuture<TraversalState> fetchNextPathToLeaf(@Nonnull final ReadTransaction readTransaction,
-                                                                  @Nonnull final TraversalState traversalState,
+    private CompletableFuture<TraversalState> fetchNextPathToLeaf(final ReadTransaction readTransaction,
+                                                                  final TraversalState traversalState,
                                                                   @Nullable final BigInteger lastHilbertValue,
                                                                   @Nullable final Tuple lastKey,
-                                                                  @Nonnull final Predicate<Rectangle> mbrPredicate,
-                                                                  @Nonnull final BiPredicate<Tuple, Tuple> suffixPredicate) {
+                                                                  final Predicate<Rectangle> mbrPredicate,
+                                                                  final BiPredicate<Tuple, Tuple> suffixPredicate) {
 
         final List<Deque<ChildSlot>> toBeProcessed = traversalState.getToBeProcessed();
         final AtomicReference<LeafNode> leafNode = new AtomicReference<>(null);
@@ -710,10 +685,10 @@ public class RTree {
      */
     @Nullable
     @SuppressWarnings("PMD.AvoidBranchingStatementAsLastInLoop")
-    private static ChildSlot resolveNextIdForFetch(@Nonnull final List<Deque<ChildSlot>> toBeProcessed,
-                                                   @Nonnull final Predicate<Rectangle> mbrPredicate,
-                                                   @Nonnull final BiPredicate<Tuple, Tuple> suffixPredicate,
-                                                   @Nonnull final OnReadListener onReadListener) {
+    private static ChildSlot resolveNextIdForFetch(final List<Deque<ChildSlot>> toBeProcessed,
+                                                   final Predicate<Rectangle> mbrPredicate,
+                                                   final BiPredicate<Tuple, Tuple> suffixPredicate,
+                                                   final OnReadListener onReadListener) {
         for (int level = toBeProcessed.size() - 1; level >= 0; level--) {
             final Deque<ChildSlot> toBeProcessedThisLevel = toBeProcessed.get(level);
 
@@ -755,11 +730,10 @@ public class RTree {
      * @param value the additional value to be stored with the item
      * @return a completable future that completes when the insert is completed
      */
-    @Nonnull
-    public CompletableFuture<Void> insertOrUpdate(@Nonnull final TransactionContext tc,
-                                                  @Nonnull final Point point,
-                                                  @Nonnull final Tuple keySuffix,
-                                                  @Nonnull final Tuple value) {
+    public CompletableFuture<Void> insertOrUpdate(final TransactionContext tc,
+                                                  final Point point,
+                                                  final Tuple keySuffix,
+                                                  final Tuple value) {
         final BigInteger hilbertValue = hilbertValueFunction.apply(point);
         final Tuple itemKey = Tuple.from(point.getCoordinates(), keySuffix);
 
@@ -787,13 +761,12 @@ public class RTree {
      * @param value the additional value to be stored with the item
      * @return a completable future that completes when the insert/update is completed
      */
-    @Nonnull
-    private CompletableFuture<Void> insertOrUpdateSlot(@Nonnull final Transaction transaction,
-                                                       @Nonnull final LeafNode targetNode,
-                                                       @Nonnull final Point point,
-                                                       @Nonnull final BigInteger hilbertValue,
-                                                       @Nonnull final Tuple key,
-                                                       @Nonnull final Tuple value) {
+    private CompletableFuture<Void> insertOrUpdateSlot(final Transaction transaction,
+                                                       final LeafNode targetNode,
+                                                       final Point point,
+                                                       final BigInteger hilbertValue,
+                                                       final Tuple key,
+                                                       final Tuple value) {
         Verify.verify(targetNode.size() <= config.getMaxM());
 
         final AtomicInteger level = new AtomicInteger(0);
@@ -864,13 +837,12 @@ public class RTree {
      *        information; we can avoid searching for the proper spot on our own.
      * @return a completable future that when completed indicates what needs to be done next (see {@link NodeOrAdjust}).
      */
-    @Nonnull
-    private CompletableFuture<NodeOrAdjust> insertSlotIntoTargetNode(@Nonnull final Transaction transaction,
+    private CompletableFuture<NodeOrAdjust> insertSlotIntoTargetNode(final Transaction transaction,
                                                                      final int level,
-                                                                     @Nonnull final BigInteger hilbertValue,
-                                                                     @Nonnull final Tuple key,
-                                                                     @Nonnull final Node targetNode,
-                                                                     @Nonnull final NodeSlot newSlot,
+                                                                     final BigInteger hilbertValue,
+                                                                     final Tuple key,
+                                                                     final Node targetNode,
+                                                                     final NodeSlot newSlot,
                                                                      final int slotIndexInTargetNode) {
         if (targetNode.size() < config.getMaxM()) {
             // enough space left in target
@@ -1055,9 +1027,9 @@ public class RTree {
      * @param level the level counting starting at {@code 0} indicating the leaf level increasing upwards
      * @param oldRootNode the old root node
      */
-    private void splitRootNode(@Nonnull final Transaction transaction,
+    private void splitRootNode(final Transaction transaction,
                                final int level,
-                               @Nonnull final Node oldRootNode) {
+                               final Node oldRootNode) {
         final Node leftNode = oldRootNode.newOfSameKind(nodeIdSupplier.get());
         final Node rightNode = oldRootNode.newOfSameKind(nodeIdSupplier.get());
         final int leftSize = oldRootNode.size() / 2;
@@ -1097,10 +1069,9 @@ public class RTree {
      * @param keySuffix the additional key to be stored with the item
      * @return a completable future that completes when the delete operation is completed
      */
-    @Nonnull
-    public CompletableFuture<Void> delete(@Nonnull final TransactionContext tc,
-                                          @Nonnull final Point point,
-                                          @Nonnull final Tuple keySuffix) {
+    public CompletableFuture<Void> delete(final TransactionContext tc,
+                                          final Point point,
+                                          final Tuple keySuffix) {
         final BigInteger hilbertValue = hilbertValueFunction.apply(point);
         final Tuple itemKey = Tuple.from(point.getCoordinates(), keySuffix);
 
@@ -1126,11 +1097,10 @@ public class RTree {
      * @param key the additional key to be stored with the item
      * @return a completable future that completes when the delete is completed
      */
-    @Nonnull
-    private CompletableFuture<Void> deleteSlotIfExists(@Nonnull final Transaction transaction,
-                                                       @Nonnull final LeafNode targetNode,
-                                                       @Nonnull final BigInteger hilbertValue,
-                                                       @Nonnull final Tuple key) {
+    private CompletableFuture<Void> deleteSlotIfExists(final Transaction transaction,
+                                                       final LeafNode targetNode,
+                                                       final BigInteger hilbertValue,
+                                                       final Tuple key) {
         Verify.verify(targetNode.size() <= config.getMaxM());
 
         final AtomicInteger level = new AtomicInteger(0);
@@ -1203,13 +1173,12 @@ public class RTree {
      *        information; we can avoid searching for the proper spot on our own.
      * @return a completable future that when completed indicates what needs to be done next (see {@link NodeOrAdjust}).
      */
-    @Nonnull
-    private CompletableFuture<NodeOrAdjust> deleteSlotFromTargetNode(@Nonnull final Transaction transaction,
+    private CompletableFuture<NodeOrAdjust> deleteSlotFromTargetNode(final Transaction transaction,
                                                                      final int level,
                                                                      final BigInteger hilbertValue,
                                                                      final Tuple key,
-                                                                     @Nonnull final Node targetNode,
-                                                                     @Nonnull final NodeSlot deleteSlot,
+                                                                     final Node targetNode,
+                                                                     final NodeSlot deleteSlot,
                                                                      final int slotIndexInTargetNode) {
         //
         // We need to keep the number of slots per node between minM <= size() <= maxM unless this is the root node.
@@ -1384,7 +1353,7 @@ public class RTree {
      * @param oldRootNode the old root node
      * @param toBePromotedNode node to be promoted.
      */
-    private void promoteNodeToRoot(final @Nonnull Transaction transaction, final int level, final IntermediateNode oldRootNode,
+    private void promoteNodeToRoot(final Transaction transaction, final int level, final IntermediateNode oldRootNode,
                                    final Node toBePromotedNode) {
         oldRootNode.deleteAllSlots(storageAdapter, level);
 
@@ -1412,12 +1381,11 @@ public class RTree {
      *         {@link NodeOrAdjust#ADJUST} if the slots of the parent node of the target node need to be adjusted as
      *         well.
      */
-    @Nonnull
-    private CompletableFuture<NodeOrAdjust> updateSlotsAndAdjustNode(@Nonnull final Transaction transaction,
+    private CompletableFuture<NodeOrAdjust> updateSlotsAndAdjustNode(final Transaction transaction,
                                                                      final int level,
-                                                                     @Nonnull final BigInteger hilbertValue,
-                                                                     @Nonnull final Tuple key,
-                                                                     @Nonnull final Node targetNode,
+                                                                     final BigInteger hilbertValue,
+                                                                     final Tuple key,
+                                                                     final Node targetNode,
                                                                      final boolean isInsertUpdate) {
         storageAdapter.writeNodes(transaction, Collections.singletonList(targetNode));
 
@@ -1438,7 +1406,7 @@ public class RTree {
      *         inform the caller if modifications need to be persisted and/or if the parent node itseld=f needs to be
      *         adjusted as well.
      */
-    private boolean adjustSlotInParent(@Nonnull final Node targetNode, final int level) {
+    private boolean adjustSlotInParent(final Node targetNode, final int level) {
         Preconditions.checkArgument(!targetNode.isRoot());
         boolean slotHasChanged;
         final IntermediateNode parentNode = Objects.requireNonNull(targetNode.getParentNode());
@@ -1462,10 +1430,9 @@ public class RTree {
         return slotHasChanged;
     }
 
-    @Nonnull
-    private CompletableFuture<LeafNode> fetchPathForModification(@Nonnull final Transaction transaction,
-                                                                 @Nonnull final BigInteger hilbertValue,
-                                                                 @Nonnull final Tuple key,
+    private CompletableFuture<LeafNode> fetchPathForModification(final Transaction transaction,
+                                                                 final BigInteger hilbertValue,
+                                                                 final Tuple key,
                                                                  final boolean isInsertUpdate) {
         if (config.isUseNodeSlotIndex()) {
             return scanIndexAndFetchLeafNode(transaction, hilbertValue, key, isInsertUpdate);
@@ -1474,10 +1441,9 @@ public class RTree {
         }
     }
 
-    @Nonnull
-    private CompletableFuture<LeafNode> scanIndexAndFetchLeafNode(@Nonnull final ReadTransaction transaction,
-                                                                  @Nonnull final BigInteger hilbertValue,
-                                                                  @Nonnull final Tuple key,
+    private CompletableFuture<LeafNode> scanIndexAndFetchLeafNode(final ReadTransaction transaction,
+                                                                  final BigInteger hilbertValue,
+                                                                  final Tuple key,
                                                                   final boolean isInsertUpdate) {
         return storageAdapter.scanNodeIndexAndFetchNode(transaction, 0, hilbertValue, key, isInsertUpdate)
                 .thenApply(node -> {
@@ -1487,11 +1453,10 @@ public class RTree {
                 });
     }
 
-    @Nonnull
-    private CompletableFuture<IntermediateNode> scanIndexAndFetchIntermediateNode(@Nonnull final ReadTransaction transaction,
+    private CompletableFuture<IntermediateNode> scanIndexAndFetchIntermediateNode(final ReadTransaction transaction,
                                                                                   final int level,
-                                                                                  @Nonnull final BigInteger hilbertValue,
-                                                                                  @Nonnull final Tuple key,
+                                                                                  final BigInteger hilbertValue,
+                                                                                  final Tuple key,
                                                                                   final boolean isInsertUpdate) {
         Verify.verify(level > 0);
         return storageAdapter.scanNodeIndexAndFetchNode(transaction, level, hilbertValue, key, isInsertUpdate)
@@ -1508,12 +1473,11 @@ public class RTree {
                 });
     }
 
-    @Nonnull
-    private CompletableFuture<IntermediateNode> fetchParentNodeIfNecessary(@Nonnull final ReadTransaction transaction,
-                                                                           @Nonnull final Node node,
+    private CompletableFuture<IntermediateNode> fetchParentNodeIfNecessary(final ReadTransaction transaction,
+                                                                           final Node node,
                                                                            final int level,
-                                                                           @Nonnull final BigInteger hilbertValue,
-                                                                           @Nonnull final Tuple key,
+                                                                           final BigInteger hilbertValue,
+                                                                           final Tuple key,
                                                                            final boolean isInsertUpdate) {
         Verify.verify(!node.isRoot());
         final IntermediateNode linkedParentNode = node.getParentNode();
@@ -1547,10 +1511,9 @@ public class RTree {
      *         all intermediate nodes up to the root node that may get affected by an insert, update, or delete
      *         of the specified item.
      */
-    @Nonnull
-    private CompletableFuture<LeafNode> fetchUpdatePathToLeaf(@Nonnull final Transaction transaction,
-                                                              @Nonnull final BigInteger hilbertValue,
-                                                              @Nonnull final Tuple key,
+    private CompletableFuture<LeafNode> fetchUpdatePathToLeaf(final Transaction transaction,
+                                                              final BigInteger hilbertValue,
+                                                              final Tuple key,
                                                               final boolean isInsertUpdate) {
         final AtomicReference<IntermediateNode> parentNode = new AtomicReference<>(null);
         final AtomicInteger slotInParent = new AtomicInteger(-1);
@@ -1612,9 +1575,8 @@ public class RTree {
      *         passed in as good as possible meaning that we attempt to return the node passed in as middle-most element
      *         of the returned list.
      */
-    @Nonnull
-    private CompletableFuture<List<Node>> fetchSiblings(@Nonnull final Transaction transaction,
-                                                        @Nonnull final Node node) {
+    private CompletableFuture<List<Node>> fetchSiblings(final Transaction transaction,
+                                                        final Node node) {
         // this deque is only modified by once upon creation
         final ArrayDeque<byte[]> toBeProcessed = new ArrayDeque<>();
         final List<CompletableFuture<Void>> working = Lists.newArrayList();
@@ -1683,7 +1645,7 @@ public class RTree {
      * @param transactionContext transaction context to be used
      * @return the depth of the R-tree
      */
-    public int depth(@Nonnull final TransactionContext transactionContext) {
+    public int depth(final TransactionContext transactionContext) {
         //
         // find the number of levels in this tree
         //
@@ -1708,7 +1670,7 @@ public class RTree {
      * Method to validate the Hilbert R-tree.
      * @param db the database to use
      */
-    public void validate(@Nonnull final Database db) {
+    public void validate(final Database db) {
         validate(db, Integer.MAX_VALUE);
     }
 
@@ -1717,7 +1679,7 @@ public class RTree {
      * @param db the database to use
      * @param maxNumNodesToBeValidated a maximum number of nodes this call should attempt to validate
      */
-    public void validate(@Nonnull final Database db,
+    public void validate(final Database db,
                          final int maxNumNodesToBeValidated) {
 
         ArrayDeque<ValidationTraversalState> toBeProcessed = new ArrayDeque<>();
@@ -1736,10 +1698,9 @@ public class RTree {
      * @return a completable future that completes successfully with the current deque of to-be-processed nodes if the
      *         portion of the tree that was validated is in fact valid, completes with failure otherwise
      */
-    @Nonnull
-    private CompletableFuture<ArrayDeque<ValidationTraversalState>> validate(@Nonnull final Transaction transaction,
+    private CompletableFuture<ArrayDeque<ValidationTraversalState>> validate(final Transaction transaction,
                                                                              final int maxNumNodesToBeValidated,
-                                                                             @Nonnull final ArrayDeque<ValidationTraversalState> toBeProcessed) {
+                                                                             final ArrayDeque<ValidationTraversalState> toBeProcessed) {
         final AtomicInteger numNodesEnqueued = new AtomicInteger(0);
         final List<CompletableFuture<List<ValidationTraversalState>>> working = Lists.newArrayList();
 
@@ -1854,9 +1815,9 @@ public class RTree {
      *         compared smaller than {@code p}. If, on the contrary, a record is deleted and a slot covering {@code p}
      *         cannot be found, this method returns {@code -1}.
      */
-    private static int findChildSlotIndex(@Nonnull final IntermediateNode intermediateNode,
-                                          @Nonnull final BigInteger hilbertValue,
-                                          @Nonnull final Tuple key,
+    private static int findChildSlotIndex(final IntermediateNode intermediateNode,
+                                          final BigInteger hilbertValue,
+                                          final Tuple key,
                                           final boolean isInsertUpdate) {
         Verify.verify(!intermediateNode.isEmpty());
 
@@ -1900,7 +1861,7 @@ public class RTree {
      * @return if found the 0-based slot index that corresponds to slot using holding the given {@code childId};
      *         {@code -1} otherwise
      */
-    private static int findChildSlotIndex(@Nonnull final IntermediateNode parentNode, @Nonnull final byte[] childId) {
+    private static int findChildSlotIndex(final IntermediateNode parentNode, final byte[] childId) {
         for (int slotIndex = 0; slotIndex < parentNode.size(); slotIndex++) {
             final ChildSlot childSlot = parentNode.getSlot(slotIndex);
 
@@ -1921,9 +1882,9 @@ public class RTree {
      *         the 0-based slot index that represents the insertion point index of the given {@code (hilbertValue, key)}
      *         pair, otherwise
      */
-    private static int findInsertUpdateItemSlotIndex(@Nonnull final LeafNode leafNode,
-                                                     @Nonnull final BigInteger hilbertValue,
-                                                     @Nonnull final Tuple key) {
+    private static int findInsertUpdateItemSlotIndex(final LeafNode leafNode,
+                                                     final BigInteger hilbertValue,
+                                                     final Tuple key) {
         for (int slotIndex = 0; slotIndex < leafNode.size(); slotIndex++) {
             final ItemSlot slot = leafNode.getSlot(slotIndex);
 
@@ -1950,9 +1911,9 @@ public class RTree {
      *         the 0-based slot index that corresponds to the slot for the given {@code (hilbertValue, key)}
      *         pair, otherwise
      */
-    private static int findDeleteItemSlotIndex(@Nonnull final LeafNode leafNode,
-                                               @Nonnull final BigInteger hilbertValue,
-                                               @Nonnull final Tuple key) {
+    private static int findDeleteItemSlotIndex(final LeafNode leafNode,
+                                               final BigInteger hilbertValue,
+                                               final Tuple key) {
         for (int slotIndex = 0; slotIndex < leafNode.size(); slotIndex++) {
             final ItemSlot slot = leafNode.getSlot(slotIndex);
 
@@ -1989,12 +1950,10 @@ public class RTree {
             this.currentLeafNode = currentLeafNode;
         }
 
-        @Nonnull
         public List<Deque<ChildSlot>> getToBeProcessed() {
             return Objects.requireNonNull(toBeProcessed);
         }
 
-        @Nonnull
         public LeafNode getCurrentLeafNode() {
             return Objects.requireNonNull(currentLeafNode);
         }
@@ -2003,7 +1962,7 @@ public class RTree {
             return currentLeafNode == null;
         }
 
-        public static TraversalState of(@Nonnull final List<Deque<ChildSlot>> toBeProcessed, @Nonnull final LeafNode currentLeafNode) {
+        public static TraversalState of(final List<Deque<ChildSlot>> toBeProcessed, final LeafNode currentLeafNode) {
             return new TraversalState(toBeProcessed, currentLeafNode);
         }
 
@@ -2020,17 +1979,13 @@ public class RTree {
      * intermediate {@link TraversalState}s created by these methods.
      */
     private class LeafIterator implements AsyncIterator<LeafNode> {
-        @Nonnull
         private final ReadTransaction readTransaction;
-        @Nonnull
         private final byte[] rootId;
         @Nullable
         private final BigInteger lastHilbertValue;
         @Nullable
         private final Tuple lastKey;
-        @Nonnull
         private final Predicate<Rectangle> mbrPredicate;
-        @Nonnull
         private final BiPredicate<Tuple, Tuple> suffixKeyPredicate;
 
         @Nullable
@@ -2038,9 +1993,9 @@ public class RTree {
         @Nullable
         private CompletableFuture<TraversalState> nextStateFuture;
 
-        public LeafIterator(@Nonnull final ReadTransaction readTransaction, @Nonnull final byte[] rootId,
+        public LeafIterator(final ReadTransaction readTransaction, final byte[] rootId,
                             @Nullable final BigInteger lastHilbertValue, @Nullable final Tuple lastKey,
-                            @Nonnull final Predicate<Rectangle> mbrPredicate, @Nonnull final BiPredicate<Tuple, Tuple> suffixKeyPredicate) {
+                            final Predicate<Rectangle> mbrPredicate, final BiPredicate<Tuple, Tuple> suffixKeyPredicate) {
             Preconditions.checkArgument((lastHilbertValue == null && lastKey == null) ||
                                         (lastHilbertValue != null && lastKey != null));
             this.readTransaction = readTransaction;
@@ -2097,14 +2052,13 @@ public class RTree {
      * {@code Streams.stream(leafIterator).flatMap(leafNode -> leafNode.getItems().stream()).toIterator()}.
      */
     public static class ItemSlotIterator implements AsyncIterator<ItemSlot> {
-        @Nonnull
         private final AsyncIterator<LeafNode> leafIterator;
         @Nullable
         private LeafNode currentLeafNode;
         @Nullable
         private Iterator<ItemSlot> currenLeafItemsIterator;
 
-        private ItemSlotIterator(@Nonnull final AsyncIterator<LeafNode> leafIterator) {
+        private ItemSlotIterator(final AsyncIterator<LeafNode> leafIterator) {
             this.leafIterator = leafIterator;
             this.currentLeafNode = null;
             this.currenLeafItemsIterator = null;
@@ -2198,10 +2152,9 @@ public class RTree {
         final int level;
         @Nullable
         private final IntermediateNode parentNode;
-        @Nonnull
         private final byte[] childId;
 
-        public ValidationTraversalState(final int level, @Nullable final IntermediateNode parentNode, @Nonnull final byte[] childId) {
+        public ValidationTraversalState(final int level, @Nullable final IntermediateNode parentNode, final byte[] childId) {
             this.level = level;
             this.parentNode = parentNode;
             this.childId = childId;
@@ -2216,7 +2169,6 @@ public class RTree {
             return parentNode;
         }
 
-        @Nonnull
         public byte[] getChildId() {
             return childId;
         }
@@ -2228,15 +2180,13 @@ public class RTree {
      * numbers.
      */
     public static class Point {
-        @Nonnull
         private final Tuple coordinates;
 
-        public Point(@Nonnull final Tuple coordinates) {
+        public Point(final Tuple coordinates) {
             Preconditions.checkArgument(!coordinates.isEmpty());
             this.coordinates = coordinates;
         }
 
-        @Nonnull
         public Tuple getCoordinates() {
             return coordinates;
         }
@@ -2272,7 +2222,6 @@ public class RTree {
             return coordinates.hashCode();
         }
 
-        @Nonnull
         @Override
         public String toString() {
             return coordinates.toString();
@@ -2290,7 +2239,6 @@ public class RTree {
          * {@code (low1, low2, ..., lowN, high1, high2, ..., highN}. Note that we don't use nested {@link Tuple}s for
          * space-saving reasons (when the tuple is serialized).
          */
-        @Nonnull
         private final Tuple ranges;
 
         public Rectangle(final Tuple ranges) {
@@ -2302,22 +2250,18 @@ public class RTree {
             return ranges.size() >> 1;
         }
 
-        @Nonnull
         public Tuple getRanges() {
             return ranges;
         }
 
-        @Nonnull
         public Object getLow(final int dimension) {
             return ranges.get(dimension);
         }
 
-        @Nonnull
         public Object getHigh(final int dimension) {
             return ranges.get((ranges.size() >> 1) + dimension);
         }
 
-        @Nonnull
         public BigInteger area() {
             BigInteger currentArea = BigInteger.ONE;
             for (int d = 0; d < getNumDimensions(); d++) {
@@ -2326,8 +2270,7 @@ public class RTree {
             return currentArea;
         }
 
-        @Nonnull
-        public Rectangle unionWith(@Nonnull final Point point) {
+        public Rectangle unionWith(final Point point) {
             Preconditions.checkArgument(getNumDimensions() == point.getNumDimensions());
             boolean isModified = false;
             Object[] ranges = new Object[getNumDimensions() << 1];
@@ -2361,8 +2304,7 @@ public class RTree {
             return new Rectangle(Tuple.from(ranges));
         }
 
-        @Nonnull
-        public Rectangle unionWith(@Nonnull final Rectangle other) {
+        public Rectangle unionWith(final Rectangle other) {
             Preconditions.checkArgument(getNumDimensions() == other.getNumDimensions());
             boolean isModified = false;
             Object[] ranges = new Object[getNumDimensions() << 1];
@@ -2398,7 +2340,7 @@ public class RTree {
             return new Rectangle(Tuple.from(ranges));
         }
 
-        public boolean isOverlapping(@Nonnull final Rectangle other) {
+        public boolean isOverlapping(final Rectangle other) {
             Preconditions.checkArgument(getNumDimensions() == other.getNumDimensions());
 
             for (int d = 0; d < getNumDimensions(); d++) {
@@ -2416,7 +2358,7 @@ public class RTree {
             return true;
         }
 
-        public boolean contains(@Nonnull final Point point) {
+        public boolean contains(final Point point) {
             Preconditions.checkArgument(getNumDimensions() == point.getNumDimensions());
 
             for (int d = 0; d < getNumDimensions(); d++) {
@@ -2450,7 +2392,6 @@ public class RTree {
             return ranges.hashCode();
         }
 
-        @Nonnull
         public String toPlotString() {
             final StringBuilder builder = new StringBuilder();
             for (int d = 0; d < getNumDimensions(); d++) {
@@ -2471,14 +2412,12 @@ public class RTree {
             return builder.toString();
         }
 
-        @Nonnull
         @Override
         public String toString() {
             return ranges.toString();
         }
         
-        @Nonnull
-        public static Rectangle fromPoint(@Nonnull final Point point) {
+        public static Rectangle fromPoint(final Point point) {
             final Object[] mbrRanges = new Object[point.getNumDimensions() * 2];
             for (int d = 0; d < point.getNumDimensions(); d++) {
                 final Object coordinate = point.getCoordinate(d);

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/RTree.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/RTree.java
@@ -813,9 +813,12 @@ public class RTree {
                             }
                             currentNode.set(currentNodeValue.getParentNode());
                             parentSlot.set(nodeOrAdjust.getSlotInParent());
-                            insertSlotIndex.set(nodeOrAdjust.getSplitNode() == null ? -1 : nodeOrAdjust.getSplitNode().getSlotIndexInParent());
+                            // Captured once rather than calling getSplitNode() three times; SpotBugs
+                            // (NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE) cannot tell that the separate calls would agree.
+                            final Node splitNode = nodeOrAdjust.getSplitNode();
+                            insertSlotIndex.set(splitNode == null ? -1 : splitNode.getSlotIndexInParent());
                             level.incrementAndGet();
-                            return nodeOrAdjust.getSplitNode() != null || nodeOrAdjust.parentNeedsAdjustment();
+                            return splitNode != null || nodeOrAdjust.parentNeedsAdjustment();
                         });
             } else {
                 // adjustment only
@@ -1153,9 +1156,12 @@ public class RTree {
                             }
                             currentNode.set(currentNodeValue.getParentNode());
                             parentSlot.set(nodeOrAdjust.getSlotInParent());
-                            deleteSlotIndex.set(nodeOrAdjust.getTombstoneNode() == null ? -1 : nodeOrAdjust.getTombstoneNode().getSlotIndexInParent());
+                            // Captured once rather than calling getTombstoneNode() three times; SpotBugs
+                            // (NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE) cannot tell that the separate calls would agree.
+                            final Node tombstoneNode = nodeOrAdjust.getTombstoneNode();
+                            deleteSlotIndex.set(tombstoneNode == null ? -1 : tombstoneNode.getSlotIndexInParent());
                             level.incrementAndGet();
-                            return nodeOrAdjust.getTombstoneNode() != null || nodeOrAdjust.parentNeedsAdjustment();
+                            return tombstoneNode != null || nodeOrAdjust.parentNeedsAdjustment();
                         });
             } else {
                 // adjustment only
@@ -1676,9 +1682,14 @@ public class RTree {
         }
 
         int numLevels = 1;
-        while (node.getParentNode() != null) {
+        // Captured once per level rather than calling getParentNode() twice (once in the loop condition, once in
+        // the body); SpotBugs (NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE) cannot tell that two separate calls would
+        // agree.
+        IntermediateNode parentNode = node.getParentNode();
+        while (parentNode != null) {
             numLevels ++;
-            node = node.getParentNode();
+            node = parentNode;
+            parentNode = node.getParentNode();
         }
         Verify.verify(node.isRoot(), "end of update path should be the root");
         logger.trace("numLevels = {}", numLevels);

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/RTree.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/RTree.java
@@ -563,10 +563,14 @@ public class RTree {
         final AtomicReference<byte[]> currentId = new AtomicReference<>(nodeId);
         final List<Deque<ChildSlot>> toBeProcessed = Lists.newArrayList();
         final AtomicReference<LeafNode> leafNode = new AtomicReference<>(null);
-        return AsyncUtil.whileTrue(() -> onReadListener.onAsyncRead(storageAdapter.fetchNode(readTransaction, currentId.get()))
+        return AsyncUtil.whileTrue(() -> {
+            // currentId is only ever set (below) via Objects.requireNonNull(...), so it is never actually null;
+            // NullAway still models AtomicReference#get() as @Nullable, so the invariant is re-asserted here.
+            final byte[] currentIdValue = Objects.requireNonNull(currentId.get());
+            return onReadListener.onAsyncRead(storageAdapter.fetchNode(readTransaction, currentIdValue))
                 .thenApply(node -> {
                     if (node == null) {
-                        if (Arrays.equals(currentId.get(), rootId)) {
+                        if (Arrays.equals(currentIdValue, rootId)) {
                             Verify.verify(leafNode.get() == null);
                             return false;
                         }
@@ -621,7 +625,8 @@ public class RTree {
                         leafNode.set((LeafNode)node);
                         return false;
                     }
-                }), executor).thenApply(vignore -> leafNode.get() == null
+                });
+        }, executor).thenApply(vignore -> leafNode.get() == null
                                                    ? TraversalState.end()
                                                    : TraversalState.of(toBeProcessed, leafNode.get()));
     }
@@ -795,14 +800,18 @@ public class RTree {
         //
         return AsyncUtil.whileTrue(() -> {
             final NodeSlot currentNewSlot = parentSlot.get();
+            // currentNode is only ever set (below) to the parent of a node already confirmed non-root, which by
+            // the tree's linkage invariant is always non-null once reached; NullAway still models
+            // AtomicReference#get() as @Nullable, so the invariant is re-asserted here.
+            final Node currentNodeValue = Objects.requireNonNull(currentNode.get());
 
             if (currentNewSlot != null) {
-                return insertSlotIntoTargetNode(transaction, level.get(), hilbertValue, key, currentNode.get(), currentNewSlot, insertSlotIndex.get())
+                return insertSlotIntoTargetNode(transaction, level.get(), hilbertValue, key, currentNodeValue, currentNewSlot, insertSlotIndex.get())
                         .thenApply(nodeOrAdjust -> {
-                            if (currentNode.get().isRoot()) {
+                            if (currentNodeValue.isRoot()) {
                                 return false;
                             }
-                            currentNode.set(currentNode.get().getParentNode());
+                            currentNode.set(currentNodeValue.getParentNode());
                             parentSlot.set(nodeOrAdjust.getSlotInParent());
                             insertSlotIndex.set(nodeOrAdjust.getSplitNode() == null ? -1 : nodeOrAdjust.getSplitNode().getSlotIndexInParent());
                             level.incrementAndGet();
@@ -810,13 +819,13 @@ public class RTree {
                         });
             } else {
                 // adjustment only
-                return updateSlotsAndAdjustNode(transaction, level.get(), hilbertValue, key, currentNode.get(), true)
+                return updateSlotsAndAdjustNode(transaction, level.get(), hilbertValue, key, currentNodeValue, true)
                         .thenApply(nodeOrAdjust -> {
                             Verify.verify(nodeOrAdjust.getSlotInParent() == null);
-                            if (currentNode.get().isRoot()) {
+                            if (currentNodeValue.isRoot()) {
                                 return false;
                             }
-                            currentNode.set(currentNode.get().getParentNode());
+                            currentNode.set(currentNodeValue.getParentNode());
                             level.incrementAndGet();
                             return nodeOrAdjust.parentNeedsAdjustment();
                         });
@@ -1131,14 +1140,18 @@ public class RTree {
         //
         return AsyncUtil.whileTrue(() -> {
             final NodeSlot currentDeleteSlot = parentSlot.get();
+            // currentNode is only ever set (below) to the parent of a node already confirmed non-root, which by
+            // the tree's linkage invariant is always non-null once reached; NullAway still models
+            // AtomicReference#get() as @Nullable, so the invariant is re-asserted here.
+            final Node currentNodeValue = Objects.requireNonNull(currentNode.get());
 
             if (currentDeleteSlot != null) {
-                return deleteSlotFromTargetNode(transaction, level.get(), hilbertValue, key, currentNode.get(), currentDeleteSlot, deleteSlotIndex.get())
+                return deleteSlotFromTargetNode(transaction, level.get(), hilbertValue, key, currentNodeValue, currentDeleteSlot, deleteSlotIndex.get())
                         .thenApply(nodeOrAdjust -> {
-                            if (currentNode.get().isRoot()) {
+                            if (currentNodeValue.isRoot()) {
                                 return false;
                             }
-                            currentNode.set(currentNode.get().getParentNode());
+                            currentNode.set(currentNodeValue.getParentNode());
                             parentSlot.set(nodeOrAdjust.getSlotInParent());
                             deleteSlotIndex.set(nodeOrAdjust.getTombstoneNode() == null ? -1 : nodeOrAdjust.getTombstoneNode().getSlotIndexInParent());
                             level.incrementAndGet();
@@ -1146,13 +1159,13 @@ public class RTree {
                         });
             } else {
                 // adjustment only
-                return updateSlotsAndAdjustNode(transaction, level.get(), hilbertValue, key, currentNode.get(), false)
+                return updateSlotsAndAdjustNode(transaction, level.get(), hilbertValue, key, currentNodeValue, false)
                         .thenApply(nodeOrAdjust -> {
                             Verify.verify(nodeOrAdjust.getSlotInParent() == null);
-                            if (currentNode.get().isRoot()) {
+                            if (currentNodeValue.isRoot()) {
                                 return false;
                             }
-                            currentNode.set(currentNode.get().getParentNode());
+                            currentNode.set(currentNodeValue.getParentNode());
                             level.incrementAndGet();
                             return nodeOrAdjust.parentNeedsAdjustment();
                         });
@@ -1519,10 +1532,15 @@ public class RTree {
         final AtomicInteger slotInParent = new AtomicInteger(-1);
         final AtomicReference<byte[]> currentId = new AtomicReference<>(rootId);
         final AtomicReference<LeafNode> leafNode = new AtomicReference<>(null);
-        return AsyncUtil.whileTrue(() -> storageAdapter.fetchNode(transaction, currentId.get())
+        return AsyncUtil.whileTrue(() -> {
+                    // currentId is only ever set (below) to a ChildSlot's non-null child id, so it is never
+                    // actually null; NullAway still models AtomicReference#get() as @Nullable, so the
+                    // invariant is re-asserted here.
+                    final byte[] currentIdValue = Objects.requireNonNull(currentId.get());
+                    return storageAdapter.fetchNode(transaction, currentIdValue)
                         .thenApply(node -> {
                             if (node == null) {
-                                if (Arrays.equals(currentId.get(), rootId)) {
+                                if (Arrays.equals(currentIdValue, rootId)) {
                                     Verify.verify(leafNode.get() == null);
                                     return false;
                                 }
@@ -1551,7 +1569,8 @@ public class RTree {
                                 leafNode.set((LeafNode)node);
                                 return false;
                             }
-                        }), executor)
+                        });
+                }, executor)
                 .thenApply(ignored -> {
                     final LeafNode node = leafNode.get();
                     if (logger.isTraceEnabled()) {
@@ -2270,6 +2289,13 @@ public class RTree {
             return currentArea;
         }
 
+        // A Tuple's element can genuinely be null (Tuple explicitly supports null entries), so
+        // point.getCoordinate(d) is correctly declared @Nullable. ranges is a plain Object[] here (rather
+        // than a @Nullable Object[]) because it is ultimately handed to Tuple.from(Object...), an external,
+        // unannotated varargs API that NullAway would misflag as array-of-nullable-into-array-of-nonnull
+        // regardless of how ranges is declared. Suppressed at the method level since every null-related
+        // finding in this method traces back to this one, already-understood situation.
+        @SuppressWarnings("NullAway")
         public Rectangle unionWith(final Point point) {
             Preconditions.checkArgument(getNumDimensions() == point.getNumDimensions());
             boolean isModified = false;
@@ -2362,6 +2388,9 @@ public class RTree {
             Preconditions.checkArgument(getNumDimensions() == point.getNumDimensions());
 
             for (int d = 0; d < getNumDimensions(); d++) {
+                // A Tuple's element (point.getCoordinate(d)) can genuinely be null; Tuple.from(Object...) is an
+                // external, unannotated varargs API that NullAway misflags as requiring non-null elements.
+                @SuppressWarnings("NullAway")
                 final Tuple otherTuple = Tuple.from(point.getCoordinate(d));
 
                 final Tuple lowTuple = Tuple.from(getLow(d));
@@ -2417,6 +2446,9 @@ public class RTree {
             return ranges.toString();
         }
         
+        // A Tuple's element can genuinely be null (see unionWith(Point) above for the full rationale);
+        // mbrRanges ends up passed to the external, unannotated Tuple.from(Object...) either way.
+        @SuppressWarnings("NullAway")
         public static Rectangle fromPoint(final Point point) {
             final Object[] mbrRanges = new Object[point.getNumDimensions() * 2];
             for (int d = 0; d < point.getNumDimensions(); d++) {

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/RTree.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/RTree.java
@@ -1533,44 +1533,44 @@ public class RTree {
         final AtomicReference<byte[]> currentId = new AtomicReference<>(rootId);
         final AtomicReference<LeafNode> leafNode = new AtomicReference<>(null);
         return AsyncUtil.whileTrue(() -> {
-                    // currentId is only ever set (below) to a ChildSlot's non-null child id, so it is never
-                    // actually null; NullAway still models AtomicReference#get() as @Nullable, so the
-                    // invariant is re-asserted here.
-                    final byte[] currentIdValue = Objects.requireNonNull(currentId.get());
-                    return storageAdapter.fetchNode(transaction, currentIdValue)
-                        .thenApply(node -> {
-                            if (node == null) {
-                                if (Arrays.equals(currentIdValue, rootId)) {
-                                    Verify.verify(leafNode.get() == null);
-                                    return false;
-                                }
-                                throw new IllegalStateException("unable to fetch node for insert or update");
-                            }
-                            if (parentNode.get() != null) {
-                                node.linkToParent(parentNode.get(), slotInParent.get());
-                            }
-                            if (node.getKind() == NodeKind.INTERMEDIATE) {
-                                final IntermediateNode intermediateNode = (IntermediateNode)node;
-                                final int slotIndex = findChildSlotIndex(intermediateNode, hilbertValue, key, isInsertUpdate);
-                                if (slotIndex < 0) {
-                                    Verify.verify(!isInsertUpdate);
-                                    //
-                                    // This is for a delete operation and we were unable to find a child that covers
-                                    // the Hilbert Value/key to be deleted
-                                    return false;
-                                }
+            // currentId is only ever set (below) to a ChildSlot's non-null child id, so it is never
+            // actually null; NullAway still models AtomicReference#get() as @Nullable, so the
+            // invariant is re-asserted here.
+            final byte[] currentIdValue = Objects.requireNonNull(currentId.get());
+            return storageAdapter.fetchNode(transaction, currentIdValue)
+                .thenApply(node -> {
+                    if (node == null) {
+                        if (Arrays.equals(currentIdValue, rootId)) {
+                            Verify.verify(leafNode.get() == null);
+                            return false;
+                        }
+                        throw new IllegalStateException("unable to fetch node for insert or update");
+                    }
+                    if (parentNode.get() != null) {
+                        node.linkToParent(parentNode.get(), slotInParent.get());
+                    }
+                    if (node.getKind() == NodeKind.INTERMEDIATE) {
+                        final IntermediateNode intermediateNode = (IntermediateNode)node;
+                        final int slotIndex = findChildSlotIndex(intermediateNode, hilbertValue, key, isInsertUpdate);
+                        if (slotIndex < 0) {
+                            Verify.verify(!isInsertUpdate);
+                            //
+                            // This is for a delete operation and we were unable to find a child that covers
+                            // the Hilbert Value/key to be deleted
+                            return false;
+                        }
 
-                                parentNode.set(intermediateNode);
-                                slotInParent.set(slotIndex);
-                                final ChildSlot childSlot = intermediateNode.getSlot(slotIndex);
-                                currentId.set(childSlot.getChildId());
-                                return true;
-                            } else {
-                                leafNode.set((LeafNode)node);
-                                return false;
-                            }
-                        });
-                }, executor)
+                        parentNode.set(intermediateNode);
+                        slotInParent.set(slotIndex);
+                        final ChildSlot childSlot = intermediateNode.getSlot(slotIndex);
+                        currentId.set(childSlot.getChildId());
+                        return true;
+                    } else {
+                        leafNode.set((LeafNode)node);
+                        return false;
+                    }
+                });
+        }, executor)
                 .thenApply(ignored -> {
                     final LeafNode node = leafNode.get();
                     if (logger.isTraceEnabled()) {

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/RTreeHilbertCurveHelpers.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/RTreeHilbertCurveHelpers.java
@@ -22,7 +22,6 @@ package com.apple.foundationdb.async.rtree;
 
 import com.apple.foundationdb.annotation.API;
 
-import javax.annotation.Nonnull;
 import java.math.BigInteger;
 import java.util.Arrays;
 
@@ -37,7 +36,7 @@ public class RTreeHilbertCurveHelpers {
         // do not instantiate
     }
 
-    public static BigInteger hilbertValue(@Nonnull final RTree.Point point) {
+    public static BigInteger hilbertValue(final RTree.Point point) {
         int numBits = 64;
         final long[] shiftedCoordinates = new long[point.getNumDimensions()];
         for (int i = 0; i < point.getNumDimensions(); i++) {

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/StorageAdapter.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/StorageAdapter.java
@@ -25,8 +25,7 @@ import com.apple.foundationdb.Transaction;
 import com.apple.foundationdb.subspace.Subspace;
 import com.apple.foundationdb.tuple.Tuple;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.math.BigInteger;
 import java.util.List;
 import java.util.UUID;
@@ -40,7 +39,6 @@ interface StorageAdapter {
      * Get the {@link RTree.Config} associated with this storage adapter.
      * @return the configuration used by this storage adapter
      */
-    @Nonnull
     RTree.Config getConfig();
 
     /**
@@ -48,7 +46,6 @@ interface StorageAdapter {
      *
      * @return r-tree subspace
      */
-    @Nonnull
     Subspace getSubspace();
 
     /**
@@ -64,7 +61,6 @@ interface StorageAdapter {
      *
      * @return the on-write listener.
      */
-    @Nonnull
     OnWriteListener getOnWriteListener();
 
     /**
@@ -72,7 +68,6 @@ interface StorageAdapter {
      *
      * @return the on-read listener.
      */
-    @Nonnull
     OnReadListener getOnReadListener();
 
     /**
@@ -82,7 +77,7 @@ interface StorageAdapter {
      * @param level the level counting starting at {@code 0} indicating the leaf level increasing upwards
      * @param nodeSlot the {@link NodeSlot} to be inserted
      */
-    void insertIntoNodeIndexIfNecessary(@Nonnull Transaction transaction, int level, @Nonnull NodeSlot nodeSlot);
+    void insertIntoNodeIndexIfNecessary(Transaction transaction, int level, NodeSlot nodeSlot);
 
     /**
      * Deletes an entry from the node index if configuration indicates we should maintain such an index.
@@ -91,7 +86,7 @@ interface StorageAdapter {
      * @param level the level counting starting at {@code 0} indicating the leaf level increasing upwards
      * @param nodeSlot the {@link NodeSlot} to be deleted
      */
-    void deleteFromNodeIndexIfNecessary(@Nonnull Transaction transaction, int level, @Nonnull NodeSlot nodeSlot);
+    void deleteFromNodeIndexIfNecessary(Transaction transaction, int level, NodeSlot nodeSlot);
 
     /**
      * Persist a node slot.
@@ -100,7 +95,7 @@ interface StorageAdapter {
      * @param node node whose slot to persist
      * @param itemSlot the node slot to persist
      */
-    void writeLeafNodeSlot(@Nonnull Transaction transaction, @Nonnull LeafNode node, @Nonnull ItemSlot itemSlot);
+    void writeLeafNodeSlot(Transaction transaction, LeafNode node, ItemSlot itemSlot);
 
     /**
      * Clear out a leaf node slot.
@@ -109,7 +104,7 @@ interface StorageAdapter {
      * @param node node whose slot is cleared out
      * @param itemSlot the node slot to clear out
      */
-    void clearLeafNodeSlot(@Nonnull Transaction transaction, @Nonnull LeafNode node, @Nonnull ItemSlot itemSlot);
+    void clearLeafNodeSlot(Transaction transaction, LeafNode node, ItemSlot itemSlot);
 
     /**
      * Method to (re-)persist a list of nodes passed in.
@@ -117,7 +112,7 @@ interface StorageAdapter {
      * @param transaction the transaction to use
      * @param nodes a list of nodes to be (re-persisted)
      */
-    void writeNodes(@Nonnull Transaction transaction, @Nonnull List<? extends Node> nodes);
+    void writeNodes(Transaction transaction, List<? extends Node> nodes);
 
     /**
      * Scan the node slot index for the given Hilbert Value/key pair and return the appropriate {@link Node}.
@@ -134,9 +129,8 @@ interface StorageAdapter {
      * @return a future that when completed holds the appropriate {@link Node} or {@code null} if such a
      * {@link Node} could not be found.
      */
-    @Nonnull
-    CompletableFuture<Node> scanNodeIndexAndFetchNode(@Nonnull ReadTransaction transaction, int level,
-                                                      @Nonnull BigInteger hilbertValue, @Nonnull Tuple key,
+    CompletableFuture<Node> scanNodeIndexAndFetchNode(ReadTransaction transaction, int level,
+                                                      BigInteger hilbertValue, Tuple key,
                                                       boolean isInsertUpdate);
 
     /**
@@ -151,6 +145,5 @@ interface StorageAdapter {
      * @return A completable future containing the {@link Node} that was fetched from the database once completed.
      * The node may be an object of {@link LeafNode} or of {@link IntermediateNode}.
      */
-    @Nonnull
-    CompletableFuture<Node> fetchNode(@Nonnull ReadTransaction transaction, @Nonnull byte[] nodeId);
+    CompletableFuture<Node> fetchNode(ReadTransaction transaction, byte[] nodeId);
 }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/package-info.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/async/rtree/package-info.java
@@ -21,4 +21,7 @@
 /**
  * Classes and interfaces related to the Hilbert R-tree implementation.
  */
+@NullMarked
 package com.apple.foundationdb.async.rtree;
+
+import org.jspecify.annotations.NullMarked;

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/clientlog/DatabaseClientLogEventCounter.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/clientlog/DatabaseClientLogEventCounter.java
@@ -27,7 +27,6 @@ import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.async.CloseableAsyncIterator;
 
-import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -38,7 +37,6 @@ import java.util.concurrent.CompletableFuture;
  */
 @API(API.Status.EXPERIMENTAL)
 public class DatabaseClientLogEventCounter implements DatabaseClientLogEvents.EventConsumer {
-    @Nonnull
     private final TupleKeyCountTree root;
     private final boolean countReads;
     private final boolean countWrites;
@@ -46,7 +44,7 @@ public class DatabaseClientLogEventCounter implements DatabaseClientLogEvents.Ev
     private final boolean countRanges;
     private final boolean byAddress;
 
-    public DatabaseClientLogEventCounter(@Nonnull TupleKeyCountTree root, boolean countReads, boolean countWrites, boolean countSingleKeys, boolean countRanges, boolean byAddress) {
+    public DatabaseClientLogEventCounter(TupleKeyCountTree root, boolean countReads, boolean countWrites, boolean countSingleKeys, boolean countRanges, boolean byAddress) {
         this.root = root;
         this.countReads = countReads;
         this.countWrites = countWrites;
@@ -62,7 +60,7 @@ public class DatabaseClientLogEventCounter implements DatabaseClientLogEvents.Ev
      * @return a future that completes when the event has been processed
      */
     @Override
-    public CompletableFuture<Void> accept(@Nonnull Transaction tr, @Nonnull FDBClientLogEvents.Event event) {
+    public CompletableFuture<Void> accept(Transaction tr, FDBClientLogEvents.Event event) {
         switch (event.getType()) {
             case FDBClientLogEvents.GET_VERSION_LATENCY:
                 break;
@@ -102,7 +100,7 @@ public class DatabaseClientLogEventCounter implements DatabaseClientLogEvents.Ev
         return AsyncUtil.DONE;
     }
 
-    protected CompletableFuture<Void> addKey(@Nonnull Transaction tr, @Nonnull byte[] key) {
+    protected CompletableFuture<Void> addKey(Transaction tr, byte[] key) {
         if (byAddress) {
             return addKeyAddresses(tr, key);
         } else {
@@ -111,7 +109,7 @@ public class DatabaseClientLogEventCounter implements DatabaseClientLogEvents.Ev
         }
     }
 
-    protected CompletableFuture<Void> addKeyAddresses(@Nonnull Transaction tr, @Nonnull byte[] key) {
+    protected CompletableFuture<Void> addKeyAddresses(Transaction tr, byte[] key) {
         return LocalityUtil.getAddressesForKey(tr, key).handle((addresses, ex) -> {
             if (ex == null) {
                 for (String address : addresses) {
@@ -122,7 +120,7 @@ public class DatabaseClientLogEventCounter implements DatabaseClientLogEvents.Ev
         });
     }
 
-    protected CompletableFuture<Void> addRange(@Nonnull Transaction tr, @Nonnull Range range) {
+    protected CompletableFuture<Void> addRange(Transaction tr, Range range) {
         if (byAddress) {
             return addKeyAddresses(tr, range.begin).thenCompose(vignore -> {
                 final CloseableAsyncIterator<byte[]> boundaryKeys = LocalityUtil.getBoundaryKeys(tr, range.begin, range.end);
@@ -145,7 +143,7 @@ public class DatabaseClientLogEventCounter implements DatabaseClientLogEvents.Ev
         }
     }
 
-    protected CompletableFuture<Void> addCommit(@Nonnull Transaction tr, @Nonnull FDBClientLogEvents.CommitRequest commitRequest) {
+    protected CompletableFuture<Void> addCommit(Transaction tr, FDBClientLogEvents.CommitRequest commitRequest) {
         final List<CompletableFuture<Void>> futures = new ArrayList<>();
         for (FDBClientLogEvents.Mutation mutation : commitRequest.getMutations()) {
             CompletableFuture<Void> future = AsyncUtil.DONE;

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/clientlog/DatabaseClientLogEvents.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/clientlog/DatabaseClientLogEvents.java
@@ -35,6 +35,7 @@ import com.apple.foundationdb.tuple.ByteArrayUtil;
 import org.jspecify.annotations.Nullable;
 
 import java.time.Instant;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
@@ -126,8 +127,11 @@ public class DatabaseClientLogEvents {
 
         public CompletableFuture<DatabaseClientLogEvents> run() {
             return AsyncUtil.whileTrue(this::loop).thenApply(vignore -> {
-                events.updateForRun(eventCount, limitReached);
-                return events;
+                // loop() always ensures events is set (either it was already, or the first iteration created
+                // one) before this future can complete, but that invariant does not survive the lambda boundary.
+                final DatabaseClientLogEvents currentEvents = Objects.requireNonNull(events);
+                currentEvents.updateForRun(eventCount, limitReached);
+                return currentEvents;
             });
         }
 
@@ -137,7 +141,11 @@ public class DatabaseClientLogEvents {
             transactionOptions.setReadSystemKeys();
             transactionOptions.setReadLockAware();
             if (events == null) {
-                return versionRangeProducer.apply(tr).thenCompose(versions -> {
+                // events == null implies versionRangeProducer != null: the two constructors set exactly one of
+                // the two fields, and events only ever transitions from null to non-null (never back), but
+                // NullAway cannot correlate the nullness of two different fields.
+                final Function<ReadTransaction, CompletableFuture<Long[]>> currentVersionRangeProducer = Objects.requireNonNull(versionRangeProducer);
+                return currentVersionRangeProducer.apply(tr).thenCompose(versions -> {
                     final Long startVersion = versions[0];
                     final byte[] startKey = startVersion == null ? SystemKeyspace.CLIENT_LOG_KEY_PREFIX : FDBClientLogEvents.eventKeyForVersion(startVersion);
                     final Long endVersion = versions[1];
@@ -151,9 +159,13 @@ public class DatabaseClientLogEvents {
         }
 
         private CompletableFuture<Boolean> loopBody() {
-            final AsyncIterable<KeyValue> range = events.getRange(tr);
+            // events and tr are always set by loop() before it calls this method (either on a previous call, or
+            // just above on this one), but NullAway does not track that across the two methods.
+            final DatabaseClientLogEvents currentEvents = Objects.requireNonNull(events);
+            final Transaction currentTr = Objects.requireNonNull(tr);
+            final AsyncIterable<KeyValue> range = currentEvents.getRange(currentTr);
             return FDBClientLogEvents.forEachEvent(range, this).thenApply(lastProcessedKey -> {
-                events.updateForTransaction(lastProcessedKey);
+                currentEvents.updateForTransaction(lastProcessedKey);
                 return false;   // Return to caller if range processed or limit reached.
             }).handle((b, t) -> {
                 if (tr != null) {
@@ -179,8 +191,11 @@ public class DatabaseClientLogEvents {
         @Override
         public CompletableFuture<Void> accept(FDBClientLogEvents.Event event) {
             eventCount++;
-            events.updateForEvent(event.getStartTimestamp());
-            return callback.accept(tr, event);
+            // Set by loop()/loopBody() before this callback can be invoked (see loopBody() above).
+            final DatabaseClientLogEvents currentEvents = Objects.requireNonNull(events);
+            final Transaction currentTr = Objects.requireNonNull(tr);
+            currentEvents.updateForEvent(event.getStartTimestamp());
+            return callback.accept(currentTr, event);
         }
 
         @Override
@@ -205,7 +220,11 @@ public class DatabaseClientLogEvents {
 
     private void updateForTransaction(@Nullable byte[] lastProcessedKey) {
         if (lastProcessedKey != null) {
-            startKey = ByteArrayUtil.join(lastProcessedKey, new byte[1]);   // The immediately following key.
+            // NullAway does not reliably narrow @Nullable byte[] locals, even via a direct null check on the
+            // same variable immediately above.
+            @SuppressWarnings("NullAway")
+            final byte[] joined = ByteArrayUtil.join(lastProcessedKey, new byte[1]);   // The immediately following key.
+            startKey = joined;
         } else {
             startKey = endKey;  // Empty range.
         }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/clientlog/DatabaseClientLogEvents.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/clientlog/DatabaseClientLogEvents.java
@@ -160,10 +160,11 @@ public class DatabaseClientLogEvents {
 
         private CompletableFuture<Boolean> loopBody() {
             // events and tr are always set by loop() before it calls this method (either on a previous call, or
-            // just above on this one), but NullAway does not track that across the two methods.
+            // just above on this one), but NullAway does not track that across the two methods. tr is deliberately
+            // not bound to a local variable here (only passed inline) so that the close() on the tr field below
+            // remains the sole, PMD-visible close point for this Transaction.
             final DatabaseClientLogEvents currentEvents = Objects.requireNonNull(events);
-            final Transaction currentTr = Objects.requireNonNull(tr);
-            final AsyncIterable<KeyValue> range = currentEvents.getRange(currentTr);
+            final AsyncIterable<KeyValue> range = currentEvents.getRange(Objects.requireNonNull(tr));
             return FDBClientLogEvents.forEachEvent(range, this).thenApply(lastProcessedKey -> {
                 currentEvents.updateForTransaction(lastProcessedKey);
                 return false;   // Return to caller if range processed or limit reached.
@@ -191,11 +192,11 @@ public class DatabaseClientLogEvents {
         @Override
         public CompletableFuture<Void> accept(FDBClientLogEvents.Event event) {
             eventCount++;
-            // Set by loop()/loopBody() before this callback can be invoked (see loopBody() above).
+            // Set by loop()/loopBody() before this callback can be invoked (see loopBody() above). tr is
+            // deliberately not bound to a local variable here (see the comment in loopBody() above).
             final DatabaseClientLogEvents currentEvents = Objects.requireNonNull(events);
-            final Transaction currentTr = Objects.requireNonNull(tr);
             currentEvents.updateForEvent(event.getStartTimestamp());
-            return callback.accept(currentTr, event);
+            return callback.accept(Objects.requireNonNull(tr), event);
         }
 
         @Override

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/clientlog/DatabaseClientLogEvents.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/clientlog/DatabaseClientLogEvents.java
@@ -32,8 +32,8 @@ import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.system.SystemKeyspace;
 import com.apple.foundationdb.tuple.ByteArrayUtil;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import java.time.Instant;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -45,9 +45,7 @@ import java.util.function.Function;
  */
 @API(API.Status.EXPERIMENTAL)
 public class DatabaseClientLogEvents {
-    @Nonnull
     private byte[] startKey;
-    @Nonnull
     private byte[] endKey;
     @Nullable
     private Instant earliestTimestamp;
@@ -61,10 +59,10 @@ public class DatabaseClientLogEvents {
      */
     @FunctionalInterface
     public interface EventConsumer {
-        CompletableFuture<Void> accept(@Nonnull Transaction tr, @Nonnull FDBClientLogEvents.Event event);
+        CompletableFuture<Void> accept(Transaction tr, FDBClientLogEvents.Event event);
     }
     
-    private DatabaseClientLogEvents(@Nonnull byte[] startKey, @Nonnull byte[] endKey) {
+    private DatabaseClientLogEvents(byte[] startKey, byte[] endKey) {
         this.startKey = startKey;
         this.endKey = endKey;
     }
@@ -88,13 +86,10 @@ public class DatabaseClientLogEvents {
     }
 
     protected static class EventRunner implements FDBClientLogEvents.EventConsumer {
-        @Nonnull
         private final Database database;
-        @Nonnull
         private final Executor executor;
         @Nullable
         private Transaction tr;
-        @Nonnull
         private final EventConsumer callback;
         @Nullable
         private DatabaseClientLogEvents events;
@@ -106,8 +101,8 @@ public class DatabaseClientLogEvents {
         private final long timeLimitMillis;
         private boolean limitReached;
 
-        public EventRunner(@Nonnull Database database, @Nonnull Executor executor, @Nonnull EventConsumer callback,
-                           @Nonnull Function<ReadTransaction, CompletableFuture<Long[]>> versionRangeProducer,
+        public EventRunner(Database database, Executor executor, EventConsumer callback,
+                           Function<ReadTransaction, CompletableFuture<Long[]>> versionRangeProducer,
                            int eventCountLimit, long timeLimitMillis) {
             this.database = database;
             this.executor = executor;
@@ -117,8 +112,8 @@ public class DatabaseClientLogEvents {
             this.timeLimitMillis = timeLimitMillis;
         }
 
-        public EventRunner(@Nonnull Database database, @Nonnull Executor executor, @Nonnull EventConsumer callback,
-                           @Nonnull DatabaseClientLogEvents events,
+        public EventRunner(Database database, Executor executor, EventConsumer callback,
+                           DatabaseClientLogEvents events,
                            int eventCountLimit, long timeLimitMillis) {
             this.database = database;
             this.executor = executor;
@@ -197,11 +192,11 @@ public class DatabaseClientLogEvents {
         }
     }
 
-    private AsyncIterable<KeyValue> getRange(@Nonnull ReadTransaction tr) {
+    private AsyncIterable<KeyValue> getRange(ReadTransaction tr) {
         return tr.getRange(startKey, endKey);
     }
 
-    private void updateForEvent(@Nonnull Instant eventTimestamp) {
+    private void updateForEvent(Instant eventTimestamp) {
         if (earliestTimestamp == null) {
             earliestTimestamp = eventTimestamp;
         }
@@ -221,10 +216,9 @@ public class DatabaseClientLogEvents {
         more = limitReached;    // Otherwise range was processed, possibly in multiple transactions.
     }
 
-    @Nonnull
-    public static CompletableFuture<DatabaseClientLogEvents> forEachEvent(@Nonnull Database database, @Nonnull Executor executor,
-                                                                          @Nonnull EventConsumer callback,
-                                                                          @Nonnull Function<ReadTransaction, CompletableFuture<Long[]>> versionRangeProducer,
+    public static CompletableFuture<DatabaseClientLogEvents> forEachEvent(Database database, Executor executor,
+                                                                          EventConsumer callback,
+                                                                          Function<ReadTransaction, CompletableFuture<Long[]>> versionRangeProducer,
                                                                           int eventCountLimit, long timeLimitMillis) {
         final EventRunner runner = new EventRunner(database, executor, callback, versionRangeProducer,
                                                    eventCountLimit, timeLimitMillis);
@@ -242,9 +236,8 @@ public class DatabaseClientLogEvents {
      * @param timeLimitMillis the maximum time to process before returning
      * @return a future which completes when the version range has been processed by the callback with an object that can be used to resume the scan
      */
-    @Nonnull
-    public static CompletableFuture<DatabaseClientLogEvents> forEachEventBetweenVersions(@Nonnull Database database, @Nonnull Executor executor,
-                                                                                         @Nonnull EventConsumer callback,
+    public static CompletableFuture<DatabaseClientLogEvents> forEachEventBetweenVersions(Database database, Executor executor,
+                                                                                         EventConsumer callback,
                                                                                          @Nullable Long startVersion, @Nullable Long endVersion,
                                                                                          int eventCountLimit, long timeLimitMillis) {
         return forEachEvent(database, executor, callback,
@@ -263,9 +256,8 @@ public class DatabaseClientLogEvents {
      * @param timeLimitMillis the maximum time to process before returning
      * @return a future which completes when the version range has been processed by the callback with an object that can be used to resume the scan
      */
-    @Nonnull
-    public static CompletableFuture<DatabaseClientLogEvents> forEachEventBetweenTimestamps(@Nonnull Database database, @Nonnull Executor executor,
-                                                                                           @Nonnull EventConsumer callback,
+    public static CompletableFuture<DatabaseClientLogEvents> forEachEventBetweenTimestamps(Database database, Executor executor,
+                                                                                           EventConsumer callback,
                                                                                            @Nullable Instant startTimestamp, @Nullable Instant endTimestamp,
                                                                                            int eventCountLimit, long timeLimitMillis) {
         return forEachEvent(database, executor, callback, tr -> {
@@ -287,8 +279,8 @@ public class DatabaseClientLogEvents {
      * @param timeLimitMillis the maximum time to process before returning
      * @return a future which completes when the version range has been processed by the callback with an object that can be used to resume the scan again
      */
-    public CompletableFuture<DatabaseClientLogEvents> forEachEventContinued(@Nonnull Database database, @Nonnull Executor executor,
-                                                                            @Nonnull EventConsumer callback,
+    public CompletableFuture<DatabaseClientLogEvents> forEachEventContinued(Database database, Executor executor,
+                                                                            EventConsumer callback,
                                                                             int eventCountLimit, long timeLimitMillis) {
         final EventRunner runner = new EventRunner(database, executor, callback, this,
                                                    eventCountLimit, timeLimitMillis);

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/clientlog/FDBClientLogEvents.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/clientlog/FDBClientLogEvents.java
@@ -32,8 +32,8 @@ import com.apple.foundationdb.system.SystemKeyspace;
 import com.apple.foundationdb.tuple.ByteArrayUtil;
 import com.google.common.primitives.Longs;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
@@ -219,10 +219,9 @@ public class FDBClientLogEvents {
     public static class EventGet extends Event {
         private final double latency;
         private final int size;
-        @Nonnull
         private final byte[] key;
 
-        public EventGet(double startTimestamp, String dcId, String tenant, double latency, int size, @Nonnull byte[] key) {
+        public EventGet(double startTimestamp, String dcId, String tenant, double latency, int size, byte[] key) {
             super(startTimestamp, dcId, tenant);
             this.latency = latency;
             this.size = size;
@@ -242,7 +241,6 @@ public class FDBClientLogEvents {
             return size;
         }
 
-        @Nonnull
         public byte[] getKey() {
             return key;
         }
@@ -263,10 +261,9 @@ public class FDBClientLogEvents {
     public static class EventGetRange extends Event {
         private final double latency;
         private final int size;
-        @Nonnull
         private final Range range;
 
-        public EventGetRange(double startTimestamp, String dcId, String tenant, double latency, int size, @Nonnull Range range) {
+        public EventGetRange(double startTimestamp, String dcId, String tenant, double latency, int size, Range range) {
             super(startTimestamp, dcId, tenant);
             this.latency = latency;
             this.size = size;
@@ -286,7 +283,6 @@ public class FDBClientLogEvents {
             return size;
         }
 
-        @Nonnull
         public Range getRange() {
             return range;
         }
@@ -309,11 +305,10 @@ public class FDBClientLogEvents {
         private final int numMutations;
         private final int commitBytes;
         private final long commitVersion;
-        @Nonnull
         private final CommitRequest commitRequest;
 
         public EventCommit(double startTimestamp, String dcId, String tenant, double latency, int numMutations, int commitBytes, long commitVersion,
-                           @Nonnull CommitRequest commitRequest) {
+                           CommitRequest commitRequest) {
             super(startTimestamp, dcId, tenant);
             this.latency = latency;
             this.numMutations = numMutations;
@@ -339,7 +334,6 @@ public class FDBClientLogEvents {
             return commitBytes;
         }
 
-        @Nonnull
         public CommitRequest getCommitRequest() {
             return commitRequest;
         }
@@ -362,10 +356,9 @@ public class FDBClientLogEvents {
     @SpotBugsSuppressWarnings("EI_EXPOSE_REP")
     public static class EventGetError extends Event {
         private final int errorCode;
-        @Nonnull
         private final byte[] key;
 
-        public EventGetError(double startTimestamp, String dcId, String tenant, int errorCode, @Nonnull byte[] key) {
+        public EventGetError(double startTimestamp, String dcId, String tenant, int errorCode, byte[] key) {
             super(startTimestamp, dcId, tenant);
             this.errorCode = errorCode;
             this.key = key;
@@ -380,7 +373,6 @@ public class FDBClientLogEvents {
             return errorCode;
         }
 
-        @Nonnull
         public byte[] getKey() {
             return key;
         }
@@ -399,10 +391,9 @@ public class FDBClientLogEvents {
      */
     public static class EventGetRangeError extends Event {
         private final int errorCode;
-        @Nonnull
         private final Range range;
 
-        public EventGetRangeError(double startTimestamp, String dcId, String tenant, int errorCode, @Nonnull Range range) {
+        public EventGetRangeError(double startTimestamp, String dcId, String tenant, int errorCode, Range range) {
             super(startTimestamp, dcId, tenant);
             this.errorCode = errorCode;
             this.range = range;
@@ -417,7 +408,6 @@ public class FDBClientLogEvents {
             return errorCode;
         }
 
-        @Nonnull
         public Range getRange() {
             return range;
         }
@@ -436,10 +426,9 @@ public class FDBClientLogEvents {
      */
     public static class EventCommitError extends Event {
         private final int errorCode;
-        @Nonnull
         private final CommitRequest commitRequest;
 
-        public EventCommitError(double startTimestamp, String dcId, String tenant, int errorCode, @Nonnull CommitRequest commitRequest) {
+        public EventCommitError(double startTimestamp, String dcId, String tenant, int errorCode, CommitRequest commitRequest) {
             super(startTimestamp, dcId, tenant);
             this.errorCode = errorCode;
             this.commitRequest = commitRequest;
@@ -454,7 +443,6 @@ public class FDBClientLogEvents {
             return errorCode;
         }
 
-        @Nonnull
         public CommitRequest getCommitRequest() {
             return commitRequest;
         }
@@ -480,12 +468,10 @@ public class FDBClientLogEvents {
         public static final int AND_V2 = 19;
 
         private final int type;
-        @Nonnull
         private final byte[] key;
-        @Nonnull
         private final byte[] param;
 
-        public Mutation(int type, @Nonnull byte[] key, @Nonnull byte[] param) {
+        public Mutation(int type, byte[] key, byte[] param) {
             this.type = type;
             this.key = key;
             this.param = param;
@@ -495,12 +481,10 @@ public class FDBClientLogEvents {
             return type;
         }
 
-        @Nonnull
         public byte[] getKey() {
             return key;
         }
 
-        @Nonnull
         public byte[] getParam() {
             return param;
         }
@@ -534,11 +518,8 @@ public class FDBClientLogEvents {
      */
     @SpotBugsSuppressWarnings("EI_EXPOSE_REP")
     public static class CommitRequest {
-        @Nonnull
         private final Range[] readConflictRanges;
-        @Nonnull
         private final Range[] writeConflictRanges;
-        @Nonnull
         private final Mutation[] mutations;
         private final long snapshotVersion;
         private final boolean reportConflictingKeys;
@@ -546,9 +527,9 @@ public class FDBClientLogEvents {
         @Nullable
         private final SpanContext spanContext;
 
-        public CommitRequest(@Nonnull Range[] readConflictRanges,
-                             @Nonnull Range[] writeConflictRanges,
-                             @Nonnull Mutation[] mutations,
+        public CommitRequest(Range[] readConflictRanges,
+                             Range[] writeConflictRanges,
+                             Mutation[] mutations,
                              long snapshotVersion,
                              boolean reportConflictingKeys,
                              boolean lockAware,
@@ -562,17 +543,14 @@ public class FDBClientLogEvents {
             this.spanContext = spanContext;
         }
 
-        @Nonnull
         public Range[] getReadConflictRanges() {
             return readConflictRanges;
         }
 
-        @Nonnull
         public Range[] getWriteConflictRanges() {
             return writeConflictRanges;
         }
 
-        @Nonnull
         public Mutation[] getMutations() {
             return mutations;
         }
@@ -616,7 +594,7 @@ public class FDBClientLogEvents {
      * @param callback an asynchronous function to apply to each entry
      * @return a future that completes when all items have been processed
      */
-    public static CompletableFuture<Void> deserializeEvents(@Nonnull ByteBuffer buffer, @Nonnull AsyncConsumer<Event> callback) {
+    public static CompletableFuture<Void> deserializeEvents(ByteBuffer buffer, AsyncConsumer<Event> callback) {
         buffer.order(ByteOrder.LITTLE_ENDIAN);
         final long protocolVersion = buffer.getLong();
         if (Longs.indexOf(SUPPORTED_PROTOCOL_VERSIONS, protocolVersion) < 0) {
@@ -687,21 +665,18 @@ public class FDBClientLogEvents {
         });
     }
 
-    @Nonnull
-    protected static byte[] deserializeByteArray(@Nonnull ByteBuffer buffer) {
+    protected static byte[] deserializeByteArray(ByteBuffer buffer) {
         final int length = buffer.getInt();
         final byte[] result = new byte[length];
         buffer.get(result);
         return result;
     }
 
-    @Nonnull
-    protected static Range deserializeRange(@Nonnull ByteBuffer buffer) {
+    protected static Range deserializeRange(ByteBuffer buffer) {
         return new Range(deserializeByteArray(buffer), deserializeByteArray(buffer));
     }
 
-    @Nonnull
-    protected static Range[] deserializeRangeArray(@Nonnull ByteBuffer buffer) {
+    protected static Range[] deserializeRangeArray(ByteBuffer buffer) {
         final int length = buffer.getInt();
         final Range[] result = new Range[length];
         for (int i = 0; i < length; i++) {
@@ -710,13 +685,11 @@ public class FDBClientLogEvents {
         return result;
     }
 
-    @Nonnull
-    protected static Mutation deserializeMutation(@Nonnull ByteBuffer buffer) {
+    protected static Mutation deserializeMutation(ByteBuffer buffer) {
         return new Mutation(buffer.get(), deserializeByteArray(buffer), deserializeByteArray(buffer));
     }
 
-    @Nonnull
-    protected static Mutation[] deserializeMutationArray(@Nonnull ByteBuffer buffer) {
+    protected static Mutation[] deserializeMutationArray(ByteBuffer buffer) {
         final int length = buffer.getInt();
         final Mutation[] result = new Mutation[length];
         for (int i = 0; i < length; i++) {
@@ -725,8 +698,7 @@ public class FDBClientLogEvents {
         return result;
     }
 
-    @Nonnull
-    protected static CommitRequest deserializeCommit(long protocolVersion, @Nonnull ByteBuffer buffer) {
+    protected static CommitRequest deserializeCommit(long protocolVersion, ByteBuffer buffer) {
         final Range[] readConflictRanges = deserializeRangeArray(buffer);
         final Range[] writeConflictRanges = deserializeRangeArray(buffer);
         final Mutation[] mutations = deserializeMutationArray(buffer);
@@ -805,7 +777,6 @@ public class FDBClientLogEvents {
     }
 
     protected static class EventDeserializer implements AsyncConsumer<KeyValue> {
-        @Nonnull
         private final AsyncConsumer<Event> callback;
         @Nullable
         private ByteBuffer splitBuffer;
@@ -813,7 +784,7 @@ public class FDBClientLogEvents {
         private int splitPosition;
         private byte[] lastProcessedKey;
 
-        public EventDeserializer(@Nonnull AsyncConsumer<Event> callback) {
+        public EventDeserializer(AsyncConsumer<Event> callback) {
             this.callback = callback;
         }
 
@@ -883,8 +854,7 @@ public class FDBClientLogEvents {
      * @param callback the callback to invoke
      * @return a future which completes when all (whole) events in the range have been processed
      */
-    @Nonnull
-    public static CompletableFuture<byte[]> forEachEvent(@Nonnull AsyncIterable<KeyValue> range, @Nonnull EventConsumer callback) {
+    public static CompletableFuture<byte[]> forEachEvent(AsyncIterable<KeyValue> range, EventConsumer callback) {
         final EventDeserializer deserializer = new EventDeserializer(callback);
         final AsyncIterator<KeyValue> iterator = range.iterator();
         return AsyncUtil.whileTrue(() -> iterator.onHasNext()
@@ -897,7 +867,6 @@ public class FDBClientLogEvents {
      * @param version the version, in the same extent as, e.g., {@link com.apple.foundationdb.Transaction#getReadVersion()}
      * @return the encoded key
      */
-    @Nonnull
     public static byte[] eventKeyForVersion(long version) {
         // Do not include the two bytes for the transaction number at this version.
         final byte[] result = new byte[EVENT_KEY_VERSION_END_INDEX - 2];

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/clientlog/FDBClientLogEvents.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/clientlog/FDBClientLogEvents.java
@@ -42,6 +42,7 @@ import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.StringJoiner;
 import java.util.concurrent.CompletableFuture;
 
@@ -780,10 +781,16 @@ public class FDBClientLogEvents {
         private final AsyncConsumer<Event> callback;
         @Nullable
         private ByteBuffer splitBuffer;
+        @Nullable
         private byte[] splitId;
         private int splitPosition;
+        @Nullable
         private byte[] lastProcessedKey;
 
+        // NullAway does not reliably recognize @Nullable on byte[]-typed fields, so it incorrectly insists that
+        // splitId and lastProcessedKey (both declared @Nullable byte[] above, and legitimately unset until the
+        // first chunked/whole key is processed) be assigned here.
+        @SuppressWarnings("NullAway")
         public EventDeserializer(AsyncConsumer<Event> callback) {
             this.callback = callback;
         }
@@ -810,17 +817,22 @@ public class FDBClientLogEvents {
                     splitId = transactionId;
                     splitPosition = 1;
                 } else if (chunkNumber == splitPosition && Arrays.equals(transactionId, splitId)) {
-                    if (splitBuffer.remaining() < keyValue.getValue().length) {
-                        final ByteBuffer newBuffer = ByteBuffer.allocate(splitBuffer.position() + keyValue.getValue().length);
-                        splitBuffer.flip();
-                        newBuffer.put(splitBuffer);
+                    // splitPosition is only ever advanced to a value that can match chunkNumber here after the
+                    // chunkNumber == 1 branch above has run (on this or an earlier call to accept()), which is
+                    // exactly when splitBuffer is allocated; NullAway cannot verify an invariant across calls.
+                    ByteBuffer currentSplitBuffer = Objects.requireNonNull(splitBuffer);
+                    if (currentSplitBuffer.remaining() < keyValue.getValue().length) {
+                        final ByteBuffer newBuffer = ByteBuffer.allocate(currentSplitBuffer.position() + keyValue.getValue().length);
+                        currentSplitBuffer.flip();
+                        newBuffer.put(currentSplitBuffer);
                         splitBuffer = newBuffer;
+                        currentSplitBuffer = newBuffer;
                     }
-                    splitBuffer.put(keyValue.getValue());
+                    currentSplitBuffer.put(keyValue.getValue());
                     splitPosition++;
                     if (splitPosition == numChunks) {
-                        splitBuffer.flip();
-                        ByteBuffer buffer = splitBuffer;
+                        currentSplitBuffer.flip();
+                        ByteBuffer buffer = currentSplitBuffer;
                         splitBuffer = null;
                         lastProcessedKey = keyValue.getKey();
                         return deserializeEvents(buffer, callback);

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/clientlog/TupleKeyCountTree.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/clientlog/TupleKeyCountTree.java
@@ -26,8 +26,8 @@ import com.apple.foundationdb.tuple.ByteArrayUtil;
 import com.apple.foundationdb.tuple.Tuple;
 import com.apple.foundationdb.tuple.TupleHelpers;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -44,7 +44,6 @@ import java.util.TreeMap;
 @API(API.Status.EXPERIMENTAL)
 @SpotBugsSuppressWarnings("EI_EXPOSE_REP")
 public class TupleKeyCountTree {
-    @Nonnull
     private final byte[] bytes;
     @Nullable
     private final Object object;
@@ -52,7 +51,6 @@ public class TupleKeyCountTree {
     private int count;
     @Nullable
     private final TupleKeyCountTree parent;
-    @Nonnull
     private final Map<byte[], TupleKeyCountTree> children;
 
     private boolean visible = true;
@@ -70,7 +68,7 @@ public class TupleKeyCountTree {
         this(null, new byte[0], null);
     }
 
-    public TupleKeyCountTree(@Nullable TupleKeyCountTree parent, @Nonnull byte[] bytes, @Nullable Object object) {
+    public TupleKeyCountTree(@Nullable TupleKeyCountTree parent, byte[] bytes, @Nullable Object object) {
         this.bytes = bytes;
         this.object = object;
 
@@ -79,7 +77,6 @@ public class TupleKeyCountTree {
         this.children = new TreeMap<>(BYTES_COMPARATOR);
     }
     
-    @Nonnull
     public byte[] getBytes() {
         return bytes;
     }
@@ -104,7 +101,7 @@ public class TupleKeyCountTree {
      * Each element is added to the next deeper level in the tree, incrementing the count as it goes.
      * @param tuple the tuple to add
      */
-    public void add(@Nonnull Tuple tuple) {
+    public void add(Tuple tuple) {
         addInternal(tuple.getItems(), 0, tuple.pack(), 0);
     }
 
@@ -113,7 +110,7 @@ public class TupleKeyCountTree {
      *
      * @param packed the packed form of a tuple to be parsed and added to the tree
      */
-    public void add(@Nonnull byte[] packed) {
+    public void add(byte[] packed) {
         List<Object> items = null;
         int endPosition = packed.length;
         while (endPosition > 0) {
@@ -134,7 +131,7 @@ public class TupleKeyCountTree {
     }
 
     @SuppressWarnings("PMD.CompareObjectsWithEquals")
-    private synchronized void addInternal(@Nonnull List<Object> items, int itemPosition, @Nonnull byte[] bytes, int bytePosition) {
+    private synchronized void addInternal(List<Object> items, int itemPosition, byte[] bytes, int bytePosition) {
         count++;
         if (itemPosition < items.size()) {
             final Object childObject = items.get(itemPosition);
@@ -150,20 +147,17 @@ public class TupleKeyCountTree {
      * @param prefix an object for the top level child of the tree
      * @return a subtree for the given object
      */
-    @Nonnull
-    public TupleKeyCountTree addPrefixChild(@Nonnull Object prefix) {
+    public TupleKeyCountTree addPrefixChild(Object prefix) {
         count++;
         final byte[] prefixBytes = Tuple.from(prefix).pack();
         return children.computeIfAbsent(prefixBytes, b -> newPrefixChild(prefixBytes, prefix));
     }
 
-    @Nonnull
-    protected TupleKeyCountTree newPrefixChild(@Nonnull byte[] prefixBytes, @Nonnull Object prefix) {
+    protected TupleKeyCountTree newPrefixChild(byte[] prefixBytes, Object prefix) {
         return newChild(prefixBytes, prefix);
     }
 
-    @Nonnull
-    protected TupleKeyCountTree newChild(@Nonnull byte[] childBytes, @Nonnull Object object) {
+    protected TupleKeyCountTree newChild(byte[] childBytes, Object object) {
         return new TupleKeyCountTree(this, childBytes, object);
     }
 
@@ -176,7 +170,6 @@ public class TupleKeyCountTree {
         return parent;
     }
 
-    @Nonnull
     public Collection<TupleKeyCountTree> getChildren() {
         return children.values();
     }
@@ -206,7 +199,7 @@ public class TupleKeyCountTree {
      */
     @FunctionalInterface
     public interface Printer {
-        void print(int depth, @Nonnull List<TupleKeyCountTree> path);
+        void print(int depth, List<TupleKeyCountTree> path);
     }
 
     /**
@@ -214,7 +207,7 @@ public class TupleKeyCountTree {
      * @param printer the printer to be called for each visible level of the tree
      * @param collapseSeparator a string to be used to separate the printed forms of levels with only a single child
      */
-    public void printTree(@Nonnull Printer printer, @Nullable String collapseSeparator) {
+    public void printTree(Printer printer, @Nullable String collapseSeparator) {
         if (parent != null) {
             printTree(0, 0, printer, collapseSeparator);
         } else {
@@ -225,7 +218,7 @@ public class TupleKeyCountTree {
         }
     }
 
-    protected void printTree(int depth, int nancestors, @Nonnull Printer printer, @Nullable String collapseSeparator) {
+    protected void printTree(int depth, int nancestors, Printer printer, @Nullable String collapseSeparator) {
         if (visible) {
             if (collapseSeparator != null) {
                 TupleKeyCountTree onlyChild = null;

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/clientlog/TupleKeyCountTree.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/clientlog/TupleKeyCountTree.java
@@ -243,7 +243,11 @@ public class TupleKeyCountTree {
                 TupleKeyCountTree ancestor = this;
                 for (int i = 0; i <= nancestors; i++) {
                     path.add(0, ancestor);
-                    ancestor = ancestor.parent;
+                    // nancestors only ever increases in step with an actual recursion into a real child (see
+                    // the onlyChild.printTree(...) call above), so this node is guaranteed to have at least
+                    // `nancestors` real ancestors above it; NullAway cannot verify an invariant across
+                    // recursive calls like this.
+                    ancestor = Objects.requireNonNull(ancestor.parent);
                 }
             } else {
                 path = Collections.singletonList(this);

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/clientlog/VersionFromTimestamp.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/clientlog/VersionFromTimestamp.java
@@ -29,7 +29,6 @@ import com.apple.foundationdb.system.SystemKeyspace;
 import com.apple.foundationdb.tuple.ByteArrayUtil;
 import com.apple.foundationdb.tuple.Tuple;
 
-import javax.annotation.Nonnull;
 import java.time.Instant;
 import java.util.concurrent.CompletableFuture;
 
@@ -45,8 +44,7 @@ public class VersionFromTimestamp {
      * @param timestamp the wall-clock time
      * @return a future that completes with the recorded version that comes immediately before the target time
      */
-    @Nonnull
-    public static CompletableFuture<Long> lastVersionBefore(@Nonnull ReadTransaction tr, @Nonnull Instant timestamp) {
+    public static CompletableFuture<Long> lastVersionBefore(ReadTransaction tr, Instant timestamp) {
         return versionFromTimestamp(tr, timestamp, true);
     }
 
@@ -56,12 +54,11 @@ public class VersionFromTimestamp {
      * @param timestamp the wall-clock time
      * @return a future that completes with the recorded version that comes immediately after the target time
      */
-    @Nonnull
-    public static CompletableFuture<Long> nextVersionAfter(@Nonnull ReadTransaction tr, @Nonnull Instant timestamp) {
+    public static CompletableFuture<Long> nextVersionAfter(ReadTransaction tr, Instant timestamp) {
         return versionFromTimestamp(tr, timestamp, false);
     }
 
-    private static CompletableFuture<Long> versionFromTimestamp(@Nonnull ReadTransaction tr, @Nonnull Instant timestamp, boolean start) {
+    private static CompletableFuture<Long> versionFromTimestamp(ReadTransaction tr, Instant timestamp, boolean start) {
         final byte[] dateKey = ByteArrayUtil.join(SystemKeyspace.TIMEKEEPER_KEY_PREFIX, Tuple.from(timestamp.getEpochSecond()).pack());
         final KeySelector startKey;
         final KeySelector endKey;

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/clientlog/package-info.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/clientlog/package-info.java
@@ -21,4 +21,7 @@
 /**
  * Utilities for interpreting events written to system keyspace.
  */
+@NullMarked
 package com.apple.foundationdb.clientlog;
+
+import org.jspecify.annotations.NullMarked;

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/kmeans/KMeans.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/kmeans/KMeans.java
@@ -29,8 +29,8 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -73,7 +73,6 @@ public final class KMeans {
      *
      * @return a non-null overflow-quadratic penalty function
      */
-    @Nonnull
     public static SizePenalty overflowQuadraticPenalty() {
         return (proj, target) -> {
             final int overflow = Math.max(0, proj - target);
@@ -121,11 +120,11 @@ public final class KMeans {
      * @param <C> caller's centroid representation
      * @return the best partitioning found across all restarts, ranked by geometric SSE
      */
-    public static <V, C> Result<C> fit(@Nonnull final SplittableRandom random,
-                                       @Nonnull final DistanceEstimator distanceEstimator,
-                                       @Nonnull final Lens<V, RealVector> vectorLens,
-                                       @Nonnull final Lens<C, RealVector> centroidLens,
-                                       @Nonnull final List<V> vectors,
+    public static <V, C> Result<C> fit(final SplittableRandom random,
+                                       final DistanceEstimator distanceEstimator,
+                                       final Lens<V, RealVector> vectorLens,
+                                       final Lens<C, RealVector> centroidLens,
+                                       final List<V> vectors,
                                        final int k,
                                        final int maxIterations,
                                        final int maxRestarts,
@@ -305,11 +304,10 @@ public final class KMeans {
      * @param <C> caller's centroid representation
      * @return a single-cluster {@link Result}
      */
-    @Nonnull
-    private static <V, C> Result<C> singleClusterResult(@Nonnull final MetricAdapter metricAdapter,
-                                                        @Nonnull final Lens<V, RealVector> vectorLens,
-                                                        @Nonnull final Lens<C, RealVector> centroidLens,
-                                                        @Nonnull final List<V> vectors,
+    private static <V, C> Result<C> singleClusterResult(final MetricAdapter metricAdapter,
+                                                        final Lens<V, RealVector> vectorLens,
+                                                        final Lens<C, RealVector> centroidLens,
+                                                        final List<V> vectors,
                                                         final int numDimensions) {
         final int n = vectors.size();
 
@@ -361,10 +359,10 @@ public final class KMeans {
      * @param sizePenalty optional size penalty hook; if {@code null} no penalty is added
      * @return the score; lower is better
      */
-    private static double score(@Nonnull final MetricAdapter metricAdapter,
-                                @Nonnull final RealVector vector,
+    private static double score(final MetricAdapter metricAdapter,
+                                final RealVector vector,
                                 final int c,
-                                @Nonnull final List<MutableDoubleRealVector> centroids,
+                                final List<MutableDoubleRealVector> centroids,
                                 final int[] projectedSizes,
                                 final int targetSize,
                                 final double lambda,
@@ -409,14 +407,14 @@ public final class KMeans {
      * @return the number of vectors whose new assignment differs from their prior value in
      *         {@code assignment}
      */
-    private static <V> int assignmentStep(@Nonnull final MetricAdapter metricAdapter,
-                                          @Nonnull final Lens<V, RealVector> vectorLens,
-                                          @Nonnull final List<V> vectors,
-                                          @Nonnull final List<MutableDoubleRealVector> centroids,
+    private static <V> int assignmentStep(final MetricAdapter metricAdapter,
+                                          final Lens<V, RealVector> vectorLens,
+                                          final List<V> vectors,
+                                          final List<MutableDoubleRealVector> centroids,
                                           final int k,
-                                          @Nonnull final int[] order,
-                                          @Nonnull final int[] assignment,
-                                          @Nonnull final int[] projected,
+                                          final int[] order,
+                                          final int[] assignment,
+                                          final int[] projected,
                                           final int targetSize,
                                           final double lambda,
                                           @Nullable final SizePenalty sizePenalty) {
@@ -485,11 +483,10 @@ public final class KMeans {
      * @return a list of {@code k} freshly allocated mutable centroids, copied from the chosen
      *         input vectors
      */
-    @Nonnull
-    private static <V> List<MutableDoubleRealVector> initKMeansPP(@Nonnull final MetricAdapter metricAdapter,
-                                                                  @Nonnull final SplittableRandom random,
-                                                                  @Nonnull final Lens<V, RealVector> vectorLens,
-                                                                  @Nonnull final List<V> vectors,
+    private static <V> List<MutableDoubleRealVector> initKMeansPP(final MetricAdapter metricAdapter,
+                                                                  final SplittableRandom random,
+                                                                  final Lens<V, RealVector> vectorLens,
+                                                                  final List<V> vectors,
                                                                   final int k) {
         final int n = vectors.size();
 
@@ -577,10 +574,10 @@ public final class KMeans {
      * @return the index in {@code vectors} of the farthest point
      */
     @VisibleForTesting
-    static <V> int farthestVectorIndex(@Nonnull final MetricAdapter metricAdapter,
-                                       @Nonnull final Lens<V, RealVector> vectorLens,
-                                       @Nonnull final List<V> vectors,
-                                       @Nonnull final List<? extends RealVector> centroids) {
+    static <V> int farthestVectorIndex(final MetricAdapter metricAdapter,
+                                       final Lens<V, RealVector> vectorLens,
+                                       final List<V> vectors,
+                                       final List<? extends RealVector> centroids) {
         double best = -1.0d;
         int bestIdx = 0;
 
@@ -614,9 +611,8 @@ public final class KMeans {
      * @param <V> caller's input vector representation
      * @return the extracted vector; never {@code null}
      */
-    @Nonnull
-    private static <V> RealVector getVector(@Nonnull final Lens<V, RealVector> vectorLens,
-                                            @Nonnull final List<V> vectors,
+    private static <V> RealVector getVector(final Lens<V, RealVector> vectorLens,
+                                            final List<V> vectors,
                                             final int index) {
         return vectorLens.getNonnull(vectors.get(index));
     }
@@ -630,7 +626,7 @@ public final class KMeans {
      * @param random random source
      * @param a array shuffled in place
      */
-    private static void shuffleInPlace(@Nonnull final SplittableRandom random, @Nonnull final int[] a) {
+    private static void shuffleInPlace(final SplittableRandom random, final int[] a) {
         for (int i = a.length - 1; i > 0; i--) {
             final int j = random.nextInt(i + 1);
             final int tmp = a[i];
@@ -647,9 +643,8 @@ public final class KMeans {
      * @throws UnsupportedOperationException if the estimator's metric is neither
      *         {@code EUCLIDEAN_METRIC} nor {@code COSINE_METRIC}
      */
-    @Nonnull
     @VisibleForTesting
-    static MetricAdapter fromEstimator(@Nonnull final DistanceEstimator distanceEstimator) {
+    static MetricAdapter fromEstimator(final DistanceEstimator distanceEstimator) {
         return switch (distanceEstimator.getMetric()) {
             case EUCLIDEAN_METRIC -> new EuclideanMetricAdapter(distanceEstimator);
             case COSINE_METRIC -> new CosineMetricAdapter(distanceEstimator);
@@ -673,7 +668,7 @@ public final class KMeans {
          * @param centroid the centroid being scored against
          * @return the per-pair contribution to the clustering objective
          */
-        double baseObjective(@Nonnull RealVector vector, @Nonnull RealVector centroid);
+        double baseObjective(RealVector vector, RealVector centroid);
 
         /**
          * Renormalizes a freshly averaged centroid in place if the metric requires it (e.g.
@@ -685,8 +680,7 @@ public final class KMeans {
          *         for convenience in fluent expressions
          */
         @CanIgnoreReturnValue
-        @Nonnull
-        MutableDoubleRealVector renormalizeIfNecessary(@Nonnull MutableDoubleRealVector vector);
+        MutableDoubleRealVector renormalizeIfNecessary(MutableDoubleRealVector vector);
 
         /**
          * Returns whether the given vector has a "meaningless" norm under this metric — for
@@ -696,7 +690,7 @@ public final class KMeans {
          * @param vector the vector to test
          * @return {@code true} if the vector's norm is meaningless under this metric
          */
-        boolean isMeaninglessNorm(@Nonnull RealVector vector);
+        boolean isMeaninglessNorm(RealVector vector);
     }
 
     /**
@@ -718,16 +712,15 @@ public final class KMeans {
      * well-defined.
      */
     private static class EuclideanMetricAdapter implements MetricAdapter {
-        @Nonnull
         private final DistanceEstimator distanceEstimator;
 
-        public EuclideanMetricAdapter(@Nonnull final DistanceEstimator distanceEstimator) {
+        public EuclideanMetricAdapter(final DistanceEstimator distanceEstimator) {
             this.distanceEstimator = distanceEstimator;
         }
 
         @Override
-        public double baseObjective(@Nonnull final RealVector vector,
-                                    @Nonnull final RealVector centroid) {
+        public double baseObjective(final RealVector vector,
+                                    final RealVector centroid) {
             if (distanceEstimator.isOptimized(vector, centroid)) {
                 final double d = distanceEstimator.distance(vector, centroid);
                 return d * d;
@@ -735,14 +728,13 @@ public final class KMeans {
             return vector.l2SquaredDistance(centroid);
         }
 
-        @Nonnull
         @Override
-        public MutableDoubleRealVector renormalizeIfNecessary(@Nonnull final MutableDoubleRealVector vector) {
+        public MutableDoubleRealVector renormalizeIfNecessary(final MutableDoubleRealVector vector) {
             return vector;
         }
 
         @Override
-        public boolean isMeaninglessNorm(@Nonnull final RealVector vector) {
+        public boolean isMeaninglessNorm(final RealVector vector) {
             return false;
         }
     }
@@ -753,27 +745,25 @@ public final class KMeans {
      * near-zero-norm centroid is treated as meaningless and triggers a reseed.
      */
     private static class CosineMetricAdapter implements MetricAdapter {
-        @Nonnull
         private final DistanceEstimator distanceEstimator;
 
-        public CosineMetricAdapter(@Nonnull final DistanceEstimator distanceEstimator) {
+        public CosineMetricAdapter(final DistanceEstimator distanceEstimator) {
             this.distanceEstimator = distanceEstimator;
         }
 
         @Override
-        public double baseObjective(@Nonnull final RealVector vector,
-                                    @Nonnull final RealVector centroid) {
+        public double baseObjective(final RealVector vector,
+                                    final RealVector centroid) {
             return distanceEstimator.distance(vector, centroid);
         }
 
-        @Nonnull
         @Override
-        public MutableDoubleRealVector renormalizeIfNecessary(@Nonnull final MutableDoubleRealVector vector) {
+        public MutableDoubleRealVector renormalizeIfNecessary(final MutableDoubleRealVector vector) {
             return vector.normalizeThis();
         }
 
         @Override
-        public boolean isMeaninglessNorm(@Nonnull final RealVector vector) {
+        public boolean isMeaninglessNorm(final RealVector vector) {
             return vector.isNearlyZeroNorm();
         }
     }
@@ -806,10 +796,10 @@ public final class KMeans {
      *                  objective alone
      * @param <C> caller's centroid representation
      */
-    public record Result<C>(@Nonnull List<C> clusterCentroids,
-                            @Nonnull int[] clusterSizes,
-                            @Nonnull int[] assignment,
-                            @Nonnull double[] distances,
+    public record Result<C>(List<C> clusterCentroids,
+                            int[] clusterSizes,
+                            int[] assignment,
+                            double[] distances,
                             double objective) {
     }
 

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/kmeans/KMeans.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/kmeans/KMeans.java
@@ -34,6 +34,7 @@ import org.jspecify.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.SplittableRandom;
 
 /**
@@ -283,7 +284,10 @@ public final class KMeans {
             }
         }
 
-        return best;
+        // The restart loop below runs `r` from 0 to maxRestarts inclusive, so it always executes at least once,
+        // and its first iteration unconditionally sets best (the `best == null || ...` check is true on that
+        // pass), so best is always non-null here; NullAway cannot verify a loop invariant like this.
+        return Objects.requireNonNull(best);
     }
 
     /**

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/kmeans/PartitionEvaluator.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/kmeans/PartitionEvaluator.java
@@ -28,7 +28,6 @@ import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -82,13 +81,12 @@ public class PartitionEvaluator {
      * @return an {@link EvaluationResult} carrying the decision, both stats, and the metrics
      *         that led to the decision
      */
-    @Nonnull
-    public static <V> EvaluationResult evaluate(@Nonnull final List<V> currentVectors,
-                                                @Nonnull final Partition<?> current,
-                                                @Nonnull final List<V> candidateVectors,
-                                                @Nonnull final Partition<?> candidate,
-                                                @Nonnull final Lens<V, RealVector> vectorLens,
-                                                @Nonnull final Parameters parameters) {
+    public static <V> EvaluationResult evaluate(final List<V> currentVectors,
+                                                final Partition<?> current,
+                                                final List<V> candidateVectors,
+                                                final Partition<?> candidate,
+                                                final Lens<V, RealVector> vectorLens,
+                                                final Parameters parameters) {
 
         validate(currentVectors, current);
         validate(candidateVectors, candidate);
@@ -181,11 +179,10 @@ public class PartitionEvaluator {
      * @return a populated {@link EvaluationResult} carrying the inputs and a
      *         {@link Decision#KEEP_CURRENT} decision
      */
-    @Nonnull
-    private static EvaluationResult keepCurrent(@Nonnull final PartitionStats currentStats,
-                                                @Nonnull final PartitionStats candidateStats,
+    private static EvaluationResult keepCurrent(final PartitionStats currentStats,
+                                                final PartitionStats candidateStats,
                                                 final double relativeSseGain, final double scoreGain,
-                                                @Nonnull final String reason) {
+                                                final String reason) {
         currentStats.log(logger, "current stats");
         candidateStats.log(logger, "candidate stats");
         if (logger.isTraceEnabled()) {
@@ -209,11 +206,10 @@ public class PartitionEvaluator {
      * @return a populated {@link EvaluationResult} carrying the inputs and a
      *         {@link Decision#INVALID_CANDIDATE} decision
      */
-    @Nonnull
-    private static EvaluationResult invalid(@Nonnull final PartitionStats currentStats,
-                                            @Nonnull final PartitionStats candidateStats,
+    private static EvaluationResult invalid(final PartitionStats currentStats,
+                                            final PartitionStats candidateStats,
                                             final double relativeSseGain, final double scoreGain,
-                                            @Nonnull final String reason) {
+                                            final String reason) {
         currentStats.log(logger, "current stats");
         candidateStats.log(logger, "candidate stats");
         if (logger.isDebugEnabled()) {
@@ -236,11 +232,10 @@ public class PartitionEvaluator {
      * @return a populated {@link EvaluationResult} carrying the inputs and a
      *         {@link Decision#ACCEPT_CANDIDATE} decision
      */
-    @Nonnull
-    private static EvaluationResult accept(@Nonnull final PartitionStats currentStats,
-                                           @Nonnull final PartitionStats candidateStats,
+    private static EvaluationResult accept(final PartitionStats currentStats,
+                                           final PartitionStats candidateStats,
                                            final double relativeSseGain, final double scoreGain,
-                                           @Nonnull final String reason) {
+                                           final String reason) {
         currentStats.log(logger, "current stats");
         candidateStats.log(logger, "candidate stats");
         if (logger.isDebugEnabled()) {
@@ -261,8 +256,8 @@ public class PartitionEvaluator {
      * @param partition the partitioning to validate
      * @throws IllegalArgumentException if the partition is not well-formed
      */
-    private static void validate(@Nonnull final List<?> vectors,
-                                 @Nonnull final Partition<?> partition) {
+    private static void validate(final List<?> vectors,
+                                 final Partition<?> partition) {
         if (vectors.isEmpty()) {
             throw new IllegalArgumentException("vectors must not be empty");
         }
@@ -301,11 +296,10 @@ public class PartitionEvaluator {
      * @param <V> caller's input vector representation
      * @return the computed statistics
      */
-    @Nonnull
-    private static <V> PartitionStats evaluatePartition(@Nonnull final List<V> vectors,
-                                                        @Nonnull final Lens<V, RealVector> vectorLens,
-                                                        @Nonnull final Partition<?> partition,
-                                                        @Nonnull final Parameters parameters) {
+    private static <V> PartitionStats evaluatePartition(final List<V> vectors,
+                                                        final Lens<V, RealVector> vectorLens,
+                                                        final Partition<?> partition,
+                                                        final Parameters parameters) {
         final DistanceEstimator distanceEstimator = parameters.distanceEstimator();
         final int n = vectors.size();
         final int k = partition.k();
@@ -345,9 +339,9 @@ public class PartitionEvaluator {
      *                   when the caller did not request it (i.e. when the low-margin threshold is
      *                   either explicitly overridden or fixed by the metric)
      */
-    private record SecondPassResult(double sse, @Nonnull int[] childSizes,
-                                    @Nonnull List<Double>[] childRadii,
-                                    @Nonnull List<Double> margins,
+    private record SecondPassResult(double sse, int[] childSizes,
+                                    List<Double>[] childRadii,
+                                    List<Double> margins,
                                     double overallP95) {
     }
 
@@ -398,11 +392,10 @@ public class PartitionEvaluator {
      * @param <V> caller's input vector representation
      * @return the accumulated results
      */
-    @Nonnull
-    private static <V> SecondPassResult accumulate(@Nonnull final List<V> vectors,
-                                                   @Nonnull final Lens<V, RealVector> vectorLens,
-                                                   @Nonnull final Partition<?> partition,
-                                                   @Nonnull final DistanceEstimator distanceEstimator,
+    private static <V> SecondPassResult accumulate(final List<V> vectors,
+                                                   final Lens<V, RealVector> vectorLens,
+                                                   final Partition<?> partition,
+                                                   final DistanceEstimator distanceEstimator,
                                                    final boolean computeOverallP95) {
         final int n = vectors.size();
         final int k = partition.k();
@@ -465,9 +458,9 @@ public class PartitionEvaluator {
      * @throws UnsupportedOperationException if the estimator's metric is neither
      *         {@code EUCLIDEAN_METRIC} nor {@code COSINE_METRIC}
      */
-    private static double computeMargin(@Nonnull final DistanceEstimator distanceEstimator,
-                                        @Nonnull final Partition<?> partition,
-                                        @Nonnull final RealVector v,
+    private static double computeMargin(final DistanceEstimator distanceEstimator,
+                                        final Partition<?> partition,
+                                        final RealVector v,
                                         final int own) {
         final int k = partition.k();
         final RealVector ownC = partition.getCentroid(own);
@@ -508,7 +501,7 @@ public class PartitionEvaluator {
      * @param vector2 right operand
      * @return {@code vector1 · vector2} clamped to {@code [-1, 1]}
      */
-    private static double clampedDot(@Nonnull final RealVector vector1, @Nonnull final RealVector vector2) {
+    private static double clampedDot(final RealVector vector1, final RealVector vector2) {
         final double dot = vector1.dot(vector2);
         return Math.max(-1.0d, Math.min(1.0d, dot));
     }
@@ -521,8 +514,7 @@ public class PartitionEvaluator {
      * @param n total vector count
      * @return the imbalance and the smallest/largest cluster fractions
      */
-    @Nonnull
-    private static SizeStats summarizeSizes(@Nonnull final int[] childSizes, final int n) {
+    private static SizeStats summarizeSizes(final int[] childSizes, final int n) {
         final int k = childSizes.length;
         final double target = (double) n / k;
         double sumSquaredDiff = 0.0;
@@ -547,7 +539,7 @@ public class PartitionEvaluator {
      * @return the maximum p95 radius across non-empty clusters, or {@code 0.0} if every cluster is
      *         empty
      */
-    private static double maxRadius95(@Nonnull final List<Double>[] childRadii) {
+    private static double maxRadius95(final List<Double>[] childRadii) {
         double max = 0.0;
         for (final List<Double> radii : childRadii) {
             if (!radii.isEmpty()) {
@@ -567,8 +559,8 @@ public class PartitionEvaluator {
      * @param maxRadius95 scale reference used to normalize the minimum pairwise centroid distance
      * @return the normalized inter-centroid separation, or {@link Double#NaN} if {@code k < 2}
      */
-    private static double separation(@Nonnull final Partition<?> partition,
-                                     @Nonnull final DistanceEstimator distanceEstimator,
+    private static double separation(final Partition<?> partition,
+                                     final DistanceEstimator distanceEstimator,
                                      final double maxRadius95) {
         final int k = partition.k();
         if (k < 2) {
@@ -595,8 +587,7 @@ public class PartitionEvaluator {
      * @param k number of clusters in the partitioning
      * @return the margin distribution summary, or NaN/{@code 0.0} sentinels when {@code k < 2}
      */
-    @Nonnull
-    private static MarginStats marginStats(@Nonnull final List<Double> margins,
+    private static MarginStats marginStats(final List<Double> margins,
                                            final double lowMarginThreshold,
                                            final int n,
                                            final int k) {
@@ -627,7 +618,7 @@ public class PartitionEvaluator {
      * @return the resolved low-margin threshold
      */
     @SuppressWarnings("SwitchStatementWithTooFewBranches")
-    private static double computeLowMarginThreshold(@Nonnull final Parameters parameters,
+    private static double computeLowMarginThreshold(final Parameters parameters,
                                                     final double overallP95) {
         return switch (parameters.distanceEstimator.getMetric()) {
             case COSINE_METRIC -> parameters.lowMarginThreshold > 0.0 ? parameters.lowMarginThreshold : 0.02;
@@ -647,8 +638,8 @@ public class PartitionEvaluator {
      * @throws UnsupportedOperationException if the estimator's metric is neither
      *         {@code EUCLIDEAN_METRIC} nor {@code COSINE_METRIC}
      */
-    private static double geometricDistance(@Nonnull final DistanceEstimator distanceEstimator, @Nonnull final RealVector a,
-                                            @Nonnull final RealVector b) {
+    private static double geometricDistance(final DistanceEstimator distanceEstimator, final RealVector a,
+                                            final RealVector b) {
         return switch (distanceEstimator.getMetric()) {
             case COSINE_METRIC, EUCLIDEAN_METRIC -> distanceEstimator.distance(a, b);
             default -> throw new UnsupportedOperationException("metric is not supported");
@@ -673,8 +664,8 @@ public class PartitionEvaluator {
      * @throws UnsupportedOperationException if the estimator's metric is neither
      *         {@code EUCLIDEAN_METRIC} nor {@code COSINE_METRIC}
      */
-    private static double distanceForSse(@Nonnull final DistanceEstimator distanceEstimator, @Nonnull final RealVector v,
-                                         @Nonnull final RealVector c) {
+    private static double distanceForSse(final DistanceEstimator distanceEstimator, final RealVector v,
+                                         final RealVector c) {
         return switch (distanceEstimator.getMetric()) {
             case COSINE_METRIC -> 2.0d * distanceEstimator.distance(v, c);
             case EUCLIDEAN_METRIC -> v.l2SquaredDistance(c);
@@ -692,7 +683,7 @@ public class PartitionEvaluator {
      *         {@code values} has exactly one element, that element is returned regardless of
      *         {@code p}
      */
-    private static double percentile(@Nonnull final List<Double> values, double p) {
+    private static double percentile(final List<Double> values, double p) {
         Preconditions.checkArgument(p >= 0.0d, "desired percentile should be >= 0");
         Preconditions.checkArgument(p <= 1.0d, "desired percentile should be <= 1");
 
@@ -743,9 +734,9 @@ public class PartitionEvaluator {
      * @param assignments per-vector cluster assignment; {@code assignments[i]} is the centroid index
      *        for the i-th vector in the corresponding vector list
      */
-    public record Partition<V>(@Nonnull List<V> centroids,
-                               @Nonnull Lens<V, RealVector> vectorLens,
-                               @Nonnull int[] assignments) {
+    public record Partition<V>(List<V> centroids,
+                               Lens<V, RealVector> vectorLens,
+                               int[] assignments) {
 
         /**
          * Returns the centroid at the given cluster index as a {@link RealVector}, dereferenced
@@ -754,7 +745,6 @@ public class PartitionEvaluator {
          * @param index cluster index in {@code [0, k())}
          * @return the centroid as a {@link RealVector}; never {@code null}
          */
-        @Nonnull
         public RealVector getCentroid(final int index) {
             return vectorLens.getNonnull(centroids.get(index));
         }
@@ -844,7 +834,7 @@ public class PartitionEvaluator {
          * @param logger the SLF4J logger to write to
          * @param messagePrefix free-form prefix prepended to the structured log line
          */
-        public void log(@Nonnull final Logger logger, @Nonnull final String messagePrefix) {
+        public void log(final Logger logger, final String messagePrefix) {
             if (logger.isTraceEnabled()) {
                 logger.trace("{} k={}, sse={}, imbalance={}, separation={}, largestFrac={}, smallestFrac={}" +
                                 ", maxRadius95={}, medianMargin={}, p10Margin={}, lowMarginRate={}",
@@ -889,7 +879,7 @@ public class PartitionEvaluator {
      * @param minScoreGain minimum composite score improvement the candidate must achieve over the
      *        current partitioning to be accepted
      */
-    public record Parameters(@Nonnull DistanceEstimator distanceEstimator, double minRelativeSseGain, double minSeparation,
+    public record Parameters(DistanceEstimator distanceEstimator, double minRelativeSseGain, double minSeparation,
                              double maxLowMarginRate, double minSmallestFrac, double maxLargestFrac,
                              double lowMarginThreshold, double alphaSseGain, double betaSeparationGain,
                              double gammaImbalancePenalty, double deltaLowMarginPenalty, double minScoreGain) {
@@ -903,7 +893,7 @@ public class PartitionEvaluator {
          *
          * @param distanceEstimator the distance estimator used for all distance computations
          */
-        public Parameters(@Nonnull final DistanceEstimator distanceEstimator) {
+        public Parameters(final DistanceEstimator distanceEstimator) {
             this(distanceEstimator,
                     0.10d,
                     0.3d,
@@ -931,8 +921,8 @@ public class PartitionEvaluator {
      * @param scoreGain composite quality score difference between candidate and current
      * @param reason human-readable explanation of why this decision was made
      */
-    public record EvaluationResult(@Nonnull Decision decision, @Nonnull PartitionStats currentStats,
-                                   @Nonnull PartitionStats candidateStats, double relativeSseGain, double scoreGain,
+    public record EvaluationResult(Decision decision, PartitionStats currentStats,
+                                   PartitionStats candidateStats, double relativeSseGain, double scoreGain,
                                    String reason) {
     }
 }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/kmeans/package-info.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/kmeans/package-info.java
@@ -21,4 +21,7 @@
 /**
  * k-means++ algorithm.
  */
+@NullMarked
 package com.apple.foundationdb.kmeans;
+
+import org.jspecify.annotations.NullMarked;

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/linear/AbstractRealVector.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/linear/AbstractRealVector.java
@@ -23,7 +23,6 @@ package com.apple.foundationdb.linear;
 import com.google.common.base.Suppliers;
 import com.google.common.base.Verify;
 
-import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.function.Supplier;
@@ -44,18 +43,14 @@ import java.util.stream.Collectors;
  * (per the {@link #AbstractRealVector(double[]) constructor contract}).
  */
 public abstract class AbstractRealVector implements RealVector {
-    @Nonnull
     protected final double[] data;
 
-    @Nonnull
     @SuppressWarnings("this-escape")
     protected Supplier<Integer> hashCodeSupplier = Suppliers.memoize(this::computeHashCode);
 
-    @Nonnull
     @SuppressWarnings("this-escape")
     private final Supplier<byte[]> toRawDataSupplier = Suppliers.memoize(this::computeRawData);
 
-    @Nonnull
     @SuppressWarnings("this-escape")
     private final Supplier<Double> l2SquaredNormSupplier = Suppliers.memoize(this::computeL2SquaredNorm);
 
@@ -69,7 +64,7 @@ public abstract class AbstractRealVector implements RealVector {
      * @param data the components of this vector
      * @throws NullPointerException if the provided {@code data} array is null.
      */
-    protected AbstractRealVector(@Nonnull final double[] data) {
+    protected AbstractRealVector(final double[] data) {
         this.data = data;
     }
 
@@ -106,7 +101,6 @@ public abstract class AbstractRealVector implements RealVector {
      * unless the concrete subtype is {@link MutableDoubleRealVector}.
      * @return the data array, never {@code null}.
      */
-    @Nonnull
     @Override
     public double[] getData() {
         return data;
@@ -119,7 +113,6 @@ public abstract class AbstractRealVector implements RealVector {
      * implementation-specific and should be documented by the concrete class that implements this method.
      * @return a non-null byte array containing the raw data.
      */
-    @Nonnull
     @Override
     public byte[] getRawData() {
         return toRawDataSupplier.get();
@@ -132,7 +125,6 @@ public abstract class AbstractRealVector implements RealVector {
      * implementation-specific and should be documented by the concrete class that implements this method.
      * @return a non-null byte array containing the raw data.
      */
-    @Nonnull
     protected abstract byte[] computeRawData();
 
     /**
@@ -239,8 +231,7 @@ public abstract class AbstractRealVector implements RealVector {
      * @return a new {@code double[]} of the same length, each element widened from the
      *         corresponding {@code ints[i]}
      */
-    @Nonnull
-    protected static double[] fromInts(@Nonnull final int[] ints) {
+    protected static double[] fromInts(final int[] ints) {
         final double[] result = new double[ints.length];
         for (int i = 0; i < ints.length; i++) {
             result[i] = ints[i];
@@ -259,8 +250,7 @@ public abstract class AbstractRealVector implements RealVector {
      * @return a new {@code double[]} of the same length, each element widened from the
      *         corresponding {@code longs[i]}
      */
-    @Nonnull
-    protected static double[] fromLongs(@Nonnull final long[] longs) {
+    protected static double[] fromLongs(final long[] longs) {
         final double[] result = new double[longs.length];
         for (int i = 0; i < longs.length; i++) {
             result[i] = longs[i];

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/linear/AffineOperator.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/linear/AffineOperator.java
@@ -23,8 +23,7 @@ package com.apple.foundationdb.linear;
 import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.google.common.base.Preconditions;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Vector operator that applies/unapplies a linear operator and an addition to a vector.
@@ -54,9 +53,8 @@ public class AffineOperator implements VectorOperator {
                   : -1);
     }
 
-    @Nonnull
     @Override
-    public RealVector apply(@Nonnull final RealVector vector) {
+    public RealVector apply(final RealVector vector) {
         RealVector result = vector;
 
         if (linearOperator != null) {
@@ -70,9 +68,8 @@ public class AffineOperator implements VectorOperator {
         return  result;
     }
 
-    @Nonnull
     @Override
-    public RealVector invertedApply(@Nonnull final RealVector vector) {
+    public RealVector invertedApply(final RealVector vector) {
         RealVector result = vector;
 
         if (translationVector != null) {
@@ -86,7 +83,6 @@ public class AffineOperator implements VectorOperator {
         return result;
     }
 
-    @Nonnull
     public static AffineOperator identity() {
         return IDENTITY_OPERATOR;
     }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/linear/Backend.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/linear/Backend.java
@@ -22,7 +22,6 @@ package com.apple.foundationdb.linear;
 
 import com.apple.foundationdb.annotation.API;
 
-import javax.annotation.Nonnull;
 
 /**
  * Per-component vector arithmetic primitives on {@code double[]} arrays. Implementations may be a
@@ -50,7 +49,6 @@ public interface Backend {
      *
      * @return a non-null label that uniquely identifies this backend at runtime
      */
-    @Nonnull
     String name();
 
     /**
@@ -65,7 +63,7 @@ public interface Backend {
      * @param out destination array; receives {@code a + b} component-wise. Must have the same
      *        length as {@code a} and {@code b}
      */
-    void addInto(@Nonnull double[] a, @Nonnull double[] b, @Nonnull double[] out);
+    void addInto(double[] a, double[] b, double[] out);
 
     /**
      * Computes the broadcast sum {@code out[i] = a[i] + scalar} for every {@code i}.
@@ -77,7 +75,7 @@ public interface Backend {
      * @param out destination array; receives {@code a + scalar} component-wise. Must have the
      *        same length as {@code a}
      */
-    void addInto(@Nonnull double[] a, double scalar, @Nonnull double[] out);
+    void addInto(double[] a, double scalar, double[] out);
 
     /**
      * Computes the element-wise difference {@code out[i] = a[i] - b[i]} for every {@code i}.
@@ -89,7 +87,7 @@ public interface Backend {
      * @param out destination array; receives {@code a - b} component-wise. Must have the same
      *        length as {@code a} and {@code b}
      */
-    void subtractInto(@Nonnull double[] a, @Nonnull double[] b, @Nonnull double[] out);
+    void subtractInto(double[] a, double[] b, double[] out);
 
     /**
      * Computes the broadcast difference {@code out[i] = a[i] - scalar} for every {@code i}.
@@ -101,7 +99,7 @@ public interface Backend {
      * @param out destination array; receives {@code a - scalar} component-wise. Must have the
      *        same length as {@code a}
      */
-    void subtractInto(@Nonnull double[] a, double scalar, @Nonnull double[] out);
+    void subtractInto(double[] a, double scalar, double[] out);
 
     /**
      * Computes the broadcast product {@code out[i] = a[i] * scalar} for every {@code i}. Used
@@ -115,7 +113,7 @@ public interface Backend {
      * @param out destination array; receives {@code a * scalar} component-wise. Must have the
      *        same length as {@code a}
      */
-    void multiplyInto(@Nonnull double[] a, double scalar, @Nonnull double[] out);
+    void multiplyInto(double[] a, double scalar, double[] out);
 
     /**
      * Computes the AXPY-shaped fused multiply-add {@code out[i] = scalar * x[i] + y[i]} for every
@@ -145,8 +143,8 @@ public interface Backend {
      * @param from inclusive start index
      * @param length number of elements to write
      */
-    void multiplyAddInto(double scalar, @Nonnull double[] x, @Nonnull double[] y,
-                         @Nonnull double[] out, int from, int length);
+    void multiplyAddInto(double scalar, double[] x, double[] y,
+                         double[] out, int from, int length);
 
     /**
      * Returns the dot product {@code Σ a[i] * b[i]} as a single {@code double}.
@@ -161,7 +159,7 @@ public interface Backend {
      * @param b right operand; must have the same length as {@code a}
      * @return the dot product of {@code a} and {@code b}
      */
-    double dot(@Nonnull double[] a, @Nonnull double[] b);
+    double dot(double[] a, double[] b);
 
     /**
      * Returns the dot product {@code Σ_{i ∈ [from, from+length)} a[i] * b[i]} over a contiguous
@@ -177,7 +175,7 @@ public interface Backend {
      *        {@code [from, from+length)} must lie within both arrays
      * @return the dot product over the slice
      */
-    double dot(@Nonnull double[] a, @Nonnull double[] b, int from, int length);
+    double dot(double[] a, double[] b, int from, int length);
 
     /**
      * Returns the squared L2 norm {@code Σ a[i] * a[i]} as a single {@code double}. Equivalent
@@ -189,7 +187,7 @@ public interface Backend {
      * @param a vector to take the norm of
      * @return the squared L2 norm of {@code a}
      */
-    double l2SquaredNorm(@Nonnull double[] a);
+    double l2SquaredNorm(double[] a);
 
     /**
      * Returns the squared L2 norm {@code Σ_{i ∈ [from, from+length)} a[i] * a[i]} over a contiguous
@@ -202,7 +200,7 @@ public interface Backend {
      *        {@code a}
      * @return the squared L2 norm over the slice
      */
-    double l2SquaredNorm(@Nonnull double[] a, int from, int length);
+    double l2SquaredNorm(double[] a, int from, int length);
 
     /**
      * Returns the squared Euclidean distance {@code Σ (a[i] - b[i])^2} as a single {@code double}.
@@ -215,5 +213,5 @@ public interface Backend {
      * @param b right operand; must have the same length as {@code a}
      * @return the squared Euclidean distance between {@code a} and {@code b}
      */
-    double euclideanSquared(@Nonnull double[] a, @Nonnull double[] b);
+    double euclideanSquared(double[] a, double[] b);
 }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/linear/ColumnMajorRealMatrix.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/linear/ColumnMajorRealMatrix.java
@@ -24,23 +24,19 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 
-import javax.annotation.Nonnull;
 import java.util.Arrays;
 
 public class ColumnMajorRealMatrix implements RealMatrix {
-    @Nonnull
     private final double[][] data;
-    @Nonnull
     @SuppressWarnings("this-escape")
     private final Supplier<Integer> hashCodeSupplier = Suppliers.memoize(this::valueBasedHashCode);
 
-    public ColumnMajorRealMatrix(@Nonnull final double[][] data) {
+    public ColumnMajorRealMatrix(final double[][] data) {
         Preconditions.checkArgument(data.length > 0);
         Preconditions.checkArgument(data[0].length > 0);
         this.data = data;
     }
 
-    @Nonnull
     private double[][] getData() {
         return data;
     }
@@ -60,12 +56,10 @@ public class ColumnMajorRealMatrix implements RealMatrix {
         return data[column][row];
     }
 
-    @Nonnull
     public double[] getColumn(final int column) {
         return data[column];
     }
 
-    @Nonnull
     @Override
     public ColumnMajorRealMatrix transpose() {
         int n = getNumRowDimensions();
@@ -79,9 +73,8 @@ public class ColumnMajorRealMatrix implements RealMatrix {
         return new ColumnMajorRealMatrix(result);
     }
 
-    @Nonnull
     @Override
-    public DoubleRealVector apply(@Nonnull final RealVector vector) {
+    public DoubleRealVector apply(final RealVector vector) {
         Preconditions.checkArgument(getNumColumnDimensions() == vector.getNumDimensions());
         final int n = getNumRowDimensions();
         final int m = getNumColumnDimensions();
@@ -95,9 +88,8 @@ public class ColumnMajorRealMatrix implements RealMatrix {
         return new DoubleRealVector(result);
     }
 
-    @Nonnull
     @Override
-    public DoubleRealVector transposedApply(@Nonnull final RealVector vector) {
+    public DoubleRealVector transposedApply(final RealVector vector) {
         Preconditions.checkArgument(getNumRowDimensions() == vector.getNumDimensions());
         final int n = getNumRowDimensions();
         final int m = getNumColumnDimensions();
@@ -123,9 +115,8 @@ public class ColumnMajorRealMatrix implements RealMatrix {
      *        {@code otherMatrix.getNumRowDimensions() == this.getNumColumnDimensions()}
      * @return a new {@link ColumnMajorRealMatrix} containing the product
      */
-    @Nonnull
     @Override
-    public ColumnMajorRealMatrix multiply(@Nonnull final RealMatrix otherMatrix) {
+    public ColumnMajorRealMatrix multiply(final RealMatrix otherMatrix) {
         Preconditions.checkArgument(getNumColumnDimensions() == otherMatrix.getNumRowDimensions());
         final int n = getNumRowDimensions();
         final int m = otherMatrix.getNumColumnDimensions();
@@ -142,7 +133,6 @@ public class ColumnMajorRealMatrix implements RealMatrix {
         return new ColumnMajorRealMatrix(result);
     }
 
-    @Nonnull
     @Override
     public ColumnMajorRealMatrix subMatrix(final int startRow, final int lengthRow,
                                            final int startColumn, final int lengthColumn) {
@@ -155,37 +145,31 @@ public class ColumnMajorRealMatrix implements RealMatrix {
         return new ColumnMajorRealMatrix(subData);
     }
 
-    @Nonnull
     @Override
     public RowMajorRealMatrix toRowMajor() {
         return new RowMajorRealMatrix(getRowMajorData());
     }
 
-    @Nonnull
     @Override
     public double[][] getRowMajorData() {
         return transpose().getData();
     }
 
-    @Nonnull
     @Override
     public ColumnMajorRealMatrix toColumnMajor() {
         return this;
     }
 
-    @Nonnull
     @Override
     public double[][] getColumnMajorData() {
         return getData();
     }
 
-    @Nonnull
     @Override
     public RowMajorRealMatrix quickTranspose() {
         return new RowMajorRealMatrix(getColumnMajorData());
     }
 
-    @Nonnull
     @Override
     public RowMajorRealMatrix flipMajor() {
         return (RowMajorRealMatrix)RealMatrix.super.flipMajor();

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/linear/DistanceEstimator.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/linear/DistanceEstimator.java
@@ -20,7 +20,6 @@
 
 package com.apple.foundationdb.linear;
 
-import javax.annotation.Nonnull;
 
 /**
  * Computes a distance between two vectors. Implementations are typically tied to a specific
@@ -34,7 +33,6 @@ public interface DistanceEstimator {
     /**
      * Returns the underlying {@link Metric} this estimator computes.
      */
-    @Nonnull
     Metric getMetric();
 
     /**
@@ -42,8 +40,8 @@ public interface DistanceEstimator {
      * underlying vectors from {@link Transformed} containers and forwards to the
      * {@code RealVector} variant.
      */
-    default boolean isOptimized(@Nonnull final Transformed<? extends RealVector> vector1,
-                                @Nonnull final Transformed<? extends RealVector> vector2) {
+    default boolean isOptimized(final Transformed<? extends RealVector> vector1,
+                                final Transformed<? extends RealVector> vector2) {
         return isOptimized(vector1.getUnderlyingVector(), vector2.getUnderlyingVector());
     }
 
@@ -63,16 +61,16 @@ public interface DistanceEstimator {
      * @return {@code true} iff this estimator has a metric-specific fast path for the given
      *         pair
      */
-    boolean isOptimized(@Nonnull RealVector vector1,
-                        @Nonnull RealVector vector2);
+    boolean isOptimized(RealVector vector1,
+                        RealVector vector2);
 
     /**
      * Convenience overload of {@link #distance(RealVector, RealVector)} that unwraps the
      * underlying vectors from {@link Transformed} containers and forwards to the
      * {@code RealVector} variant.
      */
-    default double distance(@Nonnull final Transformed<? extends RealVector> vector1,
-                            @Nonnull final Transformed<? extends RealVector> vector2) {
+    default double distance(final Transformed<? extends RealVector> vector1,
+                            final Transformed<? extends RealVector> vector2) {
         return distance(vector1.getUnderlyingVector(), vector2.getUnderlyingVector());
     }
 
@@ -90,8 +88,8 @@ public interface DistanceEstimator {
      * @param vector2 the second pre-rotated and translated vector
      * @return a non-negative {@code double} representing the distance between the two vectors
      */
-    double distance(@Nonnull RealVector vector1,
-                    @Nonnull RealVector vector2);
+    double distance(RealVector vector1,
+                    RealVector vector2);
 
     /**
      * Returns a plain {@link DistanceEstimator} that delegates straight to {@code metric.distance(...)}.
@@ -101,22 +99,20 @@ public interface DistanceEstimator {
      * @param metric the metric to wrap
      * @return a non-null estimator that computes {@code metric}'s distance directly
      */
-    @Nonnull
-    static DistanceEstimator ofMetric(@Nonnull final Metric metric) {
+    static DistanceEstimator ofMetric(final Metric metric) {
         return new DistanceEstimator() {
-            @Nonnull
             @Override
             public Metric getMetric() {
                 return metric;
             }
 
             @Override
-            public boolean isOptimized(@Nonnull final RealVector vector1, @Nonnull final RealVector vector2) {
+            public boolean isOptimized(final RealVector vector1, final RealVector vector2) {
                 return false;
             }
 
             @Override
-            public double distance(@Nonnull final RealVector vector1, @Nonnull final RealVector vector2) {
+            public double distance(final RealVector vector1, final RealVector vector2) {
                 final double distance = metric.distance(vector1, vector2);
                 if (!Double.isFinite(distance)) {
                     throw new IllegalArgumentException("vector has an L2 norm of infinite, not a number, or 0");

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/linear/DoubleRealVector.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/linear/DoubleRealVector.java
@@ -23,7 +23,6 @@ package com.apple.foundationdb.linear;
 import com.google.common.base.Suppliers;
 import com.google.common.base.Verify;
 
-import javax.annotation.Nonnull;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.function.Supplier;
@@ -36,10 +35,8 @@ import java.util.function.Supplier;
  * {@link MutableDoubleRealVector}.
  */
 public class DoubleRealVector extends AbstractRealVector {
-    @Nonnull
     @SuppressWarnings("this-escape")
     private final Supplier<HalfRealVector> toHalfVectorSupplier = Suppliers.memoize(this::computeHalfRealVector);
-    @Nonnull
     @SuppressWarnings("this-escape")
     private final Supplier<FloatRealVector> toFloatVectorSupplier = Suppliers.memoize(this::computeFloatRealVector);
 
@@ -50,7 +47,7 @@ public class DoubleRealVector extends AbstractRealVector {
      *
      * @param doubleData the components of the new vector
      */
-    public DoubleRealVector(@Nonnull final Double[] doubleData) {
+    public DoubleRealVector(final Double[] doubleData) {
         this(computeDoubleData(doubleData));
     }
 
@@ -62,7 +59,7 @@ public class DoubleRealVector extends AbstractRealVector {
      *
      * @param data the components of the new vector; ownership transfers to this vector
      */
-    public DoubleRealVector(@Nonnull final double[] data) {
+    public DoubleRealVector(final double[] data) {
         super(data);
     }
 
@@ -72,7 +69,7 @@ public class DoubleRealVector extends AbstractRealVector {
      *
      * @param intData the components of the new vector
      */
-    public DoubleRealVector(@Nonnull final int[] intData) {
+    public DoubleRealVector(final int[] intData) {
         this(fromInts(intData));
     }
 
@@ -83,14 +80,13 @@ public class DoubleRealVector extends AbstractRealVector {
      *
      * @param longData the components of the new vector
      */
-    public DoubleRealVector(@Nonnull final long[] longData) {
+    public DoubleRealVector(final long[] longData) {
         this(fromLongs(longData));
     }
 
     /**
      * Returns the memoized half-precision projection of this vector.
      */
-    @Nonnull
     @Override
     public HalfRealVector toHalfRealVector() {
         return toHalfVectorSupplier.get();
@@ -103,7 +99,6 @@ public class DoubleRealVector extends AbstractRealVector {
      *
      * @return a new {@link HalfRealVector} with this vector's components
      */
-    @Nonnull
     protected HalfRealVector computeHalfRealVector() {
         return new HalfRealVector(data);
     }
@@ -111,7 +106,6 @@ public class DoubleRealVector extends AbstractRealVector {
     /**
      * Returns the memoized single-precision projection of this vector.
      */
-    @Nonnull
     @Override
     public FloatRealVector toFloatRealVector() {
         return toFloatVectorSupplier.get();
@@ -124,7 +118,6 @@ public class DoubleRealVector extends AbstractRealVector {
      *
      * @return a new {@link FloatRealVector} with this vector's components
      */
-    @Nonnull
     protected FloatRealVector computeFloatRealVector() {
         return new FloatRealVector(data);
     }
@@ -132,7 +125,6 @@ public class DoubleRealVector extends AbstractRealVector {
     /**
      * Returns {@code this} — already a double-precision vector, so no conversion is needed.
      */
-    @Nonnull
     @Override
     public DoubleRealVector toDoubleRealVector() {
         return this;
@@ -146,16 +138,14 @@ public class DoubleRealVector extends AbstractRealVector {
      * @param data the components of the new vector
      * @return a fresh immutable double-precision vector
      */
-    @Nonnull
     @Override
-    public DoubleRealVector withData(@Nonnull final double[] data) {
+    public DoubleRealVector withData(final double[] data) {
         return new DoubleRealVector(data);
     }
 
     /**
      * Returns {@code this} — instances of this class are already immutable.
      */
-    @Nonnull
     @Override
     public DoubleRealVector toImmutable() {
         return this;
@@ -168,7 +158,6 @@ public class DoubleRealVector extends AbstractRealVector {
      *
      * @return a new byte array representing the serialized vector data; never {@code null}
      */
-    @Nonnull
     @Override
     protected byte[] computeRawData() {
         final byte[] vectorBytes = new byte[1 + 8 * getNumDimensions()];
@@ -185,7 +174,6 @@ public class DoubleRealVector extends AbstractRealVector {
      *
      * <p>Narrows the return type to {@link DoubleRealVector}.
      */
-    @Nonnull
     @Override
     public DoubleRealVector normalize() {
         return withData(RealVectorPrimitives.normalizeInto(this.getData(), new double[getNumDimensions()]));
@@ -196,9 +184,8 @@ public class DoubleRealVector extends AbstractRealVector {
      *
      * <p>Narrows the return type to {@link DoubleRealVector}.
      */
-    @Nonnull
     @Override
-    public DoubleRealVector add(@Nonnull final RealVector other) {
+    public DoubleRealVector add(final RealVector other) {
         return withData(RealVectorPrimitives.addInto(this.getData(), other.getData(), new double[getNumDimensions()]));
     }
 
@@ -207,7 +194,6 @@ public class DoubleRealVector extends AbstractRealVector {
      *
      * <p>Narrows the return type to {@link DoubleRealVector}.
      */
-    @Nonnull
     @Override
     public DoubleRealVector add(final double scalar) {
         return withData(RealVectorPrimitives.addInto(this.getData(), scalar, new double[getNumDimensions()]));
@@ -218,9 +204,8 @@ public class DoubleRealVector extends AbstractRealVector {
      *
      * <p>Narrows the return type to {@link DoubleRealVector}.
      */
-    @Nonnull
     @Override
-    public DoubleRealVector subtract(@Nonnull final RealVector other) {
+    public DoubleRealVector subtract(final RealVector other) {
         return withData(RealVectorPrimitives.subtractInto(this.getData(), other.getData(), new double[getNumDimensions()]));
     }
 
@@ -229,7 +214,6 @@ public class DoubleRealVector extends AbstractRealVector {
      *
      * <p>Narrows the return type to {@link DoubleRealVector}.
      */
-    @Nonnull
     @Override
     public DoubleRealVector subtract(final double scalar) {
         return withData(RealVectorPrimitives.subtractInto(this.getData(), scalar, new double[getNumDimensions()]));
@@ -240,7 +224,6 @@ public class DoubleRealVector extends AbstractRealVector {
      *
      * <p>Narrows the return type to {@link DoubleRealVector}.
      */
-    @Nonnull
     @Override
     public DoubleRealVector multiply(final double scalar) {
         return withData(RealVectorPrimitives.multiplyInto(this.getData(), scalar, new double[getNumDimensions()]));
@@ -251,7 +234,6 @@ public class DoubleRealVector extends AbstractRealVector {
      * @param numDimensions number of dimensions
      * @return a vector whose components are all zero
      */
-    @Nonnull
     public static DoubleRealVector zeroVector(final int numDimensions) {
         return new DoubleRealVector(new double[numDimensions]);
     }
@@ -264,8 +246,7 @@ public class DoubleRealVector extends AbstractRealVector {
      * @param doubleData the boxed components
      * @return a new primitive array of the same length and values
      */
-    @Nonnull
-    protected static double[] computeDoubleData(@Nonnull Double[] doubleData) {
+    protected static double[] computeDoubleData(Double[] doubleData) {
         double[] result = new double[doubleData.length];
         for (int i = 0; i < doubleData.length; i++) {
             result[i] = doubleData[i];
@@ -282,8 +263,7 @@ public class DoubleRealVector extends AbstractRealVector {
      * @param vectorBytes the non-null byte array to convert
      * @return a new {@link DoubleRealVector} instance created from the byte array
      */
-    @Nonnull
-    public static DoubleRealVector fromBytes(@Nonnull final byte[] vectorBytes) {
+    public static DoubleRealVector fromBytes(final byte[] vectorBytes) {
         return new DoubleRealVector(decodeDoubleBytes(vectorBytes));
     }
 
@@ -296,8 +276,7 @@ public class DoubleRealVector extends AbstractRealVector {
      * @param vectorBytes the non-null byte array to decode
      * @return a freshly allocated {@code double[]} with the decoded components
      */
-    @Nonnull
-    protected static double[] decodeDoubleBytes(@Nonnull final byte[] vectorBytes) {
+    protected static double[] decodeDoubleBytes(final byte[] vectorBytes) {
         final ByteBuffer buffer = ByteBuffer.wrap(vectorBytes).order(ByteOrder.BIG_ENDIAN);
         Verify.verify(buffer.get() == VectorType.DOUBLE.ordinal());
         final int numDimensions = vectorBytes.length >> 3;

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/linear/FhtKacRotator.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/linear/FhtKacRotator.java
@@ -22,7 +22,6 @@ package com.apple.foundationdb.linear;
 
 import com.google.common.annotations.VisibleForTesting;
 
-import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Random;
@@ -109,14 +108,12 @@ public final class FhtKacRotator implements LinearOperator {
         return true;
     }
 
-    @Nonnull
     @Override
-    public RealVector apply(@Nonnull final RealVector x) {
+    public RealVector apply(final RealVector x) {
         return new DoubleRealVector(operate(x.getData()));
     }
 
-    @Nonnull
-    private double[] operate(@Nonnull final double[] x) {
+    private double[] operate(final double[] x) {
         if (x.length != numDimensions) {
             throw new IllegalArgumentException("dimensionality of x != n");
         }
@@ -140,14 +137,12 @@ public final class FhtKacRotator implements LinearOperator {
         return y;
     }
 
-    @Nonnull
     @Override
-    public RealVector transposedApply(@Nonnull final RealVector x) {
+    public RealVector transposedApply(final RealVector x) {
         return new DoubleRealVector(operateTranspose(x.getData()));
     }
 
-    @Nonnull
-    private double[] operateTranspose(@Nonnull final double[] x) {
+    private double[] operateTranspose(final double[] x) {
         if (x.length != numDimensions) {
             throw new IllegalArgumentException("dimensionality of x != n");
         }
@@ -174,7 +169,6 @@ public final class FhtKacRotator implements LinearOperator {
     /**
      *  Build dense P as double[n][n] (row-major). This method exists for testing purposes only.
      */
-    @Nonnull
     @VisibleForTesting
     public RowMajorRealMatrix computeP() {
         final double[][] p = new double[numDimensions][numDimensions];

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/linear/FloatRealVector.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/linear/FloatRealVector.java
@@ -23,7 +23,6 @@ package com.apple.foundationdb.linear;
 import com.google.common.base.Suppliers;
 import com.google.common.base.Verify;
 
-import javax.annotation.Nonnull;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.function.Supplier;
@@ -37,7 +36,6 @@ import java.util.function.Supplier;
  * memoized (it simply wraps the existing array).
  */
 public class FloatRealVector extends AbstractRealVector {
-    @Nonnull
     @SuppressWarnings("this-escape")
     private final Supplier<HalfRealVector> toHalfRealVectorSupplier = Suppliers.memoize(this::computeHalfRealVector);
 
@@ -48,7 +46,7 @@ public class FloatRealVector extends AbstractRealVector {
      *
      * @param floatData the components of the new vector
      */
-    public FloatRealVector(@Nonnull final Float[] floatData) {
+    public FloatRealVector(final Float[] floatData) {
         this(computeDoubleData(floatData));
     }
 
@@ -59,7 +57,7 @@ public class FloatRealVector extends AbstractRealVector {
      *
      * @param floatData the components of the new vector
      */
-    public FloatRealVector(@Nonnull final float[] floatData) {
+    public FloatRealVector(final float[] floatData) {
         this(computeDoubleData(floatData));
     }
 
@@ -71,7 +69,7 @@ public class FloatRealVector extends AbstractRealVector {
      *
      * @param data the components of the new vector, in {@code double} precision
      */
-    public FloatRealVector(@Nonnull final double[] data) {
+    public FloatRealVector(final double[] data) {
         super(truncateDoubleData(data));
     }
 
@@ -81,7 +79,7 @@ public class FloatRealVector extends AbstractRealVector {
      *
      * @param intData the components of the new vector
      */
-    public FloatRealVector(@Nonnull final int[] intData) {
+    public FloatRealVector(final int[] intData) {
         this(fromInts(intData));
     }
 
@@ -93,14 +91,13 @@ public class FloatRealVector extends AbstractRealVector {
      *
      * @param longData the components of the new vector
      */
-    public FloatRealVector(@Nonnull final long[] longData) {
+    public FloatRealVector(final long[] longData) {
         this(fromLongs(longData));
     }
 
     /**
      * Returns the memoized half-precision projection of this vector.
      */
-    @Nonnull
     @Override
     public HalfRealVector toHalfRealVector() {
         return toHalfRealVectorSupplier.get();
@@ -112,7 +109,6 @@ public class FloatRealVector extends AbstractRealVector {
      *
      * @return a new {@link HalfRealVector} with this vector's components
      */
-    @Nonnull
     public HalfRealVector computeHalfRealVector() {
         return new HalfRealVector(data);
     }
@@ -120,7 +116,6 @@ public class FloatRealVector extends AbstractRealVector {
     /**
      * Returns {@code this} — already a single-precision vector, so no conversion is needed.
      */
-    @Nonnull
     @Override
     public FloatRealVector toFloatRealVector() {
         return this;
@@ -131,7 +126,6 @@ public class FloatRealVector extends AbstractRealVector {
      * Note that the underlying values are still float-truncated; the conversion only changes the
      * runtime type, not the precision of the data.
      */
-    @Nonnull
     @Override
     public DoubleRealVector toDoubleRealVector() {
         return new DoubleRealVector(data);
@@ -144,16 +138,14 @@ public class FloatRealVector extends AbstractRealVector {
      * @param data the components of the new vector
      * @return a fresh immutable single-precision vector
      */
-    @Nonnull
     @Override
-    public FloatRealVector withData(@Nonnull final double[] data) {
+    public FloatRealVector withData(final double[] data) {
         return new FloatRealVector(data);
     }
 
     /**
      * Returns {@code this} — instances of this class are already immutable.
      */
-    @Nonnull
     @Override
     public FloatRealVector toImmutable() {
         return this;
@@ -166,7 +158,6 @@ public class FloatRealVector extends AbstractRealVector {
      *
      * @return a new byte array representing the serialized vector data; never {@code null}
      */
-    @Nonnull
     @Override
     protected byte[] computeRawData() {
         final byte[] vectorBytes = new byte[1 + 4 * getNumDimensions()];
@@ -183,7 +174,6 @@ public class FloatRealVector extends AbstractRealVector {
      *
      * <p>Narrows the return type to {@link FloatRealVector}.
      */
-    @Nonnull
     @Override
     public FloatRealVector normalize() {
         return withData(RealVectorPrimitives.normalizeInto(this.getData(), new double[getNumDimensions()]));
@@ -194,9 +184,8 @@ public class FloatRealVector extends AbstractRealVector {
      *
      * <p>Narrows the return type to {@link FloatRealVector}.
      */
-    @Nonnull
     @Override
-    public FloatRealVector add(@Nonnull final RealVector other) {
+    public FloatRealVector add(final RealVector other) {
         return withData(RealVectorPrimitives.addInto(this.getData(), other.getData(), new double[getNumDimensions()]));
     }
 
@@ -205,7 +194,6 @@ public class FloatRealVector extends AbstractRealVector {
      *
      * <p>Narrows the return type to {@link FloatRealVector}.
      */
-    @Nonnull
     @Override
     public FloatRealVector add(final double scalar) {
         return withData(RealVectorPrimitives.addInto(this.getData(), scalar, new double[getNumDimensions()]));
@@ -216,9 +204,8 @@ public class FloatRealVector extends AbstractRealVector {
      *
      * <p>Narrows the return type to {@link FloatRealVector}.
      */
-    @Nonnull
     @Override
-    public FloatRealVector subtract(@Nonnull final RealVector other) {
+    public FloatRealVector subtract(final RealVector other) {
         return withData(RealVectorPrimitives.subtractInto(this.getData(), other.getData(), new double[getNumDimensions()]));
     }
 
@@ -227,7 +214,6 @@ public class FloatRealVector extends AbstractRealVector {
      *
      * <p>Narrows the return type to {@link FloatRealVector}.
      */
-    @Nonnull
     @Override
     public FloatRealVector subtract(final double scalar) {
         return withData(RealVectorPrimitives.subtractInto(this.getData(), scalar, new double[getNumDimensions()]));
@@ -238,7 +224,6 @@ public class FloatRealVector extends AbstractRealVector {
      *
      * <p>Narrows the return type to {@link FloatRealVector}.
      */
-    @Nonnull
     @Override
     public FloatRealVector multiply(final double scalar) {
         return withData(RealVectorPrimitives.multiplyInto(this.getData(), scalar, new double[getNumDimensions()]));
@@ -249,7 +234,6 @@ public class FloatRealVector extends AbstractRealVector {
      * @param numDimensions number of dimensions
      * @return a vector whose components are all zero
      */
-    @Nonnull
     public static FloatRealVector zeroVector(final int numDimensions) {
         return new FloatRealVector(new float[numDimensions]);
     }
@@ -262,8 +246,7 @@ public class FloatRealVector extends AbstractRealVector {
      * @return a new {@code double[]} of the same length, each element widened from the
      *         corresponding {@code floatData[i]}
      */
-    @Nonnull
-    private static double[] computeDoubleData(@Nonnull Float[] floatData) {
+    private static double[] computeDoubleData(Float[] floatData) {
         double[] result = new double[floatData.length];
         for (int i = 0; i < floatData.length; i++) {
             result[i] = floatData[i];
@@ -279,8 +262,7 @@ public class FloatRealVector extends AbstractRealVector {
      * @return a new {@code double[]} of the same length, each element widened from the
      *         corresponding {@code floatData[i]}
      */
-    @Nonnull
-    private static double[] computeDoubleData(@Nonnull float[] floatData) {
+    private static double[] computeDoubleData(float[] floatData) {
         double[] result = new double[floatData.length];
         for (int i = 0; i < floatData.length; i++) {
             result[i] = floatData[i];
@@ -298,8 +280,7 @@ public class FloatRealVector extends AbstractRealVector {
      * @return a new {@code double[]} of the same length, each element truncated through
      *         {@code float}
      */
-    @Nonnull
-    private static double[] truncateDoubleData(@Nonnull double[] doubleData) {
+    private static double[] truncateDoubleData(double[] doubleData) {
         double[] result = new double[doubleData.length];
         for (int i = 0; i < doubleData.length; i++) {
             result[i] = (float)doubleData[i];
@@ -316,8 +297,7 @@ public class FloatRealVector extends AbstractRealVector {
      * @param vectorBytes the non-null byte array to convert
      * @return a new {@link FloatRealVector} instance created from the byte array
      */
-    @Nonnull
-    public static FloatRealVector fromBytes(@Nonnull final byte[] vectorBytes) {
+    public static FloatRealVector fromBytes(final byte[] vectorBytes) {
         final ByteBuffer buffer = ByteBuffer.wrap(vectorBytes).order(ByteOrder.BIG_ENDIAN);
         Verify.verify(buffer.get() == VectorType.SINGLE.ordinal());
         final int numDimensions = vectorBytes.length >> 2;

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/linear/HalfRealVector.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/linear/HalfRealVector.java
@@ -23,7 +23,6 @@ package com.apple.foundationdb.linear;
 import com.apple.foundationdb.half.Half;
 import com.google.common.base.Verify;
 
-import javax.annotation.Nonnull;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
@@ -44,7 +43,7 @@ public class HalfRealVector extends AbstractRealVector {
      *
      * @param halfData the components of the new vector
      */
-    public HalfRealVector(@Nonnull final Half[] halfData) {
+    public HalfRealVector(final Half[] halfData) {
         this(computeDoubleData(halfData));
     }
 
@@ -56,7 +55,7 @@ public class HalfRealVector extends AbstractRealVector {
      *
      * @param data the components of the new vector, in {@code double} precision
      */
-    public HalfRealVector(@Nonnull final double[] data) {
+    public HalfRealVector(final double[] data) {
         super(truncateDoubleData(data));
     }
 
@@ -68,7 +67,7 @@ public class HalfRealVector extends AbstractRealVector {
      *
      * @param intData the components of the new vector
      */
-    public HalfRealVector(@Nonnull final int[] intData) {
+    public HalfRealVector(final int[] intData) {
         this(fromInts(intData));
     }
 
@@ -79,14 +78,13 @@ public class HalfRealVector extends AbstractRealVector {
      *
      * @param longData the components of the new vector
      */
-    public HalfRealVector(@Nonnull final long[] longData) {
+    public HalfRealVector(final long[] longData) {
         this(fromLongs(longData));
     }
 
     /**
      * Returns {@code this} — already a half-precision vector, so no conversion is needed.
      */
-    @Nonnull
     @Override
     public HalfRealVector toHalfRealVector() {
         return this;
@@ -97,7 +95,6 @@ public class HalfRealVector extends AbstractRealVector {
      * Note that the underlying values are still half-truncated; the conversion only changes the
      * runtime type, not the precision of the data.
      */
-    @Nonnull
     @Override
     public FloatRealVector toFloatRealVector() {
         return new FloatRealVector(data);
@@ -108,7 +105,6 @@ public class HalfRealVector extends AbstractRealVector {
      * Note that the underlying values are still half-truncated; the conversion only changes the
      * runtime type, not the precision of the data.
      */
-    @Nonnull
     @Override
     public DoubleRealVector toDoubleRealVector() {
         return new DoubleRealVector(data);
@@ -121,9 +117,8 @@ public class HalfRealVector extends AbstractRealVector {
      * @param data the components of the new vector
      * @return a fresh immutable half-precision vector
      */
-    @Nonnull
     @Override
-    public HalfRealVector withData(@Nonnull final double[] data) {
+    public HalfRealVector withData(final double[] data) {
         return new HalfRealVector(data);
     }
 
@@ -135,7 +130,6 @@ public class HalfRealVector extends AbstractRealVector {
      *
      * @return a new byte array representing the serialized vector data; never {@code null}
      */
-    @Nonnull
     @Override
     protected byte[] computeRawData() {
         final byte[] vectorBytes = new byte[1 + 2 * getNumDimensions()];
@@ -152,7 +146,6 @@ public class HalfRealVector extends AbstractRealVector {
      *
      * <p>Narrows the return type to {@link HalfRealVector}.
      */
-    @Nonnull
     @Override
     public HalfRealVector normalize() {
         return withData(RealVectorPrimitives.normalizeInto(this.getData(), new double[getNumDimensions()]));
@@ -163,9 +156,8 @@ public class HalfRealVector extends AbstractRealVector {
      *
      * <p>Narrows the return type to {@link HalfRealVector}.
      */
-    @Nonnull
     @Override
-    public HalfRealVector add(@Nonnull final RealVector other) {
+    public HalfRealVector add(final RealVector other) {
         return withData(RealVectorPrimitives.addInto(this.getData(), other.getData(), new double[getNumDimensions()]));
     }
 
@@ -174,7 +166,6 @@ public class HalfRealVector extends AbstractRealVector {
      *
      * <p>Narrows the return type to {@link HalfRealVector}.
      */
-    @Nonnull
     @Override
     public HalfRealVector add(final double scalar) {
         return withData(RealVectorPrimitives.addInto(this.getData(), scalar, new double[getNumDimensions()]));
@@ -185,9 +176,8 @@ public class HalfRealVector extends AbstractRealVector {
      *
      * <p>Narrows the return type to {@link HalfRealVector}.
      */
-    @Nonnull
     @Override
-    public HalfRealVector subtract(@Nonnull final RealVector other) {
+    public HalfRealVector subtract(final RealVector other) {
         return withData(RealVectorPrimitives.subtractInto(this.getData(), other.getData(), new double[getNumDimensions()]));
     }
 
@@ -196,7 +186,6 @@ public class HalfRealVector extends AbstractRealVector {
      *
      * <p>Narrows the return type to {@link HalfRealVector}.
      */
-    @Nonnull
     @Override
     public HalfRealVector subtract(final double scalar) {
         return withData(RealVectorPrimitives.subtractInto(this.getData(), scalar, new double[getNumDimensions()]));
@@ -207,7 +196,6 @@ public class HalfRealVector extends AbstractRealVector {
      *
      * <p>Narrows the return type to {@link HalfRealVector}.
      */
-    @Nonnull
     @Override
     public HalfRealVector multiply(final double scalar) {
         return withData(RealVectorPrimitives.multiplyInto(this.getData(), scalar, new double[getNumDimensions()]));
@@ -218,7 +206,6 @@ public class HalfRealVector extends AbstractRealVector {
      * @param numDimensions number of dimensions
      * @return a vector whose components are all zero
      */
-    @Nonnull
     public static HalfRealVector zeroVector(final int numDimensions) {
         return new HalfRealVector(new double[numDimensions]);
     }
@@ -231,8 +218,7 @@ public class HalfRealVector extends AbstractRealVector {
      * @return a new {@code double[]} of the same length, each element widened from the
      *         corresponding {@code halfData[i]}
      */
-    @Nonnull
-    private static double[] computeDoubleData(@Nonnull Half[] halfData) {
+    private static double[] computeDoubleData(Half[] halfData) {
         double[] result = new double[halfData.length];
         for (int i = 0; i < halfData.length; i++) {
             result[i] = halfData[i].doubleValue();
@@ -250,8 +236,7 @@ public class HalfRealVector extends AbstractRealVector {
      * @return a new {@code double[]} of the same length, each element truncated through
      *         {@link Half}
      */
-    @Nonnull
-    private static double[] truncateDoubleData(@Nonnull double[] doubleData) {
+    private static double[] truncateDoubleData(double[] doubleData) {
         double[] result = new double[doubleData.length];
         for (int i = 0; i < doubleData.length; i++) {
             result[i] = Half.valueOf(doubleData[i]).doubleValue();
@@ -262,7 +247,6 @@ public class HalfRealVector extends AbstractRealVector {
     /**
      * Returns {@code this} — instances of this class are already immutable.
      */
-    @Nonnull
     @Override
     public HalfRealVector toImmutable() {
         return this;
@@ -277,8 +261,7 @@ public class HalfRealVector extends AbstractRealVector {
      * @param vectorBytes the non-null byte array to convert
      * @return a new {@link HalfRealVector} instance created from the byte array
      */
-    @Nonnull
-    public static HalfRealVector fromBytes(@Nonnull final byte[] vectorBytes) {
+    public static HalfRealVector fromBytes(final byte[] vectorBytes) {
         final ByteBuffer buffer = ByteBuffer.wrap(vectorBytes).order(ByteOrder.BIG_ENDIAN);
         Verify.verify(buffer.get() == VectorType.HALF.ordinal());
         final int numDimensions = vectorBytes.length >> 1;

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/linear/LinearOperator.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/linear/LinearOperator.java
@@ -20,7 +20,6 @@
 
 package com.apple.foundationdb.linear;
 
-import javax.annotation.Nonnull;
 
 public interface LinearOperator extends VectorOperator {
     int getNumRowDimensions();
@@ -38,12 +37,10 @@ public interface LinearOperator extends VectorOperator {
 
     boolean isTransposable();
 
-    @Nonnull
     @Override
-    default RealVector invertedApply(@Nonnull RealVector vector) {
+    default RealVector invertedApply(RealVector vector) {
         return transposedApply(vector);
     }
 
-    @Nonnull
-    RealVector transposedApply(@Nonnull RealVector vector);
+    RealVector transposedApply(RealVector vector);
 }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/linear/MatrixHelpers.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/linear/MatrixHelpers.java
@@ -20,7 +20,6 @@
 
 package com.apple.foundationdb.linear;
 
-import javax.annotation.Nonnull;
 import java.util.Random;
 
 public class MatrixHelpers {
@@ -29,13 +28,11 @@ public class MatrixHelpers {
         // nothing
     }
     
-    @Nonnull
-    public static RealMatrix randomOrthogonalMatrix(@Nonnull final Random random, final int dimension) {
+    public static RealMatrix randomOrthogonalMatrix(final Random random, final int dimension) {
         return QRDecomposition.decomposeMatrix(randomGaussianMatrix(random, dimension, dimension)).getQ();
     }
 
-    @Nonnull
-    public static RealMatrix randomGaussianMatrix(@Nonnull final Random random,
+    public static RealMatrix randomGaussianMatrix(final Random random,
                                                   final int rowDimension,
                                                   final int columnDimension) {
         final double[][] resultMatrix = new double[rowDimension][columnDimension];

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/linear/Metric.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/linear/Metric.java
@@ -20,7 +20,6 @@
 
 package com.apple.foundationdb.linear;
 
-import javax.annotation.Nonnull;
 
 /**
  * Represents various distance calculation strategies (metrics) for vectors.
@@ -78,14 +77,13 @@ public enum Metric implements MetricDefinition {
      */
     DOT_PRODUCT_METRIC(new MetricDefinition.DotProductMetric());
 
-    @Nonnull
     private final MetricDefinition metricDefinition;
 
     /**
      * Constructs a new Metric instance with the specified metric.
      * @param metricDefinition the metric to be associated with this Metric instance; must not be null.
      */
-    Metric(@Nonnull final MetricDefinition metricDefinition) {
+    Metric(final MetricDefinition metricDefinition) {
         this.metricDefinition = metricDefinition;
     }
 
@@ -116,7 +114,7 @@ public enum Metric implements MetricDefinition {
 
 
     @Override
-    public double distance(@Nonnull final double[] vectorData1, @Nonnull final double[] vectorData2) {
+    public double distance(final double[] vectorData1, final double[] vectorData2) {
         return metricDefinition.distance(vectorData1, vectorData2);
     }
 
@@ -135,7 +133,7 @@ public enum Metric implements MetricDefinition {
      * @throws IllegalArgumentException if the vectors have different lengths.
      * @throws NullPointerException if either {@code vector1} or {@code vector2} is null.
      */
-    public double distance(@Nonnull RealVector vector1, @Nonnull RealVector vector2) {
+    public double distance(RealVector vector1, RealVector vector2) {
         return distance(vector1.getData(), vector2.getData());
     }
 

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/linear/MetricDefinition.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/linear/MetricDefinition.java
@@ -20,7 +20,6 @@
 
 package com.apple.foundationdb.linear;
 
-import javax.annotation.Nonnull;
 
 /**
  * Defines a metric for measuring the distance or similarity between n-dimensional vectors.
@@ -84,8 +83,7 @@ interface MetricDefinition {
                 satisfiesTriangleInequality();
     }
 
-    @Nonnull
-    static String toString(@Nonnull final MetricDefinition metricDefinition) {
+    static String toString(final MetricDefinition metricDefinition) {
         return metricDefinition.getClass().getSimpleName() + ";" + metricDefinition.isTrueMetric() + " metric";
     }
 
@@ -104,7 +102,7 @@ interface MetricDefinition {
      * @throws IllegalArgumentException if the vectors have different lengths.
      * @throws NullPointerException if either {@code vector1} or {@code vector2} is null.
      */
-    double distance(@Nonnull double[] vector1, @Nonnull double[] vector2);
+    double distance(double[] vector1, double[] vector2);
 
     /**
      * A helper method to validate that vectors can be compared.
@@ -134,14 +132,13 @@ interface MetricDefinition {
      */
     final class EuclideanMetric implements MetricDefinition {
         @Override
-        public double distance(@Nonnull final double[] vector1, @Nonnull final double[] vector2) {
+        public double distance(final double[] vector1, final double[] vector2) {
             MetricDefinition.validate(vector1, vector2);
 
             return Math.sqrt(RealVectorPrimitives.euclideanSquared(vector1, vector2));
         }
 
         @Override
-        @Nonnull
         public String toString() {
             return MetricDefinition.toString(this);
         }
@@ -167,13 +164,12 @@ interface MetricDefinition {
         }
 
         @Override
-        public double distance(@Nonnull final double[] vector1, @Nonnull final double[] vector2) {
+        public double distance(final double[] vector1, final double[] vector2) {
             MetricDefinition.validate(vector1, vector2);
             return RealVectorPrimitives.euclideanSquared(vector1, vector2);
         }
 
         @Override
-        @Nonnull
         public String toString() {
             return MetricDefinition.toString(this);
         }
@@ -200,7 +196,7 @@ interface MetricDefinition {
         }
 
         @Override
-        public double distance(@Nonnull final double[] vector1, @Nonnull final double[] vector2) {
+        public double distance(final double[] vector1, final double[] vector2) {
             MetricDefinition.validate(vector1, vector2);
 
             final double normA = RealVectorPrimitives.l2SquaredNorm(vector1);
@@ -221,7 +217,6 @@ interface MetricDefinition {
         }
 
         @Override
-        @Nonnull
         public String toString() {
             return MetricDefinition.toString(this);
         }
@@ -259,17 +254,16 @@ interface MetricDefinition {
         }
 
         @Override
-        public double distance(@Nonnull final double[] vector1, @Nonnull final double[] vector2) {
+        public double distance(final double[] vector1, final double[] vector2) {
             return -dotProduct(vector1, vector2);
         }
 
-        public static double dotProduct(@Nonnull final double[] vector1, @Nonnull final double[] vector2) {
+        public static double dotProduct(final double[] vector1, final double[] vector2) {
             MetricDefinition.validate(vector1, vector2);
             return RealVectorPrimitives.dot(vector1, vector2);
         }
 
         @Override
-        @Nonnull
         public String toString() {
             return MetricDefinition.toString(this);
         }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/linear/MutableDoubleRealVector.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/linear/MutableDoubleRealVector.java
@@ -23,7 +23,6 @@ package com.apple.foundationdb.linear;
 import com.google.common.base.Preconditions;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 
-import javax.annotation.Nonnull;
 import java.util.Arrays;
 
 /**
@@ -77,7 +76,7 @@ public class MutableDoubleRealVector extends DoubleRealVector {
      *
      * @param doubleData the components of the new vector
      */
-    public MutableDoubleRealVector(@Nonnull final Double[] doubleData) {
+    public MutableDoubleRealVector(final Double[] doubleData) {
         this(computeDoubleData(doubleData));
     }
 
@@ -90,7 +89,7 @@ public class MutableDoubleRealVector extends DoubleRealVector {
      * @param data the components of the new vector; ownership is shared with the caller per the
      *             aliasing contract above
      */
-    public MutableDoubleRealVector(@Nonnull final double[] data) {
+    public MutableDoubleRealVector(final double[] data) {
         super(data);
     }
 
@@ -100,7 +99,7 @@ public class MutableDoubleRealVector extends DoubleRealVector {
      *
      * @param intData the components of the new vector
      */
-    public MutableDoubleRealVector(@Nonnull final int[] intData) {
+    public MutableDoubleRealVector(final int[] intData) {
         this(fromInts(intData));
     }
 
@@ -110,7 +109,7 @@ public class MutableDoubleRealVector extends DoubleRealVector {
      *
      * @param longData the components of the new vector
      */
-    public MutableDoubleRealVector(@Nonnull final long[] longData) {
+    public MutableDoubleRealVector(final long[] longData) {
         this(fromLongs(longData));
     }
 
@@ -121,7 +120,6 @@ public class MutableDoubleRealVector extends DoubleRealVector {
      * vectors never change. This class's contents can change, so memoization would return stale
      * values — every call recomputes from the current data.
      */
-    @Nonnull
     @Override
     public HalfRealVector toHalfRealVector() {
         return computeHalfRealVector();
@@ -133,7 +131,6 @@ public class MutableDoubleRealVector extends DoubleRealVector {
      * <p>Override note: same reasoning as {@link #toHalfRealVector()} — recomputed on every call
      * because the underlying data may have changed since the last invocation.
      */
-    @Nonnull
     @Override
     public FloatRealVector toFloatRealVector() {
         return computeFloatRealVector();
@@ -144,7 +141,6 @@ public class MutableDoubleRealVector extends DoubleRealVector {
      * shares storage with the receiver, so any subsequent mutation is visible through both
      * references.
      */
-    @Nonnull
     @Override
     public MutableDoubleRealVector toDoubleRealVector() {
         return this;
@@ -155,7 +151,6 @@ public class MutableDoubleRealVector extends DoubleRealVector {
      * need an independent mutable buffer should explicitly construct one over
      * {@code getData().clone()}.
      */
-    @Nonnull
     @Override
     public MutableDoubleRealVector toMutable() {
         return this;
@@ -166,7 +161,6 @@ public class MutableDoubleRealVector extends DoubleRealVector {
      * {@link DoubleRealVector}. The underlying {@code double[]} is cloned, so subsequent
      * mutations of the receiver do not affect the returned value.
      */
-    @Nonnull
     @Override
     public DoubleRealVector toImmutable() {
         return new DoubleRealVector(getData().clone());
@@ -182,8 +176,7 @@ public class MutableDoubleRealVector extends DoubleRealVector {
      * @throws IllegalArgumentException if {@code data.length} does not match this vector's
      *         dimensionality
      */
-    @Nonnull
-    public MutableDoubleRealVector setData(@Nonnull final double[] data) {
+    public MutableDoubleRealVector setData(final double[] data) {
         Preconditions.checkArgument(this.data.length == data.length);
         System.arraycopy(data, 0, this.data, 0, this.data.length);
         return this;
@@ -195,7 +188,6 @@ public class MutableDoubleRealVector extends DoubleRealVector {
      * <p>Override note: the parent's memoized raw-bytes representation would be stale once any
      * mutation happens; this override recomputes on every call.
      */
-    @Nonnull
     @Override
     public byte[] getRawData() {
         return computeRawData();
@@ -225,7 +217,6 @@ public class MutableDoubleRealVector extends DoubleRealVector {
      * @return {@code this} for chaining
      * @throws IllegalArgumentException if this vector's L2 norm is zero, infinite, or NaN
      */
-    @Nonnull
     public MutableDoubleRealVector normalizeThis() {
         RealVectorPrimitives.normalizeInto(this.getData(), getData());
         return this;
@@ -237,8 +228,7 @@ public class MutableDoubleRealVector extends DoubleRealVector {
      * @param other the vector to add; must have the same dimensionality as this vector
      * @return {@code this} for chaining
      */
-    @Nonnull
-    public MutableDoubleRealVector addToThis(@Nonnull final RealVector other) {
+    public MutableDoubleRealVector addToThis(final RealVector other) {
         RealVectorPrimitives.addInto(this.getData(), other.getData(), getData());
         return this;
     }
@@ -249,7 +239,6 @@ public class MutableDoubleRealVector extends DoubleRealVector {
      * @param scalar the value to add to each component
      * @return {@code this} for chaining
      */
-    @Nonnull
     public MutableDoubleRealVector addToThis(final double scalar) {
         RealVectorPrimitives.addInto(this.getData(), scalar, getData());
         return this;
@@ -261,8 +250,7 @@ public class MutableDoubleRealVector extends DoubleRealVector {
      * @param other the vector to subtract; must have the same dimensionality as this vector
      * @return {@code this} for chaining
      */
-    @Nonnull
-    public MutableDoubleRealVector subtractFromThis(@Nonnull final RealVector other) {
+    public MutableDoubleRealVector subtractFromThis(final RealVector other) {
         RealVectorPrimitives.subtractInto(this.getData(), other.getData(), getData());
         return this;
     }
@@ -273,7 +261,6 @@ public class MutableDoubleRealVector extends DoubleRealVector {
      * @param scalar the value to subtract from each component
      * @return {@code this} for chaining
      */
-    @Nonnull
     public MutableDoubleRealVector subtractFromThis(final double scalar) {
         RealVectorPrimitives.subtractInto(this.getData(), scalar, getData());
         return this;
@@ -285,7 +272,6 @@ public class MutableDoubleRealVector extends DoubleRealVector {
      * @param scalar the factor to scale each component by
      * @return {@code this} for chaining
      */
-    @Nonnull
     public MutableDoubleRealVector multiplyThisBy(final double scalar) {
         RealVectorPrimitives.multiplyInto(this.getData(), scalar, getData());
         return this;
@@ -298,7 +284,6 @@ public class MutableDoubleRealVector extends DoubleRealVector {
      *         because callers commonly reset state without consuming the result
      */
     @CanIgnoreReturnValue
-    @Nonnull
     public MutableDoubleRealVector zeroThis() {
         Arrays.fill(getData(), 0.0d);
         return this;
@@ -310,7 +295,6 @@ public class MutableDoubleRealVector extends DoubleRealVector {
      * @param numDimensions number of dimensions; must be non-negative
      * @return a freshly allocated zero vector
      */
-    @Nonnull
     public static MutableDoubleRealVector zeroVector(final int numDimensions) {
         return new MutableDoubleRealVector(new double[numDimensions]);
     }
@@ -326,8 +310,7 @@ public class MutableDoubleRealVector extends DoubleRealVector {
      * @param vectorBytes the serialized form
      * @return a new mutable vector with the decoded components
      */
-    @Nonnull
-    public static MutableDoubleRealVector fromBytes(@Nonnull final byte[] vectorBytes) {
+    public static MutableDoubleRealVector fromBytes(final byte[] vectorBytes) {
         return new MutableDoubleRealVector(DoubleRealVector.decodeDoubleBytes(vectorBytes));
     }
 }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/linear/QRDecomposition.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/linear/QRDecomposition.java
@@ -22,7 +22,6 @@ package com.apple.foundationdb.linear;
 
 import com.google.common.base.Preconditions;
 
-import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.function.Supplier;
 
@@ -59,8 +58,7 @@ public class QRDecomposition {
      *
      * @throws IllegalArgumentException if the provided {@code matrix} is not square.
      */
-    @Nonnull
-    public static Result decomposeMatrix(@Nonnull final RealMatrix matrix) {
+    public static Result decomposeMatrix(final RealMatrix matrix) {
         Preconditions.checkArgument(matrix.isSquare());
 
         final double[] rDiagonal = new double[matrix.getNumRowDimensions()];
@@ -144,7 +142,6 @@ public class QRDecomposition {
      * Returns the matrix {@code Q} of the decomposition where {@code Q} is an orthogonal matrix.
      * @return the {@code Q} matrix
      */
-    @Nonnull
     private static RealMatrix getQ(final double[][] qrt, final double[] rDiagonal) {
         final int m = qrt.length;
         final double[][] q = new double[m][m];
@@ -197,7 +194,6 @@ public class QRDecomposition {
      *
      * @return The reconstructed upper-triangular R matrix as a {@link RealMatrix}.
      */
-    @Nonnull
     private static RealMatrix getR(final double[][] qrt, final double[] rDiagonal) {
         final int m = qrt.length; // square in this helper
         final double[][] r = new double[m][m];
@@ -222,22 +218,18 @@ public class QRDecomposition {
 
     @SuppressWarnings("checkstyle:MemberName")
     public static class Result {
-        @Nonnull
         private final Supplier<RealMatrix> qSupplier;
-        @Nonnull
         private final Supplier<RealMatrix> rSupplier;
 
-        public Result(@Nonnull final Supplier<RealMatrix> qSupplier, @Nonnull final Supplier<RealMatrix> rSupplier) {
+        public Result(final Supplier<RealMatrix> qSupplier, final Supplier<RealMatrix> rSupplier) {
             this.qSupplier = qSupplier;
             this.rSupplier = rSupplier;
         }
 
-        @Nonnull
         RealMatrix getQ() {
             return qSupplier.get();
         }
 
-        @Nonnull
         RealMatrix getR() {
             return rSupplier.get();
         }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/linear/Quantizer.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/linear/Quantizer.java
@@ -20,7 +20,6 @@
 
 package com.apple.foundationdb.linear;
 
-import javax.annotation.Nonnull;
 
 /**
  * Defines the contract for a quantizer, a component responsible for encoding data vectors into a different, ideally
@@ -38,11 +37,9 @@ public interface Quantizer {
      *
      * @return the {@link DistanceEstimator} instance, which is guaranteed to be non-null.
      */
-    @Nonnull
     DistanceEstimator estimator();
 
-    @Nonnull
-    default Transformed<RealVector> encode(@Nonnull final Transformed<RealVector> vector) {
+    default Transformed<RealVector> encode(final Transformed<RealVector> vector) {
         return Transformed.underlyingLens().identityTransform(encode(vector.getUnderlyingVector()));
     }
 
@@ -57,8 +54,7 @@ public interface Quantizer {
      *        of the specific quantizer.
      * @return the encoded vector representation of the input data, guaranteed to be non-null.
      */
-    @Nonnull
-    RealVector encode(@Nonnull RealVector vector);
+    RealVector encode(RealVector vector);
 
     /**
      * Creates a no-op {@code Quantizer} that does not perform any data transformation.
@@ -73,18 +69,15 @@ public interface Quantizer {
      * @param metric the {@link Metric} used to build the distance estimator for the quantizer.
      * @return a new {@link Quantizer} instance that performs no operation.
      */
-    @Nonnull
-    static Quantizer noOpQuantizer(@Nonnull final Metric metric) {
+    static Quantizer noOpQuantizer(final Metric metric) {
         return new Quantizer() {
-            @Nonnull
             @Override
             public DistanceEstimator estimator() {
                 return DistanceEstimator.ofMetric(metric);
             }
 
-            @Nonnull
             @Override
-            public RealVector encode(@Nonnull final RealVector vector) {
+            public RealVector encode(final RealVector vector) {
                 return vector;
             }
         };

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/linear/RealMatrix.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/linear/RealMatrix.java
@@ -22,8 +22,7 @@ package com.apple.foundationdb.linear;
 
 import com.google.common.base.Verify;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 
 public interface RealMatrix extends LinearOperator {
     double getEntry(int row, int column);
@@ -33,12 +32,10 @@ public interface RealMatrix extends LinearOperator {
         return true;
     }
 
-    @Nonnull
     RealMatrix transpose();
 
-    @Nonnull
     @Override
-    default RealVector apply(@Nonnull final RealVector vector) {
+    default RealVector apply(final RealVector vector) {
         Verify.verify(getNumColumnDimensions() == vector.getNumDimensions());
         final double[] result = new double[getNumRowDimensions()];
         for (int i = 0; i < getNumRowDimensions(); i ++) {
@@ -51,9 +48,8 @@ public interface RealMatrix extends LinearOperator {
         return new DoubleRealVector(result);
     }
 
-    @Nonnull
     @Override
-    default RealVector transposedApply(@Nonnull final RealVector vector) {
+    default RealVector transposedApply(final RealVector vector) {
         Verify.verify(getNumRowDimensions() == vector.getNumDimensions());
         final double[] result = new double[getNumColumnDimensions()];
         for (int j = 0; j < getNumColumnDimensions(); j ++) {
@@ -66,28 +62,20 @@ public interface RealMatrix extends LinearOperator {
         return new DoubleRealVector(result);
     }
 
-    @Nonnull
-    RealMatrix multiply(@Nonnull RealMatrix otherMatrix);
+    RealMatrix multiply(RealMatrix otherMatrix);
 
-    @Nonnull
     RealMatrix subMatrix(int startRow, int lengthRow, int startColumn, int lengthColumn);
 
-    @Nonnull
     RowMajorRealMatrix toRowMajor();
 
-    @Nonnull
     double[][] getRowMajorData();
 
-    @Nonnull
     ColumnMajorRealMatrix toColumnMajor();
 
-    @Nonnull
     double[][] getColumnMajorData();
 
-    @Nonnull
     RealMatrix quickTranspose();
 
-    @Nonnull
     default RealMatrix flipMajor() {
         return transpose().quickTranspose();
     }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/linear/RealVector.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/linear/RealVector.java
@@ -24,7 +24,6 @@ import com.apple.foundationdb.half.Half;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
-import javax.annotation.Nonnull;
 
 /**
  * Real-valued mathematical vector — the common API every dense vector representation in this
@@ -99,7 +98,6 @@ public interface RealVector {
      * returns a direct reference to the internal array, not a copy.
      * @return the data array of type {@code R[]}, never {@code null}.
      */
-    @Nonnull
     double[] getData();
 
     /**
@@ -111,8 +109,7 @@ public interface RealVector {
      *        dimensionality
      * @return a non-null vector with the given data
      */
-    @Nonnull
-    RealVector withData(@Nonnull double[] data);
+    RealVector withData(double[] data);
 
     /**
      * Gets the raw byte data representation of this object.
@@ -121,7 +118,6 @@ public interface RealVector {
      * implementation-specific and should be documented by the concrete class that implements this method.
      * @return a non-null byte array containing the raw data.
      */
-    @Nonnull
     byte[] getRawData();
 
     /**
@@ -133,7 +129,6 @@ public interface RealVector {
      * @return a non-null {@link HalfRealVector} containing the {@link Half} precision floating-point representation of
      *         this object.
      */
-    @Nonnull
     HalfRealVector toHalfRealVector();
 
     /**
@@ -146,7 +141,6 @@ public interface RealVector {
      * @return a non-null {@link FloatRealVector} containing the single precision floating-point representation of
      *         this object.
      */
-    @Nonnull
     FloatRealVector toFloatRealVector();
 
     /**
@@ -158,7 +152,6 @@ public interface RealVector {
      * underlying data type.
      * @return a non-null {@link DoubleRealVector} representation of this vector.
      */
-    @Nonnull
     DoubleRealVector toDoubleRealVector();
 
     /**
@@ -170,7 +163,6 @@ public interface RealVector {
      * @return a fresh (or in the case of {@link MutableDoubleRealVector}, the same) mutable
      *         double-precision vector
      */
-    @Nonnull
     default MutableDoubleRealVector toMutable() {
         return new MutableDoubleRealVector(getData().clone());
     }
@@ -183,7 +175,6 @@ public interface RealVector {
      *
      * @return a non-null immutable vector with the same components as this vector
      */
-    @Nonnull
     RealVector toImmutable();
 
     /**
@@ -193,7 +184,7 @@ public interface RealVector {
      * @return the dot product
      * @throws IllegalArgumentException if {@code other} has a different dimensionality
      */
-    default double dot(@Nonnull final RealVector other) {
+    default double dot(final RealVector other) {
         Preconditions.checkArgument(getNumDimensions() == other.getNumDimensions());
         return RealVectorPrimitives.dot(getData(), other.getData());
     }
@@ -204,7 +195,7 @@ public interface RealVector {
      * allocation), and cheaper than {@code Math.pow(estimator.distance(this, other), 2)} for the
      * Euclidean metric (skips a {@code sqrt} that would just be squared again).
      */
-    default double l2SquaredDistance(@Nonnull final RealVector other) {
+    default double l2SquaredDistance(final RealVector other) {
         Preconditions.checkArgument(getNumDimensions() == other.getNumDimensions());
         return RealVectorPrimitives.euclideanSquared(getData(), other.getData());
     }
@@ -252,7 +243,6 @@ public interface RealVector {
      * @throws IllegalArgumentException if this vector's L2 norm is zero, infinite, or NaN —
      *         direction is undefined in those cases
      */
-    @Nonnull
     default RealVector normalize() {
         return withData(RealVectorPrimitives.normalizeInto(this.getData(), new double[getNumDimensions()]));
     }
@@ -269,7 +259,7 @@ public interface RealVector {
      * @return the dot product, computed on the scalar backend
      * @throws IllegalArgumentException if {@code other} has a different dimensionality
      */
-    default double dotExact(@Nonnull final RealVector other) {
+    default double dotExact(final RealVector other) {
         Preconditions.checkArgument(getNumDimensions() == other.getNumDimensions());
         return RealVectorPrimitives.dotExact(getData(), other.getData());
     }
@@ -305,7 +295,7 @@ public interface RealVector {
      * @return the squared Euclidean distance, computed on the scalar backend
      * @throws IllegalArgumentException if {@code other} has a different dimensionality
      */
-    default double l2SquaredDistanceExact(@Nonnull final RealVector other) {
+    default double l2SquaredDistanceExact(final RealVector other) {
         Preconditions.checkArgument(getNumDimensions() == other.getNumDimensions());
         return RealVectorPrimitives.euclideanSquaredExact(getData(), other.getData());
     }
@@ -318,7 +308,6 @@ public interface RealVector {
      * @return a non-null unit-norm vector, normalized using the scalar backend
      * @throws IllegalArgumentException if this vector's L2 norm is zero, infinite, or NaN
      */
-    @Nonnull
     default RealVector normalizeExact() {
         return withData(RealVectorPrimitives.normalizeIntoExact(this.getData(), new double[getNumDimensions()]));
     }
@@ -331,8 +320,7 @@ public interface RealVector {
      * @return a non-null vector with {@code result[i] = this[i] + other[i]}
      * @throws IllegalArgumentException if {@code other} has a different dimensionality
      */
-    @Nonnull
-    default RealVector add(@Nonnull final RealVector other) {
+    default RealVector add(final RealVector other) {
         return withData(RealVectorPrimitives.addInto(this.getData(), other.getData(), new double[getNumDimensions()]));
     }
 
@@ -343,7 +331,6 @@ public interface RealVector {
      * @param scalar the value to add to each component
      * @return a non-null vector with {@code result[i] = this[i] + scalar}
      */
-    @Nonnull
     default RealVector add(final double scalar) {
         return withData(RealVectorPrimitives.addInto(this.getData(), scalar, new double[getNumDimensions()]));
     }
@@ -356,8 +343,7 @@ public interface RealVector {
      * @return a non-null vector with {@code result[i] = this[i] - other[i]}
      * @throws IllegalArgumentException if {@code other} has a different dimensionality
      */
-    @Nonnull
-    default RealVector subtract(@Nonnull final RealVector other) {
+    default RealVector subtract(final RealVector other) {
         return withData(RealVectorPrimitives.subtractInto(this.getData(), other.getData(), new double[getNumDimensions()]));
     }
 
@@ -368,7 +354,6 @@ public interface RealVector {
      * @param scalar the value to subtract from each component
      * @return a non-null vector with {@code result[i] = this[i] - scalar}
      */
-    @Nonnull
     default RealVector subtract(final double scalar) {
         return withData(RealVectorPrimitives.subtractInto(this.getData(), scalar, new double[getNumDimensions()]));
     }
@@ -380,7 +365,6 @@ public interface RealVector {
      * @param scalar the factor to scale each component by
      * @return a non-null vector with {@code result[i] = this[i] * scalar}
      */
-    @Nonnull
     default RealVector multiply(final double scalar) {
         return withData(RealVectorPrimitives.multiplyInto(this.getData(), scalar, new double[getNumDimensions()]));
     }
@@ -395,7 +379,6 @@ public interface RealVector {
      * @return the matching {@link VectorType}; never {@code null}
      * @throws IndexOutOfBoundsException if {@code ordinal} is not a valid enum ordinal
      */
-    @Nonnull
     static VectorType fromVectorTypeOrdinal(final int ordinal) {
         return VECTOR_TYPES.get(ordinal);
     }
@@ -409,8 +392,7 @@ public interface RealVector {
      * @param vectorBytes the non-null byte array to convert.
      * @return a new {@link RealVector} instance created from the byte array.
      */
-    @Nonnull
-    static RealVector fromBytes(@Nonnull final byte[] vectorBytes) {
+    static RealVector fromBytes(final byte[] vectorBytes) {
         final byte vectorTypeOrdinal = vectorBytes[0];
         return fromBytes(fromVectorTypeOrdinal(vectorTypeOrdinal), vectorBytes);
     }
@@ -424,8 +406,7 @@ public interface RealVector {
      * @param vectorBytes the non-null byte array to convert.
      * @return a new {@link RealVector} instance created from the byte array.
      */
-    @Nonnull
-    static RealVector fromBytes(@Nonnull final VectorType vectorType, @Nonnull final byte[] vectorBytes) {
+    static RealVector fromBytes(final VectorType vectorType, final byte[] vectorBytes) {
         return switch (vectorType) {
             case HALF -> HalfRealVector.fromBytes(vectorBytes);
             case SINGLE -> FloatRealVector.fromBytes(vectorBytes);

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/linear/RealVectorPrimitives.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/linear/RealVectorPrimitives.java
@@ -25,7 +25,6 @@ import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
 import java.util.Locale;
 
 /**
@@ -70,7 +69,6 @@ public final class RealVectorPrimitives {
         // nothing
     }
 
-    @Nonnull
     static Backend backend() {
         return backend;
     }
@@ -83,11 +81,9 @@ public final class RealVectorPrimitives {
      */
     @FunctionalInterface
     interface SimdBackendLoader {
-        @Nonnull
         Backend load() throws ReflectiveOperationException;
     }
 
-    @Nonnull
     private static Backend selectBackend() {
         return selectBackend(System.getProperty(simdPropertyName, "auto"), RealVectorPrimitives::loadSimdBackend);
     }
@@ -102,7 +98,6 @@ public final class RealVectorPrimitives {
      * @return a freshly instantiated SIMD backend
      * @throws ReflectiveOperationException if the SIMD backend class cannot be loaded or instantiated
      */
-    @Nonnull
     @VisibleForTesting
     @SuppressWarnings("PMD.UseProperClassLoader")
     static Backend loadSimdBackend() throws ReflectiveOperationException {
@@ -125,9 +120,8 @@ public final class RealVectorPrimitives {
      * @param simdLoader supplier of the SIMD backend; throws if it cannot be loaded
      * @return the selected backend
      */
-    @Nonnull
     @VisibleForTesting
-    static Backend selectBackend(@Nonnull final String modeProperty, @Nonnull final SimdBackendLoader simdLoader) {
+    static Backend selectBackend(final String modeProperty, final SimdBackendLoader simdLoader) {
         final String mode = modeProperty.toLowerCase(Locale.getDefault());
         if ("scalar".equals(mode)) {
             logger.info("RealVectorPrimitives backend forced to scalar via -D{}", simdPropertyName);
@@ -152,8 +146,7 @@ public final class RealVectorPrimitives {
         }
     }
 
-    @Nonnull
-    static double[] normalizeInto(@Nonnull final double[] in, @Nonnull final double[] target) {
+    static double[] normalizeInto(final double[] in, final double[] target) {
         Preconditions.checkArgument(target.length == in.length);
         final double n = Math.sqrt(backend.l2SquaredNorm(in));
         if (n == 0.0d || !Double.isFinite(n)) {
@@ -163,54 +156,49 @@ public final class RealVectorPrimitives {
         return target;
     }
 
-    @Nonnull
-    static double[] addInto(@Nonnull final double[] a,
-                            @Nonnull final double[] b,
-                            @Nonnull final double[] target) {
+    static double[] addInto(final double[] a,
+                            final double[] b,
+                            final double[] target) {
         Preconditions.checkArgument(a.length == b.length);
         Preconditions.checkArgument(target.length == a.length);
         backend.addInto(a, b, target);
         return target;
     }
 
-    @Nonnull
-    static double[] addInto(@Nonnull final double[] a,
+    static double[] addInto(final double[] a,
                             final double scalar,
-                            @Nonnull final double[] target) {
+                            final double[] target) {
         Preconditions.checkArgument(target.length == a.length);
         backend.addInto(a, scalar, target);
         return target;
     }
 
-    @Nonnull
-    static double[] subtractInto(@Nonnull final double[] a,
-                                 @Nonnull final double[] b,
-                                 @Nonnull final double[] target) {
+    static double[] subtractInto(final double[] a,
+                                 final double[] b,
+                                 final double[] target) {
         Preconditions.checkArgument(a.length == b.length);
         Preconditions.checkArgument(target.length == a.length);
         backend.subtractInto(a, b, target);
         return target;
     }
 
-    @Nonnull
-    static double[] subtractInto(@Nonnull final double[] a,
+    static double[] subtractInto(final double[] a,
                                  final double scalar,
-                                 @Nonnull final double[] target) {
+                                 final double[] target) {
         Preconditions.checkArgument(target.length == a.length);
         backend.subtractInto(a, scalar, target);
         return target;
     }
 
-    @Nonnull
-    static double[] multiplyInto(@Nonnull final double[] a,
+    static double[] multiplyInto(final double[] a,
                                  final double scalar,
-                                 @Nonnull final double[] target) {
+                                 final double[] target) {
         Preconditions.checkArgument(target.length == a.length);
         backend.multiplyInto(a, scalar, target);
         return target;
     }
 
-    static void multiplyAddInto(final double scalar, @Nonnull final double[] x, @Nonnull final double[] y,
+    static void multiplyAddInto(final double scalar, final double[] x, final double[] y,
                                 final int from, final int length) {
         // BLAS-style in-place AXPY: y := scalar * x + y over the slice. Delegates to the
         // backend's general 3-operand form with out aliased to y; the per-lane FMA is the
@@ -218,29 +206,29 @@ public final class RealVectorPrimitives {
         backend.multiplyAddInto(scalar, x, y, y, from, length);
     }
 
-    static void multiplyAddInto(final double scalar, @Nonnull final double[] x, @Nonnull final double[] y,
-                                @Nonnull final double[] out, final int from, final int length) {
+    static void multiplyAddInto(final double scalar, final double[] x, final double[] y,
+                                final double[] out, final int from, final int length) {
         backend.multiplyAddInto(scalar, x, y, out, from, length);
     }
 
-    static double dot(@Nonnull final double[] a, @Nonnull final double[] b) {
+    static double dot(final double[] a, final double[] b) {
         Preconditions.checkArgument(a.length == b.length);
         return backend.dot(a, b);
     }
 
-    static double dot(@Nonnull final double[] a, @Nonnull final double[] b, final int from, final int length) {
+    static double dot(final double[] a, final double[] b, final int from, final int length) {
         return backend.dot(a, b, from, length);
     }
 
-    static double l2SquaredNorm(@Nonnull final double[] a) {
+    static double l2SquaredNorm(final double[] a) {
         return backend.l2SquaredNorm(a);
     }
 
-    static double l2SquaredNorm(@Nonnull final double[] a, final int from, final int length) {
+    static double l2SquaredNorm(final double[] a, final int from, final int length) {
         return backend.l2SquaredNorm(a, from, length);
     }
 
-    static double euclideanSquared(@Nonnull final double[] a, @Nonnull final double[] b) {
+    static double euclideanSquared(final double[] a, final double[] b) {
         Preconditions.checkArgument(a.length == b.length);
         return backend.euclideanSquared(a, b);
     }
@@ -254,22 +242,21 @@ public final class RealVectorPrimitives {
     // independently and are already bit-identical on both backends.
     //
 
-    static double dotExact(@Nonnull final double[] a, @Nonnull final double[] b) {
+    static double dotExact(final double[] a, final double[] b) {
         Preconditions.checkArgument(a.length == b.length);
         return scalarBackend.dot(a, b);
     }
 
-    static double l2SquaredNormExact(@Nonnull final double[] a) {
+    static double l2SquaredNormExact(final double[] a) {
         return scalarBackend.l2SquaredNorm(a);
     }
 
-    static double euclideanSquaredExact(@Nonnull final double[] a, @Nonnull final double[] b) {
+    static double euclideanSquaredExact(final double[] a, final double[] b) {
         Preconditions.checkArgument(a.length == b.length);
         return scalarBackend.euclideanSquared(a, b);
     }
 
-    @Nonnull
-    static double[] normalizeIntoExact(@Nonnull final double[] in, @Nonnull final double[] target) {
+    static double[] normalizeIntoExact(final double[] in, final double[] target) {
         Preconditions.checkArgument(target.length == in.length);
         final double n = Math.sqrt(scalarBackend.l2SquaredNorm(in));
         if (n == 0.0d || !Double.isFinite(n)) {

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/linear/RowMajorRealMatrix.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/linear/RowMajorRealMatrix.java
@@ -23,24 +23,20 @@ package com.apple.foundationdb.linear;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Suppliers;
 
-import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.function.Supplier;
 
 public class RowMajorRealMatrix implements RealMatrix {
-    @Nonnull
     private final double[][] data;
-    @Nonnull
     @SuppressWarnings("this-escape")
     private final Supplier<Integer> hashCodeSupplier = Suppliers.memoize(this::valueBasedHashCode);
 
-    public RowMajorRealMatrix(@Nonnull final double[][] data) {
+    public RowMajorRealMatrix(final double[][] data) {
         Preconditions.checkArgument(data.length > 0);
         Preconditions.checkArgument(data[0].length > 0);
         this.data = data;
     }
 
-    @Nonnull
     private double[][] getData() {
         return data;
     }
@@ -60,12 +56,10 @@ public class RowMajorRealMatrix implements RealMatrix {
         return data[row][column];
     }
 
-    @Nonnull
     public double[] getRow(final int row) {
         return data[row];
     }
 
-    @Nonnull
     @Override
     public RowMajorRealMatrix transpose() {
         int n = getNumRowDimensions();
@@ -79,9 +73,8 @@ public class RowMajorRealMatrix implements RealMatrix {
         return new RowMajorRealMatrix(result);
     }
 
-    @Nonnull
     @Override
-    public DoubleRealVector apply(@Nonnull final RealVector vector) {
+    public DoubleRealVector apply(final RealVector vector) {
         Preconditions.checkArgument(getNumColumnDimensions() == vector.getNumDimensions());
         final int n = getNumRowDimensions();
         final int m = getNumColumnDimensions();
@@ -93,9 +86,8 @@ public class RowMajorRealMatrix implements RealMatrix {
         return new DoubleRealVector(result);
     }
 
-    @Nonnull
     @Override
-    public DoubleRealVector transposedApply(@Nonnull final RealVector vector) {
+    public DoubleRealVector transposedApply(final RealVector vector) {
         Preconditions.checkArgument(getNumRowDimensions() == vector.getNumDimensions());
         final int n = getNumRowDimensions();
         final int m = getNumColumnDimensions();
@@ -146,9 +138,8 @@ public class RowMajorRealMatrix implements RealMatrix {
      *        {@code otherMatrix.getNumRowDimensions() == this.getNumColumnDimensions()}
      * @return a new {@link RowMajorRealMatrix} containing the product
      */
-    @Nonnull
     @Override
-    public RowMajorRealMatrix multiply(@Nonnull final RealMatrix otherMatrix) {
+    public RowMajorRealMatrix multiply(final RealMatrix otherMatrix) {
         Preconditions.checkArgument(getNumColumnDimensions() == otherMatrix.getNumRowDimensions());
         final int n = getNumRowDimensions();
         final int m = otherMatrix.getNumColumnDimensions();
@@ -184,7 +175,6 @@ public class RowMajorRealMatrix implements RealMatrix {
         return new RowMajorRealMatrix(result);
     }
 
-    @Nonnull
     @Override
     public RowMajorRealMatrix subMatrix(final int startRow, final int lengthRow,
                                         final int startColumn, final int lengthColumn) {
@@ -197,37 +187,31 @@ public class RowMajorRealMatrix implements RealMatrix {
         return new RowMajorRealMatrix(subData);
     }
 
-    @Nonnull
     @Override
     public RowMajorRealMatrix toRowMajor() {
         return this;
     }
 
-    @Nonnull
     @Override
     public double[][] getRowMajorData() {
         return getData();
     }
 
-    @Nonnull
     @Override
     public ColumnMajorRealMatrix toColumnMajor() {
         return new ColumnMajorRealMatrix(getColumnMajorData());
     }
 
-    @Nonnull
     @Override
     public double[][] getColumnMajorData() {
         return transpose().getData();
     }
 
-    @Nonnull
     @Override
     public ColumnMajorRealMatrix quickTranspose() {
         return new ColumnMajorRealMatrix(getRowMajorData());
     }
 
-    @Nonnull
     @Override
     public ColumnMajorRealMatrix flipMajor() {
         return (ColumnMajorRealMatrix)RealMatrix.super.flipMajor();

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/linear/ScalarBackend.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/linear/ScalarBackend.java
@@ -20,7 +20,6 @@
 
 package com.apple.foundationdb.linear;
 
-import javax.annotation.Nonnull;
 
 /**
  * Scalar (plain {@code for}-loop) implementation of {@link Backend}. Always available; serves as
@@ -28,50 +27,49 @@ import javax.annotation.Nonnull;
  */
 final class ScalarBackend implements Backend {
 
-    @Nonnull
     @Override
     public String name() {
         return "scalar";
     }
 
     @Override
-    public void addInto(@Nonnull final double[] a, @Nonnull final double[] b, @Nonnull final double[] out) {
+    public void addInto(final double[] a, final double[] b, final double[] out) {
         for (int i = 0; i < a.length; i++) {
             out[i] = a[i] + b[i];
         }
     }
 
     @Override
-    public void addInto(@Nonnull final double[] a, final double scalar, @Nonnull final double[] out) {
+    public void addInto(final double[] a, final double scalar, final double[] out) {
         for (int i = 0; i < a.length; i++) {
             out[i] = a[i] + scalar;
         }
     }
 
     @Override
-    public void subtractInto(@Nonnull final double[] a, @Nonnull final double[] b, @Nonnull final double[] out) {
+    public void subtractInto(final double[] a, final double[] b, final double[] out) {
         for (int i = 0; i < a.length; i++) {
             out[i] = a[i] - b[i];
         }
     }
 
     @Override
-    public void subtractInto(@Nonnull final double[] a, final double scalar, @Nonnull final double[] out) {
+    public void subtractInto(final double[] a, final double scalar, final double[] out) {
         for (int i = 0; i < a.length; i++) {
             out[i] = a[i] - scalar;
         }
     }
 
     @Override
-    public void multiplyInto(@Nonnull final double[] a, final double scalar, @Nonnull final double[] out) {
+    public void multiplyInto(final double[] a, final double scalar, final double[] out) {
         for (int i = 0; i < a.length; i++) {
             out[i] = a[i] * scalar;
         }
     }
 
     @Override
-    public void multiplyAddInto(final double scalar, @Nonnull final double[] x, @Nonnull final double[] y,
-                                @Nonnull final double[] out, final int from, final int length) {
+    public void multiplyAddInto(final double scalar, final double[] x, final double[] y,
+                                final double[] out, final int from, final int length) {
         final int end = from + length;
         for (int i = from; i < end; i++) {
             out[i] = scalar * x[i] + y[i];
@@ -79,12 +77,12 @@ final class ScalarBackend implements Backend {
     }
 
     @Override
-    public double dot(@Nonnull final double[] a, @Nonnull final double[] b) {
+    public double dot(final double[] a, final double[] b) {
         return dot(a, b, 0, a.length);
     }
 
     @Override
-    public double dot(@Nonnull final double[] a, @Nonnull final double[] b, final int from, final int length) {
+    public double dot(final double[] a, final double[] b, final int from, final int length) {
         double sum = 0.0d;
         final int end = from + length;
         for (int i = from; i < end; i++) {
@@ -94,12 +92,12 @@ final class ScalarBackend implements Backend {
     }
 
     @Override
-    public double l2SquaredNorm(@Nonnull final double[] a) {
+    public double l2SquaredNorm(final double[] a) {
         return l2SquaredNorm(a, 0, a.length);
     }
 
     @Override
-    public double l2SquaredNorm(@Nonnull final double[] a, final int from, final int length) {
+    public double l2SquaredNorm(final double[] a, final int from, final int length) {
         double sum = 0.0d;
         final int end = from + length;
         for (int i = from; i < end; i++) {
@@ -110,7 +108,7 @@ final class ScalarBackend implements Backend {
     }
 
     @Override
-    public double euclideanSquared(@Nonnull final double[] a, @Nonnull final double[] b) {
+    public double euclideanSquared(final double[] a, final double[] b) {
         double sum = 0.0d;
         for (int i = 0; i < a.length; i++) {
             final double diff = a[i] - b[i];

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/linear/StoredVecsIterator.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/linear/StoredVecsIterator.java
@@ -23,8 +23,8 @@ package com.apple.foundationdb.linear;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ImmutableList;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import java.io.EOFException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -40,21 +40,17 @@ import java.util.List;
  * @param <T> the type of object this iterator creates and uses to represent a stored vector in memory
  */
 public abstract class StoredVecsIterator<N extends Number, T> extends AbstractIterator<T> {
-    @Nonnull
     private final FileChannel fileChannel;
 
-    protected StoredVecsIterator(@Nonnull final FileChannel fileChannel) {
+    protected StoredVecsIterator(final FileChannel fileChannel) {
         this.fileChannel = fileChannel;
     }
 
-    @Nonnull
     protected abstract N[] newComponentArray(int size);
 
-    @Nonnull
-    protected abstract N toComponent(@Nonnull ByteBuffer byteBuffer);
+    protected abstract N toComponent(ByteBuffer byteBuffer);
 
-    @Nonnull
-    protected abstract T toTarget(@Nonnull N[] components);
+    protected abstract T toTarget(N[] components);
 
     @Nullable
     @Override
@@ -99,25 +95,22 @@ public abstract class StoredVecsIterator<N extends Number, T> extends AbstractIt
      * {@link DoubleRealVector}s.
      */
     public static class StoredFVecsIterator extends StoredVecsIterator<Double, DoubleRealVector> {
-        public StoredFVecsIterator(@Nonnull final FileChannel fileChannel) {
+        public StoredFVecsIterator(final FileChannel fileChannel) {
             super(fileChannel);
         }
 
-        @Nonnull
         @Override
         protected Double[] newComponentArray(final int size) {
             return new Double[size];
         }
 
-        @Nonnull
         @Override
-        protected Double toComponent(@Nonnull final ByteBuffer byteBuffer) {
+        protected Double toComponent(final ByteBuffer byteBuffer) {
             return (double)byteBuffer.getFloat();
         }
 
-        @Nonnull
         @Override
-        protected DoubleRealVector toTarget(@Nonnull final Double[] components) {
+        protected DoubleRealVector toTarget(final Double[] components) {
             return new DoubleRealVector(components);
         }
     }
@@ -126,25 +119,22 @@ public abstract class StoredVecsIterator<N extends Number, T> extends AbstractIt
      * Iterator to read vectors from a {@link FileChannel} into a list of integers.
      */
     public static class StoredIVecsIterator extends StoredVecsIterator<Integer, List<Integer>> {
-        public StoredIVecsIterator(@Nonnull final FileChannel fileChannel) {
+        public StoredIVecsIterator(final FileChannel fileChannel) {
             super(fileChannel);
         }
 
-        @Nonnull
         @Override
         protected Integer[] newComponentArray(final int size) {
             return new Integer[size];
         }
 
-        @Nonnull
         @Override
-        protected Integer toComponent(@Nonnull final ByteBuffer byteBuffer) {
+        protected Integer toComponent(final ByteBuffer byteBuffer) {
             return byteBuffer.getInt();
         }
 
-        @Nonnull
         @Override
-        protected List<Integer> toTarget(@Nonnull final Integer[] components) {
+        protected List<Integer> toTarget(final Integer[] components) {
             return ImmutableList.copyOf(components);
         }
     }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/linear/Transformed.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/linear/Transformed.java
@@ -23,8 +23,8 @@ package com.apple.foundationdb.linear;
 import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.util.Lens;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import java.util.Objects;
 
 /**
@@ -74,19 +74,17 @@ import java.util.Objects;
  * @param <V> the wrapped kind of {@link RealVector}
  */
 public final class Transformed<V extends RealVector> {
-    @Nonnull
     private final V transformedVector;
 
-    private Transformed(@Nonnull final V transformedVector) {
+    private Transformed(final V transformedVector) {
         this.transformedVector = transformedVector;
     }
 
-    @Nonnull
     public V getUnderlyingVector() {
         return transformedVector;
     }
 
-    public Transformed<RealVector> add(@Nonnull Transformed<? extends RealVector> other) {
+    public Transformed<RealVector> add(Transformed<? extends RealVector> other) {
         return new Transformed<>(transformedVector.add(other.transformedVector));
     }
 
@@ -125,18 +123,16 @@ public final class Transformed<V extends RealVector> {
     public static class UnderlyingLens<V extends RealVector> implements Lens<Transformed<V>, V> {
         @Nullable
         @Override
-        public V get(@Nonnull final Transformed<V> transformedVector) {
+        public V get(final Transformed<V> transformedVector) {
             return transformedVector.getUnderlyingVector();
         }
 
-        @Nonnull
         @Override
         @SpotBugsSuppressWarnings("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
         public Transformed<V> set(@Nullable final Transformed<V> ignored, @Nullable final V v) {
             return new Transformed<>(Objects.requireNonNull(v, "Transformed cannot wrap a null underlying vector"));
         }
 
-        @Nonnull
         public Transformed<V> identityTransform(@Nullable final V v) {
             return wrap(v);
         }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/linear/VectorOperator.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/linear/VectorOperator.java
@@ -20,7 +20,6 @@
 
 package com.apple.foundationdb.linear;
 
-import javax.annotation.Nonnull;
 
 /**
  * Interface that represents the root of all linear and affine operators including matrices. A vector operator can
@@ -44,24 +43,21 @@ public interface VectorOperator {
      * @param vector the vector
      * @return a new vector
      */
-    @Nonnull
-    RealVector apply(@Nonnull RealVector vector);
+    RealVector apply(RealVector vector);
 
     /**
      * Apply the inverted operator to the vector passed in. {@code applyInverted(apply(v)) == v} should hold.
      * @param vector the vector
      * @return a new vector
      */
-    @Nonnull
-    RealVector invertedApply(@Nonnull RealVector vector);
+    RealVector invertedApply(RealVector vector);
 
     /**
      * Applies the operator to the vector that is passed in and creates a `Transformed` wrapper wrapping the result.
      * @param vector the vector
      * @return a {@link Transformed}-wrapped result
      */
-    @Nonnull
-    default Transformed<RealVector> transform(@Nonnull final RealVector vector) {
+    default Transformed<RealVector> transform(final RealVector vector) {
         return Transformed.underlyingLens().identityTransform(apply(vector));
     }
 
@@ -71,8 +67,7 @@ public interface VectorOperator {
      * @param vector the vector
      * @return a {@link Transformed}-wrapped result
      */
-    @Nonnull
-    default RealVector untransform(@Nonnull final Transformed<RealVector> vector) {
+    default RealVector untransform(final Transformed<RealVector> vector) {
         return invertedApply(vector.getUnderlyingVector());
     }
 }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/linear/package-info.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/linear/package-info.java
@@ -22,4 +22,7 @@
  * Package that implements basic mathematical objects such as vectors and matrices as well as
  * operations on these objects.
  */
+@NullMarked
 package com.apple.foundationdb.linear;
+
+import org.jspecify.annotations.NullMarked;

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/linear/simd/SimdBackend.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/linear/simd/SimdBackend.java
@@ -25,7 +25,6 @@ import jdk.incubator.vector.DoubleVector;
 import jdk.incubator.vector.VectorOperators;
 import jdk.incubator.vector.VectorSpecies;
 
-import javax.annotation.Nonnull;
 
 /**
  * SIMD implementation of {@link Backend} using the {@link jdk.incubator.vector} API
@@ -43,7 +42,6 @@ import javax.annotation.Nonnull;
 public final class SimdBackend implements Backend {
     private static final VectorSpecies<Double> SPECIES = DoubleVector.SPECIES_PREFERRED;
 
-    @Nonnull
     @Override
     public String name() {
         return "simd[" + SPECIES + "]";
@@ -70,7 +68,7 @@ public final class SimdBackend implements Backend {
     }
 
     @Override
-    public void addInto(@Nonnull final double[] a, @Nonnull final double[] b, @Nonnull final double[] out) {
+    public void addInto(final double[] a, final double[] b, final double[] out) {
         final int len = a.length;
         final int bound = SPECIES.loopBound(len);
         int i = 0;
@@ -85,7 +83,7 @@ public final class SimdBackend implements Backend {
     }
 
     @Override
-    public void addInto(@Nonnull final double[] a, final double scalar, @Nonnull final double[] out) {
+    public void addInto(final double[] a, final double scalar, final double[] out) {
         final int len = a.length;
         final int bound = SPECIES.loopBound(len);
         int i = 0;
@@ -98,7 +96,7 @@ public final class SimdBackend implements Backend {
     }
 
     @Override
-    public void subtractInto(@Nonnull final double[] a, @Nonnull final double[] b, @Nonnull final double[] out) {
+    public void subtractInto(final double[] a, final double[] b, final double[] out) {
         final int len = a.length;
         final int bound = SPECIES.loopBound(len);
         int i = 0;
@@ -113,7 +111,7 @@ public final class SimdBackend implements Backend {
     }
 
     @Override
-    public void subtractInto(@Nonnull final double[] a, final double scalar, @Nonnull final double[] out) {
+    public void subtractInto(final double[] a, final double scalar, final double[] out) {
         final int len = a.length;
         final int bound = SPECIES.loopBound(len);
         int i = 0;
@@ -126,7 +124,7 @@ public final class SimdBackend implements Backend {
     }
 
     @Override
-    public void multiplyInto(@Nonnull final double[] a, final double scalar, @Nonnull final double[] out) {
+    public void multiplyInto(final double[] a, final double scalar, final double[] out) {
         final int len = a.length;
         final int bound = SPECIES.loopBound(len);
         int i = 0;
@@ -139,8 +137,8 @@ public final class SimdBackend implements Backend {
     }
 
     @Override
-    public void multiplyAddInto(final double scalar, @Nonnull final double[] x, @Nonnull final double[] y,
-                                @Nonnull final double[] out, final int from, final int length) {
+    public void multiplyAddInto(final double scalar, final double[] x, final double[] y,
+                                final double[] out, final int from, final int length) {
         final int laneCount = SPECIES.length();
         final int simdEnd = from + SPECIES.loopBound(length);
         // Hoist the scalar broadcast out of the loop: jdk.incubator.vector has fma(Vec,Vec,Vec)
@@ -160,12 +158,12 @@ public final class SimdBackend implements Backend {
     }
 
     @Override
-    public double dot(@Nonnull final double[] a, @Nonnull final double[] b) {
+    public double dot(final double[] a, final double[] b) {
         return dot(a, b, 0, a.length);
     }
 
     @Override
-    public double dot(@Nonnull final double[] a, @Nonnull final double[] b, final int from, final int length) {
+    public double dot(final double[] a, final double[] b, final int from, final int length) {
         final int laneCount = SPECIES.length();
         final int simdEnd = from + SPECIES.loopBound(length);
         // Four independent FMA accumulators break the loop-carried dependency on a single
@@ -203,12 +201,12 @@ public final class SimdBackend implements Backend {
     }
 
     @Override
-    public double l2SquaredNorm(@Nonnull final double[] a) {
+    public double l2SquaredNorm(final double[] a) {
         return l2SquaredNorm(a, 0, a.length);
     }
 
     @Override
-    public double l2SquaredNorm(@Nonnull final double[] a, final int from, final int length) {
+    public double l2SquaredNorm(final double[] a, final int from, final int length) {
         final int laneCount = SPECIES.length();
         final int simdEnd = from + SPECIES.loopBound(length);
         DoubleVector acc0 = DoubleVector.zero(SPECIES);
@@ -243,7 +241,7 @@ public final class SimdBackend implements Backend {
     }
 
     @Override
-    public double euclideanSquared(@Nonnull final double[] a, @Nonnull final double[] b) {
+    public double euclideanSquared(final double[] a, final double[] b) {
         final int len = a.length;
         final int laneCount = SPECIES.length();
         final int bound = SPECIES.loopBound(len);

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/linear/simd/package-info.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/linear/simd/package-info.java
@@ -33,4 +33,7 @@
  * {@code compileJava} task that compiles this package. To exercise the SIMD path at runtime, the
  * same flag must be passed to the JVM.
  */
+@NullMarked
 package com.apple.foundationdb.linear.simd;
+
+import org.jspecify.annotations.NullMarked;

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/map/BunchedMap.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/map/BunchedMap.java
@@ -37,8 +37,8 @@ import com.apple.foundationdb.tuple.ByteArrayUtil;
 import com.apple.foundationdb.tuple.ByteArrayUtil2;
 import com.apple.foundationdb.util.LogMessageKeys;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -105,9 +105,7 @@ public class BunchedMap<K, V> {
     private static final int MAX_VALUE_SIZE = 10_000; // The actual max value size is 100_000, but let's stay clear of that
     private static final byte[] ZERO_ARRAY = { 0x00 };
 
-    @Nonnull
     private final Comparator<K> keyComparator;
-    @Nonnull
     private final BunchedSerializer<K, V> serializer;
     private final int bunchSize;
 
@@ -126,7 +124,7 @@ public class BunchedMap<K, V> {
      * @param keyComparator comparator used to order keys
      * @param bunchSize maximum size of bunch within the database
      */
-    public BunchedMap(@Nonnull BunchedSerializer<K, V> serializer, @Nonnull Comparator<K> keyComparator, int bunchSize) {
+    public BunchedMap(BunchedSerializer<K, V> serializer, Comparator<K> keyComparator, int bunchSize) {
         this.serializer = serializer;
         this.keyComparator = keyComparator;
         this.bunchSize = bunchSize;
@@ -140,11 +138,11 @@ public class BunchedMap<K, V> {
      *
      * @param model original {@link BunchedMap} to base the new one on
      */
-    protected BunchedMap(@Nonnull BunchedMap<K, V> model) {
+    protected BunchedMap(BunchedMap<K, V> model) {
         this(model.serializer, model.keyComparator, model.bunchSize);
     }
 
-    private static <T> List<T> makeMutable(@Nonnull List<T> list) {
+    private static <T> List<T> makeMutable(List<T> list) {
         if (list instanceof ArrayList<?>) {
             return list;
         } else {
@@ -160,8 +158,7 @@ public class BunchedMap<K, V> {
      * @param readFuture a future that will complete to a list of keys and values
      * @return an instrumented future that returns the same values as the original future
      */
-    @Nonnull
-    protected CompletableFuture<List<KeyValue>> instrumentRangeRead(@Nonnull CompletableFuture<List<KeyValue>> readFuture) {
+    protected CompletableFuture<List<KeyValue>> instrumentRangeRead(CompletableFuture<List<KeyValue>> readFuture) {
         return readFuture;
     }
 
@@ -175,7 +172,7 @@ public class BunchedMap<K, V> {
      * @param value the new value being written to the key
      * @param oldValue the previous value being overwritten or {@code null} if the key is new or the previous value unknown
      */
-    protected void instrumentWrite(@Nonnull byte[] key, @Nonnull byte[] value, @Nullable byte[] oldValue) {
+    protected void instrumentWrite(byte[] key, byte[] value, @Nullable byte[] oldValue) {
 
     }
 
@@ -188,11 +185,11 @@ public class BunchedMap<K, V> {
      * @param key the key being deleted
      * @param oldValue the previous value being delete or {@code null} if the previous value is unknown
      */
-    protected void instrumentDelete(@Nonnull byte[] key, @Nullable byte[] oldValue) {
+    protected void instrumentDelete(byte[] key, @Nullable byte[] oldValue) {
 
     }
 
-    private CompletableFuture<Optional<KeyValue>> entryForKey(@Nonnull Transaction tr, @Nonnull byte[] subspaceKey, @Nonnull K key) {
+    private CompletableFuture<Optional<KeyValue>> entryForKey(Transaction tr, byte[] subspaceKey, K key) {
         byte[] keyBytes = ByteArrayUtil.join(subspaceKey, serializer.serializeKey(key));
         tr.addReadConflictKey(keyBytes);
         // We need to use a range read rather than a getKey with a single key selector
@@ -269,21 +266,21 @@ public class BunchedMap<K, V> {
     // comment. But in addition to proving them correct, a fair amount of testing has gone into
     // trying to verify that they work as intended through randomized testing.
 
-    private void addEntryListReadConflictRange(@Nonnull Transaction tr, @Nonnull byte[] subspaceKey, @Nonnull byte[] keyBytes, @Nonnull List<Map.Entry<K, V>> entryList) {
+    private void addEntryListReadConflictRange(Transaction tr, byte[] subspaceKey, byte[] keyBytes, List<Map.Entry<K, V>> entryList) {
         byte[] end = ByteArrayUtil.join(subspaceKey, serializer.serializeKey(entryList.get(entryList.size() - 1).getKey()), ZERO_ARRAY);
         tr.addReadConflictRange(keyBytes, end);
     }
 
-    private void insertAlone(@Nonnull Transaction tr, @Nonnull byte[] keyBytes, @Nonnull Map.Entry<K, V> entry) {
+    private void insertAlone(Transaction tr, byte[] keyBytes, Map.Entry<K, V> entry) {
         tr.addReadConflictKey(keyBytes);
         byte[] valueBytes = serializer.serializeEntries(Collections.singletonList(entry));
         tr.set(keyBytes, valueBytes);
         instrumentWrite(keyBytes, valueBytes, null);
     }
 
-    private void writeEntryListWithoutChecking(@Nonnull Transaction tr, @Nonnull byte[] subspaceKey, @Nonnull byte[] keyBytes,
-                                               @Nullable KeyValue oldKv, @Nonnull byte[] newKey, @Nonnull List<Map.Entry<K, V>> entryList,
-                                               @Nonnull byte[] serializedBytes) {
+    private void writeEntryListWithoutChecking(Transaction tr, byte[] subspaceKey, byte[] keyBytes,
+                                               @Nullable KeyValue oldKv, byte[] newKey, List<Map.Entry<K, V>> entryList,
+                                               byte[] serializedBytes) {
         // The order of these operations is fairly important as, it turns out, adding an explicit
         // read conflict range does will skip over values that have already been written. This
         // means that we will miss the value that is the actual key we are writing if we
@@ -306,8 +303,8 @@ public class BunchedMap<K, V> {
         }
     }
 
-    private void writeEntryList(@Nonnull Transaction tr, @Nonnull byte[] subspaceKey, @Nonnull byte[] keyBytes,
-                                @Nullable KeyValue oldKv, @Nonnull byte[] newKey, @Nonnull List<Map.Entry<K, V>> entryList,
+    private void writeEntryList(Transaction tr, byte[] subspaceKey, byte[] keyBytes,
+                                @Nullable KeyValue oldKv, byte[] newKey, List<Map.Entry<K, V>> entryList,
                                 @Nullable KeyValue kvAfter, boolean isFirst, boolean isLast) {
         byte[] serializedBytes = serializer.serializeEntries(entryList);
         if (serializedBytes.length > MAX_VALUE_SIZE) {
@@ -360,8 +357,8 @@ public class BunchedMap<K, V> {
         }
     }
 
-    private void insertAfter(@Nonnull Transaction tr, @Nonnull byte[] subspaceKey, @Nonnull byte[] keyBytes,
-                             @Nullable KeyValue kvAfter, @Nonnull Map.Entry<K, V> entry) {
+    private void insertAfter(Transaction tr, byte[] subspaceKey, byte[] keyBytes,
+                             @Nullable KeyValue kvAfter, Map.Entry<K, V> entry) {
         if (kvAfter == null) {
             insertAlone(tr, keyBytes, entry);
         } else {
@@ -380,10 +377,9 @@ public class BunchedMap<K, V> {
         }
     }
 
-    @Nonnull
-    private Optional<V> insertEntry(@Nonnull Transaction tr, @Nonnull byte[] subspaceKey, @Nonnull byte[] keyBytes,
-                                    @Nonnull K key, @Nonnull V value, @Nullable KeyValue kvBefore, @Nullable KeyValue kvAfter,
-                                    @Nonnull Map.Entry<K, V> entry) {
+    private Optional<V> insertEntry(Transaction tr, byte[] subspaceKey, byte[] keyBytes,
+                                    K key, V value, @Nullable KeyValue kvBefore, @Nullable KeyValue kvAfter,
+                                    Map.Entry<K, V> entry) {
         if (kvBefore == null) {
             insertAfter(tr, subspaceKey, keyBytes, kvAfter, entry);
             return Optional.empty();
@@ -473,8 +469,7 @@ public class BunchedMap<K, V> {
      * @return a future that will complete with an optional that will either contain the previous value
      *         associated with the key or be empty if there was not a previous value
      */
-    @Nonnull
-    public CompletableFuture<Optional<V>> put(@Nonnull TransactionContext tcx, @Nonnull Subspace subspace, @Nonnull K key, @Nonnull V value) {
+    public CompletableFuture<Optional<V>> put(TransactionContext tcx, Subspace subspace, K key, V value) {
         return tcx.runAsync(tr -> {
             byte[] subspaceKey = subspace.pack();
             byte[] keyBytes = ByteArrayUtil.join(subspaceKey, serializer.serializeKey(key));
@@ -547,8 +542,7 @@ public class BunchedMap<K, V> {
      * @return a future that will be completed to <code>true</code> if the map contains <code>key</code>
      *         and <code>false</code> otherwise
      */
-    @Nonnull
-    public CompletableFuture<Boolean> containsKey(@Nonnull TransactionContext tcx, @Nonnull Subspace subspace, @Nonnull K key) {
+    public CompletableFuture<Boolean> containsKey(TransactionContext tcx, Subspace subspace, K key) {
         final byte[] subspaceKey = subspace.getKey();
         return tcx.runAsync(tr -> entryForKey(tr, subspaceKey, key)
             .thenApply(optionalEntry -> optionalEntry
@@ -575,8 +569,7 @@ public class BunchedMap<K, V> {
      * @return a future that will be completed with an optional that will be present with the value
      *         associated with the key in the database or empty if the key is not contained within the map
      */
-    @Nonnull
-    public CompletableFuture<Optional<V>> get(@Nonnull TransactionContext tcx, @Nonnull Subspace subspace, @Nonnull K key) {
+    public CompletableFuture<Optional<V>> get(TransactionContext tcx, Subspace subspace, K key) {
         final byte[] subspaceKey = subspace.getKey();
         return tcx.runAsync(tr -> entryForKey(tr, subspaceKey, key)
             .thenApply(optionalEntry -> optionalEntry
@@ -613,8 +606,7 @@ public class BunchedMap<K, V> {
      * @return a future that will be completed with an optional that will be present with the value associated
      *         with the key in the database (prior to removal) or will be empty if the key was not present
      */
-    @Nonnull
-    public CompletableFuture<Optional<V>> remove(@Nonnull TransactionContext tcx, @Nonnull Subspace subspace, @Nonnull K key) {
+    public CompletableFuture<Optional<V>> remove(TransactionContext tcx, Subspace subspace, K key) {
         final byte[] subspaceKey = subspace.getKey();
         return tcx.runAsync(tr -> entryForKey(tr, subspaceKey, key).thenApply(optionalEntry -> optionalEntry.flatMap((KeyValue kv) -> {
             K mapKey = serializer.deserializeKey(kv.getKey(), subspaceKey.length);
@@ -674,8 +666,7 @@ public class BunchedMap<K, V> {
      * @param subspace subspace within which the map's data are located
      * @return a future that will complete when the integrity check has finished
      */
-    @Nonnull
-    public CompletableFuture<Void> verifyIntegrity(@Nonnull TransactionContext tcx, @Nonnull Subspace subspace) {
+    public CompletableFuture<Void> verifyIntegrity(TransactionContext tcx, Subspace subspace) {
         return tcx.runAsync(tr -> {
             AtomicReference<K> lastKey = new AtomicReference<>(null);
             byte[] subspaceKey = subspace.getKey();
@@ -703,9 +694,9 @@ public class BunchedMap<K, V> {
         });
     }
 
-    private void flushEntryList(@Nonnull Transaction tr, @Nonnull byte[] subspaceKey,
-                                @Nonnull List<Map.Entry<K, V>> currentEntryList,
-                                @Nonnull AtomicReference<K> lastKey) {
+    private void flushEntryList(Transaction tr, byte[] subspaceKey,
+                                List<Map.Entry<K, V>> currentEntryList,
+                                AtomicReference<K> lastKey) {
         byte[] keyBytes = ByteArrayUtil.join(subspaceKey, serializer.serializeKey(currentEntryList.get(0).getKey()));
         writeEntryListWithoutChecking(tr, subspaceKey, keyBytes, null, keyBytes, currentEntryList,
                 serializer.serializeEntries(currentEntryList));
@@ -726,8 +717,7 @@ public class BunchedMap<K, V> {
      * @return future that will complete with a continuation that can be used to complete
      *         the compaction across multiple transactions (<code>null</code> if finished)
      */
-    @Nonnull
-    protected CompletableFuture<byte[]> compact(@Nonnull TransactionContext tcx, @Nonnull Subspace subspace,
+    protected CompletableFuture<byte[]> compact(TransactionContext tcx, Subspace subspace,
                                               int keyLimit, @Nullable byte[] continuation) {
         return tcx.runAsync(tr -> {
             byte[] subspaceKey = subspace.getKey();
@@ -792,7 +782,6 @@ public class BunchedMap<K, V> {
      * @return this map's serializer
      * @see BunchedSerializer
      */
-    @Nonnull
     public BunchedSerializer<K, V> getSerializer() {
         return serializer;
     }
@@ -802,7 +791,6 @@ public class BunchedMap<K, V> {
      *
      * @return this map's key comparator
      */
-    @Nonnull
     public Comparator<K> getKeyComparator() {
         return keyComparator;
     }
@@ -829,8 +817,7 @@ public class BunchedMap<K, V> {
      * @param subspace subspace in which the map's data are located
      * @return an iterator over the entries in the map
      */
-    @Nonnull
-    public BunchedMapIterator<K, V> scan(@Nonnull ReadTransaction tr, @Nonnull Subspace subspace) {
+    public BunchedMapIterator<K, V> scan(ReadTransaction tr, Subspace subspace) {
         return scan(tr, subspace, null, Transaction.ROW_LIMIT_UNLIMITED, false);
     }
 
@@ -845,8 +832,7 @@ public class BunchedMap<K, V> {
      * @param continuation continuation from a previous scan (or <code>null</code> to start from the beginning)
      * @return an iterator over the entries in the map
      */
-    @Nonnull
-    public BunchedMapIterator<K, V> scan(@Nonnull ReadTransaction tr, @Nonnull Subspace subspace, @Nullable byte[] continuation) {
+    public BunchedMapIterator<K, V> scan(ReadTransaction tr, Subspace subspace, @Nullable byte[] continuation) {
         return scan(tr, subspace, continuation, ReadTransaction.ROW_LIMIT_UNLIMITED, false);
     }
 
@@ -866,8 +852,7 @@ public class BunchedMap<K, V> {
      * @param reverse <code>true</code> if keys are wanted in descending instead of ascending order
      * @return an iterator over the entries in the map
      */
-    @Nonnull
-    public BunchedMapIterator<K, V> scan(@Nonnull ReadTransaction tr, @Nonnull Subspace subspace, @Nullable byte[] continuation, int limit, boolean reverse) {
+    public BunchedMapIterator<K, V> scan(ReadTransaction tr, Subspace subspace, @Nullable byte[] continuation, int limit, boolean reverse) {
         byte[] subspaceKey = subspace.getKey();
         AsyncIterable<KeyValue> rangeReadIterable;
         K continuationKey;
@@ -908,8 +893,7 @@ public class BunchedMap<K, V> {
      * @param <T> type of the tag of each map subspace
      * @return an iterator over the entries in multiple maps
      */
-    @Nonnull
-    public <T> BunchedMapMultiIterator<K, V, T> scanMulti(@Nonnull ReadTransaction tr, @Nonnull Subspace subspace, @Nonnull SubspaceSplitter<T> splitter) {
+    public <T> BunchedMapMultiIterator<K, V, T> scanMulti(ReadTransaction tr, Subspace subspace, SubspaceSplitter<T> splitter) {
         return scanMulti(tr, subspace, splitter, null, ReadTransaction.ROW_LIMIT_UNLIMITED, false);
     }
 
@@ -928,8 +912,7 @@ public class BunchedMap<K, V> {
      * @param <T> type of the tag of each map subspace
      * @return an iterator over the entries in multiple maps
      */
-    @Nonnull
-    public <T> BunchedMapMultiIterator<K, V, T> scanMulti(@Nonnull ReadTransaction tr, @Nonnull Subspace subspace, @Nonnull SubspaceSplitter<T> splitter,
+    public <T> BunchedMapMultiIterator<K, V, T> scanMulti(ReadTransaction tr, Subspace subspace, SubspaceSplitter<T> splitter,
                                                         @Nullable byte[] continuation, int limit, boolean reverse) {
         return scanMulti(tr, subspace, splitter, null, null, continuation, limit, reverse);
     }
@@ -985,8 +968,7 @@ public class BunchedMap<K, V> {
      * @param <T> type of the tag of each map subspace
      * @return an iterator over the entries in multiple maps
      */
-    @Nonnull
-    public <T> BunchedMapMultiIterator<K, V, T> scanMulti(@Nonnull ReadTransaction tr, @Nonnull Subspace subspace, @Nonnull SubspaceSplitter<T> splitter,
+    public <T> BunchedMapMultiIterator<K, V, T> scanMulti(ReadTransaction tr, Subspace subspace, SubspaceSplitter<T> splitter,
                                                           @Nullable byte[] subspaceStart, @Nullable byte[] subspaceEnd,
                                                           @Nullable byte[] continuation, int limit, boolean reverse) {
         return scanMulti(tr, subspace, splitter, subspaceStart, subspaceEnd, continuation, limit, null, reverse);
@@ -1010,8 +992,7 @@ public class BunchedMap<K, V> {
      * @return an iterator over the entries in multiple maps
      * @see #scanMulti(ReadTransaction, Subspace, SubspaceSplitter, byte[], byte[], byte[], int, Consumer, boolean)
      */
-    @Nonnull
-    public <T> BunchedMapMultiIterator<K, V, T> scanMulti(@Nonnull ReadTransaction tr, @Nonnull Subspace subspace, @Nonnull SubspaceSplitter<T> splitter,
+    public <T> BunchedMapMultiIterator<K, V, T> scanMulti(ReadTransaction tr, Subspace subspace, SubspaceSplitter<T> splitter,
                                                           @Nullable byte[] subspaceStart, @Nullable byte[] subspaceEnd,
                                                           @Nullable byte[] continuation, int limit, @Nullable Consumer<KeyValue> postReadCallback, boolean reverse) {
         byte[] subspaceKey = subspace.getKey();

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/map/BunchedMap.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/map/BunchedMap.java
@@ -46,6 +46,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -189,6 +190,12 @@ public class BunchedMap<K, V> {
 
     }
 
+    // NullAway does not reliably honor @Nullable on byte[]-typed parameters when checking a call's arguments,
+    // even for our own methods declared immediately above with an @Nullable byte[] parameter. A bare `null`
+    // literal, or an already-@Nullable-tracked byte[] value, passed to instrumentWrite/instrumentDelete is
+    // therefore misflagged as a NonNull violation. Call sites below wrap such calls in a Runnable so the
+    // resulting suppression can be scoped to a single local declaration rather than a whole method body.
+
     private CompletableFuture<Optional<KeyValue>> entryForKey(Transaction tr, byte[] subspaceKey, K key) {
         byte[] keyBytes = ByteArrayUtil.join(subspaceKey, serializer.serializeKey(key));
         tr.addReadConflictKey(keyBytes);
@@ -275,7 +282,9 @@ public class BunchedMap<K, V> {
         tr.addReadConflictKey(keyBytes);
         byte[] valueBytes = serializer.serializeEntries(Collections.singletonList(entry));
         tr.set(keyBytes, valueBytes);
-        instrumentWrite(keyBytes, valueBytes, null);
+        @SuppressWarnings("NullAway")
+        final Runnable instrumentAction = () -> instrumentWrite(keyBytes, valueBytes, null);
+        instrumentAction.run();
     }
 
     private void writeEntryListWithoutChecking(Transaction tr, byte[] subspaceKey, byte[] keyBytes,
@@ -289,7 +298,9 @@ public class BunchedMap<K, V> {
         addEntryListReadConflictRange(tr, subspaceKey, newKey, entryList);
         final byte[] oldKey = oldKv == null ? null : oldKv.getKey();
         final byte[] oldValue;
-        if (oldKey != null && !Arrays.equals(oldKey, newKey)) {
+        // oldKv != null is implied by oldKey != null (oldKey is derived from it above), but NullAway cannot
+        // correlate the nullness of two different variables, so the check is spelled out explicitly here.
+        if (oldKey != null && oldKv != null && !Arrays.equals(oldKey, newKey)) {
             tr.clear(oldKey);
             instrumentDelete(oldKey, oldKv.getValue());
             oldValue = null; // set the old value to null so that the instrumentation of the write doesn't double-count the delete
@@ -297,7 +308,11 @@ public class BunchedMap<K, V> {
             oldValue = oldKv == null ? null : oldKv.getValue();
         }
         tr.set(newKey, serializedBytes);
-        instrumentWrite(newKey, serializedBytes, oldValue);
+        // NullAway does not reliably honor @Nullable on byte[]-typed parameters, so forwarding the
+        // already-@Nullable-tracked oldValue local into instrumentWrite is misflagged as a NonNull violation.
+        @SuppressWarnings("NullAway")
+        final Runnable instrumentAction = () -> instrumentWrite(newKey, serializedBytes, oldValue);
+        instrumentAction.run();
         if (!Arrays.equals(keyBytes, newKey)) {
             tr.addWriteConflictKey(keyBytes);
         }
@@ -339,7 +354,12 @@ public class BunchedMap<K, V> {
                 addEntryListReadConflictRange(tr, subspaceKey, newKey, entryList);
                 byte[] appendBytes = serializer.serializeEntry(entryList.get(entryList.size() - 1));
                 tr.mutate(MutationType.APPEND_IF_FITS, newKey, appendBytes);
-                instrumentWrite(newKey, appendBytes, null); // do not include old value in instrumentation as we are incrementing the total size
+                // NullAway does not reliably honor @Nullable on byte[]-typed parameters, so the null literal
+                // below is misflagged as a NonNull violation even though instrumentWrite's oldValue parameter
+                // is declared @Nullable byte[].
+                @SuppressWarnings("NullAway")
+                final Runnable instrumentAction = () -> instrumentWrite(newKey, appendBytes, null); // do not include old value in instrumentation as we are incrementing the total size
+                instrumentAction.run();
                 tr.addWriteConflictKey(keyBytes);
             } else {
                 writeEntryListWithoutChecking(tr, subspaceKey, keyBytes, oldKv, newKey, entryList, serializedBytes);
@@ -629,7 +649,12 @@ public class BunchedMap<K, V> {
                     // The only key that was in the range was the key that
                     // we are currently removing, so just remove it.
                     tr.clear(kv.getKey());
-                    instrumentDelete(kv.getKey(), null);
+                    // NullAway does not reliably honor @Nullable on byte[]-typed parameters, so the null
+                    // literal below is misflagged as a NonNull violation even though instrumentDelete's
+                    // oldValue parameter is declared @Nullable byte[].
+                    @SuppressWarnings("NullAway")
+                    final Runnable instrumentAction = () -> instrumentDelete(kv.getKey(), null);
+                    instrumentAction.run();
                 } else {
                     // We have other items in the entry. Remove the entry
                     // we actually care about and serialize the rest.
@@ -648,7 +673,12 @@ public class BunchedMap<K, V> {
                     }
                     final byte[] newValue = serializer.serializeEntries(entryList);
                     tr.set(newKey, newValue);
-                    instrumentWrite(newKey, newValue, oldValue);
+                    // NullAway does not reliably honor @Nullable on byte[]-typed parameters, so forwarding the
+                    // already-@Nullable-tracked oldValue local into instrumentWrite is misflagged as a NonNull
+                    // violation.
+                    @SuppressWarnings("NullAway")
+                    final Runnable instrumentAction = () -> instrumentWrite(newKey, newValue, oldValue);
+                    instrumentAction.run();
                 }
                 return Optional.of(oldEntry.getValue());
             } else {
@@ -721,7 +751,10 @@ public class BunchedMap<K, V> {
                                               int keyLimit, @Nullable byte[] continuation) {
         return tcx.runAsync(tr -> {
             byte[] subspaceKey = subspace.getKey();
-            byte[] begin = (continuation == null) ? subspaceKey : continuation;
+            // NullAway does not reliably narrow @Nullable byte[] locals inside a ternary, even though
+            // continuation is provably non-null in the else branch here.
+            @SuppressWarnings("NullAway")
+            final byte[] begin = (continuation == null) ? subspaceKey : continuation;
             byte[] end = subspace.range().end;
             final AsyncIterable<KeyValue> iterable = tr.snapshot().getRange(begin, end, keyLimit);
             List<Map.Entry<K, V>> currentEntryList = new ArrayList<>(bunchSize);
@@ -740,12 +773,16 @@ public class BunchedMap<K, V> {
                     lastReadKeyBytes.set(null);
                     return;
                 }
-                if (lastReadKeyBytes.get() == null) {
-                    lastReadKeyBytes.set(kv.getKey());
+                // lastReadKeyBytes.get() is re-fetched (rather than reused from the check above) after
+                // possibly being set just below, so capture it once here for both use and null-safety.
+                byte[] lastRead = lastReadKeyBytes.get();
+                if (lastRead == null) {
+                    lastRead = kv.getKey();
+                    lastReadKeyBytes.set(lastRead);
                 }
                 final byte[] endKeyBytes = ByteArrayUtil.join(subspaceKey, serializer.serializeKey(entriesFromKey.get(entriesFromKey.size() - 1).getKey()), ZERO_ARRAY);
-                tr.addReadConflictRange(lastReadKeyBytes.get(), endKeyBytes);
-                tr.addWriteConflictRange(lastReadKeyBytes.get(), kv.getKey());
+                tr.addReadConflictRange(lastRead, endKeyBytes);
+                tr.addWriteConflictRange(lastRead, kv.getKey());
                 lastReadKeyBytes.set(endKeyBytes);
                 tr.clear(kv.getKey());
                 instrumentDelete(kv.getKey(), kv.getValue());
@@ -818,7 +855,11 @@ public class BunchedMap<K, V> {
      * @return an iterator over the entries in the map
      */
     public BunchedMapIterator<K, V> scan(ReadTransaction tr, Subspace subspace) {
-        return scan(tr, subspace, null, Transaction.ROW_LIMIT_UNLIMITED, false);
+        // NullAway does not reliably honor @Nullable on byte[]-typed parameters, so the null literal below
+        // is misflagged as a NonNull violation even though scan()'s continuation parameter is @Nullable byte[].
+        @SuppressWarnings("NullAway")
+        final BunchedMapIterator<K, V> result = scan(tr, subspace, null, Transaction.ROW_LIMIT_UNLIMITED, false);
+        return result;
     }
 
     /**
@@ -860,8 +901,11 @@ public class BunchedMap<K, V> {
             continuationKey = null;
             rangeReadIterable = tr.getRange(subspace.range(), ReadTransaction.ROW_LIMIT_UNLIMITED, reverse);
         } else {
-            continuationKey = serializer.deserializeKey(continuation);
-            byte[] continuationKeyBytes = ByteArrayUtil.join(subspaceKey, continuation);
+            // continuation is provably non-null here (the if-branch above handles the null case), but
+            // NullAway does not reliably narrow @Nullable byte[] locals, so it is re-asserted explicitly.
+            final byte[] nonNullContinuation = Objects.requireNonNull(continuation);
+            continuationKey = serializer.deserializeKey(nonNullContinuation);
+            byte[] continuationKeyBytes = ByteArrayUtil.join(subspaceKey, nonNullContinuation);
             if (reverse) {
                 rangeReadIterable = tr.getRange(subspaceKey, continuationKeyBytes, ReadTransaction.ROW_LIMIT_UNLIMITED, true);
             } else {
@@ -894,7 +938,11 @@ public class BunchedMap<K, V> {
      * @return an iterator over the entries in multiple maps
      */
     public <T> BunchedMapMultiIterator<K, V, T> scanMulti(ReadTransaction tr, Subspace subspace, SubspaceSplitter<T> splitter) {
-        return scanMulti(tr, subspace, splitter, null, ReadTransaction.ROW_LIMIT_UNLIMITED, false);
+        // NullAway does not reliably honor @Nullable on byte[]-typed parameters, so the null literal below
+        // is misflagged as a NonNull violation even though the continuation parameter is @Nullable byte[].
+        @SuppressWarnings("NullAway")
+        final BunchedMapMultiIterator<K, V, T> result = scanMulti(tr, subspace, splitter, null, ReadTransaction.ROW_LIMIT_UNLIMITED, false);
+        return result;
     }
 
     /**
@@ -914,7 +962,11 @@ public class BunchedMap<K, V> {
      */
     public <T> BunchedMapMultiIterator<K, V, T> scanMulti(ReadTransaction tr, Subspace subspace, SubspaceSplitter<T> splitter,
                                                         @Nullable byte[] continuation, int limit, boolean reverse) {
-        return scanMulti(tr, subspace, splitter, null, null, continuation, limit, reverse);
+        // NullAway does not reliably honor @Nullable on byte[]-typed parameters, so the null literals below
+        // are misflagged as NonNull violations even though subspaceStart/subspaceEnd are @Nullable byte[].
+        @SuppressWarnings("NullAway")
+        final BunchedMapMultiIterator<K, V, T> result = scanMulti(tr, subspace, splitter, null, null, continuation, limit, reverse);
+        return result;
     }
 
     /**
@@ -996,13 +1048,20 @@ public class BunchedMap<K, V> {
                                                           @Nullable byte[] subspaceStart, @Nullable byte[] subspaceEnd,
                                                           @Nullable byte[] continuation, int limit, @Nullable Consumer<KeyValue> postReadCallback, boolean reverse) {
         byte[] subspaceKey = subspace.getKey();
-        byte[] startBytes = (subspaceStart == null ? subspaceKey : ByteArrayUtil.join(subspaceKey, subspaceStart));
-        byte[] endBytes = (subspaceEnd == null ? ByteArrayUtil.strinc(subspaceKey) : ByteArrayUtil.join(subspaceKey, subspaceEnd));
+        // NullAway does not reliably propagate non-null-ness through generic substitution (e.g.
+        // Objects.requireNonNull) or ternary narrowing when the type involved is byte[], so the calls below
+        // are misflagged as NonNull violations even though subspaceStart/subspaceEnd/continuation are
+        // provably non-null on the join(...) side of each expression.
+        @SuppressWarnings("NullAway")
+        final byte[] startBytes = (subspaceStart == null ? subspaceKey : ByteArrayUtil.join(subspaceKey, subspaceStart));
+        @SuppressWarnings("NullAway")
+        final byte[] endBytes = (subspaceEnd == null ? ByteArrayUtil.strinc(subspaceKey) : ByteArrayUtil.join(subspaceKey, subspaceEnd));
         AsyncIterable<KeyValue> rangeReadIterable;
         if (continuation == null) {
             rangeReadIterable = tr.getRange(startBytes, endBytes, ReadTransaction.ROW_LIMIT_UNLIMITED, reverse);
         } else {
-            byte[] continuationEndpoint = ByteArrayUtil.join(subspaceKey, continuation);
+            @SuppressWarnings("NullAway")
+            final byte[] continuationEndpoint = ByteArrayUtil.join(subspaceKey, continuation);
             if (reverse) {
                 if (ByteArrayUtil.compareUnsigned(continuationEndpoint, endBytes) < 0) {
                     rangeReadIterable = tr.getRange(startBytes, continuationEndpoint, ReadTransaction.ROW_LIMIT_UNLIMITED, true);

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/map/BunchedMapException.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/map/BunchedMapException.java
@@ -23,6 +23,8 @@ package com.apple.foundationdb.map;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.util.LoggableException;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Exception class that can be thrown by a {@link BunchedMap}. Exceptions of this class
  * might be thrown if some internal invariant of the <code>BunchedMap</code> class
@@ -55,13 +57,13 @@ public class BunchedMapException extends LoggableException {
     }
 
     @Override
-    public BunchedMapException addLogInfo(String description, Object object) {
+    public BunchedMapException addLogInfo(String description, @Nullable Object object) {
         super.addLogInfo(description, object);
         return this;
     }
 
     @Override
-    public BunchedMapException addLogInfo(Object... keyValue) {
+    public BunchedMapException addLogInfo(@Nullable Object... keyValue) {
         super.addLogInfo(keyValue);
         return this;
     }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/map/BunchedMapException.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/map/BunchedMapException.java
@@ -22,7 +22,6 @@ package com.apple.foundationdb.map;
 
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.util.LoggableException;
-import javax.annotation.Nonnull;
 
 /**
  * Exception class that can be thrown by a {@link BunchedMap}. Exceptions of this class
@@ -41,7 +40,7 @@ public class BunchedMapException extends LoggableException {
      * Create a new exception with a static message.
      * @param message error message
      */
-    public BunchedMapException(@Nonnull String message) {
+    public BunchedMapException(String message) {
         super(message);
     }
 
@@ -51,20 +50,18 @@ public class BunchedMapException extends LoggableException {
      * @param message error message
      * @param cause cause
      */
-    public BunchedMapException(@Nonnull String message, @Nonnull Throwable cause) {
+    public BunchedMapException(String message, Throwable cause) {
         super(message, cause);
     }
 
-    @Nonnull
     @Override
-    public BunchedMapException addLogInfo(@Nonnull String description, Object object) {
+    public BunchedMapException addLogInfo(String description, Object object) {
         super.addLogInfo(description, object);
         return this;
     }
 
-    @Nonnull
     @Override
-    public BunchedMapException addLogInfo(@Nonnull Object... keyValue) {
+    public BunchedMapException addLogInfo(Object... keyValue) {
         super.addLogInfo(keyValue);
         return this;
     }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/map/BunchedMapIterator.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/map/BunchedMapIterator.java
@@ -199,6 +199,9 @@ public class BunchedMapIterator<K, V> implements AsyncPeekIterator<Map.Entry<K, 
      * @return a continuation that can be used to resume iteration later
      */
     @Nullable
+    // NullAway does not reliably recognize @Nullable on array-typed return values, so the `return null;`
+    // below is misflagged as returning @Nullable from a @NonNull-returning method despite the annotation.
+    @SuppressWarnings("NullAway")
     public byte[] getContinuation() {
         if (lastKey == null || done && (limit == ReadTransaction.ROW_LIMIT_UNLIMITED || returned < limit)) {
             // We exhausted the scan.

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/map/BunchedMapIterator.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/map/BunchedMapIterator.java
@@ -28,8 +28,8 @@ import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.subspace.Subspace;
 import com.apple.foundationdb.tuple.ByteArrayUtil;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -47,11 +47,11 @@ import java.util.concurrent.CompletableFuture;
  */
 @API(API.Status.EXPERIMENTAL)
 public class BunchedMapIterator<K, V> implements AsyncPeekIterator<Map.Entry<K, V>> {
-    @Nonnull private final AsyncPeekIterator<KeyValue> underlying;
-    @Nonnull private final Subspace subspace;
-    @Nonnull private final ReadTransaction tr;
-    @Nonnull private final byte[] subspaceKey;
-    @Nonnull private final BunchedMap<K, V> bunchedMap;
+    private final AsyncPeekIterator<KeyValue> underlying;
+    private final Subspace subspace;
+    private final ReadTransaction tr;
+    private final byte[] subspaceKey;
+    private final BunchedMap<K, V> bunchedMap;
     @Nullable private final K continuationKey;
     private final boolean reverse;
     private final int limit;
@@ -66,11 +66,11 @@ public class BunchedMapIterator<K, V> implements AsyncPeekIterator<Map.Entry<K, 
 
     // In general, this class should not be instantiated by code outside
     // this package. Instead, it should use the scan() method on BunchedMaps.
-    BunchedMapIterator(@Nonnull AsyncPeekIterator<KeyValue> underlying,
-                       @Nonnull ReadTransaction tr,
-                       @Nonnull Subspace subspace,
-                       @Nonnull byte[] subspaceKey,
-                       @Nonnull BunchedMap<K, V> bunchedMap,
+    BunchedMapIterator(AsyncPeekIterator<KeyValue> underlying,
+                       ReadTransaction tr,
+                       Subspace subspace,
+                       byte[] subspaceKey,
+                       BunchedMap<K, V> bunchedMap,
                        @Nullable K continuationKey,
                        int limit,
                        boolean reverse) {
@@ -163,7 +163,6 @@ public class BunchedMapIterator<K, V> implements AsyncPeekIterator<Map.Entry<K, 
     }
 
     @Override
-    @Nonnull
     public Map.Entry<K, V> peek() {
         if (hasNext()) {
             // The hasNext method should enforce that currEntryList is not null
@@ -178,7 +177,6 @@ public class BunchedMapIterator<K, V> implements AsyncPeekIterator<Map.Entry<K, 
     }
 
     @Override
-    @Nonnull
     public Map.Entry<K, V> next() {
         Map.Entry<K, V> nextEntry = peek();
         lastKey = nextEntry.getKey();

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/map/BunchedMapMultiIterator.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/map/BunchedMapMultiIterator.java
@@ -28,8 +28,8 @@ import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.subspace.Subspace;
 import com.apple.foundationdb.tuple.ByteArrayUtil;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import java.util.Arrays;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -52,12 +52,12 @@ import java.util.concurrent.CompletableFuture;
  */
 @API(API.Status.EXPERIMENTAL)
 public class BunchedMapMultiIterator<K, V, T> implements AsyncPeekIterator<BunchedMapScanEntry<K, V, T>> {
-    @Nonnull private final AsyncPeekIterator<KeyValue> underlying;
-    @Nonnull private final ReadTransaction tr;
-    @Nonnull private final Subspace subspace;
-    @Nonnull private final byte[] subspaceKey;
-    @Nonnull private final SubspaceSplitter<T> splitter;
-    @Nonnull private final BunchedMap<K, V> bunchedMap;
+    private final AsyncPeekIterator<KeyValue> underlying;
+    private final ReadTransaction tr;
+    private final Subspace subspace;
+    private final byte[] subspaceKey;
+    private final SubspaceSplitter<T> splitter;
+    private final BunchedMap<K, V> bunchedMap;
     @Nullable private final byte[] continuation;
     private final boolean reverse;
     private final int limit;
@@ -75,12 +75,12 @@ public class BunchedMapMultiIterator<K, V, T> implements AsyncPeekIterator<Bunch
     private int returned;
     private boolean done;
 
-    BunchedMapMultiIterator(@Nonnull AsyncPeekIterator<KeyValue> underlying,
-                            @Nonnull ReadTransaction tr,
-                            @Nonnull Subspace subspace,
-                            @Nonnull byte[] subspaceKey,
-                            @Nonnull SubspaceSplitter<T> splitter,
-                            @Nonnull BunchedMap<K, V> bunchedMap,
+    BunchedMapMultiIterator(AsyncPeekIterator<KeyValue> underlying,
+                            ReadTransaction tr,
+                            Subspace subspace,
+                            byte[] subspaceKey,
+                            SubspaceSplitter<T> splitter,
+                            BunchedMap<K, V> bunchedMap,
                             @Nullable byte[] continuation,
                             int limit,
                             boolean reverse) {
@@ -229,7 +229,6 @@ public class BunchedMapMultiIterator<K, V, T> implements AsyncPeekIterator<Bunch
     }
 
     @Override
-    @Nonnull
     public BunchedMapScanEntry<K, V, T> peek() {
         if (hasNext() && nextEntry != null) {
             return nextEntry;
@@ -239,7 +238,6 @@ public class BunchedMapMultiIterator<K, V, T> implements AsyncPeekIterator<Bunch
     }
 
     @Override
-    @Nonnull
     public BunchedMapScanEntry<K, V, T> next() {
         BunchedMapScanEntry<K, V, T> nextEntry = peek();
         lastKey = nextEntry.getKey();

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/map/BunchedMapMultiIterator.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/map/BunchedMapMultiIterator.java
@@ -33,6 +33,7 @@ import org.jspecify.annotations.Nullable;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -75,6 +76,10 @@ public class BunchedMapMultiIterator<K, V, T> implements AsyncPeekIterator<Bunch
     private int returned;
     private boolean done;
 
+    // NullAway does not reliably recognize @Nullable on byte[]-typed fields (currentSubspaceSuffix,
+    // currentSubspaceKey above), so it both misflags the null literals assigned below and, separately,
+    // insists -- incorrectly, since they are declared @Nullable -- that they be definitely assigned here.
+    @SuppressWarnings("NullAway")
     BunchedMapMultiIterator(AsyncPeekIterator<KeyValue> underlying,
                             ReadTransaction tr,
                             Subspace subspace,
@@ -134,10 +139,14 @@ public class BunchedMapMultiIterator<K, V, T> implements AsyncPeekIterator<Bunch
                 byte[] nextSubspaceSuffix = Arrays.copyOfRange(nextSubspaceKey, subspaceKey.length, nextSubspaceKey.length);
                 K continuationKey = null;
                 if (!continuationSatisfied) {
-                    if (ByteArrayUtil.startsWith(continuation, nextSubspaceSuffix)) {
-                        continuationKey = bunchedMap.getSerializer().deserializeKey(continuation, nextSubspaceSuffix.length);
+                    // !continuationSatisfied implies continuation != null: continuationSatisfied starts out as
+                    // (continuation == null) and is only ever subsequently set to true, never back to false. But
+                    // NullAway cannot correlate the nullness of two different fields, so it is reasserted here.
+                    final byte[] nonNullContinuation = Objects.requireNonNull(continuation);
+                    if (ByteArrayUtil.startsWith(nonNullContinuation, nextSubspaceSuffix)) {
+                        continuationKey = bunchedMap.getSerializer().deserializeKey(nonNullContinuation, nextSubspaceSuffix.length);
                         continuationSatisfied = true;
-                    } else if (ByteArrayUtil.compareUnsigned(nextSubspaceSuffix, continuation) * (reverse ? -1 : 1) > 0) {
+                    } else if (ByteArrayUtil.compareUnsigned(nextSubspaceSuffix, nonNullContinuation) * (reverse ? -1 : 1) > 0) {
                         // We have already satisfied the continuation, so we are can just say it is satisfied
                         continuationSatisfied = true;
                         continuationKey = null;
@@ -200,12 +209,18 @@ public class BunchedMapMultiIterator<K, V, T> implements AsyncPeekIterator<Bunch
         }
         if (hasNextFuture == null) {
             if (mapIterator != null) {
-                hasNextFuture = mapIterator.onHasNext().thenCompose(mapHasNext -> {
+                // Captured to a local because the null-check above does not survive the lambda boundary below
+                // (mapIterator is a mutable field).
+                final BunchedMapIterator<K, V> currentMapIterator = mapIterator;
+                hasNextFuture = currentMapIterator.onHasNext().thenCompose(mapHasNext -> {
                     if (mapHasNext) {
-                        Map.Entry<K, V> entry = mapIterator.next();
-                        assert currentSubspace != null;
-                        assert currentSubspaceKey != null;
-                        nextEntry = new BunchedMapScanEntry<>(currentSubspace, currentSubspaceTag, entry.getKey(), entry.getValue());
+                        Map.Entry<K, V> entry = currentMapIterator.next();
+                        // currentSubspace/currentSubspaceKey are always set together with mapIterator (see
+                        // getNextMapIterator()), so they are non-null here too; assert is not used because
+                        // NullAway does not treat it as a null-check (and assertions may be disabled at runtime).
+                        final Subspace nonNullCurrentSubspace = Objects.requireNonNull(currentSubspace);
+                        Objects.requireNonNull(currentSubspaceKey);
+                        nextEntry = new BunchedMapScanEntry<>(nonNullCurrentSubspace, currentSubspaceTag, entry.getKey(), entry.getValue());
                         return AsyncUtil.READY_TRUE;
                     } else if (limit != ReadTransaction.ROW_LIMIT_UNLIMITED && returned == limit) {
                         // Because we pass limit information to the sub-iterators,
@@ -257,14 +272,19 @@ public class BunchedMapMultiIterator<K, V, T> implements AsyncPeekIterator<Bunch
      * @return a continuation that can be used to resume iteration later
      */
     @Nullable
+    // NullAway does not reliably recognize @Nullable on array-typed return values, so the `return null;`
+    // below is misflagged as returning @Nullable from a @NonNull-returning method despite the annotation.
+    @SuppressWarnings("NullAway")
     public byte[] getContinuation() {
         if (lastKey == null || currentSubspaceKey == null || done && (limit == ReadTransaction.ROW_LIMIT_UNLIMITED || returned < limit)) {
             // We exhausted the scan.
             return null;
         } else {
-            // Return a continuation with the information about the subspace key
-            // and the last key serialized.
-            return ByteArrayUtil.join(currentSubspaceSuffix, bunchedMap.getSerializer().serializeKey(lastKey));
+            // Return a continuation with the information about the subspace key and the last key serialized.
+            // currentSubspaceSuffix is always set together with currentSubspaceKey (see getNextMapIterator()),
+            // so it is non-null here too, but NullAway cannot correlate the nullness of two different fields.
+            final byte[] nonNullCurrentSubspaceSuffix = Objects.requireNonNull(currentSubspaceSuffix);
+            return ByteArrayUtil.join(nonNullCurrentSubspaceSuffix, bunchedMap.getSerializer().serializeKey(lastKey));
         }
     }
 

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/map/BunchedMapScanEntry.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/map/BunchedMapScanEntry.java
@@ -22,8 +22,7 @@ package com.apple.foundationdb.map;
 
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.subspace.Subspace;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Struct containing the results of scanning one or more {@link BunchedMap}s using the
@@ -40,13 +39,13 @@ import javax.annotation.Nullable;
  */
 @API(API.Status.EXPERIMENTAL)
 public class BunchedMapScanEntry<K, V, T> {
-    @Nonnull private final Subspace subspace;
+    private final Subspace subspace;
     @Nullable private final T subspaceTag;
-    @Nonnull private final K key;
-    @Nonnull private final V value;
+    private final K key;
+    private final V value;
 
-    BunchedMapScanEntry(@Nonnull final Subspace subspace, @Nullable final T subspaceTag,
-                        @Nonnull final K key, @Nonnull final V value) {
+    BunchedMapScanEntry(final Subspace subspace, @Nullable final T subspaceTag,
+                        final K key, final V value) {
         this.subspace = subspace;
         this.subspaceTag = subspaceTag;
         this.key = key;
@@ -59,7 +58,6 @@ public class BunchedMapScanEntry<K, V, T> {
      *
      * @return the subspace containing this entry
      */
-    @Nonnull
     public Subspace getSubspace() {
         return subspace;
     }
@@ -84,7 +82,6 @@ public class BunchedMapScanEntry<K, V, T> {
      *
      * @return the map key associated with this entry
      */
-    @Nonnull
     public K getKey() {
         return key;
     }
@@ -94,7 +91,6 @@ public class BunchedMapScanEntry<K, V, T> {
      *
      * @return the map value associated with this entry
      */
-    @Nonnull
     public V getValue() {
         return value;
     }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/map/BunchedSerializationException.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/map/BunchedSerializationException.java
@@ -37,7 +37,11 @@ import java.util.Arrays;
 @SuppressWarnings("serial")
 public class BunchedSerializationException extends BunchedMapException {
     @Nullable
-    private byte[] data;
+    // NullAway does not reliably recognize @Nullable on byte[]-typed fields, so the explicit `= null` here
+    // (needed so neither constructor is separately flagged for not "guaranteeing" this field is initialized)
+    // is itself misflagged as a NonNull violation.
+    @SuppressWarnings("NullAway")
+    private byte[] data = null;
     @Nullable
     private Object value;
 
@@ -81,6 +85,9 @@ public class BunchedSerializationException extends BunchedMapException {
      * @return the data array that triggered the exception
      */
     @Nullable
+    // NullAway does not reliably recognize @Nullable on array-typed return values, so the `null` branch below
+    // is misflagged as returning @Nullable from a @NonNull-returning method despite the annotation.
+    @SuppressWarnings("NullAway")
     public byte[] getData() {
         return (data == null) ? null : Arrays.copyOf(data, data.length);
     }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/map/BunchedSerializationException.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/map/BunchedSerializationException.java
@@ -23,8 +23,8 @@ package com.apple.foundationdb.map;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.tuple.ByteArrayUtil2;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import java.util.Arrays;
 
 /**
@@ -45,7 +45,7 @@ public class BunchedSerializationException extends BunchedMapException {
      * Create a new exception with a static message.
      * @param message error message
      */
-    public BunchedSerializationException(@Nonnull String message) {
+    public BunchedSerializationException(String message) {
         super(message);
     }
 
@@ -55,7 +55,7 @@ public class BunchedSerializationException extends BunchedMapException {
      * @param message error message
      * @param cause cause
      */
-    public BunchedSerializationException(@Nonnull String message, @Nonnull Throwable cause) {
+    public BunchedSerializationException(String message, Throwable cause) {
         super(message, cause);
     }
 
@@ -67,8 +67,7 @@ public class BunchedSerializationException extends BunchedMapException {
      * @param data raw data array that triggered this exception
      * @return this <code>BunchedSerializationException</code>
      */
-    @Nonnull
-    public BunchedSerializationException setData(@Nonnull byte[] data) {
+    public BunchedSerializationException setData(byte[] data) {
         this.data = Arrays.copyOf(data, data.length);
         addLogInfo("data", ByteArrayUtil2.loggable(data));
         return this;
@@ -95,8 +94,7 @@ public class BunchedSerializationException extends BunchedMapException {
      * @param value the value that triggered the exception
      * @return this <code>BunchedSerializationException</code>
      */
-    @Nonnull
-    public BunchedSerializationException setValue(@Nonnull Object value) {
+    public BunchedSerializationException setValue(Object value) {
         this.value = value;
         addLogInfo("value", value);
         return this;

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/map/BunchedSerializer.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/map/BunchedSerializer.java
@@ -25,7 +25,6 @@ import com.apple.foundationdb.annotation.API;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
 
 /**
  * A class to serialize and deserialize entries of a {@link BunchedMap}. This
@@ -48,8 +47,7 @@ public interface BunchedSerializer<K, V> {
      * @return the serialized key
      * @throws BunchedSerializationException if serializing the key fails
      */
-    @Nonnull
-    byte[] serializeKey(@Nonnull K key);
+    byte[] serializeKey(K key);
 
     /**
      * Serialize a single entry to bytes. This serializes a single key and
@@ -63,8 +61,7 @@ public interface BunchedSerializer<K, V> {
      * @return the serialized entry
      * @throws BunchedSerializationException if serializing the entry fails
      */
-    @Nonnull
-    byte[] serializeEntry(@Nonnull K key, @Nonnull V value);
+    byte[] serializeEntry(K key, V value);
 
     /**
      * Serialize a single entry to bytes. This has the same semantics
@@ -75,8 +72,7 @@ public interface BunchedSerializer<K, V> {
      * @return the serialized entry
      * @throws BunchedSerializationException if serializing the entry fails
      */
-    @Nonnull
-    default byte[] serializeEntry(@Nonnull Map.Entry<K, V> entry) {
+    default byte[] serializeEntry(Map.Entry<K, V> entry) {
         return serializeEntry(entry.getKey(), entry.getValue());
     }
 
@@ -94,8 +90,7 @@ public interface BunchedSerializer<K, V> {
      * @return the serialized list
      * @throws BunchedSerializationException if serializing the entries fails
      */
-    @Nonnull
-    byte[] serializeEntries(@Nonnull List<Map.Entry<K, V>> entries);
+    byte[] serializeEntries(List<Map.Entry<K, V>> entries);
 
     /**
      * Deserialize a byte array into a key. This assumes that the entire
@@ -106,8 +101,7 @@ public interface BunchedSerializer<K, V> {
      * @return key deserialized from reading <code>data</code>
      * @throws BunchedSerializationException if deserializing the key fails
      */
-    @Nonnull
-    default K deserializeKey(@Nonnull byte[] data) {
+    default K deserializeKey(byte[] data) {
         return deserializeKey(data, 0, data.length);
     }
 
@@ -121,8 +115,7 @@ public interface BunchedSerializer<K, V> {
      * @return key deserialized from reading <code>data</code>
      * @throws BunchedSerializationException if deserializing the key fails
      */
-    @Nonnull
-    default K deserializeKey(@Nonnull byte[] data, int offset) {
+    default K deserializeKey(byte[] data, int offset) {
         return deserializeKey(data, offset, data.length - offset);
     }
 
@@ -138,8 +131,7 @@ public interface BunchedSerializer<K, V> {
      * @return key deserialized from reading <code>data</code>
      * @throws BunchedSerializationException if deserializing the key fails
      */
-    @Nonnull
-    K deserializeKey(@Nonnull byte[] data, int offset, int length);
+    K deserializeKey(byte[] data, int offset, int length);
 
     /**
      * Deserialize raw data to a list of entries. This should be
@@ -155,8 +147,7 @@ public interface BunchedSerializer<K, V> {
      * @return entry list deserialized from reading <code>data</code>
      * @throws BunchedSerializationException if deserializing the entries fails
      */
-    @Nonnull
-    List<Map.Entry<K, V>> deserializeEntries(@Nonnull K key, @Nonnull byte[] data);
+    List<Map.Entry<K, V>> deserializeEntries(K key, byte[] data);
 
     /**
      * Deserialize raw data to a list of keys. This expects that <code>data</code>
@@ -171,8 +162,7 @@ public interface BunchedSerializer<K, V> {
      * @return key list deserialized from reading <code>data</code>
      * @throws BunchedSerializationException if deserializing the keys fails
      */
-    @Nonnull
-    default List<K> deserializeKeys(@Nonnull K key, @Nonnull byte[] data) {
+    default List<K> deserializeKeys(K key, byte[] data) {
         return deserializeEntries(key, data).stream().map(Map.Entry::getKey).collect(Collectors.toList());
     }
 

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/map/BunchedTupleSerializer.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/map/BunchedTupleSerializer.java
@@ -115,7 +115,12 @@ public class BunchedTupleSerializer implements BunchedSerializer<Tuple, Tuple> {
                 serializedEntries.add(serializeEntry(entry));
             }
         }
-        return ByteArrayUtil.join(null, serializedEntries);
+        // ByteArrayUtil.join is from the unannotated fdb-java client library; passing null for the separator is
+        // its documented way of requesting no separator between parts, but the parameter is treated as @NonNull
+        // by NullAway's defaults.
+        @SuppressWarnings("NullAway")
+        final byte[] result = ByteArrayUtil.join(null, serializedEntries);
+        return result;
     }
 
     @Override

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/map/BunchedTupleSerializer.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/map/BunchedTupleSerializer.java
@@ -29,7 +29,6 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nonnull;
 
 /**
  * A {@link BunchedSerializer} that uses {@link Tuple}s as both the expected key
@@ -40,7 +39,6 @@ import javax.annotation.Nonnull;
  */
 @API(API.Status.EXPERIMENTAL)
 public class BunchedTupleSerializer implements BunchedSerializer<Tuple, Tuple> {
-    @Nonnull
     static final byte[] PREFIX = { 0x10 };
     private static final BunchedTupleSerializer INSTANCE = new BunchedTupleSerializer();
 
@@ -63,9 +61,8 @@ public class BunchedTupleSerializer implements BunchedSerializer<Tuple, Tuple> {
      * @param key key to serialize to bytes
      * @return the serialized key
      */
-    @Nonnull
     @Override
-    public byte[] serializeKey(@Nonnull Tuple key) {
+    public byte[] serializeKey(Tuple key) {
         try {
             return key.pack();
         } catch (IllegalArgumentException e) {
@@ -84,9 +81,8 @@ public class BunchedTupleSerializer implements BunchedSerializer<Tuple, Tuple> {
      * @param value the value of the map entry
      * @return the serialized entry
      */
-    @Nonnull
     @Override
-    public byte[] serializeEntry(@Nonnull Tuple key, @Nonnull Tuple value) {
+    public byte[] serializeEntry(Tuple key, Tuple value) {
         try {
             return Tuple.from(key, value).pack();
         } catch (IllegalArgumentException e) {
@@ -103,9 +99,8 @@ public class BunchedTupleSerializer implements BunchedSerializer<Tuple, Tuple> {
      * @param entries the list of entries to serialize
      * @return the serialized entry list
      */
-    @Nonnull
     @Override
-    public byte[] serializeEntries(@Nonnull List<Map.Entry<Tuple, Tuple>> entries) {
+    public byte[] serializeEntries(List<Map.Entry<Tuple, Tuple>> entries) {
         if (entries.isEmpty()) {
             throw new BunchedSerializationException("cannot serialize empty entry list");
         }
@@ -123,9 +118,8 @@ public class BunchedTupleSerializer implements BunchedSerializer<Tuple, Tuple> {
         return ByteArrayUtil.join(null, serializedEntries);
     }
 
-    @Nonnull
     @Override
-    public Tuple deserializeKey(@Nonnull byte[] data, int offset, int length) {
+    public Tuple deserializeKey(byte[] data, int offset, int length) {
         // It seems that bounds checking should be done by the Tuple layer rather
         // than here, but it apparently is not.
         if (offset < 0 || offset > data.length || length < 0 || offset + length > data.length) {
@@ -139,9 +133,8 @@ public class BunchedTupleSerializer implements BunchedSerializer<Tuple, Tuple> {
         }
     }
 
-    @Nonnull
     @SuppressWarnings("unchecked") // we catch the ClassCastException in the calling method
-    private static Tuple toTuple(@Nonnull Object o) {
+    private static Tuple toTuple(Object o) {
         if (o instanceof Tuple) {
             return (Tuple)o;
         } else {
@@ -149,9 +142,8 @@ public class BunchedTupleSerializer implements BunchedSerializer<Tuple, Tuple> {
         }
     }
 
-    @Nonnull
     @Override
-    public List<Map.Entry<Tuple, Tuple>> deserializeEntries(@Nonnull Tuple key, @Nonnull byte[] data) {
+    public List<Map.Entry<Tuple, Tuple>> deserializeEntries(Tuple key, byte[] data) {
         if (!ByteArrayUtil.startsWith(data, PREFIX)) {
             throw new BunchedSerializationException("data did not begin with expected prefix")
                     .setData(data);

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/map/SubspaceSplitter.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/map/SubspaceSplitter.java
@@ -22,8 +22,7 @@ package com.apple.foundationdb.map;
 
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.subspace.Subspace;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * An interface to split a raw FoundationDB key into a subspace and (possibly) a
@@ -53,8 +52,7 @@ public interface SubspaceSplitter<T> {
      * @param keyBytes the raw bytes of some FoundationDB key
      * @return a {@link Subspace} that contains <code>keyBytes</code>
      */
-    @Nonnull
-    Subspace subspaceOf(@Nonnull byte[] keyBytes);
+    Subspace subspaceOf(byte[] keyBytes);
 
     /**
      * Compute and return some application-specific "tag" for
@@ -77,7 +75,7 @@ public interface SubspaceSplitter<T> {
      * @return some tag to associate with the provided subspace.
      */
     @Nullable
-    default T subspaceTag(@Nonnull Subspace subspace) {
+    default T subspaceTag(Subspace subspace) {
         return null;
     }
 }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/map/package-info.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/map/package-info.java
@@ -30,4 +30,7 @@
  * The other classes are used to support the {@code BunchedMap} class in various ways.
  * </p>
  */
+@NullMarked
 package com.apple.foundationdb.map;
+
+import org.jspecify.annotations.NullMarked;

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/package-info.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/package-info.java
@@ -21,4 +21,7 @@
 /**
  * FDB client code that might conceivably be in the standard Java binding someday.
  */
+@NullMarked
 package com.apple.foundationdb;
+
+import org.jspecify.annotations.NullMarked;

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/rabitq/EncodedRealVector.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/rabitq/EncodedRealVector.java
@@ -28,7 +28,6 @@ import com.apple.foundationdb.linear.VectorType;
 import com.google.common.base.Suppliers;
 import com.google.common.base.Verify;
 
-import javax.annotation.Nonnull;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Arrays;
@@ -80,7 +79,6 @@ public class EncodedRealVector implements RealVector {
      * {@code numExBits + 1} bits when packed into the wire format. Length equals
      * {@link #getNumDimensions()}.
      */
-    @Nonnull
     private final int[] encoded;
 
     /**
@@ -103,22 +101,16 @@ public class EncodedRealVector implements RealVector {
      */
     private final double fErrorEx;
 
-    @Nonnull
     @SuppressWarnings("this-escape")
     private final Supplier<Integer> hashCodeSupplier = Suppliers.memoize(this::computeHashCode);
-    @Nonnull
     @SuppressWarnings("this-escape")
     private final Supplier<double[]> dataSupplier = Suppliers.memoize(this::computeData);
-    @Nonnull
     @SuppressWarnings("this-escape")
     private final Supplier<byte[]> rawDataSupplier = Suppliers.memoize(this::computeRawData);
-    @Nonnull
     @SuppressWarnings("this-escape")
     private final Supplier<HalfRealVector> toHalfRealVectorSupplier = Suppliers.memoize(this::computeHalfRealVector);
-    @Nonnull
     @SuppressWarnings("this-escape")
     private final Supplier<FloatRealVector> toFloatRealVectorSupplier = Suppliers.memoize(this::computeFloatRealVector);
-    @Nonnull
     @SuppressWarnings("this-escape")
     private final Supplier<Double> l2SquaredNormSupplier = Suppliers.memoize(this::computeL2SquaredNorm);
 
@@ -133,7 +125,7 @@ public class EncodedRealVector implements RealVector {
      * @param fRescaleEx the multiplicative rescale ({@link #getRescaleEx()})
      * @param fErrorEx the per-vector error bound ({@link #getErrorEx()})
      */
-    public EncodedRealVector(final int numExBits, @Nonnull final int[] encoded, final double fAddEx, final double fRescaleEx,
+    public EncodedRealVector(final int numExBits, final int[] encoded, final double fAddEx, final double fRescaleEx,
                              final double fErrorEx) {
         this.numExBits = numExBits;
         this.encoded = encoded;
@@ -149,7 +141,6 @@ public class EncodedRealVector implements RealVector {
      *
      * @return the per-dimension code array
      */
-    @Nonnull
     public int[] getEncodedData() {
         return encoded;
     }
@@ -253,7 +244,6 @@ public class EncodedRealVector implements RealVector {
      * is approximate (see {@link #computeData()} for details) and memoized so repeated calls
      * are cheap.
      */
-    @Nonnull
     @Override
     public double[] getData() {
         return dataSupplier.get();
@@ -268,9 +258,8 @@ public class EncodedRealVector implements RealVector {
      * methods ({@code add}, {@code subtract}, {@code multiply}, {@code normalize}) all drop
      * back to ordinary double-precision results.
      */
-    @Nonnull
     @Override
-    public RealVector withData(@Nonnull final double[] data) {
+    public RealVector withData(final double[] data) {
         // we explicitly make this a normal double vector instead of an encoded vector
         return new DoubleRealVector(data);
     }
@@ -314,7 +303,6 @@ public class EncodedRealVector implements RealVector {
      * @return a freshly allocated {@code double[]} with the reconstructed components; never
      *         {@code null}
      */
-    @Nonnull
     double[] computeData() {
         final int numDimensions = getNumDimensions();
         final double cb = (1 << numExBits) - 0.5;
@@ -344,7 +332,6 @@ public class EncodedRealVector implements RealVector {
      * Returns the memoized wire-format serialization of this vector (see
      * {@link #computeRawData()} for the format).
      */
-    @Nonnull
     @Override
     public byte[] getRawData() {
         return rawDataSupplier.get();
@@ -366,7 +353,6 @@ public class EncodedRealVector implements RealVector {
      *
      * @return the serialized form; never {@code null}
      */
-    @Nonnull
     protected byte[] computeRawData() {
         int numBits = getNumDimensions() * (numExBits + 1); // congruency with paper
         final int length = 25 +        // RABITQ (byte) + fAddEx (double) + fRescaleEx (double) + fErrorEx (double)
@@ -390,7 +376,7 @@ public class EncodedRealVector implements RealVector {
      * @param numExBits number of magnitude bits per component (sign bit added implicitly)
      * @param buffer the destination, positioned where packed bits should start being written
      */
-    private void packEncodedComponents(final int numExBits, @Nonnull final ByteBuffer buffer) {
+    private void packEncodedComponents(final int numExBits, final ByteBuffer buffer) {
         // big-endian
         final int bitsPerComponent = numExBits + 1; // congruency with paper
         int remainingBitsInByte = 8;
@@ -434,7 +420,6 @@ public class EncodedRealVector implements RealVector {
      * <p>Computed from the lazily reconstructed dense form (see {@link #getData()}); the
      * resulting {@link HalfRealVector} is memoized.
      */
-    @Nonnull
     @Override
     public HalfRealVector toHalfRealVector() {
         return toHalfRealVectorSupplier.get();
@@ -444,7 +429,6 @@ public class EncodedRealVector implements RealVector {
      * Builds a fresh half-precision dense vector from the reconstructed components. Used as
      * the supplier behind {@link #toHalfRealVector()}.
      */
-    @Nonnull
     private HalfRealVector computeHalfRealVector() {
         return new HalfRealVector(getData());
     }
@@ -455,7 +439,6 @@ public class EncodedRealVector implements RealVector {
      * <p>Computed from the lazily reconstructed dense form (see {@link #getData()}); the
      * resulting {@link FloatRealVector} is memoized.
      */
-    @Nonnull
     @Override
     public FloatRealVector toFloatRealVector() {
         return toFloatRealVectorSupplier.get();
@@ -465,7 +448,6 @@ public class EncodedRealVector implements RealVector {
      * Builds a fresh single-precision dense vector from the reconstructed components. Used as
      * the supplier behind {@link #toFloatRealVector()}.
      */
-    @Nonnull
     private FloatRealVector computeFloatRealVector() {
         return new FloatRealVector(getData());
     }
@@ -478,7 +460,6 @@ public class EncodedRealVector implements RealVector {
      * {@code double[]} reconstruction is already memoized by {@link #getData()}, so wrapping
      * it again is cheap.
      */
-    @Nonnull
     @Override
     public DoubleRealVector toDoubleRealVector() {
         return new DoubleRealVector(getData());
@@ -487,7 +468,6 @@ public class EncodedRealVector implements RealVector {
     /**
      * Returns {@code this} — instances of this class are already immutable.
      */
-    @Nonnull
     @Override
     public EncodedRealVector toImmutable() {
         return this;
@@ -529,8 +509,7 @@ public class EncodedRealVector implements RealVector {
      * @throws com.google.common.base.VerifyException if the leading type tag is not
      *         {@link VectorType#RABITQ}
      */
-    @Nonnull
-    public static EncodedRealVector fromBytes(@Nonnull final byte[] vectorBytes,
+    public static EncodedRealVector fromBytes(final byte[] vectorBytes,
                                               final int numDimensions,
                                               final int numExBits) {
         final ByteBuffer buffer = ByteBuffer.wrap(vectorBytes).order(ByteOrder.BIG_ENDIAN);
@@ -553,8 +532,7 @@ public class EncodedRealVector implements RealVector {
      * @param numExBits number of magnitude bits per component (sign bit implicit)
      * @return a freshly allocated array of decoded codes
      */
-    @Nonnull
-    private static int[] unpackComponents(@Nonnull final ByteBuffer buffer,
+    private static int[] unpackComponents(final ByteBuffer buffer,
                                           final int numDimensions,
                                           final int numExBits) {
         int[] result = new int[numDimensions];

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/rabitq/RaBitDistanceEstimator.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/rabitq/RaBitDistanceEstimator.java
@@ -25,27 +25,24 @@ import com.apple.foundationdb.linear.DistanceEstimator;
 import com.apple.foundationdb.linear.Metric;
 import com.apple.foundationdb.linear.RealVector;
 
-import javax.annotation.Nonnull;
 
 public class RaBitDistanceEstimator implements DistanceEstimator {
-    @Nonnull
     private final Metric metric;
     private final int numExBits;
 
-    public RaBitDistanceEstimator(@Nonnull final Metric metric,
+    public RaBitDistanceEstimator(final Metric metric,
                                   final int numExBits) {
         this.metric = metric;
         this.numExBits = numExBits;
     }
 
-    @Nonnull
     @Override
     public Metric getMetric() {
         return metric;
     }
 
     @Override
-    public boolean isOptimized(@Nonnull final RealVector vector1, @Nonnull final RealVector vector2) {
+    public boolean isOptimized(final RealVector vector1, final RealVector vector2) {
         return vector1 instanceof EncodedRealVector || vector2 instanceof EncodedRealVector;
     }
 
@@ -54,7 +51,7 @@ public class RaBitDistanceEstimator implements DistanceEstimator {
     }
 
     @Override
-    public double distance(@Nonnull final RealVector vector1, @Nonnull final RealVector vector2) {
+    public double distance(final RealVector vector1, final RealVector vector2) {
         final double distance;
         if (!(vector1 instanceof EncodedRealVector) && vector2 instanceof EncodedRealVector) {
             // use the estimator if the first vector is not encoded, but the second is
@@ -74,13 +71,12 @@ public class RaBitDistanceEstimator implements DistanceEstimator {
         return distance;
     }
 
-    private double distance(@Nonnull final RealVector query, @Nonnull final EncodedRealVector encodedVector) {
+    private double distance(final RealVector query, final EncodedRealVector encodedVector) {
         return estimateDistanceAndErrorBound(query, encodedVector).getDistance();
     }
 
-    @Nonnull
-    public Result estimateDistanceAndErrorBound(@Nonnull final RealVector query,
-                                                @Nonnull final EncodedRealVector encodedVector) {
+    public Result estimateDistanceAndErrorBound(final RealVector query,
+                                                final EncodedRealVector encodedVector) {
         final double qNormSqr = query.l2SquaredNorm();
 
         if (metric == Metric.COSINE_METRIC) {

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/rabitq/RaBitQuantizer.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/rabitq/RaBitQuantizer.java
@@ -27,7 +27,6 @@ import com.apple.foundationdb.linear.RealVector;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 
-import javax.annotation.Nonnull;
 import java.util.Comparator;
 import java.util.PriorityQueue;
 
@@ -60,7 +59,6 @@ public final class RaBitQuantizer implements Quantizer {
     };
 
     final int numExBits;
-    @Nonnull
     private final Metric metric;
 
     /**
@@ -72,7 +70,7 @@ public final class RaBitQuantizer implements Quantizer {
      * @param metric the {@link Metric} to be used for quantization; must not be null.
      * @param numExBits the number of extra bits for quantization.
      */
-    public RaBitQuantizer(@Nonnull final Metric metric, final int numExBits) {
+    public RaBitQuantizer(final Metric metric, final int numExBits) {
         Preconditions.checkArgument(numExBits > 0 && numExBits < TIGHT_START.length);
         Preconditions.checkArgument(
                 metric == Metric.EUCLIDEAN_METRIC ||
@@ -94,7 +92,6 @@ public final class RaBitQuantizer implements Quantizer {
      *
      * @return a new, non-null instance of {@link RaBitDistanceEstimator}
      */
-    @Nonnull
     @Override
     public RaBitDistanceEstimator estimator() {
         return new RaBitDistanceEstimator(metric, numExBits);
@@ -111,9 +108,8 @@ public final class RaBitQuantizer implements Quantizer {
      *
      * @return the resulting {@link EncodedRealVector}, guaranteed to be non-null.
      */
-    @Nonnull
     @Override
-    public EncodedRealVector encode(@Nonnull final RealVector vector) {
+    public EncodedRealVector encode(final RealVector vector) {
         if (vector instanceof EncodedRealVector) {
             return (EncodedRealVector)vector;
         }
@@ -136,9 +132,8 @@ public final class RaBitQuantizer implements Quantizer {
      *
      * @throws IllegalArgumentException if the configured {@code metric} is not supported for encoding.
      */
-    @Nonnull
     @VisibleForTesting
-    Result encodeInternal(@Nonnull final RealVector data) {
+    Result encodeInternal(final RealVector data) {
         final int dims = data.getNumDimensions();
 
         final QuantizeExResult base = exBitsCode(data);
@@ -204,7 +199,7 @@ public final class RaBitQuantizer implements Quantizer {
      * returns the code, {@code t}, and {@code ipNormInv}.
      * @param residual rotated residual vector r.
      */
-    private QuantizeExResult exBitsCode(@Nonnull final RealVector residual) {
+    private QuantizeExResult exBitsCode(final RealVector residual) {
         int dims = residual.getNumDimensions();
 
         // oAbs = |r| normalized (RaBitQ does this before quantizeEx)
@@ -237,7 +232,7 @@ public final class RaBitQuantizer implements Quantizer {
      *         {@code t = 0}, and {@code ipNormInv = 1} (benign fallback). Downstream code uses {@code ipNormInv} to
      *         compute {@code fRescaleEx}, etc.
      */
-    private QuantizeExResult quantizeEx(@Nonnull final RealVector oAbs) {
+    private QuantizeExResult quantizeEx(final RealVector oAbs) {
         final int dim = oAbs.getNumDimensions();
         final int maxLevel = (1 << numExBits) - 1;
 
@@ -292,7 +287,7 @@ public final class RaBitQuantizer implements Quantizer {
      * @return The optimal scaling factor {@code t} that maximizes the objective function,
      * or 0.0 if the input vector is all zeros.
      */
-    private double bestRescaleFactor(@Nonnull final RealVector oAbs) {
+    private double bestRescaleFactor(final RealVector oAbs) {
         final int numDimensions = oAbs.getNumDimensions();
 
         // max_o = max(oAbs)
@@ -384,7 +379,7 @@ public final class RaBitQuantizer implements Quantizer {
      * @return a new {@code RealVector} containing the absolute values of the components of the
      * normalized input vector.
      */
-    private static RealVector absOfNormalized(@Nonnull final RealVector x) {
+    private static RealVector absOfNormalized(final RealVector x) {
         // Scalar backend: this norm feeds oAbs, which drives both the chosen scale t and the
         // per-dimension floor() codes. A ULP difference here can flip an integer code near a
         // boundary, so the encoded bytes would otherwise depend on the ambient backend.
@@ -406,7 +401,7 @@ public final class RaBitQuantizer implements Quantizer {
         public final double t;
         public final double ipNormInv;
 
-        public Result(@Nonnull final EncodedRealVector encodedVector, double t, double ipNormInv) {
+        public Result(final EncodedRealVector encodedVector, double t, double ipNormInv) {
             this.encodedVector = encodedVector;
             this.t = t;
             this.ipNormInv = ipNormInv;

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/rabitq/package-info.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/rabitq/package-info.java
@@ -21,4 +21,7 @@
 /**
  * RaBitQ implementation.
  */
+@NullMarked
 package com.apple.foundationdb.rabitq;
+
+import org.jspecify.annotations.NullMarked;

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/synchronizedsession/SynchronizedSession.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/synchronizedsession/SynchronizedSession.java
@@ -33,7 +33,6 @@ import com.apple.foundationdb.util.LoggableException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
@@ -69,17 +68,13 @@ import java.util.concurrent.CompletableFuture;
 public class SynchronizedSession {
     private static final Logger LOGGER = LoggerFactory.getLogger(SynchronizedSession.class);
 
-    @Nonnull
     private Subspace lockSubspace;
-    @Nonnull
     private UUID sessionId;
     private long leaseLengthMillis;
 
     // The UUID stored here indicates which session holds the lock.
-    @Nonnull
     private final byte[] lockSessionIdSubspaceKey;
     // The timestamp stored here indicates the session above holds the lock until which time if the lease is not renewed.
-    @Nonnull
     private final byte[] lockSessionLeaseEndTimeSubspaceKey;
 
     // The UUID of the session owning the lock.
@@ -94,7 +89,7 @@ public class SynchronizedSession {
      * @param sessionId session ID
      * @param leaseLengthMillis length between last access and lease's end time in milliseconds
      */
-    public SynchronizedSession(@Nonnull Subspace lockSubspace, @Nonnull UUID sessionId, long leaseLengthMillis) {
+    public SynchronizedSession(Subspace lockSubspace, UUID sessionId, long leaseLengthMillis) {
         this.lockSubspace = lockSubspace;
         this.sessionId = sessionId;
         this.leaseLengthMillis = leaseLengthMillis;
@@ -102,11 +97,11 @@ public class SynchronizedSession {
         lockSessionLeaseEndTimeSubspaceKey = lockSessionLeaseEndTimeSubspaceKey(lockSubspace);
     }
 
-    private static byte[] lockSessionIdSubspaceKey(@Nonnull Subspace lockSubspace) {
+    private static byte[] lockSessionIdSubspaceKey(Subspace lockSubspace) {
         return lockSubspace.subspace(Tuple.from(LOCK_SESSION_ID_KEY)).pack();
     }
 
-    private static byte[] lockSessionLeaseEndTimeSubspaceKey(@Nonnull Subspace lockSubspace) {
+    private static byte[] lockSessionLeaseEndTimeSubspaceKey(Subspace lockSubspace) {
         return lockSubspace.subspace(Tuple.from(LOCK_SESSION_TIME_KEY)).pack();
     }
 
@@ -115,7 +110,7 @@ public class SynchronizedSession {
      * @param tr transaction to use
      * @return a future that will return {@code null} when the session is initialized
      */
-    public CompletableFuture<Void> initializeSessionAsync(@Nonnull Transaction tr) {
+    public CompletableFuture<Void> initializeSessionAsync(Transaction tr) {
         // Though sessionTime is not necessarily needed in some cases, it's read in parallel with the lockSessionId read
         // in the hope of that the FDB client then batches those two operations together into a single request.
         return getLockSessionId(tr).thenAcceptBoth(getLockSessionTime(tr.snapshot()), (lockSessionId, sessionTime) -> {
@@ -151,7 +146,7 @@ public class SynchronizedSession {
         });
     }
 
-    private void takeSessionLock(@Nonnull Transaction tr) {
+    private void takeSessionLock(Transaction tr) {
         setLockSessionId(tr);
         updateLockSessionLeaseEndTime(tr);
     }
@@ -160,7 +155,6 @@ public class SynchronizedSession {
      * Get session ID.
      * @return session ID
      */
-    @Nonnull
     public UUID getSessionId() {
         return sessionId;
     }
@@ -171,7 +165,7 @@ public class SynchronizedSession {
      * @param tr transaction to use
      * @return a future that will return {@code null} when the lock is checked
      */
-    public CompletableFuture<Void> checkLockAsync(@Nonnull Transaction tr) {
+    public CompletableFuture<Void> checkLockAsync(Transaction tr) {
         return getLockSessionId(tr)
                 .thenCompose(lockSessionId -> {
                     if (!sessionId.equals(lockSessionId)) { // Note sessionId is nonnull and lockSessionId is nullable.
@@ -189,7 +183,7 @@ public class SynchronizedSession {
      * @param tr transaction to use
      * @return a future that will return {@code null} when the lock is no longer this session
      */
-    public CompletableFuture<Void> releaseLock(@Nonnull Transaction tr) {
+    public CompletableFuture<Void> releaseLock(Transaction tr) {
         return getLockSessionId(tr).thenApply(lockSessionId -> {
             if (sessionId.equals(lockSessionId)) {
                 tr.clear(lockSubspace.range());
@@ -208,7 +202,7 @@ public class SynchronizedSession {
      * </p>
      * @param tr transaction to use
      */
-    public void endAnySession(@Nonnull Transaction tr) {
+    public void endAnySession(Transaction tr) {
         endAnySession(tr, lockSubspace);
     }
 
@@ -222,7 +216,7 @@ public class SynchronizedSession {
      * @param tr transaction to use
      * @param lockSubspace the lock whose active session needs to be ended
      */
-    public static void endAnySession(@Nonnull Transaction tr, @Nonnull Subspace lockSubspace) {
+    public static void endAnySession(Transaction tr, Subspace lockSubspace) {
         tr.clear(lockSubspace.range());
     }
 
@@ -233,7 +227,7 @@ public class SynchronizedSession {
      * @param lockSubspace the lock whose active session needs to be checked
      * @return {@code true} if there is any active session, otherwise {@code false}
      */
-    public static CompletableFuture<Boolean> checkActiveSessionExists(@Nonnull Transaction tr, @Nonnull Subspace lockSubspace) {
+    public static CompletableFuture<Boolean> checkActiveSessionExists(Transaction tr, Subspace lockSubspace) {
         // It is false in the situations where initializeSessionAsync of a new session ID would takeSessionLock.
         return getLockSessionId(tr, lockSubspace).thenCombineAsync(getLockSessionTime(tr.snapshot(), lockSubspace), (lockSessionId, sessionTime) -> {
             if (lockSessionId == null) {
@@ -250,20 +244,20 @@ public class SynchronizedSession {
         });
     }
 
-    private static CompletableFuture<UUID> getLockSessionId(@Nonnull Transaction tr, @Nonnull Subspace lockSubspace) {
+    private static CompletableFuture<UUID> getLockSessionId(Transaction tr, Subspace lockSubspace) {
         return tr.get(lockSessionIdSubspaceKey(lockSubspace))
                 .thenApply(value -> value == null ? null : Tuple.fromBytes(value).getUUID(0));
     }
 
-    private CompletableFuture<UUID> getLockSessionId(@Nonnull Transaction tr) {
+    private CompletableFuture<UUID> getLockSessionId(Transaction tr) {
         return getLockSessionId(tr, lockSubspace);
     }
 
-    private void setLockSessionId(@Nonnull Transaction tr) {
+    private void setLockSessionId(Transaction tr) {
         tr.set(lockSessionIdSubspaceKey, Tuple.from(sessionId).pack());
     }
 
-    private static CompletableFuture<Long> getLockSessionTime(@Nonnull ReadTransaction tr, @Nonnull Subspace lockSubspace) {
+    private static CompletableFuture<Long> getLockSessionTime(ReadTransaction tr, Subspace lockSubspace) {
         return tr.get(lockSessionLeaseEndTimeSubspaceKey(lockSubspace))
                 .thenApply(value -> value == null ? null : Tuple.fromBytes(value).getLong(0));
     }
@@ -276,7 +270,7 @@ public class SynchronizedSession {
     //   final value comes not from whoever gets committed last but whoever writes the largest value
     // - When the session time is read during session initialization, it should be a snapshot read so it will not have
     //   conflicts with working transactions (which write to session time).
-    private CompletableFuture<Long> getLockSessionTime(@Nonnull ReadTransaction tr) {
+    private CompletableFuture<Long> getLockSessionTime(ReadTransaction tr) {
         return getLockSessionTime(tr, lockSubspace);
     }
 
@@ -285,7 +279,7 @@ public class SynchronizedSession {
      * alive.
      * @param tr transaction to use
      */
-    public void updateLockSessionLeaseEndTime(@Nonnull Transaction tr) {
+    public void updateLockSessionLeaseEndTime(Transaction tr) {
         long leaseEndTime = System.currentTimeMillis() + leaseLengthMillis;
         // Use BYTE_MAX rather than MAX because `Tuple`s write their integers in big Endian.
         tr.mutate(MutationType.BYTE_MAX, lockSessionLeaseEndTimeSubspaceKey, Tuple.from(leaseEndTime).pack());

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/synchronizedsession/SynchronizedSessionLockedException.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/synchronizedsession/SynchronizedSessionLockedException.java
@@ -23,8 +23,7 @@ package com.apple.foundationdb.synchronizedsession;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.util.LoggableException;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * This exception means that the synchronized session is not valid anymore, probably because another synchronized session
@@ -34,7 +33,7 @@ import javax.annotation.Nullable;
 @API(API.Status.EXPERIMENTAL)
 @SuppressWarnings("serial")
 public class SynchronizedSessionLockedException extends LoggableException {
-    public SynchronizedSessionLockedException(@Nonnull String msg, @Nullable Object... keyValues) {
+    public SynchronizedSessionLockedException(String msg, @Nullable Object... keyValues) {
         super(msg, keyValues);
     }
 }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/synchronizedsession/package-info.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/synchronizedsession/package-info.java
@@ -22,4 +22,7 @@
  * Basic classes to support running operations in synchronized sessions.
  * @see com.apple.foundationdb.synchronizedsession.SynchronizedSession
  */
+@NullMarked
 package com.apple.foundationdb.synchronizedsession;
+
+import org.jspecify.annotations.NullMarked;

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/system/SystemKeyspace.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/system/SystemKeyspace.java
@@ -24,7 +24,6 @@ import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.tuple.ByteArrayUtil;
 
-import javax.annotation.Nonnull;
 import java.nio.charset.StandardCharsets;
 
 /**
@@ -97,15 +96,15 @@ public class SystemKeyspace {
 
     public static final byte[] TRANSACTION_CONFLICTING_KEYS_PREFIX = specialPrefixedKey("/transaction/conflicting_keys/");
 
-    private static byte[] systemPrefixedKey(@Nonnull String key) {
+    private static byte[] systemPrefixedKey(String key) {
         return ByteArrayUtil.join(SYSTEM_PREFIX, key.getBytes(StandardCharsets.US_ASCII));
     }
 
-    private static byte[] system2PrefixedKey(@Nonnull String key) {
+    private static byte[] system2PrefixedKey(String key) {
         return ByteArrayUtil.join(SYSTEM_2_PREFIX, key.getBytes(StandardCharsets.US_ASCII));
     }
 
-    private static byte[] specialPrefixedKey(@Nonnull String key) {
+    private static byte[] specialPrefixedKey(String key) {
         return ByteArrayUtil.join(SPECIAL_PREFIX, key.getBytes(StandardCharsets.US_ASCII));
     }
 

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/system/package-info.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/system/package-info.java
@@ -29,4 +29,7 @@
  * <a href="https://github.com/apple/foundationdb/blob/master/design/special-key-space.md">Special key space</a>.
  * </p>
  */
+@NullMarked
 package com.apple.foundationdb.system;
+
+import org.jspecify.annotations.NullMarked;

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/tuple/ByteArrayUtil2.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/tuple/ByteArrayUtil2.java
@@ -22,8 +22,8 @@ package com.apple.foundationdb.tuple;
 
 import com.apple.foundationdb.annotation.API;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -156,7 +156,7 @@ public class ByteArrayUtil2 {
      * @return whether the first {@code prefixSize} bytes from {@code bytes1} match
      *      the first {@code prefixSize} bytes from {@code bytes2}
      */
-    public static boolean hasCommonPrefix(@Nonnull byte[] bytes1, @Nonnull byte[] bytes2, int prefixSize) {
+    public static boolean hasCommonPrefix(byte[] bytes1, byte[] bytes2, int prefixSize) {
         if (bytes1.length < prefixSize || bytes2.length < prefixSize) {
             return false;
         }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/tuple/ByteArrayUtil2.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/tuple/ByteArrayUtil2.java
@@ -114,6 +114,9 @@ public class ByteArrayUtil2 {
      */
     @API(API.Status.UNSTABLE)
     @Nullable
+    // NullAway does not reliably recognize @Nullable on array-typed return values, so the `return null;`
+    // below is misflagged as returning @Nullable from a @NonNull-returning method despite the annotation above.
+    @SuppressWarnings("NullAway")
     public static byte[] unprint(@Nullable String loggedBytes) {
         if (loggedBytes == null) {
             return null;

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/tuple/TupleHelpers.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/tuple/TupleHelpers.java
@@ -23,8 +23,8 @@ package com.apple.foundationdb.tuple;
 import com.apple.foundationdb.FDB;
 import com.apple.foundationdb.annotation.API;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import java.math.BigInteger;
 import java.util.List;
 
@@ -34,18 +34,15 @@ import java.util.List;
 @API(API.Status.UNSTABLE)
 public class TupleHelpers {
 
-    @Nonnull
     public static final Tuple EMPTY = Tuple.from();
 
-    @Nonnull
-    public static Tuple set(@Nonnull Tuple src, int index, Object value) {
+    public static Tuple set(Tuple src, int index, Object value) {
         final List<Object> items = src.getItems();
         items.set(index, value);
         return Tuple.fromList(items);
     }
 
-    @Nonnull
-    public static Tuple subTuple(@Nonnull Tuple src, int start, int end) {
+    public static Tuple subTuple(Tuple src, int start, int end) {
         final List<Object> items = src.getItems();
         return Tuple.fromList(items.subList(start, end));
     }
@@ -62,7 +59,7 @@ public class TupleHelpers {
      *         a value greater than {@code 0} if {@code t1} would sort after {@code t2}
      */
     @API(API.Status.UNSTABLE)
-    public static int compare(@Nonnull Tuple t1, @Nonnull Tuple t2) {
+    public static int compare(Tuple t1, Tuple t2) {
         final int t1Len = t1.size();
         final int t2Len = t2.size();
         final int len = Math.min(t1Len, t2Len);
@@ -100,7 +97,7 @@ public class TupleHelpers {
      * @param number the number to be negated
      * @return a negated number suitable for use in a new {@link Tuple}
      */
-    public static Number negate(@Nonnull Number number) {
+    public static Number negate(Number number) {
         if (number instanceof Long || number instanceof Integer || number instanceof Short || number instanceof Byte) {
             long l = number.longValue();
             if (l == Long.MIN_VALUE) {  // The only long whose negation is not a long.
@@ -145,7 +142,7 @@ public class TupleHelpers {
      * @param wholeTuple the whole tuple
      * @return {@code true} if {@code potentialPrefix} is a prefix of {@code wholeTuple}
      */
-    public static boolean isPrefix(@Nonnull Tuple potentialPrefix, @Nonnull Tuple wholeTuple) {
+    public static boolean isPrefix(Tuple potentialPrefix, Tuple wholeTuple) {
         final int len = potentialPrefix.size();
         if (wholeTuple.size() < len) {
             return false;
@@ -165,7 +162,7 @@ public class TupleHelpers {
      * @param size size of desired subtuple
      * @return the index into {@code bytes} that ends the sub-tuple or {@code -1} if {@code bytes} is too short or decoding fails
      */
-    public static int prefixLengthOfSize(@Nonnull byte[] bytes, int size) {
+    public static int prefixLengthOfSize(byte[] bytes, int size) {
         TupleUtil.DecodeState state = new TupleUtil.DecodeState();
         int pos = 0;
         int end = bytes.length;

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/tuple/TupleOrdering.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/tuple/TupleOrdering.java
@@ -22,8 +22,8 @@ package com.apple.foundationdb.tuple;
 
 import com.apple.foundationdb.annotation.API;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.List;
@@ -121,7 +121,6 @@ public class TupleOrdering {
             return inverted != counterflowNulls;
         }
 
-        @Nonnull
         public Direction reverseDirection() {
             switch (this) {
                 case ASC_NULLS_FIRST:
@@ -147,8 +146,7 @@ public class TupleOrdering {
      * @param direction direction of desired ordering
      * @return a byte string that compares properly
      */
-    @Nonnull
-    public static byte[] pack(@Nonnull Tuple tuple, @Nonnull Direction direction) {
+    public static byte[] pack(Tuple tuple, Direction direction) {
         final byte[] packed = direction.isCounterflowNulls() ? packNullsLast(tuple.elements) : tuple.pack();
         return direction.isInverted() ? invert(packed) : packed;
     }
@@ -159,14 +157,12 @@ public class TupleOrdering {
      * @param direction direction used by encoding
      * @return tuple that would encode that way
      */
-    @Nonnull
-    public static Tuple unpack(@Nonnull byte[] packed, @Nonnull Direction direction) {
+    public static Tuple unpack(byte[] packed, Direction direction) {
         final byte[] bytes = direction.isInverted() ? uninvert(packed) : packed;
         return direction.isCounterflowNulls() ? Tuple.fromList(unpackNullsLast(bytes)) : Tuple.fromBytes(bytes);
     }
 
-    @Nonnull
-    static byte[] packNullsLast(@Nonnull List<Object> elements) {
+    static byte[] packNullsLast(List<Object> elements) {
         ByteBuffer dest = ByteBuffer.allocate(TupleUtil.getPackedSize(elements, false));
         ByteOrder origOrder = dest.order();
         TupleUtil.EncodeState state = new TupleUtil.EncodeState(dest);
@@ -180,7 +176,7 @@ public class TupleOrdering {
         return dest.array();
     }
 
-    static void encodeNullsLast(@Nonnull TupleUtil.EncodeState state, @Nullable Object obj) {
+    static void encodeNullsLast(TupleUtil.EncodeState state, @Nullable Object obj) {
         if (obj == null) {
             state.add(NULL_LAST);
         } else {
@@ -188,8 +184,7 @@ public class TupleOrdering {
         }
     }
 
-    @Nonnull
-    static List<Object> unpackNullsLast(@Nonnull byte[] bytes) {
+    static List<Object> unpackNullsLast(byte[] bytes) {
         TupleUtil.DecodeState decodeState = new TupleUtil.DecodeState();
         int pos = 0;
         int end = bytes.length;
@@ -200,7 +195,7 @@ public class TupleOrdering {
         return decodeState.values;
     }
 
-    static void decodeNullsLast(@Nonnull TupleUtil.DecodeState state, @Nonnull byte[] bytes, int pos, int end) {
+    static void decodeNullsLast(TupleUtil.DecodeState state, byte[] bytes, int pos, int end) {
         if (bytes[pos] == NULL_LAST) {
             state.add(null, pos + 1);
         } else {
@@ -222,8 +217,7 @@ public class TupleOrdering {
      * @param bytes byte array to be inverted
      * @return a byte array that compared in the reverse direction
      */
-    @Nonnull
-    static byte[] invert(@Nonnull byte[] bytes) {
+    static byte[] invert(byte[] bytes) {
         final int originalLength = bytes.length;
         final int invertedLength = (originalLength * 8 + 6) / 7 + 1;
         final byte[] inverted = new byte[invertedLength];
@@ -252,8 +246,7 @@ public class TupleOrdering {
         return inverted;
     }
 
-    @Nonnull
-    static byte[] uninvert(@Nonnull byte[] inverted) {
+    static byte[] uninvert(byte[] inverted) {
         final int invertedLength = inverted.length;
         if (invertedLength == 0 || (inverted[invertedLength - 1] & 0x80) == 0) {
             throw new IllegalArgumentException("inverted bytes not in expected format");

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/tuple/TupleOrdering.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/tuple/TupleOrdering.java
@@ -195,6 +195,10 @@ public class TupleOrdering {
         return decodeState.values;
     }
 
+    // state.add(...) is from the unannotated fdb-java client library, so its Object value parameter is treated
+    // as @NonNull by NullAway's defaults; a decoded NULL_LAST marker legitimately represents a null tuple
+    // element, so passing null here is correct.
+    @SuppressWarnings("NullAway")
     static void decodeNullsLast(TupleUtil.DecodeState state, byte[] bytes, int pos, int end) {
         if (bytes[pos] == NULL_LAST) {
             state.add(null, pos + 1);

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/tuple/package-info.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/tuple/package-info.java
@@ -23,4 +23,7 @@
  * These are to assist with using the {@link com.apple.foundationdb.tuple.Tuple} class and complement
  * the {@link com.apple.foundationdb.tuple.ByteArrayUtil} class found within the FoundationDB Java bindings.
  */
+@NullMarked
 package com.apple.foundationdb.tuple;
+
+import org.jspecify.annotations.NullMarked;

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/util/CallbackUtils.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/util/CallbackUtils.java
@@ -23,8 +23,8 @@ package com.apple.foundationdb.util;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.async.AsyncUtil;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -48,8 +48,7 @@ public class CallbackUtils {
      * that holds the exceptions thrown during unsuccessful invocations
      */
     @API(API.Status.INTERNAL)
-    @Nonnull
-    public static <T> InvokeResults<T> invokeAll(@Nonnull List<Supplier<T>> callbacks) {
+    public static <T> InvokeResults<T> invokeAll(List<Supplier<T>> callbacks) {
         List<T> results = new ArrayList<>(callbacks.size());
         CallbackException accumulatedException = null;
         for (Supplier<T> callback : callbacks) {
@@ -78,8 +77,7 @@ public class CallbackUtils {
      * holds all the exceptions that were thrown during the process
      */
     @API(API.Status.INTERNAL)
-    @Nonnull
-    public static <T> CompletableFuture<Void> invokeAllFutures(@Nonnull List<Supplier<CompletableFuture<T>>> callbacks) {
+    public static <T> CompletableFuture<Void> invokeAllFutures(List<Supplier<CompletableFuture<T>>> callbacks) {
         if (callbacks.isEmpty()) {
             return AsyncUtil.DONE;
         }
@@ -102,17 +100,15 @@ public class CallbackUtils {
     }
 
     public static class InvokeResults<T> {
-        @Nonnull
         private final List<T> results;
         @Nullable
         private final CallbackException accumulatedException;
 
-        public InvokeResults(@Nonnull List<T> results, @Nullable CallbackException accumulatedException) {
+        public InvokeResults(List<T> results, @Nullable CallbackException accumulatedException) {
             this.results = results;
             this.accumulatedException = accumulatedException;
         }
 
-        @Nonnull
         public List<T> getResults() {
             return results;
         }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/util/Lens.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/util/Lens.java
@@ -172,13 +172,20 @@ public interface Lens<C, A> {
             @Nullable
             @Override
             public A2 get(final C c) {
-                return downstream.get(Lens.this.get(c));
+                // The intermediate A may be absent (get() is documented to allow null); in that case there is
+                // nothing for downstream to focus into, so the composed attribute is absent too.
+                final A intermediate = Lens.this.get(c);
+                return intermediate == null ? null : downstream.get(intermediate);
             }
 
             @Override
             @SpotBugsSuppressWarnings("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
             public C set(@Nullable final C c, @Nullable final A2 a2) {
-                return Lens.this.set(c, downstream.set(Lens.this.get(c), a2));
+                // Lens.this.get() requires a non-null container; when c is null (the "build a fresh container"
+                // case), there is no existing intermediate A to read, so treat it as absent rather than calling
+                // Lens.this.get(null).
+                final A currentA = c == null ? null : Lens.this.get(c);
+                return Lens.this.set(c, downstream.set(currentA, a2));
             }
         };
     }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/util/Lens.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/util/Lens.java
@@ -23,8 +23,8 @@ package com.apple.foundationdb.util;
 import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.google.common.collect.ImmutableList;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import java.util.List;
 import java.util.Objects;
 import java.util.function.UnaryOperator;
@@ -98,8 +98,7 @@ public interface Lens<C, A> {
      * @return the extracted attribute, never {@code null}
      * @throws NullPointerException if {@code get(c)} returns {@code null}
      */
-    @Nonnull
-    default A getNonnull(@Nonnull final C c) {
+    default A getNonnull(final C c) {
         return Objects.requireNonNull(get(c));
     }
 
@@ -110,7 +109,7 @@ public interface Lens<C, A> {
      * @return the attribute, or {@code null} if the implementation models an absent attribute
      */
     @Nullable
-    A get(@Nonnull C c);
+    A get(C c);
 
     /**
      * Builds a fresh container around {@code a} — equivalent to {@code set(null, a)} but reads
@@ -120,7 +119,6 @@ public interface Lens<C, A> {
      *          containers without the attribute
      * @return a non-null container holding {@code a}
      */
-    @Nonnull
     default C wrap(@Nullable final A a) {
         return set(null, a);
     }
@@ -136,7 +134,6 @@ public interface Lens<C, A> {
      *          supports containers without the attribute
      * @return a non-null container with the attribute set to {@code a}
      */
-    @Nonnull
     C set(@Nullable C c, @Nullable A a);
 
     /**
@@ -149,9 +146,8 @@ public interface Lens<C, A> {
      * @param operator transformation applied to the extracted attribute
      * @return a container reflecting the transformed attribute, possibly {@code c} itself
      */
-    @Nonnull
     @SuppressWarnings("PMD.CompareObjectsWithEquals")
-    default C map(@Nonnull final C c, @Nonnull final UnaryOperator<A> operator) {
+    default C map(final C c, final UnaryOperator<A> operator) {
         final A oldA = get(c);
         final A newA = operator.apply(oldA);
         if (newA == oldA) {
@@ -171,15 +167,14 @@ public interface Lens<C, A> {
      * @param <A2> the deeply focused attribute type
      * @return a composed lens from {@code C} to {@code A2}
      */
-    default <A2> Lens<C, A2> compose(@Nonnull final Lens<A, A2> downstream) {
+    default <A2> Lens<C, A2> compose(final Lens<A, A2> downstream) {
         return new Lens<>() {
             @Nullable
             @Override
-            public A2 get(@Nonnull final C c) {
+            public A2 get(final C c) {
                 return downstream.get(Lens.this.get(c));
             }
 
-            @Nonnull
             @Override
             @SpotBugsSuppressWarnings("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
             public C set(@Nullable final C c, @Nullable final A2 a2) {
@@ -196,16 +191,13 @@ public interface Lens<C, A> {
      * @param <T> shared container/attribute type
      * @return a lens that focuses each element on itself
      */
-    @Nonnull
     static <T> Lens<T, T> identity() {
         return new Lens<>() {
-            @Nonnull
             @Override
-            public T get(@Nonnull final T t) {
+            public T get(final T t) {
                 return t;
             }
 
-            @Nonnull
             @Override
             @SpotBugsSuppressWarnings("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
             public T set(@Nullable final T t, @Nullable final T t2) {
@@ -226,8 +218,7 @@ public interface Lens<C, A> {
      * @return an immutable list of extracted attributes in source order; never {@code null}
      * @throws NullPointerException if any element extraction yields {@code null}
      */
-    @Nonnull
-    static <T1, T2> List<T2> extract(@Nonnull final Lens<T1, T2> lens, @Nonnull final List<T1> elements) {
+    static <T1, T2> List<T2> extract(final Lens<T1, T2> lens, final List<T1> elements) {
         final ImmutableList.Builder<T2> resultsBuilder = ImmutableList.builder();
         for (final T1 element : elements) {
             resultsBuilder.add(lens.getNonnull(element));

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/util/Lens.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/util/Lens.java
@@ -179,7 +179,6 @@ public interface Lens<C, A> {
             }
 
             @Override
-            @SpotBugsSuppressWarnings("NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE")
             public C set(@Nullable final C c, @Nullable final A2 a2) {
                 // Lens.this.get() requires a non-null container; when c is null (the "build a fresh container"
                 // case), there is no existing intermediate A to read, so treat it as absent rather than calling

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/util/LoggableException.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/util/LoggableException.java
@@ -22,8 +22,8 @@ package com.apple.foundationdb.util;
 
 import com.apple.foundationdb.annotation.API;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import java.util.Map;
 
 /**
@@ -33,7 +33,7 @@ import java.util.Map;
 @SuppressWarnings("serial")
 @API(API.Status.UNSTABLE)
 public class LoggableException extends RuntimeException implements LoggableKeysAndValues<LoggableException> {
-    @Nonnull private final LoggableKeysAndValuesImpl loggableKeysAndValuesImpl = new LoggableKeysAndValuesImpl();
+    private final LoggableKeysAndValuesImpl loggableKeysAndValuesImpl = new LoggableKeysAndValuesImpl();
 
     /**
      * Create an exception with the given message a the sequence of key-value pairs.
@@ -44,7 +44,7 @@ public class LoggableException extends RuntimeException implements LoggableKeysA
      * @param keyValues list
      * @see #addLogInfo(Object...)
      */
-    public LoggableException(@Nonnull String msg, @Nullable Object ... keyValues) {
+    public LoggableException(String msg, @Nullable Object ... keyValues) {
         super(msg);
         this.loggableKeysAndValuesImpl.addLogInfo(keyValues);
     }
@@ -53,11 +53,11 @@ public class LoggableException extends RuntimeException implements LoggableKeysA
         super(cause);
     }
 
-    public LoggableException(@Nonnull String msg, @Nullable Throwable cause) {
+    public LoggableException(String msg, @Nullable Throwable cause) {
         super(msg, cause);
     }
 
-    public LoggableException(@Nonnull String msg) {
+    public LoggableException(String msg) {
         super(msg);
     }
 
@@ -72,7 +72,6 @@ public class LoggableException extends RuntimeException implements LoggableKeysA
      *
      * @return a single map with all log information
      */
-    @Nonnull
     @Override
     public Map<String, Object> getLogInfo() {
         return loggableKeysAndValuesImpl.getLogInfo();
@@ -86,9 +85,8 @@ public class LoggableException extends RuntimeException implements LoggableKeysA
      * @param object value of the log info pair
      * @return this <code>LoggableException</code>
      */
-    @Nonnull
     @Override
-    public LoggableException addLogInfo(@Nonnull String description, Object object) {
+    public LoggableException addLogInfo(String description, Object object) {
         loggableKeysAndValuesImpl.addLogInfo(description, object);
         return this;
     }
@@ -106,9 +104,8 @@ public class LoggableException extends RuntimeException implements LoggableKeysA
      * @return this <code>LoggableException</code>
      * @throws IllegalArgumentException if <code>keyValue</code> has odd length
      */
-    @Nonnull
     @Override
-    public LoggableException addLogInfo(@Nonnull Object ... keyValue) {
+    public LoggableException addLogInfo(Object ... keyValue) {
         loggableKeysAndValuesImpl.addLogInfo(keyValue);
         return this;
     }
@@ -123,7 +120,6 @@ public class LoggableException extends RuntimeException implements LoggableKeysA
      *
      * @return a flattened map of key-value pairs
      */
-    @Nonnull
     @Override
     public Object[] exportLogInfo() {
         return loggableKeysAndValuesImpl.exportLogInfo();

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/util/LoggableException.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/util/LoggableException.java
@@ -73,7 +73,7 @@ public class LoggableException extends RuntimeException implements LoggableKeysA
      * @return a single map with all log information
      */
     @Override
-    public Map<String, Object> getLogInfo() {
+    public Map<String, @Nullable Object> getLogInfo() {
         return loggableKeysAndValuesImpl.getLogInfo();
     }
 
@@ -82,11 +82,11 @@ public class LoggableException extends RuntimeException implements LoggableKeysA
      * given as the key and the object provided as the value.
      *
      * @param description description of the log info pair
-     * @param object value of the log info pair
+     * @param object value of the log info pair, which may be {@code null}
      * @return this <code>LoggableException</code>
      */
     @Override
-    public LoggableException addLogInfo(String description, Object object) {
+    public LoggableException addLogInfo(String description, @Nullable Object object) {
         loggableKeysAndValuesImpl.addLogInfo(description, object);
         return this;
     }
@@ -105,7 +105,7 @@ public class LoggableException extends RuntimeException implements LoggableKeysA
      * @throws IllegalArgumentException if <code>keyValue</code> has odd length
      */
     @Override
-    public LoggableException addLogInfo(Object ... keyValue) {
+    public LoggableException addLogInfo(@Nullable Object ... keyValue) {
         loggableKeysAndValuesImpl.addLogInfo(keyValue);
         return this;
     }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/util/LoggableKeysAndValues.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/util/LoggableKeysAndValues.java
@@ -20,7 +20,6 @@
 
 package com.apple.foundationdb.util;
 
-import javax.annotation.Nonnull;
 import java.util.Map;
 
 /**
@@ -44,7 +43,6 @@ public interface LoggableKeysAndValues<T extends LoggableKeysAndValues<T>> {
      *
      * @return a single map with all log information
      */
-    @Nonnull
     Map<String, Object> getLogInfo();
 
     /**
@@ -55,8 +53,7 @@ public interface LoggableKeysAndValues<T extends LoggableKeysAndValues<T>> {
      * @param object value of the log info pair
      * @return this <code>LoggableException</code>
      */
-    @Nonnull
-    T addLogInfo(@Nonnull String description, Object object);
+    T addLogInfo(String description, Object object);
 
     /**
      * Add a list of key/value pairs to the log information. This will treat the
@@ -71,8 +68,7 @@ public interface LoggableKeysAndValues<T extends LoggableKeysAndValues<T>> {
      * @return this <code>T</code>
      * @throws IllegalArgumentException if <code>keyValue</code> has odd length
      */
-    @Nonnull
-    T addLogInfo(@Nonnull Object ... keyValue);
+    T addLogInfo(Object ... keyValue);
 
     /**
      * Export the log information to a flattened array. This will flatten the map that would
@@ -84,7 +80,6 @@ public interface LoggableKeysAndValues<T extends LoggableKeysAndValues<T>> {
      *
      * @return a flattened map of key-value pairs
      */
-    @Nonnull
     Object[] exportLogInfo();
 
 }

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/util/LoggableKeysAndValues.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/util/LoggableKeysAndValues.java
@@ -20,6 +20,8 @@
 
 package com.apple.foundationdb.util;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.Map;
 
 /**
@@ -43,17 +45,17 @@ public interface LoggableKeysAndValues<T extends LoggableKeysAndValues<T>> {
      *
      * @return a single map with all log information
      */
-    Map<String, Object> getLogInfo();
+    Map<String, @Nullable Object> getLogInfo();
 
     /**
      * Add a key/value pair to the log information. This will use the description
      * given as the key and the object provided as the value.
      *
      * @param description description of the log info pair
-     * @param object value of the log info pair
+     * @param object value of the log info pair, which may be {@code null}
      * @return this <code>LoggableException</code>
      */
-    T addLogInfo(String description, Object object);
+    T addLogInfo(String description, @Nullable Object object);
 
     /**
      * Add a list of key/value pairs to the log information. This will treat the
@@ -68,7 +70,7 @@ public interface LoggableKeysAndValues<T extends LoggableKeysAndValues<T>> {
      * @return this <code>T</code>
      * @throws IllegalArgumentException if <code>keyValue</code> has odd length
      */
-    T addLogInfo(Object ... keyValue);
+    T addLogInfo(@Nullable Object ... keyValue);
 
     /**
      * Export the log information to a flattened array. This will flatten the map that would

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/util/LoggableKeysAndValuesImpl.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/util/LoggableKeysAndValuesImpl.java
@@ -22,8 +22,8 @@ package com.apple.foundationdb.util;
 
 import com.apple.foundationdb.annotation.API;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -56,7 +56,6 @@ public final class LoggableKeysAndValuesImpl implements LoggableKeysAndValues<Lo
      *
      * @return a single map with all log information
      */
-    @Nonnull
     @Override
     public Map<String, Object> getLogInfo() {
         if (logInfo == null) {
@@ -73,9 +72,8 @@ public final class LoggableKeysAndValuesImpl implements LoggableKeysAndValues<Lo
      * @param object value of the log info pair
      * @return this <code>LoggableException</code>
      */
-    @Nonnull
     @Override
-    public LoggableKeysAndValuesImpl addLogInfo(@Nonnull String description, Object object) {
+    public LoggableKeysAndValuesImpl addLogInfo(String description, Object object) {
         if (logInfo == null) {
             logInfo = new HashMap<>();
         }
@@ -96,9 +94,8 @@ public final class LoggableKeysAndValuesImpl implements LoggableKeysAndValues<Lo
      * @return this <code>LoggableException</code>
      * @throws IllegalArgumentException if <code>keyValue</code> has odd length
      */
-    @Nonnull
     @Override
-    public LoggableKeysAndValuesImpl addLogInfo(@Nonnull Object ... keyValue) {
+    public LoggableKeysAndValuesImpl addLogInfo(Object ... keyValue) {
         if ((keyValue.length % 2) != 0) {
             throw new IllegalArgumentException("Unbalanced key/value logging info");
         }
@@ -118,7 +115,6 @@ public final class LoggableKeysAndValuesImpl implements LoggableKeysAndValues<Lo
      *
      * @return a flattened map of key-value pairs
      */
-    @Nonnull
     @Override
     public Object[] exportLogInfo() {
         if (logInfo == null) {

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/util/LoggableKeysAndValuesImpl.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/util/LoggableKeysAndValuesImpl.java
@@ -35,7 +35,7 @@ import java.util.Map;
 @API(API.Status.UNSTABLE)
 public final class LoggableKeysAndValuesImpl implements LoggableKeysAndValues<LoggableKeysAndValuesImpl> {
     private static final Object[] EMPTY_LOG_INFO = new Object[0];
-    @Nullable private Map<String, Object> logInfo;
+    @Nullable private Map<String, @Nullable Object> logInfo;
 
     /**
      * Create an instance with the given message and a sequence of key-value pairs.
@@ -57,11 +57,11 @@ public final class LoggableKeysAndValuesImpl implements LoggableKeysAndValues<Lo
      * @return a single map with all log information
      */
     @Override
-    public Map<String, Object> getLogInfo() {
+    public Map<String, @Nullable Object> getLogInfo() {
         if (logInfo == null) {
-            return Collections.emptyMap();
+            return Collections.<String, @Nullable Object>emptyMap();
         }
-        return Collections.unmodifiableMap(logInfo);
+        return Collections.<String, @Nullable Object>unmodifiableMap(logInfo);
     }
 
     /**
@@ -69,11 +69,11 @@ public final class LoggableKeysAndValuesImpl implements LoggableKeysAndValues<Lo
      * given as the key and the object provided as the value.
      *
      * @param description description of the log info pair
-     * @param object value of the log info pair
+     * @param object value of the log info pair, which may be {@code null}
      * @return this <code>LoggableException</code>
      */
     @Override
-    public LoggableKeysAndValuesImpl addLogInfo(String description, Object object) {
+    public LoggableKeysAndValuesImpl addLogInfo(String description, @Nullable Object object) {
         if (logInfo == null) {
             logInfo = new HashMap<>();
         }
@@ -95,7 +95,7 @@ public final class LoggableKeysAndValuesImpl implements LoggableKeysAndValues<Lo
      * @throws IllegalArgumentException if <code>keyValue</code> has odd length
      */
     @Override
-    public LoggableKeysAndValuesImpl addLogInfo(Object ... keyValue) {
+    public LoggableKeysAndValuesImpl addLogInfo(@Nullable Object ... keyValue) {
         if ((keyValue.length % 2) != 0) {
             throw new IllegalArgumentException("Unbalanced key/value logging info");
         }
@@ -122,7 +122,7 @@ public final class LoggableKeysAndValuesImpl implements LoggableKeysAndValues<Lo
         }
         Object[] exportedInfo = new Object[2 * logInfo.size()];
         int i = 0;
-        for (Map.Entry<String, Object> entry : logInfo.entrySet()) {
+        for (Map.Entry<String, @Nullable Object> entry : logInfo.entrySet()) {
             exportedInfo[i] = entry.getKey();
             exportedInfo[i + 1] = entry.getValue();
             i += 2;

--- a/fdb-extensions/src/main/java/com/apple/foundationdb/util/StringUtils.java
+++ b/fdb-extensions/src/main/java/com/apple/foundationdb/util/StringUtils.java
@@ -22,8 +22,8 @@ package com.apple.foundationdb.util;
 
 import com.google.common.base.Preconditions;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
@@ -39,7 +39,7 @@ public class StringUtils {
      * @param s string to test for numeric characters
      * @return whether {@code s} contains only numeric characters
      */
-    public static boolean isNumeric(@Nonnull String s) {
+    public static boolean isNumeric(String s) {
         return isNumeric(s, 0);
     }
 
@@ -52,7 +52,7 @@ public class StringUtils {
      * @return whether the substring of {@code s} beginning at {@code beginIndex} is non-empty and contains only
      *     numeric characters
      */
-    public static boolean isNumeric(@Nonnull String s, int beginIndex) {
+    public static boolean isNumeric(String s, int beginIndex) {
         return isNumeric(s, beginIndex, s.length());
     }
 
@@ -66,7 +66,7 @@ public class StringUtils {
      * @return whether the substring of {@code s} beginning at {@code beginIndex} and ending at {@code endIndex}
      *     is non-empty and contains only numeric characters
      */
-    public static boolean isNumeric(@Nonnull String s, int beginIndex, int endIndex) {
+    public static boolean isNumeric(String s, int beginIndex, int endIndex) {
         Preconditions.checkArgument(beginIndex >= 0 && beginIndex <= s.length(),
                 "beginIndex should be within bounds");
         Preconditions.checkArgument(endIndex >= beginIndex && endIndex <= s.length(),
@@ -132,7 +132,7 @@ public class StringUtils {
         }
 
         @Nullable
-        public Replacement nextOccurrence(@Nonnull String source) {
+        public Replacement nextOccurrence(String source) {
             int nextIndex = source.indexOf(toReplace, index + 1);
             return nextIndex < 0 ? null : new Replacement(nextIndex, toReplace, replaceWith);
         }
@@ -183,8 +183,7 @@ public class StringUtils {
      * @return a string composed by replacing all occurrences of the {@code replaceMap} keys in {@code source}
      *     with their values
      */
-    @Nonnull
-    public static String replaceEach(@Nonnull String source, @Nonnull Map<String, String> replaceMap) {
+    public static String replaceEach(String source, Map<String, String> replaceMap) {
         if (source.isEmpty() || replaceMap.isEmpty()) {
             return source;
         }
@@ -241,7 +240,7 @@ public class StringUtils {
      * @param searchStr the string to search through
      * @return whether some substring of {@code source} is equal to {@code searchStr} ignoring case
      */
-    public static boolean containsIgnoreCase(@Nonnull String source, @Nonnull String searchStr) {
+    public static boolean containsIgnoreCase(String source, String searchStr) {
         if (source.length() < searchStr.length()) {
             return false;
         } else if (source.length() == searchStr.length()) {

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/MoreAsyncUtilTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/MoreAsyncUtilTest.java
@@ -24,6 +24,7 @@ import com.apple.foundationdb.test.TestExecutors;
 import com.apple.test.ParameterizedTestUtils;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.hamcrest.Matcher;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -33,6 +34,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
@@ -239,7 +241,8 @@ public class MoreAsyncUtilTest {
         } else if (behavior1.fails || behavior2.fails) {
             final ExecutionException executionException = assertThrows(ExecutionException.class,
                     () -> future.get(getTimeoutSeconds, TimeUnit.SECONDS));
-            assertEquals(RuntimeException.class, executionException.getCause().getClass());
+            // Throwable.getCause() is nullable in general, but this test's own setup guarantees a cause is present.
+            assertEquals(RuntimeException.class, Objects.requireNonNull(executionException.getCause()).getClass());
         } else {
             assertThrows(TimeoutException.class, () -> future.get(getTimeoutSeconds, TimeUnit.SECONDS));
         }
@@ -565,14 +568,18 @@ public class MoreAsyncUtilTest {
     void dedupIterableEmitsLeadingNullAndDoesNotCollapseAdjacentNulls() {
         // The dedup filter seeds its "previous" marker with null, so the leading null passes through; and because a
         // null previous element never compares equal, a second adjacent null is not collapsed. This pins that quirk.
-        final List<String> result = AsyncUtil.collect(
-                MoreAsyncUtil.dedupIterable(EXECUTOR, iterableOf(null, null, "a", "a")), EXECUTOR).join();
+        // dedupIterable()'s <T> is (deliberately, to avoid a wider ripple) not declared <T extends @Nullable
+        // Object>, even though its implementation already tolerates a null element correctly; this test exercises
+        // exactly that internal tolerance, so the mismatch against the public signature is suppressed here.
+        @SuppressWarnings("NullAway")
+        final AsyncIterable<String> dedupedWithNulls = MoreAsyncUtil.dedupIterable(EXECUTOR, iterableOf(null, null, "a", "a"));
+        final List<String> result = AsyncUtil.collect(dedupedWithNulls, EXECUTOR).join();
         assertEquals(Arrays.asList(null, null, "a"), result);
     }
 
     @SafeVarargs
     @SuppressWarnings("varargs") // reading the non-reifiable T[] in the body trips -Xlint:varargs; the helper is safe
-    private static <T> AsyncIterable<T> iterableOf(final T... items) {
+    private static <T extends @Nullable Object> AsyncIterable<T> iterableOf(final T... items) {
         return MoreAsyncUtil.iterableFromCollection(CompletableFuture.completedFuture(Arrays.asList(items)), EXECUTOR);
     }
 

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/MoreAsyncUtilTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/MoreAsyncUtilTest.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -577,13 +576,11 @@ public class MoreAsyncUtilTest {
         return MoreAsyncUtil.iterableFromCollection(CompletableFuture.completedFuture(Arrays.asList(items)), EXECUTOR);
     }
 
-    @Nonnull
-    private static Matcher<String> isCurrentThreadNameOr(@Nonnull String threadName) {
+    private static Matcher<String> isCurrentThreadNameOr(String threadName) {
         return isCurrentThreadNameOr(equalTo(threadName));
     }
 
-    @Nonnull
-    private static Matcher<String> isCurrentThreadNameOr(@Nonnull Matcher<String> threadMatcher) {
+    private static Matcher<String> isCurrentThreadNameOr(Matcher<String> threadMatcher) {
         return either(threadMatcher).or(equalTo(Thread.currentThread().getName()));
     }
 }

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/NonAsyncIterator.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/NonAsyncIterator.java
@@ -20,7 +20,6 @@
 
 package com.apple.foundationdb.async;
 
-import javax.annotation.Nonnull;
 import java.util.Iterator;
 import java.util.concurrent.CompletableFuture;
 
@@ -29,9 +28,9 @@ import java.util.concurrent.CompletableFuture;
  * @param <T> type of iterator elements
  */
 public class NonAsyncIterator<T> implements AsyncIterator<T> {
-    @Nonnull private Iterator<T> underlying;
+    private Iterator<T> underlying;
 
-    public NonAsyncIterator(@Nonnull Iterator<T> underlying) {
+    public NonAsyncIterator(Iterator<T> underlying) {
         this.underlying = underlying;
     }
 

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/RangeSetTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/RangeSetTest.java
@@ -127,7 +127,11 @@ public class RangeSetTest {
 
     @Test
     void clear() {
-        db.run(tr -> {
+        // db.run(Function<Transaction, T>) has no void-returning overload, so this side-effect-only call
+        // returns null from the lambda; NullAway does not accept an explicit @Nullable type witness on this
+        // external, unannotated method either, so the suppression is scoped to this one declaration instead.
+        @SuppressWarnings("NullAway")
+        final Void ignored = db.run(tr -> {
             tr.set(rsSubspace.pack(new byte[]{(byte)0xde, (byte)0xad}), new byte[]{(byte)0xc0, (byte)0xde});
             return null;
         });
@@ -141,7 +145,9 @@ public class RangeSetTest {
     @Test
     void contains() {
         // Insert a few ranges manually.
-        db.run(tr -> {
+        // See clear() above for why this suppression is needed.
+        @SuppressWarnings("NullAway")
+        final Void ignored = db.run(tr -> {
             tr.set(rsSubspace.pack(new byte[]{(byte)0x10}), new byte[]{(byte)0x66});
             tr.set(rsSubspace.pack(new byte[]{(byte)0x77}), new byte[]{(byte)0x88});
             tr.set(rsSubspace.pack(new byte[]{(byte)0x88}), new byte[]{(byte)0x99});
@@ -442,7 +448,12 @@ public class RangeSetTest {
         int maxRangeByte = 2 * ranges.size() + 1;
         try (MultipleTransactions multi = MultipleTransactions.create(db, maxRangeByte + 1)) {
             // Insert the full range with the first transaction
-            assertTrue(rs.insertRange(multi.get(0), null, null, false).join());
+            // NullAway does not reliably honor @Nullable on byte[]-typed parameters, so the null literals
+            // below are misflagged as NonNull violations even though insertRange()'s begin/end parameters
+            // are declared @Nullable byte[] (null meaning "the full range").
+            @SuppressWarnings("NullAway")
+            final boolean inserted = rs.insertRange(multi.get(0), null, null, false).join();
+            assertTrue(inserted);
 
             // Check on a key in each previously inserted range
             Set<Integer> conflicts = new HashSet<>();

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/RangeSetTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/RangeSetTest.java
@@ -37,7 +37,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
-import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -83,7 +82,7 @@ public class RangeSetTest {
         return keys;
     }
 
-    private int checkConsistent(@Nonnull List<Range> ranges, @Nonnull List<byte[]> keys) {
+    private int checkConsistent(List<Range> ranges, List<byte[]> keys) {
         List<CompletableFuture<Void>> futures = new ArrayList<>();
         int present = 0;
         for (byte[] key : keys) {
@@ -101,7 +100,7 @@ public class RangeSetTest {
         return present;
     }
 
-    private boolean disjoint(@Nonnull Range r1, @Nonnull Range r2) {
+    private boolean disjoint(Range r1, Range r2) {
         return ByteArrayUtil.compareUnsigned(r1.end, r2.begin) <= 0 || ByteArrayUtil.compareUnsigned(r2.end, r1.begin) <= 0;
     }
 

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/RankedSetTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/RankedSetTest.java
@@ -105,7 +105,11 @@ public class RankedSetTest {
         for (int i = 0; i < 100; ++i) {
             keys[i] = Tuple.from(String.valueOf((char)i)).pack();
         }
-        db.run(tr -> {
+        // db.run(Function<Transaction, T>) has no void-returning overload, so this side-effect-only call
+        // returns null from the lambda; NullAway does not accept an explicit @Nullable type witness on this
+        // external, unannotated method either, so the suppression is scoped to this one declaration instead.
+        @SuppressWarnings("NullAway")
+        final Void ignored = db.run(tr -> {
             config = RankedSet.newConfigBuilder().setHashFunction(firstHashFunction).build();
             RankedSet rs = newRankedSet();
             for (byte[] k : keys) {
@@ -139,7 +143,9 @@ public class RankedSetTest {
             keys[i] = Tuple.from(i).pack();
         }
         config = RankedSet.newConfigBuilder().setCountDuplicates(true).build();
-        db.run(tr -> {
+        // See basicOperations() above for why this suppression is needed.
+        @SuppressWarnings("NullAway")
+        final Void ignored = db.run(tr -> {
             RankedSet rs = newRankedSet();
             for (int i = 0; i < keys.length; ++i) {
                 for (int j = 1; j <= i + 1; j++) {
@@ -178,7 +184,9 @@ public class RankedSetTest {
     public void concurrentAdd() throws Exception {
         // 20 does go onto level 1, 30 and 40 do not. There should be no reason for them to conflict on level 0.
         RankedSet rs = newRankedSet();
-        db.run(tr -> {
+        // See basicOperations() above for why this suppression is needed.
+        @SuppressWarnings("NullAway")
+        final Void ignored = db.run(tr -> {
             rs.add(tr, Tuple.from(20).pack()).join();
             return null;
         });
@@ -196,7 +204,9 @@ public class RankedSetTest {
         rs.add(tr2, Tuple.from(40).pack()).join();
         tr1.commit().join();
         tr2.commit().join();
-        db.read(tr -> {
+        // db.read(Function<ReadTransaction, T>) has the same no-void-overload limitation as db.run() above.
+        @SuppressWarnings("NullAway")
+        final Void ignored2 = db.read(tr -> {
             assertEquals(0L, rs.rank(tr, Tuple.from(20).pack()).join().longValue());
             assertEquals(1L, rs.rank(tr, Tuple.from(30).pack()).join().longValue());
             assertEquals(2L, rs.rank(tr, Tuple.from(40).pack()).join().longValue());
@@ -207,7 +217,9 @@ public class RankedSetTest {
     @Test
     public void concurrentRemove() throws Exception {
         RankedSet rs = newRankedSet();
-        db.run(tr -> {
+        // See basicOperations() above for why this suppression is needed.
+        @SuppressWarnings("NullAway")
+        final Void ignored = db.run(tr -> {
             // Create a higher level entry.
             rs.add(tr, Tuple.from(20).pack()).join();
             return null;
@@ -228,11 +240,14 @@ public class RankedSetTest {
         rs.add(tr2, Tuple.from(30).pack()).join();
         tr1.commit().join();
         assertThrows(CompletionException.class, () -> tr2.commit().join());
-        db.run(tr -> {
+        @SuppressWarnings("NullAway")
+        final Void ignored2 = db.run(tr -> {
             rs.add(tr, Tuple.from(30).pack()).join();
             return null;
         });
-        db.read(tr -> {
+        // See concurrentAdd() above for why this suppression is needed for db.read() too.
+        @SuppressWarnings("NullAway")
+        final Void ignored3 = db.read(tr -> {
             // If the overlapping commit had succeeded, it would have incremented the 20 entry at level 1, so 20 would be returned here.
             assertEquals(30, Tuple.fromBytes(rs.getNth(tr, 0).join()).getLong(0));
             return null;
@@ -275,7 +290,9 @@ public class RankedSetTest {
     @Test
     public void rankAsThoughPresent() {
         RankedSet rs = newRankedSet();
-        db.run(tr -> {
+        // See basicOperations() above for why this suppression is needed.
+        @SuppressWarnings("NullAway")
+        final Void ignored = db.run(tr -> {
             for (int i = 5; i < 100; i += 10) {
                 rs.add(tr, Tuple.from(i).pack()).join();
             }
@@ -300,7 +317,10 @@ public class RankedSetTest {
         int op = ThreadLocalRandom.current().nextInt(6);
         byte[] key = new byte[1];
         ThreadLocalRandom.current().nextBytes(key);
-        tc.run(tr -> {
+        // See basicOperations() above for why this suppression is needed (TransactionContext.run() has the
+        // same no-void-overload limitation as Database.run()).
+        @SuppressWarnings("NullAway")
+        final Void ignored = tc.run(tr -> {
             switch (op) {
                 case 0: {
                     rs.add(tr, key).join();

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/common/BaseTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/common/BaseTest.java
@@ -23,17 +23,13 @@ package com.apple.foundationdb.async.common;
 import com.apple.foundationdb.Database;
 import com.apple.foundationdb.subspace.Subspace;
 
-import javax.annotation.Nonnull;
 import java.nio.file.Path;
 
 public interface BaseTest {
 
-    @Nonnull
     Database getDb();
 
-    @Nonnull
     Subspace getSubspace();
 
-    @Nonnull
     Path getTempDir();
 }

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/common/CommonTestHelpers.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/common/CommonTestHelpers.java
@@ -29,7 +29,6 @@ import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
-import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
@@ -45,8 +44,7 @@ public final class CommonTestHelpers {
         // nothing
     }
 
-    @Nonnull
-    public static List<PrimaryKeyAndVector> randomVectors(@Nonnull final Random random, final int numDimensions,
+    public static List<PrimaryKeyAndVector> randomVectors(final Random random, final int numDimensions,
                                                           final int numberOfVectors) {
         final ImmutableList.Builder<PrimaryKeyAndVector> resultBuilder = ImmutableList.builder();
         for (int i = 0; i < numberOfVectors; i ++) {
@@ -57,9 +55,8 @@ public final class CommonTestHelpers {
         return resultBuilder.build();
     }
 
-    @Nonnull
-    public static List<PrimaryKeyAndVector> pickRandomVectors(@Nonnull final Random random,
-                                                              @Nonnull final Collection<PrimaryKeyAndVector> vectors,
+    public static List<PrimaryKeyAndVector> pickRandomVectors(final Random random,
+                                                              final Collection<PrimaryKeyAndVector> vectors,
                                                               final int numberOfVectors) {
         Verify.verify(numberOfVectors <= vectors.size());
         final List<PrimaryKeyAndVector> remainingVectors = Lists.newArrayList(vectors);
@@ -70,17 +67,15 @@ public final class CommonTestHelpers {
         return resultBuilder.build();
     }
 
-    @Nonnull
-    public static NavigableSet<PrimaryKeyVectorAndDistance> orderedByDistances(@Nonnull final Metric metric,
-                                                                               @Nonnull final List<PrimaryKeyAndVector> vectors,
-                                                                               @Nonnull final RealVector queryVector) {
+    public static NavigableSet<PrimaryKeyVectorAndDistance> orderedByDistances(final Metric metric,
+                                                                               final List<PrimaryKeyAndVector> vectors,
+                                                                               final RealVector queryVector) {
         return orderedByDistances(metric::distance, vectors, queryVector);
     }
 
-    @Nonnull
-    public static NavigableSet<PrimaryKeyVectorAndDistance> orderedByDistances(@Nonnull final ToDoubleBiFunction<RealVector, RealVector> distanceFunction,
-                                                                               @Nonnull final List<PrimaryKeyAndVector> vectors,
-                                                                               @Nonnull final RealVector queryVector) {
+    public static NavigableSet<PrimaryKeyVectorAndDistance> orderedByDistances(final ToDoubleBiFunction<RealVector, RealVector> distanceFunction,
+                                                                               final List<PrimaryKeyAndVector> vectors,
+                                                                               final RealVector queryVector) {
         final TreeSet<PrimaryKeyVectorAndDistance> vectorsOrderedByDistance =
                 new TreeSet<>(Comparator.comparing(PrimaryKeyVectorAndDistance::distance)
                         .thenComparing(PrimaryKeyVectorAndDistance::primaryKey));
@@ -93,12 +88,10 @@ public final class CommonTestHelpers {
         return vectorsOrderedByDistance;
     }
 
-    @Nonnull
-    public static Tuple createRandomPrimaryKey(final @Nonnull Random random) {
+    public static Tuple createRandomPrimaryKey(final Random random) {
         return createPrimaryKey(random.nextLong());
     }
 
-    @Nonnull
     public static Tuple createPrimaryKey(final long nextId) {
         return Tuple.from(nextId);
     }
@@ -113,9 +106,8 @@ public final class CommonTestHelpers {
      *
      * @return a fresh perturbed vector
      */
-    @Nonnull
-    public static DoubleRealVector perturb(@Nonnull final DoubleRealVector base,
-                                           @Nonnull final RandomHelpers.GaussianSampler sampler,
+    public static DoubleRealVector perturb(final DoubleRealVector base,
+                                           final RandomHelpers.GaussianSampler sampler,
                                            final double sigma) {
         final double[] data = base.getData().clone();
         for (int i = 0; i < data.length; i++) {

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/common/PrimaryKeyVectorAndDistance.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/common/PrimaryKeyVectorAndDistance.java
@@ -23,7 +23,6 @@ package com.apple.foundationdb.async.common;
 import com.apple.foundationdb.linear.RealVector;
 import com.apple.foundationdb.tuple.Tuple;
 
-import javax.annotation.Nonnull;
 
 /**
  * A test fixture pairing a primary key and vector with a distance (e.g. to a query vector), used to build
@@ -34,5 +33,5 @@ import javax.annotation.Nonnull;
  * @param vector the vector
  * @param distance the distance associated with this vector
  */
-public record PrimaryKeyVectorAndDistance(@Nonnull Tuple primaryKey, @Nonnull RealVector vector, double distance) {
+public record PrimaryKeyVectorAndDistance(Tuple primaryKey, RealVector vector, double distance) {
 }

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/common/TimedAsyncIterableTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/common/TimedAsyncIterableTest.java
@@ -28,7 +28,6 @@ import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 
-import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -144,8 +143,7 @@ class TimedAsyncIterableTest {
                 .isGreaterThanOrEqualTo(expectedMinNanos);
     }
 
-    @Nonnull
-    private static List<Integer> drain(@Nonnull final AsyncIterator<Integer> iterator) {
+    private static List<Integer> drain(final AsyncIterator<Integer> iterator) {
         final List<Integer> collected = new ArrayList<>();
         while (Boolean.TRUE.equals(iterator.onHasNext().join())) {
             collected.add(iterator.next());
@@ -154,8 +152,7 @@ class TimedAsyncIterableTest {
     }
 
     /** A minimal synchronous {@link AsyncIterable} over a fixed list, with a no-op {@code cancel}. */
-    @Nonnull
-    private static AsyncIterable<Integer> asyncIterableOf(@Nonnull final List<Integer> items) {
+    private static AsyncIterable<Integer> asyncIterableOf(final List<Integer> items) {
         return delayedIterableOf(items, false);
     }
 
@@ -164,15 +161,12 @@ class TimedAsyncIterableTest {
      * element injects {@code 10 * value} ms of latency — modeling the batch-fetch wait that
      * {@link TimedAsyncIterable} measures (the latency lives in the awaited {@code onHasNext}, not in {@code next}).
      */
-    @Nonnull
-    private static AsyncIterable<Integer> delayedIterableOf(@Nonnull final List<Integer> items) {
+    private static AsyncIterable<Integer> delayedIterableOf(final List<Integer> items) {
         return delayedIterableOf(items, true);
     }
 
-    @Nonnull
-    private static AsyncIterable<Integer> delayedIterableOf(@Nonnull final List<Integer> items, final boolean delayed) {
+    private static AsyncIterable<Integer> delayedIterableOf(final List<Integer> items, final boolean delayed) {
         return new AsyncIterable<>() {
-            @Nonnull
             @Override
             public AsyncIterator<Integer> iterator() {
                 return new AsyncIterator<>() {
@@ -208,7 +202,6 @@ class TimedAsyncIterableTest {
                 };
             }
 
-            @Nonnull
             @Override
             public CompletableFuture<List<Integer>> asList() {
                 return CompletableFuture.completedFuture(ImmutableList.copyOf(items));

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/guardiann/AlmostSortedAsyncIteratorTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/guardiann/AlmostSortedAsyncIteratorTest.java
@@ -28,8 +28,7 @@ import com.apple.foundationdb.test.TestExecutors;
 import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.Test;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -120,15 +119,13 @@ class AlmostSortedAsyncIteratorTest {
 
     // ------------------------------------------------------------------------------------------------------------
 
-    @Nonnull
-    private static AlmostSortedAsyncIterator<Integer> almostSorted(@Nonnull final List<Integer> input,
+    private static AlmostSortedAsyncIterator<Integer> almostSorted(final List<Integer> input,
                                                                    final int maxQueueSize) {
         return new AlmostSortedAsyncIterator<>(new NonAsyncIterator<>(input.iterator()),
                 Comparator.naturalOrder(), maxQueueSize, EXECUTOR);
     }
 
-    @Nonnull
-    private static <T> List<T> drain(@Nonnull final AsyncIterator<T> iterator) {
+    private static <T> List<T> drain(final AsyncIterator<T> iterator) {
         final List<T> result = new ArrayList<>();
         while (iterator.onHasNext().join()) {
             result.add(iterator.next());
@@ -138,12 +135,11 @@ class AlmostSortedAsyncIteratorTest {
 
     /** A closeable {@link AsyncIterator} over a list that records whether it was closed or cancelled. */
     private static final class RecordingCloseableIterator<T> implements CloseableAsyncIterator<T> {
-        @Nonnull
         private final Iterator<T> underlying;
         boolean closed;
         boolean cancelled;
 
-        RecordingCloseableIterator(@Nonnull final List<T> items) {
+        RecordingCloseableIterator(final List<T> items) {
             this.underlying = items.iterator();
         }
 
@@ -178,12 +174,11 @@ class AlmostSortedAsyncIteratorTest {
      * caches the pending answer until {@link #next()} consumes it (as a real async iterator does).
      */
     private static final class DelayingAsyncIterator<T> implements AsyncIterator<T> {
-        @Nonnull
         private final Iterator<T> underlying;
         @Nullable
         private CompletableFuture<Boolean> pending;
 
-        DelayingAsyncIterator(@Nonnull final List<T> items) {
+        DelayingAsyncIterator(final List<T> items) {
             this.underlying = items.iterator();
         }
 

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/guardiann/CollapseScenarioTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/guardiann/CollapseScenarioTest.java
@@ -52,7 +52,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.EnumSet;
@@ -97,19 +96,16 @@ public class CollapseScenarioTest implements BaseTest {
     /** Set by {@link #newGuardiann} so each test can read the COLLAPSE task counter. */
     private TestHelpers.TestOnWriteListener onWriteListener;
 
-    @Nonnull
     @Override
     public Database getDb() {
         return Objects.requireNonNull(db);
     }
 
-    @Nonnull
     @Override
     public Subspace getSubspace() {
         return subspaceExtension.getSubspace();
     }
 
-    @Nonnull
     @Override
     public Path getTempDir() {
         return tempDir;
@@ -846,7 +842,6 @@ public class CollapseScenarioTest implements BaseTest {
         }
     }
 
-    @Nonnull
     private Guardiann newGuardiann(final int primaryClusterMax, final int collapseMinDuplicates) {
         onWriteListener = new TestHelpers.TestOnWriteListener();
         final Config config = Guardiann.newConfigBuilder()
@@ -869,14 +864,12 @@ public class CollapseScenarioTest implements BaseTest {
     }
 
     /** The first SIFT-small base vector, used as the vector we insert many identical copies of. */
-    @Nonnull
     private RealVector duplicateVector() throws Exception {
         return VecsDatasetLoaders.loadVectors(SiftTestHelpers.SIFT_SMALL_BASE_PATH, 1).get(0).vector();
     }
 
     /** Inserts {@code count} copies of {@code vector} under distinct primary keys {@code [pkBase, pkBase+count)}. */
-    @Nonnull
-    private List<Tuple> insertIdentical(@Nonnull final Guardiann guardiann, @Nonnull final RealVector vector,
+    private List<Tuple> insertIdentical(final Guardiann guardiann, final RealVector vector,
                                         final long pkBase, final int count) {
         final List<Tuple> primaryKeys = new ArrayList<>(count);
         for (int i = 0; i < count; i++) {
@@ -890,20 +883,19 @@ public class CollapseScenarioTest implements BaseTest {
         return primaryKeys;
     }
 
-    @Nonnull
-    private ClusterView onlyCluster(@Nonnull final StructureSnapshot snapshot) {
+    private ClusterView onlyCluster(final StructureSnapshot snapshot) {
         return Iterables.getOnlyElement(snapshot.clusters().values());
     }
 
     /** Marks the single cluster COLLAPSE and runs a {@link CollapseTask} on it directly. */
-    private void collapseOnlyCluster(@Nonnull final Guardiann guardiann) {
+    private void collapseOnlyCluster(final Guardiann guardiann) {
         final ClusterView cluster = onlyCluster(Objects.requireNonNull(GuardiannStructureAsserts.snapshotStructure(db, guardiann)));
         setCollapseState(guardiann, cluster.clusterId());
         runCollapseDirectly(guardiann, cluster.clusterId(), cluster.transformedCentroid());
     }
 
     /** Adds {@link ClusterMetadata.State#COLLAPSE} to the cluster's states (preserving any others). */
-    private void setCollapseState(@Nonnull final Guardiann guardiann, @Nonnull final UUID clusterId) {
+    private void setCollapseState(final Guardiann guardiann, final UUID clusterId) {
         db.run(tr -> {
             final Primitives primitives = guardiann.getLocator().primitives();
             final ClusterMetadata metadata =
@@ -916,8 +908,8 @@ public class CollapseScenarioTest implements BaseTest {
     }
 
     /** Builds a {@link CollapseTask} in memory and runs it in its own transaction. */
-    private void runCollapseDirectly(@Nonnull final Guardiann guardiann, @Nonnull final UUID clusterId,
-                                     @Nonnull final Transformed<RealVector> transformedCentroid) {
+    private void runCollapseDirectly(final Guardiann guardiann, final UUID clusterId,
+                                     final Transformed<RealVector> transformedCentroid) {
         db.run(tr -> {
             final Primitives primitives = guardiann.getLocator().primitives();
             final AccessInfo accessInfo = Objects.requireNonNull(primitives.fetchAccessInfo(tr).join());
@@ -929,14 +921,13 @@ public class CollapseScenarioTest implements BaseTest {
         });
     }
 
-    @Nonnull
-    private List<VectorId> fetchCollapsedIds(@Nonnull final Guardiann guardiann, @Nonnull final UUID signature) {
+    private List<VectorId> fetchCollapsedIds(final Guardiann guardiann, final UUID signature) {
         return db.run(tr -> guardiann.getLocator().primitives().fetchCollapsedVectorIds(tr, signature).join());
     }
 
     /** Asserts a kNN query for {@code vector} returns all of {@code primaryKeys} (collapsed members included). */
-    private void assertAllResolvable(@Nonnull final Guardiann guardiann, @Nonnull final RealVector vector,
-                                     @Nonnull final List<Tuple> primaryKeys) {
+    private void assertAllResolvable(final Guardiann guardiann, final RealVector vector,
+                                     final List<Tuple> primaryKeys) {
         final int k = primaryKeys.size();
         // Keep a generous pool so every near-duplicate survives to the result: at least 2x k, but never below an
         // absolute floor of 128 for small k. Expressed as a k-relative factor, that floor becomes 128/k.
@@ -953,8 +944,8 @@ public class CollapseScenarioTest implements BaseTest {
     }
 
     /** Direct-drives a {@link ReassignTask} on a single cluster in its own transaction (no follow-up tasks). */
-    private void reassignCluster(@Nonnull final Guardiann guardiann, @Nonnull final UUID clusterId,
-                                 @Nonnull final Transformed<RealVector> transformedCentroid) {
+    private void reassignCluster(final Guardiann guardiann, final UUID clusterId,
+                                 final Transformed<RealVector> transformedCentroid) {
         final Locator locator = guardiann.getLocator();
         final Primitives primitives = locator.primitives();
         final int numNearestClusters = 1 + guardiann.getConfig().reassignNumNeighboringClusters();

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/guardiann/CollapseScenarioTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/guardiann/CollapseScenarioTest.java
@@ -89,11 +89,16 @@ public class CollapseScenarioTest implements BaseTest {
     final TestSubspaceExtension subspaceExtension = new TestSubspaceExtension(dbExtension);
 
     @TempDir
+    // Injected by JUnit's TempDirectory extension before each test; NullAway cannot see framework injection.
+    @SuppressWarnings("NullAway")
     Path tempDir;
 
     private static Database db;
 
     /** Set by {@link #newGuardiann} so each test can read the COLLAPSE task counter. */
+    // Assigned by newGuardiann(), which every test calls before touching this field; NullAway's field
+    // initialization check only recognizes constructors and JUnit lifecycle methods as initializers.
+    @SuppressWarnings("NullAway")
     private TestHelpers.TestOnWriteListener onWriteListener;
 
     @Override
@@ -217,7 +222,11 @@ public class CollapseScenarioTest implements BaseTest {
         final VectorId a2 = new VectorId(Tuple.from("a", 2), UUID.randomUUID());
         final VectorId b1 = new VectorId(Tuple.from("b", 1), UUID.randomUUID());
 
-        db.run(tr -> {
+        // db.run(Function<Transaction, T>) has no void-returning overload, so this side-effect-only call
+        // returns null from the lambda; NullAway does not accept an explicit @Nullable type witness on this
+        // external, unannotated method either, so the suppression is scoped to this one declaration instead.
+        @SuppressWarnings("NullAway")
+        final Void ignored1 = db.run(tr -> {
             primitives.writeCollapsedVectorId(tr, signatureA, a1);
             primitives.writeCollapsedVectorId(tr, signatureA, a2);
             primitives.writeCollapsedVectorId(tr, signatureB, b1);
@@ -231,7 +240,9 @@ public class CollapseScenarioTest implements BaseTest {
         assertThat(scanned).containsExactlyInAnyOrder(a1, a2, b1);
 
         // Deleting a single (signature, primaryKey) removes only that member; its siblings and other signatures stay.
-        db.run(tr -> {
+        // See the writeCollapsedVectorId block above for why this suppression is needed.
+        @SuppressWarnings("NullAway")
+        final Void ignored2 = db.run(tr -> {
             primitives.deleteCollapsedVectorId(tr, signatureA, a1.primaryKey());
             return null;
         });
@@ -283,7 +294,9 @@ public class CollapseScenarioTest implements BaseTest {
         for (int i = 0; i < 150; i++) {
             final DoubleRealVector perturbed = CommonTestHelpers.perturb(base, sampler, 0.5d);
             final Tuple pk = Tuple.from("overlap", i);
-            db.run(tr -> {
+            // See the writeCollapsedVectorId block above for why this suppression is needed.
+            @SuppressWarnings("NullAway")
+            final Void ignored3 = db.run(tr -> {
                 guardiann.insert(tr, pk, perturbed, null, true).join();
                 return null;
             });
@@ -496,7 +509,10 @@ public class CollapseScenarioTest implements BaseTest {
         for (int i = 1; i <= numDistinctPrimaries; i++) {
             final Tuple primaryKey = Tuple.from("distinct", i);
             final RealVector vector = records.get(i).vector();
-            db.run(tr -> {
+            // See collapsedVectorIdStoreScanAndDelete()'s writeCollapsedVectorId block for why this
+            // suppression is needed.
+            @SuppressWarnings("NullAway")
+            final Void ignored4 = db.run(tr -> {
                 guardiann.insert(tr, primaryKey, vector, null, true).join();
                 return null;
             });
@@ -509,7 +525,10 @@ public class CollapseScenarioTest implements BaseTest {
         final RealVector duplicate = duplicateVector();
 
         // Phase 1: write the orphaned replicas (and their still-present metadata) into the cluster.
-        db.run(tr -> {
+        // See collapsedVectorIdStoreScanAndDelete()'s writeCollapsedVectorId block for why this
+        // suppression is needed.
+        @SuppressWarnings("NullAway")
+        final Void ignored5 = db.run(tr -> {
             final AccessInfo accessInfo = Objects.requireNonNull(primitives.fetchAccessInfo(tr).join());
             final Quantizer quantizer = primitives.quantizer(accessInfo);
             final Transformed<RealVector> transformedDuplicate =
@@ -538,7 +557,10 @@ public class CollapseScenarioTest implements BaseTest {
         final UUID signature = StorageAdapter.signatureUuid(stagedReplicas.get(0).vector());
         final List<Tuple> collapsedPrimaryKeys =
                 stagedReplicas.stream().map(ref -> ref.id().primaryKey()).toList();
-        db.run(tr -> {
+        // See collapsedVectorIdStoreScanAndDelete()'s writeCollapsedVectorId block for why this
+        // suppression is needed.
+        @SuppressWarnings("NullAway")
+        final Void ignored6 = db.run(tr -> {
             for (final VectorReference replica : stagedReplicas) {
                 primitives.writeCollapsedVectorId(tr, signature, replica.id());
             }
@@ -601,7 +623,10 @@ public class CollapseScenarioTest implements BaseTest {
         for (int i = 1; i <= numDistinctPrimaries; i++) {
             final Tuple primaryKey = Tuple.from("distinct", i);
             final RealVector vector = records.get(i).vector();
-            db.run(tr -> {
+            // See collapsedVectorIdStoreScanAndDelete()'s writeCollapsedVectorId block for why this
+            // suppression is needed.
+            @SuppressWarnings("NullAway")
+            final Void ignored4 = db.run(tr -> {
                 guardiann.insert(tr, primaryKey, vector, null, true).join();
                 return null;
             });
@@ -614,7 +639,10 @@ public class CollapseScenarioTest implements BaseTest {
 
         // Phase 1: one plain (non-collapsed) member replica whose primary is (below) recorded in the collapsed set.
         final Tuple memberPrimaryKey = Tuple.from("collapsed-dup", 0);
-        db.run(tr -> {
+        // See collapsedVectorIdStoreScanAndDelete()'s writeCollapsedVectorId block for why this
+        // suppression is needed.
+        @SuppressWarnings("NullAway")
+        final Void ignored5 = db.run(tr -> {
             final AccessInfo accessInfo = Objects.requireNonNull(primitives.fetchAccessInfo(tr).join());
             final Quantizer quantizer = primitives.quantizer(accessInfo);
             final Transformed<RealVector> transformedDuplicate =
@@ -638,7 +666,10 @@ public class CollapseScenarioTest implements BaseTest {
         // Phase 2: record the member in the collapsed store (so it folds), and add a HIGHER-priority already-collapsed
         // replica of the same signature. Its primaryKey is Tuple.from(signature); we deliberately write NO collapsed-
         // store entry for (signature, Tuple.from(signature)), so its fold-time lookup returns null and it passes through.
-        db.run(tr -> {
+        // See collapsedVectorIdStoreScanAndDelete()'s writeCollapsedVectorId block for why this
+        // suppression is needed.
+        @SuppressWarnings("NullAway")
+        final Void ignored6 = db.run(tr -> {
             final AccessInfo accessInfo = Objects.requireNonNull(primitives.fetchAccessInfo(tr).join());
             final Quantizer quantizer = primitives.quantizer(accessInfo);
             final Transformed<RealVector> transformedDuplicate =
@@ -707,7 +738,10 @@ public class CollapseScenarioTest implements BaseTest {
         for (int i = 1; i <= numDistinctPrimaries; i++) {
             final Tuple primaryKey = Tuple.from("distinct", i);
             final RealVector vector = records.get(i).vector();
-            db.run(tr -> {
+            // See collapsedVectorIdStoreScanAndDelete()'s writeCollapsedVectorId block for why this
+            // suppression is needed.
+            @SuppressWarnings("NullAway")
+            final Void ignored4 = db.run(tr -> {
                 guardiann.insert(tr, primaryKey, vector, null, true).join();
                 return null;
             });
@@ -721,7 +755,10 @@ public class CollapseScenarioTest implements BaseTest {
         // A fresh, non-collapsed duplicate replica: same content (hence same signature) but a distinct primary key and,
         // crucially, NO collapsed-store entry — the state a duplicate inserted after a collapse leaves.
         final Tuple freshPrimaryKey = Tuple.from("fresh-dup", 0);
-        db.run(tr -> {
+        // See collapsedVectorIdStoreScanAndDelete()'s writeCollapsedVectorId block for why this
+        // suppression is needed.
+        @SuppressWarnings("NullAway")
+        final Void ignored5 = db.run(tr -> {
             final AccessInfo accessInfo = Objects.requireNonNull(primitives.fetchAccessInfo(tr).join());
             final Quantizer quantizer = primitives.quantizer(accessInfo);
             final Transformed<RealVector> transformedDuplicate =
@@ -742,7 +779,10 @@ public class CollapseScenarioTest implements BaseTest {
 
         // A HIGHER-priority already-collapsed representative for the same signature (processed first). No collapsed-
         // store entry for (signature, Tuple.from(signature)), so it takes the collapsed short-circuit and claims S.
-        db.run(tr -> {
+        // See collapsedVectorIdStoreScanAndDelete()'s writeCollapsedVectorId block for why this
+        // suppression is needed.
+        @SuppressWarnings("NullAway")
+        final Void ignored6 = db.run(tr -> {
             final AccessInfo accessInfo = Objects.requireNonNull(primitives.fetchAccessInfo(tr).join());
             final Quantizer quantizer = primitives.quantizer(accessInfo);
             final Transformed<RealVector> transformedDuplicate =
@@ -875,7 +915,10 @@ public class CollapseScenarioTest implements BaseTest {
         for (int i = 0; i < count; i++) {
             final Tuple primaryKey = Tuple.from(pkBase + i);
             primaryKeys.add(primaryKey);
-            db.run(tr -> {
+            // See collapsedVectorIdStoreScanAndDelete()'s writeCollapsedVectorId block for why this
+            // suppression is needed.
+            @SuppressWarnings("NullAway")
+            final Void ignored = db.run(tr -> {
                 guardiann.insert(tr, primaryKey, vector, null, true).join();
                 return null;
             });
@@ -896,7 +939,10 @@ public class CollapseScenarioTest implements BaseTest {
 
     /** Adds {@link ClusterMetadata.State#COLLAPSE} to the cluster's states (preserving any others). */
     private void setCollapseState(final Guardiann guardiann, final UUID clusterId) {
-        db.run(tr -> {
+        // See collapsedVectorIdStoreScanAndDelete()'s writeCollapsedVectorId block for why this
+        // suppression is needed.
+        @SuppressWarnings("NullAway")
+        final Void ignored = db.run(tr -> {
             final Primitives primitives = guardiann.getLocator().primitives();
             final ClusterMetadata metadata =
                     Objects.requireNonNull(primitives.fetchClusterMetadata(tr, clusterId).join());
@@ -910,7 +956,10 @@ public class CollapseScenarioTest implements BaseTest {
     /** Builds a {@link CollapseTask} in memory and runs it in its own transaction. */
     private void runCollapseDirectly(final Guardiann guardiann, final UUID clusterId,
                                      final Transformed<RealVector> transformedCentroid) {
-        db.run(tr -> {
+        // See collapsedVectorIdStoreScanAndDelete()'s writeCollapsedVectorId block for why this
+        // suppression is needed.
+        @SuppressWarnings("NullAway")
+        final Void ignored = db.run(tr -> {
             final Primitives primitives = guardiann.getLocator().primitives();
             final AccessInfo accessInfo = Objects.requireNonNull(primitives.fetchAccessInfo(tr).join());
             final UUID taskId = RandomHelpers.randomUuid(clusterId, true);
@@ -949,7 +998,10 @@ public class CollapseScenarioTest implements BaseTest {
         final Locator locator = guardiann.getLocator();
         final Primitives primitives = locator.primitives();
         final int numNearestClusters = 1 + guardiann.getConfig().reassignNumNeighboringClusters();
-        db.run(transaction -> {
+        // See collapsedVectorIdStoreScanAndDelete()'s writeCollapsedVectorId block for why this
+        // suppression is needed.
+        @SuppressWarnings("NullAway")
+        final Void ignored = db.run(transaction -> {
             final AccessInfo accessInfo = Objects.requireNonNull(primitives.fetchAccessInfo(transaction).join());
             final ClusterMetadata clusterMetadata =
                     Objects.requireNonNull(primitives.fetchClusterMetadata(transaction, clusterId).join());

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/guardiann/DataRecordsTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/guardiann/DataRecordsTest.java
@@ -33,7 +33,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
@@ -217,7 +216,7 @@ class DataRecordsTest {
 
     @ParameterizedTest
     @EnumSource(ClusterMetadata.State.class)
-    void stateCodeIsASingleDistinctBit(@Nonnull final ClusterMetadata.State state) {
+    void stateCodeIsASingleDistinctBit(final ClusterMetadata.State state) {
         final int code = state.getCode();
         Assertions.assertThat(code).as("state %s must have a positive code", state).isPositive();
         // A single set bit == a power of two; this is what directly rejects a stray non-power-of-two code like 3.
@@ -246,8 +245,8 @@ class DataRecordsTest {
      */
     @ParameterizedTest
     @MethodSource
-    void stateCodesUseIndependentBits(@Nonnull final ClusterMetadata.State state1,
-                                      @Nonnull final ClusterMetadata.State state2) {
+    void stateCodesUseIndependentBits(final ClusterMetadata.State state1,
+                                      final ClusterMetadata.State state2) {
         Assertions.assertThat(state1.getCode() & state2.getCode())
                 .as("states %s (code=%d) and %s (code=%d) must not share any bit",
                         state1, state1.getCode(), state2, state2.getCode())
@@ -263,8 +262,8 @@ class DataRecordsTest {
     // ---------------------------------------------------------------------------------------------------------
 
     private static <T> void assertHashCodeEqualsToString(final long randomSeed,
-                                                         @Nonnull final Function<Random, T> createFunction,
-                                                         @Nonnull final BiFunction<Random, T, T> createDifferentFunction) {
+                                                         final Function<Random, T> createFunction,
+                                                         final BiFunction<Random, T, T> createDifferentFunction) {
         final Random random = new Random(randomSeed);
         final long dependentRandomSeed = random.nextLong();
         final T t1 = createFunction.apply(new Random(dependentRandomSeed));
@@ -282,65 +281,54 @@ class DataRecordsTest {
     // Per-type builders: each has a create(Random) and a create(Random, original) that guarantees a different value
     // ---------------------------------------------------------------------------------------------------------
 
-    @Nonnull
-    private static VectorId vectorId(@Nonnull final Random random) {
+    private static VectorId vectorId(final Random random) {
         return new VectorId(primaryKey(random), new UUID(random.nextLong(), random.nextLong()));
     }
 
-    @Nonnull
-    private static VectorId vectorId(@Nonnull final Random random, @Nonnull final VectorId original) {
+    private static VectorId vectorId(final Random random, final VectorId original) {
         return new VectorId(primaryKey(random, original.primaryKey()),
                 new UUID(differentLong(random, original.uuid().getMostSignificantBits()), random.nextLong()));
     }
 
-    @Nonnull
-    private static VectorReference primaryCopy(@Nonnull final Random random) {
+    private static VectorReference primaryCopy(final Random random) {
         return VectorReference.primaryCopy(vectorId(random), transformed(random),
                 random.nextBoolean(), random.nextBoolean());
     }
 
-    @Nonnull
-    private static VectorReference primaryCopy(@Nonnull final Random random, @Nonnull final VectorReference original) {
+    private static VectorReference primaryCopy(final Random random, final VectorReference original) {
         return VectorReference.primaryCopy(vectorId(random, original.id()), transformed(random, original.vector()),
                 !original.isUnderreplicated(), !original.isCollapsed());
     }
 
-    @Nonnull
-    private static VectorReference replicatedCopy(@Nonnull final Random random) {
+    private static VectorReference replicatedCopy(final Random random) {
         return VectorReference.replicatedCopy(vectorId(random), transformed(random),
                 random.nextDouble(), random.nextBoolean());
     }
 
-    @Nonnull
-    private static VectorReference replicatedCopy(@Nonnull final Random random, @Nonnull final VectorReference original) {
+    private static VectorReference replicatedCopy(final Random random, final VectorReference original) {
         return VectorReference.replicatedCopy(vectorId(random, original.id()), transformed(random, original.vector()),
                 differentDouble(random, original.replicationPriority()), !original.isCollapsed());
     }
 
-    @Nonnull
-    private static AccessInfo accessInfo(@Nonnull final Random random) {
+    private static AccessInfo accessInfo(final Random random) {
         return new AccessInfo(random.nextLong(), rawVector(random));
     }
 
-    @Nonnull
-    private static AccessInfo accessInfo(@Nonnull final Random random, @Nonnull final AccessInfo original) {
+    private static AccessInfo accessInfo(final Random random, final AccessInfo original) {
         return new AccessInfo(differentLong(random, original.rotatorSeed()),
                 differentRawVector(random, original.negatedCentroid()));
     }
 
-    @Nonnull
-    private static ClusterMetadata clusterMetadata(@Nonnull final Random random) {
+    private static ClusterMetadata clusterMetadata(final Random random) {
         return clusterMetadata(random, new UUID(random.nextLong(), random.nextLong()));
     }
 
-    @Nonnull
-    private static ClusterMetadata clusterMetadata(@Nonnull final Random random, @Nonnull final ClusterMetadata original) {
+    private static ClusterMetadata clusterMetadata(final Random random, final ClusterMetadata original) {
         return clusterMetadata(random,
                 new UUID(differentLong(random, original.id().getMostSignificantBits()), random.nextLong()));
     }
 
-    @Nonnull
-    private static ClusterMetadata clusterMetadata(@Nonnull final Random random, @Nonnull final UUID id) {
+    private static ClusterMetadata clusterMetadata(final Random random, final UUID id) {
         final int numPrimaryUnderreplicatedVectors = random.nextInt(4);
         final int numReplicatedVectors = random.nextInt(6);
         // The constructor requires numElements >= numPrimaryUnderreplicatedVectors, so seed at least that many.
@@ -353,32 +341,27 @@ class DataRecordsTest {
                 random.nextInt(8));
     }
 
-    @Nonnull
-    private static Cluster cluster(@Nonnull final Random random) {
+    private static Cluster cluster(final Random random) {
         return new Cluster(clusterMetadata(random), transformed(random), vectorReferences(random));
     }
 
-    @Nonnull
-    private static Cluster cluster(@Nonnull final Random random, @Nonnull final Cluster original) {
+    private static Cluster cluster(final Random random, final Cluster original) {
         return new Cluster(clusterMetadata(random, original.clusterMetadata()),
                 transformed(random, original.centroid()), vectorReferences(random));
     }
 
-    @Nonnull
-    private static ClusterReference clusterReference(@Nonnull final Random random) {
+    private static ClusterReference clusterReference(final Random random) {
         return new ClusterReference(new UUID(random.nextLong(), random.nextLong()), transformed(random));
     }
 
-    @Nonnull
-    private static ClusterReference clusterReference(@Nonnull final Random random,
-                                                    @Nonnull final ClusterReference original) {
+    private static ClusterReference clusterReference(final Random random,
+                                                    final ClusterReference original) {
         return new ClusterReference(
                 new UUID(differentLong(random, original.clusterId().getMostSignificantBits()), random.nextLong()),
                 transformed(random, original.centroid()));
     }
 
-    @Nonnull
-    private static List<VectorReference> vectorReferences(@Nonnull final Random random) {
+    private static List<VectorReference> vectorReferences(final Random random) {
         final ImmutableList.Builder<VectorReference> builder = ImmutableList.builder();
         final int size = random.nextInt(4);
         for (int i = 0; i < size; i++) {
@@ -387,13 +370,11 @@ class DataRecordsTest {
         return builder.build();
     }
 
-    @Nonnull
-    private static Tuple primaryKey(@Nonnull final Random random) {
+    private static Tuple primaryKey(final Random random) {
         return Tuple.from(random.nextInt(1000));
     }
 
-    @Nonnull
-    private static Tuple primaryKey(@Nonnull final Random random, @Nonnull final Tuple original) {
+    private static Tuple primaryKey(final Random random, final Tuple original) {
         final int originalKey = Math.toIntExact(original.getLong(0));
         int key;
         do {
@@ -402,24 +383,20 @@ class DataRecordsTest {
         return Tuple.from(key);
     }
 
-    @Nonnull
-    private static Transformed<RealVector> transformed(@Nonnull final Random random) {
+    private static Transformed<RealVector> transformed(final Random random) {
         return AffineOperator.identity().transform(rawVector(random));
     }
 
-    @Nonnull
-    private static Transformed<RealVector> transformed(@Nonnull final Random random,
-                                                       @Nonnull final Transformed<RealVector> original) {
+    private static Transformed<RealVector> transformed(final Random random,
+                                                       final Transformed<RealVector> original) {
         return AffineOperator.identity().transform(differentRawVector(random, original.getUnderlyingVector()));
     }
 
-    @Nonnull
-    private static RealVector rawVector(@Nonnull final Random random) {
+    private static RealVector rawVector(final Random random) {
         return RealVectorTest.createRandomDoubleVector(random, DIMENSIONS);
     }
 
-    @Nonnull
-    private static RealVector differentRawVector(@Nonnull final Random random, @Nonnull final RealVector original) {
+    private static RealVector differentRawVector(final Random random, final RealVector original) {
         RealVector randomVector;
         do {
             randomVector = RealVectorTest.createRandomDoubleVector(random, DIMENSIONS);
@@ -427,7 +404,7 @@ class DataRecordsTest {
         return randomVector;
     }
 
-    private static long differentLong(@Nonnull final Random random, final long original) {
+    private static long differentLong(final Random random, final long original) {
         long randomLong;
         do {
             randomLong = random.nextLong();
@@ -435,7 +412,7 @@ class DataRecordsTest {
         return randomLong;
     }
 
-    private static double differentDouble(@Nonnull final Random random, final double original) {
+    private static double differentDouble(final Random random, final double original) {
         double randomDouble;
         do {
             randomDouble = random.nextDouble();

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/guardiann/DeleteReplicationPersistenceTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/guardiann/DeleteReplicationPersistenceTest.java
@@ -86,6 +86,8 @@ public class DeleteReplicationPersistenceTest implements BaseTest {
     final TestSubspaceExtension subspaceExtension = new TestSubspaceExtension(dbExtension);
 
     @TempDir
+    // Injected by JUnit's TempDirectory extension before each test; NullAway cannot see framework injection.
+    @SuppressWarnings("NullAway")
     Path tempDir;
 
     private static Database db;
@@ -142,7 +144,11 @@ public class DeleteReplicationPersistenceTest implements BaseTest {
         // ---- Phase 1: insert near-duplicates; the oversized cluster splits into bordered sub-clusters. ----
         onWriteListener.pushFrame();
         for (final PrimaryKeyAndVector op : inserts) {
-            db.run(transaction -> {
+            // db.run(Function<Transaction, T>) has no void-returning overload, so this side-effect-only call
+            // returns null from the lambda; NullAway does not accept an explicit @Nullable type witness on this
+            // external, unannotated method either, so the suppression is scoped to this one declaration instead.
+            @SuppressWarnings("NullAway")
+            final Void ignored = db.run(transaction -> {
                 guardiann.insert(transaction, op.primaryKey(), op.vector(), null, true).join();
                 return null;
             });
@@ -170,7 +176,9 @@ public class DeleteReplicationPersistenceTest implements BaseTest {
         final List<PrimaryKeyAndVector> deletes = inserts.subList(0, NUM_DELETES);
         onWriteListener.pushFrame();
         for (final PrimaryKeyAndVector op : deletes) {
-            db.run(transaction -> {
+            // See the insert loop above for why this suppression is needed.
+            @SuppressWarnings("NullAway")
+            final Void ignored = db.run(transaction -> {
                 guardiann.delete(transaction, op.primaryKey(), op.vector(), true).join();
                 return null;
             });

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/guardiann/DeleteReplicationPersistenceTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/guardiann/DeleteReplicationPersistenceTest.java
@@ -41,7 +41,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -91,19 +90,16 @@ public class DeleteReplicationPersistenceTest implements BaseTest {
 
     private static Database db;
 
-    @Nonnull
     @Override
     public Database getDb() {
         return Objects.requireNonNull(db);
     }
 
-    @Nonnull
     @Override
     public Subspace getSubspace() {
         return subspaceExtension.getSubspace();
     }
 
-    @Nonnull
     @Override
     public Path getTempDir() {
         return tempDir;
@@ -114,7 +110,6 @@ public class DeleteReplicationPersistenceTest implements BaseTest {
         db = dbExtension.getDatabase();
     }
 
-    @Nonnull
     private static Stream<Long> seeds() {
         return RandomizedTestUtils.randomSeeds(0xC0FFEEL, 0xDEADBEEFL, 0x5EED1234L);
     }
@@ -208,7 +203,6 @@ public class DeleteReplicationPersistenceTest implements BaseTest {
         GuardiannStructureAsserts.assertGuardiannInvariantsAfterDeletes(db, guardiann);
     }
 
-    @Nonnull
     private List<PrimaryKeyAndVector> buildInserts(final long seed) throws Exception {
         final List<PrimaryKeyAndVector> baseLoaded =
                 VecsDatasetLoaders.loadVectors(SiftTestHelpers.SIFT_SMALL_BASE_PATH, 1);

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/guardiann/DeterministicReplayTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/guardiann/DeterministicReplayTest.java
@@ -47,7 +47,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -117,19 +116,16 @@ public class DeterministicReplayTest implements BaseTest {
 
     private static Database db;
 
-    @Nonnull
     @Override
     public Database getDb() {
         return Objects.requireNonNull(db);
     }
 
-    @Nonnull
     @Override
     public Subspace getSubspace() {
         return subspaceExtension.getSubspace();
     }
 
-    @Nonnull
     @Override
     public Path getTempDir() {
         return tempDir;
@@ -140,7 +136,6 @@ public class DeterministicReplayTest implements BaseTest {
         db = dbExtension.getDatabase();
     }
 
-    @Nonnull
     private static Stream<Long> seeds() {
         return RandomizedTestUtils.randomSeeds(0xC0FFEEL, 0xDEADBEEFL, 0x5EED1234L);
     }
@@ -209,10 +204,9 @@ public class DeterministicReplayTest implements BaseTest {
      *
      * @return the captures taken after the insert phase and after the delete phase
      */
-    @Nonnull
-    private RunResult replay(@Nonnull final String runName,
-                             @Nonnull final List<PrimaryKeyAndVector> inserts,
-                             @Nonnull final List<PrimaryKeyAndVector> deletes) {
+    private RunResult replay(final String runName,
+                             final List<PrimaryKeyAndVector> inserts,
+                             final List<PrimaryKeyAndVector> deletes) {
         final Subspace runSubspace = getSubspace().subspace(Tuple.from(runName));
         final Config config = Guardiann.newConfigBuilder()
                 .setUseRaBitQ(true)
@@ -263,16 +257,15 @@ public class DeterministicReplayTest implements BaseTest {
     }
 
     /** Snapshots the cluster topology and dumps the raw stored state for the run's subspace. */
-    @Nonnull
-    private Capture capture(@Nonnull final Guardiann guardiann, @Nonnull final Subspace runSubspace) {
+    private Capture capture(final Guardiann guardiann, final Subspace runSubspace) {
         final StructureSnapshot snapshot = GuardiannStructureAsserts.snapshotStructure(db, guardiann);
         Verify.verifyNotNull(snapshot, "structure must be non-empty");
         return new Capture(snapshot.numClusters(), snapshot.totalPrimaries(), snapshot.totalReplicas(),
                 snapshot.totalCollapsedRefs(), clusterFingerprint(snapshot), dump(runSubspace));
     }
 
-    private static void logComparison(final long seed, @Nonnull final String phase,
-                                      @Nonnull final Capture a, @Nonnull final Capture b) {
+    private static void logComparison(final long seed, final String phase,
+                                      final Capture a, final Capture b) {
         logger.info("seed={} {}: comparing run-a/run-b — clusters={}/{}, primaries={}/{}, replicas={}/{}, "
                         + "collapsed={}/{}, storedKeys={}/{}",
                 String.format("%#x", seed), phase,
@@ -288,8 +281,7 @@ public class DeterministicReplayTest implements BaseTest {
      * integer vector counts, its states, and the sorted ids of its primary / replica / collapsed members. The
      * centroid and running statistics (both floating point) are intentionally excluded so the comparison is exact.
      */
-    @Nonnull
-    private static Map<UUID, String> clusterFingerprint(@Nonnull final StructureSnapshot snapshot) {
+    private static Map<UUID, String> clusterFingerprint(final StructureSnapshot snapshot) {
         final Map<UUID, String> fingerprint = new TreeMap<>();
         for (final ClusterView cv : snapshot.clusters().values()) {
             final ClusterMetadata metadata = cv.metadata();
@@ -305,8 +297,7 @@ public class DeterministicReplayTest implements BaseTest {
         return fingerprint;
     }
 
-    @Nonnull
-    private static String sortedIds(@Nonnull final Set<VectorId> ids) {
+    private static String sortedIds(final Set<VectorId> ids) {
         return ids.stream().map(VectorId::toString).sorted().collect(Collectors.joining(","));
     }
 
@@ -314,8 +305,7 @@ public class DeterministicReplayTest implements BaseTest {
      * Dumps every key/value stored under the run's subspace, keyed by the printable subspace-relative key (the
      * subspace prefix is stripped so the two runs' dumps are directly comparable).
      */
-    @Nonnull
-    private Map<String, String> dump(@Nonnull final Subspace runSubspace) {
+    private Map<String, String> dump(final Subspace runSubspace) {
         final byte[] prefix = runSubspace.pack();
         return db.run(transaction -> {
             final List<KeyValue> keyValues =
@@ -334,7 +324,6 @@ public class DeterministicReplayTest implements BaseTest {
      * Generates the insert workload from the seed: {@link #NUM_INSERTS} vectors, each a Gaussian perturbation of one
      * of {@link #NUM_BASES} distinct SIFT base vectors chosen by the seeded random.
      */
-    @Nonnull
     private List<PrimaryKeyAndVector> buildInserts(final long seed) throws Exception {
         final List<PrimaryKeyAndVector> baseLoaded =
                 VecsDatasetLoaders.loadVectors(SiftTestHelpers.SIFT_SMALL_BASE_PATH, NUM_BASES);
@@ -361,12 +350,12 @@ public class DeterministicReplayTest implements BaseTest {
                            int totalPrimaries,
                            int totalReplicas,
                            int totalCollapsedRefs,
-                           @Nonnull Map<UUID, String> clusterFingerprint,
-                           @Nonnull Map<String, String> dump) {
+                           Map<UUID, String> clusterFingerprint,
+                           Map<String, String> dump) {
     }
 
     /** The two captures taken during one replay: right after the inserts drain, and after the deletes drain. */
-    private record RunResult(@Nonnull Capture afterInsert,
-                             @Nonnull Capture afterDelete) {
+    private record RunResult(Capture afterInsert,
+                             Capture afterDelete) {
     }
 }

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/guardiann/DeterministicReplayTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/guardiann/DeterministicReplayTest.java
@@ -112,6 +112,8 @@ public class DeterministicReplayTest implements BaseTest {
     final TestSubspaceExtension subspaceExtension = new TestSubspaceExtension(dbExtension);
 
     @TempDir
+    // Injected by JUnit's TempDirectory extension before each test; NullAway cannot see framework injection.
+    @SuppressWarnings("NullAway")
     Path tempDir;
 
     private static Database db;
@@ -229,7 +231,11 @@ public class DeterministicReplayTest implements BaseTest {
 
         onWriteListener.pushFrame();
         for (final PrimaryKeyAndVector op : inserts) {
-            db.run(transaction -> {
+            // db.run(Function<Transaction, T>) has no void-returning overload, so this side-effect-only call
+            // returns null from the lambda; NullAway does not accept an explicit @Nullable type witness on this
+            // external, unannotated method either, so the suppression is scoped to this one declaration instead.
+            @SuppressWarnings("NullAway")
+            final Void ignored = db.run(transaction -> {
                 guardiann.insert(transaction, op.primaryKey(), op.vector(), null, true).join();
                 return null;
             });
@@ -242,7 +248,9 @@ public class DeterministicReplayTest implements BaseTest {
 
         onWriteListener.pushFrame();
         for (final PrimaryKeyAndVector op : deletes) {
-            db.run(transaction -> {
+            // See the insert loop above for why this suppression is needed.
+            @SuppressWarnings("NullAway")
+            final Void ignored = db.run(transaction -> {
                 guardiann.delete(transaction, op.primaryKey(), op.vector(), true).join();
                 return null;
             });

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/guardiann/MergeScenarioTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/guardiann/MergeScenarioTest.java
@@ -40,7 +40,6 @@ import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -97,19 +96,16 @@ public class MergeScenarioTest implements BaseTest {
     private static Guardiann guardiann;
     private static TestHelpers.TestOnWriteListener onWriteListener;
 
-    @Nonnull
     @Override
     public Database getDb() {
         return Objects.requireNonNull(db);
     }
 
-    @Nonnull
     @Override
     public Subspace getSubspace() {
         return subspaceExtension.getSubspace();
     }
 
-    @Nonnull
     @Override
     public Path getTempDir() {
         return tempDir;
@@ -207,7 +203,7 @@ public class MergeScenarioTest implements BaseTest {
                 .isEqualTo(REMAINING_AFTER_DELETE);
     }
 
-    private void deleteRecords(@Nonnull final List<PrimaryKeyAndVector> records) throws Exception {
+    private void deleteRecords(final List<PrimaryKeyAndVector> records) throws Exception {
         TestHelpers.deleteToCompletion(getDb(), guardiann, records);
     }
 }

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/guardiann/MergeScenarioTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/guardiann/MergeScenarioTest.java
@@ -90,6 +90,8 @@ public class MergeScenarioTest implements BaseTest {
     static final TestClassSubspaceExtension subspaceExtension = new TestClassSubspaceExtension(dbExtension);
 
     @TempDir
+    // Injected by JUnit's TempDirectory extension before each test; NullAway cannot see framework injection.
+    @SuppressWarnings("NullAway")
     Path tempDir;
 
     private static Database db;
@@ -153,7 +155,11 @@ public class MergeScenarioTest implements BaseTest {
         for (int i = 0; i < NUM_NEAR_DUPLICATES; i++) {
             final DoubleRealVector perturbed = CommonTestHelpers.perturb(base, sampler, PERTURBATION_SIGMA);
             final Tuple pk = CommonTestHelpers.createPrimaryKey(i);
-            db.run(tr -> {
+            // db.run(Function<Transaction, T>) has no void-returning overload, so this side-effect-only call
+            // returns null from the lambda; NullAway does not accept an explicit @Nullable type witness on this
+            // external, unannotated method either, so the suppression is scoped to this one declaration instead.
+            @SuppressWarnings("NullAway")
+            final Void ignored = db.run(tr -> {
                 guardiann.insert(tr, pk, perturbed, null, true).join();
                 return null;
             });
@@ -161,7 +167,7 @@ public class MergeScenarioTest implements BaseTest {
         }
         GuardiannStructureAsserts.runToQuiescence(db, guardiann);
 
-        final StructureSnapshot afterInsert = GuardiannStructureAsserts.snapshotStructure(db, guardiann);
+        final StructureSnapshot afterInsert = Objects.requireNonNull(GuardiannStructureAsserts.snapshotStructure(db, guardiann));
         assertThat(afterInsert)
                 .as("structure snapshot must be non-null after inserts")
                 .isNotNull();
@@ -194,7 +200,7 @@ public class MergeScenarioTest implements BaseTest {
         // Deletes can leave dangling replicas, so use the after-deletes invariant variant.
         GuardiannStructureAsserts.assertGuardiannInvariantsAfterDeletes(db, guardiann);
 
-        final StructureSnapshot afterDelete = GuardiannStructureAsserts.snapshotStructure(db, guardiann);
+        final StructureSnapshot afterDelete = Objects.requireNonNull(GuardiannStructureAsserts.snapshotStructure(db, guardiann));
         assertThat(afterDelete)
                 .as("structure snapshot must be non-null after deletes")
                 .isNotNull();

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/guardiann/ReassignConvergenceTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/guardiann/ReassignConvergenceTest.java
@@ -87,6 +87,8 @@ public class ReassignConvergenceTest implements BaseTest {
     final TestSubspaceExtension subspaceExtension = new TestSubspaceExtension(dbExtension);
 
     @TempDir
+    // Injected by JUnit's TempDirectory extension before each test; NullAway cannot see framework injection.
+    @SuppressWarnings("NullAway")
     Path tempDir;
 
     private static Database db;
@@ -213,7 +215,11 @@ public class ReassignConvergenceTest implements BaseTest {
         final Primitives primitives = locator.primitives();
         final int numNearestClusters = 1 + guardiann.getConfig().reassignNumNeighboringClusters();
 
-        getDb().run(transaction -> {
+        // db.run(Function<Transaction, T>) has no void-returning overload, so this side-effect-only call
+        // returns null from the lambda; NullAway does not accept an explicit @Nullable type witness on this
+        // external, unannotated method either, so the suppression is scoped to this one declaration instead.
+        @SuppressWarnings("NullAway")
+        final Void ignored = getDb().run(transaction -> {
             final AccessInfo accessInfo = primitives.fetchAccessInfo(transaction).join();
             final ClusterMetadata clusterMetadata = primitives.fetchClusterMetadata(transaction, clusterId).join();
             if (clusterMetadata == null) {

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/guardiann/ReassignConvergenceTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/guardiann/ReassignConvergenceTest.java
@@ -43,7 +43,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -92,19 +91,16 @@ public class ReassignConvergenceTest implements BaseTest {
 
     private static Database db;
 
-    @Nonnull
     @Override
     public Database getDb() {
         return Objects.requireNonNull(db);
     }
 
-    @Nonnull
     @Override
     public Subspace getSubspace() {
         return subspaceExtension.getSubspace();
     }
 
-    @Nonnull
     @Override
     public Path getTempDir() {
         return tempDir;
@@ -134,8 +130,8 @@ public class ReassignConvergenceTest implements BaseTest {
      * Shared convergence flow: insert {@code sample} and run to quiescence, then drive two reassign rounds and
      * assert the wrong-assignment count drops after round 1 and the under-replication count drops after round 2.
      */
-    private void runConvergence(final long seed, @Nonnull final Guardiann guardiann,
-                                @Nonnull final List<PrimaryKeyAndVector> sample) throws Exception {
+    private void runConvergence(final long seed, final Guardiann guardiann,
+                                final List<PrimaryKeyAndVector> sample) throws Exception {
         // ---- Phase 0: insert the sample; let everything (including auto-enqueued reassigns) run. ----
         logger.info("seed={} inserting {} vectors", seed, sample.size());
         TestHelpers.insertRecords(getDb(), guardiann, sample, BATCH_SIZE);
@@ -191,7 +187,7 @@ public class ReassignConvergenceTest implements BaseTest {
      * calling {@link ReassignTask#reassign} directly with {@code enqueueFollowUpTasks=false} (so no follow-up
      * tasks are enqueued). Logs progress so a long run is visibly advancing.
      */
-    private void reassignEveryClusterOnce(@Nonnull final Guardiann guardiann, @Nonnull final String roundName) {
+    private void reassignEveryClusterOnce(final Guardiann guardiann, final String roundName) {
         final StructureSnapshot snapshot = GuardiannStructureAsserts.snapshotStructure(getDb(), guardiann);
         if (snapshot == null) {
             return;
@@ -210,9 +206,9 @@ public class ReassignConvergenceTest implements BaseTest {
     }
 
     /** Reassigns a single cluster in its own transaction; builds the {@link ReassignTask} in memory. */
-    private void reassignOneCluster(@Nonnull final Guardiann guardiann,
-                                    @Nonnull final UUID clusterId,
-                                    @Nonnull final Transformed<RealVector> centroid) {
+    private void reassignOneCluster(final Guardiann guardiann,
+                                    final UUID clusterId,
+                                    final Transformed<RealVector> centroid) {
         final Locator locator = guardiann.getLocator();
         final Primitives primitives = locator.primitives();
         final int numNearestClusters = 1 + guardiann.getConfig().reassignNumNeighboringClusters();
@@ -247,7 +243,6 @@ public class ReassignConvergenceTest implements BaseTest {
     // ---------------------------------------------------------------------------------------------------------
 
     /** A deterministic, seed-shuffled subsample of the SIFT-small base set (uses the always-present 10k file). */
-    @Nonnull
     private static List<PrimaryKeyAndVector> seededSample(final long seed, final int size) throws Exception {
         final List<PrimaryKeyAndVector> all =
                 new ArrayList<>(VecsDatasetLoaders.loadVectors(SiftTestHelpers.SIFT_SMALL_BASE_PATH, 10_000));
@@ -260,7 +255,6 @@ public class ReassignConvergenceTest implements BaseTest {
      * {@code ReassignScenarioTest}) so the post-insert structure is rich in mis-homed and under-replicated
      * primaries for the rounds to converge.
      */
-    @Nonnull
     private Guardiann newGuardiannSmall() {
         return guardiannFor(Guardiann.newConfigBuilder()
                 .setUseRaBitQ(true)
@@ -286,7 +280,6 @@ public class ReassignConvergenceTest implements BaseTest {
      * the replica capacity ({@code replicatedClusterTarget}) stays proportionally small (~1/10 of the primary cap,
      * the library default) so under-replication still arises for the rounds to converge.
      */
-    @Nonnull
     private Guardiann newGuardiannBig() {
         return guardiannFor(Guardiann.newConfigBuilder()
                 .setUseRaBitQ(true)
@@ -302,8 +295,7 @@ public class ReassignConvergenceTest implements BaseTest {
                 .build(128));
     }
 
-    @Nonnull
-    private Guardiann guardiannFor(@Nonnull final Config config) {
+    private Guardiann guardiannFor(final Config config) {
         return new Guardiann(getSubspace(),
                 TestExecutors.defaultThreadPool(),
                 config,

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/guardiann/ReassignScenarioTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/guardiann/ReassignScenarioTest.java
@@ -115,6 +115,8 @@ public class ReassignScenarioTest implements BaseTest {
     static final TestClassSubspaceExtension subspaceExtension = new TestClassSubspaceExtension(dbExtension);
 
     @TempDir
+    // Injected by JUnit's TempDirectory extension before each test; NullAway cannot see framework injection.
+    @SuppressWarnings("NullAway")
     Path tempDir;
 
     private static Database db;
@@ -175,7 +177,11 @@ public class ReassignScenarioTest implements BaseTest {
         final List<PrimaryKeyAndVector> warmup =
                 VecsDatasetLoaders.loadVectors(SiftTestHelpers.SIFT_SMALL_BASE_PATH, NUM_WARMUP_INSERTS);
         for (final PrimaryKeyAndVector record : warmup) {
-            db.run(tr -> {
+            // db.run(Function<Transaction, T>) has no void-returning overload, so this side-effect-only call
+            // returns null from the lambda; NullAway does not accept an explicit @Nullable type witness on this
+            // external, unannotated method either, so the suppression is scoped to this one declaration instead.
+            @SuppressWarnings("NullAway")
+            final Void ignored = db.run(tr -> {
                 guardiann.insert(tr, record.primaryKey(), record.vector(), null, true).join();
                 return null;
             });
@@ -194,7 +200,9 @@ public class ReassignScenarioTest implements BaseTest {
         // accumulated on the outer (absent) frame and don't pollute this count.
         onWriteListener.pushFrame();
         try {
-            db.run(tr -> {
+            // See the warmup loop above for why this suppression is needed.
+            @SuppressWarnings("NullAway")
+            final Void ignored2 = db.run(tr -> {
                 final Primitives primitives = guardiann.getLocator().primitives();
                 final AccessInfo accessInfo =
                         Objects.requireNonNull(primitives.fetchAccessInfo(tr).join(),
@@ -275,7 +283,7 @@ public class ReassignScenarioTest implements BaseTest {
 
             GuardiannStructureAsserts.assertGuardiannInvariants(db, guardiann);
 
-            final StructureSnapshot snap = GuardiannStructureAsserts.snapshotStructure(db, guardiann);
+            final StructureSnapshot snap = Objects.requireNonNull(GuardiannStructureAsserts.snapshotStructure(db, guardiann));
             assertThat(snap)
                     .as("structure snapshot must be non-null after warmup + injection")
                     .isNotNull();

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/guardiann/ReassignScenarioTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/guardiann/ReassignScenarioTest.java
@@ -44,7 +44,6 @@ import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -122,19 +121,16 @@ public class ReassignScenarioTest implements BaseTest {
     private static Guardiann guardiann;
     private static TestHelpers.TestOnWriteListener onWriteListener;
 
-    @Nonnull
     @Override
     public Database getDb() {
         return Objects.requireNonNull(db);
     }
 
-    @Nonnull
     @Override
     public Subspace getSubspace() {
         return subspaceExtension.getSubspace();
     }
 
-    @Nonnull
     @Override
     public Path getTempDir() {
         return tempDir;

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/guardiann/SiftTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/guardiann/SiftTest.java
@@ -141,6 +141,8 @@ public class SiftTest implements BaseTest {
     final TestSubspaceExtension subspaceExtension = new TestSubspaceExtension(dbExtension);
 
     @TempDir
+    // Injected by JUnit's TempDirectory extension before each test; NullAway cannot see framework injection.
+    @SuppressWarnings("NullAway")
     Path tempDir;
 
     private static Database db;
@@ -360,7 +362,7 @@ public class SiftTest implements BaseTest {
         GuardiannStructureAsserts.assertGuardiannInvariantsAfterDeletes(getDb(), guardiann);
 
         // ---- only setB remains ----
-        final StructureSnapshot snap = GuardiannStructureAsserts.snapshotStructure(getDb(), guardiann);
+        final StructureSnapshot snap = Objects.requireNonNull(GuardiannStructureAsserts.snapshotStructure(getDb(), guardiann));
         assertThat(snap)
                 .as("structure snapshot must be non-null after the run")
                 .isNotNull();

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/guardiann/SiftTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/guardiann/SiftTest.java
@@ -47,7 +47,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayDeque;
@@ -146,19 +145,16 @@ public class SiftTest implements BaseTest {
 
     private static Database db;
 
-    @Nonnull
     @Override
     public Database getDb() {
         return Objects.requireNonNull(db);
     }
 
-    @Nonnull
     @Override
     public Subspace getSubspace() {
         return subspaceExtension.getSubspace();
     }
 
-    @Nonnull
     @Override
     public Path getTempDir() {
         return tempDir;
@@ -396,8 +392,8 @@ public class SiftTest implements BaseTest {
      * driving clusters below {@code primaryClusterMin} and exercising the merge (2&rarr;1) path.
      */
     private void runInsertThenDeleteAll(final long seed,
-                                        @Nonnull final List<PrimaryKeyAndVector> startup,
-                                        @Nonnull final List<DoubleRealVector> queries) throws Exception {
+                                        final List<PrimaryKeyAndVector> startup,
+                                        final List<DoubleRealVector> queries) throws Exception {
         final Guardiann guardiann = newGuardiann();
         logger.info("phase1: inserting startup sample ({} records) ...", startup.size());
         insertAndQuiesce(guardiann, startup);
@@ -461,7 +457,6 @@ public class SiftTest implements BaseTest {
     // Helpers
     // ---------------------------------------------------------------------------------------------------------
 
-    @Nonnull
     private Guardiann newGuardiann() {
         return new Guardiann(getSubspace(),
                 TestExecutors.defaultThreadPool(),
@@ -471,15 +466,14 @@ public class SiftTest implements BaseTest {
     }
 
     /** Insert all of {@code dataset} in batches, then drain deferred tasks to quiescence. */
-    private void insertAndQuiesce(@Nonnull final Guardiann guardiann,
-                                  @Nonnull final List<PrimaryKeyAndVector> dataset) throws Exception {
+    private void insertAndQuiesce(final Guardiann guardiann,
+                                  final List<PrimaryKeyAndVector> dataset) throws Exception {
         TestHelpers.insertRecords(getDb(), guardiann, dataset, BATCH_SIZE);
         GuardiannStructureAsserts.runToQuiescence(getDb(), guardiann);
     }
 
     /** A mutable {@code primaryKey -> vector} map over {@code records}, mirroring what is live in the index. */
-    @Nonnull
-    private static Map<Tuple, RealVector> activeMapOf(@Nonnull final List<PrimaryKeyAndVector> records) {
+    private static Map<Tuple, RealVector> activeMapOf(final List<PrimaryKeyAndVector> records) {
         final Map<Tuple, RealVector> active = new HashMap<>(records.size());
         for (final PrimaryKeyAndVector r : records) {
             active.put(r.primaryKey(), r.vector());
@@ -487,7 +481,6 @@ public class SiftTest implements BaseTest {
         return active;
     }
 
-    @Nonnull
     private static Config buildConfig() {
         return Guardiann.newConfigBuilder()
                 .setUseRaBitQ(true)
@@ -505,14 +498,13 @@ public class SiftTest implements BaseTest {
                 .build(128);
     }
 
-    @Nonnull
-    private static List<DoubleRealVector> loadQueries(@Nonnull final String queryPath) throws IOException {
+    private static List<DoubleRealVector> loadQueries(final String queryPath) throws IOException {
         final List<DoubleRealVector> all = VecsDatasetLoaders.loadQueryVectors(queryPath);
         return List.copyOf(all.subList(0, Math.min(RECALL_NUM_QUERIES, all.size())));
     }
 
-    private static void verifyDisjoint(@Nonnull final List<PrimaryKeyAndVector> a,
-                                       @Nonnull final List<PrimaryKeyAndVector> b) {
+    private static void verifyDisjoint(final List<PrimaryKeyAndVector> a,
+                                       final List<PrimaryKeyAndVector> b) {
         final Set<Tuple> pksA = a.stream()
                 .map(PrimaryKeyAndVector::primaryKey)
                 .collect(ImmutableSet.toImmutableSet());
@@ -527,9 +519,8 @@ public class SiftTest implements BaseTest {
      * Returns a freshly shuffled copy of {@code records}, using {@code rng} to drive an in-place Fisher–Yates
      * shuffle of the copy. The input list is left untouched.
      */
-    @Nonnull
-    private static List<PrimaryKeyAndVector> shuffledCopy(@Nonnull final List<PrimaryKeyAndVector> records,
-                                                          @Nonnull final SplittableRandom rng) {
+    private static List<PrimaryKeyAndVector> shuffledCopy(final List<PrimaryKeyAndVector> records,
+                                                          final SplittableRandom rng) {
         final List<PrimaryKeyAndVector> copy = new ArrayList<>(records);
         for (int i = copy.size() - 1; i > 0; i--) {
             final int j = rng.nextInt(i + 1);
@@ -544,8 +535,7 @@ public class SiftTest implements BaseTest {
      * Removes up to {@code batchSize} records from the front of {@code queue} and returns them. The final batch
      * from each queue may be smaller than {@code batchSize}; all earlier batches are exactly {@code batchSize}.
      */
-    @Nonnull
-    private static List<PrimaryKeyAndVector> takeUpTo(@Nonnull final Deque<PrimaryKeyAndVector> queue,
+    private static List<PrimaryKeyAndVector> takeUpTo(final Deque<PrimaryKeyAndVector> queue,
                                                       final int batchSize) {
         final int n = Math.min(batchSize, queue.size());
         final List<PrimaryKeyAndVector> batch = new ArrayList<>(n);
@@ -556,17 +546,17 @@ public class SiftTest implements BaseTest {
     }
 
     /** Delete a single batch (one transaction modulo the bail-out retry) of pre-selected records. */
-    private void deleteOneBatch(@Nonnull final Guardiann guardiann,
-                                @Nonnull final List<PrimaryKeyAndVector> batch) throws Exception {
+    private void deleteOneBatch(final Guardiann guardiann,
+                                final List<PrimaryKeyAndVector> batch) throws Exception {
         TestHelpers.deleteToCompletion(getDb(), guardiann, batch);
     }
 
-    static void scanCentroids(@Nonnull final Database db,
-                              @Nonnull final Subspace subspace,
-                              @Nonnull final com.apple.foundationdb.async.hnsw.Config config,
+    static void scanCentroids(final Database db,
+                              final Subspace subspace,
+                              final com.apple.foundationdb.async.hnsw.Config config,
                               final int layer,
                               final int batchSize,
-                              @Nonnull final Consumer<ResultEntry> consumer) {
+                              final Consumer<ResultEntry> consumer) {
         HNSW.scanLayer(config, subspace, db, layer, batchSize, consumer);
     }
 }

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/guardiann/SplitMergeSplitScenarioTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/guardiann/SplitMergeSplitScenarioTest.java
@@ -40,7 +40,6 @@ import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -85,19 +84,16 @@ public class SplitMergeSplitScenarioTest implements BaseTest {
     private static Guardiann guardiann;
     private static TestHelpers.TestOnWriteListener onWriteListener;
 
-    @Nonnull
     @Override
     public Database getDb() {
         return Objects.requireNonNull(db);
     }
 
-    @Nonnull
     @Override
     public Subspace getSubspace() {
         return subspaceExtension.getSubspace();
     }
 
-    @Nonnull
     @Override
     public Path getTempDir() {
         return tempDir;

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/guardiann/SplitMergeSplitScenarioTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/guardiann/SplitMergeSplitScenarioTest.java
@@ -78,6 +78,8 @@ public class SplitMergeSplitScenarioTest implements BaseTest {
     static final TestClassSubspaceExtension subspaceExtension = new TestClassSubspaceExtension(dbExtension);
 
     @TempDir
+    // Injected by JUnit's TempDirectory extension before each test; NullAway cannot see framework injection.
+    @SuppressWarnings("NullAway")
     Path tempDir;
 
     private static Database db;
@@ -146,7 +148,12 @@ public class SplitMergeSplitScenarioTest implements BaseTest {
             for (int i = 0; i < NUM_NEAR_DUPLICATES; i++) {
                 final DoubleRealVector perturbed = CommonTestHelpers.perturb(base, sampler, PERTURBATION_SIGMA);
                 final Tuple pk = CommonTestHelpers.createPrimaryKey(i);
-                db.run(tr -> {
+                // db.run(Function<Transaction, T>) has no void-returning overload, so this side-effect-only call
+                // returns null from the lambda; NullAway does not accept an explicit @Nullable type witness on
+                // this external, unannotated method either, so the suppression is scoped to this one declaration
+                // instead.
+                @SuppressWarnings("NullAway")
+                final Void ignored = db.run(tr -> {
                     guardiann.insert(tr, pk, perturbed, null, true).join();
                     return null;
                 });
@@ -165,7 +172,7 @@ public class SplitMergeSplitScenarioTest implements BaseTest {
 
             GuardiannStructureAsserts.assertGuardiannInvariants(db, guardiann);
 
-            final StructureSnapshot snap = GuardiannStructureAsserts.snapshotStructure(db, guardiann);
+            final StructureSnapshot snap = Objects.requireNonNull(GuardiannStructureAsserts.snapshotStructure(db, guardiann));
             assertThat(snap)
                     .as("structure snapshot must be non-null after inserts")
                     .isNotNull();

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/guardiann/TestHelpers.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/guardiann/TestHelpers.java
@@ -37,8 +37,7 @@ import com.google.common.collect.Maps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
 import java.nio.file.Path;
@@ -91,12 +90,11 @@ class TestHelpers {
      */
     private static final int MAX_ORDERED_BY_DISTANCE_INDEX_SIZE = 25_000;
 
-    @Nonnull
-    static List<PrimaryKeyAndVector> basicInsertBatch(@Nonnull final Database db,
-                                                      @Nonnull final Guardiann guardiann,
+    static List<PrimaryKeyAndVector> basicInsertBatch(final Database db,
+                                                      final Guardiann guardiann,
                                                       final int batchSize,
                                                       final long firstId,
-                                                      @Nonnull final BiFunction<Transaction, Long, PrimaryKeyAndVector> insertFunction)
+                                                      final BiFunction<Transaction, Long, PrimaryKeyAndVector> insertFunction)
             throws ExecutionException, InterruptedException, TimeoutException {
 
         return db.runAsync(tr -> {
@@ -152,10 +150,9 @@ class TestHelpers {
      * advancing past those records on the next call. This mirrors the contract of
      * {@link #basicInsertBatch}.
      */
-    @Nonnull
-    static List<PrimaryKeyAndVector> basicDeleteBatch(@Nonnull final Database db,
-                                                      @Nonnull final Guardiann guardiann,
-                                                      @Nonnull final List<PrimaryKeyAndVector> recordsToDelete)
+    static List<PrimaryKeyAndVector> basicDeleteBatch(final Database db,
+                                                      final Guardiann guardiann,
+                                                      final List<PrimaryKeyAndVector> recordsToDelete)
             throws ExecutionException, InterruptedException, TimeoutException {
 
         final int batchSize = recordsToDelete.size();
@@ -204,9 +201,9 @@ class TestHelpers {
      * @param guardiann the structure to delete from
      * @param records the records to delete
      */
-    static void deleteToCompletion(@Nonnull final Database db,
-                                   @Nonnull final Guardiann guardiann,
-                                   @Nonnull final List<PrimaryKeyAndVector> records)
+    static void deleteToCompletion(final Database db,
+                                   final Guardiann guardiann,
+                                   final List<PrimaryKeyAndVector> records)
             throws ExecutionException, InterruptedException, TimeoutException {
         final List<PrimaryKeyAndVector> remaining = new ArrayList<>(records);
         while (!remaining.isEmpty()) {
@@ -223,7 +220,7 @@ class TestHelpers {
      *
      * @return the total number of under-replicated primaries across all clusters
      */
-    static int countUnderReplicatedPrimaries(@Nonnull final StructureSnapshot snapshot) {
+    static int countUnderReplicatedPrimaries(final StructureSnapshot snapshot) {
         return snapshot.clusters().values().stream()
                 .mapToInt(cv -> cv.metadata().numPrimaryUnderreplicatedVectors())
                 .sum();
@@ -236,7 +233,7 @@ class TestHelpers {
      * @param a first sample
      * @param b second sample, disjoint from {@code a}
      */
-    record Samples(@Nonnull List<PrimaryKeyAndVector> a, @Nonnull List<PrimaryKeyAndVector> b) {
+    record Samples(List<PrimaryKeyAndVector> a, List<PrimaryKeyAndVector> b) {
     }
 
     /**
@@ -256,8 +253,7 @@ class TestHelpers {
      * @param sizeB size of the second sample
      * @return a {@link Samples} pair
      */
-    @Nonnull
-    static Samples loadDisjointSamples(@Nonnull final String baseFile, final long seed, final int sizeA, final int sizeB) throws IOException {
+    static Samples loadDisjointSamples(final String baseFile, final long seed, final int sizeA, final int sizeB) throws IOException {
         Verify.verify(sizeA > 0 && sizeB > 0, "sample sizes must be positive (sizeA=%s, sizeB=%s)", sizeA, sizeB);
         final List<PrimaryKeyAndVector> sampled = reservoirSample(baseFile, seed, sizeA + sizeB);
         return new Samples(
@@ -277,8 +273,7 @@ class TestHelpers {
      *
      * @return the sampled records
      */
-    @Nonnull
-    static List<PrimaryKeyAndVector> loadSample(@Nonnull final String baseFile, final long seed, final int size) throws IOException {
+    static List<PrimaryKeyAndVector> loadSample(final String baseFile, final long seed, final int size) throws IOException {
         Verify.verify(size > 0, "sample size must be positive (size=%s)", size);
         return ImmutableList.copyOf(reservoirSample(baseFile, seed, size));
     }
@@ -289,8 +284,7 @@ class TestHelpers {
      * {@code totalSize * 1KB} regardless of source-file size. Each record's primary key is its original index in
      * the stream, so any two disjoint slices of the result are collision-free by construction.
      */
-    @Nonnull
-    private static List<PrimaryKeyAndVector> reservoirSample(@Nonnull final String baseFile, final long seed, final int totalSize) throws IOException {
+    private static List<PrimaryKeyAndVector> reservoirSample(final String baseFile, final long seed, final int totalSize) throws IOException {
         // Two parallel arrays so we don't pay an Object[] indirection per slot.
         final long[] reservoirIndices = new long[totalSize];
         final DoubleRealVector[] reservoirVectors = new DoubleRealVector[totalSize];
@@ -348,9 +342,9 @@ class TestHelpers {
      * @param records the records to insert, in order
      * @param batchSize the number of records per insert transaction
      */
-    static void insertRecords(@Nonnull final Database db,
-                              @Nonnull final Guardiann guardiann,
-                              @Nonnull final List<PrimaryKeyAndVector> records,
+    static void insertRecords(final Database db,
+                              final Guardiann guardiann,
+                              final List<PrimaryKeyAndVector> records,
                               final int batchSize) throws Exception {
         for (int i = 0; i < records.size(); i += batchSize) {
             final int end = Math.min(i + batchSize, records.size());
@@ -364,9 +358,9 @@ class TestHelpers {
      * mid-transaction, until the whole batch is inserted. {@code firstGlobalIndex} is only the index base handed to
      * {@code basicInsertBatch}; the batch records carry their own primary keys.
      */
-    private static void insertBatchWithRetry(@Nonnull final Database db,
-                                             @Nonnull final Guardiann guardiann,
-                                             @Nonnull final List<PrimaryKeyAndVector> batch,
+    private static void insertBatchWithRetry(final Database db,
+                                             final Guardiann guardiann,
+                                             final List<PrimaryKeyAndVector> batch,
                                              final long firstGlobalIndex) throws Exception {
         final List<PrimaryKeyAndVector> remaining = new ArrayList<>(batch);
         long base = firstGlobalIndex;
@@ -391,8 +385,8 @@ class TestHelpers {
      * top-k); without dedup, a single in-truth primary would otherwise be counted once per
      * duplicate.
      */
-    private static double singleQueryRecall(@Nonnull final Set<Integer> groundTruthIndices,
-                                            @Nonnull final List<? extends ResultEntry> results) {
+    private static double singleQueryRecall(final Set<Integer> groundTruthIndices,
+                                            final List<? extends ResultEntry> results) {
         final Set<Integer> resultIndices = results.stream()
                 .map(re -> (int) re.primaryKey().getLong(0))
                 .collect(ImmutableSet.toImmutableSet());
@@ -430,10 +424,10 @@ class TestHelpers {
      * @param k top-k to retrieve per query
      * @param minMeanRecall floor that the mean recall must meet or exceed
      */
-    static void assertRecallAtKAtLeast(@Nonnull final Database db,
-                                       @Nonnull final Guardiann guardiann,
-                                       @Nonnull final List<? extends RealVector> queries,
-                                       @Nonnull final List<? extends Set<Integer>> groundTruth,
+    static void assertRecallAtKAtLeast(final Database db,
+                                       final Guardiann guardiann,
+                                       final List<? extends RealVector> queries,
+                                       final List<? extends Set<Integer>> groundTruth,
                                        final int k,
                                        final double minMeanRecall) {
         Verify.verify(queries.size() == groundTruth.size(),
@@ -483,10 +477,10 @@ class TestHelpers {
      * @param minMeanRecall floor that the mean recall must meet or exceed
      * @return the observed mean recall (for logging/assertions in the caller)
      */
-    static double assertRecallAtKAtLeastDynamic(@Nonnull final Database db,
-                                                @Nonnull final Guardiann guardiann,
-                                                @Nonnull final List<? extends RealVector> queries,
-                                                @Nonnull final Map<Tuple, ? extends RealVector> active,
+    static double assertRecallAtKAtLeastDynamic(final Database db,
+                                                final Guardiann guardiann,
+                                                final List<? extends RealVector> queries,
+                                                final Map<Tuple, ? extends RealVector> active,
                                                 final int k,
                                                 final double minMeanRecall) {
         Verify.verify(active.size() >= k,
@@ -534,8 +528,7 @@ class TestHelpers {
      * @param <T> the element type
      * @return up to {@code count} elements of {@code items} in a deterministic, seed-dependent order
      */
-    @Nonnull
-    static <T> List<T> deterministicSample(@Nonnull final List<T> items, final long seed, final int count) {
+    static <T> List<T> deterministicSample(final List<T> items, final long seed, final int count) {
         if (items.size() <= count) {
             return items;
         }
@@ -572,9 +565,9 @@ class TestHelpers {
      * @param minMeanQuality floor that the mean quality must meet or exceed
      * @return the observed mean quality, or {@link Double#NaN} if the check was skipped
      */
-    static double assertOrderedByDistanceQualityAtLeast(@Nonnull final Database db,
-                                                        @Nonnull final Guardiann guardiann,
-                                                        @Nonnull final List<? extends RealVector> queries,
+    static double assertOrderedByDistanceQualityAtLeast(final Database db,
+                                                        final Guardiann guardiann,
+                                                        final List<? extends RealVector> queries,
                                                         final int indexSize,
                                                         final double minMeanQuality) {
         if (indexSize > MAX_ORDERED_BY_DISTANCE_INDEX_SIZE) {
@@ -633,7 +626,7 @@ class TestHelpers {
      * @param indexSize the number of live vectors the scan should have returned (completeness denominator)
      * @return the quality score in {@code [0, 1]}
      */
-    private static double orderedByDistanceQuality(@Nonnull final List<? extends ResultEntry> results, final int indexSize) {
+    private static double orderedByDistanceQuality(final List<? extends ResultEntry> results, final int indexSize) {
         final int numReturned = results.size();
         final double completenessScore =
                 indexSize <= 0 ? 1.0d : Math.min(1.0d, (double) numReturned / (double) indexSize);
@@ -672,9 +665,8 @@ class TestHelpers {
      * Returned indices are extracted as {@code (int) primaryKey.getLong(0)}, matching the
      * convention used by {@link #singleQueryRecall} so the two are directly comparable.
      */
-    @Nonnull
-    static Set<Integer> bruteForceTopKByEuclidean(@Nonnull final RealVector query,
-                                                  @Nonnull final Map<Tuple, ? extends RealVector> active,
+    static Set<Integer> bruteForceTopKByEuclidean(final RealVector query,
+                                                  final Map<Tuple, ? extends RealVector> active,
                                                   final int k) {
         // Local record so we don't need a top-level helper class.
         record IndexedDistance(double distance, int index) { }
@@ -688,7 +680,6 @@ class TestHelpers {
     }
 
     static class TestOnWriteListener implements OnWriteListener {
-        @Nonnull
         private final ArrayDeque<Frame> frames;
 
         public TestOnWriteListener() {
@@ -696,15 +687,15 @@ class TestHelpers {
         }
 
         @Override
-        public void onKeyValueWritten(@Nonnull final byte[] key, @Nonnull final byte[] value) {
+        public void onKeyValueWritten(final byte[] key, final byte[] value) {
             for (final Frame frame : frames) {
                 frame.bytesWritten().addAndGet(key.length + value.length);
             }
         }
 
         @Override
-        public void onTaskEnqueued(@Nonnull final TaskKind taskKind,
-                                   @Nonnull final UUID taskId, @Nonnull final Set<UUID> targetClusterIds) {
+        public void onTaskEnqueued(final TaskKind taskKind,
+                                   final UUID taskId, final Set<UUID> targetClusterIds) {
             for (final Frame frame : frames) {
                 frame.numTasksEnqueuedByKind()
                         .compute(taskKind, (ignored, counter) ->
@@ -713,20 +704,18 @@ class TestHelpers {
         }
 
         @Override
-        public void onTaskExecuted(@Nonnull final TaskKind taskKind,
-                                   @Nonnull final UUID taskId, @Nonnull final Set<UUID> targetClusterIds) {
+        public void onTaskExecuted(final TaskKind taskKind,
+                                   final UUID taskId, final Set<UUID> targetClusterIds) {
             for (final Frame frame : frames) {
                 frame.numTasksExecutedByKind().compute(taskKind, (ignored, counter) ->
                         Objects.requireNonNullElse(counter, 0) + 1);
             }
         }
 
-        @Nonnull
         public Map<TaskKind, Integer> getNumTasksEnqueuedByKind() {
             return Objects.requireNonNull(frames.peek()).numTasksEnqueuedByKind();
         }
 
-        @Nonnull
         public Map<TaskKind, Integer> getNumTasksExecutedByKind() {
             return Objects.requireNonNull(frames.peek()).numTasksExecutedByKind();
         }
@@ -735,7 +724,6 @@ class TestHelpers {
             return Objects.requireNonNull(frames.peek()).numTasksExecutedByKind().values().stream().mapToInt(i -> i).sum();
         }
 
-        @Nonnull
         public Long getBytesWritten() {
             return Objects.requireNonNull(frames.peek()).bytesWritten().get();
         }
@@ -748,14 +736,13 @@ class TestHelpers {
             frames.pop();
         }
 
-        private record Frame(@Nonnull AtomicLong bytesWritten,
-                             @Nonnull Map<TaskKind, Integer> numTasksEnqueuedByKind,
-                             @Nonnull Map<TaskKind, Integer> numTasksExecutedByKind) {
+        private record Frame(AtomicLong bytesWritten,
+                             Map<TaskKind, Integer> numTasksEnqueuedByKind,
+                             Map<TaskKind, Integer> numTasksExecutedByKind) {
         }
     }
 
     static class TestOnReadListener implements OnReadListener {
-        @Nonnull
         private final ArrayDeque<AtomicLong> frames;
 
         public TestOnReadListener() {
@@ -767,7 +754,7 @@ class TestHelpers {
         }
 
         @Override
-        public void onKeyValueRead(@Nonnull final byte[] key, @Nullable final byte[] value) {
+        public void onKeyValueRead(final byte[] key, @Nullable final byte[] value) {
             for (final AtomicLong frame : frames) {
                 frame.addAndGet(key.length + (value == null ? 0 : value.length));
             }

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/CardinalityTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/CardinalityTest.java
@@ -37,7 +37,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
 
-import javax.annotation.Nonnull;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Random;
@@ -71,19 +70,16 @@ class CardinalityTest implements BaseTest {
         db = dbExtension.getDatabase();
     }
 
-    @Nonnull
     @Override
     public Database getDb() {
         return db;
     }
 
-    @Nonnull
     @Override
     public Subspace getSubspace() {
         return subspaceExtension.getSubspace();
     }
 
-    @Nonnull
     @Override
     public Path getTempDir() {
         return tempDir;
@@ -116,19 +112,17 @@ class CardinalityTest implements BaseTest {
         assertThat(cardinality(hnsw)).isEqualTo(Cardinality.MULTIPLE);
     }
 
-    @Nonnull
     private HNSW newHnsw() {
         return new HNSW(getSubspace(), TestExecutors.defaultThreadPool(),
                 HNSW.newConfigBuilder().build(NUM_DIMENSIONS),
                 new TestOnWriteListener(), new TestOnReadListener());
     }
 
-    @Nonnull
-    private Cardinality cardinality(@Nonnull final HNSW hnsw) {
+    private Cardinality cardinality(final HNSW hnsw) {
         return db.run(tr -> hnsw.cardinality(tr).join());
     }
 
-    private void insert(@Nonnull final HNSW hnsw, final int count) throws Exception {
+    private void insert(final HNSW hnsw, final int count) throws Exception {
         final List<PrimaryKeyAndVector> data =
                 CommonTestHelpers.randomVectors(new Random(SEED), NUM_DIMENSIONS, count);
         TestHelpers.basicInsertBatch(getDb(), hnsw, count, 0,

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/CardinalityTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/CardinalityTest.java
@@ -61,6 +61,8 @@ class CardinalityTest implements BaseTest {
     TestSubspaceExtension subspaceExtension = new TestSubspaceExtension(dbExtension);
 
     @TempDir
+    // Injected by JUnit's TempDirectory extension before each test; NullAway cannot see framework injection.
+    @SuppressWarnings("NullAway")
     Path tempDir;
 
     private Database db;

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/DataRecordsTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/DataRecordsTest.java
@@ -32,8 +32,7 @@ import com.google.common.collect.ImmutableList;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.List;
 import java.util.Objects;
 import java.util.Random;
@@ -147,8 +146,8 @@ class DataRecordsTest {
     }
 
     private static <T> void assertToString(final long randomSeed,
-                                           @Nonnull final Function<Random, T> createFunction,
-                                           @Nonnull final BiFunction<Random, T, T> createDifferentFunction) {
+                                           final Function<Random, T> createFunction,
+                                           final BiFunction<Random, T, T> createDifferentFunction) {
         final Random random = new Random(randomSeed);
         final long dependentRandomSeed = random.nextLong();
         final T t1 = createFunction.apply(new Random(dependentRandomSeed));
@@ -160,8 +159,8 @@ class DataRecordsTest {
     }
 
     private static <T> void assertHashCodeEqualsToString(final long randomSeed,
-                                                         @Nonnull final Function<Random, T> createFunction,
-                                                         @Nonnull final BiFunction<Random, T, T> createDifferentFunction) {
+                                                         final Function<Random, T> createFunction,
+                                                         final BiFunction<Random, T, T> createDifferentFunction) {
         final Random random = new Random(randomSeed);
         final long dependentRandomSeed = random.nextLong();
         final T t1 = createFunction.apply(new Random(dependentRandomSeed));
@@ -175,43 +174,37 @@ class DataRecordsTest {
         Assertions.assertThat(t1).doesNotHaveToString(t2.toString());
     }
 
-    @Nonnull
     private static NodeReferenceAndNode<NodeReferenceWithDistance, NodeReferenceWithVector>
-                   nodeReferenceAndNode(@Nonnull final Random random) {
+                   nodeReferenceAndNode(final Random random) {
         return new NodeReferenceAndNode<>(nodeReferenceWithDistance(random), inliningNode(random));
     }
 
-    @Nonnull
     private static NodeReferenceAndNode<NodeReferenceWithDistance, NodeReferenceWithVector>
-                   nodeReferenceAndNode(@Nonnull final Random random,
-                                        @Nonnull final NodeReferenceAndNode<NodeReferenceWithDistance, NodeReferenceWithVector> original) {
+                   nodeReferenceAndNode(final Random random,
+                                        final NodeReferenceAndNode<NodeReferenceWithDistance, NodeReferenceWithVector> original) {
         return new NodeReferenceAndNode<>(nodeReferenceWithDistance(random, original.getNodeReference()),
                 inliningNode(random, original.getNode().asInliningNode()));
     }
 
-    @Nonnull
-    private static ResultEntry resultEntry(@Nonnull final Random random) {
+    private static ResultEntry resultEntry(final Random random) {
         return new ResultEntry(primaryKey(random), rawVector(random), null, random.nextDouble(),
                 random.nextInt(100));
     }
 
-    @Nonnull
-    private static ResultEntry resultEntry(@Nonnull final Random random, @Nonnull final ResultEntry original) {
+    private static ResultEntry resultEntry(final Random random, final ResultEntry original) {
         return new ResultEntry(primaryKey(random, original.primaryKey()),
                 rawVector(random, Objects.requireNonNull(original.vector())), null,
                 differentDouble(random, original.distance()),
                 differentInteger(random, original.rankOrRowNumber(), 100));
     }
 
-    @Nonnull
-    private static CompactNode compactNode(@Nonnull final Random random) {
+    private static CompactNode compactNode(final Random random) {
         return CompactNode.factory()
                 .create(primaryKey(random), vector(random), null, nodeReferences(random))
                 .asCompactNode();
     }
 
-    @Nonnull
-    private static CompactNode compactNode(@Nonnull final Random random, @Nonnull CompactNode original) {
+    private static CompactNode compactNode(final Random random, CompactNode original) {
         return CompactNode.factory()
                 .create(primaryKey(random, original.getPrimaryKey()), vector(random, original.getVector()),
                         null, nodeReferences(random, original.getNeighbors())
@@ -219,14 +212,13 @@ class DataRecordsTest {
                 .asCompactNode();
     }
 
-    @Nonnull
-    private static InliningNode inliningNode(@Nonnull final Random random) {
+    private static InliningNode inliningNode(final Random random) {
         return InliningNode.factory()
                 .create(primaryKey(random), null, null, nodeReferenceWithVectors(random))
                 .asInliningNode();
     }
 
-    private static InliningNode inliningNode(@Nonnull final Random random, @Nonnull final InliningNode original) {
+    private static InliningNode inliningNode(final Random random, final InliningNode original) {
         return InliningNode.factory()
                 .create(primaryKey(random, original.getPrimaryKey()),
                         null, null, nodeReferenceWithVectors(random, original.getNeighbors())
@@ -234,27 +226,23 @@ class DataRecordsTest {
                 .asInliningNode();
     }
 
-    @Nonnull
-    private static NodeReferenceWithDistance nodeReferenceWithDistance(@Nonnull final Random random) {
+    private static NodeReferenceWithDistance nodeReferenceWithDistance(final Random random) {
         return new NodeReferenceWithDistance(primaryKey(random), vector(random), random.nextDouble());
     }
 
-    @Nonnull
-    private static NodeReferenceWithDistance nodeReferenceWithDistance(@Nonnull final Random random,
-                                                                       @Nonnull final NodeReferenceWithDistance original) {
+    private static NodeReferenceWithDistance nodeReferenceWithDistance(final Random random,
+                                                                       final NodeReferenceWithDistance original) {
         return new NodeReferenceWithDistance(
                 primaryKey(random, original.getPrimaryKey()),
                 vector(random, original.getVector()),
                 differentDouble(random, original.getDistance()));
     }
 
-    @Nonnull
-    private static List<NodeReferenceWithVector> nodeReferenceWithVectors(@Nonnull final Random random) {
+    private static List<NodeReferenceWithVector> nodeReferenceWithVectors(final Random random) {
         return nodeReferenceWithVectors(random, null);
     }
 
-    @Nonnull
-    private static List<NodeReferenceWithVector> nodeReferenceWithVectors(@Nonnull final Random random,
+    private static List<NodeReferenceWithVector> nodeReferenceWithVectors(final Random random,
                                                                           @Nullable final List<NodeReferenceWithVector> original) {
         final int size = original == null
                          ? random.nextInt(20)
@@ -266,25 +254,21 @@ class DataRecordsTest {
         return resultBuilder.build();
     }
 
-    @Nonnull
-    private static NodeReferenceWithVector nodeReferenceWithVector(@Nonnull final Random random) {
+    private static NodeReferenceWithVector nodeReferenceWithVector(final Random random) {
         return new NodeReferenceWithVector(primaryKey(random), vector(random));
     }
 
-    @Nonnull
-    private static NodeReferenceWithVector nodeReferenceWithVector(@Nonnull final Random random,
-                                                                   @Nonnull final NodeReferenceWithVector original) {
+    private static NodeReferenceWithVector nodeReferenceWithVector(final Random random,
+                                                                   final NodeReferenceWithVector original) {
         return new NodeReferenceWithVector(primaryKey(random, original.getPrimaryKey()),
                 vector(random, original.getVector()));
     }
 
-    @Nonnull
-    private static List<NodeReference> nodeReferences(@Nonnull final Random random) {
+    private static List<NodeReference> nodeReferences(final Random random) {
         return nodeReferences(random, null);
     }
 
-    @Nonnull
-    private static List<NodeReference> nodeReferences(@Nonnull final Random random,
+    private static List<NodeReference> nodeReferences(final Random random,
                                                       @Nullable final List<NodeReference> original) {
         final int size = original == null
                          ? random.nextInt(20)
@@ -296,81 +280,67 @@ class DataRecordsTest {
         return resultBuilder.build();
     }
 
-    @Nonnull
-    private static NodeReference nodeReference(@Nonnull final Random random) {
+    private static NodeReference nodeReference(final Random random) {
         return new NodeReference(primaryKey(random));
     }
 
-    @Nonnull
-    private static NodeReference nodeReference(@Nonnull final Random random, @Nonnull NodeReference original) {
+    private static NodeReference nodeReference(final Random random, NodeReference original) {
         return new NodeReference(primaryKey(random, original.getPrimaryKey()));
     }
 
-    @Nonnull
-    private static AggregatedVector aggregatedVector(@Nonnull final Random random) {
+    private static AggregatedVector aggregatedVector(final Random random) {
         return new AggregatedVector(random.nextInt(100), vector(random));
     }
 
-    @Nonnull
-    private static AggregatedVector aggregatedVector(@Nonnull final Random random,
-                                                     @Nonnull final AggregatedVector original) {
+    private static AggregatedVector aggregatedVector(final Random random,
+                                                     final AggregatedVector original) {
         return new AggregatedVector(differentInteger(random, original.partialCount(), 100),
                 vector(random, original.partialVector()));
     }
 
-    @Nonnull
-    private static AccessInfo accessInfo(@Nonnull final Random random) {
+    private static AccessInfo accessInfo(final Random random) {
         return new AccessInfo(entryNodeReference(random), random.nextLong(), rawVector(random));
     }
 
-    @Nonnull
-    private static AccessInfo accessInfo(@Nonnull final Random random, @Nonnull final AccessInfo original) {
+    private static AccessInfo accessInfo(final Random random, final AccessInfo original) {
         return new AccessInfo(entryNodeReference(random, original.getEntryNodeReference()),
                 differentLong(random, original.getRotatorSeed()),
                 rawVector(random, Objects.requireNonNull(original.getNegatedCentroid())));
     }
 
-    @Nonnull
-    private static EntryNodeReference entryNodeReference(@Nonnull final Random random) {
+    private static EntryNodeReference entryNodeReference(final Random random) {
         return new EntryNodeReference(primaryKey(random), vector(random), random.nextInt(10));
     }
 
-    @Nonnull
-    private static EntryNodeReference entryNodeReference(@Nonnull final Random random,
-                                                         @Nonnull final EntryNodeReference original) {
+    private static EntryNodeReference entryNodeReference(final Random random,
+                                                         final EntryNodeReference original) {
         return new EntryNodeReference(primaryKey(random, original.getPrimaryKey()),
                 vector(random, original.getVector()),
                 differentInteger(random, original.getLayer(), 10));
     }
 
-    @Nonnull
-    private static Tuple primaryKey(@Nonnull final Random random) {
+    private static Tuple primaryKey(final Random random) {
         return Tuple.from(random.nextInt(100));
     }
 
-    @Nonnull
-    private static Tuple primaryKey(@Nonnull final Random random, @Nonnull final Tuple original) {
+    private static Tuple primaryKey(final Random random, final Tuple original) {
         return Tuple.from(differentInteger(random, Math.toIntExact(original.getLong(0)), 100));
     }
 
-    @Nonnull
-    private static Transformed<RealVector> vector(@Nonnull final Random random) {
+    private static Transformed<RealVector> vector(final Random random) {
         return AffineOperator.identity().transform(rawVector(random));
     }
 
-    @Nonnull
-    private static Transformed<RealVector> vector(@Nonnull final Random random,
-                                                  @Nonnull final Transformed<RealVector> original) {
+    private static Transformed<RealVector> vector(final Random random,
+                                                  final Transformed<RealVector> original) {
         return AffineOperator.identity().transform(rawVector(random, original.getUnderlyingVector()));
     }
 
-    @Nonnull
-    private static RealVector rawVector(@Nonnull final Random random) {
+    private static RealVector rawVector(final Random random) {
         return RealVectorTest.createRandomDoubleVector(random, 768);
     }
 
-    @Nonnull
-    private static RealVector rawVector(@Nonnull final Random random, @Nonnull final RealVector original) {
+    private static RealVector rawVector(final Random random, final RealVector original) {
         RealVector randomVector;
         do {
             randomVector = RealVectorTest.createRandomDoubleVector(random, 768);
@@ -378,7 +348,7 @@ class DataRecordsTest {
         return randomVector;
     }
 
-    private static int differentInteger(@Nonnull final Random random, final int original, final int bound) {
+    private static int differentInteger(final Random random, final int original, final int bound) {
         int randomInteger;
         do {
             randomInteger = random.nextInt(bound);
@@ -386,7 +356,7 @@ class DataRecordsTest {
         return randomInteger;
     }
 
-    private static long differentLong(@Nonnull final Random random, final long original) {
+    private static long differentLong(final Random random, final long original) {
         long randomLong;
         do {
             randomLong = random.nextLong();
@@ -394,7 +364,7 @@ class DataRecordsTest {
         return randomLong;
     }
 
-    private static double differentDouble(@Nonnull final Random random, final double original) {
+    private static double differentDouble(final Random random, final double original) {
         double randomDouble;
         do {
             randomDouble = random.nextDouble();

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/OperationsTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/OperationsTest.java
@@ -68,7 +68,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -121,19 +120,16 @@ class OperationsTest implements BaseTest {
         db = dbExtension.getDatabase();
     }
 
-    @Nonnull
     @Override
     public Database getDb() {
         return db;
     }
 
-    @Nonnull
     @Override
     public Subspace getSubspace() {
         return subspaceExtension.getSubspace();
     }
 
-    @Nonnull
     @Override
     public Path getTempDir() {
         return tempDir;
@@ -235,7 +231,6 @@ class OperationsTest implements BaseTest {
                 .isGreaterThan(0);
     }
 
-    @Nonnull
     private static Stream<Arguments> seedAndIsNormalized() {
         return RandomizedTestUtils.randomSeeds(0xdeadc0deL, 0x1234567890L)
                 .flatMap(seed -> ImmutableSet.of(false, true).stream()
@@ -271,12 +266,10 @@ class OperationsTest implements BaseTest {
         }
     }
 
-    @Nonnull
     private static Stream<Arguments> differentConfigsAndMetrics() {
         return Streams.concat(differentConfigs(), differentMetrics());
     }
 
-    @Nonnull
     private static Stream<Arguments> differentConfigs() {
         return RandomizedTestUtils.randomSeeds(0xdeadc0deL)
                 .flatMap(seed -> Sets.cartesianProduct(ImmutableSet.of(false, true),
@@ -301,7 +294,6 @@ class OperationsTest implements BaseTest {
                                         .build(128)}))));
     }
 
-    @Nonnull
     private static Stream<Arguments> differentMetrics() {
         return RandomizedTestUtils.randomSeeds(0xdeadc0deL)
                 .flatMap(seed -> Sets.cartesianProduct(ImmutableSet.of(Metric.COSINE_METRIC,

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/OperationsTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/OperationsTest.java
@@ -111,6 +111,8 @@ class OperationsTest implements BaseTest {
     TestSubspaceExtension rtSecondarySubspace = new TestSubspaceExtension(dbExtension);
 
     @TempDir
+    // Injected by JUnit's TempDirectory extension before each test; NullAway cannot see framework injection.
+    @SuppressWarnings("NullAway")
     Path tempDir;
 
     private Database db;
@@ -474,7 +476,11 @@ class OperationsTest implements BaseTest {
                     CommonTestHelpers.pickRandomVectors(random, remainingData, numVectorsPerDeleteBatch);
 
             final long beginTs = System.nanoTime();
-            db.run(tr -> {
+            // db.run(Function<Transaction, T>) has no void-returning overload, so this side-effect-only call
+            // returns null from the lambda; NullAway does not accept an explicit @Nullable type witness on this
+            // external, unannotated method either, so the suppression is scoped to this one declaration instead.
+            @SuppressWarnings("NullAway")
+            final Void ignored = db.run(tr -> {
                 onWriteListener.reset();
                 onReadListener.reset();
 

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/OrderQuality.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/OrderQuality.java
@@ -26,7 +26,6 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.junit.jupiter.api.Test;
 
-import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -260,8 +259,7 @@ public final class OrderQuality {
      * @param wOutlier weight of outlier component in composite
      * @param wContig weight of contiguity component in composite
      */
-    @Nonnull
-    public static <T> Result score(@Nonnull final List<T> s, @Nonnull final List<T> u, final int x, final int okWindow,
+    public static <T> Result score(final List<T> s, final List<T> u, final int x, final int okWindow,
                                    final int outlierThreshold, final double wLocal, final double wOrder,
                                    final double wOutlier, final double wContig) {
         validateArguments(s, u, x, okWindow, outlierThreshold, wLocal, wOrder, wOutlier, wContig);
@@ -392,7 +390,7 @@ public final class OrderQuality {
         Preconditions.checkArgument(x >= 0 && x < u.size());
     }
 
-    private static <T> @Nonnull Map<T, Integer> posInU(final int n, final List<T> u) {
+    private static <T> Map<T, Integer> posInU(final int n, final List<T> u) {
         Map<T, Integer> posInU = Maps.newHashMapWithExpectedSize(n);
         for (int j = 0; j < u.size(); j++) {
             T id = u.get(j);

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/SiftTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/SiftTest.java
@@ -92,6 +92,8 @@ class SiftTest implements BaseTest {
     static final TestClassSubspaceExtension rtSecondarySubspace = new TestClassSubspaceExtension(dbExtension);
 
     @TempDir
+    // Injected by JUnit's TempDirectory extension before each test; NullAway cannot see framework injection.
+    @SuppressWarnings("NullAway")
     Path tempDir;
 
     private static Database db;

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/SiftTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/SiftTest.java
@@ -57,7 +57,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
 import java.nio.file.Path;
@@ -99,19 +98,16 @@ class SiftTest implements BaseTest {
     private static HNSW hnsw;
     private static List<PrimaryKeyAndVector> insertedData;
 
-    @Nonnull
     @Override
     public Database getDb() {
         return Objects.requireNonNull(db);
     }
 
-    @Nonnull
     @Override
     public Subspace getSubspace() {
         return subspaceExtension.getSubspace();
     }
 
-    @Nonnull
     @Override
     public Path getTempDir() {
         return tempDir;
@@ -276,7 +272,6 @@ class SiftTest implements BaseTest {
                         quality -> assertThat(quality.getContigScore()).isGreaterThan(0.9));
     }
 
-    @Nonnull
     private static RealVector readQuery(final int queryIndex) throws IOException {
         final RealVector queryVector;
         final Path siftSmallQueryPath = Paths.get(".out/extracted/siftsmall/siftsmall_query.fvecs");

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/TestHelpers.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/TestHelpers.java
@@ -400,7 +400,9 @@ class TestHelpers {
                 final ArgumentsAccessor args = parameterInfo.getArguments();
 
                 final BaseTest baseTest = (BaseTest)context.getRequiredTestInstance();
-                final Config config = (Config)args.get(1);
+                // This test extension is only ever registered on parameterized tests whose second argument is a
+                // Config; ArgumentsAccessor.get(int) is generically nullable, but that invariant guarantees non-null here.
+                final Config config = (Config)Objects.requireNonNull(args.get(1));
                 logger.error("dumping contents of HNSW to {}", baseTest.getTempDir());
                 dumpLayers(baseTest.getDb(), baseTest.getSubspace(), config, baseTest.getTempDir());
             } else {

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/TestHelpers.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/TestHelpers.java
@@ -49,8 +49,7 @@ import org.junit.jupiter.params.aggregator.ArgumentsAccessor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
@@ -86,8 +85,8 @@ import static org.assertj.core.api.Assertions.within;
 class TestHelpers {
     private static final Logger logger = LoggerFactory.getLogger(TestHelpers.class);
 
-    static void dumpQueryResults(@Nonnull final Path tempDir, @Nonnull final String prefix, final int layer,
-                                 @Nonnull final List<? extends ResultEntry> results) throws Exception {
+    static void dumpQueryResults(final Path tempDir, final String prefix, final int layer,
+                                 final List<? extends ResultEntry> results) throws Exception {
         final Path verticesFile = tempDir.resolve("vertices-" + prefix + "-" + layer + ".csv");
         try (final BufferedWriter verticesWriter = Files.newBufferedWriter(verticesFile)) {
             for (final ResultEntry result : results) {
@@ -97,12 +96,11 @@ class TestHelpers {
         }
     }
 
-    @Nonnull
-    static List<PrimaryKeyAndVector> basicInsertBatch(@Nonnull final Database db,
-                                                      @Nonnull final HNSW hnsw,
+    static List<PrimaryKeyAndVector> basicInsertBatch(final Database db,
+                                                      final HNSW hnsw,
                                                       final int batchSize,
                                                       final long firstId,
-                                                      @Nonnull final BiFunction<Transaction, Long, PrimaryKeyAndVector> insertFunction)
+                                                      final BiFunction<Transaction, Long, PrimaryKeyAndVector> insertFunction)
             throws ExecutionException, InterruptedException, TimeoutException {
         return db.runAsync(tr -> {
             final TestOnWriteListener onWriteListener = (TestOnWriteListener)hnsw.getOnWriteListener();
@@ -138,8 +136,8 @@ class TestHelpers {
         }).get(2, TimeUnit.MINUTES); // set a timeout for inserting a single batch including retries so setup won't run forever
     }
 
-    static List<PrimaryKeyAndVector> insertSIFTSmall(@Nonnull final Database db,
-                                                     @Nonnull final HNSW hnsw) throws Exception {
+    static List<PrimaryKeyAndVector> insertSIFTSmall(final Database db,
+                                                     final HNSW hnsw) throws Exception {
         final Path siftSmallPath = Paths.get(".out/extracted/siftsmall/siftsmall_base.fvecs");
 
         final ImmutableList.Builder<PrimaryKeyAndVector> insertedDataBuilder = ImmutableList.builder();
@@ -172,9 +170,9 @@ class TestHelpers {
         return insertedDataBuilder.build();
     }
 
-    static void validateSIFTSmall(@Nonnull final Database db,
-                                  @Nonnull final HNSW hnsw,
-                                  @Nonnull final List<PrimaryKeyAndVector> data,
+    static void validateSIFTSmall(final Database db,
+                                  final HNSW hnsw,
+                                  final List<PrimaryKeyAndVector> data,
                                   final int k) throws IOException {
         final Metric metric = hnsw.getConfig().metric();
         final Path siftSmallGroundTruthPath = Paths.get(".out/extracted/siftsmall/siftsmall_groundtruth.ivecs");
@@ -234,27 +232,27 @@ class TestHelpers {
         }
     }
 
-    static long countNodesOnLayer(@Nonnull Database db,
-                                  @Nonnull Subspace subspace,
-                                  @Nonnull final Config config, final int layer) {
+    static long countNodesOnLayer(Database db,
+                                  Subspace subspace,
+                                  final Config config, final int layer) {
         final AtomicLong counter = new AtomicLong();
         scanLayer(db, subspace, config, layer, 100,
                 node -> counter.incrementAndGet());
         return counter.get();
     }
 
-    static void scanLayer(@Nonnull final Database db,
-                          @Nonnull final Subspace subspace,
-                          @Nonnull final Config config,
+    static void scanLayer(final Database db,
+                          final Subspace subspace,
+                          final Config config,
                           final int layer,
                           final int batchSize,
-                          @Nonnull final Consumer<AbstractNode<? extends NodeReference>> nodeConsumer) {
+                          final Consumer<AbstractNode<? extends NodeReference>> nodeConsumer) {
         HNSW.scanLayerInternal(config, subspace, db, layer, batchSize, nodeConsumer);
     }
 
-    static int getEntryLayer(@Nonnull final Database db,
-                             @Nonnull final Subspace subspace,
-                             @Nonnull final Config config) {
+    static int getEntryLayer(final Database db,
+                             final Subspace subspace,
+                             final Config config) {
         @Nullable final AccessInfo accessInfo = db.run(readTransaction ->
                 StorageAdapter.fetchAccessInfo(config, readTransaction, subspace, OnReadListener.NOOP).join());
         return accessInfo == null
@@ -262,10 +260,10 @@ class TestHelpers {
                : accessInfo.getEntryNodeReference().getLayer();
     }
 
-    static void dumpLayers(@Nonnull final Database db,
-                           @Nonnull final Subspace subspace,
-                           @Nonnull final Config config,
-                           @Nonnull final Path tempDir) {
+    static void dumpLayers(final Database db,
+                           final Subspace subspace,
+                           final Config config,
+                           final Path tempDir) {
         final int entryLayer = getEntryLayer(db, subspace, config);
 
         if (entryLayer < 0) {
@@ -281,11 +279,11 @@ class TestHelpers {
         }
     }
 
-    static long dumpLayer(@Nonnull final Database db,
-                          @Nonnull final Subspace subspace,
-                          @Nonnull final Config config,
-                          @Nonnull final Path tempDir,
-                          @Nonnull final String prefix, final int layer) throws IOException {
+    static long dumpLayer(final Database db,
+                          final Subspace subspace,
+                          final Config config,
+                          final Path tempDir,
+                          final String prefix, final int layer) throws IOException {
         final Path verticesFile = tempDir.resolve("vertices-" + prefix + "-" + layer + ".csv");
         final Path edgesFile = tempDir.resolve("edges-" + prefix + "-" + layer + ".csv");
 
@@ -329,9 +327,9 @@ class TestHelpers {
         return numReadAtomic.get();
     }
 
-    static <N extends NodeReference> void writeNode(@Nonnull final Transaction transaction,
-                                                    @Nonnull final StorageAdapter<N> storageAdapter,
-                                                    @Nonnull final AbstractNode<N> node,
+    static <N extends NodeReference> void writeNode(final Transaction transaction,
+                                                    final StorageAdapter<N> storageAdapter,
+                                                    final AbstractNode<N> node,
                                                     final int layer) {
         final NeighborsChangeSet<N> insertChangeSet =
                 new InsertNeighborsChangeSet<>(new BaseNeighborsChangeSet<>(ImmutableList.of()),
@@ -340,9 +338,8 @@ class TestHelpers {
                 insertChangeSet);
     }
 
-    @Nonnull
-    static AbstractNode<NodeReference> createRandomCompactNode(@Nonnull final Random random,
-                                                               @Nonnull final NodeFactory<NodeReference> nodeFactory,
+    static AbstractNode<NodeReference> createRandomCompactNode(final Random random,
+                                                               final NodeFactory<NodeReference> nodeFactory,
                                                                final int numDimensions,
                                                                final int numberOfNeighbors) {
         final Tuple primaryKey = CommonTestHelpers.createRandomPrimaryKey(random);
@@ -357,9 +354,8 @@ class TestHelpers {
                 neighborsBuilder.build());
     }
 
-    @Nonnull
-    static AbstractNode<NodeReferenceWithVector> createRandomInliningNode(@Nonnull final Random random,
-                                                                          @Nonnull final NodeFactory<NodeReferenceWithVector> nodeFactory,
+    static AbstractNode<NodeReferenceWithVector> createRandomInliningNode(final Random random,
+                                                                          final NodeFactory<NodeReferenceWithVector> nodeFactory,
                                                                           final int numDimensions,
                                                                           final int numberOfNeighbors) {
         final Tuple primaryKey = CommonTestHelpers.createRandomPrimaryKey(random);
@@ -374,19 +370,17 @@ class TestHelpers {
                 neighborsBuilder.build());
     }
 
-    @Nonnull
-    static NodeReference createRandomNodeReference(@Nonnull final Random random) {
+    static NodeReference createRandomNodeReference(final Random random) {
         return new NodeReference(CommonTestHelpers.createRandomPrimaryKey(random));
     }
 
-    @Nonnull
-    static NodeReferenceWithVector createRandomNodeReferenceWithVector(@Nonnull final Random random,
+    static NodeReferenceWithVector createRandomNodeReferenceWithVector(final Random random,
                                                                        final int dimensionality) {
         return new NodeReferenceWithVector(CommonTestHelpers.createRandomPrimaryKey(random),
                 AffineOperator.identity().transform(createRandomHalfVector(random, dimensionality)));
     }
 
-    static ToDoubleBiFunction<RealVector, RealVector> ringDistance(@Nonnull final Metric metric,
+    static ToDoubleBiFunction<RealVector, RealVector> ringDistance(final Metric metric,
                                                                    final double radius) {
         return (queryVector, dataVector) ->
                 Math.abs(metric.distance(queryVector, dataVector) - radius);
@@ -394,7 +388,7 @@ class TestHelpers {
 
     static class DumpLayersIfFailure implements AfterTestExecutionCallback {
         @Override
-        public void afterTestExecution(@Nonnull final ExtensionContext context) {
+        public void afterTestExecution(final ExtensionContext context) {
             final Optional<Throwable> failure = context.getExecutionException();
             if (failure.isEmpty()) {
                 return;
@@ -431,7 +425,7 @@ class TestHelpers {
         }
 
         @Override
-        public void onNodeDeleted(final int layer, @Nonnull final Tuple primaryKey) {
+        public void onNodeDeleted(final int layer, final Tuple primaryKey) {
             deleteCountByLayer.compute(layer, (l, oldValue) -> (oldValue == null ? 0 : oldValue) + 1L);
         }
     }
@@ -466,13 +460,13 @@ class TestHelpers {
         }
 
         @Override
-        public void onNodeRead(final int layer, @Nonnull final Node<? extends NodeReference> node) {
+        public void onNodeRead(final int layer, final Node<? extends NodeReference> node) {
             nodeCountByLayer.compute(layer, (l, oldValue) -> (oldValue == null ? 0 : oldValue) + 1L);
             sumMByLayer.compute(layer, (l, oldValue) -> (oldValue == null ? 0 : oldValue) + node.getNeighbors().size());
         }
 
         @Override
-        public void onKeyValueRead(final int layer, @Nonnull final byte[] key, @Nullable final byte[] value) {
+        public void onKeyValueRead(final int layer, final byte[] key, @Nullable final byte[] value) {
             bytesReadByLayer.compute(layer, (l, oldValue) -> (oldValue == null ? 0 : oldValue) +
                     key.length + (value == null ? 0 : value.length));
         }

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/rtree/RTreeModificationTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/rtree/RTreeModificationTest.java
@@ -44,7 +44,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
@@ -138,7 +137,7 @@ public class RTreeModificationTest {
 
     @ParameterizedTest
     @MethodSource("numSamplesAndNumDeletes")
-    public void testRandomDeletes(@Nonnull final RTree.Config config, final long seed, final int numSamples, final int numDeletes) {
+    public void testRandomDeletes(final RTree.Config config, final long seed, final int numSamples, final int numDeletes) {
         final RTreeScanTest.OnReadCounters onReadCounters = new RTreeScanTest.OnReadCounters();
         final RTree rTree = new RTree(rtSubspace.getSubspace(), rtSecondarySubspace.getSubspace(), TestExecutors.defaultThreadPool(), config,
                 RTreeHilbertCurveHelpers::hilbertValue, NodeHelpers::newSequentialNodeId, OnWriteListener.NOOP,
@@ -179,7 +178,7 @@ public class RTreeModificationTest {
     void dumpRTree() {
         final OnReadListener onReadListener = new OnReadListener() {
             @Override
-            public <T extends Node> CompletableFuture<T> onAsyncRead(@Nonnull final CompletableFuture<T> future) {
+            public <T extends Node> CompletableFuture<T> onAsyncRead(final CompletableFuture<T> future) {
                 return future.thenApply(node -> {
                     if (node instanceof IntermediateNode) {
                         final IntermediateNode intermediateNode = (IntermediateNode)node;
@@ -244,7 +243,7 @@ public class RTreeModificationTest {
         return argumentsBuilder.build().stream();
     }
 
-    static Item[] randomInserts(@Nonnull final Database db, @Nonnull final RTree rTree, final long seed,
+    static Item[] randomInserts(final Database db, final RTree rTree, final long seed,
                                 final int numSamples) {
         final Random random = new Random(seed);
         final Item[] items = new Item[numSamples];
@@ -257,7 +256,7 @@ public class RTreeModificationTest {
         return items;
     }
 
-    static Item[] randomInsertsWithNulls(@Nonnull final Database db, @Nonnull final RTree rTree,
+    static Item[] randomInsertsWithNulls(final Database db, final RTree rTree,
                                          final long seed, final int numSamples) {
         final Random random = new Random(seed);
         final Item[] items = new Item[numSamples];
@@ -273,7 +272,7 @@ public class RTreeModificationTest {
         return items;
     }
 
-    static Item[] bitemporalInserts(@Nonnull final Database db, @Nonnull RTree rTree, final long seed, int numSamples) {
+    static Item[] bitemporalInserts(final Database db, RTree rTree, final long seed, int numSamples) {
         final int smear = 100;
         final Random random = new Random(seed);
         final Item[] items = new Item[numSamples];
@@ -298,7 +297,7 @@ public class RTreeModificationTest {
         return items;
     }
 
-    static void insertData(@Nonnull final Database db, @Nonnull final RTree rTree, @Nonnull final Item[] items) {
+    static void insertData(final Database db, final RTree rTree, final Item[] items) {
         final int numInsertsPerBatch = 1_000;
         for (int i = 0; i < items.length; ) {
             final int batchStart = i; // lambdas
@@ -319,35 +318,29 @@ public class RTreeModificationTest {
         }
     }
 
-    static void validateRTree(@Nonnull final Database db, @Nonnull final RTree rt) {
+    static void validateRTree(final Database db, final RTree rt) {
         rt.validate(db);
     }
 
     static class Item {
-        @Nonnull
         private final RTree.Point point;
-        @Nonnull
         private final Tuple keySuffix;
-        @Nonnull
         private final Tuple value;
 
-        public Item(@Nonnull final RTree.Point point, @Nonnull final Tuple keySuffix, @Nonnull final Tuple value) {
+        public Item(final RTree.Point point, final Tuple keySuffix, final Tuple value) {
             this.point = point;
             this.keySuffix = keySuffix;
             this.value = value;
         }
 
-        @Nonnull
         public RTree.Point getPoint() {
             return point;
         }
 
-        @Nonnull
         public Tuple getKeySuffix() {
             return keySuffix;
         }
 
-        @Nonnull
         public Tuple getValue() {
             return value;
         }

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/rtree/RTreeModificationTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/rtree/RTreeModificationTest.java
@@ -44,6 +44,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
@@ -60,6 +62,14 @@ public class RTreeModificationTest {
     private static final Logger logger = LoggerFactory.getLogger(RTreeModificationTest.class);
     private static final int NUM_TEST_RUNS = 5;
     private static final int NUM_SAMPLES = 10_000;
+
+    // Tuple.from(Object...) is from the unannotated fdb-java client library and genuinely supports null
+    // elements (randomInsertsWithNulls() below intentionally constructs points with a null coordinate);
+    // its varargs parameter is treated as @NonNull by NullAway's defaults.
+    @SuppressWarnings("NullAway")
+    private static Tuple tupleFromNullable(@Nullable Object... items) {
+        return Tuple.from(items);
+    }
 
     @RegisterExtension
     static final TestDatabaseExtension dbExtension = new TestDatabaseExtension();
@@ -111,7 +121,11 @@ public class RTreeModificationTest {
         }
 
         final AtomicLong nresults = new AtomicLong(0);
-        db.run(tr -> {
+        // db.run(Function<Transaction, T>) has no void-returning overload, so this side-effect-only call
+        // returns null from the lambda; NullAway does not accept an explicit @Nullable type witness on this
+        // external, unannotated method either, so the suppression is scoped to this one declaration instead.
+        @SuppressWarnings("NullAway")
+        final Void ignored = db.run(tr -> {
             AsyncUtil.forEachRemaining(rTree.scan(tr, mbr -> true, (l, h) -> true), itemSlot -> nresults.incrementAndGet()).join();
             return null;
         });
@@ -164,7 +178,11 @@ public class RTreeModificationTest {
         }
 
         final AtomicLong nresults = new AtomicLong(0);
-        db.run(tr -> {
+        // db.run(Function<Transaction, T>) has no void-returning overload, so this side-effect-only call
+        // returns null from the lambda; NullAway does not accept an explicit @Nullable type witness on this
+        // external, unannotated method either, so the suppression is scoped to this one declaration instead.
+        @SuppressWarnings("NullAway")
+        final Void ignored = db.run(tr -> {
             AsyncUtil.forEachRemaining(rTree.scan(tr, mbr -> true, (l, h) -> true), itemSlot -> nresults.incrementAndGet()).join();
             return null;
         });
@@ -264,7 +282,7 @@ public class RTreeModificationTest {
             final Long x = random.nextFloat() < 0.01 ? null : (Long)(long)random.nextInt(1000);
             final Long y = random.nextFloat() < 0.01 ? null : (Long)(long)random.nextInt(1000);
 
-            final RTree.Point point = new RTree.Point(Tuple.from(x, y));
+            final RTree.Point point = new RTree.Point(tupleFromNullable(x, y));
             items[i] = new Item(point, Tuple.from(i), Tuple.from("value" + i));
         }
 

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/rtree/RTreeScanTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/rtree/RTreeScanTest.java
@@ -47,8 +47,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
@@ -96,7 +95,6 @@ public class RTreeScanTest  {
         items = ObjectArrays.concat(items1, items2, Item.class);
     }
 
-    @Nonnull
     public static Stream<Arguments> queries() {
         final Random random = new Random(1);
         final ImmutableList.Builder<Arguments> argumentsBuilder = ImmutableList.builder();
@@ -117,7 +115,7 @@ public class RTreeScanTest  {
 
     @ParameterizedTest
     @MethodSource("queries")
-    public void queryWithFilters(@Nonnull final RTree.Rectangle query) {
+    public void queryWithFilters(final RTree.Rectangle query) {
         final Predicate<RTree.Rectangle> mbrPredicate =
                 rectangle -> rectangle.isOverlapping(query);
 
@@ -186,7 +184,7 @@ public class RTreeScanTest  {
     @SuppressWarnings({"UnstableApiUsage", "ResultOfMethodCallIgnored"})
     @ParameterizedTest
     @MethodSource("queries")
-    public void queryTopNWithFilters(@Nonnull final RTree.Rectangle query) {
+    public void queryTopNWithFilters(final RTree.Rectangle query) {
         final Comparator<Item> itemComparator =
                 Comparator.<Item>comparingLong(item -> item.getPoint().getCoordinates().getLong(0))
                         .thenComparing(Item::getKeySuffix);
@@ -246,20 +244,17 @@ public class RTreeScanTest  {
                 Comparator.<ItemSlot>comparingLong(itemSlot -> itemSlot.getPosition().getCoordinates().getLong(0))
                         .thenComparing(ItemSlot::getKeySuffix);
 
-        @Nonnull
         private RTree.Rectangle query;
         private final int num;
-        @Nonnull
         private final MinMaxPriorityQueue<ItemSlot> queue;
 
         @SuppressWarnings("UnstableApiUsage")
-        public TopNTraversal(@Nonnull final RTree.Rectangle query, final int num) {
+        public TopNTraversal(final RTree.Rectangle query, final int num) {
             this.query = query;
             this.num = num;
             this.queue = MinMaxPriorityQueue.orderedBy(comparator).maximumSize(num).create();
         }
 
-        @Nonnull
         public MinMaxPriorityQueue<ItemSlot> getQueue() {
             return queue;
         }
@@ -269,7 +264,7 @@ public class RTreeScanTest  {
             return rectangle.isOverlapping(query);
         }
 
-        public void addItemSlot(@Nonnull final ItemSlot itemSlot) {
+        public void addItemSlot(final ItemSlot itemSlot) {
             queue.add(itemSlot);
 
             if (queue.size() == num) {
@@ -343,17 +338,17 @@ public class RTreeScanTest  {
         }
 
         @Override
-        public void onSlotIndexEntryRead(@Nonnull final byte[] key) {
+        public void onSlotIndexEntryRead(final byte[] key) {
             readSlotIndexEntryCounter.incrementAndGet();
         }
 
         @Override
-        public <T extends Node> CompletableFuture<T> onAsyncRead(@Nonnull final CompletableFuture<T> future) {
+        public <T extends Node> CompletableFuture<T> onAsyncRead(final CompletableFuture<T> future) {
             return future;
         }
 
         @Override
-        public void onNodeRead(@Nonnull final Node node) {
+        public void onNodeRead(final Node node) {
             if (node.getKind() == NodeKind.LEAF) {
                 readLeafNodesCounter.incrementAndGet();
             } else {
@@ -363,7 +358,7 @@ public class RTreeScanTest  {
         }
 
         @Override
-        public void onKeyValueRead(@Nonnull final Node node, @Nonnull final byte[] key, @Nonnull final byte[] value) {
+        public void onKeyValueRead(final Node node, final byte[] key, final byte[] value) {
             if (node.getKind() == NodeKind.LEAF) {
                 readLeafKeyValueCounter.incrementAndGet();
                 readLeafKeyValueBytes.addAndGet(key.length + value.length);
@@ -461,18 +456,18 @@ public class RTreeScanTest  {
         }
 
         @Override
-        public void onSlotIndexEntryWritten(@Nonnull final byte[] key) {
+        public void onSlotIndexEntryWritten(final byte[] key) {
             slotIndexEntryWrittenCounter.incrementAndGet();
             slotIndexEntryWrittenBytes.addAndGet(key.length);
         }
 
         @Override
-        public void onSlotIndexEntryCleared(@Nonnull final byte[] key) {
+        public void onSlotIndexEntryCleared(final byte[] key) {
             slotIndexEntryClearedBytes.addAndGet(key.length);
         }
 
         @Override
-        public void onNodeWritten(@Nonnull final Node node) {
+        public void onNodeWritten(final Node node) {
             if (node.getKind() == NodeKind.LEAF) {
                 leafNodeWrittenCounter.incrementAndGet();
             } else {
@@ -482,7 +477,7 @@ public class RTreeScanTest  {
         }
 
         @Override
-        public void onKeyValueWritten(@Nonnull final Node node, @Nonnull final byte[] key, @Nonnull final byte[] value) {
+        public void onKeyValueWritten(final Node node, final byte[] key, final byte[] value) {
             if (node.getKind() == NodeKind.LEAF) {
                 leafKeyValueWrittenCounter.incrementAndGet();
                 leafKeyValueWrittenBytes.addAndGet(key.length + value.length);
@@ -494,7 +489,7 @@ public class RTreeScanTest  {
         }
 
         @Override
-        public void onKeyCleared(@Nonnull final Node node, @Nonnull final byte[] key) {
+        public void onKeyCleared(final Node node, final byte[] key) {
             if (node.getKind() == NodeKind.LEAF) {
                 leafKeyValueClearedBytes.addAndGet(key.length);
             } else {

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/rtree/RTreeScanTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/rtree/RTreeScanTest.java
@@ -82,6 +82,15 @@ public class RTreeScanTest  {
     @Nullable
     private static Item[] items;
 
+    // Tuple.from(Object...) is from the unannotated fdb-java client library and genuinely supports a null
+    // element (RTree.Point.getCoordinate(d) is correctly declared @Nullable, since points can have null
+    // coordinates -- see RTreeModificationTest.randomInsertsWithNulls); the varargs parameter is treated
+    // as @NonNull by NullAway's defaults.
+    @SuppressWarnings("NullAway")
+    private static Tuple tupleFromNullable(@Nullable Object... elements) {
+        return Tuple.from(elements);
+    }
+
     @BeforeAll
     public static void setUpDb() {
         db = dbExtension.getDatabase();
@@ -155,7 +164,11 @@ public class RTreeScanTest  {
                 onReadCounters);
 
         final AtomicLong nresults = new AtomicLong(0L);
-        db.run(tr -> {
+        // db.run(Function<Transaction, T>) has no void-returning overload, so this side-effect-only call
+        // returns null from the lambda; NullAway does not accept an explicit @Nullable type witness on this
+        // external, unannotated method either, so the suppression is scoped to this one declaration instead.
+        @SuppressWarnings("NullAway")
+        final Void ignored = db.run(tr -> {
             AsyncUtil.forEachRemaining(rt.scan(tr, mbrPredicate, (s, l) -> true), itemSlot -> {
                 if (query.contains(itemSlot.getPosition())) {
                     nresults.incrementAndGet();
@@ -192,9 +205,9 @@ public class RTreeScanTest  {
         final TopNTraversal topNTraversal = new TopNTraversal(query, 5);
 
         for (int i = 0; i < NUM_SAMPLES; ++i) {
-            final RTree.Point point = Objects.requireNonNull(items)[i].getPoint();
-            if (query.contains(point)) {
-                expectedResultsQueue.add(items[i]);
+            final Item item = Objects.requireNonNull(items)[i];
+            if (query.contains(item.getPoint())) {
+                expectedResultsQueue.add(item);
             }
         }
         final OnReadCounters onReadCounters = new OnReadCounters();
@@ -202,7 +215,9 @@ public class RTreeScanTest  {
                 RTreeHilbertCurveHelpers::hilbertValue, NodeHelpers::newSequentialNodeId, OnWriteListener.NOOP,
                 onReadCounters);
         final AtomicLong nresults = new AtomicLong(0L);
-        db.run(tr -> {
+        // See queryWithFilters() above for why this suppression is needed.
+        @SuppressWarnings("NullAway")
+        final Void ignored = db.run(tr -> {
             final AsyncIterator<ItemSlot> scan = rt.scan(tr, topNTraversal, (s, l) -> true);
             AsyncUtil.forEachRemaining(scan, itemSlot -> {
                 if (query.contains(itemSlot.getPosition())) {
@@ -273,7 +288,7 @@ public class RTreeScanTest  {
                 if (comparator.compare(maximumItemSlot, itemSlot) >= 0) {
                     // maximum item slot must be somewhere between minX and maxX
                     final Tuple ranges = query.getRanges();
-                    final Tuple newRanges = Tuple.from(ranges.get(0), ranges.get(1), maximumItemSlot.getPosition().getCoordinate(0), ranges.get(3));
+                    final Tuple newRanges = tupleFromNullable(ranges.get(0), ranges.get(1), maximumItemSlot.getPosition().getCoordinate(0), ranges.get(3));
                     this.query = new RTree.Rectangle(newRanges);
                 }
             }

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/clientlog/ClientLogEventCounterTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/clientlog/ClientLogEventCounterTest.java
@@ -25,6 +25,7 @@ import com.apple.foundationdb.FDB;
 
 import java.time.Instant;
 import java.time.ZonedDateTime;
+import java.util.Objects;
 import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
 
@@ -54,6 +55,10 @@ class ClientLogEventCounterTest {
             countWrites = "WRITE".equals(arg) || "BOTH".equals(arg);
         }
         FDB fdb = FDB.selectAPIVersion(630);
+        // FDB.open(String) is from the unannotated fdb-java client library; passing a null cluster file path is
+        // its documented way of using the default cluster file, but the parameter is treated as @NonNull by
+        // NullAway's defaults.
+        @SuppressWarnings("NullAway")
         Database database = fdb.open(cluster);
         Executor executor = database.getExecutor();
         TupleKeyCountTree root = new TupleKeyCountTree();
@@ -63,7 +68,9 @@ class ClientLogEventCounterTest {
                 System.out.print("  ");
             }
             System.out.print(path.stream().map(Object::toString).collect(Collectors.joining("/")));
-            int percent = (path.get(0).getCount() * 100) / path.get(0).getParent().getCount();
+            // TupleKeyCountTree.printTree() never invokes the Printer callback for the root node itself (only
+            // for its descendants), so path.get(0) is guaranteed to have a non-null parent here.
+            int percent = (path.get(0).getCount() * 100) / Objects.requireNonNull(path.get(0).getParent()).getCount();
             System.out.println(" " + percent + "%");
         };
         int eventLimit = 10_000;

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/clientlog/DatabaseClientLogEventsTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/clientlog/DatabaseClientLogEventsTest.java
@@ -45,6 +45,10 @@ class DatabaseClientLogEventsTest {
             end = ZonedDateTime.parse(args[2]).toInstant();
         }
         FDB fdb = FDB.selectAPIVersion(710);
+        // FDB.open(String) is from the unannotated fdb-java client library; passing a null cluster file path is
+        // its documented way of using the default cluster file, but the parameter is treated as @NonNull by
+        // NullAway's defaults.
+        @SuppressWarnings("NullAway")
         Database database = fdb.open(cluster);
         Executor executor = database.getExecutor();
         DatabaseClientLogEvents.EventConsumer consumer = (tr, event) -> {

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/clientlog/package-info.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/clientlog/package-info.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,14 +18,7 @@
  * limitations under the License.
  */
 
-/**
- * Utilities for logging and exception handling.
- * All exceptions in the <a href="https://foundationdb.github.io/fdb-record-layer/">Record Layer</a>
- * project are descendants of {@link com.apple.foundationdb.util.LoggableException} class. This
- * class allows the user to attach arbitrary keys and values to an {@link java.lang.Exception} when
- * thrown.
- */
 @NullMarked
-package com.apple.foundationdb.util;
+package com.apple.foundationdb.clientlog;
 
 import org.jspecify.annotations.NullMarked;

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/half/HalfTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/half/HalfTest.java
@@ -21,6 +21,7 @@ package com.apple.foundationdb.half;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 /**
  * Unit test for {@link Half}.
@@ -249,7 +250,11 @@ public class HalfTest {
 
     @Test
     public void valueOfStringNullPointerExceptionTest() {
-        Assertions.assertThrows(NullPointerException.class, () -> Half.valueOf((String)null));
+        // Half.valueOf(String) declares a @NonNull parameter, but this test deliberately passes null to verify
+        // the method's defensive (implicit, via Float.valueOf) NullPointerException behavior at the API boundary.
+        @SuppressWarnings("NullAway")
+        final Executable callWithNull = () -> Half.valueOf((String)null);
+        Assertions.assertThrows(NullPointerException.class, callWithNull);
     }
 
     @Test

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/kmeans/KMeansTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/kmeans/KMeansTest.java
@@ -40,7 +40,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -761,7 +760,7 @@ class KMeansTest {
      * (divide by {@code n}, not {@code n-1}). Used by
      * {@link #siftSmallLambdaImprovesBalance()} to measure cluster-size dispersion.
      */
-    private static double clusterSizeStddev(@Nonnull final int[] sizes) {
+    private static double clusterSizeStddev(final int[] sizes) {
         final double mean = Arrays.stream(sizes).average().orElseThrow();
         double sumSquared = 0.0d;
         for (final int s : sizes) {
@@ -836,8 +835,7 @@ class KMeansTest {
     /**
      * Returns the arithmetic mean of the given vectors as an immutable {@link RealVector}.
      */
-    @Nonnull
-    private static RealVector arithmeticMean(@Nonnull final List<RealVector> vectors) {
+    private static RealVector arithmeticMean(final List<RealVector> vectors) {
         final int d = vectors.get(0).getNumDimensions();
         final MutableDoubleRealVector sum = MutableDoubleRealVector.zeroVector(d);
         for (final RealVector v : vectors) {
@@ -853,7 +851,7 @@ class KMeansTest {
      * the global mean. The objective is the sum of squared distances from each point to that
      * mean.
      */
-    private static double baselineObjectiveSameCentroidTwice(@Nonnull final List<RealVector> pts) {
+    private static double baselineObjectiveSameCentroidTwice(final List<RealVector> pts) {
         final int d = pts.get(0).getNumDimensions();
         final MutableDoubleRealVector sum = MutableDoubleRealVector.zeroVector(d);
         for (final RealVector p : pts) {
@@ -878,8 +876,8 @@ class KMeansTest {
      * Computes the global mean, normalizes it to a unit vector, then pretends both centroids are
      * that same vector. The objective is computed using the provided {@link DistanceEstimator}.
      */
-    private static double baselineObjectiveSameCentroidTwiceNormalized(@Nonnull final List<RealVector> pts,
-                                                                       @Nonnull final DistanceEstimator distanceEstimator) {
+    private static double baselineObjectiveSameCentroidTwiceNormalized(final List<RealVector> pts,
+                                                                       final DistanceEstimator distanceEstimator) {
         final int d = pts.get(0).getNumDimensions();
         final MutableDoubleRealVector sum = MutableDoubleRealVector.zeroVector(d);
         for (final RealVector p : pts) {
@@ -896,9 +894,9 @@ class KMeansTest {
     }
 
     @SuppressWarnings("unused")
-    static void dumpVectors(@Nonnull final Path tempDir,
-                            @Nonnull final String prefix,
-                            @Nonnull final List<RealVector> vectors) throws IOException {
+    static void dumpVectors(final Path tempDir,
+                            final String prefix,
+                            final List<RealVector> vectors) throws IOException {
         final Path vectorsFile = tempDir.resolve(prefix + ".csv");
 
         try (final BufferedWriter vectorsWriter = Files.newBufferedWriter(vectorsFile)) {

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/kmeans/KMeansTestHelpers.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/kmeans/KMeansTestHelpers.java
@@ -30,7 +30,6 @@ import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
 import java.nio.file.Path;
@@ -61,7 +60,6 @@ final class KMeansTestHelpers {
      * {@link DoubleRealVector}s. The file is produced by the {@code extractSiftSmall} gradle task,
      * which {@code test} depends on.
      */
-    @Nonnull
     static List<DoubleRealVector> loadSiftSmall() throws IOException {
         final Path siftSmallPath = Paths.get(".out/extracted/siftsmall/siftsmall_base.fvecs");
         try (var fileChannel = FileChannel.open(siftSmallPath, StandardOpenOption.READ)) {
@@ -79,9 +77,8 @@ final class KMeansTestHelpers {
     /**
      * Picks {@code n} distinct random elements from {@code items} using {@code random}.
      */
-    @Nonnull
-    static <T> List<T> pickRandomSubset(@Nonnull final Random random,
-                                        @Nonnull final List<T> items,
+    static <T> List<T> pickRandomSubset(final Random random,
+                                        final List<T> items,
                                         final int n) {
         Verify.verify(n <= items.size(), "cannot pick %s elements from a list of size %s", n, items.size());
         final List<T> remaining = Lists.newArrayList(items);
@@ -96,8 +93,7 @@ final class KMeansTestHelpers {
      * Returns the L2-normalized form of every input vector. Useful for cosine-metric tests where
      * the algorithm and the asserted invariants assume unit-norm centroids.
      */
-    @Nonnull
-    static List<RealVector> normalizeAll(@Nonnull final List<? extends RealVector> vectors) {
+    static List<RealVector> normalizeAll(final List<? extends RealVector> vectors) {
         final ImmutableList.Builder<RealVector> b = ImmutableList.builderWithExpectedSize(vectors.size());
         for (final RealVector v : vectors) {
             b.add(v.normalize());
@@ -105,9 +101,8 @@ final class KMeansTestHelpers {
         return b.build();
     }
 
-    @Nonnull
-    static RealVector gaussianND(@Nonnull final SplittableRandom random,
-                                 @Nonnull final RealVector mean,
+    static RealVector gaussianND(final SplittableRandom random,
+                                 final RealVector mean,
                                  final double sigma) {
         final RandomHelpers.GaussianSampler sampler = new RandomHelpers.GaussianSampler(random);
         final int d = mean.getNumDimensions();
@@ -119,9 +114,8 @@ final class KMeansTestHelpers {
         return new DoubleRealVector(v);
     }
 
-    @Nonnull
-    static RealVector noisyUnitVector(@Nonnull final SplittableRandom random,
-                                      @Nonnull final RealVector meanUnitVector,
+    static RealVector noisyUnitVector(final SplittableRandom random,
+                                      final RealVector meanUnitVector,
                                       final double sigma) {
         return gaussianND(random, meanUnitVector, sigma).normalize();
     }
@@ -131,9 +125,9 @@ final class KMeansTestHelpers {
      * Euclidean and cosine distance for cosine. {@link KMeans.Result#getDistances()} entries
      * and {@link KMeans.Result#getObjective()} are sums of this quantity.
      */
-    static double baseObjective(@Nonnull final DistanceEstimator distanceEstimator,
-                                @Nonnull final RealVector v,
-                                @Nonnull final RealVector c) {
+    static double baseObjective(final DistanceEstimator distanceEstimator,
+                                final RealVector v,
+                                final RealVector c) {
         switch (distanceEstimator.getMetric()) {
             case EUCLIDEAN_METRIC: {
                 final double d = distanceEstimator.distance(v, c);
@@ -166,10 +160,10 @@ final class KMeansTestHelpers {
      *       reassignment pass, so this holds regardless of how the main loop exited.</li>
      * </ul>
      */
-    static void assertKMeansInvariants(@Nonnull final KMeans.Result<RealVector> result,
-                                       @Nonnull final List<? extends RealVector> vectors,
+    static void assertKMeansInvariants(final KMeans.Result<RealVector> result,
+                                       final List<? extends RealVector> vectors,
                                        final int k,
-                                       @Nonnull final DistanceEstimator distanceEstimator,
+                                       final DistanceEstimator distanceEstimator,
                                        final double lambda) {
         final int n = vectors.size();
         final int[] assignment = result.assignment();

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/kmeans/PartitionEvaluatorTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/kmeans/PartitionEvaluatorTest.java
@@ -33,7 +33,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
@@ -561,8 +560,7 @@ class PartitionEvaluatorTest {
     // helpers
     // ============================================================================================
 
-    @Nonnull
-    private static List<RealVector> twoBlobs(@Nonnull final SplittableRandom rnd, final int nPer) {
+    private static List<RealVector> twoBlobs(final SplittableRandom rnd, final int nPer) {
         final RealVector m0 = new DoubleRealVector(new double[] {-5.0d, 0.0d, 0.0d});
         final RealVector m1 = new DoubleRealVector(new double[] {+5.0d, 0.0d, 0.0d});
         final List<RealVector> result = Lists.newArrayListWithCapacity(2 * nPer);
@@ -576,8 +574,7 @@ class PartitionEvaluatorTest {
         return result;
     }
 
-    @Nonnull
-    private static List<RealVector> oneBlob(@Nonnull final SplittableRandom rnd, final int n) {
+    private static List<RealVector> oneBlob(final SplittableRandom rnd, final int n) {
         final RealVector m = new DoubleRealVector(new double[] {-5.0d, 0.0d, 0.0d});
         final List<RealVector> result = Lists.newArrayListWithCapacity(n);
         for (int i = 0; i < n; i++) {
@@ -586,8 +583,7 @@ class PartitionEvaluatorTest {
         return result;
     }
 
-    @Nonnull
-    private static List<RealVector> threeBlobs(@Nonnull final SplittableRandom rnd, final int nPer) {
+    private static List<RealVector> threeBlobs(final SplittableRandom rnd, final int nPer) {
         final List<RealVector> means = ImmutableList.of(
                 new DoubleRealVector(new double[] {-6.0d, -3.0d,  1.0d}),
                 new DoubleRealVector(new double[] { 0.0d, +4.5d, -2.0d}),
@@ -606,8 +602,7 @@ class PartitionEvaluatorTest {
      * Returns the L2-normalized form of the given components as a {@link RealVector}. Convenience
      * for constructing unit-norm centroids in cosine-metric tests.
      */
-    @Nonnull
-    private static RealVector unit(@Nonnull final double[] components) {
+    private static RealVector unit(final double[] components) {
         return new DoubleRealVector(components).normalize();
     }
 
@@ -615,8 +610,7 @@ class PartitionEvaluatorTest {
      * Cosine analogue of {@link #oneBlob}: a single tight cluster of noisy unit vectors around the
      * {@code (+x)} direction.
      */
-    @Nonnull
-    private static List<RealVector> oneDirection(@Nonnull final SplittableRandom rnd, final int n) {
+    private static List<RealVector> oneDirection(final SplittableRandom rnd, final int n) {
         final RealVector m = unit(new double[] {1.0d, 0.0d, 0.0d});
         final List<RealVector> result = Lists.newArrayListWithCapacity(n);
         for (int i = 0; i < n; i++) {
@@ -629,8 +623,7 @@ class PartitionEvaluatorTest {
      * Cosine analogue of {@link #twoBlobs}: two clusters of noisy unit vectors around orthogonal
      * unit directions {@code (+x)} and {@code (+y)}.
      */
-    @Nonnull
-    private static List<RealVector> twoDirections(@Nonnull final SplittableRandom rnd, final int nPer) {
+    private static List<RealVector> twoDirections(final SplittableRandom rnd, final int nPer) {
         final RealVector m0 = unit(new double[] {1.0d, 0.0d, 0.0d});
         final RealVector m1 = unit(new double[] {0.0d, 1.0d, 0.0d});
         final List<RealVector> result = Lists.newArrayListWithCapacity(2 * nPer);
@@ -648,11 +641,10 @@ class PartitionEvaluatorTest {
      * Builds a partition by assigning each vector to the centroid that minimizes
      * {@link KMeansTestHelpers#baseObjective}.
      */
-    @Nonnull
     private static PartitionEvaluator.Partition<RealVector>
-            nearestPartition(@Nonnull final List<RealVector> centroids,
-                             @Nonnull final List<RealVector> vectors,
-                             @Nonnull final DistanceEstimator distanceEstimator) {
+            nearestPartition(final List<RealVector> centroids,
+                             final List<RealVector> vectors,
+                             final DistanceEstimator distanceEstimator) {
         final int[] assignments = new int[vectors.size()];
         for (int i = 0; i < vectors.size(); i++) {
             double best = Double.POSITIVE_INFINITY;
@@ -672,8 +664,7 @@ class PartitionEvaluatorTest {
     /**
      * Builds a single-cluster partition whose centroid is the mean of all input vectors.
      */
-    @Nonnull
-    private static PartitionEvaluator.Partition<RealVector> singleClusterPartition(@Nonnull final List<RealVector> vectors) {
+    private static PartitionEvaluator.Partition<RealVector> singleClusterPartition(final List<RealVector> vectors) {
         final int d = vectors.get(0).getNumDimensions();
         final MutableDoubleRealVector sum = MutableDoubleRealVector.zeroVector(d);
         for (final RealVector v : vectors) {
@@ -684,7 +675,7 @@ class PartitionEvaluatorTest {
                 ImmutableList.of(centroid), Lens.identity(), new int[vectors.size()]);
     }
 
-    private static int countAssigned(@Nonnull final PartitionEvaluator.Partition<RealVector> p,
+    private static int countAssigned(final PartitionEvaluator.Partition<RealVector> p,
                                      final int cluster) {
         int n = 0;
         for (int a : p.assignments()) {
@@ -695,27 +686,24 @@ class PartitionEvaluatorTest {
         return n;
     }
 
-    @Nonnull
     private static PartitionEvaluator.Parameters withMinRelativeSseGain(
-            @Nonnull final PartitionEvaluator.Parameters p, final double v) {
+            final PartitionEvaluator.Parameters p, final double v) {
         return new PartitionEvaluator.Parameters(p.distanceEstimator(), v, p.minSeparation(),
                 p.maxLowMarginRate(), p.minSmallestFrac(), p.maxLargestFrac(), p.lowMarginThreshold(),
                 p.alphaSseGain(), p.betaSeparationGain(), p.gammaImbalancePenalty(),
                 p.deltaLowMarginPenalty(), p.minScoreGain());
     }
 
-    @Nonnull
     private static PartitionEvaluator.Parameters withMinSmallestFrac(
-            @Nonnull final PartitionEvaluator.Parameters p, final double v) {
+            final PartitionEvaluator.Parameters p, final double v) {
         return new PartitionEvaluator.Parameters(p.distanceEstimator(), p.minRelativeSseGain(), p.minSeparation(),
                 p.maxLowMarginRate(), v, p.maxLargestFrac(), p.lowMarginThreshold(),
                 p.alphaSseGain(), p.betaSeparationGain(), p.gammaImbalancePenalty(),
                 p.deltaLowMarginPenalty(), p.minScoreGain());
     }
 
-    @Nonnull
     private static PartitionEvaluator.Parameters withMaxLargestFrac(
-            @Nonnull final PartitionEvaluator.Parameters p, final double v) {
+            final PartitionEvaluator.Parameters p, final double v) {
         return new PartitionEvaluator.Parameters(p.distanceEstimator(), p.minRelativeSseGain(), p.minSeparation(),
                 p.maxLowMarginRate(), p.minSmallestFrac(), v, p.lowMarginThreshold(),
                 p.alphaSseGain(), p.betaSeparationGain(), p.gammaImbalancePenalty(),

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/kmeans/package-info.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/kmeans/package-info.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,14 +18,7 @@
  * limitations under the License.
  */
 
-/**
- * Utilities for logging and exception handling.
- * All exceptions in the <a href="https://foundationdb.github.io/fdb-record-layer/">Record Layer</a>
- * project are descendants of {@link com.apple.foundationdb.util.LoggableException} class. This
- * class allows the user to attach arbitrary keys and values to an {@link java.lang.Exception} when
- * thrown.
- */
 @NullMarked
-package com.apple.foundationdb.util;
+package com.apple.foundationdb.kmeans;
 
 import org.jspecify.annotations.NullMarked;

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/linear/AffineOperatorTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/linear/AffineOperatorTest.java
@@ -27,14 +27,12 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import javax.annotation.Nonnull;
 import java.util.Random;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.within;
 
 class AffineOperatorTest {
-    @Nonnull
     private static Stream<Arguments> randomSeedsWithNumDimensions() {
         return RandomizedTestUtils.randomSeeds(0xdeadc0deL, 0xfdb5ca1eL, 0xf005ba1L)
                 .flatMap(seed -> ImmutableSet.of(3, 5, 10, 128, 768, 1000).stream()

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/linear/FhtKacRotatorTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/linear/FhtKacRotatorTest.java
@@ -27,14 +27,12 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import javax.annotation.Nonnull;
 import java.util.Random;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.within;
 
 class FhtKacRotatorTest {
-    @Nonnull
     private static Stream<Arguments> randomSeedsWithNumDimensions() {
         return RandomizedTestUtils.randomSeeds(0xdeadc0deL, 0xfdb5ca1eL, 0xf005ba1L)
                 .flatMap(seed -> ImmutableSet.of(3, 5, 10, 128, 768, 1000).stream()

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/linear/MetricTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/linear/MetricTest.java
@@ -30,7 +30,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import javax.annotation.Nonnull;
 import java.util.Random;
 import java.util.stream.Stream;
 
@@ -54,11 +53,10 @@ class MetricTest {
 
     @ParameterizedTest
     @MethodSource("metricAndExpectedDistance")
-    void basicMetricTest(@Nonnull final Metric metric, @Nonnull final RealVector v1, @Nonnull final RealVector v2, final double expectedDistance) {
+    void basicMetricTest(final Metric metric, final RealVector v1, final RealVector v2, final double expectedDistance) {
         Assertions.assertThat(metric.distance(v1, v2)).isCloseTo(expectedDistance, Offset.offset(2E-4d));
     }
 
-    @Nonnull
     private static Stream<Arguments> randomSeedsWithMetrics() {
         return RandomizedTestUtils.randomSeeds(12345, 987654, 423, 18378195)
                 .flatMap(seed ->
@@ -85,7 +83,7 @@ class MetricTest {
 
     @ParameterizedTest
     @MethodSource("randomSeedsWithMetrics")
-    void basicPropertyTest(final long seed, @Nonnull final Metric metric, final int numDimensions) {
+    void basicPropertyTest(final long seed, final Metric metric, final int numDimensions) {
         final Random random = new Random(seed);
 
         for (int i = 0; i < 1000; i ++) {
@@ -146,15 +144,13 @@ class MetricTest {
         return distanceXZ <= distanceXY + distanceYZ + tol;
     }
 
-    @Nonnull
     @SuppressWarnings("checkstyle:MethodName")
     private static RealVector v(final double... components) {
         return new DoubleRealVector(components);
     }
 
-    @Nonnull
     @SuppressWarnings("checkstyle:MethodName")
-    private static RealVector randomV(@Nonnull final Random random, final int numDimensions) {
+    private static RealVector randomV(final Random random, final int numDimensions) {
         final double[] components = new double[numDimensions];
         for (int i = 0; i < numDimensions; i++) {
             components[i] = random.nextDouble();

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/linear/QRDecompositionTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/linear/QRDecompositionTest.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import javax.annotation.Nonnull;
 import java.util.Random;
 import java.util.stream.Stream;
 
@@ -39,7 +38,6 @@ import static org.assertj.core.api.Assertions.within;
 @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 @Tag(Tags.DualScalarSIMD)
 class QRDecompositionTest {
-    @Nonnull
     private static Stream<Arguments> randomSeedsWithNumDimensions() {
         return RandomizedTestUtils.randomSeeds(0xdeadc0deL, 0xfdb5ca1eL, 0xf005ba1L)
                 .flatMap(seed -> ImmutableSet.of(3, 5, 10, 128, 768).stream()

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/linear/RealMatrixParityTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/linear/RealMatrixParityTest.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 
-import javax.annotation.Nonnull;
 import java.util.Random;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -235,11 +234,11 @@ class RealMatrixParityTest {
      * orientation) so the scalar reference can use contiguous {@code dot} reads regardless of
      * which fast path the active backend exercised.
      */
-    private static void assertProductParity(@Nonnull final ScalarBackend scalar,
+    private static void assertProductParity(final ScalarBackend scalar,
                                             final int n, final int m, final int l,
-                                            @Nonnull final RealMatrix a,
-                                            @Nonnull final RealMatrix b,
-                                            @Nonnull final RealMatrix product) {
+                                            final RealMatrix a,
+                                            final RealMatrix b,
+                                            final RealMatrix product) {
         final RowMajorRealMatrix aRowMajor = a.toRowMajor();
         final ColumnMajorRealMatrix bColMajor = b.toColumnMajor();
         for (int i = 0; i < n; i++) {

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/linear/RealMatrixTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/linear/RealMatrixTest.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import javax.annotation.Nonnull;
 import java.util.Random;
 import java.util.stream.Stream;
 
@@ -38,7 +37,6 @@ import static org.assertj.core.api.Assertions.within;
 
 @Tag(Tags.DualScalarSIMD)
 class RealMatrixTest {
-    @Nonnull
     private static Stream<Arguments> randomSeedsWithNumDimensions() {
         return RandomizedTestUtils.randomSeeds(0xdeadc0deL, 0xfdb5ca1eL, 0xf005ba1L)
                 .flatMap(seed -> ImmutableSet.of(3, 5, 10, 128, 768, 1000).stream()
@@ -135,7 +133,7 @@ class RealMatrixTest {
         assertMultiplyMxMT(d, random, r);
     }
 
-    private static void assertMultiplyMxMT(final int d, @Nonnull final Random random, @Nonnull final RealMatrix r) {
+    private static void assertMultiplyMxMT(final int d, final Random random, final RealMatrix r) {
         final int k = random.nextInt(d);
         final int l = random.nextInt(d);
 

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/linear/RealVectorExactReductionTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/linear/RealVectorExactReductionTest.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import javax.annotation.Nonnull;
 import java.util.Random;
 import java.util.stream.Stream;
 
@@ -53,7 +52,6 @@ class RealVectorExactReductionTest {
     private static final ImmutableList<Integer> LENGTHS =
             ImmutableList.of(1, 2, 3, 7, 8, 15, 16, 17, 64, 65, 128, 1024);
 
-    @Nonnull
     private static Stream<Arguments> randomSeedsWithLengths() {
         return RandomizedTestUtils.randomSeeds(0x0fdbL, 0x5ca1eL, 123456L, 78910L, 1123581321345589L)
                 .flatMap(seed -> LENGTHS.stream().map(len -> Arguments.of(seed, len)));
@@ -119,8 +117,7 @@ class RealVectorExactReductionTest {
         }
     }
 
-    @Nonnull
-    private static double[] randomVector(@Nonnull final Random rnd, final int len) {
+    private static double[] randomVector(final Random rnd, final int len) {
         final double[] v = new double[len];
         for (int i = 0; i < len; i++) {
             v[i] = (rnd.nextDouble() - 0.5d) * 10.0d;

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/linear/RealVectorPrimitivesParityTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/linear/RealVectorPrimitivesParityTest.java
@@ -30,7 +30,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -60,7 +59,6 @@ class RealVectorPrimitivesParityTest {
     /** Per-element absolute tolerance for elementwise results. SIMD vs scalar should match within ULPs. */
     private static final double ELEMENT_ABS_TOL = 1.0e-12d;
 
-    @Nonnull
     private static Stream<Arguments> randomSeedsWithLengths() {
         return RandomizedTestUtils.randomSeeds(0x0fdbL, 0x5ca1eL, 123456L, 78910L, 1123581321345589L)
                 .flatMap(seed -> LENGTHS.stream().map(len -> Arguments.of(seed, len)));
@@ -319,7 +317,6 @@ class RealVectorPrimitivesParityTest {
      * the empty slice, prefixes/suffixes, an interior slice, and a slice straddling lane-aligned
      * boundaries. Filters to those that fit inside {@code [0, len]}.
      */
-    @Nonnull
     private static List<int[]> slices(final int len) {
         final List<int[]> result = new ArrayList<>();
         result.add(new int[] {0, 0});
@@ -340,7 +337,7 @@ class RealVectorPrimitivesParityTest {
         return result;
     }
 
-    private static void assertVectorClose(@Nonnull final double[] expected, @Nonnull final double[] actual) {
+    private static void assertVectorClose(final double[] expected, final double[] actual) {
         assertThat(actual).hasSize(expected.length);
         for (int i = 0; i < expected.length; i++) {
             assertThat(actual[i])
@@ -349,8 +346,7 @@ class RealVectorPrimitivesParityTest {
         }
     }
 
-    @Nonnull
-    private static double[] randomVector(@Nonnull final Random rnd, final int len) {
+    private static double[] randomVector(final Random rnd, final int len) {
         final double[] v = new double[len];
         for (int i = 0; i < len; i++) {
             // Range that exercises both small and large magnitudes without overflowing reductions.

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/linear/RealVectorSerializationTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/linear/RealVectorSerializationTest.java
@@ -27,12 +27,10 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import javax.annotation.Nonnull;
 import java.util.Random;
 import java.util.stream.Stream;
 
 class RealVectorSerializationTest {
-    @Nonnull
     private static Stream<Arguments> randomSeedsWithNumDimensions() {
         return RandomizedTestUtils.randomSeeds(0xdeadc0deL, 0xfdb5ca1eL, 0xf005ba1L)
                 .flatMap(seed -> ImmutableSet.of(3, 5, 10, 128, 768, 1000).stream()

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/linear/RealVectorTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/linear/RealVectorTest.java
@@ -30,14 +30,12 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import javax.annotation.Nonnull;
 import java.util.Random;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class RealVectorTest {
-    @Nonnull
     private static Stream<Arguments> randomSeedsWithNumDimensions() {
         return RandomizedTestUtils.randomSeeds(0xdeadc0deL, 0xfdb5ca1eL, 0xf005ba1L)
                 .flatMap(seed -> ImmutableSet.of(3, 5, 10, 128, 768, 1000).stream()
@@ -508,13 +506,11 @@ public class RealVectorTest {
         Assertions.assertThat(mutableRandomDoubleRealVector.toMutable()).isSameAs(mutableRandomDoubleRealVector);
     }
 
-    @Nonnull
-    public static DoubleRealVector createRandomDoubleVector(@Nonnull final Random random, final int numDimensions) {
+    public static DoubleRealVector createRandomDoubleVector(final Random random, final int numDimensions) {
         return new DoubleRealVector(createRandomVectorData(random, numDimensions));
     }
 
-    @Nonnull
-    public static DoubleRealVector createRandomNonNormalDoubleVector(@Nonnull final Random random, final int numDimensions) {
+    public static DoubleRealVector createRandomNonNormalDoubleVector(final Random random, final int numDimensions) {
         DoubleRealVector randomVector;
         do {
             final double[] randomVectorData = createRandomVectorData(random, numDimensions);
@@ -523,18 +519,15 @@ public class RealVectorTest {
         return randomVector;
     }
 
-    @Nonnull
-    public static FloatRealVector createRandomFloatVector(@Nonnull final Random random, final int numDimensions) {
+    public static FloatRealVector createRandomFloatVector(final Random random, final int numDimensions) {
         return new FloatRealVector(createRandomVectorData(random, numDimensions));
     }
 
-    @Nonnull
-    public static HalfRealVector createRandomHalfVector(@Nonnull final Random random, final int numDimensions) {
+    public static HalfRealVector createRandomHalfVector(final Random random, final int numDimensions) {
         return new HalfRealVector(createRandomVectorData(random, numDimensions));
     }
 
-    @Nonnull
-    public static double[] createRandomVectorData(@Nonnull final Random random, final int numDimensions) {
+    public static double[] createRandomVectorData(final Random random, final int numDimensions) {
         final double[] components = new double[numDimensions];
         for (int d = 0; d < numDimensions; d ++) {
             components[d] = random.nextDouble() * (random.nextBoolean() ? -1 : 1);

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/linear/package-info.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/linear/package-info.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,14 +18,7 @@
  * limitations under the License.
  */
 
-/**
- * Utilities for logging and exception handling.
- * All exceptions in the <a href="https://foundationdb.github.io/fdb-record-layer/">Record Layer</a>
- * project are descendants of {@link com.apple.foundationdb.util.LoggableException} class. This
- * class allows the user to attach arbitrary keys and values to an {@link java.lang.Exception} when
- * thrown.
- */
 @NullMarked
-package com.apple.foundationdb.util;
+package com.apple.foundationdb.linear;
 
 import org.jspecify.annotations.NullMarked;

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/map/BunchedMapScanTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/map/BunchedMapScanTest.java
@@ -43,8 +43,8 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -87,9 +87,8 @@ public class BunchedMapScanTest {
     private static Tuple value;
 
     private SubspaceSplitter<Long> splitter = new SubspaceSplitter<>() {
-        @Nonnull
         @Override
-        public Subspace subspaceOf(@Nonnull byte[] keyBytes) {
+        public Subspace subspaceOf(byte[] keyBytes) {
             try {
                 Tuple t = bmSubspace.unpack(keyBytes);
                 return bmSubspace.subspace(TupleHelpers.subTuple(t, 0, 1));
@@ -102,7 +101,7 @@ public class BunchedMapScanTest {
 
         @Nullable
         @Override
-        public Long subspaceTag(@Nonnull Subspace subspace) {
+        public Long subspaceTag(Subspace subspace) {
             return bmSubspace.unpack(subspace.getKey()).getLong(0);
         }
     };
@@ -140,7 +139,7 @@ public class BunchedMapScanTest {
         });
     }
 
-    private void testScan(int limit, boolean reverse, @Nonnull BiFunction<Transaction, byte[], BunchedMapIterator<Tuple, Tuple>> iteratorFunction) {
+    private void testScan(int limit, boolean reverse, BiFunction<Transaction, byte[], BunchedMapIterator<Tuple, Tuple>> iteratorFunction) {
         try (Transaction tr = db.createTransaction()) {
             byte[] continuation = null;
             List<Tuple> readKeys = new ArrayList<>();
@@ -207,7 +206,7 @@ public class BunchedMapScanTest {
         testScan(limit, reverse, (tr, continuation) -> map.scan(tr, bmSubspace, continuation, limit, reverse));
     }
 
-    private void getKeysContinuation(@Nonnull Transaction tr, boolean reverse) throws InterruptedException, ExecutionException {
+    private void getKeysContinuation(Transaction tr, boolean reverse) throws InterruptedException, ExecutionException {
         getKeysContinuation(10, reverse); // Bunch size limit
         getKeysContinuation(5, reverse); // Limit is half of bunch size
         getKeysContinuation(7, reverse); // Limit that doesn't hit the boundary well.
@@ -345,7 +344,7 @@ public class BunchedMapScanTest {
     }
 
     private void testScanMulti(int limit, boolean reverse, List<List<Tuple>> keyLists,
-                               @Nonnull BiFunction<Transaction, byte[], BunchedMapMultiIterator<Tuple, Tuple, Long>> iteratorFunction) {
+                               BiFunction<Transaction, byte[], BunchedMapMultiIterator<Tuple, Tuple, Long>> iteratorFunction) {
         try (Transaction tr = db.createTransaction()) {
             byte[] continuation = null;
             List<BunchedMapScanEntry<Tuple, Tuple, Long>> entryList = new ArrayList<>();

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/map/BunchedMapScanTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/map/BunchedMapScanTest.java
@@ -52,6 +52,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
@@ -318,7 +319,11 @@ public class BunchedMapScanTest {
             do {
                 List<Tuple> mostRecentReadKeys = new ArrayList<>();
                 int returned = 0;
-                BunchedMapIterator<Tuple, Tuple> bunchedMapIterator = map.scan(tr, subSubspaces.get(1), continuation, limit, reverse);
+                // NullAway does not reliably honor @Nullable on byte[]-typed parameters, so the continuation
+                // variable below is misflagged as a NonNull violation even though scan()'s continuation
+                // parameter is declared @Nullable byte[].
+                @SuppressWarnings("NullAway")
+                final BunchedMapIterator<Tuple, Tuple> bunchedMapIterator = map.scan(tr, subSubspaces.get(1), continuation, limit, reverse);
                 while (bunchedMapIterator.hasNext()) {
                     Tuple toAdd = bunchedMapIterator.peek().getKey();
                     assertEquals(toAdd, bunchedMapIterator.next().getKey());
@@ -377,11 +382,15 @@ public class BunchedMapScanTest {
                 while (iterator.hasNext()) {
                     BunchedMapScanEntry<Tuple, Tuple, Long> toAdd = iterator.peek();
                     assertEquals(toAdd, iterator.next());
+                    // This test's splitter always derives a non-null Long tag (see splitter's subspaceTag()
+                    // above), even though getSubspaceTag() is generically @Nullable.
+                    final Long toAddTag = Objects.requireNonNull(toAdd.getSubspaceTag());
                     if (lastEntry != null) {
-                        if (toAdd.getSubspaceTag().equals(lastEntry.getSubspaceTag())) {
+                        final Long lastEntryTag = Objects.requireNonNull(lastEntry.getSubspaceTag());
+                        if (toAddTag.equals(lastEntryTag)) {
                             assertEquals(reverse ? 1 : -1, Integer.signum(lastEntry.getKey().compareTo(toAdd.getKey())));
                         } else {
-                            assertEquals(reverse ? 1 : -1, Integer.signum(lastEntry.getSubspaceTag().compareTo(toAdd.getSubspaceTag())));
+                            assertEquals(reverse ? 1 : -1, Integer.signum(lastEntryTag.compareTo(toAddTag)));
                         }
                     }
                     entryList.add(toAdd);
@@ -402,16 +411,19 @@ public class BunchedMapScanTest {
             int pos = 0;
             int totalRead = 0;
             for (BunchedMapScanEntry<Tuple, Tuple, Long> entry : entryList) {
-                if (tag == null || !tag.equals(entry.getSubspaceTag())) {
+                // Same non-null guarantee as above: this test's splitter always derives a non-null Long tag.
+                final Long entryTag = Objects.requireNonNull(entry.getSubspaceTag());
+                if (tag == null || !tag.equals(entryTag)) {
                     if (tag != null) {
-                        assertEquals(tag + 1, entry.getSubspaceTag().longValue());
+                        assertEquals(tag + 1, entryTag.longValue());
                     }
-                    tag = entry.getSubspaceTag();
+                    tag = entryTag;
                     pos = 0;
                 }
-                assertEquals(keyLists.get(tag.intValue()).get(pos), entry.getKey());
+                final Long nonNullTag = Objects.requireNonNull(tag);
+                assertEquals(keyLists.get(nonNullTag.intValue()).get(pos), entry.getKey());
                 assertEquals(value, entry.getValue());
-                assertEquals(subSubspaces.get(tag.intValue()), entry.getSubspace());
+                assertEquals(subSubspaces.get(nonNullTag.intValue()), entry.getSubspace());
                 pos++;
                 totalRead++;
             }
@@ -481,7 +493,15 @@ public class BunchedMapScanTest {
 
     private void scanEmptyRangeMulti(int limit, boolean reverse) throws InterruptedException, ExecutionException {
         byte[] start = Tuple.from(subSubspaces.size() + 1).pack();
-        testScanMulti(limit, reverse, Collections.emptyList(), (tr, continuation) -> map.scanMulti(tr, bmSubspace, splitter, start, null, continuation, limit, reverse));
+        testScanMulti(limit, reverse, Collections.emptyList(), (tr, continuation) -> {
+            // NullAway does not reliably honor @Nullable on byte[]-typed parameters, so the null literal
+            // below is misflagged as a NonNull violation even though scanMulti()'s subspaceEnd parameter
+            // is declared @Nullable byte[].
+            @SuppressWarnings("NullAway")
+            final BunchedMapMultiIterator<Tuple, Tuple, Long> result =
+                    map.scanMulti(tr, bmSubspace, splitter, start, null, continuation, limit, reverse);
+            return result;
+        });
         byte[] fullStart = ByteArrayUtil.join(bmSubspace.getKey(), start);
         byte[] fullEnd = bmSubspace.range().end;
         testScanMulti(limit, reverse, Collections.emptyList(), (tr, continuation) ->
@@ -499,7 +519,13 @@ public class BunchedMapScanTest {
         );
 
         byte[] end = Tuple.from(-1).pack();
-        testScanMulti(limit, reverse, Collections.emptyList(), (tr, continuation) -> map.scanMulti(tr, bmSubspace, splitter, null, end, continuation, limit, reverse));
+        testScanMulti(limit, reverse, Collections.emptyList(), (tr, continuation) -> {
+            // See the scanMulti() lambda above for why this suppression is needed.
+            @SuppressWarnings("NullAway")
+            final BunchedMapMultiIterator<Tuple, Tuple, Long> result =
+                    map.scanMulti(tr, bmSubspace, splitter, null, end, continuation, limit, reverse);
+            return result;
+        });
         byte[] fullStart2 = bmSubspace.range().begin;
         byte[] fullEnd2 = ByteArrayUtil.join(bmSubspace.getKey(), end);
         testScanMulti(limit, reverse, Collections.emptyList(), (tr, continuation) ->
@@ -556,10 +582,17 @@ public class BunchedMapScanTest {
                 }
                 // Here, the limit goes out in front of the continuation, so we note that the continuation
                 // is already satisfied and don't do more work.
+                // See the scanEmptyRangeMulti() lambdas above for why these suppressions are needed.
                 if (reverse) {
-                    return map.scanMulti(tr, bmSubspace, splitter, null, Tuple.from(keyLists.size() - iteration).pack(), continuation, limit, true);
+                    @SuppressWarnings("NullAway")
+                    final BunchedMapMultiIterator<Tuple, Tuple, Long> result =
+                            map.scanMulti(tr, bmSubspace, splitter, null, Tuple.from(keyLists.size() - iteration).pack(), continuation, limit, true);
+                    return result;
                 } else {
-                    return map.scanMulti(tr, bmSubspace, splitter, Tuple.from(iteration).pack(), null, continuation, limit, false);
+                    @SuppressWarnings("NullAway")
+                    final BunchedMapMultiIterator<Tuple, Tuple, Long> result =
+                            map.scanMulti(tr, bmSubspace, splitter, Tuple.from(iteration).pack(), null, continuation, limit, false);
+                    return result;
                 }
             });
             assertEquals(keyLists.size() + 1, loops.get());

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/map/BunchedMapScanTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/map/BunchedMapScanTest.java
@@ -122,7 +122,11 @@ public class BunchedMapScanTest {
 
     private void clearAndPopulate() {
         // Populate data
-        db.run(tr -> {
+        // db.run(Function<Transaction, T>) has no void-returning overload, so this side-effect-only call returns
+        // null from the lambda; NullAway does not accept an explicit @Nullable type witness on this external,
+        // unannotated method either, so the suppression is scoped to this one declaration instead.
+        @SuppressWarnings("NullAway")
+        final Void ignored = db.run(tr -> {
             tr.clear(bmSubspace.range());
             keys.forEach(k -> map.put(tr, bmSubspace, k, value).join());
             return null;
@@ -130,7 +134,9 @@ public class BunchedMapScanTest {
     }
 
     private void clearAndPopulateMulti() {
-        db.run(tr -> {
+        // See clearAndPopulate() above for why this suppression is needed.
+        @SuppressWarnings("NullAway")
+        final Void ignored = db.run(tr -> {
             tr.clear(bmSubspace.range());
             for (int i = 0; i < keys.size(); i++) {
                 map.put(tr, subSubspaces.get(i % subSubspaces.size()), keys.get(i), value).join();
@@ -176,7 +182,13 @@ public class BunchedMapScanTest {
     }
 
     private void getKeys(boolean reverse) throws InterruptedException, ExecutionException {
-        testScan(ReadTransaction.ROW_LIMIT_UNLIMITED, reverse, (tr, bignore) -> map.scan(tr, bmSubspace, null, ReadTransaction.ROW_LIMIT_UNLIMITED, reverse));
+        testScan(ReadTransaction.ROW_LIMIT_UNLIMITED, reverse, (tr, bignore) -> {
+            // NullAway does not reliably honor @Nullable on byte[]-typed parameters, so the null literal below
+            // is misflagged as a NonNull violation even though scan()'s continuation parameter is @Nullable byte[].
+            @SuppressWarnings("NullAway")
+            final BunchedMapIterator<Tuple, Tuple> result = map.scan(tr, bmSubspace, null, ReadTransaction.ROW_LIMIT_UNLIMITED, reverse);
+            return result;
+        });
     }
 
     @Test
@@ -218,6 +230,9 @@ public class BunchedMapScanTest {
         getKeysContinuationRescan(1, reverse); // Limit of 1 to test every key
 
         // Unlimited should return null continuation.
+        // NullAway does not reliably honor @Nullable on byte[]-typed parameters, so the null literal below is
+        // misflagged as a NonNull violation even though scan()'s continuation parameter is @Nullable byte[].
+        @SuppressWarnings("NullAway")
         BunchedMapIterator<Tuple, Tuple> iterator = map.scan(tr, bmSubspace, null, ReadTransaction.ROW_LIMIT_UNLIMITED, reverse);
         List<Tuple> readKeys = AsyncUtil.collectRemaining(AsyncUtil.mapIterator(iterator, Map.Entry::getKey)).get();
         if (reverse) {
@@ -227,18 +242,25 @@ public class BunchedMapScanTest {
         assertNull(iterator.getContinuation());
 
         // Limited that returns everything because it is is limit aligned should return a non-null continuation.
-        iterator = map.scan(tr, bmSubspace, null, keys.size(), reverse);
+        // See the comment above: same NullAway array-parameter limitation applies to each reassignment below.
+        @SuppressWarnings("NullAway")
+        final BunchedMapIterator<Tuple, Tuple> iterator2 = map.scan(tr, bmSubspace, null, keys.size(), reverse);
+        iterator = iterator2;
         readKeys = AsyncUtil.collectRemaining(AsyncUtil.mapIterator(iterator, Map.Entry::getKey)).get();
         if (reverse) {
             readKeys = Lists.reverse(readKeys);
         }
         assertEquals(keys, readKeys);
         assertNotNull(iterator.getContinuation());
-        iterator = map.scan(tr, bmSubspace, iterator.getContinuation(), ReadTransaction.ROW_LIMIT_UNLIMITED, reverse);
+        @SuppressWarnings("NullAway")
+        final BunchedMapIterator<Tuple, Tuple> iterator3 = map.scan(tr, bmSubspace, iterator.getContinuation(), ReadTransaction.ROW_LIMIT_UNLIMITED, reverse);
+        iterator = iterator3;
         assertFalse(iterator.hasNext());
 
         // Limited with a limit greater than the actual number of keys should return a null continuation.
-        iterator = map.scan(tr, bmSubspace, null, keys.size() + 1, reverse);
+        @SuppressWarnings("NullAway")
+        final BunchedMapIterator<Tuple, Tuple> iterator4 = map.scan(tr, bmSubspace, null, keys.size() + 1, reverse);
+        iterator = iterator4;
         readKeys = AsyncUtil.collectRemaining(AsyncUtil.mapIterator(iterator, Map.Entry::getKey)).get();
         if (reverse) {
             readKeys = Lists.reverse(readKeys);

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/map/BunchedMapTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/map/BunchedMapTest.java
@@ -45,8 +45,8 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -114,7 +114,7 @@ public class BunchedMapTest {
         }
     }
 
-    private static List<KeyValue> inconsistentScan(@Nonnull Database db, @Nonnull Subspace subspace) {
+    private static List<KeyValue> inconsistentScan(Database db, Subspace subspace) {
         Transaction tr = db.createTransaction();  // Note that tr is mutated in the block, hence not using try-with-resources
         try {
             KeySelector begin = KeySelector.firstGreaterOrEqual(subspace.range().begin);
@@ -244,7 +244,7 @@ public class BunchedMapTest {
         }
     }
 
-    private void verifyBoundaryKeys(@Nonnull List<Tuple> boundaryKeys) throws ExecutionException, InterruptedException {
+    private void verifyBoundaryKeys(List<Tuple> boundaryKeys) throws ExecutionException, InterruptedException {
         try (Transaction tr = db.createTransaction()) {
             map.verifyIntegrity(tr, bmSubspace).get();
             List<KeyValue> rangeKVs = tr.getRange(bmSubspace.range()).asList().get();
@@ -261,9 +261,9 @@ public class BunchedMapTest {
         }
     }
 
-    private void runWithTwoTrs(@Nonnull BiConsumer<? super Transaction, ? super Transaction> operation,
+    private void runWithTwoTrs(BiConsumer<? super Transaction, ? super Transaction> operation,
                                boolean legal,
-                               @Nonnull List<Tuple> boundaryKeys) throws ExecutionException, InterruptedException {
+                               List<Tuple> boundaryKeys) throws ExecutionException, InterruptedException {
         final String id = "two-trs-" + UUID.randomUUID().toString();
         try (Transaction tr1 = db.createTransaction(); Transaction tr2 = db.createTransaction()) {
             tr1.options().setDebugTransactionIdentifier(id + "-1");
@@ -497,7 +497,7 @@ public class BunchedMapTest {
         }
     }
 
-    private byte[] getLogKey(@Nonnull Subspace logSubspace, int mapIndex, @Nonnull AtomicInteger localOrder) {
+    private byte[] getLogKey(Subspace logSubspace, int mapIndex, AtomicInteger localOrder) {
         return logSubspace.subspace(Tuple.from(mapIndex)).packWithVersionstamp(Tuple.from(Versionstamp.incomplete(localOrder.getAndIncrement())));
     }
 

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/map/BunchedMapTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/map/BunchedMapTest.java
@@ -114,6 +114,14 @@ public class BunchedMapTest {
         }
     }
 
+    // Tuple.from(Object...) is from the unannotated fdb-java client library and genuinely supports null
+    // elements (many tests below intentionally construct or log tuples with a null/absent component); its
+    // varargs parameter is treated as @NonNull by NullAway's defaults.
+    @SuppressWarnings("NullAway")
+    private static Tuple tupleFromNullable(@Nullable Object... items) {
+        return Tuple.from(items);
+    }
+
     private static List<KeyValue> inconsistentScan(Database db, Subspace subspace) {
         Transaction tr = db.createTransaction();  // Note that tr is mutated in the block, hence not using try-with-resources
         try {
@@ -193,7 +201,11 @@ public class BunchedMapTest {
         final List<Tuple> firstTuples = LongStream.range(100L, 110L).boxed().map(Tuple::from).collect(Collectors.toList());
         final List<Tuple> secondTuples = LongStream.range(120L, 130L).boxed().map(Tuple::from).collect(Collectors.toList());
 
-        db.run(tr -> {
+        // db.run(Function<Transaction, T>) has no void-returning overload, so this side-effect-only call returns
+        // null from the lambda; NullAway does not accept an explicit @Nullable type witness on this external,
+        // unannotated method either, so the suppression is scoped to this one declaration instead.
+        @SuppressWarnings("NullAway")
+        final Void ignored1 = db.run(tr -> {
             firstTuples.forEach(t -> map.put(tr, bmSubspace, t, value).join());
             secondTuples.forEach(t -> map.put(tr, bmSubspace, t, value).join());
 
@@ -294,7 +306,7 @@ public class BunchedMapTest {
 
     @Test
     public void concurrentLegalUpdates() throws ExecutionException, InterruptedException {
-        final Tuple value = Tuple.from((Object)null);
+        final Tuple value = tupleFromNullable((Object)null);
 
         // From initial database, essentially any two updates will cause each one
         // to get its own key.
@@ -308,7 +320,11 @@ public class BunchedMapTest {
         }
 
         final List<Tuple> tuples = LongStream.range(100L, 115L).boxed().map(Tuple::from).collect(Collectors.toList());
-        db.run(tr -> {
+        // db.run(Function<Transaction, T>) has no void-returning overload, so this side-effect-only call returns
+        // null from the lambda; NullAway does not accept an explicit @Nullable type witness on this external,
+        // unannotated method either, so the suppression is scoped to this one declaration instead.
+        @SuppressWarnings("NullAway")
+        final Void ignored2 = db.run(tr -> {
             tuples.forEach(t -> map.put(tr, bmSubspace, t, value).join());
             return null;
         });
@@ -331,11 +347,11 @@ public class BunchedMapTest {
         runWithTwoTrs((tr1, tr2) -> {
             // As the first one is full, the logic chooses to put (109L, null)
             // as the first key of the second set of things.
-            map.put(tr1, bmSubspace, Tuple.from(109L, null), value).join();
+            map.put(tr1, bmSubspace, tupleFromNullable(109L, null), value).join();
             // As the split is in the middle, it will choose to put
             // (107L, null) in the first group of transactions.
-            map.put(tr2, bmSubspace, Tuple.from(107L, null), value).join();
-        }, true, Arrays.asList(Tuple.from(100L), Tuple.from(105L), Tuple.from(109L, null)));
+            map.put(tr2, bmSubspace, tupleFromNullable(107L, null), value).join();
+        }, true, Arrays.asList(Tuple.from(100L), Tuple.from(105L), tupleFromNullable(109L, null)));
         try (Transaction tr = db.createTransaction()) {
             map.verifyIntegrity(tr, bmSubspace).get();
             // Fill up the (100L,) to (105L,) range.
@@ -351,7 +367,7 @@ public class BunchedMapTest {
         runWithTwoTrs((tr1, tr2) -> {
             map.put(tr1, bmSubspace, Tuple.from(104L, 100L), value).join();
             assertEquals(value, map.get(tr2, bmSubspace, Tuple.from(107L)).join().get());
-        }, true, Arrays.asList(Tuple.from(100L), Tuple.from(104L, 100L), Tuple.from(109L, null)));
+        }, true, Arrays.asList(Tuple.from(100L), Tuple.from(104L, 100L), tupleFromNullable(109L, null)));
         try (Transaction tr = db.createTransaction()) {
             // Fill up (104L, 100L) to (109, null).
             LongStream.range(101L, 104L)
@@ -365,13 +381,13 @@ public class BunchedMapTest {
         runWithTwoTrs((tr1, tr2) -> {
             map.put(tr1, bmSubspace, Tuple.from(104L, 42L), value).join();
             map.put(tr2, bmSubspace, Tuple.from(104L, 43L), value).join();
-        }, true, Arrays.asList(Tuple.from(100L), Tuple.from(104L, 42L), Tuple.from(104L, 43L), Tuple.from(104L, 100L), Tuple.from(109L, null)));
+        }, true, Arrays.asList(Tuple.from(100L), Tuple.from(104L, 42L), Tuple.from(104L, 43L), Tuple.from(104L, 100L), tupleFromNullable(109L, null)));
 
         // Case 6: Two keys before all filled ranges.
         runWithTwoTrs((tr1, tr2) -> {
             map.put(tr1, bmSubspace, Tuple.from(42L), value).join();
             map.put(tr2, bmSubspace, Tuple.from(43L), value).join();
-        }, true, Arrays.asList(Tuple.from(42L), Tuple.from(43L), Tuple.from(100L), Tuple.from(104L, 42L), Tuple.from(104L, 43L), Tuple.from(104L, 100L), Tuple.from(109L, null)));
+        }, true, Arrays.asList(Tuple.from(42L), Tuple.from(43L), Tuple.from(100L), Tuple.from(104L, 42L), Tuple.from(104L, 43L), Tuple.from(104L, 100L), tupleFromNullable(109L, null)));
         try (Transaction tr = db.createTransaction()) {
             // Fill up the last range.
             LongStream.range(117L, 120L)
@@ -385,17 +401,22 @@ public class BunchedMapTest {
         runWithTwoTrs((tr1, tr2) -> {
             map.put(tr1, bmSubspace, Tuple.from(120L), value).join();
             map.put(tr2, bmSubspace, Tuple.from(121L), value).join();
-        }, true, Arrays.asList(Tuple.from(42L), Tuple.from(43L), Tuple.from(100L), Tuple.from(104L, 42L), Tuple.from(104L, 43L), Tuple.from(104L, 100L), Tuple.from(109L, null), Tuple.from(120L), Tuple.from(121L)));
+        }, true, Arrays.asList(Tuple.from(42L), Tuple.from(43L), Tuple.from(100L), Tuple.from(104L, 42L), Tuple.from(104L, 43L), Tuple.from(104L, 100L), tupleFromNullable(109L, null), Tuple.from(120L), Tuple.from(121L)));
 
         // Case 8: Adding to a full range while simultaneously adding something after the range.
         runWithTwoTrs((tr1, tr2) -> {
             map.put(tr1, bmSubspace, Tuple.from(102L, 0L), value).join();
             map.put(tr2, bmSubspace, Tuple.from(104L, 41L), value).join();
-        }, true, Arrays.asList(Tuple.from(42L), Tuple.from(43L), Tuple.from(100L), Tuple.from(104L), Tuple.from(104L, 41L), Tuple.from(104L, 43L), Tuple.from(104L, 100L), Tuple.from(109L, null), Tuple.from(120L), Tuple.from(121L)));
+        }, true, Arrays.asList(Tuple.from(42L), Tuple.from(43L), Tuple.from(100L), Tuple.from(104L), Tuple.from(104L, 41L), Tuple.from(104L, 43L), Tuple.from(104L, 100L), tupleFromNullable(109L, null), Tuple.from(120L), Tuple.from(121L)));
 
         // Compact the data to a minimal number of keys.
         try (Transaction tr = db.createTransaction()) {
-            assertNull(map.compact(tr, bmSubspace, 0, null).get());
+            // NullAway does not reliably honor @Nullable on byte[]-typed parameters, so the null literal below
+            // is misflagged as a NonNull violation even though compact()'s continuation parameter is
+            // declared @Nullable byte[].
+            @SuppressWarnings("NullAway")
+            final byte[] nextContinuation = map.compact(tr, bmSubspace, 0, null).get();
+            assertNull(nextContinuation);
             map.verifyIntegrity(tr, bmSubspace).get();
             tr.commit().get();
         }
@@ -404,7 +425,7 @@ public class BunchedMapTest {
 
     @Test
     public void concurrentIllegalUpdates() throws ExecutionException, InterruptedException {
-        final Tuple value = Tuple.from(Tuple.from((Object)null));
+        final Tuple value = Tuple.from(tupleFromNullable((Object)null));
 
         runWithTwoTrs((tr1, tr2) -> {
             map.put(tr1, bmSubspace, Tuple.from(0L), value).join();
@@ -427,7 +448,11 @@ public class BunchedMapTest {
         }
 
         final List<Tuple> tuples = LongStream.range(100L, 115L).boxed().map(Tuple::from).collect(Collectors.toList());
-        db.run(tr -> {
+        // db.run(Function<Transaction, T>) has no void-returning overload, so this side-effect-only call returns
+        // null from the lambda; NullAway does not accept an explicit @Nullable type witness on this external,
+        // unannotated method either, so the suppression is scoped to this one declaration instead.
+        @SuppressWarnings("NullAway")
+        final Void ignored3 = db.run(tr -> {
             tr.clear(bmSubspace.range());
             tuples.forEach(t -> map.put(tr, bmSubspace, t, value).join());
             return null;
@@ -473,7 +498,7 @@ public class BunchedMapTest {
 
         // Case 6: Write a value that would end up being overwritten in a split
         runWithTwoTrs((tr1, tr2) -> {
-            map.put(tr1, bmSubspace, Tuple.from(102L, null), value).join();
+            map.put(tr1, bmSubspace, tupleFromNullable(102L, null), value).join();
             map.put(tr2, bmSubspace, Tuple.from(107L), value.add(3.14d)).join();
         }, false, Arrays.asList(Tuple.from(100L), Tuple.from(104L), Tuple.from(110L)));
         assertEquals(value, map.get(db, bmSubspace, Tuple.from(107L)).get().get());
@@ -508,7 +533,11 @@ public class BunchedMapTest {
     private void stressTest(final Random r, final int trTotal, final int opTotal, final int keyCount, final int workerCount, boolean addBytesToValue, AtomicLong globalTrCount, int mapCount) throws InterruptedException, ExecutionException {
         final long initialTrCount = globalTrCount.get();
         final Subspace logSubspace = DirectoryLayer.getDefault().createOrOpen(db, PathUtil.from(getClass().getName(), "log")).get();
-        db.run(tr -> {
+        // db.run(Function<Transaction, T>) has no void-returning overload, so this side-effect-only call returns
+        // null from the lambda; NullAway does not accept an explicit @Nullable type witness on this external,
+        // unannotated method either, so the suppression is scoped to this one declaration instead.
+        @SuppressWarnings("NullAway")
+        final Void ignored4 = db.run(tr -> {
             tr.clear(bmSubspace.range());
             tr.clear(logSubspace.range());
             // If the database is empty, putting these here stop scans from hitting the log subspace within a transaction
@@ -560,7 +589,7 @@ public class BunchedMapTest {
                         int mapIndex = r.nextInt(mapCount);
                         Tuple key = Tuple.from(r.nextInt(keyCount));
                         op = workerMap.get(tr, bmSubspace.get(mapIndex), key).thenAccept(optionalValue ->
-                                tr.mutate(MutationType.SET_VERSIONSTAMPED_KEY, getLogKey(logSubspace, mapIndex, localOrder), Tuple.from("GET", key, optionalValue.orElse(null)).pack())
+                                tr.mutate(MutationType.SET_VERSIONSTAMPED_KEY, getLogKey(logSubspace, mapIndex, localOrder), tupleFromNullable("GET", key, optionalValue.orElse(null)).pack())
                         );
                     } else if (opCode == 2) {
                         // Check contains key
@@ -574,7 +603,7 @@ public class BunchedMapTest {
                         int mapIndex = r.nextInt(mapCount);
                         Tuple key = Tuple.from(r.nextInt(keyCount));
                         op = workerMap.remove(tr, bmSubspace.subspace(Tuple.from(mapIndex)), key).thenAccept(oldValue ->
-                                tr.mutate(MutationType.SET_VERSIONSTAMPED_KEY, getLogKey(logSubspace, mapIndex, localOrder), Tuple.from("REMOVE", key, oldValue.orElse(null)).pack())
+                                tr.mutate(MutationType.SET_VERSIONSTAMPED_KEY, getLogKey(logSubspace, mapIndex, localOrder), tupleFromNullable("REMOVE", key, oldValue.orElse(null)).pack())
                         );
                     }
                     return op.thenApply(ignore -> opCount.incrementAndGet() < opTotal);
@@ -670,10 +699,17 @@ public class BunchedMapTest {
         AtomicInteger mapIndex = new AtomicInteger(0);
         CompletableFuture<Void> compactingWorker = AsyncUtil.whileTrue(() -> {
             AtomicReference<byte[]> continuation = new AtomicReference<>(null);
-            return AsyncUtil.whileTrue(() -> map.compact(db, bmSubspace.subspace(Tuple.from(mapIndex.get())), 5, continuation.get()).thenApply(nextContinuation -> {
-                continuation.set(nextContinuation);
-                return nextContinuation != null;
-            })).thenApply(vignore -> {
+            return AsyncUtil.whileTrue(() -> {
+                // continuation genuinely starts and can remain null (meaning "no continuation yet" / "compaction
+                // complete"), but NullAway does not reliably honor @Nullable on byte[]-typed parameters.
+                @SuppressWarnings("NullAway")
+                final CompletableFuture<byte[]> compactFuture =
+                        map.compact(db, bmSubspace.subspace(Tuple.from(mapIndex.get())), 5, continuation.get());
+                return compactFuture.thenApply(nextContinuation -> {
+                    continuation.set(nextContinuation);
+                    return nextContinuation != null;
+                });
+            }).thenApply(vignore -> {
                 mapIndex.getAndUpdate(oldIndex -> (oldIndex + 1) % mapCount);
                 return stillWorking.get();
             });

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/map/BunchedMapTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/map/BunchedMapTest.java
@@ -158,7 +158,11 @@ public class BunchedMapTest {
     public void insertSingleKey() {
         List<Tuple> testTuples = Stream.of(1066L, 1776L, 1415L, 800L).map(Tuple::from).collect(Collectors.toList());
         Tuple value = Tuple.from(1415L);
-        db.run(tr -> {
+        // db.run(Function<Transaction, T>) has no void-returning overload, so tests that only care about side
+        // effects return null from the lambda; NullAway does not accept an explicit @Nullable type witness on
+        // this external, unannotated method either, so the suppression is scoped to this one declaration instead.
+        @SuppressWarnings("NullAway")
+        final Void ignored = db.run(tr -> {
             Tuple minSoFar = null;
             for (int i = 0; i < testTuples.size(); i++) {
                 Tuple key = testTuples.get(i);

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/map/BunchedTupleSerializerTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/map/BunchedTupleSerializerTest.java
@@ -25,6 +25,8 @@ import com.apple.foundationdb.tuple.ByteArrayUtil;
 import com.apple.foundationdb.tuple.Tuple;
 import org.junit.jupiter.api.Test;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -41,19 +43,27 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * Tests for serialization in {@link BunchedMap}.
  */
 public class BunchedTupleSerializerTest {
+    // Tuple.from(Object...) is from the unannotated fdb-java client library and genuinely supports null
+    // elements (several entries below intentionally construct tuples with a null component); its varargs
+    // parameter is treated as @NonNull by NullAway's defaults.
+    @SuppressWarnings("NullAway")
+    private static Tuple tupleFromNullable(@Nullable Object... items) {
+        return Tuple.from(items);
+    }
+
     private static final List<Tuple> TEST_TUPLES = Arrays.asList(
             Tuple.from(),
-            Tuple.from((Object)null),
+            tupleFromNullable((Object)null),
             Tuple.from(1066L),
-            Tuple.from(1066L, null),
+            tupleFromNullable(1066L, null),
             Tuple.from(1066L, "hello"),
             Tuple.from(1415L),
             Tuple.from(Tuple.from(1066L)),
             Tuple.from(Tuple.from(1066L), "hello"),
-            Tuple.from(Tuple.from(1066L, null), "hello"),
+            Tuple.from(tupleFromNullable(1066L, null), "hello"),
             Tuple.from(Tuple.from(1066L, 1415L), "hello"),
             Tuple.from(Tuple.from(1066L, "hello")),
-            Tuple.from(Tuple.from(1066L, "hello"), null)
+            tupleFromNullable(Tuple.from(1066L, "hello"), null)
     );
     private static final BunchedTupleSerializer serializer = BunchedTupleSerializer.instance();
 

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/map/package-info.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/map/package-info.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,14 +18,7 @@
  * limitations under the License.
  */
 
-/**
- * Utilities for logging and exception handling.
- * All exceptions in the <a href="https://foundationdb.github.io/fdb-record-layer/">Record Layer</a>
- * project are descendants of {@link com.apple.foundationdb.util.LoggableException} class. This
- * class allows the user to attach arbitrary keys and values to an {@link java.lang.Exception} when
- * thrown.
- */
 @NullMarked
-package com.apple.foundationdb.util;
+package com.apple.foundationdb.map;
 
 import org.jspecify.annotations.NullMarked;

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/rabitq/RaBitQuantizerTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/rabitq/RaBitQuantizerTest.java
@@ -38,7 +38,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Random;
@@ -49,7 +48,6 @@ import static com.apple.foundationdb.linear.RealVectorTest.createRandomDoubleVec
 public class RaBitQuantizerTest {
     private static final Logger logger = LoggerFactory.getLogger(RaBitQuantizerTest.class);
 
-    @Nonnull
     private static Stream<Arguments> randomSeedsWithNumDimensionsAndNumExBits() {
         return RandomizedTestUtils.randomSeeds(0xdeadc0deL, 0xfdb5ca1eL, 0xf005ba1L)
                 .flatMap(seed ->
@@ -59,7 +57,6 @@ public class RaBitQuantizerTest {
                                 .map(arguments -> Arguments.of(seed, arguments.get(0), arguments.get(1))));
     }
 
-    @Nonnull
     private static Stream<Arguments> randomSeedsWithMetricsNumDimensionsAndNumExBits() {
         return RandomizedTestUtils.randomSeeds(0xdeadc0deL, 0xfdb5ca1eL, 0xf005ba1L)
                 .flatMap(seed ->
@@ -264,7 +261,6 @@ public class RaBitQuantizerTest {
         Assertions.assertThat(estimatedDistance).isCloseTo(-1.0d, Offset.offset(0.01));
     }
 
-    @Nonnull
     private static Stream<Arguments> estimationArgs() {
         return Stream.of(
                 Arguments.of(new double[]{0.5d, 0.5d}, new double[]{1.0d, 1.0d}, new double[]{-1.0d, 1.0d}, 4.0d),
@@ -388,7 +384,7 @@ public class RaBitQuantizerTest {
 
     @ParameterizedTest
     @MethodSource("randomSeedsWithMetricsNumDimensionsAndNumExBits")
-    void encodeManyWithEstimationsCosineDotProductMetricTest(final long seed, @Nonnull final Metric metric,
+    void encodeManyWithEstimationsCosineDotProductMetricTest(final long seed, final Metric metric,
                                                              final int numDimensions, final int numExBits) {
         final Random random = new Random(seed);
         final FhtKacRotator rotator = new FhtKacRotator(seed, numDimensions, 10);

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/rabitq/RaBitQuantizerTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/rabitq/RaBitQuantizerTest.java
@@ -321,11 +321,12 @@ public class RaBitQuantizerTest {
                 if (sum == null) {
                     sum = v;
                 } else {
-                    sum.add(v);
+                    sum = sum.add(v);
                 }
             }
             Objects.requireNonNull(v);
             Objects.requireNonNull(q);
+            Objects.requireNonNull(sum);
 
             final RealVector centroid = sum.multiply(1.0d / numVectorsForCentroid);
 

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/rabitq/package-info.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/rabitq/package-info.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,14 +18,7 @@
  * limitations under the License.
  */
 
-/**
- * Utilities for logging and exception handling.
- * All exceptions in the <a href="https://foundationdb.github.io/fdb-record-layer/">Record Layer</a>
- * project are descendants of {@link com.apple.foundationdb.util.LoggableException} class. This
- * class allows the user to attach arbitrary keys and values to an {@link java.lang.Exception} when
- * thrown.
- */
 @NullMarked
-package com.apple.foundationdb.util;
+package com.apple.foundationdb.rabitq;
 
 import org.jspecify.annotations.NullMarked;

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/tuple/ByteArrayUtil2Test.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/tuple/ByteArrayUtil2Test.java
@@ -24,6 +24,7 @@ import com.apple.test.RandomSeedSource;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 
+import java.util.Objects;
 import java.util.Random;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -41,6 +42,9 @@ public class ByteArrayUtil2Test {
         String hexRegex = "^\\\\x[0-9a-f][0-9a-f]$";
         for (int i = Byte.MIN_VALUE; i < (byte)' '; i++) {
             String l = ByteArrayUtil2.loggable(new byte[]{(byte)i});
+            // loggable() is only @Nullable to handle a null input array; the literal array above is never
+            // null, so the result cannot be null either.
+            Objects.requireNonNull(l);
             assertTrue(l.matches(hexRegex), l + " matches /" + hexRegex + "/");
         }
         for (int i = (byte)' '; i < (byte)'"'; i++) {
@@ -93,6 +97,9 @@ public class ByteArrayUtil2Test {
         final String loggable = ByteArrayUtil2.loggable(bytes);
         byte[] unlogged = ByteArrayUtil2.unprint(loggable);
         assertArrayEquals(bytes, unlogged, "Unprinting loggable bytes should reconstruct original array");
+        // loggable() is only @Nullable to handle a null input array; bytes above is never null, so the
+        // result cannot be null either.
+        Objects.requireNonNull(loggable);
         assertFalse(loggable.contains("="), "loggable string should not contain equals sign");
         assertFalse(loggable.contains("\""), "loggable string should not contain quote");
         assertFalse(loggable.contains("\'"), "loggable string should not contain single quote");

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/tuple/TupleHelpersTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/tuple/TupleHelpersTest.java
@@ -24,6 +24,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.UUID;
 import java.util.stream.Stream;
 
@@ -31,6 +33,14 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TupleHelpersTest {
+
+    // Tuple.from(Object...) is from the unannotated fdb-java client library and genuinely supports null
+    // elements (several cases below intentionally construct tuples with a null component); its varargs
+    // parameter is treated as @NonNull by NullAway's defaults.
+    @SuppressWarnings("NullAway")
+    private static Tuple tupleFromNullable(@Nullable Object... items) {
+        return Tuple.from(items);
+    }
 
     static Stream<Arguments> isPrefixTrueCases() {
         UUID uuid1 = UUID.fromString("12345678-1234-1234-1234-123456789abc");
@@ -65,9 +75,9 @@ class TupleHelpersTest {
                 Arguments.of("uuids", 
                         Tuple.from("test", uuid1), 
                         Tuple.from("test", uuid1, UUID.randomUUID())),
-                Arguments.of("null values", 
-                        Tuple.from("test", null), 
-                        Tuple.from("test", null, "more")),
+                Arguments.of("null values",
+                        tupleFromNullable("test", null),
+                        tupleFromNullable("test", null, "more")),
                 Arguments.of("number variations", 
                         Tuple.from(42, 3.14, -7L), 
                         Tuple.from(42, 3.14, -7L, "suffix")),
@@ -113,20 +123,20 @@ class TupleHelpersTest {
                 Arguments.of("different binary data", 
                         Tuple.from("test", data1), 
                         Tuple.from("test", data2, "more")),
-                Arguments.of("null mismatch", 
-                        Tuple.from("test", null), 
+                Arguments.of("null mismatch",
+                        tupleFromNullable("test", null),
                         Tuple.from("test", "not-null")),
                 Arguments.of("null vs empty string",
-                        Tuple.from("test", null),
+                        tupleFromNullable("test", null),
                         Tuple.from("test", "")),
                 Arguments.of("null vs 0",
-                        Tuple.from("test", null),
+                        tupleFromNullable("test", null),
                         Tuple.from("test", 0)),
                 Arguments.of("null vs false",
-                        Tuple.from("test", null),
+                        tupleFromNullable("test", null),
                         Tuple.from("test", false)),
                 Arguments.of("null vs byte[0]",
-                        Tuple.from("test", null),
+                        tupleFromNullable("test", null),
                         Tuple.from("test", new byte[0])),
                 Arguments.of("number mismatch", 
                         Tuple.from(42, 3.14), 

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/tuple/TupleTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/tuple/TupleTest.java
@@ -47,6 +47,14 @@ public class TupleTest {
     private static final char weirdCharacter = 3;
     private static final char ffCharacter = 0xff;
 
+    // Tuple.from(Object...) is from the unannotated fdb-java client library and genuinely supports a null
+    // element (obj is null for the null-value test cases below); its varargs parameter is treated as
+    // @NonNull by NullAway's defaults.
+    @SuppressWarnings("NullAway")
+    private static Tuple tupleFromNullable(@Nullable Object obj) {
+        return Tuple.from(obj);
+    }
+
     private static List<ExpectedTupleEncoding<?>> tests = ImmutableList.<ExpectedTupleEncoding<?>>builder()
             .add(new ExpectedTupleEncoding<>(null, "\\x00"))
             .add(new ExpectedTupleEncoding<>(new UUID(0, 0),
@@ -147,14 +155,16 @@ public class TupleTest {
         }
 
         public void check() {
-            byte[] actualAlone = Tuple.from(obj).pack();
+            byte[] actualAlone = tupleFromNullable(obj).pack();
             if (encodedLoggable == null) {
                 // This is used to generate new test cases.
                 // To add a new test case, create a new ExpectedTupleEncoding with a null string, then run
                 // testTuple above. Then copy the encoding into the test case from standard output
                 if (actualAlone != null) {
-                    System.out.println("\"" +
-                            ByteArrayUtil2.loggable(actualAlone).replaceAll("\\\\", "\\\\\\\\") + "\"");
+                    String loggable = ByteArrayUtil2.loggable(actualAlone);
+                    if (loggable != null) {
+                        System.out.println("\"" + loggable.replaceAll("\\\\", "\\\\\\\\") + "\"");
+                    }
                 }
             } else {
                 assertEquals(encodedLoggable, ByteArrayUtil2.loggable(actualAlone));

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/tuple/TupleTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/tuple/TupleTest.java
@@ -25,8 +25,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -107,7 +107,6 @@ public class TupleTest {
             .add()
             .build();
 
-    @Nonnull
     static Stream<ExpectedTupleEncoding<?>> testTuple() {
         return tests.stream();
     }

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/tuple/package-info.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/tuple/package-info.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,14 +18,7 @@
  * limitations under the License.
  */
 
-/**
- * Utilities for logging and exception handling.
- * All exceptions in the <a href="https://foundationdb.github.io/fdb-record-layer/">Record Layer</a>
- * project are descendants of {@link com.apple.foundationdb.util.LoggableException} class. This
- * class allows the user to attach arbitrary keys and values to an {@link java.lang.Exception} when
- * thrown.
- */
 @NullMarked
-package com.apple.foundationdb.util;
+package com.apple.foundationdb.tuple;
 
 import org.jspecify.annotations.NullMarked;

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/util/CallbackUtilsTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/util/CallbackUtilsTest.java
@@ -20,10 +20,12 @@
 
 package com.apple.foundationdb.util;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -56,8 +58,10 @@ class CallbackUtilsTest {
         final CallbackUtils.InvokeResults<String> result = CallbackUtils.invokeAll(
                 List.of(successCallback("s1"), failureCallback("s2"), successCallback("s3")));
         Assertions.assertNotNull(result.getAccumulatedException());
-        Assertions.assertEquals(CallbackException.class, result.getAccumulatedException().getClass());
-        Assertions.assertEquals("s2", result.getAccumulatedException().getCause().getMessage());
+        // This test's own setup (one failing callback) guarantees an accumulated exception is present.
+        final CallbackException accumulatedException = Objects.requireNonNull(result.getAccumulatedException());
+        Assertions.assertEquals(CallbackException.class, accumulatedException.getClass());
+        Assertions.assertEquals("s2", Objects.requireNonNull(accumulatedException.getCause()).getMessage());
         Assertions.assertEquals(List.of("s1", "s3"), result.getResults());
     }
 
@@ -66,8 +70,10 @@ class CallbackUtilsTest {
         final CallbackUtils.InvokeResults<String> result = CallbackUtils.invokeAll(
                 List.of(failureCallback("f1"), failureCallback("f2"), failureCallback("f3")));
         Assertions.assertNotNull(result.getAccumulatedException());
-        Assertions.assertEquals("f1", result.getAccumulatedException().getCause().getMessage());
-        final Throwable[] suppressed = result.getAccumulatedException().getSuppressed();
+        // This test's own setup (all callbacks fail) guarantees an accumulated exception is present.
+        final CallbackException accumulatedException = Objects.requireNonNull(result.getAccumulatedException());
+        Assertions.assertEquals("f1", Objects.requireNonNull(accumulatedException.getCause()).getMessage());
+        final Throwable[] suppressed = accumulatedException.getSuppressed();
         Assertions.assertEquals(2, suppressed.length);
         Assertions.assertEquals("f2", suppressed[0].getMessage());
         Assertions.assertEquals("f3", suppressed[1].getMessage());
@@ -79,15 +85,23 @@ class CallbackUtilsTest {
         final CallbackUtils.InvokeResults<String> result = CallbackUtils.invokeAll(
                 List.of(successCallback("s1"), successCallback("s2"), failureCallback("f3")));
         Assertions.assertNotNull(result.getAccumulatedException());
-        Assertions.assertEquals("f3", result.getAccumulatedException().getCause().getMessage());
-        Assertions.assertEquals(0, result.getAccumulatedException().getSuppressed().length);
+        // This test's own setup (last callback fails) guarantees an accumulated exception is present.
+        final CallbackException accumulatedException = Objects.requireNonNull(result.getAccumulatedException());
+        Assertions.assertEquals("f3", Objects.requireNonNull(accumulatedException.getCause()).getMessage());
+        Assertions.assertEquals(0, accumulatedException.getSuppressed().length);
         Assertions.assertEquals(List.of("s1", "s2"), result.getResults());
     }
 
     @Test
     void invokeAllNullReturn() {
+        // successCallback's str parameter is @NonNull String, but this test intentionally exercises the case
+        // where a Supplier<T> passed to invokeAll returns null (verifying invokeAll doesn't reject or crash on
+        // it); CallbackUtils.invokeAll's generic contract does not actually enforce non-null results at
+        // runtime, so widening successCallback's signature just for this one test isn't warranted.
+        @SuppressWarnings("NullAway")
+        final Supplier<String> nullReturningCallback = successCallback(null);
         final CallbackUtils.InvokeResults<String> result = CallbackUtils.invokeAll(
-                List.of(successCallback(null), successCallback("s2")));
+                List.of(nullReturningCallback, successCallback("s2")));
         Assertions.assertNull(result.getAccumulatedException());
         Assertions.assertEquals(2, result.getResults().size());
         Assertions.assertNull(result.getResults().get(0));
@@ -126,10 +140,13 @@ class CallbackUtilsTest {
                 tracked(futureSuccess("s3"), f3Done)));
         final CompletionException exception = assertThrows(CompletionException.class, future::join);
         Assertions.assertInstanceOf(CallbackException.class, exception.getCause());
-        final CallbackException closeException = (CallbackException)exception.getCause();
+        // Throwable.getCause() is nullable in general, but the assertInstanceOf just above guarantees a cause
+        // is present here.
+        final CallbackException closeException = (CallbackException)Objects.requireNonNull(exception.getCause());
         // allOf wraps non-CompletionException causes in a CompletionException before propagating
         Assertions.assertInstanceOf(CompletionException.class, closeException.getCause());
-        Assertions.assertEquals("f2", closeException.getCause().getCause().getMessage());
+        final Throwable closeExceptionCause = Objects.requireNonNull(closeException.getCause());
+        Assertions.assertEquals("f2", Objects.requireNonNull(closeExceptionCause.getCause()).getMessage());
         Assertions.assertEquals(0, closeException.getSuppressed().length);
         Assertions.assertTrue(f1Done.get());
         Assertions.assertTrue(f2Done.get());
@@ -146,8 +163,10 @@ class CallbackUtilsTest {
                 tracked(futureSuccess("s2"), f2Done),
                 tracked(futureFailure("f3"), f3Done)));
         final CompletionException exception = assertThrows(CompletionException.class, future::join);
-        final CallbackException callbackException = (CallbackException)exception.getCause();
-        Assertions.assertEquals("f1", callbackException.getCause().getCause().getMessage());
+        // Throwable.getCause() is nullable in general, but this test's own setup guarantees a cause is present.
+        final CallbackException callbackException = (CallbackException)Objects.requireNonNull(exception.getCause());
+        final Throwable callbackExceptionCause = Objects.requireNonNull(callbackException.getCause());
+        Assertions.assertEquals("f1", Objects.requireNonNull(callbackExceptionCause.getCause()).getMessage());
         Assertions.assertEquals(0, callbackException.getSuppressed().length);
         // When multiple futures fail, whenAll only throws one of the exceptions, so we can't assert on f3
         Assertions.assertTrue(f1Done.get());
@@ -166,9 +185,9 @@ class CallbackUtilsTest {
                 tracked(futureSuccess("s3"), f3Done)));
         final CompletionException exception = assertThrows(CompletionException.class, future::join);
         Assertions.assertInstanceOf(CallbackException.class, exception.getCause());
-        final CallbackException callbackException = (CallbackException)exception.getCause();
+        final CallbackException callbackException = (CallbackException)Objects.requireNonNull(exception.getCause());
         // The CloseException's cause is the exception thrown by the supplier
-        Assertions.assertEquals("t2", callbackException.getCause().getMessage());
+        Assertions.assertEquals("t2", Objects.requireNonNull(callbackException.getCause()).getMessage());
         Assertions.assertEquals(0, callbackException.getSuppressed().length);
         Assertions.assertTrue(f1Done.get());
         Assertions.assertTrue(f3Done.get());
@@ -180,8 +199,8 @@ class CallbackUtilsTest {
                 List.of(throwingSupplier("t1"), throwingSupplier("t2")));
         final CompletionException exception = assertThrows(CompletionException.class, future::join);
         Assertions.assertInstanceOf(CallbackException.class, exception.getCause());
-        final CallbackException callbackException = (CallbackException)exception.getCause();
-        Assertions.assertEquals("t1", callbackException.getCause().getMessage());
+        final CallbackException callbackException = (CallbackException)Objects.requireNonNull(exception.getCause());
+        Assertions.assertEquals("t1", Objects.requireNonNull(callbackException.getCause()).getMessage());
         Assertions.assertEquals(1, callbackException.getSuppressed().length);
         Assertions.assertEquals("t2", callbackException.getSuppressed()[0].getMessage());
     }
@@ -195,11 +214,11 @@ class CallbackUtilsTest {
                 throwingSupplier("t2")));
         final CompletionException exception = assertThrows(CompletionException.class, future::join);
         Assertions.assertInstanceOf(CallbackException.class, exception.getCause());
-        final CallbackException callbackException = (CallbackException)exception.getCause();
+        final CallbackException callbackException = (CallbackException)Objects.requireNonNull(exception.getCause());
         // The supplier exception is the primary cause; the future failure is suppressed
-        Assertions.assertEquals("t2", callbackException.getCause().getMessage());
+        Assertions.assertEquals("t2", Objects.requireNonNull(callbackException.getCause()).getMessage());
         Assertions.assertEquals(1, callbackException.getSuppressed().length);
-        Assertions.assertEquals("f1", callbackException.getSuppressed()[0].getCause().getMessage());
+        Assertions.assertEquals("f1", Objects.requireNonNull(callbackException.getSuppressed()[0].getCause()).getMessage());
         Assertions.assertTrue(f1Done.get());
     }
 

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/util/CallbackUtilsTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/util/CallbackUtilsTest.java
@@ -20,7 +20,6 @@
 
 package com.apple.foundationdb.util;
 
-import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/util/CloseableUtilsTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/util/CloseableUtilsTest.java
@@ -20,8 +20,11 @@
 
 package com.apple.foundationdb.util;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -60,7 +63,8 @@ class CloseableUtilsTest {
     void closeAllSingleFailure() {
         SimpleCloseable c1 = new SimpleCloseable(true, "c1");
         final CloseException exception = assertThrows(CloseException.class, () -> CloseableUtils.closeAll(c1));
-        Assertions.assertEquals("c1", exception.getCause().getMessage());
+        // Throwable.getCause() is nullable in general, but this test's own setup guarantees a cause is present.
+        Assertions.assertEquals("c1", Objects.requireNonNull(exception.getCause()).getMessage());
         Assertions.assertEquals(0, exception.getSuppressed().length);
         Assertions.assertTrue(c1.isClosed());
     }
@@ -85,7 +89,8 @@ class CloseableUtilsTest {
         SimpleCloseable c3 = new SimpleCloseable(false, null);
         final CloseException exception = assertThrows(CloseException.class,
                 () -> CloseableUtils.closeAll(c1, c2, c3));
-        Assertions.assertEquals("c1", exception.getCause().getMessage());
+        // Throwable.getCause() is nullable in general, but this test's own setup guarantees a cause is present.
+        Assertions.assertEquals("c1", Objects.requireNonNull(exception.getCause()).getMessage());
         Assertions.assertEquals(1, exception.getSuppressed().length);
         Assertions.assertInstanceOf(InterruptedException.class, exception.getSuppressed()[0]);
         Assertions.assertTrue(c1.isClosed());
@@ -102,7 +107,8 @@ class CloseableUtilsTest {
 
         final CloseException exception = assertThrows(CloseException.class, () -> CloseableUtils.closeAll(c1, c2, c3));
 
-        Assertions.assertEquals("c1", exception.getCause().getMessage());
+        // Throwable.getCause() is nullable in general, but this test's own setup guarantees a cause is present.
+        Assertions.assertEquals("c1", Objects.requireNonNull(exception.getCause()).getMessage());
         final Throwable[] suppressed = exception.getSuppressed();
         Assertions.assertEquals(2, suppressed.length);
         Assertions.assertEquals("c2", suppressed[0].getMessage());
@@ -121,7 +127,8 @@ class CloseableUtilsTest {
 
         final CloseException exception = assertThrows(CloseException.class, () -> CloseableUtils.closeAll(c1, c2, c3));
 
-        Assertions.assertEquals("c1", exception.getCause().getMessage());
+        // Throwable.getCause() is nullable in general, but this test's own setup guarantees a cause is present.
+        Assertions.assertEquals("c1", Objects.requireNonNull(exception.getCause()).getMessage());
         final Throwable[] suppressed = exception.getSuppressed();
         Assertions.assertEquals(1, suppressed.length);
         Assertions.assertEquals("c3", suppressed[0].getMessage());
@@ -133,10 +140,11 @@ class CloseableUtilsTest {
 
     private static class SimpleCloseable implements AutoCloseable {
         private final boolean fail;
+        @Nullable
         private final String message;
         private boolean closed = false;
 
-        public SimpleCloseable(boolean fail, String message) {
+        public SimpleCloseable(boolean fail, @Nullable String message) {
             this.fail = fail;
             this.message = message;
         }

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/util/LensTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/util/LensTest.java
@@ -23,8 +23,8 @@ package com.apple.foundationdb.util;
 import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.Test;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import java.util.List;
 import java.util.Objects;
 
@@ -106,15 +106,13 @@ class LensTest {
         assertThat(lens.set(a, 20)).satisfies(newA -> assertThat(newA.b().d().x()).isEqualTo(20));
     }
 
-    private record A(@Nonnull B b, @Nonnull C c) {
+    private record A(B b, C c) {
         private static final Lens<A, B> bLens = new Lens<>() {
-            @Nonnull
             @Override
-            public B get(@Nonnull final A a) {
+            public B get(final A a) {
                 return a.b();
             }
 
-            @Nonnull
             @Override
             public A set(@Nullable final A a, @Nullable final B b) {
                 return new A(Objects.requireNonNull(b), Objects.requireNonNull(a).c());
@@ -122,13 +120,11 @@ class LensTest {
         };
 
         private static final Lens<A, C> cLens = new Lens<>() {
-            @Nonnull
             @Override
-            public C get(@Nonnull final A a) {
+            public C get(final A a) {
                 return a.c();
             }
 
-            @Nonnull
             @Override
             public A set(@Nullable final A a, @Nullable final C c) {
                 return new A(Objects.requireNonNull(a).b(), Objects.requireNonNull(c));
@@ -136,15 +132,13 @@ class LensTest {
         };
     }
 
-    private record B(@Nonnull D d) {
+    private record B(D d) {
         private static final Lens<B, D> dLens = new Lens<>() {
-            @Nonnull
             @Override
-            public D get(@Nonnull final B b) {
+            public D get(final B b) {
                 return b.d();
             }
 
-            @Nonnull
             @Override
             public B set(@Nullable final B b, @Nullable final D d) {
                 return new B(Objects.requireNonNull(d));
@@ -156,11 +150,10 @@ class LensTest {
         private static final Lens<C, D> dLens = new Lens<>() {
             @Nullable
             @Override
-            public D get(@Nonnull final C c) {
+            public D get(final C c) {
                 return c.d();
             }
 
-            @Nonnull
             @Override
             public C set(@Nullable final C c, @Nullable final D d) {
                 return new C(d);
@@ -170,13 +163,11 @@ class LensTest {
 
     private record D(int x) {
         private static final Lens<D, Integer> xLens = new Lens<>() {
-            @Nonnull
             @Override
-            public Integer get(@Nonnull final D d) {
+            public Integer get(final D d) {
                 return d.x();
             }
 
-            @Nonnull
             @Override
             public D set(@Nullable final D d, @Nullable final Integer x) {
                 return new D(Objects.requireNonNull(x));

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/util/LoggableExceptionTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/util/LoggableExceptionTest.java
@@ -41,6 +41,10 @@ public class LoggableExceptionTest {
     @Test
     public void emptyLogInfo() {
         LoggableException e = new LoggableException("this has no k/v pairs");
+        // NullAway does not reliably read @Nullable on nested generic type arguments
+        // (Map<String, @Nullable Object>) from LoggableException's already-compiled classfile, even though
+        // the annotation is correctly present there (confirmed via javap -v's RuntimeVisibleTypeAnnotations).
+        @SuppressWarnings("NullAway")
         Map<String, @Nullable Object> logInfo = e.getLogInfo();
         assertNotNull(logInfo);
         assertEquals(Collections.emptyMap(), logInfo);
@@ -53,6 +57,10 @@ public class LoggableExceptionTest {
     public void oneLogInfo() {
         LoggableException e = new LoggableException("this has one k/v pair")
                 .addLogInfo("key", "value");
+        // NullAway does not reliably read @Nullable on nested generic type arguments
+        // (Map<String, @Nullable Object>) from LoggableException's already-compiled classfile, even though
+        // the annotation is correctly present there (confirmed via javap -v's RuntimeVisibleTypeAnnotations).
+        @SuppressWarnings("NullAway")
         Map<String, @Nullable Object> logInfo = e.getLogInfo();
         assertNotNull(logInfo);
         assertEquals(Collections.singletonMap("key", "value"), logInfo);
@@ -68,6 +76,10 @@ public class LoggableExceptionTest {
         expectedLogInfo.put("k1", "v1");
         expectedLogInfo.put("k2", "v2");
         LoggableException e = new LoggableException("this has multiple k/v pairs", "k0", "v0", "k1", "v1", "k2", "v2");
+        // NullAway does not reliably read @Nullable on nested generic type arguments
+        // (Map<String, @Nullable Object>) from LoggableException's already-compiled classfile, even though
+        // the annotation is correctly present there (confirmed via javap -v's RuntimeVisibleTypeAnnotations).
+        @SuppressWarnings("NullAway")
         Map<String, @Nullable Object> logInfo = e.getLogInfo();
         assertNotNull(logInfo);
         assertEquals(expectedLogInfo, logInfo);

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/util/LoggableExceptionTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/util/LoggableExceptionTest.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.util;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.Collections;
@@ -40,7 +41,7 @@ public class LoggableExceptionTest {
     @Test
     public void emptyLogInfo() {
         LoggableException e = new LoggableException("this has no k/v pairs");
-        Map<String, Object> logInfo = e.getLogInfo();
+        Map<String, @Nullable Object> logInfo = e.getLogInfo();
         assertNotNull(logInfo);
         assertEquals(Collections.emptyMap(), logInfo);
         Object[] logInfoArray = e.exportLogInfo();
@@ -52,7 +53,7 @@ public class LoggableExceptionTest {
     public void oneLogInfo() {
         LoggableException e = new LoggableException("this has one k/v pair")
                 .addLogInfo("key", "value");
-        Map<String, Object> logInfo = e.getLogInfo();
+        Map<String, @Nullable Object> logInfo = e.getLogInfo();
         assertNotNull(logInfo);
         assertEquals(Collections.singletonMap("key", "value"), logInfo);
         Object[] logInfoArray = e.exportLogInfo();
@@ -67,7 +68,7 @@ public class LoggableExceptionTest {
         expectedLogInfo.put("k1", "v1");
         expectedLogInfo.put("k2", "v2");
         LoggableException e = new LoggableException("this has multiple k/v pairs", "k0", "v0", "k1", "v1", "k2", "v2");
-        Map<String, Object> logInfo = e.getLogInfo();
+        Map<String, @Nullable Object> logInfo = e.getLogInfo();
         assertNotNull(logInfo);
         assertEquals(expectedLogInfo, logInfo);
         Object[] logInfoArray = e.exportLogInfo();

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/util/StringUtilsTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/util/StringUtilsTest.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import javax.annotation.Nonnull;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
@@ -287,7 +286,7 @@ public class StringUtilsTest {
 
     @ParameterizedTest(name = "containsIgnoreCase[source={0}, searchString={1}]")
     @MethodSource
-    void containsIgnoreCase(@Nonnull String source, @Nonnull String searchString, boolean expected) {
+    void containsIgnoreCase(String source, String searchString, boolean expected) {
         assertEquals(expected, StringUtils.containsIgnoreCase(source, searchString),
                 () -> "string \"" + source + "\" should " + (expected ? "" : "not ") + "contain \"" + searchString + "\" ignoring case");
     }

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/util/package-info.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/util/package-info.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2015-2019 Apple Inc. and the FoundationDB project authors
+ * Copyright 2015-2026 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,13 +18,6 @@
  * limitations under the License.
  */
 
-/**
- * Utilities for logging and exception handling.
- * All exceptions in the <a href="https://foundationdb.github.io/fdb-record-layer/">Record Layer</a>
- * project are descendants of {@link com.apple.foundationdb.util.LoggableException} class. This
- * class allows the user to attach arbitrary keys and values to an {@link java.lang.Exception} when
- * thrown.
- */
 @NullMarked
 package com.apple.foundationdb.util;
 

--- a/gradle/codequality/spotbugs_exclude.xml
+++ b/gradle/codequality/spotbugs_exclude.xml
@@ -62,4 +62,23 @@
     <Match>
         <Class name="~com\.google\.common\.graph\..*" />
     </Match>
+
+    <!-- SpotBugs does not treat javax.annotation.Nullable (JSR-305) and org.jspecify.annotations.Nullable as
+       equivalent when comparing an overriding method's parameter annotation against its superclass. As jspecify
+       is adopted module-by-module, any not-yet-migrated subclass of an already-migrated base class trips this
+       check even when both sides genuinely agree the parameter is nullable. It also fires, independent of the
+       migration, on our exception hierarchy's deliberate pattern of requiring a non-null cause on a (message,
+       cause) constructor overload while the superclass constructor still allows null. -->
+    <Match>
+        <Bug pattern="NP_METHOD_PARAMETER_TIGHTENS_ANNOTATION" />
+    </Match>
+
+    <!-- Subspace.pack() is not annotated @Nonnull by the vendored FDB client, but never actually returns null;
+       ByteArrayUtil2.loggable() only returns null when handed a null array, which cannot happen here. Surfaced
+       once ByteArrayUtil2 picked up an explicit jspecify @Nullable that SpotBugs could resolve. -->
+    <Match>
+        <Class name="com.apple.foundationdb.record.provider.foundationdb.SubspaceProviderBySubspace" />
+        <Method name="toString" />
+        <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE" />
+    </Match>
 </FindBugsFilter>


### PR DESCRIPTION
6th of a 14-PR stack adopting jspecify + NullAway null-checking, stacked on #4578 (`fdb-record-layer-icu`). Same treatment applied to `fdb-extensions`, split into two independently-worked chunks (async/vector-search packages; linear/math and misc-utility packages) then merged. See inline comments for specific findings.