### PR TITLE
Adopt jspecify + NullAway null-checking on fdb-record-layer-spatial

### DIFF
--- a/fdb-record-layer-spatial/fdb-record-layer-spatial.gradle
+++ b/fdb-record-layer-spatial/fdb-record-layer-spatial.gradle
@@ -21,6 +21,10 @@
 import de.undercouch.gradle.tasks.download.Download
 import de.undercouch.gradle.tasks.download.Verify
 
+plugins {
+    alias(libs.plugins.errorprone)
+}
+
 apply from: rootProject.file('gradle/proto.gradle')
 apply from: rootProject.file('gradle/publishing.gradle')
 
@@ -32,9 +36,12 @@ dependencies {
     implementation(libs.protobuf)
     implementation(libs.slf4j.api)
     implementation(libs.slf4j.julBridge)
-    compileOnly(libs.jsr305)
+    compileOnly(libs.jspecify)
     compileOnly(libs.autoService)
     annotationProcessor(libs.autoService)
+
+    errorprone(libs.errorprone.core)
+    errorprone(libs.nullaway)
 
     testImplementation(libs.bundles.test.impl)
     testRuntimeOnly(libs.bundles.test.runtime)
@@ -42,6 +49,25 @@ dependencies {
     testImplementation(libs.snakeyaml)
     testImplementation project(':fdb-test-utils')
     testImplementation(testFixtures(project(coreProject)))
+}
+
+// jspecify + NullAway null-checking, scoped to this module only. See @NullMarked package-info.java
+// files in com.apple.foundationdb.record.spatial.common / .geophile. Companion change to the
+// fdb-relational-grpc / fdb-relational-jdbc null-checking adoption.
+// The test proto (test_records_geo.proto) generates TestRecordsGeoProto.java directly into the
+// com.apple.foundationdb.record.spatial.geophile package (same package as our own test/main
+// sources, not a separate subpackage), so it can't be carved out via NullAway:UnannotatedSubPackages
+// the way generated grpc/protobuf code was in other modules; exclude generated sources by path
+// instead, matching the existing **/generated/** exclusion used for checkstyle/PMD in gradle/check.gradle.
+tasks.withType(JavaCompile).configureEach {
+    options.errorprone {
+        disableAllChecks = true
+        error("NullAway")
+        option("NullAway:AnnotatedPackages", "com.apple.foundationdb.record.spatial")
+        option("NullAway:JSpecifyMode", "true")
+        option("NullAway:AcknowledgeRestrictiveAnnotations", "true")
+        excludedPaths.set(".*/generated/.*")
+    }
 }
 
 def geonamesFilesDirectory = project.ext.downloadsDirectory.dir("geonames")

--- a/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/common/DoubleValueOrParameter.java
+++ b/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/common/DoubleValueOrParameter.java
@@ -24,7 +24,8 @@ import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.EvaluationContext;
 import com.apple.foundationdb.record.PlanHashable;
 
-import javax.annotation.Nonnull;
+import org.jspecify.annotations.Nullable;
+
 import java.util.Objects;
 
 /**
@@ -37,14 +38,14 @@ public abstract class DoubleValueOrParameter implements PlanHashable {
      * @param context the query context
      * @return a double value or {@code null}.
      */
-    public abstract Double getValue(@Nonnull EvaluationContext context);
+    @Nullable
+    public abstract Double getValue(EvaluationContext context);
 
     /**
      * Get a coordinate for a constant value.
      * @param value the coordinate value
      * @return a new coordinate using the given value
      */
-    @Nonnull
     public static DoubleValueOrParameter value(double value) {
         return new DoubleValue(value);
     }
@@ -54,8 +55,7 @@ public abstract class DoubleValueOrParameter implements PlanHashable {
      * @param parameter the parameter name
      * @return a new coordinate using the given parameter
      */
-    @Nonnull
-    public static DoubleValueOrParameter parameter(@Nonnull String parameter) {
+    public static DoubleValueOrParameter parameter(String parameter) {
         return new DoubleParameter(parameter);
     }
 
@@ -67,12 +67,13 @@ public abstract class DoubleValueOrParameter implements PlanHashable {
         }
 
         @Override
-        public Double getValue(@Nonnull EvaluationContext context) {
+        @Nullable
+        public Double getValue(EvaluationContext context) {
             return value;
         }
 
         @Override
-        public int planHash(@Nonnull final PlanHashMode mode) {
+        public int planHash(final PlanHashMode mode) {
             return Double.hashCode(value);
         }
 
@@ -100,20 +101,20 @@ public abstract class DoubleValueOrParameter implements PlanHashable {
     }
 
     static class DoubleParameter extends DoubleValueOrParameter {
-        @Nonnull
         private final String parameter;
 
-        DoubleParameter(@Nonnull String parameter) {
+        DoubleParameter(String parameter) {
             this.parameter = parameter;
         }
 
         @Override
-        public Double getValue(@Nonnull EvaluationContext context) {
+        @Nullable
+        public Double getValue(EvaluationContext context) {
             return (Double)context.getBinding(parameter);
         }
 
         @Override
-        public int planHash(@Nonnull final PlanHashMode mode) {
+        public int planHash(final PlanHashMode mode) {
             return parameter.hashCode();
         }
 

--- a/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/common/GeoPointWithinDistanceComponent.java
+++ b/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/common/GeoPointWithinDistanceComponent.java
@@ -36,8 +36,8 @@ import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Supplier;
@@ -49,22 +49,16 @@ import java.util.function.Supplier;
 public class GeoPointWithinDistanceComponent implements ComponentWithNoChildren {
     private static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("Geo-Point-Within-Distance-Component");
 
-    @Nonnull
     private final DoubleValueOrParameter centerLatitude;
-    @Nonnull
     private final DoubleValueOrParameter centerLongitude;
-    @Nonnull
     private final DoubleValueOrParameter distance;
-    @Nonnull
     private final String latitudeFieldName;
-    @Nonnull
     private final String longitudeFieldName;
-    @Nonnull
     private final GeometryFactory geometryFactory = new GeometryFactory();
 
-    public GeoPointWithinDistanceComponent(@Nonnull DoubleValueOrParameter centerLatitude, @Nonnull DoubleValueOrParameter centerLongitude,
-                                           @Nonnull DoubleValueOrParameter distance,
-                                           @Nonnull String latitudeFieldName, @Nonnull String longitudeFieldName) {
+    public GeoPointWithinDistanceComponent(DoubleValueOrParameter centerLatitude, DoubleValueOrParameter centerLongitude,
+                                           DoubleValueOrParameter distance,
+                                           String latitudeFieldName, String longitudeFieldName) {
         this.centerLatitude = centerLatitude;
         this.centerLongitude = centerLongitude;
         this.distance = distance;
@@ -74,7 +68,7 @@ public class GeoPointWithinDistanceComponent implements ComponentWithNoChildren 
 
     @Nullable
     @Override
-    public <M extends Message> Boolean evalMessage(@Nonnull FDBRecordStoreBase<M> store, @Nonnull EvaluationContext context, @Nullable FDBRecord<M> rec, @Nullable Message message) {
+    public <M extends Message> Boolean evalMessage(FDBRecordStoreBase<M> store, EvaluationContext context, @Nullable FDBRecord<M> rec, @Nullable Message message) {
         Double distanceValue = distance.getValue(context);
         Double centerLatitudeValue = centerLatitude.getValue(context);
         Double centerLongitudeValue = centerLongitude.getValue(context);
@@ -92,7 +86,7 @@ public class GeoPointWithinDistanceComponent implements ComponentWithNoChildren 
     }
 
     @Nullable
-    private Double getCoordinateField(@Nullable Message message, @Nonnull String fieldName) {
+    private Double getCoordinateField(@Nullable Message message, String fieldName) {
         if (message == null) {
             return null;
         }
@@ -104,12 +98,12 @@ public class GeoPointWithinDistanceComponent implements ComponentWithNoChildren 
     }
 
     @Override
-    public void validate(@Nonnull Descriptors.Descriptor descriptor) {
+    public void validate(Descriptors.Descriptor descriptor) {
         validateCoordinateField(descriptor, latitudeFieldName);
         validateCoordinateField(descriptor, longitudeFieldName);
     }
 
-    private void validateCoordinateField(@Nonnull Descriptors.Descriptor descriptor, @Nonnull String fieldName) {
+    private void validateCoordinateField(Descriptors.Descriptor descriptor, String fieldName) {
         Descriptors.FieldDescriptor field = descriptor.findFieldByName(fieldName);
         if (field == null) {
             throw new Query.InvalidExpressionException("Missing field " + fieldName);
@@ -122,16 +116,15 @@ public class GeoPointWithinDistanceComponent implements ComponentWithNoChildren 
         }
     }
 
-    @Nonnull
     @Override
-    public GraphExpansion expand(@Nonnull final Quantifier.ForEach baseQuantifier,
-                                 @Nonnull final Supplier<Quantifier.ForEach> outerQuantifierSupplier,
-                                 @Nonnull final List<String> fieldNamePrefix) {
+    public GraphExpansion expand(final Quantifier.ForEach baseQuantifier,
+                                 final Supplier<Quantifier.ForEach> outerQuantifierSupplier,
+                                 final List<String> fieldNamePrefix) {
         throw new UnsupportedOperationException("not yet implemented");
     }
 
     @Override
-    public int planHash(@Nonnull final PlanHashMode mode) {
+    public int planHash(final PlanHashMode mode) {
         switch (mode.getKind()) {
             case LEGACY:
                 return PlanHashable.objectsPlanHash(mode, centerLatitude, centerLongitude, distance, latitudeFieldName, longitudeFieldName);

--- a/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/common/package-info.java
+++ b/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/common/package-info.java
@@ -21,4 +21,7 @@
 /**
  * Common classes for (geo-)spatial queries.
  */
+@NullMarked
 package com.apple.foundationdb.record.spatial.common;
+
+import org.jspecify.annotations.NullMarked;

--- a/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileCoveringPointRecord.java
+++ b/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileCoveringPointRecord.java
@@ -25,8 +25,7 @@ import com.apple.foundationdb.tuple.Tuple;
 import com.geophile.z.SpatialObject;
 import com.geophile.z.spatialobject.d2.Point;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Index entry with original point in the value portion.
@@ -34,16 +33,14 @@ import javax.annotation.Nullable;
  * This allow more efficient filtering out of spatial join false positives.
  */
 class GeophileCoveringPointRecord extends GeophileRecordImpl {
-    @Nonnull
     private final SpatialObject spatialObject;
 
-    GeophileCoveringPointRecord(@Nonnull IndexEntry indexEntry, @Nullable Tuple prefix) {
+    GeophileCoveringPointRecord(IndexEntry indexEntry, @Nullable Tuple prefix) {
         super(indexEntry, prefix);
         Tuple value = indexEntry.getValue();
         this.spatialObject = new Point(value.getDouble(0), value.getDouble(1));
     }
 
-    @Nonnull
     @Override
     public SpatialObject spatialObject() {
         return spatialObject;

--- a/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileCursorImpl.java
+++ b/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileCursorImpl.java
@@ -87,6 +87,9 @@ class GeophileCursorImpl extends Cursor<GeophileRecordImpl> {
     }
 
     @Override
+    // Passes a null continuation into IndexMaintainer#scan; NullAway does not reliably recognize
+    // @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     public void goTo(GeophileRecordImpl key) {
         // TODO: For many kinds of spatial joins, it should be possible to pick an max Z value as well.
         //  This does not affect correctness, but without it the underlying key-value store does extra work.

--- a/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileCursorImpl.java
+++ b/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileCursorImpl.java
@@ -30,8 +30,8 @@ import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainer;
 import com.apple.foundationdb.tuple.Tuple;
 import com.geophile.z.Cursor;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import java.util.function.BiFunction;
 
 /**
@@ -55,16 +55,16 @@ import java.util.function.BiFunction;
  * </ul>
  */
 class GeophileCursorImpl extends Cursor<GeophileRecordImpl> {
-    @Nonnull
     private final IndexMaintainer indexMaintainer;
     @Nullable
     private final Tuple prefix;
-    @Nonnull
     private final BiFunction<IndexEntry, Tuple, GeophileRecordImpl> recordFunction;
+    // Not set until goTo() is called; next() guards against use before then.
+    @Nullable
     private RecordCursor<IndexEntry> recordCursor;
 
-    GeophileCursorImpl(@Nonnull GeophileIndexImpl index, @Nonnull IndexMaintainer indexMaintainer, @Nullable Tuple prefix,
-                       @Nonnull BiFunction<IndexEntry, Tuple, GeophileRecordImpl> recordFunction) {
+    GeophileCursorImpl(GeophileIndexImpl index, IndexMaintainer indexMaintainer, @Nullable Tuple prefix,
+                       BiFunction<IndexEntry, Tuple, GeophileRecordImpl> recordFunction) {
         super(index);
         this.indexMaintainer = indexMaintainer;
         this.prefix = prefix;
@@ -87,7 +87,7 @@ class GeophileCursorImpl extends Cursor<GeophileRecordImpl> {
     }
 
     @Override
-    public void goTo(@Nonnull GeophileRecordImpl key) {
+    public void goTo(GeophileRecordImpl key) {
         // TODO: For many kinds of spatial joins, it should be possible to pick an max Z value as well.
         //  This does not affect correctness, but without it the underlying key-value store does extra work.
         TupleRange range = new TupleRange(Tuple.from(key.z()), null, EndpointType.RANGE_INCLUSIVE, EndpointType.TREE_END);

--- a/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileIndexImpl.java
+++ b/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileIndexImpl.java
@@ -27,23 +27,21 @@ import com.geophile.z.Cursor;
 import com.geophile.z.Index;
 import com.geophile.z.Record;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import java.util.function.BiFunction;
 
 /**
  * Adapt {@link GeophileIndexMaintainer} to Geophile {@link Index}.
  */
 class GeophileIndexImpl extends Index<GeophileRecordImpl> {
-    @Nonnull
     private final IndexMaintainer indexMaintainer;
     @Nullable
     private final Tuple prefix;
-    @Nonnull
     private final BiFunction<IndexEntry, Tuple, GeophileRecordImpl> recordFunction;
 
-    GeophileIndexImpl(@Nonnull IndexMaintainer indexMaintainer, @Nullable Tuple prefix,
-                      @Nonnull BiFunction<IndexEntry, Tuple, GeophileRecordImpl> recordFunction) {
+    GeophileIndexImpl(IndexMaintainer indexMaintainer, @Nullable Tuple prefix,
+                      BiFunction<IndexEntry, Tuple, GeophileRecordImpl> recordFunction) {
         this.indexMaintainer = indexMaintainer;
         this.prefix = prefix;
         this.recordFunction = recordFunction;

--- a/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileIndexMaintainer.java
+++ b/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileIndexMaintainer.java
@@ -36,8 +36,8 @@ import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerState;
 import com.apple.foundationdb.record.provider.foundationdb.indexes.StandardIndexMaintainer;
 import com.geophile.z.Space;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import java.util.List;
 
 /**
@@ -46,7 +46,6 @@ import java.util.List;
  */
 @API(API.Status.EXPERIMENTAL)
 public class GeophileIndexMaintainer extends StandardIndexMaintainer {
-    @Nonnull
     private final Space space;
 
     public GeophileIndexMaintainer(IndexMaintainerState state) {
@@ -55,8 +54,7 @@ public class GeophileIndexMaintainer extends StandardIndexMaintainer {
     }
 
     // If the bottom-right child is GeophileSpatialFunctionKeyExpression, return it. Else error.
-    @Nonnull
-    static GeophileSpatialFunctionKeyExpression getSpatialFunction(@Nonnull Index index) {
+    static GeophileSpatialFunctionKeyExpression getSpatialFunction(Index index) {
         KeyExpression rootKey = index.getRootExpression();
         if (rootKey instanceof KeyWithValueExpression) {
             rootKey = ((KeyWithValueExpression)rootKey).getKeyExpression();
@@ -80,14 +78,15 @@ public class GeophileIndexMaintainer extends StandardIndexMaintainer {
         }
     }
 
-    @Nonnull
     public Space getSpace() {
         return space;
     }
 
-    @Nonnull
     @Override
-    public RecordCursor<IndexEntry> scan(@Nonnull IndexScanType scanType, @Nonnull TupleRange range, @Nullable byte[] continuation, @Nonnull ScanProperties scanProperties) {
+    @SuppressWarnings("NullAway") // NullAway/JSpecify does not currently recognize @Nullable on array (byte[]) parameters when overriding this unannotated-interface method; continuation genuinely may be null, same as before this migration.
+    public RecordCursor<IndexEntry> scan(IndexScanType scanType, TupleRange range,
+                                          @Nullable byte[] continuation,
+                                          ScanProperties scanProperties) {
         if (scanType.equals(GeophileScanTypes.GO_TO_Z)) {
             return scan(range, continuation, scanProperties);
         } else {

--- a/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileIndexMaintainerFactory.java
+++ b/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileIndexMaintainerFactory.java
@@ -29,7 +29,6 @@ import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerFactor
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerState;
 import com.google.auto.service.AutoService;
 
-import javax.annotation.Nonnull;
 import java.util.Arrays;
 
 /**
@@ -42,26 +41,22 @@ public class GeophileIndexMaintainerFactory implements IndexMaintainerFactory {
     private static final IndexGeneralAttributes GENERAL_ATTRIBUTES = new IndexGeneralAttributes(true);
 
     @Override
-    @Nonnull
     public Iterable<String> getIndexTypes() {
         return Arrays.asList(TYPES);
     }
 
-    @Nonnull
     @Override
     public IndexValidator getIndexValidator(Index index) {
         return new GeophileIndexValidator(index);
     }
 
-    @Nonnull
     @Override
-    public IndexMaintainer getIndexMaintainer(@Nonnull IndexMaintainerState state) {
+    public IndexMaintainer getIndexMaintainer(IndexMaintainerState state) {
         return new GeophileIndexMaintainer(state);
     }
 
-    @Nonnull
     @Override
-    public IndexGeneralAttributes getIndexGeneralAttributes(@Nonnull final Index index) {
+    public IndexGeneralAttributes getIndexGeneralAttributes(final Index index) {
         return GENERAL_ATTRIBUTES;
     }
 

--- a/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileIndexValidator.java
+++ b/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileIndexValidator.java
@@ -25,8 +25,6 @@ import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.IndexValidator;
 import com.apple.foundationdb.record.metadata.MetaDataValidator;
 
-import javax.annotation.Nonnull;
-
 /**
  * Validate that the key expression in a spatial index is valid.
  */
@@ -37,7 +35,7 @@ class GeophileIndexValidator extends IndexValidator {
     }
 
     @Override
-    public void validate(@Nonnull MetaDataValidator metaDataValidator) {
+    public void validate(MetaDataValidator metaDataValidator) {
         super.validate(metaDataValidator);
         validateNotGrouping();
         validateNotVersion();

--- a/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophilePointWithinDistanceQueryPlan.java
+++ b/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophilePointWithinDistanceQueryPlan.java
@@ -42,7 +42,6 @@ import com.apple.foundationdb.record.query.plan.plans.RecordQueryFetchFromPartia
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryPlan;
 import com.apple.foundationdb.record.spatial.common.DoubleValueOrParameter;
 import com.apple.foundationdb.tuple.Tuple;
-import com.geophile.z.SpatialJoin;
 import com.geophile.z.SpatialObject;
 import com.geophile.z.index.RecordWithSpatialObject;
 import com.geophile.z.spatialobject.d2.Point;
@@ -53,12 +52,14 @@ import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.BiFunction;
+
+import static com.geophile.z.SpatialJoin.Filter;
 
 /**
  * Query spatial index for points (latitude, longitude) within a given distance (inclusive) of a given center.
@@ -68,17 +69,14 @@ import java.util.function.BiFunction;
 public class GeophilePointWithinDistanceQueryPlan extends GeophileSpatialObjectQueryPlan {
     private static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("Geophile-Point-Within-Distance-Query-Plan");
 
-    @Nonnull
     private final DoubleValueOrParameter centerLatitude;
-    @Nonnull
     private final DoubleValueOrParameter centerLongitude;
-    @Nonnull
     private final DoubleValueOrParameter distance;
     private final boolean covering;
 
-    public GeophilePointWithinDistanceQueryPlan(@Nonnull DoubleValueOrParameter centerLatitude, @Nonnull DoubleValueOrParameter centerLongitude,
-                                                @Nonnull DoubleValueOrParameter distance,
-                                                @Nonnull String indexName, @Nonnull ScanComparisons prefixComparisons, boolean covering) {
+    public GeophilePointWithinDistanceQueryPlan(DoubleValueOrParameter centerLatitude, DoubleValueOrParameter centerLongitude,
+                                                DoubleValueOrParameter distance,
+                                                String indexName, ScanComparisons prefixComparisons, boolean covering) {
         super(indexName, prefixComparisons);
         this.centerLatitude = centerLatitude;
         this.centerLongitude = centerLongitude;
@@ -88,7 +86,7 @@ public class GeophilePointWithinDistanceQueryPlan extends GeophileSpatialObjectQ
 
     @Nullable
     @Override
-    protected SpatialObject getSpatialObject(@Nonnull EvaluationContext context) {
+    protected SpatialObject getSpatialObject(EvaluationContext context) {
         Double distanceValue = distance.getValue(context);
         Double centerLatitudeValue = centerLatitude.getValue(context);
         Double centerLongitudeValue = centerLongitude.getValue(context);
@@ -102,7 +100,7 @@ public class GeophilePointWithinDistanceQueryPlan extends GeophileSpatialObjectQ
 
     @Nullable
     @Override
-    protected SpatialJoin.Filter<RecordWithSpatialObject, GeophileRecordImpl> getFilter(@Nonnull EvaluationContext context) {
+    protected Filter<RecordWithSpatialObject, GeophileRecordImpl> getFilter(EvaluationContext context) {
         if (covering) {
             Double distanceValue = distance.getValue(context);
             Double centerLatitudeValue = centerLatitude.getValue(context);
@@ -131,26 +129,23 @@ public class GeophilePointWithinDistanceQueryPlan extends GeophileSpatialObjectQ
         }
     }
 
-    @Nonnull
     @Override
     public AvailableFields getAvailableFields() {
         return AvailableFields.NO_FIELDS;
     }
 
-    @Nonnull
     @Override
     public RecordQueryFetchFromPartialRecordPlan.FetchIndexRecords getFetchIndexRecords() {
         return RecordQueryFetchFromPartialRecordPlan.FetchIndexRecords.PRIMARY_KEY;
     }
 
-    @Nonnull
     @Override
     public Value getResultValue() {
         return new QueriedValue();
     }
 
     @Override
-    public int planHash(@Nonnull final PlanHashMode mode) {
+    public int planHash(final PlanHashMode mode) {
         // TODO: Is this right?
         switch (mode.getKind()) {
             case LEGACY:
@@ -164,8 +159,8 @@ public class GeophilePointWithinDistanceQueryPlan extends GeophileSpatialObjectQ
 
     @Override
     @SuppressWarnings("PMD.CompareObjectsWithEquals")
-    public boolean equalsWithoutChildren(@Nonnull final RelationalExpression otherExpression,
-                                         @Nonnull final AliasMap equivalencesMap) {
+    public boolean equalsWithoutChildren(final RelationalExpression otherExpression,
+                                         final AliasMap equivalencesMap) {
         if (this == otherExpression) {
             return true;
         }
@@ -184,21 +179,19 @@ public class GeophilePointWithinDistanceQueryPlan extends GeophileSpatialObjectQ
         return Objects.hash(super.computeHashCodeWithoutChildren(), centerLatitude, centerLongitude, distance, covering);
     }
 
-    @Nonnull
     @Override
-    public PlannerGraph rewritePlannerGraph(@Nonnull final List<? extends PlannerGraph> childGraphs) {
+    public PlannerGraph rewritePlannerGraph(final List<? extends PlannerGraph> childGraphs) {
         return createIndexPlannerGraph(this,
                 covering ? NodeInfo.COVERING_SPATIAL_INDEX_SCAN_OPERATOR : NodeInfo.SPATIAL_INDEX_SCAN_OPERATOR,
                 ImmutableList.of(),
                 ImmutableMap.of());
     }
 
-    @Nonnull
     @Override
-    public PlannerGraph createIndexPlannerGraph(@Nonnull final RecordQueryPlan identity,
-                                                @Nonnull final NodeInfo nodeInfo,
-                                                @Nonnull final List<String> additionalDetails,
-                                                @Nonnull final Map<String, Attribute> additionalAttributeMap) {
+    public PlannerGraph createIndexPlannerGraph(final RecordQueryPlan identity,
+                                                final NodeInfo nodeInfo,
+                                                final List<String> additionalDetails,
+                                                final Map<String, Attribute> additionalAttributeMap) {
         final ImmutableList.Builder<String> detailsBuilder = ImmutableList.builder();
         final ImmutableMap.Builder<String, Attribute> attributeMapBuilder = ImmutableMap.builder();
 
@@ -227,15 +220,13 @@ public class GeophilePointWithinDistanceQueryPlan extends GeophileSpatialObjectQ
                                 ImmutableList.of())));
     }
 
-    @Nonnull
     @Override
-    public Message toProto(@Nonnull final PlanSerializationContext serializationContext) {
+    public Message toProto(final PlanSerializationContext serializationContext) {
         throw new RecordCoreException("serialization of this plan is not supported");
     }
 
-    @Nonnull
     @Override
-    public PRecordQueryPlan toRecordQueryPlanProto(@Nonnull final PlanSerializationContext serializationContext) {
+    public PRecordQueryPlan toRecordQueryPlanProto(final PlanSerializationContext serializationContext) {
         throw new RecordCoreException("serialization of this plan is not supported");
     }
 }

--- a/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileRecordImpl.java
+++ b/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileRecordImpl.java
@@ -26,8 +26,8 @@ import com.geophile.z.Record;
 import com.geophile.z.Space;
 import com.geophile.z.SpatialObject;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import java.util.Objects;
 
 /**
@@ -49,7 +49,6 @@ class GeophileRecordImpl implements Record {
         return indexEntry;
     }
 
-    @Nonnull
     public SpatialObject spatialObject() {
         throw new UnsupportedOperationException("this index does not have covering spatial objects");
     }

--- a/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileSpatial.java
+++ b/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileSpatial.java
@@ -39,7 +39,7 @@ import org.locationtech.jts.io.geojson.GeoJsonReader;
 import org.locationtech.jts.io.geojson.GeoJsonWriter;
 import org.slf4j.bridge.SLF4JBridgeHandler;
 
-import javax.annotation.Nonnull;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Helper methods for interfacing with Geophile, specifically for implementing geospatial with lat, lon coordinates.
@@ -171,11 +171,18 @@ class GeophileSpatial {
 
     private static class IO {
         private final GeometryFactory factory = new GeometryFactory();
+        // Lazily initialized on first use by the corresponding getter below.
+        @Nullable
         private GeoJsonReader geoJsonReader;
+        @Nullable
         private GeoJsonWriter geoJsonWriter;
+        @Nullable
         private WKBReader wkbReader;
+        @Nullable
         private WKBWriter wkbWriter;
+        @Nullable
         private WKTReader wktReader;
+        @Nullable
         private WKTWriter wktWriter;
 
         public GeoJsonReader geoJsonReader() {
@@ -229,7 +236,7 @@ class GeophileSpatial {
      * @param geometry the geometry to be transformed
      * @return the transformed geometry
      */
-    public static Geometry swapLatLong(@Nonnull Geometry geometry) {
+    public static Geometry swapLatLong(Geometry geometry) {
         geometry.apply(SWAPPING_FILTER);
         return geometry;
     }

--- a/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileSpatialFunctionKeyExpression.java
+++ b/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileSpatialFunctionKeyExpression.java
@@ -35,8 +35,8 @@ import com.geophile.z.spatialobject.d2.Point;
 import com.google.protobuf.Message;
 import org.locationtech.jts.io.ParseException;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -50,23 +50,21 @@ public abstract class GeophileSpatialFunctionKeyExpression extends FunctionKeyEx
 
     private final Space space;
 
-    protected GeophileSpatialFunctionKeyExpression(@Nonnull String name, @Nonnull KeyExpression arguments) {
+    protected GeophileSpatialFunctionKeyExpression(String name, KeyExpression arguments) {
         super(name, arguments);
         // TODO: How do we make this a part of the key expression? A naming convention?
         this.space = SPACE_LAT_LON;
     }
 
-    @Nonnull
     public Space getSpace() {
         return space;
     }
 
     @Nullable
-    protected abstract SpatialObject parseSpatialObject(@Nonnull Key.Evaluated arguments) throws ParseException;
+    protected abstract SpatialObject parseSpatialObject(Key.Evaluated arguments) throws ParseException;
 
-    @Nonnull
     @Override
-    public <M extends Message> List<Key.Evaluated> evaluateFunction(@Nullable FDBRecord<M> record, @Nullable Message message, @Nonnull Key.Evaluated arguments) {
+    public <M extends Message> List<Key.Evaluated> evaluateFunction(@Nullable FDBRecord<M> record, @Nullable Message message, Key.Evaluated arguments) {
         SpatialObject spatialObject;
         try {
             spatialObject = parseSpatialObject(arguments);
@@ -98,8 +96,10 @@ public abstract class GeophileSpatialFunctionKeyExpression extends FunctionKeyEx
         return 1;
     }
 
-    protected boolean shouldSwapLatLong(@Nonnull Key.Evaluated arguments) {
-        return arguments.size() > 1 && arguments.getObject(1, Boolean.class);
+    protected boolean shouldSwapLatLong(Key.Evaluated arguments) {
+        // Boolean.TRUE.equals(...) rather than unboxing, since a null argument value (unlikely, but not
+        // statically impossible) would otherwise NPE here; treat it the same as an absent/false argument.
+        return arguments.size() > 1 && Boolean.TRUE.equals(arguments.getObject(1, Boolean.class));
     }
 
     /**
@@ -110,13 +110,13 @@ public abstract class GeophileSpatialFunctionKeyExpression extends FunctionKeyEx
     public static class GeoPointZ extends GeophileSpatialFunctionKeyExpression {
         private static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("Geo-Point-Z");
 
-        public GeoPointZ(@Nonnull String name, @Nonnull KeyExpression arguments) {
+        public GeoPointZ(String name, KeyExpression arguments) {
             super(name, arguments);
         }
 
         @Nullable
         @Override
-        protected SpatialObject parseSpatialObject(@Nonnull Key.Evaluated arguments) {
+        protected SpatialObject parseSpatialObject(Key.Evaluated arguments) {
             Double latitude = arguments.getNullableDouble(0);
             Double longitude = arguments.getNullableDouble(1);
             if (latitude == null || longitude == null) {
@@ -137,13 +137,12 @@ public abstract class GeophileSpatialFunctionKeyExpression extends FunctionKeyEx
         }
 
         @Override
-        public int planHash(@Nonnull final PlanHashable.PlanHashMode mode) {
+        public int planHash(final PlanHashable.PlanHashMode mode) {
             return super.basePlanHash(mode, BASE_HASH);
         }
 
-        @Nonnull
         @Override
-        public Value toValue(@Nonnull final List<? extends Value> argumentValues) {
+        public Value toValue(final List<? extends Value> argumentValues) {
             throw new UnsupportedOperationException("not implemented");
         }
     }
@@ -156,13 +155,13 @@ public abstract class GeophileSpatialFunctionKeyExpression extends FunctionKeyEx
     public static class GeoJsonZ extends GeophileSpatialFunctionKeyExpression {
         private static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("Geo-Json-Z");
 
-        public GeoJsonZ(@Nonnull String name, @Nonnull KeyExpression arguments) {
+        public GeoJsonZ(String name, KeyExpression arguments) {
             super(name, arguments);
         }
 
         @Nullable
         @Override
-        protected SpatialObject parseSpatialObject(@Nonnull Key.Evaluated arguments) throws ParseException {
+        protected SpatialObject parseSpatialObject(Key.Evaluated arguments) throws ParseException {
             String json = arguments.getString(0);
             if (json == null) {
                 return null;
@@ -182,13 +181,12 @@ public abstract class GeophileSpatialFunctionKeyExpression extends FunctionKeyEx
         }
 
         @Override
-        public int planHash(@Nonnull final PlanHashable.PlanHashMode mode) {
+        public int planHash(final PlanHashable.PlanHashMode mode) {
             return super.basePlanHash(mode, BASE_HASH);
         }
 
-        @Nonnull
         @Override
-        public Value toValue(@Nonnull final List<? extends Value> argumentValues) {
+        public Value toValue(final List<? extends Value> argumentValues) {
             throw new UnsupportedOperationException("not implemented");
         }
     }
@@ -202,13 +200,13 @@ public abstract class GeophileSpatialFunctionKeyExpression extends FunctionKeyEx
     public static class GeoWKBZ extends GeophileSpatialFunctionKeyExpression {
         private static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("Geo-WKB-Z");
 
-        public GeoWKBZ(@Nonnull String name, @Nonnull KeyExpression arguments) {
+        public GeoWKBZ(String name, KeyExpression arguments) {
             super(name, arguments);
         }
 
         @Nullable
         @Override
-        protected SpatialObject parseSpatialObject(@Nonnull Key.Evaluated arguments) throws ParseException {
+        protected SpatialObject parseSpatialObject(Key.Evaluated arguments) throws ParseException {
             byte[] wkb = arguments.getObject(0, byte[].class);
             if (wkb == null) {
                 return null;
@@ -228,13 +226,12 @@ public abstract class GeophileSpatialFunctionKeyExpression extends FunctionKeyEx
         }
 
         @Override
-        public int planHash(@Nonnull final PlanHashable.PlanHashMode mode) {
+        public int planHash(final PlanHashable.PlanHashMode mode) {
             return super.basePlanHash(mode, BASE_HASH);
         }
 
-        @Nonnull
         @Override
-        public Value toValue(@Nonnull final List<? extends Value> argumentValues) {
+        public Value toValue(final List<? extends Value> argumentValues) {
             throw new UnsupportedOperationException("not implemented");
         }
     }
@@ -248,13 +245,13 @@ public abstract class GeophileSpatialFunctionKeyExpression extends FunctionKeyEx
     public static class GeoWKTZ extends GeophileSpatialFunctionKeyExpression {
         private static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("Geo-WKT-Z");
 
-        public GeoWKTZ(@Nonnull String name, @Nonnull KeyExpression arguments) {
+        public GeoWKTZ(String name, KeyExpression arguments) {
             super(name, arguments);
         }
 
         @Nullable
         @Override
-        protected SpatialObject parseSpatialObject(@Nonnull Key.Evaluated arguments) throws ParseException {
+        protected SpatialObject parseSpatialObject(Key.Evaluated arguments) throws ParseException {
             String wkt = arguments.getString(0);
             if (wkt == null) {
                 return null;
@@ -274,13 +271,12 @@ public abstract class GeophileSpatialFunctionKeyExpression extends FunctionKeyEx
         }
 
         @Override
-        public int planHash(@Nonnull final PlanHashable.PlanHashMode mode) {
+        public int planHash(final PlanHashable.PlanHashMode mode) {
             return super.basePlanHash(mode, BASE_HASH);
         }
 
-        @Nonnull
         @Override
-        public Value toValue(@Nonnull final List<? extends Value> argumentValues) {
+        public Value toValue(final List<? extends Value> argumentValues) {
             throw new UnsupportedOperationException("not implemented");
         }
     }

--- a/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileSpatialFunctionKeyExpressionFactory.java
+++ b/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileSpatialFunctionKeyExpressionFactory.java
@@ -24,7 +24,6 @@ import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.metadata.expressions.FunctionKeyExpression;
 import com.google.auto.service.AutoService;
 
-import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.List;
 
@@ -35,7 +34,6 @@ import java.util.List;
 @AutoService(FunctionKeyExpression.Factory.class)
 @API(API.Status.EXPERIMENTAL)
 public class GeophileSpatialFunctionKeyExpressionFactory implements FunctionKeyExpression.Factory {
-    @Nonnull
     @Override
     public List<FunctionKeyExpression.Builder> getBuilders() {
         return Arrays.asList(

--- a/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileSpatialIndexJoinPlan.java
+++ b/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileSpatialIndexJoinPlan.java
@@ -34,7 +34,7 @@ import com.geophile.z.SpatialIndex;
 import com.geophile.z.SpatialJoin;
 import com.google.protobuf.Message;
 
-import javax.annotation.Nonnull;
+import java.util.Objects;
 
 /**
  * Something like a query plan for joining spatial indexes.
@@ -44,25 +44,20 @@ import javax.annotation.Nonnull;
  */
 @API(API.Status.EXPERIMENTAL)
 public class GeophileSpatialIndexJoinPlan {
-    @Nonnull
     private final String leftIndexName;
-    @Nonnull
     private final ScanComparisons leftPrefixComparisons;
-    @Nonnull
     private final String rightIndexName;
-    @Nonnull
     private final ScanComparisons rightPrefixComparisons;
 
-    public GeophileSpatialIndexJoinPlan(@Nonnull String leftIndexName, @Nonnull ScanComparisons leftPrefixComparisons,
-                                        @Nonnull String rightIndexName, @Nonnull ScanComparisons rightPrefixComparisons) {
+    public GeophileSpatialIndexJoinPlan(String leftIndexName, ScanComparisons leftPrefixComparisons,
+                                        String rightIndexName, ScanComparisons rightPrefixComparisons) {
         this.leftIndexName = leftIndexName;
         this.leftPrefixComparisons = leftPrefixComparisons;
         this.rightIndexName = rightIndexName;
         this.rightPrefixComparisons = rightPrefixComparisons;
     }
 
-    @Nonnull
-    public <M extends Message> RecordCursor<Pair<FDBIndexedRecord<M>, FDBIndexedRecord<M>>> execute(@Nonnull FDBRecordStoreBase<M> store, @Nonnull EvaluationContext context) {
+    public <M extends Message> RecordCursor<Pair<FDBIndexedRecord<M>, FDBIndexedRecord<M>>> execute(FDBRecordStoreBase<M> store, EvaluationContext context) {
         final SpatialJoin spatialJoin = SpatialJoin.newSpatialJoin(SpatialJoin.Duplicates.INCLUDE);
         final GeophileSpatialJoin geophileSpatialJoin = new GeophileSpatialJoin(spatialJoin, store.getUntypedRecordStore(), context);
         final SpatialIndex<GeophileRecordImpl> leftSpatialIndex = geophileSpatialJoin.getSpatialIndex(leftIndexName, leftPrefixComparisons);
@@ -71,12 +66,13 @@ public class GeophileSpatialIndexJoinPlan {
     }
 
     // TODO: Probably once there is a real join cursor signature, something like this is a method on the store and loadIndexEntryRecord doesn't need to be public.
-    @Nonnull
-    public <M extends Message> RecordCursor<Pair<FDBIndexedRecord<M>, FDBIndexedRecord<M>>> fetchIndexRecords(@Nonnull FDBRecordStoreBase<M> store,
-                                                                                                              @Nonnull RecordCursor<Pair<IndexEntry, IndexEntry>> indexCursor) {
+    public <M extends Message> RecordCursor<Pair<FDBIndexedRecord<M>, FDBIndexedRecord<M>>> fetchIndexRecords(FDBRecordStoreBase<M> store,
+                                                                                                              RecordCursor<Pair<IndexEntry, IndexEntry>> indexCursor) {
+        // Both sides are statically @Nullable (GeophileRecordImpl.getIndexEntry() can be null for Geophile's internal
+        // scratch records), but a completed spatial join only ever emits records built from real index entries.
         return indexCursor.mapPipelined(pair ->
-                        store.loadIndexEntryRecord(pair.getLeft(), IndexOrphanBehavior.ERROR)
-                                .thenCombine(store.loadIndexEntryRecord(pair.getRight(), IndexOrphanBehavior.ERROR), Pair::of),
+                        store.loadIndexEntryRecord(Objects.requireNonNull(pair.getLeft()), IndexOrphanBehavior.ERROR)
+                                .thenCombine(store.loadIndexEntryRecord(Objects.requireNonNull(pair.getRight()), IndexOrphanBehavior.ERROR), Pair::of),
                 store.getPipelineSize(PipelineOperation.INDEX_TO_RECORD));
     }
 

--- a/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileSpatialJoin.java
+++ b/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileSpatialJoin.java
@@ -37,7 +37,6 @@ import com.geophile.z.SpatialIndex;
 import com.geophile.z.SpatialJoin;
 import com.geophile.z.SpatialObject;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.function.BiFunction;
@@ -46,34 +45,28 @@ import java.util.function.BiFunction;
  * Generate {@link RecordCursor} from {@link GeophileIndexMaintainer} using Geophile {@link SpatialJoin}.
  */
 class GeophileSpatialJoin {
-    @Nonnull
     private final SpatialJoin spatialJoin;
-    @Nonnull
     private final FDBRecordStore store;
-    @Nonnull
     private final EvaluationContext context;
 
-    GeophileSpatialJoin(@Nonnull SpatialJoin spatialJoin, @Nonnull FDBRecordStore store, @Nonnull EvaluationContext context) {
+    GeophileSpatialJoin(SpatialJoin spatialJoin, FDBRecordStore store, EvaluationContext context) {
         this.spatialJoin = spatialJoin;
         this.store = store;
         this.context = context;
     }
 
-    @Nonnull
-    public SpatialIndex<GeophileRecordImpl> getSpatialIndex(@Nonnull String indexName) {
+    public SpatialIndex<GeophileRecordImpl> getSpatialIndex(String indexName) {
         return getSpatialIndex(indexName, ScanComparisons.EMPTY);
     }
 
-    @Nonnull
-    public SpatialIndex<GeophileRecordImpl> getSpatialIndex(@Nonnull String indexName,
-                                                            @Nonnull ScanComparisons prefixComparisons) {
+    public SpatialIndex<GeophileRecordImpl> getSpatialIndex(String indexName,
+                                                            ScanComparisons prefixComparisons) {
         return getSpatialIndex(indexName, prefixComparisons, GeophileRecordImpl::new);
     }
 
-    @Nonnull
-    public SpatialIndex<GeophileRecordImpl> getSpatialIndex(@Nonnull String indexName,
-                                                            @Nonnull ScanComparisons prefixComparisons,
-                                                            @Nonnull BiFunction<IndexEntry, Tuple, GeophileRecordImpl> recordFunction) {
+    public SpatialIndex<GeophileRecordImpl> getSpatialIndex(String indexName,
+                                                            ScanComparisons prefixComparisons,
+                                                            BiFunction<IndexEntry, Tuple, GeophileRecordImpl> recordFunction) {
         if (!prefixComparisons.isEquality()) {
             throw new RecordCoreArgumentException("prefix comparisons must only have equality");
         }
@@ -93,10 +86,9 @@ class GeophileSpatialJoin {
         }
     }
 
-    @Nonnull
     @SuppressWarnings("PMD.CloseResource")
-    public RecordCursor<IndexEntry> recordCursor(@Nonnull SpatialObject spatialObject,
-                                                 @Nonnull SpatialIndex<GeophileRecordImpl> spatialIndex) {
+    public RecordCursor<IndexEntry> recordCursor(SpatialObject spatialObject,
+                                                 SpatialIndex<GeophileRecordImpl> spatialIndex) {
         // TODO: This is a synchronous implementation using Iterators. A proper RecordCursor implementation needs
         //  Geophile async extensions. Also need to pass down executeProperties.
         final Iterator<GeophileRecordImpl> iterator;
@@ -112,10 +104,9 @@ class GeophileSpatialJoin {
         return recordCursor.map(GeophileRecordImpl::getIndexEntry);
     }
 
-    @Nonnull
     @SuppressWarnings("PMD.CloseResource")
-    public RecordCursor<Pair<IndexEntry, IndexEntry>> recordCursor(@Nonnull SpatialIndex<GeophileRecordImpl> left,
-                                                                   @Nonnull SpatialIndex<GeophileRecordImpl> right) {
+    public RecordCursor<Pair<IndexEntry, IndexEntry>> recordCursor(SpatialIndex<GeophileRecordImpl> left,
+                                                                   SpatialIndex<GeophileRecordImpl> right) {
         // TODO: This is a synchronous implementation using Iterators. A proper RecordCursor implementation needs
         //  Geophile async extensions. Also need to pass down executeProperties.
         final Iterator<com.geophile.z.Pair<GeophileRecordImpl, GeophileRecordImpl>> iterator;

--- a/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileSpatialJoin.java
+++ b/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileSpatialJoin.java
@@ -39,6 +39,7 @@ import com.geophile.z.SpatialObject;
 
 import java.io.IOException;
 import java.util.Iterator;
+import java.util.Objects;
 import java.util.function.BiFunction;
 
 /**
@@ -101,7 +102,11 @@ class GeophileSpatialJoin {
             throw new RecordCoreException(ex);
         }
         final RecordCursor<GeophileRecordImpl> recordCursor = RecordCursor.fromIterator(store.getExecutor(), iterator);
-        return recordCursor.map(GeophileRecordImpl::getIndexEntry);
+        // getIndexEntry() is @Nullable in general (GeophileIndexImpl#newRecord() constructs a
+        // GeophileRecordImpl with a null entry as an internal Geophile scratch/comparison object), but
+        // records yielded by this iterator are always built from a real index entry (see
+        // GeophileCursorImpl#next()).
+        return recordCursor.map(record -> Objects.requireNonNull(record.getIndexEntry()));
     }
 
     @SuppressWarnings("PMD.CloseResource")

--- a/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileSpatialObjectQueryPlan.java
+++ b/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/GeophileSpatialObjectQueryPlan.java
@@ -48,8 +48,8 @@ import com.geophile.z.index.RecordWithSpatialObject;
 import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.Message;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -57,17 +57,17 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiFunction;
 
+import static com.geophile.z.SpatialJoin.Filter;
+
 /**
  * Base class for query plans that execute a spatial join between a single spatial object and a spatial index.
  */
 @API(API.Status.EXPERIMENTAL)
 public abstract class GeophileSpatialObjectQueryPlan extends AbstractRelationalExpressionWithoutChildren implements RecordQueryPlanWithNoChildren, RecordQueryPlanWithIndex {
-    @Nonnull
     private final String indexName;
-    @Nonnull
     private final ScanComparisons prefixComparisons;
 
-    protected GeophileSpatialObjectQueryPlan(@Nonnull String indexName, @Nonnull ScanComparisons prefixComparisons) {
+    protected GeophileSpatialObjectQueryPlan(String indexName, ScanComparisons prefixComparisons) {
         this.indexName = indexName;
         this.prefixComparisons = prefixComparisons;
     }
@@ -78,7 +78,7 @@ public abstract class GeophileSpatialObjectQueryPlan extends AbstractRelationalE
      * @return a spatial object to use in spatial join or {@code null} if some bound parameter is null.
      */
     @Nullable
-    protected abstract SpatialObject getSpatialObject(@Nonnull EvaluationContext context);
+    protected abstract SpatialObject getSpatialObject(EvaluationContext context);
 
     /**
      * Get a optional filter to eliminate false positives from the spatial join.
@@ -93,7 +93,7 @@ public abstract class GeophileSpatialObjectQueryPlan extends AbstractRelationalE
      */
     @Nullable
     @SuppressWarnings("PMD.EmptyMethodInAbstractClassShouldBeAbstract") // null is a reasonable default
-    protected SpatialJoin.Filter<RecordWithSpatialObject, GeophileRecordImpl> getFilter(@Nonnull EvaluationContext context) {
+    protected Filter<RecordWithSpatialObject, GeophileRecordImpl> getFilter(EvaluationContext context) {
         return null;
     }
 
@@ -107,35 +107,31 @@ public abstract class GeophileSpatialObjectQueryPlan extends AbstractRelationalE
         return GeophileRecordImpl::new;
     }
 
-    @Nonnull
     public ScanComparisons getPrefixComparisons() {
         return prefixComparisons;
     }
 
-    @Nonnull
     @Override
     public String getIndexName() {
         return indexName;
     }
 
-    @Nonnull
     @Override
     public IndexScanType getScanType() {
         return GeophileScanTypes.GO_TO_Z;
     }
 
-    @Nonnull
     @Override
     public Optional<? extends MatchCandidate> getMatchCandidateMaybe() {
         return Optional.empty();
     }
 
-    @Nonnull
     @Override
-    public <M extends Message> RecordCursor<IndexEntry> executeEntries(@Nonnull FDBRecordStoreBase<M> store,
-                                                                       @Nonnull EvaluationContext context,
+    @SuppressWarnings("NullAway") // NullAway/JSpecify does not currently recognize @Nullable on array (byte[]) parameters when overriding this unannotated-interface method; continuation genuinely may be null, same as before this migration.
+    public <M extends Message> RecordCursor<IndexEntry> executeEntries(FDBRecordStoreBase<M> store,
+                                                                       EvaluationContext context,
                                                                        @Nullable byte[] continuation,
-                                                                       @Nonnull ExecuteProperties executeProperties) {
+                                                                       ExecuteProperties executeProperties) {
         if (continuation != null) {
             throw new RecordCoreException("continuations are not yet supported");
         }
@@ -165,11 +161,10 @@ public abstract class GeophileSpatialObjectQueryPlan extends AbstractRelationalE
     }
 
     @Override
-    public boolean hasIndexScan(@Nonnull String indexName) {
+    public boolean hasIndexScan(String indexName) {
         return this.indexName.equals(indexName);
     }
 
-    @Nonnull
     @Override
     public Set<String> getUsedIndexes() {
         return Collections.singleton(indexName);
@@ -190,30 +185,27 @@ public abstract class GeophileSpatialObjectQueryPlan extends AbstractRelationalE
         return 1;
     }
 
-    @Nonnull
     @Override
     public List<? extends Quantifier> getQuantifiers() {
         return Collections.emptyList();
     }
 
-    @Nonnull
     @Override
     public Set<CorrelationIdentifier> computeCorrelatedToWithoutChildren() {
         return ImmutableSet.of();
     }
 
-    @Nonnull
     @Override
-    public GeophileSpatialObjectQueryPlan translateCorrelations(@Nonnull final TranslationMap translationMap,
+    public GeophileSpatialObjectQueryPlan translateCorrelations(final TranslationMap translationMap,
                                                                 final boolean shouldSimplifyValues,
-                                                                @Nonnull final List<? extends Quantifier> translatedQuantifiers) {
+                                                                final List<? extends Quantifier> translatedQuantifiers) {
         return this;
     }
 
     @Override
     @SuppressWarnings("PMD.CompareObjectsWithEquals")
-    public boolean equalsWithoutChildren(@Nonnull RelationalExpression otherExpression,
-                                         @Nonnull final AliasMap equivalencesMap) {
+    public boolean equalsWithoutChildren(RelationalExpression otherExpression,
+                                         final AliasMap equivalencesMap) {
         if (this == otherExpression) {
             return true;
         }

--- a/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/package-info.java
+++ b/fdb-record-layer-spatial/src/main/java/com/apple/foundationdb/record/spatial/geophile/package-info.java
@@ -21,4 +21,7 @@
 /**
  * Classes for doing geospatial queries with <a href="https://github.com/geophile/geophile">Geophile</a>.
  */
+@NullMarked
 package com.apple.foundationdb.record.spatial.geophile;
+
+import org.jspecify.annotations.NullMarked;

--- a/fdb-record-layer-spatial/src/test/java/com/apple/foundationdb/record/spatial/geophile/GeophileQueryTest.java
+++ b/fdb-record-layer-spatial/src/test/java/com/apple/foundationdb/record/spatial/geophile/GeophileQueryTest.java
@@ -48,6 +48,7 @@ import com.apple.test.Tags;
 import com.google.common.base.Throwables;
 import com.google.protobuf.Message;
 import org.hamcrest.Matchers;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
@@ -261,6 +262,9 @@ public class GeophileQueryTest extends FDBRecordStoreQueryTestBase {
 
     @Test
     @Tag(Tags.Slow)
+    // Passes a null/@Nullable continuation into RecordQueryPlan#execute; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     public void testDistance() throws Exception {
         final RecordMetaDataHook hook = md -> {
             md.addIndex("City", CITY_LOCATION_COVERING_INDEX);
@@ -274,7 +278,7 @@ public class GeophileQueryTest extends FDBRecordStoreQueryTestBase {
 
         final RecordQueryPlan scanPlan = distanceFilterScan(distance);
         final Set<Integer> scanResults = new HashSet<>();
-        byte [] continuation = null;
+        byte @Nullable [] continuation = null;
         do {
             try (FDBRecordContext context = openContext()) {
                 openRecordStore(context, hook);

--- a/fdb-record-layer-spatial/src/test/java/com/apple/foundationdb/record/spatial/geophile/GeophileQueryTest.java
+++ b/fdb-record-layer-spatial/src/test/java/com/apple/foundationdb/record/spatial/geophile/GeophileQueryTest.java
@@ -60,12 +60,12 @@ import org.locationtech.jts.io.geojson.GeoJsonReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
 import java.io.BufferedReader;
 import java.io.FileInputStream;
 import java.io.InputStreamReader;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletionException;
 
@@ -216,7 +216,6 @@ public class GeophileQueryTest extends FDBRecordStoreQueryTestBase {
         }
     }
 
-    @Nonnull
     protected RecordQueryPlan distanceFilter(double distance, RecordQueryPlan input) {
         return new RecordQueryFilterPlan(input,
                 Query.field("location").matches(new GeoPointWithinDistanceComponent(
@@ -226,7 +225,6 @@ public class GeophileQueryTest extends FDBRecordStoreQueryTestBase {
                         "latitude", "longitude")));
     }
 
-    @Nonnull
     protected RecordQueryPlan distanceFilterScan(double distance) {
         return distanceFilter(distance,
                 new RecordQueryTypeFilterPlan(
@@ -234,7 +232,6 @@ public class GeophileQueryTest extends FDBRecordStoreQueryTestBase {
                         Collections.singleton("City")));
     }
 
-    @Nonnull
     protected RecordQueryPlan distanceSpatialQuery(double distance, boolean covering) {
         RecordQueryPlan spatialQuery = new GeophilePointWithinDistanceQueryPlan(
                         DoubleValueOrParameter.parameter("center_latitude"),
@@ -248,7 +245,6 @@ public class GeophileQueryTest extends FDBRecordStoreQueryTestBase {
         }
     }
 
-    @Nonnull
     protected EvaluationContext bindCenter(int cityId) {
         Bindings.Builder bindings = Bindings.newBuilder();
         FDBStoredRecord<Message> city = recordStore.loadRecord(Tuple.from(cityId));
@@ -359,9 +355,9 @@ public class GeophileQueryTest extends FDBRecordStoreQueryTestBase {
             final GeoJsonReader geoJsonReader = new GeoJsonReader(geometryFactory);
             recordCursor.forEach(pair -> {
                 TestRecordsGeoProto.City.Builder cityBuilder = TestRecordsGeoProto.City.newBuilder()
-                        .mergeFrom(pair.getLeft().getRecord());
+                        .mergeFrom(Objects.requireNonNull(pair.getLeft()).getRecord());
                 TestRecordsGeoProto.Country.Builder countryBuilder = TestRecordsGeoProto.Country.newBuilder()
-                        .mergeFrom(pair.getRight().getRecord());
+                        .mergeFrom(Objects.requireNonNull(pair.getRight()).getRecord());
                 Point cityLocation = geometryFactory.createPoint(new Coordinate(cityBuilder.getLocation().getLatitude(), cityBuilder.getLocation().getLongitude()));
                 Geometry countryShape;
                 try {


### PR DESCRIPTION
9th of a 14-PR stack adopting jspecify + NullAway null-checking, stacked on #4581 (`fdb-record-layer-core`). Same treatment applied to `fdb-record-layer-spatial`. See inline comments for specific findings.