### PR TITLE
Adopt jspecify + NullAway null-checking on fdb-record-layer-debugger

### DIFF
--- a/fdb-record-layer-debugger/fdb-record-layer-debugger.gradle
+++ b/fdb-record-layer-debugger/fdb-record-layer-debugger.gradle
@@ -18,6 +18,10 @@
  * limitations under the License.
  */
 
+plugins {
+    alias(libs.plugins.errorprone)
+}
+
 apply from: rootProject.file('gradle/publishing.gradle')
 
 configurations {
@@ -34,14 +38,31 @@ dependencies {
     implementation(libs.slf4j.api)
     implementation(libs.slf4j.julBridge)
     implementation(libs.jline)
-    compileOnly(libs.jsr305)
+    compileOnly(libs.jspecify)
     compileOnly(libs.autoService)
     annotationProcessor(libs.autoService)
+
+    errorprone(libs.errorprone.core)
+    errorprone(libs.nullaway)
 
     testImplementation(libs.junit.platform)
     testImplementation(libs.bundles.test.impl)
     testRuntimeOnly(libs.bundles.test.runtime)
     testCompileOnly(libs.bundles.test.compileOnly)
+}
+
+// Adopts jspecify + NullAway, scoped to this module only. See the @NullMarked package-info.java in
+// com.apple.foundationdb.record.query.plan.cascades.debug (this module shares that package name with a
+// package of the same simple name in fdb-record-layer-core, but each module's compileJava only analyzes
+// its own classes).
+tasks.withType(JavaCompile).configureEach {
+    options.errorprone {
+        disableAllChecks = true
+        error("NullAway")
+        option("NullAway:AnnotatedPackages", "com.apple.foundationdb.record.query.plan.cascades.debug")
+        option("NullAway:JSpecifyMode", "true")
+        option("NullAway:AcknowledgeRestrictiveAnnotations", "true")
+    }
 }
 
 publishing {

--- a/fdb-record-layer-debugger/src/main/java/com/apple/foundationdb/record/query/plan/cascades/debug/Commands.java
+++ b/fdb-record-layer-debugger/src/main/java/com/apple/foundationdb/record/query/plan/cascades/debug/Commands.java
@@ -39,8 +39,8 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import org.jline.reader.ParsedLine;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Deque;
@@ -79,16 +79,15 @@ public class Commands {
          * @return {@code true} if planning should continue afterward, {@code false} if the REPL should prompt
          *         for the next command after the execution of this command has finished.
          */
-        boolean executeCommand(@Nonnull PlannerRepl plannerRepl, @Nonnull E event, @Nonnull ParsedLine parsedLine);
+        boolean executeCommand(PlannerRepl plannerRepl, E event, ParsedLine parsedLine);
 
         /**
          * The command in as a string.
          * @return the comman token
          */
-        @Nonnull
         String getCommandToken();
 
-        void printUsage(@Nonnull PlannerRepl plannerRepl);
+        void printUsage(PlannerRepl plannerRepl);
     }
 
     /**
@@ -106,9 +105,9 @@ public class Commands {
     @AutoService(Command.class)
     public static class BreakCommand implements Command<PlannerEvent> {
         @Override
-        public boolean executeCommand(@Nonnull final PlannerRepl plannerRepl,
-                                      @Nonnull final PlannerEvent plannerEvent,
-                                      @Nonnull final ParsedLine parsedLine) {
+        public boolean executeCommand(final PlannerRepl plannerRepl,
+                                      final PlannerEvent plannerEvent,
+                                      final ParsedLine parsedLine) {
             final List<String> words = parsedLine.words();
 
             if (words.size() == 1) {
@@ -265,14 +264,13 @@ public class Commands {
             }
         }
 
-        @Nonnull
         @Override
         public String getCommandToken() {
             return "BREAK";
         }
 
         @Override
-        public void printUsage(@Nonnull final PlannerRepl plannerRepl) {
+        public void printUsage(final PlannerRepl plannerRepl) {
             plannerRepl.printlnKeyValue("break [list | yield <id> | remove <index> | <event> [ <location>]]", "manage breakpoints");
         }
     }
@@ -283,20 +281,19 @@ public class Commands {
     @AutoService(Command.class)
     public static class ContinueCommand implements Command<PlannerEvent> {
         @Override
-        public boolean executeCommand(@Nonnull final PlannerRepl plannerRepl,
-                                      @Nonnull final PlannerEvent plannerEvent,
-                                      @Nonnull final ParsedLine parsedLine) {
+        public boolean executeCommand(final PlannerRepl plannerRepl,
+                                      final PlannerEvent plannerEvent,
+                                      final ParsedLine parsedLine) {
             return true;
         }
 
-        @Nonnull
         @Override
         public String getCommandToken() {
             return "CONT";
         }
 
         @Override
-        public void printUsage(@Nonnull final PlannerRepl plannerRepl) {
+        public void printUsage(final PlannerRepl plannerRepl) {
             plannerRepl.printlnKeyValue("cont", "continue execution");
         }
     }
@@ -307,9 +304,9 @@ public class Commands {
     @AutoService(Command.class)
     public static class CurrentCommand implements Command<PlannerEvent> {
         @Override
-        public boolean executeCommand(@Nonnull final PlannerRepl plannerRepl,
-                                      @Nonnull final PlannerEvent plannerEvent,
-                                      @Nonnull final ParsedLine parsedLine) {
+        public boolean executeCommand(final PlannerRepl plannerRepl,
+                                      final PlannerEvent plannerEvent,
+                                      final ParsedLine parsedLine) {
             final RegisteredEntities registeredEntities = plannerRepl.getCurrentRegisteredEntities();
             final List<PlannerEvent> plannerEvents = registeredEntities.getEvents();
             if (plannerEvents == null) {
@@ -321,14 +318,13 @@ public class Commands {
             return false;
         }
 
-        @Nonnull
         @Override
         public String getCommandToken() {
             return "CURRENT";
         }
 
         @Override
-        public void printUsage(@Nonnull final PlannerRepl plannerRepl) {
+        public void printUsage(final PlannerRepl plannerRepl) {
             plannerRepl.printlnKeyValue("current", "dump current event");
         }
     }
@@ -339,9 +335,9 @@ public class Commands {
     @AutoService(Command.class)
     public static class EventsCommand implements Command<PlannerEvent> {
         @Override
-        public boolean executeCommand(@Nonnull final PlannerRepl plannerRepl,
-                                      @Nonnull final PlannerEvent plannerEvent,
-                                      @Nonnull final ParsedLine parsedLine) {
+        public boolean executeCommand(final PlannerRepl plannerRepl,
+                                      final PlannerEvent plannerEvent,
+                                      final ParsedLine parsedLine) {
             final RegisteredEntities registeredEntities = plannerRepl.getCurrentRegisteredEntities();
             final List<PlannerEvent> plannerEvents = registeredEntities.getEvents();
             if (plannerEvents == null) {
@@ -362,14 +358,13 @@ public class Commands {
             return false;
         }
 
-        @Nonnull
         @Override
         public String getCommandToken() {
             return "EVENTS";
         }
 
         @Override
-        public void printUsage(@Nonnull final PlannerRepl plannerRepl) {
+        public void printUsage(final PlannerRepl plannerRepl) {
             plannerRepl.printlnKeyValue("events", "list history of events");
         }
     }
@@ -380,9 +375,9 @@ public class Commands {
     @AutoService(Command.class)
     public static class ExpsCommand implements Command<PlannerEvent> {
         @Override
-        public boolean executeCommand(@Nonnull final PlannerRepl plannerRepl,
-                                      @Nonnull final PlannerEvent plannerEvent,
-                                      @Nonnull final ParsedLine parsedLine) {
+        public boolean executeCommand(final PlannerRepl plannerRepl,
+                                      final PlannerEvent plannerEvent,
+                                      final ParsedLine parsedLine) {
             final RegisteredEntities registeredEntities = plannerRepl.getCurrentRegisteredEntities();
             final Cache<Integer, RelationalExpression> expressionCache = registeredEntities.getExpressionCache();
             final List<Integer> ids = Lists.newArrayList(expressionCache.asMap().keySet());
@@ -402,14 +397,13 @@ public class Commands {
             return false;
         }
 
-        @Nonnull
         @Override
         public String getCommandToken() {
             return "EXPS";
         }
 
         @Override
-        public void printUsage(@Nonnull final PlannerRepl plannerRepl) {
+        public void printUsage(final PlannerRepl plannerRepl) {
             plannerRepl.printlnKeyValue("exps", "list all expressions");
         }
     }
@@ -420,9 +414,9 @@ public class Commands {
     @AutoService(Command.class)
     public static class HelpCommand implements Command<PlannerEvent> {
         @Override
-        public boolean executeCommand(@Nonnull final PlannerRepl plannerRepl,
-                                      @Nonnull final PlannerEvent plannerEvent,
-                                      @Nonnull final ParsedLine parsedLine) {
+        public boolean executeCommand(final PlannerRepl plannerRepl,
+                                      final PlannerEvent plannerEvent,
+                                      final ParsedLine parsedLine) {
             plannerRepl.printlnHighlighted("Basic Usage");
             plannerRepl.println();
             for (final Command<PlannerEvent> command : PlannerRepl.getCommands()) {
@@ -432,14 +426,13 @@ public class Commands {
             return false;
         }
 
-        @Nonnull
         @Override
         public String getCommandToken() {
             return "HELP";
         }
 
         @Override
-        public void printUsage(@Nonnull final PlannerRepl plannerRepl) {
+        public void printUsage(final PlannerRepl plannerRepl) {
             plannerRepl.printlnKeyValue("help", "print this help");
         }
     }
@@ -450,9 +443,9 @@ public class Commands {
     @AutoService(Command.class)
     public static class RefsCommand implements Command<PlannerEvent> {
         @Override
-        public boolean executeCommand(@Nonnull final PlannerRepl plannerRepl,
-                                      @Nonnull final PlannerEvent plannerEvent,
-                                      @Nonnull final ParsedLine parsedLine) {
+        public boolean executeCommand(final PlannerRepl plannerRepl,
+                                      final PlannerEvent plannerEvent,
+                                      final ParsedLine parsedLine) {
             final RegisteredEntities registeredEntities = plannerRepl.getCurrentRegisteredEntities();
             final Cache<Integer, Reference> referenceCache = registeredEntities.getReferenceCache();
             final List<Integer> ids = Lists.newArrayList(referenceCache.asMap().keySet());
@@ -477,14 +470,13 @@ public class Commands {
             return false;
         }
 
-        @Nonnull
         @Override
         public String getCommandToken() {
             return "REFS";
         }
 
         @Override
-        public void printUsage(@Nonnull final PlannerRepl plannerRepl) {
+        public void printUsage(final PlannerRepl plannerRepl) {
             plannerRepl.printlnKeyValue("refs", "list all references");
         }
     }
@@ -495,9 +487,9 @@ public class Commands {
     @AutoService(Command.class)
     public static class RestartCommand implements Command<PlannerEvent> {
         @Override
-        public boolean executeCommand(@Nonnull final PlannerRepl plannerRepl,
-                                      @Nonnull final PlannerEvent plannerEvent,
-                                      @Nonnull final ParsedLine parsedLine) {
+        public boolean executeCommand(final PlannerRepl plannerRepl,
+                                      final PlannerEvent plannerEvent,
+                                      final ParsedLine parsedLine) {
             plannerRepl.restartState();
             plannerRepl.addInternalBreakPoint(new PlannerRepl.CountingTautologyBreakPoint(1));
             plannerRepl.printHighlighted("restarting planning...");
@@ -505,14 +497,13 @@ public class Commands {
             throw new RestartException();
         }
 
-        @Nonnull
         @Override
         public String getCommandToken() {
             return "RESTART";
         }
 
         @Override
-        public void printUsage(@Nonnull final PlannerRepl plannerRepl) {
+        public void printUsage(final PlannerRepl plannerRepl) {
             plannerRepl.printlnKeyValue("restart", "restart the planner and return to tick 0");
         }
     }
@@ -524,9 +515,9 @@ public class Commands {
     @AutoService(Command.class)
     public static class ShowCommand implements Command<PlannerEvent> {
         @Override
-        public boolean executeCommand(@Nonnull final PlannerRepl plannerRepl,
-                                      @Nonnull final PlannerEvent plannerEvent,
-                                      @Nonnull final ParsedLine parsedLine) {
+        public boolean executeCommand(final PlannerRepl plannerRepl,
+                                      final PlannerEvent plannerEvent,
+                                      final ParsedLine parsedLine) {
             final List<String> words = parsedLine.words();
             if (words.size() < 2) {
                 plannerRepl.printlnError("usage show [(exp|ref|qun)id] | graph | matches | finals");
@@ -575,14 +566,13 @@ public class Commands {
             return false;
         }
 
-        @Nonnull
         @Override
         public String getCommandToken() {
             return "SHOW";
         }
 
         @Override
-        public void printUsage(@Nonnull final PlannerRepl plannerRepl) {
+        public void printUsage(final PlannerRepl plannerRepl) {
             plannerRepl.printlnKeyValue("show (<expId> | <refId> | <qunId>)", "render the entity graphically");
         }
     }
@@ -594,9 +584,9 @@ public class Commands {
     @SuppressWarnings("PMD.ForLoopCanBeForeach") // false positive due to the descending iteration
     public static class TasksCommand implements Command<PlannerEvent> {
         @Override
-        public boolean executeCommand(@Nonnull final PlannerRepl plannerRepl,
-                                      @Nonnull final PlannerEvent plannerEvent,
-                                      @Nonnull final ParsedLine parsedLine) {
+        public boolean executeCommand(final PlannerRepl plannerRepl,
+                                      final PlannerEvent plannerEvent,
+                                      final ParsedLine parsedLine) {
             if (plannerEvent instanceof PlannerEventWithState) {
                 final Deque<CascadesPlanner.Task> taskStack = ((PlannerEventWithState)plannerEvent).getTaskStack();
                 for (final Iterator<CascadesPlanner.Task> iterator = taskStack.descendingIterator(); iterator.hasNext();) {
@@ -617,14 +607,13 @@ public class Commands {
             return false;
         }
 
-        @Nonnull
         @Override
         public String getCommandToken() {
             return "TASKS";
         }
 
         @Override
-        public void printUsage(@Nonnull final PlannerRepl plannerRepl) {
+        public void printUsage(final PlannerRepl plannerRepl) {
             plannerRepl.printlnKeyValue("tasks", "show the current state of the task stack");
         }
     }
@@ -636,9 +625,9 @@ public class Commands {
     @AutoService(Command.class)
     public static class StepCommand implements Command<PlannerEvent> {
         @Override
-        public boolean executeCommand(@Nonnull final PlannerRepl plannerRepl,
-                                      @Nonnull final PlannerEvent plannerEvent,
-                                      @Nonnull final ParsedLine parsedLine) {
+        public boolean executeCommand(final PlannerRepl plannerRepl,
+                                      final PlannerEvent plannerEvent,
+                                      final ParsedLine parsedLine) {
             final List<String> words = parsedLine.words();
             final int steps;
             if (words.size() == 2) {
@@ -662,14 +651,13 @@ public class Commands {
             return true;
         }
 
-        @Nonnull
         @Override
         public String getCommandToken() {
             return "STEP";
         }
 
         @Override
-        public void printUsage(@Nonnull final PlannerRepl plannerRepl) {
+        public void printUsage(final PlannerRepl plannerRepl) {
             plannerRepl.printlnKeyValue("step [<number>]", "continue execution by the number of specified steps (default: 1)");
         }
     }
@@ -682,9 +670,9 @@ public class Commands {
     @AutoService(Command.class)
     public static class PhaseCommand implements Command<PlannerEvent> {
         @Override
-        public boolean executeCommand(@Nonnull final PlannerRepl plannerRepl,
-                                      @Nonnull final PlannerEvent plannerEvent,
-                                      @Nonnull final ParsedLine parsedLine) {
+        public boolean executeCommand(final PlannerRepl plannerRepl,
+                                      final PlannerEvent plannerEvent,
+                                      final ParsedLine parsedLine) {
             final List<String> words = parsedLine.words();
             final PlannerPhase plannerPhase;
             if (words.size() == 2) {
@@ -703,14 +691,13 @@ public class Commands {
             return true;
         }
 
-        @Nonnull
         @Override
         public String getCommandToken() {
             return "PHASE";
         }
 
         @Override
-        public void printUsage(@Nonnull final PlannerRepl plannerRepl) {
+        public void printUsage(final PlannerRepl plannerRepl) {
             plannerRepl.printlnKeyValue("phase [rewriting, planning]",
                     "continue execution until the next initphase of the desired planner phase occurs.");
         }
@@ -722,9 +709,9 @@ public class Commands {
     @AutoService(Command.class)
     public static class QunsCommand implements Command<PlannerEvent> {
         @Override
-        public boolean executeCommand(@Nonnull final PlannerRepl plannerRepl,
-                                      @Nonnull final PlannerEvent plannerEvent,
-                                      @Nonnull final ParsedLine parsedLine) {
+        public boolean executeCommand(final PlannerRepl plannerRepl,
+                                      final PlannerEvent plannerEvent,
+                                      final ParsedLine parsedLine) {
             final RegisteredEntities registeredEntities = plannerRepl.getCurrentRegisteredEntities();
             final List<Integer> ids = Lists.newArrayList(registeredEntities.getQuantifierCache().asMap().keySet());
             Collections.sort(ids);
@@ -742,14 +729,13 @@ public class Commands {
             return false;
         }
 
-        @Nonnull
         @Override
         public String getCommandToken() {
             return "QUNS";
         }
 
         @Override
-        public void printUsage(@Nonnull final PlannerRepl plannerRepl) {
+        public void printUsage(final PlannerRepl plannerRepl) {
             plannerRepl.printlnKeyValue("quns", "list all quantifiers");
         }
     }
@@ -762,9 +748,9 @@ public class Commands {
     @SuppressWarnings("PMD.DoNotTerminateVM")
     public static class QuitCommand implements Command<PlannerEvent> {
         @Override
-        public boolean executeCommand(@Nonnull final PlannerRepl plannerRepl,
-                                      @Nonnull final PlannerEvent plannerEvent,
-                                      @Nonnull final ParsedLine parsedLine) {
+        public boolean executeCommand(final PlannerRepl plannerRepl,
+                                      final PlannerEvent plannerEvent,
+                                      final ParsedLine parsedLine) {
             plannerRepl.printlnHighlighted("I hope you found the problem.");
             if (plannerRepl.shouldExitOnQuit()) {
                 System.exit(0);
@@ -773,14 +759,13 @@ public class Commands {
             return true;
         }
 
-        @Nonnull
         @Override
         public String getCommandToken() {
             return "QUIT";
         }
 
         @Override
-        public void printUsage(@Nonnull final PlannerRepl plannerRepl) {
+        public void printUsage(final PlannerRepl plannerRepl) {
             plannerRepl.printlnKeyValue("quit", "System.exit(0)");
         }
     }

--- a/fdb-record-layer-debugger/src/main/java/com/apple/foundationdb/record/query/plan/cascades/debug/PlannerRepl.java
+++ b/fdb-record-layer-debugger/src/main/java/com/apple/foundationdb/record/query/plan/cascades/debug/PlannerRepl.java
@@ -58,8 +58,8 @@ import org.jline.utils.InfoCmp;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.LinkedList;
@@ -109,21 +109,19 @@ public class PlannerRepl implements Debugger {
     private String queryAsString;
     @Nullable
     private PlanContext planContext;
-    @Nonnull
     private final Map<Object, Integer> singletonToIndexMap;
 
-    @Nonnull
     private final Terminal terminal;
     @Nullable
     private LineReader lineReader;
 
     private final boolean exitOnQuit;
 
-    public PlannerRepl(@Nonnull final Terminal terminal) {
+    public PlannerRepl(final Terminal terminal) {
         this(terminal, true);
     }
 
-    public PlannerRepl(@Nonnull final Terminal terminal, boolean exitOnQuit) {
+    public PlannerRepl(final Terminal terminal, boolean exitOnQuit) {
         this.registeredEntitiesStack = new ArrayDeque<>();
         this.breakPoints = HashBiMap.create();
         this.currentBreakPointIndex = 0;
@@ -139,7 +137,6 @@ public class PlannerRepl implements Debugger {
         return exitOnQuit;
     }
 
-    @Nonnull
     RegisteredEntities getCurrentRegisteredEntities() {
         return Objects.requireNonNull(registeredEntitiesStack.peek());
     }
@@ -157,32 +154,32 @@ public class PlannerRepl implements Debugger {
     }
 
     @Override
-    public int onGetIndex(@Nonnull final Class<?> clazz) {
+    public int onGetIndex(final Class<?> clazz) {
         return getCurrentRegisteredEntities().getIndex(clazz);
     }
 
     @Override
-    public int onUpdateIndex(@Nonnull final Class<?> clazz, @Nonnull final IntUnaryOperator updateFn) {
+    public int onUpdateIndex(final Class<?> clazz, final IntUnaryOperator updateFn) {
         return getCurrentRegisteredEntities().updateIndex(clazz, updateFn);
     }
 
     @Override
-    public void onRegisterExpression(@Nonnull final RelationalExpression expression) {
+    public void onRegisterExpression(final RelationalExpression expression) {
         getCurrentRegisteredEntities().registerExpression(expression);
     }
 
     @Override
-    public void onRegisterReference(@Nonnull final Reference reference) {
+    public void onRegisterReference(final Reference reference) {
         getCurrentRegisteredEntities().registerReference(reference);
     }
 
     @Override
-    public void onRegisterQuantifier(@Nonnull final Quantifier quantifier) {
+    public void onRegisterQuantifier(final Quantifier quantifier) {
         getCurrentRegisteredEntities().registerQuantifier(quantifier);
     }
 
     @Override
-    public int onGetOrRegisterSingleton(@Nonnull final Object singleton) {
+    public int onGetOrRegisterSingleton(final Object singleton) {
         final var size = singletonToIndexMap.size();
         return singletonToIndexMap.computeIfAbsent(singleton, s -> size);
     }
@@ -204,12 +201,12 @@ public class PlannerRepl implements Debugger {
     }
 
     @Override
-    public void onShow(@Nonnull final Reference ref) {
+    public void onShow(final Reference ref) {
         PlannerGraphVisitor.show(true, ref);
     }
 
     @Override
-    public void onQuery(@Nonnull final String queryAsString, @Nonnull final PlanContext planContext) {
+    public void onQuery(final String queryAsString, final PlanContext planContext) {
         this.registeredEntitiesStack.push(RegisteredEntities.copyOf(getCurrentRegisteredEntities()));
         this.queryAsString = queryAsString;
         this.planContext = planContext;
@@ -386,12 +383,11 @@ public class PlannerRepl implements Debugger {
         }
     }
 
-    @Nonnull
-    String nameForObjectOrNotInCache(@Nonnull final Object object) {
+    String nameForObjectOrNotInCache(final Object object) {
         return Optional.ofNullable(nameForObject(object)).orElse("not in cache");
     }
 
-    boolean isValidEntityName(@Nonnull final String identifier) {
+    boolean isValidEntityName(final String identifier) {
         final String lowerCase = identifier.toLowerCase(Locale.ROOT);
         if (!lowerCase.startsWith("exp") &&
                 !lowerCase.startsWith("ref") &&
@@ -405,7 +401,7 @@ public class PlannerRepl implements Debugger {
 
     @Nullable
     @Override
-    public String nameForObject(@Nonnull final Object object) {
+    public String nameForObject(final Object object) {
         final RegisteredEntities registeredEntities = getCurrentRegisteredEntities();
         if (object instanceof RelationalExpression) {
             @Nullable final Integer id = registeredEntities.getInvertedExpressionsCache().getIfPresent(object);
@@ -471,14 +467,16 @@ public class PlannerRepl implements Debugger {
     }
 
     void printlnQuery() {
-        printlnKeyValue("query", queryAsString);
+        // Always called from onQuery() right after queryAsString is assigned; never null at this call site
+        // even though the field itself is nulled out again in reset().
+        printlnKeyValue("query", Objects.requireNonNull(queryAsString));
     }
 
-    void printlnReference(@Nonnull final Reference reference) {
+    void printlnReference(final Reference reference) {
         printlnReference(reference, "");
     }
 
-    void printlnReference(@Nonnull final Reference reference, final String prefix) {
+    void printlnReference(final Reference reference, final String prefix) {
         printlnKeyValue(prefix + "class", reference.getClass().getSimpleName());
         getSilently("reference.toString()", reference::toString)
                 .ifPresent(referenceAsString ->
@@ -492,11 +490,11 @@ public class PlannerRepl implements Debugger {
         }
     }
 
-    void printlnExpression(@Nonnull final RelationalExpression expression) {
+    void printlnExpression(final RelationalExpression expression) {
         printlnExpression(expression, "");
     }
 
-    void printlnExpression(@Nonnull final RelationalExpression expression, final String prefix) {
+    void printlnExpression(final RelationalExpression expression, final String prefix) {
         printlnKeyValue(prefix + "class", expression.getClass().getSimpleName());
         getSilently("expression.toString()", expression::toString)
                 .ifPresent(expressionAsString ->
@@ -517,11 +515,11 @@ public class PlannerRepl implements Debugger {
         }
     }
 
-    void printlnQuantifier(@Nonnull final Quantifier quantifier) {
+    void printlnQuantifier(final Quantifier quantifier) {
         printlnQuantifier(quantifier, "");
     }
 
-    void printlnQuantifier(@Nonnull final Quantifier quantifier, final String prefix) {
+    void printlnQuantifier(final Quantifier quantifier, final String prefix) {
         printlnKeyValue(prefix + "class", quantifier.getClass().getSimpleName());
         printlnKeyValue(prefix + "name", nameForObjectOrNotInCache(quantifier));
         printlnKeyValue(prefix + "kind", quantifier.getShorthand());
@@ -564,11 +562,11 @@ public class PlannerRepl implements Debugger {
                 .append(value).toAnsi());
     }
 
-    void print(@Nonnull final String string) {
+    void print(final String string) {
         Objects.requireNonNull(terminal).writer().print(string);
     }
 
-    void println(@Nonnull final String string) {
+    void println(final String string) {
         Objects.requireNonNull(terminal).writer().println(string);
     }
 
@@ -577,7 +575,7 @@ public class PlannerRepl implements Debugger {
     }
 
     @SuppressWarnings({"CallToPrintStackTrace", "PMD.AvoidPrintStackTrace"})
-    private void doSilently(@Nonnull final String actionName, @Nonnull final RunnableWithException runnable) {
+    private void doSilently(final String actionName, final RunnableWithException runnable) {
         try {
             runnable.run();
         } catch (final RestartException rE) {
@@ -590,9 +588,8 @@ public class PlannerRepl implements Debugger {
         }
     }
 
-    @Nonnull
     @SuppressWarnings({"CallToPrintStackTrace", "PMD.AvoidPrintStackTrace"})
-    private <T> Optional<T> getSilently(@Nonnull final String actionName, @Nonnull final SupplierWithException<T> supplier) {
+    private <T> Optional<T> getSilently(final String actionName, final SupplierWithException<T> supplier) {
         try {
             return Optional.ofNullable(supplier.get());
         } catch (final RestartException rE) {
@@ -622,13 +619,11 @@ public class PlannerRepl implements Debugger {
         return commandsMapBuilder.build();
     }
 
-    @Nonnull
     static Set<Commands.Command<PlannerEvent>> getCommands() {
         return ImmutableSet.copyOf(commandsMap.values());
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
-    @Nonnull
     private static SetMultimap<Class<? extends PlannerEvent>, Processors.Processor<? extends PlannerEvent>> loadProcessors() {
         SetMultimap<Class<? extends PlannerEvent>, Processors.Processor<? extends PlannerEvent>> processorsMap = HashMultimap.create();
         final Iterable<Processors.Processor> loader
@@ -644,9 +639,8 @@ public class PlannerRepl implements Debugger {
         return processorsMap;
     }
 
-    @Nonnull
-    private static <E extends PlannerEvent> Optional<Commands.Command<E>> resolveCommand(@Nonnull final ImmutableMap<String, Commands.Command<E>> commandsMap,
-                                                                                         @Nonnull final ParsedLine parsedLine,
+    private static <E extends PlannerEvent> Optional<Commands.Command<E>> resolveCommand(final ImmutableMap<String, Commands.Command<E>> commandsMap,
+                                                                                         final ParsedLine parsedLine,
                                                                                          final int wordIndex) {
         final List<String> words = parsedLine.words();
         if (words.size() <= wordIndex) {
@@ -751,28 +745,25 @@ public class PlannerRepl implements Debugger {
      * Breakpoint that breaks on a particular event.
      */
     public static class OnEventTypeBreakPoint extends BreakPoint {
-        @Nonnull
         private final Shorthand shorthand;
         @Nullable
         private final String referenceName;
-        @Nonnull
         private final Location location;
 
-        public OnEventTypeBreakPoint(@Nonnull final Shorthand shorthand,
-                                     @Nonnull final Location location) {
+        public OnEventTypeBreakPoint(final Shorthand shorthand,
+                                     final Location location) {
             this(shorthand, null, location);
         }
 
-        public OnEventTypeBreakPoint(@Nonnull final Shorthand shorthand,
+        public OnEventTypeBreakPoint(final Shorthand shorthand,
                                      @Nullable final String referenceName,
-                                     @Nonnull final Location location) {
+                                     final Location location) {
             super(event -> event.getShorthand() == shorthand && (location == Location.ANY || event.getLocation() == location));
             this.shorthand = shorthand;
             this.referenceName = referenceName == null ? null : referenceName.toLowerCase(Locale.ROOT);
             this.location = location;
         }
 
-        @Nonnull
         public Shorthand getShorthand() {
             return shorthand;
         }
@@ -782,7 +773,6 @@ public class PlannerRepl implements Debugger {
             return referenceName;
         }
 
-        @Nonnull
         public Location getLocation() {
             return location;
         }
@@ -806,8 +796,9 @@ public class PlannerRepl implements Debugger {
             super.onList(plannerRepl);
             plannerRepl.print("; ");
             plannerRepl.printKeyValue("shorthand", getShorthand().name().toLowerCase(Locale.ROOT) + "; ");
-            if (getReferenceName() != null) {
-                plannerRepl.printKeyValue("reference", getReferenceName().toLowerCase(Locale.ROOT) + "; ");
+            final String referenceName = getReferenceName();
+            if (referenceName != null) {
+                plannerRepl.printKeyValue("reference", referenceName.toLowerCase(Locale.ROOT) + "; ");
             }
             plannerRepl.printKeyValue("location", getLocation().name().toLowerCase(Locale.ROOT));
         }
@@ -837,12 +828,11 @@ public class PlannerRepl implements Debugger {
      * to break on any such event or on an event initiating a particular new {@link PlannerPhase}.
      */
     public static class OnPhaseBreakPoint extends BreakPoint {
-        @Nonnull
         private final Location location;
         @Nullable
         private final PlannerPhase plannerPhase;
 
-        public OnPhaseBreakPoint(@Nonnull final Location location,
+        public OnPhaseBreakPoint(final Location location,
                                  @Nullable final PlannerPhase plannerPhase) {
             super(event -> (event instanceof InitiatePhasePlannerEvent) &&
                     event.getShorthand() == Shorthand.INITPHASE &&
@@ -852,12 +842,10 @@ public class PlannerRepl implements Debugger {
             this.plannerPhase = plannerPhase;
         }
 
-        @Nonnull
         public Shorthand getShorthand() {
             return Shorthand.INITPHASE;
         }
 
-        @Nonnull
         public Location getLocation() {
             return location;
         }
@@ -873,8 +861,9 @@ public class PlannerRepl implements Debugger {
             plannerRepl.print("; ");
             plannerRepl.printKeyValue("shorthand", getShorthand().name().toLowerCase(Locale.ROOT) + "; ");
             plannerRepl.printKeyValue("location", getLocation().name().toLowerCase(Locale.ROOT) + "; ");
+            final PlannerPhase plannerPhase = getPlannerPhase();
             plannerRepl.printKeyValue("plannerPhase",
-                    (getPlannerPhase() == null ? getPlannerPhase().name() : "any").toLowerCase(Locale.ROOT));
+                    (plannerPhase == null ? "any" : plannerPhase.name()).toLowerCase(Locale.ROOT));
         }
 
         @Override
@@ -893,8 +882,9 @@ public class PlannerRepl implements Debugger {
 
         @Override
         public int hashCode() {
+            final PlannerPhase plannerPhase = getPlannerPhase();
             return Objects.hash(getShorthand(), getLocation(),
-                    getPlannerPhase() == null ? null : getPlannerPhase().name());
+                    plannerPhase == null ? null : plannerPhase.name());
         }
     }
 
@@ -902,10 +892,9 @@ public class PlannerRepl implements Debugger {
      * Breakpoint that breaks when a transform rule call yields an expression.
      */
     public static class OnYieldExpressionBreakPoint extends BreakPoint {
-        @Nonnull
         private final String expressionName;
 
-        public OnYieldExpressionBreakPoint(@Nonnull final String expressionName) {
+        public OnYieldExpressionBreakPoint(final String expressionName) {
             super(event -> event.getShorthand() == Shorthand.RULECALL &&
                            event.getLocation() == Location.END &&
                            event instanceof TransformRuleCallPlannerEvent);
@@ -957,10 +946,9 @@ public class PlannerRepl implements Debugger {
      * Breakpoint that breaks when a transform rule call yields a new match for a given candidate.
      */
     public static class OnYieldMatchBreakPoint extends BreakPoint {
-        @Nonnull
         private final String candidateName;
 
-        public OnYieldMatchBreakPoint(@Nonnull final String candidateName) {
+        public OnYieldMatchBreakPoint(final String candidateName) {
             super(event -> event.getShorthand() == Shorthand.RULECALL &&
                            event.getLocation() == Location.END &&
                            event instanceof TransformRuleCallPlannerEvent);
@@ -1011,13 +999,11 @@ public class PlannerRepl implements Debugger {
      */
     public static class OnRuleBreakPoint extends BreakPoint {
 
-        @Nonnull
         private final String ruleNamePrefix;
 
-        @Nonnull
         private final Location location;
 
-        public OnRuleBreakPoint(@Nonnull final String ruleNamePrefix, @Nonnull final Location location) {
+        public OnRuleBreakPoint(final String ruleNamePrefix, final Location location) {
             super(event -> event.getShorthand() == Shorthand.TRANSFORM &&
                            event.getLocation() == location &&
                            event instanceof TransformPlannerEvent);
@@ -1072,13 +1058,11 @@ public class PlannerRepl implements Debugger {
      */
     public static class OnRuleCallBreakPoint extends BreakPoint {
 
-        @Nonnull
         private final String ruleNamePrefix;
 
-        @Nonnull
         private final Location location;
 
-        public OnRuleCallBreakPoint(@Nonnull final String ruleNamePrefix, @Nonnull final Location location) {
+        public OnRuleCallBreakPoint(final String ruleNamePrefix, final Location location) {
             super(event -> event.getShorthand() == Shorthand.RULECALL &&
                            event.getLocation() == location &&
                            event instanceof TransformRuleCallPlannerEvent);

--- a/fdb-record-layer-debugger/src/main/java/com/apple/foundationdb/record/query/plan/cascades/debug/package-info.java
+++ b/fdb-record-layer-debugger/src/main/java/com/apple/foundationdb/record/query/plan/cascades/debug/package-info.java
@@ -21,4 +21,7 @@
 /**
  * Implementation for planner repl.
  */
+@NullMarked
 package com.apple.foundationdb.record.query.plan.cascades.debug;
+
+import org.jspecify.annotations.NullMarked;

--- a/fdb-record-layer-debugger/src/test/java/com/apple/foundationdb/record/query/plan/cascades/debug/CommandsTest.java
+++ b/fdb-record-layer-debugger/src/test/java/com/apple/foundationdb/record/query/plan/cascades/debug/CommandsTest.java
@@ -64,7 +64,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
-import javax.annotation.Nonnull;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PipedInputStream;
@@ -106,6 +105,8 @@ class CommandsTest {
     }
 
     @AfterAll
+    @SuppressWarnings("NullAway") // Debugger.setDebugger's parameter (fdb-record-layer-core, outside this module) is
+    // documented and implemented to accept null to clear the current debugger, but is not itself annotated @Nullable.
     static void tearDown() {
         Debugger.setDebugger(null);
     }
@@ -419,9 +420,9 @@ class CommandsTest {
                         ReplTestUtil.coloredKeyValue("shorthand", "transform"),
                         ReplTestUtil.coloredKeyValue("location", "begin"),
                         ReplTestUtil.coloredKeyValue("description", "transform"),
-                        ReplTestUtil.coloredKeyValue("root", Debugger.getDebugger().nameForObject(ref)),
-                        ReplTestUtil.coloredKeyValue("group", Debugger.getDebugger().nameForObject(ref)),
-                        ReplTestUtil.coloredKeyValue("expression", Debugger.getDebugger().nameForObject(exp)),
+                        ReplTestUtil.coloredKeyValue("root", debugger.nameForObject(ref)),
+                        ReplTestUtil.coloredKeyValue("group", debugger.nameForObject(ref)),
+                        ReplTestUtil.coloredKeyValue("expression", debugger.nameForObject(exp)),
                         ReplTestUtil.coloredKeyValue("rule", "ImplementSimpleSelectRule")
                 )
         ).doesNotContain(
@@ -430,9 +431,9 @@ class CommandsTest {
                         ReplTestUtil.coloredKeyValue("shorthand", "transform"),
                         ReplTestUtil.coloredKeyValue("location", "begin"),
                         ReplTestUtil.coloredKeyValue("description", "transform"),
-                        ReplTestUtil.coloredKeyValue("root", Debugger.getDebugger().nameForObject(ref)),
-                        ReplTestUtil.coloredKeyValue("group", Debugger.getDebugger().nameForObject(ref)),
-                        ReplTestUtil.coloredKeyValue("expression", Debugger.getDebugger().nameForObject(exp)),
+                        ReplTestUtil.coloredKeyValue("root", debugger.nameForObject(ref)),
+                        ReplTestUtil.coloredKeyValue("group", debugger.nameForObject(ref)),
+                        ReplTestUtil.coloredKeyValue("expression", debugger.nameForObject(exp)),
                         ReplTestUtil.coloredKeyValue("rule", "ImplementExplodeRule")
                 )
         );
@@ -477,9 +478,9 @@ class CommandsTest {
                         ReplTestUtil.coloredKeyValue("shorthand", "rulecall"),
                         ReplTestUtil.coloredKeyValue("location", "begin"),
                         ReplTestUtil.coloredKeyValue("description", "transform rule call"),
-                        ReplTestUtil.coloredKeyValue("root", Debugger.getDebugger().nameForObject(ref)),
-                        ReplTestUtil.coloredKeyValue("group", Debugger.getDebugger().nameForObject(ref)),
-                        ReplTestUtil.coloredKeyValue("expression", Debugger.getDebugger().nameForObject(exp)),
+                        ReplTestUtil.coloredKeyValue("root", debugger.nameForObject(ref)),
+                        ReplTestUtil.coloredKeyValue("group", debugger.nameForObject(ref)),
+                        ReplTestUtil.coloredKeyValue("expression", debugger.nameForObject(exp)),
                         ReplTestUtil.coloredKeyValue("rule", "ImplementSimpleSelectRule")
                 )
         ).doesNotContain(
@@ -488,9 +489,9 @@ class CommandsTest {
                         ReplTestUtil.coloredKeyValue("shorthand", "rulecall"),
                         ReplTestUtil.coloredKeyValue("location", "begin"),
                         ReplTestUtil.coloredKeyValue("description", "transform rule call"),
-                        ReplTestUtil.coloredKeyValue("root", Debugger.getDebugger().nameForObject(ref)),
-                        ReplTestUtil.coloredKeyValue("group", Debugger.getDebugger().nameForObject(ref)),
-                        ReplTestUtil.coloredKeyValue("expression", Debugger.getDebugger().nameForObject(exp)),
+                        ReplTestUtil.coloredKeyValue("root", debugger.nameForObject(ref)),
+                        ReplTestUtil.coloredKeyValue("group", debugger.nameForObject(ref)),
+                        ReplTestUtil.coloredKeyValue("expression", debugger.nameForObject(exp)),
                         ReplTestUtil.coloredKeyValue("rule", "ImplementExplodeRule")
                 )
         );
@@ -555,13 +556,11 @@ class CommandsTest {
                 EmptyKeyExpression.EMPTY
         );
         debugger.onQuery("SELECT * FROM A", new PlanContext() {
-            @Nonnull
             @Override
             public RecordQueryPlannerConfiguration getPlannerConfiguration() {
                 return RecordQueryPlannerConfiguration.defaultPlannerConfiguration();
             }
 
-            @Nonnull
             @Override
             public Set<MatchCandidate> getMatchCandidates() {
                 return Set.of(matchCandidate);
@@ -607,7 +606,6 @@ class CommandsTest {
     }
 
     private static class DummyCascadesTask implements CascadesPlanner.Task {
-        @Nonnull
         @Override
         public PlannerPhase getPlannerPhase() {
             return PlannerPhase.PLANNING;
@@ -625,14 +623,14 @@ class CommandsTest {
     }
 
     private static class DummyMatchInfo implements MatchInfo {
-        @Nonnull
         @Override
         public List<OrderingPart.MatchedOrderingPart> getMatchedOrderingParts() {
             return List.of();
         }
 
-        @Nonnull
         @Override
+        @SuppressWarnings("NullAway") // returns null, violating the @Nonnull contract of MatchInfo#getMaxMatchMap; this dummy
+        // is only used to exercise yieldPartialMatch() in testOnYieldMatchBreakPoint, which never calls this method.
         public MaxMatchMap getMaxMatchMap() {
             return null;
         }
@@ -642,19 +640,18 @@ class CommandsTest {
             return false;
         }
 
-        @Nonnull
         @Override
+        @SuppressWarnings("NullAway") // returns null, violating the @Nonnull contract of MatchInfo#getRegularMatchInfo; this
+        // dummy is only used to exercise yieldPartialMatch() in testOnYieldMatchBreakPoint, which never calls this method.
         public RegularMatchInfo getRegularMatchInfo() {
             return null;
         }
 
-        @Nonnull
         @Override
-        public Map<QueryPredicate, PredicateMultiMap.PredicateMapping> collectPulledUpPredicateMappings(@Nonnull final RelationalExpression candidateExpression, @Nonnull final Set<QueryPredicate> interestingPredicates) {
+        public Map<QueryPredicate, PredicateMultiMap.PredicateMapping> collectPulledUpPredicateMappings(final RelationalExpression candidateExpression, final Set<QueryPredicate> interestingPredicates) {
             return Map.of();
         }
 
-        @Nonnull
         @Override
         public GroupByMappings getGroupByMappings() {
             return GroupByMappings.empty();

--- a/fdb-record-layer-debugger/src/test/java/com/apple/foundationdb/record/query/plan/cascades/debug/PlannerReplTest.java
+++ b/fdb-record-layer-debugger/src/test/java/com/apple/foundationdb/record/query/plan/cascades/debug/PlannerReplTest.java
@@ -67,6 +67,8 @@ class PlannerReplTest {
     }
 
     @AfterAll
+    @SuppressWarnings("NullAway") // Debugger.setDebugger's parameter (fdb-record-layer-core, outside this module) is
+    // documented and implemented to accept null to clear the current debugger, but is not itself annotated @Nullable.
     static void tearDown() {
         Debugger.setDebugger(null);
     }

--- a/fdb-record-layer-debugger/src/test/java/com/apple/foundationdb/record/query/plan/cascades/debug/ReplRunner.java
+++ b/fdb-record-layer-debugger/src/test/java/com/apple/foundationdb/record/query/plan/cascades/debug/ReplRunner.java
@@ -33,7 +33,8 @@ import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
 import org.junit.platform.launcher.core.LauncherFactory;
 import org.junit.platform.launcher.listeners.SummaryGeneratingListener;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import java.io.PrintWriter;
 import java.nio.file.Path;
 import java.util.HashSet;

--- a/fdb-record-layer-debugger/src/test/java/com/apple/foundationdb/record/query/plan/cascades/debug/ReplTestUtil.java
+++ b/fdb-record-layer-debugger/src/test/java/com/apple/foundationdb/record/query/plan/cascades/debug/ReplTestUtil.java
@@ -22,6 +22,7 @@ package com.apple.foundationdb.record.query.plan.cascades.debug;
 
 import org.jline.utils.AttributedStringBuilder;
 import org.jline.utils.AttributedStyle;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Static test utilities for testing {@link PlannerRepl} functionality.
@@ -34,15 +35,17 @@ final class ReplTestUtil {
     /**
      * Return a key and a value colored using the same colors used in {@link PlannerRepl} as a {@link String}.
      * @param key key to include in return string
-     * @param value value to include in return string
+     * @param value value to include in return string; may be {@code null}, e.g. when the caller looks up an
+     *        entity name that {@link PlannerRepl#nameForObject} could not find, in which case it is rendered as
+     *        the literal string {@code "null"}
      * @return a {@link String} with {@code key} and {@code value} concatenated with the expected colors.
      */
-    static String coloredKeyValue(final String key, final String value) {
+    static String coloredKeyValue(final String key, @Nullable final String value) {
         return new AttributedStringBuilder()
                 .style(AttributedStyle.DEFAULT.foreground(AttributedStyle.YELLOW + AttributedStyle.BRIGHT).bold())
                 .append(key)
                 .append(": ")
                 .style(AttributedStyle.DEFAULT)
-                .append(value).toAnsi();
+                .append(String.valueOf(value)).toAnsi();
     }
 }


### PR DESCRIPTION
7th of a 14-PR stack adopting jspecify + NullAway null-checking, stacked on #4579 (`fdb-extensions`). Same treatment applied to `fdb-record-layer-debugger`. See inline comments for specific findings.