### PR TITLE
Adopt jspecify + NullAway null-checking on fdb-record-layer-lucene

### DIFF
--- a/fdb-record-layer-lucene/fdb-record-layer-lucene.gradle
+++ b/fdb-record-layer-lucene/fdb-record-layer-lucene.gradle
@@ -18,6 +18,10 @@
  * limitations under the License.
  */
 
+plugins {
+    alias(libs.plugins.errorprone)
+}
+
 apply from: rootProject.file('gradle/proto.gradle')
 apply from: rootProject.file('gradle/publishing.gradle')
 
@@ -34,6 +38,9 @@ dependencies {
     compileOnly(libs.jspecify)
     annotationProcessor(libs.autoService)
 
+    errorprone(libs.errorprone.core)
+    errorprone(libs.nullaway)
+
     testImplementation project(':fdb-test-utils')
     testImplementation(testFixtures(project(coreProject)))
     testImplementation(libs.bundles.test.impl)
@@ -41,8 +48,38 @@ dependencies {
     testRuntimeOnly(libs.bundles.test.runtime)
     testRuntimeOnly(libs.junit.vintage)
     testCompileOnly(libs.bundles.test.compileOnly)
+    testCompileOnly(libs.jspecify)
     testImplementation(libs.snakeyaml)
     testAnnotationProcessor(libs.autoService)
+}
+
+// jspecify + NullAway null-checking, scoped to this module only. See @NullMarked
+// package-info.java files under com.apple.foundationdb.record.lucene (and its sub-packages).
+// Generated protobuf code that shares the top-level com.apple.foundationdb.record.lucene
+// package (LuceneContinuationProto, LuceneFieldInfosProto, LuceneFileSystemProto,
+// LucenePartitionInfoProto, LucenePendingWriteQueueProto, LuceneStoredFieldsProto -- each a
+// java_outer_classname wrapping the message/builder types as nested classes) is carved out
+// via UnannotatedClasses rather than UnannotatedSubPackages, because it lives directly in the
+// annotated package itself rather than in a genuine sub-package. The other generated protos
+// for this module (com.apple.foundationdb.record.planprotos) land in a sibling top-level
+// package, so they're already outside AnnotatedPackages and need no carve-out.
+tasks.withType(JavaCompile).configureEach {
+    options.compilerArgs << '-Xmaxerrs' << '10000' // TEMP-DIAGNOSTIC: remove before commit
+    options.errorprone {
+        disableAllChecks = true
+        error("NullAway")
+        option("NullAway:AnnotatedPackages", "com.apple.foundationdb.record.lucene")
+        option("NullAway:UnannotatedClasses", [
+                "com.apple.foundationdb.record.lucene.LuceneContinuationProto",
+                "com.apple.foundationdb.record.lucene.LuceneFieldInfosProto",
+                "com.apple.foundationdb.record.lucene.LuceneFileSystemProto",
+                "com.apple.foundationdb.record.lucene.LucenePartitionInfoProto",
+                "com.apple.foundationdb.record.lucene.LucenePendingWriteQueueProto",
+                "com.apple.foundationdb.record.lucene.LuceneStoredFieldsProto",
+        ].join(","))
+        option("NullAway:JSpecifyMode", "true")
+        option("NullAway:AcknowledgeRestrictiveAnnotations", "true")
+    }
 }
 
 // Disable blocking detection, because we do this *a lot* in lucene

--- a/fdb-record-layer-lucene/fdb-record-layer-lucene.gradle
+++ b/fdb-record-layer-lucene/fdb-record-layer-lucene.gradle
@@ -64,7 +64,6 @@ dependencies {
 // for this module (com.apple.foundationdb.record.planprotos) land in a sibling top-level
 // package, so they're already outside AnnotatedPackages and need no carve-out.
 tasks.withType(JavaCompile).configureEach {
-    options.compilerArgs << '-Xmaxerrs' << '10000' // TEMP-DIAGNOSTIC: remove before commit
     options.errorprone {
         disableAllChecks = true
         error("NullAway")

--- a/fdb-record-layer-lucene/fdb-record-layer-lucene.gradle
+++ b/fdb-record-layer-lucene/fdb-record-layer-lucene.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation(libs.lucene.highlighter)
     implementation(libs.slf4j.api)
     compileOnly(libs.autoService)
+    compileOnly(libs.jspecify)
     annotationProcessor(libs.autoService)
 
     testImplementation project(':fdb-test-utils')

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/AlphanumericCjkAnalyzer.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/AlphanumericCjkAnalyzer.java
@@ -36,8 +36,7 @@ import org.apache.lucene.analysis.standard.UAX29URLEmailTokenizer;
 import org.apache.lucene.analysis.synonym.SynonymGraphFilter;
 import org.apache.lucene.analysis.synonym.SynonymMap;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A CJK Analyzer which applies a minimum and maximum token length to non-CJK tokens. This is useful
@@ -58,19 +57,19 @@ public class AlphanumericCjkAnalyzer extends StopwordAnalyzerBase {
     //when set to false, this will ignore tokens which exceed the max token length
     private final boolean breakLongTokens;
 
-    public AlphanumericCjkAnalyzer(@Nonnull CharArraySet stopWords) {
+    public AlphanumericCjkAnalyzer(CharArraySet stopWords) {
         this(stopWords, null);
     }
 
-    public AlphanumericCjkAnalyzer(@Nonnull CharArraySet stopWords, boolean breakLongTokens) {
+    public AlphanumericCjkAnalyzer(CharArraySet stopWords, boolean breakLongTokens) {
         this(stopWords, DEFAULT_MIN_TOKEN_LENGTH, StandardAnalyzer.DEFAULT_MAX_TOKEN_LENGTH, breakLongTokens, null);
     }
 
-    public AlphanumericCjkAnalyzer(@Nonnull CharArraySet stopWords, @Nullable String synonymName) {
+    public AlphanumericCjkAnalyzer(CharArraySet stopWords, @Nullable String synonymName) {
         this(stopWords, DEFAULT_MIN_TOKEN_LENGTH, StandardAnalyzer.DEFAULT_MAX_TOKEN_LENGTH, true, synonymName);
     }
 
-    public AlphanumericCjkAnalyzer(@Nonnull CharArraySet stopWords,
+    public AlphanumericCjkAnalyzer(CharArraySet stopWords,
                                    int minTokenLength,
                                    int maxTokenLength,
                                    @Nullable String synonymName) {
@@ -90,7 +89,7 @@ public class AlphanumericCjkAnalyzer extends StopwordAnalyzerBase {
      * @param breakLongTokens if true, the long tokens are broken up.
      * @param synonymName the name of the synonym map to use, or {@code null} if no synonyms are to be used
      */
-    public AlphanumericCjkAnalyzer(@Nonnull CharArraySet stopWords,
+    public AlphanumericCjkAnalyzer(CharArraySet stopWords,
                                    int minTokenLength,
                                    int maxTokenLength,
                                    boolean breakLongTokens,

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/AnalyzerChooser.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/AnalyzerChooser.java
@@ -22,12 +22,9 @@ package com.apple.foundationdb.record.lucene;
 
 import org.apache.lucene.analysis.Analyzer;
 
-import javax.annotation.Nonnull;
-
 /**
  * Choose an {@link Analyzer}.
  */
 public interface AnalyzerChooser {
-    @Nonnull
     LuceneAnalyzerWrapper chooseAnalyzer();
 }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/EmailCjkSynonymAnalyzer.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/EmailCjkSynonymAnalyzer.java
@@ -37,8 +37,7 @@ import org.apache.lucene.analysis.standard.UAX29URLEmailTokenizerFactory;
 import org.apache.lucene.analysis.synonym.SynonymGraphFilter;
 import org.apache.lucene.analysis.synonym.SynonymMap;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.Collections;
 
 /**
@@ -58,7 +57,7 @@ public class EmailCjkSynonymAnalyzer extends StopwordAnalyzerBase {
     @Nullable
     private final SynonymMap synonymMap;
 
-    public EmailCjkSynonymAnalyzer(@Nonnull CharArraySet stopwords, int minTokenLength, int minAlphanumericTokenLength, int maxTokenLength,
+    public EmailCjkSynonymAnalyzer(CharArraySet stopwords, int minTokenLength, int minAlphanumericTokenLength, int maxTokenLength,
                                    boolean withEmailTokenizer,
                                    boolean withSynonymGraphFilter, @Nullable SynonymMap synonymMap) {
         super(stopwords);
@@ -119,7 +118,6 @@ public class EmailCjkSynonymAnalyzer extends StopwordAnalyzerBase {
         return withEmailTokenizer;
     }
 
-    @Nonnull
     protected SynonymMap getSynonymMap() {
         if (!withSynonymGraphFilter || synonymMap == null) {
             throw new RecordCoreException("Invalid call to get synonym map for EmailCjkSynonymAnalyzer, which is not enabled with synonym and valid map");

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/EmailCjkSynonymAnalyzerFactory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/EmailCjkSynonymAnalyzerFactory.java
@@ -28,7 +28,6 @@ import com.google.auto.service.AutoService;
 import org.apache.lucene.analysis.CharArraySet;
 import org.apache.lucene.analysis.standard.UAX29URLEmailAnalyzer;
 
-import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Optional;
 
@@ -45,22 +44,19 @@ public class EmailCjkSynonymAnalyzerFactory implements LuceneAnalyzerFactory {
 
     public static final CharArraySet MINIMAL_STOP_WORDS = new CharArraySet(List.of("into", "onto", "the"), true);
 
-    @Nonnull
     @Override
     public String getName() {
         return ANALYZER_FACTORY_NAME;
     }
 
-    @Nonnull
     @Override
     public LuceneAnalyzerType getType() {
         return LuceneAnalyzerType.FULL_TEXT;
     }
 
     @SuppressWarnings("deprecation")
-    @Nonnull
     @Override
-    public AnalyzerChooser getIndexAnalyzerChooser(@Nonnull Index index) {
+    public AnalyzerChooser getIndexAnalyzerChooser(Index index) {
         try {
             final String minLengthString = Optional.ofNullable(index.getOption(IndexOptions.TEXT_TOKEN_MIN_SIZE)).orElse(DEFAULT_MINIMUM_TOKEN_LENGTH);
             final String maxLengthString = Optional.ofNullable(index.getOption(IndexOptions.TEXT_TOKEN_MAX_SIZE)).orElse(Integer.toString(UAX29URLEmailAnalyzer.DEFAULT_MAX_TOKEN_LENGTH));
@@ -74,9 +70,8 @@ public class EmailCjkSynonymAnalyzerFactory implements LuceneAnalyzerFactory {
     }
 
     @SuppressWarnings("deprecation")
-    @Nonnull
     @Override
-    public AnalyzerChooser getQueryAnalyzerChooser(@Nonnull Index index, @Nonnull AnalyzerChooser indexAnalyzerChooser) {
+    public AnalyzerChooser getQueryAnalyzerChooser(Index index, AnalyzerChooser indexAnalyzerChooser) {
         try {
             final String minLengthString = Optional.ofNullable(index.getOption(IndexOptions.TEXT_TOKEN_MIN_SIZE)).orElse(DEFAULT_MINIMUM_TOKEN_LENGTH);
             final String maxLengthString = Optional.ofNullable(index.getOption(IndexOptions.TEXT_TOKEN_MAX_SIZE)).orElse(DEFAULT_MAXIMUM_TOKEN_LENGTH);

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneAnalyzerCombinationProvider.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneAnalyzerCombinationProvider.java
@@ -22,8 +22,7 @@ package com.apple.foundationdb.record.lucene;
 
 import org.apache.lucene.analysis.miscellaneous.PerFieldAnalyzerWrapper;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -36,32 +35,27 @@ import java.util.stream.Collectors;
  */
 public class LuceneAnalyzerCombinationProvider {
 
-    @Nonnull
     private final LuceneAnalyzerWrapper indexAnalyzerWrapper;
-    @Nonnull
     private final LuceneAnalyzerWrapper queryAnalyzerWrapper;
 
-    public LuceneAnalyzerCombinationProvider(@Nonnull AnalyzerChooser defaultIndexAnalyzerChooser,
-                                             @Nonnull AnalyzerChooser defaultQueryAnalyzerChooser,
+    public LuceneAnalyzerCombinationProvider(AnalyzerChooser defaultIndexAnalyzerChooser,
+                                             AnalyzerChooser defaultQueryAnalyzerChooser,
                                              @Nullable Map<String, AnalyzerChooser> indexAnalyzerChooserPerFieldOverride,
                                              @Nullable Map<String, AnalyzerChooser> queryAnalyzerChooserPerFieldOverride) {
         indexAnalyzerWrapper = buildAnalyzerWrapper(defaultIndexAnalyzerChooser, indexAnalyzerChooserPerFieldOverride);
         queryAnalyzerWrapper = buildAnalyzerWrapper(defaultQueryAnalyzerChooser, queryAnalyzerChooserPerFieldOverride);
     }
 
-    @Nonnull
     public LuceneAnalyzerWrapper provideIndexAnalyzer() {
         return indexAnalyzerWrapper;
     }
 
-    @Nonnull
     public LuceneAnalyzerWrapper provideQueryAnalyzer() {
         return queryAnalyzerWrapper;
     }
 
-    @Nonnull
     @SuppressWarnings("PMD.CloseResource")
-    private static LuceneAnalyzerWrapper buildAnalyzerWrapper(@Nonnull AnalyzerChooser defaultAnalyzerChooser,
+    private static LuceneAnalyzerWrapper buildAnalyzerWrapper(AnalyzerChooser defaultAnalyzerChooser,
                                                               @Nullable Map<String, AnalyzerChooser> customizedAnalyzerChooserPerField) {
         final LuceneAnalyzerWrapper defaultAnalyzerWrapper = defaultAnalyzerChooser.chooseAnalyzer();
         if (customizedAnalyzerChooserPerField != null) {
@@ -78,7 +72,7 @@ public class LuceneAnalyzerCombinationProvider {
         }
     }
 
-    private static String buildAnalyzerIdentifier(@Nonnull LuceneAnalyzerWrapper defaultAnalyzerWrapper, @Nonnull Map<String, LuceneAnalyzerWrapper> analyzerWrapperMap) {
+    private static String buildAnalyzerIdentifier(LuceneAnalyzerWrapper defaultAnalyzerWrapper, Map<String, LuceneAnalyzerWrapper> analyzerWrapperMap) {
         final StringBuilder builder = new StringBuilder();
         builder.append(defaultAnalyzerWrapper.getUniqueIdentifier());
         for (String id : analyzerWrapperMap.keySet()) {

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneAnalyzerFactory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneAnalyzerFactory.java
@@ -24,8 +24,6 @@ import com.apple.foundationdb.record.metadata.Index;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 
-import javax.annotation.Nonnull;
-
 /**
  * Each implementation of {@link Analyzer} should have its own implementation
  * of this factory interface to provide instances of the analyzers for indexing and query to a
@@ -42,14 +40,12 @@ public interface LuceneAnalyzerFactory {
      *
      * @return the name of the analyzer that this factory creates
      */
-    @Nonnull
     String getName();
 
     /**
      * Get the {@link LuceneAnalyzerType} for the Lucene analyzer factory.
      * @return the {@link LuceneScanTypes} used to determine how the analyzers build by this factory is used
      */
-    @Nonnull
     LuceneAnalyzerType getType();
 
     /**
@@ -59,8 +55,7 @@ public interface LuceneAnalyzerFactory {
      * @param index the index thi analyzer is used for
      * @return an instance of the {@link AnalyzerChooser} for indexing that this factory creates
      */
-    @Nonnull
-    AnalyzerChooser getIndexAnalyzerChooser(@Nonnull Index index);
+    AnalyzerChooser getIndexAnalyzerChooser(Index index);
 
     /**
      * Get an instance of {@link AnalyzerChooser} that chooses the Lucene analyzer for query given the {@link Index}.
@@ -73,8 +68,7 @@ public interface LuceneAnalyzerFactory {
      * @param indexAnalyzerChooser indexAnalyzerChooser the instance of {@link AnalyzerChooser} for indexing used by this factory, that can be returned by this method in case it is also used for query
      * @return an instance of the {@link AnalyzerChooser} for query that this factory creates, the default one is always using {@link StandardAnalyzer}
      */
-    @Nonnull
-    default AnalyzerChooser getQueryAnalyzerChooser(@Nonnull Index index, @Nonnull AnalyzerChooser indexAnalyzerChooser) {
+    default AnalyzerChooser getQueryAnalyzerChooser(Index index, AnalyzerChooser indexAnalyzerChooser) {
         return LuceneAnalyzerWrapper::getStandardAnalyzerWrapper;
     }
 }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneAnalyzerRegistry.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneAnalyzerRegistry.java
@@ -22,7 +22,6 @@ package com.apple.foundationdb.record.lucene;
 
 import com.apple.foundationdb.record.metadata.Index;
 
-import javax.annotation.Nonnull;
 import java.util.Map;
 
 /**
@@ -39,8 +38,7 @@ import java.util.Map;
 @SuppressWarnings("unused")
 public interface LuceneAnalyzerRegistry {
 
-    @Nonnull
-    LuceneAnalyzerCombinationProvider getLuceneAnalyzerCombinationProvider(@Nonnull Index index,
-                                                                           @Nonnull LuceneAnalyzerType type,
-                                                                           @Nonnull Map<String, LuceneIndexExpressions.DocumentFieldDerivation> auxiliaryFieldInfo);
+    LuceneAnalyzerCombinationProvider getLuceneAnalyzerCombinationProvider(Index index,
+                                                                           LuceneAnalyzerType type,
+                                                                           Map<String, LuceneIndexExpressions.DocumentFieldDerivation> auxiliaryFieldInfo);
 }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneAnalyzerRegistryImpl.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneAnalyzerRegistryImpl.java
@@ -30,8 +30,7 @@ import com.apple.foundationdb.record.util.pair.NonnullPair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -46,15 +45,11 @@ import java.util.TreeMap;
  * in order to choose the analyzer for a block of text.
  */
 public class LuceneAnalyzerRegistryImpl implements LuceneAnalyzerRegistry {
-    @Nonnull
     private static final Logger LOGGER = LoggerFactory.getLogger(LuceneAnalyzerRegistryImpl.class);
-    @Nonnull
     private static final LuceneAnalyzerRegistryImpl INSTANCE = new LuceneAnalyzerRegistryImpl();
 
-    @Nonnull
     private final Map<LuceneAnalyzerType, Map<String, LuceneAnalyzerFactory>> registry;
 
-    @Nonnull
     private static Map<LuceneAnalyzerType, Map<String, LuceneAnalyzerFactory>> initRegistry() {
         final Map<LuceneAnalyzerType, Map<String, LuceneAnalyzerFactory>> registry = new HashMap<>();
         for (LuceneAnalyzerFactory factory : ServiceLoaderProvider.load(LuceneAnalyzerFactory.class)) {
@@ -80,7 +75,6 @@ public class LuceneAnalyzerRegistryImpl implements LuceneAnalyzerRegistry {
     }
 
     @SpotBugsSuppressWarnings(value = "MS_EXPOSE_REP", justification = "Object is actually immutable")
-    @Nonnull
     public static LuceneAnalyzerRegistry instance() {
         return INSTANCE;
     }
@@ -89,11 +83,10 @@ public class LuceneAnalyzerRegistryImpl implements LuceneAnalyzerRegistry {
         registry = initRegistry();
     }
 
-    @Nonnull
     @Override
-    public LuceneAnalyzerCombinationProvider getLuceneAnalyzerCombinationProvider(@Nonnull final Index index,
-                                                                                  @Nonnull final LuceneAnalyzerType type,
-                                                                                  @Nonnull final Map<String, LuceneIndexExpressions.DocumentFieldDerivation> auxiliaryFieldInfo) {
+    public LuceneAnalyzerCombinationProvider getLuceneAnalyzerCombinationProvider(final Index index,
+                                                                                  final LuceneAnalyzerType type,
+                                                                                  final Map<String, LuceneIndexExpressions.DocumentFieldDerivation> auxiliaryFieldInfo) {
         final String defaultAnalyzerName = index.getOption(type.getAnalyzerOptionKey());
         final String analyzerPerFieldName = index.getOption(type.getAnalyzerPerFieldOptionKey());
         NonnullPair<AnalyzerChooser, AnalyzerChooser> defaultAnalyzerChooserPair = getAnalyzerChooser(index, defaultAnalyzerName, type);
@@ -118,11 +111,11 @@ public class LuceneAnalyzerRegistryImpl implements LuceneAnalyzerRegistry {
                 indexAnalyzerChooserPerFieldOverride, queryAnalyzerChooserPerFieldOverride);
     }
 
-    private void addPerFieldAnalyzerIfNecessary(@Nonnull final Map<String, AnalyzerChooser> chooserPerFieldOverride,
-                                                @Nonnull final String fieldName,
-                                                @Nonnull final LuceneIndexExpressions.DocumentFieldDerivation fieldInfo,
-                                                @Nonnull final Index index,
-                                                @Nonnull final LuceneAnalyzerType type) {
+    private void addPerFieldAnalyzerIfNecessary(final Map<String, AnalyzerChooser> chooserPerFieldOverride,
+                                                final String fieldName,
+                                                final LuceneIndexExpressions.DocumentFieldDerivation fieldInfo,
+                                                final Index index,
+                                                final LuceneAnalyzerType type) {
         if (chooserPerFieldOverride.containsKey(fieldName)) {
             return; // do not override already chosen field analyzer.
         }
@@ -141,11 +134,11 @@ public class LuceneAnalyzerRegistryImpl implements LuceneAnalyzerRegistry {
         }
     }
 
-    private static boolean isEligibleForNoOpAnalyzer(@Nonnull final LuceneIndexExpressions.DocumentFieldDerivation fieldInfo) {
+    private static boolean isEligibleForNoOpAnalyzer(final LuceneIndexExpressions.DocumentFieldDerivation fieldInfo) {
         return fieldInfo.getType() != LuceneIndexExpressions.DocumentFieldType.TEXT;
     }
 
-    private NonnullPair<AnalyzerChooser, AnalyzerChooser> getAnalyzerChooser(@Nonnull Index index, @Nullable String analyzerName, @Nonnull LuceneAnalyzerType type) {
+    private NonnullPair<AnalyzerChooser, AnalyzerChooser> getAnalyzerChooser(Index index, @Nullable String analyzerName, LuceneAnalyzerType type) {
         final Map<String, LuceneAnalyzerFactory> registryForType = Objects.requireNonNullElse(registry.get(type), Collections.emptyMap());
         if (analyzerName == null || !registryForType.containsKey(analyzerName)) {
             return NonnullPair.of(LuceneAnalyzerWrapper::getStandardAnalyzerWrapper,

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneAnalyzerRegistryImpl.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneAnalyzerRegistryImpl.java
@@ -123,14 +123,14 @@ public class LuceneAnalyzerRegistryImpl implements LuceneAnalyzerRegistry {
             return; // not sure how to deal with other types (i.e. AUTO_COMPLETE) yet.
         }
         if (isEligibleForNoOpAnalyzer(fieldInfo)) {
-            if (registry.isEmpty()
-                    || registry.get(type) == null
-                    || registry.get(type).get(ExactTokenAnalyzerFactory.NAME) == null) {
+            final Map<String, LuceneAnalyzerFactory> registryForType = registry.get(type);
+            final LuceneAnalyzerFactory exactTokenFactory = registryForType == null ? null : registryForType.get(ExactTokenAnalyzerFactory.NAME);
+            if (registry.isEmpty() || registryForType == null || exactTokenFactory == null) {
                 throw new MetaDataException("could not retrieve analyzer",
                         LuceneLogMessageKeys.ANALYZER_NAME, ExactTokenAnalyzerFactory.NAME,
                         LuceneLogMessageKeys.ANALYZER_TYPE, type);
             }
-            chooserPerFieldOverride.put(fieldName, registry.get(type).get(ExactTokenAnalyzerFactory.NAME).getIndexAnalyzerChooser(index));
+            chooserPerFieldOverride.put(fieldName, exactTokenFactory.getIndexAnalyzerChooser(index));
         }
     }
 

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneAnalyzerRegistryImpl.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneAnalyzerRegistryImpl.java
@@ -84,6 +84,11 @@ public class LuceneAnalyzerRegistryImpl implements LuceneAnalyzerRegistry {
     }
 
     @Override
+    // defaultAnalyzerChooserPair is a NonnullPair, whose getLeft()/getRight() are guaranteed non-null by
+    // construction (NonnullPair.of() enforces this via Objects.requireNonNull()); SpotBugs's
+    // NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE analysis falls back to the wider @Nullable contract declared by
+    // Pair.getLeft()/getRight() rather than the narrowed override in NonnullPair.
+    @SpotBugsSuppressWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     public LuceneAnalyzerCombinationProvider getLuceneAnalyzerCombinationProvider(final Index index,
                                                                                   final LuceneAnalyzerType type,
                                                                                   final Map<String, LuceneIndexExpressions.DocumentFieldDerivation> auxiliaryFieldInfo) {

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneAnalyzerType.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneAnalyzerType.java
@@ -22,8 +22,6 @@ package com.apple.foundationdb.record.lucene;
 
 import org.apache.lucene.analysis.Analyzer;
 
-import javax.annotation.Nonnull;
-
 /**
  * The type used to determine how the {@link Analyzer} built by {@link LuceneAnalyzerFactory} is used.
  */
@@ -34,17 +32,15 @@ public enum LuceneAnalyzerType {
     private String analyzerOptionKey;
     private String analyzerPerFieldOptionKey;
 
-    LuceneAnalyzerType(@Nonnull String indexOptionKey, @Nonnull String analyzerPerFieldOptionKey) {
+    LuceneAnalyzerType(String indexOptionKey, String analyzerPerFieldOptionKey) {
         this.analyzerOptionKey = indexOptionKey;
         this.analyzerPerFieldOptionKey = analyzerPerFieldOptionKey;
     }
 
-    @Nonnull
     public String getAnalyzerOptionKey() {
         return analyzerOptionKey;
     }
 
-    @Nonnull
     public String getAnalyzerPerFieldOptionKey() {
         return analyzerPerFieldOptionKey;
     }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneAnalyzerWrapper.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneAnalyzerWrapper.java
@@ -24,8 +24,6 @@ import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.en.EnglishAnalyzer;
 import org.apache.lucene.analysis.standard.UAX29URLEmailAnalyzer;
 
-import javax.annotation.Nonnull;
-
 /**
  * A wrapper for {@link Analyzer} and its unique identifier.
  */
@@ -35,7 +33,7 @@ public class LuceneAnalyzerWrapper {
     private final String uniqueIdentifier;
     private final Analyzer analyzer;
 
-    public LuceneAnalyzerWrapper(@Nonnull String uniqueIdentifier, @Nonnull Analyzer analyzer) {
+    public LuceneAnalyzerWrapper(String uniqueIdentifier, Analyzer analyzer) {
         this.uniqueIdentifier = uniqueIdentifier;
         this.analyzer = analyzer;
     }
@@ -45,17 +43,14 @@ public class LuceneAnalyzerWrapper {
      * This identifier is to exclusively identify the {@link Analyzer}, which could be different given different texts input.
      * @return this analyzer's unique identifier
      */
-    @Nonnull
     public String getUniqueIdentifier() {
         return uniqueIdentifier;
     }
 
-    @Nonnull
     public Analyzer getAnalyzer() {
         return analyzer;
     }
 
-    @Nonnull
     @SuppressWarnings("PMD.CloseResource") //intentional
     public static LuceneAnalyzerWrapper getStandardAnalyzerWrapper() {
         final UAX29URLEmailAnalyzer backingAnalyzer = new UAX29URLEmailAnalyzer(EnglishAnalyzer.ENGLISH_STOP_WORDS_SET);

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneAutoCompleteAnalyzerFactory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneAutoCompleteAnalyzerFactory.java
@@ -23,8 +23,6 @@ package com.apple.foundationdb.record.lucene;
 import com.apple.foundationdb.record.metadata.Index;
 import com.google.auto.service.AutoService;
 
-import javax.annotation.Nonnull;
-
 /**
  * Factory to build index and query {@link org.apache.lucene.analysis.Analyzer} for auto-complete suggestions.
  */
@@ -32,22 +30,19 @@ import javax.annotation.Nonnull;
 public class LuceneAutoCompleteAnalyzerFactory implements LuceneAnalyzerFactory {
     public static final String ANALYZER_FACTORY_NAME = "AUTO_COMPLETE_DEFAULT";
 
-    @Nonnull
     @Override
     public String getName() {
         return ANALYZER_FACTORY_NAME;
     }
 
-    @Nonnull
     @Override
     public LuceneAnalyzerType getType() {
         return LuceneAnalyzerType.AUTO_COMPLETE;
     }
 
     @SuppressWarnings("deprecation")
-    @Nonnull
     @Override
-    public AnalyzerChooser getIndexAnalyzerChooser(@Nonnull Index index) {
+    public AnalyzerChooser getIndexAnalyzerChooser(Index index) {
         return LuceneAnalyzerWrapper::getStandardAnalyzerWrapper;
     }
 }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneAutoCompleteHelpers.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneAutoCompleteHelpers.java
@@ -37,8 +37,7 @@ import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.analysis.tokenattributes.OffsetAttribute;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.Collection;
@@ -64,7 +63,6 @@ public class LuceneAutoCompleteHelpers {
      * @return the token info comprised of query tokens and a final token if it needs to be added as a "prefix" component
      *         to the final query
      */
-    @Nonnull
     public static AutoCompleteTokens getQueryTokens(Analyzer queryAnalyzer, String searchKey) {
         final ImmutableList.Builder<String> tokensBuilder = ImmutableList.builder();
         String prefixToken = null;
@@ -107,9 +105,8 @@ public class LuceneAutoCompleteHelpers {
         return new AutoCompleteTokens(tokensBuilder.build(), prefixToken == null ? ImmutableSet.of() : ImmutableSet.of(prefixToken));
     }
 
-    @Nonnull
-    public static List<String> computeAllMatches(@Nonnull String fieldName, @Nonnull Analyzer queryAnalyzer,
-                                                 @Nonnull String text, @Nonnull AutoCompleteTokens tokens,
+    public static List<String> computeAllMatches(String fieldName, Analyzer queryAnalyzer,
+                                                 String text, AutoCompleteTokens tokens,
                                                  final int numAdditionalTokens) {
         final var resultBuilder = ImmutableList.<TermAcceptor>builder();
         final var acceptors = Lists.<TermAcceptor>newArrayList();
@@ -171,10 +168,9 @@ public class LuceneAutoCompleteHelpers {
         }
     }
 
-    @Nonnull
     @SuppressWarnings("PMD.CompareObjectsWithEquals")
-    public static List<String> computeAllMatchesForPhrase(@Nonnull final String fieldName, @Nonnull final Analyzer queryAnalyzer,
-                                                          @Nonnull final String text, @Nonnull final AutoCompleteTokens tokens,
+    public static List<String> computeAllMatchesForPhrase(final String fieldName, final Analyzer queryAnalyzer,
+                                                          final String text, final AutoCompleteTokens tokens,
                                                           final int numAdditionalTokens) {
         final var queryTokens = tokens.getQueryTokens();
         final var prefixTokens = tokens.getPrefixTokens();
@@ -237,8 +233,7 @@ public class LuceneAutoCompleteHelpers {
             return additionalTokenCount > 0;
         }
 
-        @Nonnull
-        public String getAcceptedString(@Nonnull final String originalString) {
+        public String getAcceptedString(final String originalString) {
             return originalString.substring(startOffset, endOffset);
         }
     }
@@ -251,9 +246,7 @@ public class LuceneAutoCompleteHelpers {
             ACCEPTED_PREFIX_TOKEN;
         }
 
-        @Nonnull
         private final List<String> acceptedTokens;
-        @Nonnull
         private final PeekingIterator<String> queryTokensRemainingIterator;
         @Nullable
         private final String prefixToken;
@@ -264,8 +257,8 @@ public class LuceneAutoCompleteHelpers {
 
         private boolean isEndState;
 
-        private PhraseAcceptor(@Nonnull final Iterator<String> queryTokensRemainingIterator, @Nullable final String prefixToken,
-                               @Nonnull final List<String> acceptedTokens, final boolean isEndState, final int startOffset,
+        private PhraseAcceptor(final Iterator<String> queryTokensRemainingIterator, @Nullable final String prefixToken,
+                               final List<String> acceptedTokens, final boolean isEndState, final int startOffset,
                                final int endOffset, final int additionalTokenCount) {
             this.queryTokensRemainingIterator = Iterators.peekingIterator(queryTokensRemainingIterator);
             this.prefixToken = prefixToken;
@@ -276,7 +269,6 @@ public class LuceneAutoCompleteHelpers {
             this.additionalTokenCount = additionalTokenCount;
         }
 
-        @Nonnull
         public Iterator<String> getQueryTokensRemainingIterator() {
             return queryTokensRemainingIterator;
         }
@@ -286,13 +278,11 @@ public class LuceneAutoCompleteHelpers {
             return prefixToken;
         }
 
-        @Nonnull
         public List<String> getAcceptedTokens() {
             return acceptedTokens;
         }
 
-        @Nonnull
-        public String getAcceptedPhrase(@Nonnull final String originalString) {
+        public String getAcceptedPhrase(final String originalString) {
             return originalString.substring(startOffset, endOffset);
         }
 
@@ -300,7 +290,7 @@ public class LuceneAutoCompleteHelpers {
             return isEndState;
         }
 
-        public boolean accept(@Nonnull final String currentToken, @Nonnull final String currentMatchedString, final int currentEndOffset) {
+        public boolean accept(final String currentToken, final String currentMatchedString, final int currentEndOffset) {
             if (isEndState) {
                 if (additionalTokenCount > 0) {
                     additionalTokenCount --;
@@ -338,8 +328,8 @@ public class LuceneAutoCompleteHelpers {
         }
 
         @Nullable
-        public static PhraseAcceptor acceptFirstToken(@Nonnull final String currentToken, @Nonnull final String currentMatchedString,
-                                                      @Nonnull final List<String> queryTokens, @Nullable final String prefixToken,
+        public static PhraseAcceptor acceptFirstToken(final String currentToken, final String currentMatchedString,
+                                                      final List<String> queryTokens, @Nullable final String prefixToken,
                                                       final int additionalTokenCount, final int startOffset, final int currentEndOffset) {
             final var firstQueryToken = queryTokens.isEmpty() ? null : queryTokens.get(0);
             final var acceptState = acceptToken(currentToken, firstQueryToken, prefixToken);
@@ -359,7 +349,7 @@ public class LuceneAutoCompleteHelpers {
             }
         }
 
-        private static AcceptState acceptToken(@Nonnull final String currentToken, @Nullable final String currentQueryToken, @Nullable final String prefixToken) {
+        private static AcceptState acceptToken(final String currentToken, @Nullable final String currentQueryToken, @Nullable final String prefixToken) {
             Preconditions.checkArgument(currentQueryToken != null || prefixToken != null);
             if (currentQueryToken != null) {
                 return currentToken.equals(currentQueryToken) ? AcceptState.ACCEPTED_QUERY_TOKEN : AcceptState.NOT_ACCEPTED;
@@ -368,17 +358,15 @@ public class LuceneAutoCompleteHelpers {
         }
     }
 
-    public static boolean isPhraseSearch(@Nonnull final String search) {
+    public static boolean isPhraseSearch(final String search) {
         return search.startsWith("\"") && search.endsWith("\"");
     }
 
-    @Nonnull
-    public static String searchKeyFromSearchArgument(@Nonnull final String search) {
+    public static String searchKeyFromSearchArgument(final String search) {
         return searchKeyFromSearchArgument(search, isPhraseSearch(search));
     }
 
-    @Nonnull
-    public static String searchKeyFromSearchArgument(@Nonnull final String search, final boolean isPhraseSearch) {
+    public static String searchKeyFromSearchArgument(final String search, final boolean isPhraseSearch) {
         return isPhraseSearch ? search.substring(1, search.length() - 1) : search;
     }
 
@@ -416,31 +404,25 @@ public class LuceneAutoCompleteHelpers {
      * Helper class to capture token information synthesized from a search key.
      */
     public static class AutoCompleteTokens {
-        @Nonnull
         private final List<String> queryTokens;
-        @Nonnull
         private final Set<String> prefixTokens;
 
-        @Nonnull
         private final Supplier<Set<String>> queryTokensAsSetSupplier;
 
-        public AutoCompleteTokens(@Nonnull final Collection<String> queryTokens, @Nonnull final Set<String> prefixTokens) {
+        public AutoCompleteTokens(final Collection<String> queryTokens, final Set<String> prefixTokens) {
             this.queryTokens = ImmutableList.copyOf(queryTokens);
             this.prefixTokens = ImmutableSet.copyOf(prefixTokens);
             this.queryTokensAsSetSupplier = Suppliers.memoize(() -> ImmutableSet.copyOf(queryTokens));
         }
 
-        @Nonnull
         public List<String> getQueryTokens() {
             return queryTokens;
         }
 
-        @Nonnull
         public Set<String> getQueryTokensAsSet() {
             return queryTokensAsSetSupplier.get();
         }
 
-        @Nonnull
         public Set<String> getPrefixTokens() {
             return prefixTokens;
         }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneAutoCompleteQueryClause.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneAutoCompleteQueryClause.java
@@ -59,8 +59,7 @@ import org.apache.lucene.search.spans.SpanTermQuery;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.ArrayList;
@@ -80,21 +79,18 @@ public class LuceneAutoCompleteQueryClause extends LuceneQueryClause {
     // Used as a marker at the end to capture the stop-word gaps between the initial phrase and the end prefix when parsing the search key
     private static final String NONSTOPWORD = "$nonstopword";
 
-    @Nonnull
     private final String search;
     private final boolean isParameter;
-    @Nonnull
     private final Set<String> fields;
 
-    public LuceneAutoCompleteQueryClause(@Nonnull final String search, final boolean isParameter,
-                                         @Nonnull final Iterable<String> fields) {
+    public LuceneAutoCompleteQueryClause(final String search, final boolean isParameter,
+                                         final Iterable<String> fields) {
         super(LuceneQueryType.AUTO_COMPLETE);
         this.search = search;
         this.isParameter = isParameter;
         this.fields = ImmutableSet.copyOf(fields);
     }
 
-    @Nonnull
     public String getSearch() {
         return search;
     }
@@ -104,7 +100,7 @@ public class LuceneAutoCompleteQueryClause extends LuceneQueryClause {
     }
 
     @Override
-    public BoundQuery bind(@Nonnull FDBRecordStoreBase<?> store, @Nonnull Index index, @Nonnull EvaluationContext context) {
+    public BoundQuery bind(FDBRecordStoreBase<?> store, Index index, EvaluationContext context) {
         final String searchArgument =
                 isParameter
                 ? Verify.verifyNotNull((String)context.getBinding(search))
@@ -140,7 +136,7 @@ public class LuceneAutoCompleteQueryClause extends LuceneQueryClause {
     }
 
     @Override
-    public void getPlannerGraphDetails(@Nonnull ImmutableList.Builder<String> detailsBuilder, @Nonnull ImmutableMap.Builder<String, Attribute> attributeMapBuilder) {
+    public void getPlannerGraphDetails(ImmutableList.Builder<String> detailsBuilder, ImmutableMap.Builder<String, Attribute> attributeMapBuilder) {
         if (isParameter) {
             detailsBuilder.add("param: {{param}}");
             attributeMapBuilder.put("param", Attribute.gml(search));
@@ -151,7 +147,7 @@ public class LuceneAutoCompleteQueryClause extends LuceneQueryClause {
     }
 
     @Override
-    public int planHash(@Nonnull final PlanHashMode mode) {
+    public int planHash(final PlanHashMode mode) {
         return PlanHashable.objectsPlanHash(mode, search, isParameter);
     }
 
@@ -198,7 +194,7 @@ public class LuceneAutoCompleteQueryClause extends LuceneQueryClause {
      */
     @Nullable
     @VisibleForTesting
-    static String getQueryTokens(Analyzer queryAnalyzer, String searchKey, @Nonnull List<String> tokens) {
+    static String getQueryTokens(Analyzer queryAnalyzer, String searchKey, List<String> tokens) {
         String prefixToken = null;
         try (TokenStream ts = queryAnalyzer.tokenStream("", new StringReader(searchKey))) {
             ts.reset();
@@ -251,10 +247,9 @@ public class LuceneAutoCompleteQueryClause extends LuceneQueryClause {
      * @param useGapForPrefix option to represent the last token as a gap (if it's a stopword)
      * @return a Lucene Query that matches phrase using the last token as a prefix
      */
-    @Nonnull
-    public static Query buildPhraseQueryWithPrefix(@Nonnull QueryParser parser,
-                                                   @Nonnull Collection<String> fieldNames,
-                                                   @Nonnull String phrase,
+    public static Query buildPhraseQueryWithPrefix(QueryParser parser,
+                                                   Collection<String> fieldNames,
+                                                   String phrase,
                                                    @Nullable String prefix,
                                                    final boolean useGapForPrefix) {
 
@@ -326,10 +321,9 @@ public class LuceneAutoCompleteQueryClause extends LuceneQueryClause {
         }
     }
 
-    @Nonnull
-    public static Query buildQueryForPhraseMatching(@Nonnull QueryParser parser,
-                                                    @Nonnull Collection<String> fieldNames,
-                                                    @Nonnull String searchKey) {
+    public static Query buildQueryForPhraseMatching(QueryParser parser,
+                                                    Collection<String> fieldNames,
+                                                    String searchKey) {
         // Construct a query that is essentially:
         //  - in any field,
         //  - the phrase must occur (with possibly the last token in the phrase as a prefix)
@@ -365,7 +359,7 @@ public class LuceneAutoCompleteQueryClause extends LuceneQueryClause {
         }
     }
 
-    private static boolean isStopWord(@Nonnull QueryParser queryParser, @Nonnull String prefix) {
+    private static boolean isStopWord(QueryParser queryParser, String prefix) {
         try {
             final Query query = queryParser.parse(prefix);
             if (query instanceof BooleanQuery) {
@@ -378,10 +372,9 @@ public class LuceneAutoCompleteQueryClause extends LuceneQueryClause {
         }
     }
 
-    @Nonnull
-    private static Query buildQueryForTermsMatching(@Nonnull Analyzer queryAnalyzer,
-                                                    @Nonnull Collection<String> fieldNames,
-                                                    @Nonnull String searchKey) {
+    private static Query buildQueryForTermsMatching(Analyzer queryAnalyzer,
+                                                    Collection<String> fieldNames,
+                                                    String searchKey) {
         // Construct a query that is essentially:
         //  - in any field,
         //  - all of the tokens must occur (with the last one as a prefix)

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneBooleanQuery.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneBooleanQuery.java
@@ -32,7 +32,6 @@ import com.google.common.collect.Maps;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 
-import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -44,29 +43,25 @@ import java.util.stream.Collectors;
  */
 @API(API.Status.UNSTABLE)
 public class LuceneBooleanQuery extends LuceneQueryClause {
-    @Nonnull
     private final List<LuceneQueryClause> children;
-    @Nonnull
     private final BooleanClause.Occur occur;
 
-    public LuceneBooleanQuery(@Nonnull LuceneQueryType queryType, @Nonnull List<LuceneQueryClause> children, @Nonnull BooleanClause.Occur occur) {
+    public LuceneBooleanQuery(LuceneQueryType queryType, List<LuceneQueryClause> children, BooleanClause.Occur occur) {
         super(queryType);
         this.children = children;
         this.occur = occur;
     }
 
-    @Nonnull
     protected List<LuceneQueryClause> getChildren() {
         return children;
     }
 
-    @Nonnull
     protected BooleanClause.Occur getOccur() {
         return occur;
     }
 
     @Override
-    public BoundQuery bind(@Nonnull FDBRecordStoreBase<?> store, @Nonnull Index index, @Nonnull EvaluationContext context) {
+    public BoundQuery bind(FDBRecordStoreBase<?> store, Index index, EvaluationContext context) {
         BooleanQuery.Builder builder = new BooleanQuery.Builder();
         Map<String, Set<String>> highlightingTermsMap = null;
         for (LuceneQueryClause child : children) {
@@ -84,7 +79,7 @@ public class LuceneBooleanQuery extends LuceneQueryClause {
     }
 
     @Override
-    public void getPlannerGraphDetails(@Nonnull ImmutableList.Builder<String> detailsBuilder, @Nonnull ImmutableMap.Builder<String, Attribute> attributeMapBuilder) {
+    public void getPlannerGraphDetails(ImmutableList.Builder<String> detailsBuilder, ImmutableMap.Builder<String, Attribute> attributeMapBuilder) {
         detailsBuilder.add("occur: {{occur}}");
         attributeMapBuilder.put("occur", Attribute.gml(occur));
         for (LuceneQueryClause child : children) {
@@ -93,7 +88,7 @@ public class LuceneBooleanQuery extends LuceneQueryClause {
     }
 
     @Override
-    public int planHash(@Nonnull final PlanHashMode mode) {
+    public int planHash(final PlanHashMode mode) {
         return PlanHashable.iterablePlanHash(mode, children);
     }
 

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneComparisonQuery.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneComparisonQuery.java
@@ -28,8 +28,7 @@ import org.apache.lucene.search.QueryVisitor;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Weight;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.io.IOException;
 import java.util.Objects;
 
@@ -43,9 +42,9 @@ public class LuceneComparisonQuery extends Query {
     private final Comparisons.Type comparisonType;
     private final Object comparand;
 
-    public LuceneComparisonQuery(@Nonnull final Query query,
-                                 @Nonnull final String fieldName,
-                                 @Nonnull final Comparisons.Type comparisonType,
+    public LuceneComparisonQuery(final Query query,
+                                 final String fieldName,
+                                 final Comparisons.Type comparisonType,
                                  @Nullable final Object comparand) {
         this.query = query;
         this.fieldName = fieldName;

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneComparisonQuery.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneComparisonQuery.java
@@ -40,6 +40,7 @@ public class LuceneComparisonQuery extends Query {
     private final Query query;
     private final String fieldName;
     private final Comparisons.Type comparisonType;
+    @Nullable
     private final Object comparand;
 
     public LuceneComparisonQuery(final Query query,
@@ -75,6 +76,7 @@ public class LuceneComparisonQuery extends Query {
         return comparisonType;
     }
 
+    @Nullable
     public Object getComparand() {
         return comparand;
     }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneConcurrency.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneConcurrency.java
@@ -30,8 +30,7 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBExceptions;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -62,7 +61,7 @@ public class LuceneConcurrency {
      */
     @Nullable
     @API(API.Status.INTERNAL)
-    public static <T> T asyncToSync(@Nonnull StoreTimer.Wait event, @Nonnull CompletableFuture<T> async, @Nonnull FDBRecordContext recordContext) {
+    public static <T> T asyncToSync(StoreTimer.Wait event, CompletableFuture<T> async, FDBRecordContext recordContext) {
         if (recordContext.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_USE_LEGACY_ASYNC_TO_SYNC)) {
             return recordContext.asyncToSync(event, async);
         }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneConcurrency.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneConcurrency.java
@@ -32,6 +32,7 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 
 import org.jspecify.annotations.Nullable;
 import java.time.Duration;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -62,12 +63,13 @@ public class LuceneConcurrency {
     @Nullable
     @API(API.Status.INTERNAL)
     public static <T> T asyncToSync(StoreTimer.Wait event, CompletableFuture<T> async, FDBRecordContext recordContext) {
-        if (recordContext.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_USE_LEGACY_ASYNC_TO_SYNC)) {
+        if (Objects.requireNonNull(recordContext.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_USE_LEGACY_ASYNC_TO_SYNC))) {
             return recordContext.asyncToSync(event, async);
         }
 
         if (recordContext.hasHookForAsyncToSync() && !MoreAsyncUtil.isCompletedNormally(async)) {
-            recordContext.getHookForAsyncToSync().accept(event);
+            // hasHookForAsyncToSync() returning true means the hook field is non-null.
+            Objects.requireNonNull(recordContext.getHookForAsyncToSync()).accept(event);
         }
 
         recordContext.getDatabase().checkIfBlockingInFuture(async);
@@ -94,11 +96,11 @@ public class LuceneConcurrency {
             } catch (TimeoutException ex) {
                 if (timer != null) {
                     timer.recordTimeout(event, startTime);
-                    throw new AsyncToSyncTimeoutException(ex.getMessage(), ex,
+                    throw new AsyncToSyncTimeoutException(Objects.requireNonNullElse(ex.getMessage(), "asyncToSync timed out"), ex,
                             LogMessageKeys.TIME_LIMIT.toString(), asyncToSyncTimeout.toNanos(),
                             LogMessageKeys.TIME_UNIT.toString(), TimeUnit.NANOSECONDS);
                 }
-                throw new AsyncToSyncTimeoutException(ex.getMessage(), ex);
+                throw new AsyncToSyncTimeoutException(Objects.requireNonNullElse(ex.getMessage(), "asyncToSync timed out"), ex);
             } catch (ExecutionException ex) {
                 throw FDBExceptions.wrapException(ex);
             } catch (InterruptedException ex) {

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneCursorContinuation.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneCursorContinuation.java
@@ -29,8 +29,7 @@ import org.apache.lucene.search.FieldDoc;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.util.BytesRef;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Continuation from scanning a Lucene index. This wraps the LuceneIndexContinuation protobuf message,
@@ -39,13 +38,12 @@ import javax.annotation.Nullable;
  * feature to resume a query.
  */
 class LuceneCursorContinuation implements RecordCursorContinuation {
-    @Nonnull
     private final LuceneContinuationProto.LuceneIndexContinuation protoContinuation;
 
     @SuppressWarnings("squid:S3077") // Byte array is immutable once created, so does not need to use atomic array
     private volatile byte[] byteContinuation;
 
-    private LuceneCursorContinuation(@Nonnull LuceneContinuationProto.LuceneIndexContinuation protoContinuation) {
+    private LuceneCursorContinuation(LuceneContinuationProto.LuceneIndexContinuation protoContinuation) {
         this.protoContinuation = protoContinuation;
     }
 
@@ -62,7 +60,6 @@ class LuceneCursorContinuation implements RecordCursorContinuation {
         return byteContinuation;
     }
 
-    @Nonnull
     @Override
     public ByteString toByteString() {
         return protoContinuation.toByteString();
@@ -111,8 +108,7 @@ class LuceneCursorContinuation implements RecordCursorContinuation {
         return new LuceneCursorContinuation(builder.build());
     }
 
-    @Nonnull
-    public static ScoreDoc toScoreDoc(@Nonnull LuceneContinuationProto.LuceneIndexContinuation luceneIndexContinuation) {
+    public static ScoreDoc toScoreDoc(LuceneContinuationProto.LuceneIndexContinuation luceneIndexContinuation) {
         int doc = (int)luceneIndexContinuation.getDoc();
         float score = luceneIndexContinuation.getScore();
         int shard = (int)luceneIndexContinuation.getShard();

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneCursorContinuation.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneCursorContinuation.java
@@ -41,7 +41,7 @@ class LuceneCursorContinuation implements RecordCursorContinuation {
     private final LuceneContinuationProto.LuceneIndexContinuation protoContinuation;
 
     @SuppressWarnings("squid:S3077") // Byte array is immutable once created, so does not need to use atomic array
-    private volatile byte[] byteContinuation;
+    private volatile byte @Nullable [] byteContinuation;
 
     private LuceneCursorContinuation(LuceneContinuationProto.LuceneIndexContinuation protoContinuation) {
         this.protoContinuation = protoContinuation;
@@ -49,6 +49,10 @@ class LuceneCursorContinuation implements RecordCursorContinuation {
 
     @Nullable
     @Override
+    // NullAway doesn't reliably parse the @Nullable byte[] return of RecordCursorContinuation.toBytes() (core,
+    // unannotated), so it thinks this override is illegally widening a non-null contract; it isn't -- the supertype
+    // is documented (and javax.annotation.Nullable-annotated) as returning null when isEnd() is true.
+    @SuppressWarnings("NullAway")
     public byte[] toBytes() {
         if (byteContinuation == null) {
             synchronized (this) {
@@ -116,7 +120,7 @@ class LuceneCursorContinuation implements RecordCursorContinuation {
         if (nfields == 0) {
             return new ScoreDoc(doc, score, shard);
         }
-        Object[] fields = new Object[nfields];
+        @Nullable Object[] fields = new Object[nfields];
         for (int i = 0; i < nfields; i++) {
             Object value;
             LuceneContinuationProto.LuceneIndexContinuation.Field field = luceneIndexContinuation.getFields(i);

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneDocumentFromRecord.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneDocumentFromRecord.java
@@ -33,8 +33,7 @@ import com.apple.foundationdb.tuple.TupleHelpers;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -49,8 +48,7 @@ public class LuceneDocumentFromRecord {
     private LuceneDocumentFromRecord() {
     }
 
-    @Nonnull
-    protected static <M extends Message> Map<Tuple, List<DocumentField>> getRecordFields(@Nonnull KeyExpression root,
+    protected static <M extends Message> Map<Tuple, List<DocumentField>> getRecordFields(KeyExpression root,
                                                                                          @Nullable FDBRecord<M> rec) {
         Map<Tuple, List<DocumentField>> result = new HashMap<>();
         if (rec != null) {
@@ -69,10 +67,10 @@ public class LuceneDocumentFromRecord {
     // Grouping keys are evaluated more or less normally, turning into multiple groups.
     // Each group corresponds to a single document in a separate index / directory.
     // Within that document, the grouped fields are merged.
-    protected static <M extends Message> void getGroupedFields(@Nonnull List<KeyExpression> keys, int keyIndex, int keyPosition,
-                                                               int groupingCount, @Nonnull Tuple groupPrefix,
-                                                               @Nonnull FDBRecord<M> rec, @Nonnull Message message,
-                                                               @Nonnull Map<Tuple, List<DocumentField>> result,
+    protected static <M extends Message> void getGroupedFields(List<KeyExpression> keys, int keyIndex, int keyPosition,
+                                                               int groupingCount, Tuple groupPrefix,
+                                                               FDBRecord<M> rec, Message message,
+                                                               Map<Tuple, List<DocumentField>> result,
                                                                @Nullable String fieldNamePrefix) {
         if (keyIndex >= keys.size()) {
             return;
@@ -123,9 +121,8 @@ public class LuceneDocumentFromRecord {
                 groupingCount, groupPrefix, rec, message, result, fieldNamePrefix);
     }
 
-    @Nonnull
-    public static <M extends Message> List<DocumentField> getFields(@Nonnull KeyExpression expression, @Nonnull FDBRecord<M> rec,
-                                                                    @Nonnull Message message, @Nullable String fieldNamePrefix) {
+    public static <M extends Message> List<DocumentField> getFields(KeyExpression expression, FDBRecord<M> rec,
+                                                                    Message message, @Nullable String fieldNamePrefix) {
         final DocumentFieldList<FDBRecordSource<M>> fields = new DocumentFieldList<>();
         LuceneIndexExpressions.getFields(expression, new FDBRecordSource<>(rec, message), fields, fieldNamePrefix);
         return fields.getFields();
@@ -137,17 +134,14 @@ public class LuceneDocumentFromRecord {
      * @param <M> the message type contained in the source.
      */
     public static class FDBRecordSource<M extends Message> implements LuceneIndexExpressions.RecordSource<FDBRecordSource<M>> {
-        @Nonnull
         private final FDBRecord<M> rec;
-        @Nonnull
         private final Message message;
 
-        public FDBRecordSource(@Nonnull final FDBRecord<M> rec, @Nonnull final Message message) {
+        public FDBRecordSource(final FDBRecord<M> rec, final Message message) {
             this.rec = rec;
             this.message = message;
         }
 
-        @Nonnull
         public Message getMessage() {
             return message;
         }
@@ -190,29 +184,27 @@ public class LuceneDocumentFromRecord {
         }
 
         @Override
-        public void addField(@Nonnull T source, @Nonnull String fieldName, @Nullable final Object value,
-                                      @Nonnull LuceneIndexExpressions.DocumentFieldType type,
+        public void addField(T source, String fieldName, @Nullable final Object value,
+                                      LuceneIndexExpressions.DocumentFieldType type,
                                       final boolean fieldNameOverride, @Nullable List<String> namedFieldPath, @Nullable String namedFieldSuffix,
                                       boolean stored, boolean sorted,
-                                      @Nonnull List<Integer> overriddenKeyRanges, int groupingKeyIndex, int keyIndex,
-                                      @Nonnull Map<String, Object> fieldConfigs) {
+                                      List<Integer> overriddenKeyRanges, int groupingKeyIndex, int keyIndex,
+                                      Map<String, Object> fieldConfigs) {
             fields.add(new DocumentField(fieldName, value, type, stored, sorted, fieldConfigs));
         }
     }
 
     public static class DocumentField {
-        @Nonnull
         private final String fieldName;
         @Nullable
         private final Object value;
         private final LuceneIndexExpressions.DocumentFieldType type;
         private final boolean stored;
         private final boolean sorted;
-        @Nonnull
         private final Map<String, Object> fieldConfigs;
 
-        public DocumentField(@Nonnull String fieldName, @Nullable Object value, LuceneIndexExpressions.DocumentFieldType type,
-                             boolean stored, boolean sorted, @Nonnull Map<String, Object> fieldConfigs) {
+        public DocumentField(String fieldName, @Nullable Object value, LuceneIndexExpressions.DocumentFieldType type,
+                             boolean stored, boolean sorted, Map<String, Object> fieldConfigs) {
             this.fieldName = fieldName;
             this.value = value;
             this.type = type;
@@ -221,7 +213,6 @@ public class LuceneDocumentFromRecord {
             this.fieldConfigs = fieldConfigs;
         }
 
-        @Nonnull
         public String getFieldName() {
             return fieldName;
         }
@@ -243,13 +234,12 @@ public class LuceneDocumentFromRecord {
             return sorted;
         }
 
-        @Nonnull
         public Map<String, Object> getFieldConfigs() {
             return Collections.unmodifiableMap(fieldConfigs);
         }
 
         @Nullable
-        public Object getConfig(@Nonnull String key) {
+        public Object getConfig(String key) {
             return fieldConfigs.get(key);
         }
 

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneEvents.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneEvents.java
@@ -23,6 +23,8 @@ package com.apple.foundationdb.record.lucene;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.provider.common.StoreTimer;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * A {@link StoreTimer} events associated with Lucene operations.
  */
@@ -83,7 +85,7 @@ public class LuceneEvents {
         private final String title;
         private final String logKey;
 
-        Events(String title, String logKey) {
+        Events(String title, @Nullable String logKey) {
             this.title = title;
             this.logKey = (logKey != null) ? logKey : StoreTimer.Event.super.logKey();
         }
@@ -114,7 +116,7 @@ public class LuceneEvents {
         private final String title;
         private final String logKey;
 
-        DetailEvents(String title, String logKey) {
+        DetailEvents(String title, @Nullable String logKey) {
             this.title = title;
             this.logKey = (logKey != null) ? logKey : StoreTimer.DetailEvent.super.logKey();
         }
@@ -187,7 +189,7 @@ public class LuceneEvents {
         private final String title;
         private final String logKey;
 
-        Waits(String title, String logKey) {
+        Waits(String title, @Nullable String logKey) {
             this.title = title;
             this.logKey = (logKey != null) ? logKey : StoreTimer.Wait.super.logKey();
         }
@@ -257,7 +259,7 @@ public class LuceneEvents {
         private final String logKey;
         private final boolean delayedUntilCommit;
 
-        Counts(String title, boolean isSize, String logKey, boolean delayedUntilCommit) {
+        Counts(String title, boolean isSize, @Nullable String logKey, boolean delayedUntilCommit) {
             this.title = title;
             this.isSize = isSize;
             this.logKey = (logKey != null) ? logKey : StoreTimer.Count.super.logKey();

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneEvents.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneEvents.java
@@ -23,8 +23,6 @@ package com.apple.foundationdb.record.lucene;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.provider.common.StoreTimer;
 
-import javax.annotation.Nonnull;
-
 /**
  * A {@link StoreTimer} events associated with Lucene operations.
  */
@@ -101,7 +99,6 @@ public class LuceneEvents {
         }
 
         @Override
-        @Nonnull
         public String logKey() {
             return this.logKey;
         }
@@ -133,7 +130,6 @@ public class LuceneEvents {
         }
 
         @Override
-        @Nonnull
         public String logKey() {
             return this.logKey;
         }
@@ -206,7 +202,6 @@ public class LuceneEvents {
         }
 
         @Override
-        @Nonnull
         public String logKey() {
             return this.logKey;
         }
@@ -279,7 +274,6 @@ public class LuceneEvents {
         }
 
         @Override
-        @Nonnull
         public String logKey() {
             return this.logKey;
         }
@@ -319,11 +313,11 @@ public class LuceneEvents {
         private final String title;
         private final boolean delayedUntilCommit;
 
-        SizeEvents(@Nonnull String title) {
+        SizeEvents(String title) {
             this(title, false);
         }
 
-        SizeEvents(@Nonnull String title, boolean delayedUntilCommit) {
+        SizeEvents(String title, boolean delayedUntilCommit) {
             this.title = title;
             this.delayedUntilCommit = delayedUntilCommit;
         }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneExceptions.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneExceptions.java
@@ -54,7 +54,10 @@ public class LuceneExceptions {
                 transactionIsTooOldException.addSuppressed(ex);
                 return transactionIsTooOldException;
             } else {
-                // This should not happen - LuceneTransactionTooOldException should have FDBStoreTransactionIsTooOldException as cause
+                // This should not happen - LuceneTransactionTooOldException should have FDBStoreTransactionIsTooOldException as cause.
+                // FDBStoreTransactionIsTooOldException(String, FDBException) requires a non-null FDBException cause, but none is
+                // available in this defensive fallback; the original exception is preserved below via addSuppressed instead.
+                @SuppressWarnings("NullAway")
                 RecordCoreException result = new FDBExceptions.FDBStoreTransactionIsTooOldException(message + ": " + ex.getMessage(), null)
                         .addLogInfo(additionalLogInfo);
                 result.addSuppressed(ex);

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneExceptions.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneExceptions.java
@@ -25,6 +25,7 @@ import com.apple.foundationdb.record.lucene.directory.FDBDirectoryLockFactory;
 import com.apple.foundationdb.record.provider.foundationdb.FDBExceptions;
 import com.apple.foundationdb.util.LoggableKeysAndValues;
 import org.apache.lucene.store.LockObtainFailedException;
+import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
 
@@ -39,7 +40,7 @@ public class LuceneExceptions {
      * @param additionalLogInfo (optional) additional log infos to add to the created exception
      * @return the {@link RecordCoreException} that should be thrown
      */
-    public static RuntimeException toRecordCoreException(String message, IOException ex, Object... additionalLogInfo) {
+    public static RuntimeException toRecordCoreException(@Nullable String message, IOException ex, @Nullable Object... additionalLogInfo) {
         if (ex instanceof LockObtainFailedException) {
             // Use the retryable exception for this case
             return new FDBExceptions.FDBStoreLockTakenException(message + ": " + ex.getMessage(), ex)
@@ -82,9 +83,10 @@ public class LuceneExceptions {
     /**
      * Convert an exception thrown by the lower levels to one that can be thrown by Lucene ({@link IOException}).
      * @param ex the exception thrown by FDB
+     * @param suppressed an additional exception to record as suppressed on the result, or {@code null} if none
      * @return the {@link IOException} that can be thrown through Lucene APIs
      */
-    public static IOException toIoException(Throwable ex, Throwable suppressed) {
+    public static IOException toIoException(@Nullable Throwable ex, @Nullable Throwable suppressed) {
         IOException result;
         if (ex instanceof FDBExceptions.FDBStoreTransactionIsTooOldException) {
             result = new LuceneExceptions.LuceneTransactionTooOldException((FDBExceptions.FDBStoreTransactionIsTooOldException)ex);

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneFunctionKeyExpression.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneFunctionKeyExpression.java
@@ -21,6 +21,7 @@
 package com.apple.foundationdb.record.lucene;
 
 import com.apple.foundationdb.annotation.API;
+import com.apple.foundationdb.record.IndexEntry;
 import com.apple.foundationdb.record.metadata.Key;
 import com.apple.foundationdb.record.metadata.expressions.FunctionKeyExpression;
 import com.apple.foundationdb.record.metadata.expressions.KeyExpression;
@@ -313,8 +314,11 @@ public abstract class LuceneFunctionKeyExpression extends FunctionKeyExpression 
         @Override
         public <M extends Message> List<Key.Evaluated> evaluateFunction(@Nullable final FDBRecord<M> rec, @Nullable final Message message, final Key.Evaluated argvals) {
             Key.Evaluated result;
-            if (rec instanceof FDBQueriedRecord && ((FDBQueriedRecord<M>)rec).getIndexEntry() instanceof LuceneRecordCursor.ScoreDocIndexEntry) {
-                final ScoreDoc scoreDoc = ((LuceneRecordCursor.ScoreDocIndexEntry)((FDBQueriedRecord<M>)rec).getIndexEntry()).getScoreDoc();
+            // Capture getIndexEntry() once rather than calling it twice (it is @Nullable in general); SpotBugs
+            // (NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE) cannot tell that two separate calls would agree.
+            final IndexEntry indexEntry = rec instanceof FDBQueriedRecord ? ((FDBQueriedRecord<M>) rec).getIndexEntry() : null;
+            if (indexEntry instanceof LuceneRecordCursor.ScoreDocIndexEntry) {
+                final ScoreDoc scoreDoc = ((LuceneRecordCursor.ScoreDocIndexEntry) indexEntry).getScoreDoc();
                 final Object value;
                 if (isRelevance()) {
                     value = scoreDoc.score;

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneFunctionKeyExpression.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneFunctionKeyExpression.java
@@ -34,8 +34,7 @@ import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
 import org.apache.lucene.search.ScoreDoc;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -49,13 +48,12 @@ import static com.apple.foundationdb.record.lucene.LuceneFunctionNames.LUCENE_SO
  */
 @API(API.Status.EXPERIMENTAL)
 public abstract class LuceneFunctionKeyExpression extends FunctionKeyExpression {
-    protected LuceneFunctionKeyExpression(@Nonnull String name, @Nonnull KeyExpression arguments) {
+    protected LuceneFunctionKeyExpression(String name, KeyExpression arguments) {
         super(name, arguments);
     }
 
-    @Nonnull
     @Override
-    public <M extends Message> List<Key.Evaluated> evaluateFunction(@Nullable FDBRecord<M> rec, @Nullable Message message, @Nonnull Key.Evaluated argvals) {
+    public <M extends Message> List<Key.Evaluated> evaluateFunction(@Nullable FDBRecord<M> rec, @Nullable Message message, Key.Evaluated argvals) {
         return arguments.evaluateMessage(rec, message);
     }
 
@@ -65,7 +63,7 @@ public abstract class LuceneFunctionKeyExpression extends FunctionKeyExpression 
     }
 
     @Override
-    public int planHash(@Nonnull final PlanHashMode mode) {
+    public int planHash(final PlanHashMode mode) {
         throw new IllegalStateException("Should not be used in a plan");
     }
 
@@ -75,7 +73,7 @@ public abstract class LuceneFunctionKeyExpression extends FunctionKeyExpression 
      * Common cases of the name expression would be a literal string or null or another field whose value determines the name at index time.
      */
     public static class LuceneFieldName extends LuceneFunctionKeyExpression {
-        public LuceneFieldName(@Nonnull String name, @Nonnull KeyExpression arguments) {
+        public LuceneFieldName(String name, KeyExpression arguments) {
             super(name, arguments);
         }
 
@@ -95,7 +93,7 @@ public abstract class LuceneFunctionKeyExpression extends FunctionKeyExpression 
         }
 
         @Override
-        public List<Descriptors.FieldDescriptor> validate(@Nonnull Descriptors.Descriptor descriptor) {
+        public List<Descriptors.FieldDescriptor> validate(Descriptors.Descriptor descriptor) {
             final List<Descriptors.FieldDescriptor> result = super.validate(descriptor);
             if (!(arguments instanceof ThenKeyExpression && ((ThenKeyExpression)arguments).getChildren().size() == 2 && ((ThenKeyExpression)arguments).getChildren().get(1).getColumnSize() == 1)) {
                 throw new InvalidExpressionException("Lucene field name subexpression should be single column");
@@ -107,7 +105,6 @@ public abstract class LuceneFunctionKeyExpression extends FunctionKeyExpression 
          * Get the expression for which a name is given.
          * @return the expression that is named
          */
-        @Nonnull
         public KeyExpression getNamedExpression() {
             return ((KeyExpressionWithChildren)arguments).getChildren().get(0);
         }
@@ -116,14 +113,12 @@ public abstract class LuceneFunctionKeyExpression extends FunctionKeyExpression 
          * Get the expression to determine the name.
          * @return the expression to be evaluated to produce the name
          */
-        @Nonnull
         public KeyExpression getNameExpression() {
             return ((KeyExpressionWithChildren)arguments).getChildren().get(1);
         }
 
-        @Nonnull
         @Override
-        public Value toValue(@Nonnull final List<? extends Value> argumentValues) {
+        public Value toValue(final List<? extends Value> argumentValues) {
             throw new UnsupportedOperationException("not implemented");
         }
     }
@@ -133,7 +128,7 @@ public abstract class LuceneFunctionKeyExpression extends FunctionKeyExpression 
      * The field argument to this function is additionally stored in the Lucene documents and not just indexed.
      */
     public static class LuceneStored extends LuceneFunctionKeyExpression {
-        public LuceneStored(@Nonnull String name, @Nonnull KeyExpression arguments) {
+        public LuceneStored(String name, KeyExpression arguments) {
             super(name, arguments);
         }
 
@@ -156,14 +151,12 @@ public abstract class LuceneFunctionKeyExpression extends FunctionKeyExpression 
          * Get the expression that is marked as stored.
          * @return the stored expression
          */
-        @Nonnull
         public KeyExpression getStoredExpression() {
             return arguments;
         }
 
-        @Nonnull
         @Override
-        public Value toValue(@Nonnull final List<? extends Value> argumentValues) {
+        public Value toValue(final List<? extends Value> argumentValues) {
             throw new UnsupportedOperationException("not implemented");
         }
     }
@@ -173,7 +166,7 @@ public abstract class LuceneFunctionKeyExpression extends FunctionKeyExpression 
      * The field argument to this function is additionally sorted in the Lucene index.
      */
     public static class LuceneSorted extends LuceneFunctionKeyExpression {
-        public LuceneSorted(@Nonnull String name, @Nonnull KeyExpression arguments) {
+        public LuceneSorted(String name, KeyExpression arguments) {
             super(name, arguments);
         }
 
@@ -196,14 +189,12 @@ public abstract class LuceneFunctionKeyExpression extends FunctionKeyExpression 
          * Get the expression that is marked as stored.
          * @return the stored expression
          */
-        @Nonnull
         public KeyExpression getSortedExpression() {
             return arguments;
         }
 
-        @Nonnull
         @Override
-        public Value toValue(@Nonnull final List<? extends Value> argumentValues) {
+        public Value toValue(final List<? extends Value> argumentValues) {
             throw new UnsupportedOperationException("not implemented");
         }
     }
@@ -213,7 +204,7 @@ public abstract class LuceneFunctionKeyExpression extends FunctionKeyExpression 
      * The field arguments to this function are tokenized as full text when building the index.
      */
     public static class LuceneText extends LuceneFunctionKeyExpression {
-        public LuceneText(@Nonnull String name, @Nonnull KeyExpression arguments) {
+        public LuceneText(String name, KeyExpression arguments) {
             super(name, arguments);
         }
 
@@ -236,7 +227,6 @@ public abstract class LuceneFunctionKeyExpression extends FunctionKeyExpression 
          * Get the record field that is tokenized as text using Lucene.
          * @return the field expression
          */
-        @Nonnull
         public KeyExpression getFieldExpression() {
             if (arguments.getColumnSize() > 1) {
                 return ((KeyExpressionWithChildren)arguments).getChildren().get(0);
@@ -245,7 +235,6 @@ public abstract class LuceneFunctionKeyExpression extends FunctionKeyExpression 
             }
         }
 
-        @Nonnull
         public Map<String, Object> getFieldConfigs() {
             Map<String, Object> configs = new HashMap<>();
             if (arguments instanceof ThenKeyExpression) {
@@ -262,9 +251,8 @@ public abstract class LuceneFunctionKeyExpression extends FunctionKeyExpression 
             return configs;
         }
 
-        @Nonnull
         @Override
-        public Value toValue(@Nonnull final List<? extends Value> argumentValues) {
+        public Value toValue(final List<? extends Value> argumentValues) {
             throw new UnsupportedOperationException("not implemented");
         }
     }
@@ -274,7 +262,7 @@ public abstract class LuceneFunctionKeyExpression extends FunctionKeyExpression 
      * The value arguments to this function are applied as the configs for the corresponding Lucene text field when building the index.
      */
     public static class LuceneFieldConfig extends LuceneFunctionKeyExpression {
-        public LuceneFieldConfig(@Nonnull String name, @Nonnull KeyExpression arguments) {
+        public LuceneFieldConfig(String name, KeyExpression arguments) {
             super(name, arguments);
         }
 
@@ -293,9 +281,8 @@ public abstract class LuceneFunctionKeyExpression extends FunctionKeyExpression 
             return 1;
         }
 
-        @Nonnull
         @Override
-        public Value toValue(@Nonnull final List<? extends Value> argumentValues) {
+        public Value toValue(final List<? extends Value> argumentValues) {
             throw new UnsupportedOperationException("not implemented");
         }
     }
@@ -304,7 +291,7 @@ public abstract class LuceneFunctionKeyExpression extends FunctionKeyExpression 
      * Key function representing one of the Lucene built-in sorting techniques.
      */
     public static class LuceneSortBy extends LuceneFunctionKeyExpression {
-        public LuceneSortBy(@Nonnull String name, @Nonnull KeyExpression arguments) {
+        public LuceneSortBy(String name, KeyExpression arguments) {
             super(name, arguments);
         }
 
@@ -323,9 +310,8 @@ public abstract class LuceneFunctionKeyExpression extends FunctionKeyExpression 
             return 1;
         }
 
-        @Nonnull
         @Override
-        public <M extends Message> List<Key.Evaluated> evaluateFunction(@Nullable final FDBRecord<M> rec, @Nullable final Message message, @Nonnull final Key.Evaluated argvals) {
+        public <M extends Message> List<Key.Evaluated> evaluateFunction(@Nullable final FDBRecord<M> rec, @Nullable final Message message, final Key.Evaluated argvals) {
             Key.Evaluated result;
             if (rec instanceof FDBQueriedRecord && ((FDBQueriedRecord<M>)rec).getIndexEntry() instanceof LuceneRecordCursor.ScoreDocIndexEntry) {
                 final ScoreDoc scoreDoc = ((LuceneRecordCursor.ScoreDocIndexEntry)((FDBQueriedRecord<M>)rec).getIndexEntry()).getScoreDoc();
@@ -346,9 +332,8 @@ public abstract class LuceneFunctionKeyExpression extends FunctionKeyExpression 
             return LUCENE_SORT_BY_RELEVANCE.equals(getName());
         }
 
-        @Nonnull
         @Override
-        public Value toValue(@Nonnull final List<? extends Value> argumentValues) {
+        public Value toValue(final List<? extends Value> argumentValues) {
             throw new UnsupportedOperationException("not implemented");
         }
     }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneFunctionKeyExpressionFactory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneFunctionKeyExpressionFactory.java
@@ -24,7 +24,6 @@ import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.metadata.expressions.FunctionKeyExpression;
 import com.google.auto.service.AutoService;
 
-import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.List;
 
@@ -35,7 +34,6 @@ import java.util.List;
 @AutoService(FunctionKeyExpression.Factory.class)
 @API(API.Status.EXPERIMENTAL)
 public class LuceneFunctionKeyExpressionFactory implements FunctionKeyExpression.Factory {
-    @Nonnull
     @Override
     public List<FunctionKeyExpression.Builder> getBuilders() {
         return Arrays.asList(

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneGetMetadataInfo.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneGetMetadataInfo.java
@@ -24,8 +24,7 @@ import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.provider.foundationdb.IndexOperation;
 import com.apple.foundationdb.tuple.Tuple;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Get metadata information about a given lucene index.
@@ -36,7 +35,6 @@ import javax.annotation.Nullable;
 @API(API.Status.EXPERIMENTAL)
 public class LuceneGetMetadataInfo extends IndexOperation {
 
-    @Nonnull
     private final Tuple groupingKey;
     @Nullable
     private final Integer partitionId;
@@ -53,7 +51,7 @@ public class LuceneGetMetadataInfo extends IndexOperation {
      * @param justPartitionInfo if {@code true} then only the partition info will be fetched, otherwise information from
      * lucene itself will be fetched
      */
-    public LuceneGetMetadataInfo(@Nonnull Tuple groupingKey,
+    public LuceneGetMetadataInfo(Tuple groupingKey,
                                  @Nullable Integer partitionId,
                                  boolean justPartitionInfo) {
         this.groupingKey = groupingKey;
@@ -65,7 +63,6 @@ public class LuceneGetMetadataInfo extends IndexOperation {
      * The grouping key to inspect.
      * @return the grouping key or an empty {@code Tuple} if this index is not grouped
      */
-    @Nonnull
     public Tuple getGroupingKey() {
         return groupingKey;
     }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexExpressions.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexExpressions.java
@@ -171,6 +171,7 @@ public class LuceneIndexExpressions {
          *
          * @return the PointsConfig for this field.
          */
+        @Nullable
         public PointsConfig getPointsConfig() {
             switch (type) {
                 case INT:

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexExpressions.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexExpressions.java
@@ -39,8 +39,7 @@ import com.google.common.collect.Streams;
 import com.google.protobuf.Descriptors;
 import org.apache.lucene.queryparser.flexible.standard.config.PointsConfig;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -103,7 +102,7 @@ public class LuceneIndexExpressions {
      * @param root the {@code LUCENE} index root expresison
      * @param recordType Protobuf meta-data for record type
      */
-    public static void validate(@Nonnull KeyExpression root, @Nonnull Descriptors.Descriptor recordType) {
+    public static void validate(KeyExpression root, Descriptors.Descriptor recordType) {
         getFields(root, new MetaDataSource(recordType), (source, fieldName, value, type, fieldNameOverride, namedFieldPath, namedFieldSuffix, stored, sorted, overriddeKeyRanges, groupingKeyIndex, keyIndex, fieldConfigsIgnored) -> {
         }, null);
     }
@@ -113,11 +112,8 @@ public class LuceneIndexExpressions {
      */
     // TODO: Make this a JDK 14 record.
     public static class DocumentFieldDerivation {
-        @Nonnull
         private final String documentField;
-        @Nonnull
         private final List<String> recordFieldPath;
-        @Nonnull
         private final DocumentFieldType type;
         // TRUE when we have overridden the field name and replaced the original field with another
         private final boolean fieldNameOverride;
@@ -127,8 +123,8 @@ public class LuceneIndexExpressions {
         private final boolean stored;
         private final boolean sorted;
 
-        public DocumentFieldDerivation(@Nonnull String documentField, @Nonnull List<String> recordFieldPath,
-                                       @Nonnull DocumentFieldType type,
+        public DocumentFieldDerivation(String documentField, List<String> recordFieldPath,
+                                       DocumentFieldType type,
                                        boolean fieldNameOverride, @Nullable String namedFieldSuffix,
                                        boolean stored, boolean sorted) {
             this.documentField = documentField;
@@ -140,17 +136,14 @@ public class LuceneIndexExpressions {
             this.sorted = sorted;
         }
 
-        @Nonnull
         public String getDocumentField() {
             return documentField;
         }
 
-        @Nonnull
         public List<String> getRecordFieldPath() {
             return recordFieldPath;
         }
 
-        @Nonnull
         public DocumentFieldType getType() {
             return type;
         }
@@ -198,8 +191,7 @@ public class LuceneIndexExpressions {
         }
     }
 
-    @Nonnull
-    public static Map<String, DocumentFieldDerivation> getDocumentFieldDerivations(@Nonnull final Index index, @Nonnull final RecordMetaData metadata) {
+    public static Map<String, DocumentFieldDerivation> getDocumentFieldDerivations(final Index index, final RecordMetaData metadata) {
         Map<String, LuceneIndexExpressions.DocumentFieldDerivation> combined = null;
         for (RecordType recordType : metadata.recordTypesForIndex(index)) {
             final var documentFields = getDocumentFieldDerivations(index.getRootExpression(), recordType.getDescriptor());
@@ -221,7 +213,7 @@ public class LuceneIndexExpressions {
      * @param recordType Protobuf meta-data for record type
      * @return a map of document field names to {@link DocumentFieldDerivation}
      */
-    public static Map<String, DocumentFieldDerivation> getDocumentFieldDerivations(@Nonnull KeyExpression root, @Nonnull Descriptors.Descriptor recordType) {
+    public static Map<String, DocumentFieldDerivation> getDocumentFieldDerivations(KeyExpression root, Descriptors.Descriptor recordType) {
         final Map<String, DocumentFieldDerivation> fields = new HashMap<>();
         getFields(root,
                 new MetaDataSource(recordType),
@@ -251,9 +243,8 @@ public class LuceneIndexExpressions {
      * @param index The index.
      * @return a mapping between an index field name and its {@link PointsConfig}.
      */
-    @Nonnull
-    public static Map<String, PointsConfig> constructPointConfigMap(@Nonnull final FDBRecordStoreBase<?> store,
-                                                                    @Nonnull Index index) {
+    public static Map<String, PointsConfig> constructPointConfigMap(final FDBRecordStoreBase<?> store,
+                                                                    Index index) {
         final Map<String, PointsConfig> result = new HashMap<>();
         for (final RecordType type : store.getRecordMetaData().recordTypesForIndex(index)) {
             LuceneIndexExpressions.getDocumentFieldDerivations(index.getRootExpression(), type.getDescriptor()).forEach((key, value) -> {
@@ -276,14 +267,11 @@ public class LuceneIndexExpressions {
      * @param <T> the actual type of this source
      */
     public interface RecordSource<T extends RecordSource<T>> {
-        @Nonnull
         Descriptors.Descriptor getDescriptor();
 
-        @Nonnull
-        Iterable<T> getChildren(@Nonnull FieldKeyExpression parentExpression);
+        Iterable<T> getChildren(FieldKeyExpression parentExpression);
 
-        @Nonnull
-        Iterable<Object> getValues(@Nonnull KeyExpression keyExpression);
+        Iterable<Object> getValues(KeyExpression keyExpression);
     }
 
     /**
@@ -308,9 +296,9 @@ public class LuceneIndexExpressions {
          * @param fieldConfigs -
          */
         @SuppressWarnings("java:S107")
-        void addField(@Nonnull T source, @Nonnull String fieldName, @Nullable Object value, @Nonnull DocumentFieldType type,
+        void addField(T source, String fieldName, @Nullable Object value, DocumentFieldType type,
                       boolean fieldNameOverride, @Nullable List<String> namedFieldPath, @Nullable String namedFieldSuffix,
-                      boolean stored, boolean sorted, @Nonnull List<Integer> overriddenKeyRanges, int groupingKeyIndex, int keyIndex, @Nonnull Map<String, Object> fieldConfigs);
+                      boolean stored, boolean sorted, List<Integer> overriddenKeyRanges, int groupingKeyIndex, int keyIndex, Map<String, Object> fieldConfigs);
     }
 
     /**
@@ -321,9 +309,8 @@ public class LuceneIndexExpressions {
      * @param destination the document / document meta-data
      * @param fieldNamePrefix prefix for generated field names
      */
-    @Nonnull
-    public static <T extends RecordSource<T>> void getFields(@Nonnull KeyExpression root, @Nonnull T source,
-                                                             @Nonnull DocumentDestination<T> destination, @Nullable String fieldNamePrefix) {
+    public static <T extends RecordSource<T>> void getFields(KeyExpression root, T source,
+                                                             DocumentDestination<T> destination, @Nullable String fieldNamePrefix) {
         KeyExpression expression;
         if (root instanceof GroupingKeyExpression) {
             expression = ((GroupingKeyExpression)root).getGroupedSubKey();
@@ -335,10 +322,10 @@ public class LuceneIndexExpressions {
     }
 
     @SuppressWarnings("squid:S3776")
-    public static <T extends RecordSource<T>> void getFieldsRecursively(@Nonnull KeyExpression expression,
-                                                                        @Nonnull T source, @Nonnull DocumentDestination<T> destination,
+    public static <T extends RecordSource<T>> void getFieldsRecursively(KeyExpression expression,
+                                                                        T source, DocumentDestination<T> destination,
                                                                         @Nullable String fieldNamePrefix, int keyIndex, int groupingCount,
-                                                                        @Nonnull List<Integer> overriddenKeyRanges) {
+                                                                        List<Integer> overriddenKeyRanges) {
         // Record type evaluation of primary key based on this expression for the partial record is not needed,
         // because this partial record to build has the correct record type.
         if (expression instanceof RecordTypeKeyExpression) {
@@ -486,7 +473,7 @@ public class LuceneIndexExpressions {
         throw new RecordCoreException("Unknown Lucene field key expression");
     }
 
-    private static void addOverriddenKeyRange(@Nonnull List<Integer> overriddenKeyRanges, @Nullable String fieldNamePrefix, @Nullable String fieldNameSuffix) {
+    private static void addOverriddenKeyRange(List<Integer> overriddenKeyRanges, @Nullable String fieldNamePrefix, @Nullable String fieldNameSuffix) {
         if (fieldNamePrefix == null) {
             overriddenKeyRanges.add(0);
             overriddenKeyRanges.add((fieldNameSuffix == null || fieldNameSuffix.isEmpty()) ? 0 : fieldNameSuffix.length());
@@ -496,7 +483,7 @@ public class LuceneIndexExpressions {
         }
     }
 
-    private static void removedLastOverriddenKeyRange(@Nonnull List<Integer> overriddenKeyRanges) {
+    private static void removedLastOverriddenKeyRange(List<Integer> overriddenKeyRanges) {
         if (overriddenKeyRanges.size() < 2) {
             throw new RecordCoreException("Invalid call to remove last overridden key range, since the list has not a full range to remove");
         }
@@ -520,14 +507,13 @@ public class LuceneIndexExpressions {
         private final MetaDataSource parent;
         @Nullable
         private final String field;
-        @Nonnull
         private final Descriptors.Descriptor descriptor;
 
-        MetaDataSource(@Nonnull Descriptors.Descriptor descriptor) {
+        MetaDataSource(Descriptors.Descriptor descriptor) {
             this(null, null, descriptor);
         }
 
-        MetaDataSource(@Nullable MetaDataSource parent, @Nullable String field, @Nonnull Descriptors.Descriptor descriptor) {
+        MetaDataSource(@Nullable MetaDataSource parent, @Nullable String field, Descriptors.Descriptor descriptor) {
             this.parent = parent;
             this.field = field;
             this.descriptor = descriptor;
@@ -549,14 +535,14 @@ public class LuceneIndexExpressions {
         }
 
         @Override
-        public Iterable<MetaDataSource> getChildren(@Nonnull FieldKeyExpression parentExpression) {
+        public Iterable<MetaDataSource> getChildren(FieldKeyExpression parentExpression) {
             final String parentField = parentExpression.getFieldName();
             final Descriptors.FieldDescriptor fieldDescriptor = descriptor.findFieldByName(parentField);
             return Collections.singletonList(new MetaDataSource(this, parentField, fieldDescriptor.getMessageType()));
         }
 
         @Override
-        public Iterable<Object> getValues(@Nonnull KeyExpression keyExpression) {
+        public Iterable<Object> getValues(KeyExpression keyExpression) {
             List<Object> result = new ArrayList<>();
             KeyExpression current = keyExpression;
             while (current != null) {

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexKeyValueToPartialRecordUtils.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexKeyValueToPartialRecordUtils.java
@@ -50,14 +50,14 @@ import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
 import com.google.protobuf.MessageLite;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
 import static com.apple.foundationdb.record.planprotos.LuceneRecordQueryPlanProto.luceneSpellCheckCopier;
+import static com.google.protobuf.Descriptors.FieldDescriptor;
 
 /**
  * A utility class to build a partial record for an auto-complete suggestion value, with grouping keys if there exist.
@@ -66,15 +66,15 @@ public class LuceneIndexKeyValueToPartialRecordUtils {
     private LuceneIndexKeyValueToPartialRecordUtils() {
     }
 
-    public static void buildPartialRecord(@Nonnull KeyExpression root, @Nonnull Descriptors.Descriptor descriptor,
-                                          @Nonnull Message.Builder builder, @Nonnull String luceneField,
-                                          @Nonnull String suggestion) {
+    public static void buildPartialRecord(KeyExpression root, Descriptors.Descriptor descriptor,
+                                          Message.Builder builder, String luceneField,
+                                          String suggestion) {
         buildPartialRecord(root, descriptor, builder, luceneField, suggestion, TupleHelpers.EMPTY);
     }
 
-    public static void buildPartialRecord(@Nonnull KeyExpression root, @Nonnull Descriptors.Descriptor descriptor,
-                                          @Nonnull Message.Builder builder, @Nonnull String luceneField,
-                                          @Nonnull String suggestion, @Nonnull Tuple groupingKey) {
+    public static void buildPartialRecord(KeyExpression root, Descriptors.Descriptor descriptor,
+                                          Message.Builder builder, String luceneField,
+                                          String suggestion, Tuple groupingKey) {
         final KeyExpression expression = root instanceof GroupingKeyExpression ? ((GroupingKeyExpression) root).getWholeKey() : root;
         LuceneIndexExpressions.getFieldsRecursively(expression, new PartialRecordBuildSource(null, descriptor, builder),
                 (source, fieldName, value, type, fieldNameOverride, namedFieldPath, namedFieldSuffix, stored, sorted, overriddenKeyRanges, groupingKeyIndex, keyIndex, fieldConfigsIgnored) -> {
@@ -91,15 +91,15 @@ public class LuceneIndexKeyValueToPartialRecordUtils {
                 null, 0, root instanceof GroupingKeyExpression ? ((GroupingKeyExpression) root).getGroupingCount() : 0, new ArrayList<>());
     }
 
-    public static void populatePrimaryKey(@Nonnull KeyExpression primaryKey, @Nonnull Descriptors.Descriptor descriptor, @Nonnull Message.Builder builder, @Nonnull Tuple tuple) {
+    public static void populatePrimaryKey(KeyExpression primaryKey, Descriptors.Descriptor descriptor, Message.Builder builder, Tuple tuple) {
         LuceneIndexExpressions.getFields(primaryKey, new PartialRecordBuildSource(null, descriptor, builder),
                 (source, fieldName, value, type, fieldNameOverride, namedFieldPath, namedFieldSuffix, stored, sorted, overriddenKeyRanges, groupingKeyIndex, keyIndex, fieldConfigsIgnored) -> {
                     source.buildMessage(tuple.get(keyIndex), (String) value, null, null, false);
                 }, null);
     }
 
-    private static void buildIfFieldNameMatch(@Nonnull PartialRecordBuildSource source, @Nonnull String concatenatedFieldPath, @Nonnull String givenFieldName,
-                                                 @Nonnull List<Integer> overriddenKeyRanges, @Nonnull String suggestion, @Nonnull String protoFieldName) {
+    private static void buildIfFieldNameMatch(PartialRecordBuildSource source, String concatenatedFieldPath, String givenFieldName,
+                                                 List<Integer> overriddenKeyRanges, String suggestion, String protoFieldName) {
         // If field is not overridden, the names have to match exactly
         if (overriddenKeyRanges.isEmpty()) {
             if (concatenatedFieldPath.equals(givenFieldName)) {
@@ -183,8 +183,8 @@ public class LuceneIndexKeyValueToPartialRecordUtils {
      * @return a pair of the list of fixed names and that of the dynamic ones
      */
     @SuppressWarnings("PMD.CompareObjectsWithEquals")
-    private static NonnullPair<List<String>, List<String>> getOriginalAndMappedFieldElements(@Nonnull String entireFieldName,
-                                                                                             @Nonnull List<Integer> overriddenKeyRanges) {
+    private static NonnullPair<List<String>, List<String>> getOriginalAndMappedFieldElements(String entireFieldName,
+                                                                                             List<Integer> overriddenKeyRanges) {
         int size = overriddenKeyRanges.size();
         final List<String> fixedFieldNames = new ArrayList<>();
         final List<String> dynamicFieldNames = new ArrayList<>();
@@ -229,11 +229,10 @@ public class LuceneIndexKeyValueToPartialRecordUtils {
      * @return a partial record generator
      */
     @SuppressWarnings("UnstableApiUsage")
-    @Nonnull
     @VisibleForTesting
-    public static IndexKeyValueToPartialRecord getToPartialRecord(@Nonnull Index index,
-                                                                  @Nonnull RecordType recordType,
-                                                                  @Nonnull IndexScanType scanType) {
+    public static IndexKeyValueToPartialRecord getToPartialRecord(Index index,
+                                                                  RecordType recordType,
+                                                                  IndexScanType scanType) {
         final IndexKeyValueToPartialRecord.Builder builder = IndexKeyValueToPartialRecord.newBuilder(recordType);
 
         KeyExpression root = index.getRootExpression();
@@ -268,22 +267,20 @@ public class LuceneIndexKeyValueToPartialRecordUtils {
     static class PartialRecordBuildSource implements LuceneIndexExpressions.RecordSource<PartialRecordBuildSource> {
         @Nullable
         private final PartialRecordBuildSource parent;
-        @Nonnull
         private final Descriptors.Descriptor descriptor;
         @Nullable
-        private final Descriptors.FieldDescriptor fieldDescriptor;
-        @Nonnull
+        private final FieldDescriptor fieldDescriptor;
         private final Message.Builder builder;
         private boolean hasBeenBuilt = false;
 
-        PartialRecordBuildSource(@Nullable PartialRecordBuildSource parent, @Nonnull Descriptors.Descriptor descriptor, @Nonnull Message.Builder builder) {
+        PartialRecordBuildSource(@Nullable PartialRecordBuildSource parent, Descriptors.Descriptor descriptor, Message.Builder builder) {
             this.parent = parent;
             this.descriptor = descriptor;
             this.fieldDescriptor = null;
             this.builder = builder;
         }
 
-        PartialRecordBuildSource(@Nullable PartialRecordBuildSource parent, @Nonnull Descriptors.FieldDescriptor fieldDescriptor, @Nonnull Message.Builder builder) {
+        PartialRecordBuildSource(@Nullable PartialRecordBuildSource parent, FieldDescriptor fieldDescriptor, Message.Builder builder) {
             this.parent = parent;
             this.descriptor = fieldDescriptor.getMessageType();
             this.fieldDescriptor = fieldDescriptor;
@@ -296,14 +293,14 @@ public class LuceneIndexKeyValueToPartialRecordUtils {
         }
 
         @Override
-        public Iterable<PartialRecordBuildSource> getChildren(@Nonnull FieldKeyExpression parentExpression) {
+        public Iterable<PartialRecordBuildSource> getChildren(FieldKeyExpression parentExpression) {
             final String parentField = parentExpression.getFieldName();
-            final Descriptors.FieldDescriptor parentFieldDescriptor = descriptor.findFieldByName(parentField);
+            final FieldDescriptor parentFieldDescriptor = descriptor.findFieldByName(parentField);
             return Collections.singletonList(new PartialRecordBuildSource(this, parentFieldDescriptor, builder.newBuilderForField(parentFieldDescriptor)));
         }
 
         @Override
-        public Iterable<Object> getValues(@Nonnull KeyExpression keyExpression) {
+        public Iterable<Object> getValues(KeyExpression keyExpression) {
             List<Object> result = new ArrayList<>();
             KeyExpression current = keyExpression;
             while (current != null) {
@@ -322,7 +319,7 @@ public class LuceneIndexKeyValueToPartialRecordUtils {
             return result;
         }
 
-        public void buildMessage(@Nullable Object value, @Nonnull String field, @Nullable String customizedKey, @Nullable String mappedKeyField, boolean forLuceneField) {
+        public void buildMessage(@Nullable Object value, String field, @Nullable String customizedKey, @Nullable String mappedKeyField, boolean forLuceneField) {
             if (hasBeenBuilt()) {
                 return;
             }
@@ -330,8 +327,8 @@ public class LuceneIndexKeyValueToPartialRecordUtils {
         }
 
         @SuppressWarnings("java:S3776")
-        private void buildMessage(@Nullable Object value, Descriptors.FieldDescriptor subFieldDescriptor, @Nullable String customizedKey, @Nullable String mappedKeyField, boolean forLuceneField) {
-            final Descriptors.FieldDescriptor mappedKeyFieldDescriptor = mappedKeyField == null ? null : descriptor.findFieldByName(mappedKeyField);
+        private void buildMessage(@Nullable Object value, FieldDescriptor subFieldDescriptor, @Nullable String customizedKey, @Nullable String mappedKeyField, boolean forLuceneField) {
+            final FieldDescriptor mappedKeyFieldDescriptor = mappedKeyField == null ? null : descriptor.findFieldByName(mappedKeyField);
             if (mappedKeyFieldDescriptor != null) {
                 if (customizedKey == null) {
                     return;
@@ -365,11 +362,11 @@ public class LuceneIndexKeyValueToPartialRecordUtils {
             }
         }
 
-        private static MessageLite.Builder addRequiredFieldsToBuilder(@Nonnull final Message.Builder builder) {
+        private static MessageLite.Builder addRequiredFieldsToBuilder(final Message.Builder builder) {
             final var recordDescriptor = builder.getDescriptorForType();
-            for (Descriptors.FieldDescriptor fieldDescriptor : recordDescriptor.getFields()) {
+            for (FieldDescriptor fieldDescriptor : recordDescriptor.getFields()) {
                 if (fieldDescriptor.isRequired() &&
-                        fieldDescriptor.getType() == Descriptors.FieldDescriptor.Type.MESSAGE &&
+                        fieldDescriptor.getType() == FieldDescriptor.Type.MESSAGE &&
                         !builder.hasField(fieldDescriptor)) {
                     final var fieldBuilder = builder.newBuilderForField(fieldDescriptor);
                     builder.setField(fieldDescriptor, addRequiredFieldsToBuilder(fieldBuilder).build());
@@ -403,8 +400,8 @@ public class LuceneIndexKeyValueToPartialRecordUtils {
         }
 
         @Override
-        public boolean copy(@Nonnull Descriptors.Descriptor recordDescriptor, @Nonnull Message.Builder recordBuilder,
-                            @Nonnull IndexEntry kv) {
+        public boolean copy(Descriptors.Descriptor recordDescriptor, Message.Builder recordBuilder,
+                            IndexEntry kv) {
             Tuple keyTuple = kv.getKey();
             if (keyTuple.size() < 2) {
                 throw new RecordCoreException("Invalid key tuple for auto-complete suggestion's index entry")
@@ -436,30 +433,27 @@ public class LuceneIndexKeyValueToPartialRecordUtils {
         }
 
         @Override
-        public int planHash(@Nonnull final PlanHashMode hashMode) {
+        public int planHash(final PlanHashMode hashMode) {
             return PlanHashable.objectsPlanHash(hashMode, BASE_HASH, groupingColumnSize);
         }
 
-        @Nonnull
         @Override
-        public PLuceneSpellCheckCopier toProto(@Nonnull final PlanSerializationContext serializationContext) {
+        public PLuceneSpellCheckCopier toProto(final PlanSerializationContext serializationContext) {
             return PLuceneSpellCheckCopier.newBuilder()
                     .setGroupingColumnSize(groupingColumnSize)
                     .build();
         }
 
-        @Nonnull
         @Override
-        public PCopier toCopierProto(@Nonnull final PlanSerializationContext serializationContext) {
+        public PCopier toCopierProto(final PlanSerializationContext serializationContext) {
             return PCopier.newBuilder()
                     .setExtension(luceneSpellCheckCopier, toProto(serializationContext))
                     .build();
         }
 
-        @Nonnull
         @SuppressWarnings("unused")
-        public static LuceneSpellCheckCopier fromProto(@Nonnull final PlanSerializationContext serializationContext,
-                                                       @Nonnull final PLuceneSpellCheckCopier luceneSpellCheckCopierProto) {
+        public static LuceneSpellCheckCopier fromProto(final PlanSerializationContext serializationContext,
+                                                       final PLuceneSpellCheckCopier luceneSpellCheckCopierProto) {
             return new LuceneSpellCheckCopier(PlanSerialization.getFieldOrThrow(luceneSpellCheckCopierProto,
                     PLuceneSpellCheckCopier::hasGroupingColumnSize,
                     PLuceneSpellCheckCopier::getGroupingColumnSize));
@@ -470,16 +464,14 @@ public class LuceneIndexKeyValueToPartialRecordUtils {
          */
         @AutoService(PlanDeserializer.class)
         public static class Deserializer implements PlanDeserializer<PLuceneSpellCheckCopier, LuceneSpellCheckCopier> {
-            @Nonnull
             @Override
             public Class<PLuceneSpellCheckCopier> getProtoMessageClass() {
                 return PLuceneSpellCheckCopier.class;
             }
 
-            @Nonnull
             @Override
-            public LuceneSpellCheckCopier fromProto(@Nonnull final PlanSerializationContext serializationContext,
-                                                    @Nonnull final PLuceneSpellCheckCopier luceneSpellCheckCopierProto) {
+            public LuceneSpellCheckCopier fromProto(final PlanSerializationContext serializationContext,
+                                                    final PLuceneSpellCheckCopier luceneSpellCheckCopierProto) {
                 return LuceneSpellCheckCopier.fromProto(serializationContext, luceneSpellCheckCopierProto);
             }
         }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexKeyValueToPartialRecordUtils.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexKeyValueToPartialRecordUtils.java
@@ -83,9 +83,9 @@ public class LuceneIndexKeyValueToPartialRecordUtils {
                             throw new RecordCoreException("Invalid grouping value tuple given a grouping key")
                                     .addLogInfo(LogMessageKeys.VALUE, groupingKey.toString());
                         }
-                        source.buildMessage(groupingKey.get(groupingKeyIndex), (String) value, null, null, false);
+                        source.buildMessage(groupingKey.get(groupingKeyIndex), (String) Objects.requireNonNull(value), null, null, false);
                     } else if (type.equals(LuceneIndexExpressions.DocumentFieldType.TEXT)) {
-                        buildIfFieldNameMatch(source, fieldName, luceneField, overriddenKeyRanges, suggestion, (String) value);
+                        buildIfFieldNameMatch(source, fieldName, luceneField, overriddenKeyRanges, suggestion, (String) Objects.requireNonNull(value));
                     }
                 },
                 null, 0, root instanceof GroupingKeyExpression ? ((GroupingKeyExpression) root).getGroupingCount() : 0, new ArrayList<>());
@@ -94,7 +94,7 @@ public class LuceneIndexKeyValueToPartialRecordUtils {
     public static void populatePrimaryKey(KeyExpression primaryKey, Descriptors.Descriptor descriptor, Message.Builder builder, Tuple tuple) {
         LuceneIndexExpressions.getFields(primaryKey, new PartialRecordBuildSource(null, descriptor, builder),
                 (source, fieldName, value, type, fieldNameOverride, namedFieldPath, namedFieldSuffix, stored, sorted, overriddenKeyRanges, groupingKeyIndex, keyIndex, fieldConfigsIgnored) -> {
-                    source.buildMessage(tuple.get(keyIndex), (String) value, null, null, false);
+                    source.buildMessage(tuple.get(keyIndex), (String) Objects.requireNonNull(value), null, null, false);
                 }, null);
     }
 
@@ -355,7 +355,9 @@ public class LuceneIndexKeyValueToPartialRecordUtils {
 
             if (parent != null) {
                 addRequiredFieldsToBuilder(builder);
-                parent.buildMessage(builder.build(), this.fieldDescriptor, mappedKeyFieldDescriptor == null ? customizedKey : null, mappedKeyFieldDescriptor == null ? mappedKeyField : null, forLuceneField);
+                // Only the root source (whose parent is always null) is constructed with a null fieldDescriptor;
+                // any source with a non-null parent has a non-null fieldDescriptor.
+                parent.buildMessage(builder.build(), Objects.requireNonNull(this.fieldDescriptor), mappedKeyFieldDescriptor == null ? customizedKey : null, mappedKeyFieldDescriptor == null ? mappedKeyField : null, forLuceneField);
             }
             if (forLuceneField) {
                 this.hasBeenBuilt = true;

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexKeyValueToPartialRecordUtils.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexKeyValueToPartialRecordUtils.java
@@ -20,6 +20,7 @@
 
 package com.apple.foundationdb.record.lucene;
 
+import com.apple.foundationdb.annotation.SpotBugsSuppressWarnings;
 import com.apple.foundationdb.record.IndexEntry;
 import com.apple.foundationdb.record.IndexScanType;
 import com.apple.foundationdb.record.ObjectPlanHash;
@@ -98,6 +99,11 @@ public class LuceneIndexKeyValueToPartialRecordUtils {
                 }, null);
     }
 
+    // pair is a NonnullPair, whose getLeft()/getRight() are guaranteed non-null by construction
+    // (NonnullPair.of() enforces this via Objects.requireNonNull()); SpotBugs's
+    // NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE analysis falls back to the wider @Nullable contract declared by
+    // Pair.getLeft()/getRight() rather than the narrowed override in NonnullPair.
+    @SpotBugsSuppressWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     private static void buildIfFieldNameMatch(PartialRecordBuildSource source, String concatenatedFieldPath, String givenFieldName,
                                                  List<Integer> overriddenKeyRanges, String suggestion, String protoFieldName) {
         // If field is not overridden, the names have to match exactly

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
@@ -72,8 +72,7 @@ import org.apache.lucene.search.Query;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
@@ -96,7 +95,6 @@ import java.util.stream.Stream;
 public class LuceneIndexMaintainer extends StandardIndexMaintainer {
     private static final Logger LOG = LoggerFactory.getLogger(LuceneIndexMaintainer.class);
 
-    @Nonnull
     private final FDBDirectoryManager directoryManager;
     private final LuceneAnalyzerCombinationProvider autoCompleteAnalyzerSelector;
     public static final String PRIMARY_KEY_FIELD_NAME = "_p";
@@ -105,11 +103,10 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
     private final Executor executor;
     LuceneIndexKeySerializer keySerializer;
 
-    @Nonnull
     private final LucenePartitioner partitioner;
 
     @SuppressWarnings("this-escape")
-    public LuceneIndexMaintainer(@Nonnull final IndexMaintainerState state, @Nonnull Executor executor) {
+    public LuceneIndexMaintainer(final IndexMaintainerState state, Executor executor) {
         super(state);
         this.executor = executor;
         this.directoryManager = createDirectoryManager(state);
@@ -124,9 +121,8 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
         return autoCompleteAnalyzerSelector;
     }
 
-    @Nonnull
     @Override
-    public RecordCursor<IndexEntry> scan(@Nonnull final IndexScanType scanType, @Nonnull final TupleRange range, @Nullable final byte[] continuation, @Nonnull final ScanProperties scanProperties) {
+    public RecordCursor<IndexEntry> scan(final IndexScanType scanType, final TupleRange range, @Nullable final byte[] continuation, final ScanProperties scanProperties) {
         throw new RecordCoreException("unsupported scan type for Lucene index: " + scanType);
     }
 
@@ -138,10 +134,9 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
      * @param scanProperties skip, limit and other properties of the scan
      * @return RecordCursor of index entries reconstituted from Lucene documents
      */
-    @Nonnull
     @Override
     @SuppressWarnings("PMD.CloseResource")
-    public RecordCursor<IndexEntry> scan(@Nonnull final IndexScanBounds scanBounds, @Nullable final byte[] continuation, @Nonnull final ScanProperties scanProperties) {
+    public RecordCursor<IndexEntry> scan(final IndexScanBounds scanBounds, @Nullable final byte[] continuation, final ScanProperties scanProperties) {
         final IndexScanType scanType = scanBounds.getScanType();
         LOG.trace("scan scanType={}", scanType);
 
@@ -198,7 +193,7 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
     public void writeDocumentBypassQueue(Tuple groupingKey,
                                          Integer partitionId,
                                          Tuple primaryKey,
-                                         @Nonnull List<LuceneDocumentFromRecord.DocumentField> fields) throws IOException {
+                                         List<LuceneDocumentFromRecord.DocumentField> fields) throws IOException {
         final long startTime = System.nanoTime();
         LuceneIndexMaintainerHelper.writeDocument(
                 directoryManager.getIndexWriter(groupingKey, partitionId),
@@ -237,9 +232,9 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
     }
 
     @VisibleForTesting
-    public void mergeIndexForTesting(@Nonnull final Tuple groupingKey,
+    public void mergeIndexForTesting(final Tuple groupingKey,
                                      @Nullable final Integer partitionId,
-                                     @Nonnull final AgilityContext agilityContext) {
+                                     final AgilityContext agilityContext) {
         try {
             state.store.getIndexDeferredMaintenanceControl().setExplicitMergePath(true);
             directoryManager.mergeIndexWithContext(groupingKey, partitionId, agilityContext);
@@ -249,13 +244,11 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
         }
     }
 
-    @Nonnull
     @VisibleForTesting
     public LucenePartitioner getPartitioner() {
         return partitioner;
     }
 
-    @Nonnull
     private static LucenePartitioner getPartitioner(final Index index, final FDBRecordStore store) {
         final IndexMaintainer indexMaintainer = store.getIndexMaintainer(index);
         if (indexMaintainer instanceof LuceneIndexMaintainer) {
@@ -321,14 +314,12 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
                                                 }))), repartitioningLogMessages.logMessages), state.context.getExecutor());
     }
 
-    @Nonnull
     @Override
     public <M extends Message> CompletableFuture<Void> update(@Nullable FDBIndexableRecord<M> oldRecord,
                                                               @Nullable FDBIndexableRecord<M> newRecord) {
         return update(oldRecord, newRecord, null);
     }
 
-    @Nonnull
     <M extends Message> CompletableFuture<Void> update(@Nullable FDBIndexableRecord<M> oldRecordUnfiltered,
                                                        @Nullable FDBIndexableRecord<M> newRecordUnfiltered,
                                                        @Nullable Integer destinationPartitionIdHint) {
@@ -405,8 +396,8 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
      * @param <M> message
      * @return count of deleted docs
      */
-    private <M extends Message> CompletableFuture<Integer> tryDeleteInWriteOnlyMode(@Nonnull FDBIndexableRecord<M> record,
-                                                                                    @Nonnull Tuple groupingKey) {
+    private <M extends Message> CompletableFuture<Integer> tryDeleteInWriteOnlyMode(FDBIndexableRecord<M> record,
+                                                                                    Tuple groupingKey) {
         if (!state.store.getIndexState(state.index).isWriteOnly()) {
             // no op
             return CompletableFuture.completedFuture(0);
@@ -424,8 +415,8 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
      * @return count of deleted docs: 1 indicates that the record has been deleted, 0 means that either no record was deleted or it was deleted by
      * query.
      */
-    private <M extends Message> CompletableFuture<Integer> tryDelete(@Nonnull FDBIndexableRecord<M> record,
-                                                                     @Nonnull Tuple groupingKey) {
+    private <M extends Message> CompletableFuture<Integer> tryDelete(FDBIndexableRecord<M> record,
+                                                                     Tuple groupingKey) {
         try {
             // non-partitioned
             if (!partitioner.isPartitioningEnabled()) {
@@ -449,8 +440,7 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
         });
     }
 
-    @Nonnull
-    public CompletableFuture<Integer> postDeleteUpdatePartitionCounter(final @Nonnull Tuple groupingKey, int partitionId, final int countDeleted) {
+    public CompletableFuture<Integer> postDeleteUpdatePartitionCounter(final Tuple groupingKey, int partitionId, final int countDeleted) {
         if (countDeleted > 0) {
             return partitioner.decrementCountAndSave(groupingKey, countDeleted, partitionId)
                     .thenApply(ignore -> countDeleted);
@@ -460,7 +450,6 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
         }
     }
 
-    @Nonnull
     @Override
     public RecordCursor<InvalidIndexEntry> validateEntries(@Nullable byte[] continuation, @Nullable ScanProperties scanProperties) {
         LOG.trace("validateEntries");
@@ -468,31 +457,29 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
     }
 
     @Override
-    public boolean canEvaluateRecordFunction(@Nonnull IndexRecordFunction<?> function) {
+    public boolean canEvaluateRecordFunction(IndexRecordFunction<?> function) {
         LOG.trace("canEvaluateRecordFunction() function={}", function);
         return false;
     }
 
-    @Nonnull
     @Override
-    public <T, M extends Message> CompletableFuture<T> evaluateRecordFunction(@Nonnull EvaluationContext context,
-                                                                              @Nonnull IndexRecordFunction<T> function,
-                                                                              @Nonnull FDBRecord<M> record) {
+    public <T, M extends Message> CompletableFuture<T> evaluateRecordFunction(EvaluationContext context,
+                                                                              IndexRecordFunction<T> function,
+                                                                              FDBRecord<M> record) {
         LOG.warn("evaluateRecordFunction() function={}", function);
         return unsupportedRecordFunction(function);
     }
 
     @Override
-    public boolean canEvaluateAggregateFunction(@Nonnull IndexAggregateFunction function) {
+    public boolean canEvaluateAggregateFunction(IndexAggregateFunction function) {
         LOG.trace("canEvaluateAggregateFunction() function={}", function);
         return false;
     }
 
-    @Nonnull
     @Override
-    public CompletableFuture<Tuple> evaluateAggregateFunction(@Nonnull IndexAggregateFunction function,
-                                                              @Nonnull TupleRange range,
-                                                              @Nonnull IsolationLevel isolationLevel) {
+    public CompletableFuture<Tuple> evaluateAggregateFunction(IndexAggregateFunction function,
+                                                              TupleRange range,
+                                                              IsolationLevel isolationLevel) {
         LOG.warn("evaluateAggregateFunction() function={}", function);
         return unsupportedAggregateFunction(function);
     }
@@ -503,30 +490,27 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
         return true;
     }
 
-    @Nonnull
     @Override
-    public CompletableFuture<Boolean> addedRangeWithKey(@Nonnull Tuple primaryKey) {
+    public CompletableFuture<Boolean> addedRangeWithKey(Tuple primaryKey) {
         LOG.trace("addedRangeWithKey primaryKey={}", primaryKey);
         return AsyncUtil.READY_FALSE;
     }
 
     @Override
-    public boolean canDeleteWhere(@Nonnull QueryToKeyMatcher matcher, @Nonnull Key.Evaluated evaluated) {
+    public boolean canDeleteWhere(QueryToKeyMatcher matcher, Key.Evaluated evaluated) {
         LOG.trace("canDeleteWhere matcher={}", matcher);
         return canDeleteGroup(matcher, evaluated);
     }
 
     @Override
-    @Nonnull
-    public CompletableFuture<Void> deleteWhere(Transaction tr, @Nonnull Tuple prefix) {
+    public CompletableFuture<Void> deleteWhere(Transaction tr, Tuple prefix) {
         LOG.trace("deleteWhere transaction={}, prefix={}", tr, prefix);
         directoryManager.invalidatePrefix(prefix);
         return super.deleteWhere(tr, prefix);
     }
 
     @Override
-    @Nonnull
-    public CompletableFuture<IndexOperationResult> performOperation(@Nonnull IndexOperation operation) {
+    public CompletableFuture<IndexOperationResult> performOperation(IndexOperation operation) {
         LOG.trace("performOperation operation={}", operation);
         if (operation instanceof LuceneGetMetadataInfo) {
             final LuceneGetMetadataInfo request = (LuceneGetMetadataInfo)operation;
@@ -604,7 +588,6 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
         }
     }
 
-    @Nonnull
     private static List<LuceneMetadataInfo.LuceneFileInfo> toLuceneFileInfo(final Map<String, FDBLuceneFileReference> fileList) {
         return fileList.entrySet().stream()
                 .map(entry -> new LuceneMetadataInfo.LuceneFileInfo(
@@ -615,7 +598,7 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
     }
 
     @VisibleForTesting
-    protected FDBDirectory getDirectory(@Nonnull Tuple groupingKey, @Nullable Integer partitionId) {
+    protected FDBDirectory getDirectory(Tuple groupingKey, @Nullable Integer partitionId) {
         return directoryManager.getDirectory(groupingKey, partitionId);
     }
 
@@ -625,8 +608,7 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
     }
 
     @VisibleForTesting
-    @Nonnull
-    protected FDBDirectoryManager createDirectoryManager(final @Nonnull IndexMaintainerState state) {
+    protected FDBDirectoryManager createDirectoryManager(final IndexMaintainerState state) {
         return FDBDirectoryManager.getManager(state);
     }
 
@@ -636,7 +618,7 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
         return directory.shouldUseQueue();
     }
 
-    private static int getIncarnationSafe(@Nonnull FDBRecordStore store) {
+    private static int getIncarnationSafe(FDBRecordStore store) {
         return store.getFormatVersionEnum().isAtLeast(FormatVersion.INCARNATION)
                ? store.getIncarnation()
                : 0;

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
@@ -546,8 +546,9 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
                     // There isn't a more efficient way to get partition info by id than loading it all, and
                     // if you can't load it all and one partition's lucene index in a single transaction,
                     // you won't be able to repartition, so we always provide all the partition info.
-                    if (request.getPartitionId() != null) {
-                        infoStream = infoStream.filter(info -> info.getId() == request.getPartitionId());
+                    final Integer partitionId = request.getPartitionId();
+                    if (partitionId != null) {
+                        infoStream = infoStream.filter(info -> info.getId() == partitionId);
                     }
                     final List<CompletableFuture<Map.Entry<Integer, LuceneMetadataInfo.LuceneInfo>>> luceneInfos =
                             infoStream.map(partitionInfo ->

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainer.java
@@ -122,7 +122,7 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
     }
 
     @Override
-    public RecordCursor<IndexEntry> scan(final IndexScanType scanType, final TupleRange range, @Nullable final byte[] continuation, final ScanProperties scanProperties) {
+    public RecordCursor<IndexEntry> scan(final IndexScanType scanType, final TupleRange range, final byte @Nullable [] continuation, final ScanProperties scanProperties) {
         throw new RecordCoreException("unsupported scan type for Lucene index: " + scanType);
     }
 
@@ -136,7 +136,7 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
      */
     @Override
     @SuppressWarnings("PMD.CloseResource")
-    public RecordCursor<IndexEntry> scan(final IndexScanBounds scanBounds, @Nullable final byte[] continuation, final ScanProperties scanProperties) {
+    public RecordCursor<IndexEntry> scan(final IndexScanBounds scanBounds, final byte @Nullable [] continuation, final ScanProperties scanProperties) {
         final IndexScanType scanType = scanBounds.getScanType();
         LOG.trace("scan scanType={}", scanType);
 
@@ -152,7 +152,7 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
 
             return new LuceneRecordCursor(executor, state.context.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_EXECUTOR_SERVICE),
                     partitioner,
-                    state.context.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_INDEX_CURSOR_PAGE_SIZE),
+                    Objects.requireNonNull(state.context.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_INDEX_CURSOR_PAGE_SIZE)),
                     scanProperties, state, scanQuery.getQuery(), scanQuery.getSort(), continuation,
                     scanQuery.getGroupKey(), partitionInfo, scanQuery.getLuceneQueryHighlightParameters(), scanQuery.getTermMap(),
                     scanQuery.getStoredFields(), scanQuery.getStoredFieldTypes(), directoryManager.getAnalyzerSelector(), autoCompleteAnalyzerSelector);
@@ -182,7 +182,7 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
         }
     }
 
-    <M extends Message> void writeDocumentBypassQueue(final FDBIndexableRecord<M> newRecord, final Map.Entry<Tuple, List<LuceneDocumentFromRecord.DocumentField>> entry, final Integer partitionId) {
+    <M extends Message> void writeDocumentBypassQueue(final FDBIndexableRecord<M> newRecord, final Map.Entry<Tuple, List<LuceneDocumentFromRecord.DocumentField>> entry, @Nullable final Integer partitionId) {
         try {
             writeDocumentBypassQueue(entry.getKey(), partitionId, newRecord.getPrimaryKey(), entry.getValue());
         } catch (IOException e) {
@@ -191,7 +191,7 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
     }
 
     public void writeDocumentBypassQueue(Tuple groupingKey,
-                                         Integer partitionId,
+                                         @Nullable Integer partitionId,
                                          Tuple primaryKey,
                                          List<LuceneDocumentFromRecord.DocumentField> fields) throws IOException {
         final long startTime = System.nanoTime();
@@ -302,7 +302,7 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
                 () -> runner.runAsync(
                         context -> context.instrument(LuceneEvents.Events.LUCENE_REBALANCE_PARTITION_TRANSACTION,
                                 storeBuilder.setContext(context).openAsync().thenCompose(store ->
-                                        getPartitioner(state.index, store).rebalancePartitions(continuation.get(), repartitionDocumentCount, repartitioningLogMessages)
+                                        getPartitioner(state.index, store).rebalancePartitions(Objects.requireNonNull(continuation.get()), repartitionDocumentCount, repartitioningLogMessages)
                                                 .thenApply(newContinuation -> {
                                                     if (newContinuation.isEnd() || maxIterations.decrementAndGet() == 0) {
                                                         mergeControl.setRepartitionCapped(!newContinuation.isEnd());
@@ -353,7 +353,7 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
                 .thenCompose(ignored ->
                     // update new
                     AsyncUtil.whenAll(newRecordFields.entrySet().stream()
-                        .map(entry -> updateRecord(newRecord, destinationPartitionIdHint, entry))
+                        .map(entry -> updateRecord(Objects.requireNonNull(newRecord), destinationPartitionIdHint, entry))
                         .collect(Collectors.toList())));
     }
 
@@ -365,7 +365,7 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
      */
     private <M extends Message> CompletableFuture<Void> updateRecord(
             final FDBIndexableRecord<M> newRecord,
-            final Integer destinationPartitionIdHint,
+            @Nullable final Integer destinationPartitionIdHint,
             final Map.Entry<Tuple, List<LuceneDocumentFromRecord.DocumentField>> entry) {
         return tryDeleteInWriteOnlyMode(Objects.requireNonNull(newRecord), entry.getKey()).thenCompose(countDeleted ->
                 partitioner.addToAndSavePartitionMetadata(newRecord, entry.getKey(), destinationPartitionIdHint)
@@ -373,7 +373,7 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
     }
 
     @Nullable
-    public <M extends Message> FDBIndexableRecord<M> maybeFilterRecord(FDBIndexableRecord<M> rec) {
+    public <M extends Message> FDBIndexableRecord<M> maybeFilterRecord(@Nullable FDBIndexableRecord<M> rec) {
         if (rec != null) {
             final IndexMaintenanceFilter.IndexValues filterType = IndexMaintenanceUtils.getFilterTypeForRecord(state, rec);
             if (filterType == IndexMaintenanceFilter.IndexValues.NONE) {
@@ -451,7 +451,7 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
     }
 
     @Override
-    public RecordCursor<InvalidIndexEntry> validateEntries(@Nullable byte[] continuation, @Nullable ScanProperties scanProperties) {
+    public RecordCursor<InvalidIndexEntry> validateEntries(byte @Nullable [] continuation, @Nullable ScanProperties scanProperties) {
         LOG.trace("validateEntries");
         return RecordCursor.empty(executor);
     }
@@ -563,7 +563,7 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
 
 
     @SuppressWarnings("PMD.CloseResource") // the indexReader and directory are closed by the directoryManager
-    private CompletableFuture<LuceneMetadataInfo.LuceneInfo> getLuceneInfo(final Tuple groupingKey, final Integer partitionId) {
+    private CompletableFuture<LuceneMetadataInfo.LuceneInfo> getLuceneInfo(final Tuple groupingKey, @Nullable final Integer partitionId) {
         try {
             try (IndexReader indexReader = directoryManager.getIndexReader(groupingKey, partitionId)) {
                 final FDBDirectory directory = getDirectory(groupingKey, partitionId);
@@ -613,7 +613,7 @@ public class LuceneIndexMaintainer extends StandardIndexMaintainer {
     }
 
     @SuppressWarnings("PMD.CloseResource")
-    private boolean shouldUseQueue(Tuple groupingKey, Integer partitionId) {
+    private boolean shouldUseQueue(Tuple groupingKey, @Nullable Integer partitionId) {
         FDBDirectory directory = directoryManager.getDirectory(groupingKey, partitionId);
         return directory.shouldUseQueue();
     }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainerFactory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainerFactory.java
@@ -29,7 +29,6 @@ import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerFactor
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerState;
 import com.google.auto.service.AutoService;
 
-import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.List;
 
@@ -41,7 +40,6 @@ import java.util.List;
 @API(API.Status.EXPERIMENTAL)
 public class LuceneIndexMaintainerFactory implements IndexMaintainerFactory {
 
-    @Nonnull
     private static final List<String> TYPES = Collections.singletonList(LuceneIndexTypes.LUCENE);
     private static final IndexGeneralAttributes GENERAL_ATTRIBUTES = new IndexGeneralAttributes(false);
 
@@ -50,21 +48,18 @@ public class LuceneIndexMaintainerFactory implements IndexMaintainerFactory {
         return TYPES;
     }
 
-    @Nonnull
     @Override
-    public IndexValidator getIndexValidator(@Nonnull Index index) {
+    public IndexValidator getIndexValidator(Index index) {
         return new LuceneIndexValidator(index);
     }
 
     @Override
-    @Nonnull
-    public IndexMaintainer getIndexMaintainer(@Nonnull final IndexMaintainerState state) {
+    public IndexMaintainer getIndexMaintainer(final IndexMaintainerState state) {
         return new LuceneIndexMaintainer(state, state.context.getExecutor());
     }
 
-    @Nonnull
     @Override
-    public IndexGeneralAttributes getIndexGeneralAttributes(@Nonnull final Index index) {
+    public IndexGeneralAttributes getIndexGeneralAttributes(final Index index) {
         return GENERAL_ATTRIBUTES;
     }
 }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainerHelper.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainerHelper.java
@@ -49,8 +49,7 @@ import org.apache.lucene.util.NumericUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.EnumMap;
@@ -208,8 +207,7 @@ public final class LuceneIndexMaintainerHelper {
         newWriter.addDocument(document);
     }
 
-    @Nonnull
-    private static Map<IndexOptions, List<LuceneDocumentFromRecord.DocumentField>> getIndexOptionsToFieldsMap(@Nonnull List<LuceneDocumentFromRecord.DocumentField> fields) {
+    private static Map<IndexOptions, List<LuceneDocumentFromRecord.DocumentField>> getIndexOptionsToFieldsMap(List<LuceneDocumentFromRecord.DocumentField> fields) {
         final Map<IndexOptions, List<LuceneDocumentFromRecord.DocumentField>> map = new EnumMap<>(IndexOptions.class);
         fields.forEach(f -> {
             final IndexOptions indexOptions = getIndexOptions((String) Objects.requireNonNullElse(f.getConfig(LuceneFunctionNames.LUCENE_AUTO_COMPLETE_FIELD_INDEX_OPTIONS),
@@ -293,7 +291,7 @@ public final class LuceneIndexMaintainerHelper {
         return ft;
     }
 
-    private static IndexOptions getIndexOptions(@Nonnull String value) {
+    private static IndexOptions getIndexOptions(String value) {
         try {
             return IndexOptions.valueOf(value);
         } catch (IllegalArgumentException ex) {

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainerHelper.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintainerHelper.java
@@ -22,6 +22,7 @@ package com.apple.foundationdb.record.lucene;
 
 import com.apple.foundationdb.record.RecordCoreArgumentException;
 import com.apple.foundationdb.record.logging.KeyValueLogMessage;
+import com.apple.foundationdb.record.lucene.LucenePrimaryKeySegmentIndex.DocumentIndexEntry;
 import com.apple.foundationdb.record.lucene.directory.FDBDirectoryManager;
 import com.apple.foundationdb.record.lucene.idformat.LuceneIndexKeySerializer;
 import com.apple.foundationdb.record.lucene.idformat.RecordCoreFormatException;
@@ -69,7 +70,7 @@ public final class LuceneIndexMaintainerHelper {
                                      FDBDirectoryManager directoryManager,
                                      Index index,
                                      Tuple groupingKey,
-                                     Integer partitionId,
+                                     @Nullable Integer partitionId,
                                      Tuple primaryKey,
                                      boolean isWriteOnlyMode) throws IOException {
         final long startTime = System.nanoTime();
@@ -77,7 +78,7 @@ public final class LuceneIndexMaintainerHelper {
         @Nullable final LucenePrimaryKeySegmentIndex segmentIndex = directoryManager.getDirectory(groupingKey, partitionId).getPrimaryKeySegmentIndex();
 
         if (segmentIndex != null) {
-            final LucenePrimaryKeySegmentIndex.DocumentIndexEntry documentIndexEntry = getDocumentIndexEntryWithRetry(directoryManager, segmentIndex, groupingKey, partitionId, primaryKey);
+            final DocumentIndexEntry documentIndexEntry = getDocumentIndexEntryWithRetry(directoryManager, segmentIndex, groupingKey, partitionId, primaryKey);
             if (documentIndexEntry != null) {
                 context.ensureActive().clear(documentIndexEntry.entryKey); // TODO: Only if valid?
                 long valid = indexWriter.tryDeleteDocument(documentIndexEntry.indexReader, documentIndexEntry.docId);
@@ -158,9 +159,10 @@ public final class LuceneIndexMaintainerHelper {
      * @throws IOException in case of error
      */
     @SuppressWarnings("PMD.CloseResource")
-    private static LucenePrimaryKeySegmentIndex.DocumentIndexEntry getDocumentIndexEntryWithRetry(FDBDirectoryManager directoryManager, LucenePrimaryKeySegmentIndex segmentIndex, final Tuple groupingKey, final Integer partitionId, final Tuple primaryKey) throws IOException {
+    @Nullable
+    private static DocumentIndexEntry getDocumentIndexEntryWithRetry(FDBDirectoryManager directoryManager, LucenePrimaryKeySegmentIndex segmentIndex, final Tuple groupingKey, @Nullable final Integer partitionId, final Tuple primaryKey) throws IOException {
         DirectoryReader directoryReader = directoryManager.getWriterReader(groupingKey, partitionId, false);
-        LucenePrimaryKeySegmentIndex.DocumentIndexEntry documentIndexEntry = segmentIndex.findDocument(directoryReader, primaryKey);
+        DocumentIndexEntry documentIndexEntry = segmentIndex.findDocument(directoryReader, primaryKey);
         if (documentIndexEntry != null) {
             return documentIndexEntry;
         } else {
@@ -240,19 +242,22 @@ public final class LuceneIndexMaintainerHelper {
                 storedField = null;
                 break;
             case INT:
-                luceneField = new IntPoint(fieldName, (Integer)value);
-                sortedField = field.isSorted() ? new NumericDocValuesField(fieldName, (Integer)value) : null;
-                storedField = field.isStored() ? new StoredField(fieldName, (Integer)value) : null;
+                final Integer intValue = Objects.requireNonNull((Integer)value, "INT field value must not be null");
+                luceneField = new IntPoint(fieldName, intValue);
+                sortedField = field.isSorted() ? new NumericDocValuesField(fieldName, intValue) : null;
+                storedField = field.isStored() ? new StoredField(fieldName, intValue) : null;
                 break;
             case LONG:
-                luceneField = new LongPoint(fieldName, (Long)value);
-                sortedField = field.isSorted() ? new NumericDocValuesField(fieldName, (Long)value) : null;
-                storedField = field.isStored() ? new StoredField(fieldName, (Long)value) : null;
+                final Long longValue = Objects.requireNonNull((Long)value, "LONG field value must not be null");
+                luceneField = new LongPoint(fieldName, longValue);
+                sortedField = field.isSorted() ? new NumericDocValuesField(fieldName, longValue) : null;
+                storedField = field.isStored() ? new StoredField(fieldName, longValue) : null;
                 break;
             case DOUBLE:
-                luceneField = new DoublePoint(fieldName, (Double)value);
-                sortedField = field.isSorted() ? new NumericDocValuesField(fieldName, NumericUtils.doubleToSortableLong((Double)value)) : null;
-                storedField = field.isStored() ? new StoredField(fieldName, (Double)value) : null;
+                final Double doubleValue = Objects.requireNonNull((Double)value, "DOUBLE field value must not be null");
+                luceneField = new DoublePoint(fieldName, doubleValue);
+                sortedField = field.isSorted() ? new NumericDocValuesField(fieldName, NumericUtils.doubleToSortableLong(doubleValue)) : null;
+                storedField = field.isStored() ? new StoredField(fieldName, doubleValue) : null;
                 break;
             case BOOLEAN:
                 byte[] bytes = Boolean.TRUE.equals(value) ? BooleanPointsConfig.TRUE_BYTES : BooleanPointsConfig.FALSE_BYTES;

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexOptions.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexOptions.java
@@ -23,7 +23,6 @@ package com.apple.foundationdb.record.lucene;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.RecordCoreException;
 
-import javax.annotation.Nonnull;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -135,7 +134,7 @@ public class LuceneIndexOptions {
      * @param optionValue the raw string for option's value
      * @return the map
      */
-    public static Map<String, String> parseKeyValuePairOptionValue(@Nonnull String optionValue) {
+    public static Map<String, String> parseKeyValuePairOptionValue(String optionValue) {
         final String[] elements = optionValue.strip().split(LuceneIndexOptions.DELIMITER_BETWEEN_ELEMENTS);
         final Map<String, String> map = new HashMap<>();
         for (String element : elements) {
@@ -152,7 +151,7 @@ public class LuceneIndexOptions {
      * @param optionValue the raw string for option's value
      * @return map
      */
-    public static Set<String> parseMultipleElementsOptionValue(@Nonnull String optionValue) {
+    public static Set<String> parseMultipleElementsOptionValue(String optionValue) {
         final String[] elements = optionValue.strip().split(LuceneIndexOptions.DELIMITER_BETWEEN_ELEMENTS);
         final Set<String> list = new HashSet<>();
         for (String fieldName : elements) {
@@ -166,7 +165,7 @@ public class LuceneIndexOptions {
      * @param optionValue the raw string for option's value
      * @param exceptionToThrow the exception to throw if it is invalid
      */
-    public static void validateKeyValuePairOptionValue(@Nonnull String optionValue, @Nonnull RecordCoreException exceptionToThrow) {
+    public static void validateKeyValuePairOptionValue(String optionValue, RecordCoreException exceptionToThrow) {
         optionValue = optionValue.strip();
         if (optionValue.startsWith(LuceneIndexOptions.DELIMITER_BETWEEN_ELEMENTS) || optionValue.endsWith(LuceneIndexOptions.DELIMITER_BETWEEN_ELEMENTS)) {
             throw exceptionToThrow;
@@ -188,7 +187,7 @@ public class LuceneIndexOptions {
      * @param optionValue the raw string for option's value
      * @param exceptionToThrow the exception to throw if it is invalid
      */
-    public static void validateMultipleElementsOptionValue(@Nonnull String optionValue, @Nonnull RecordCoreException exceptionToThrow) {
+    public static void validateMultipleElementsOptionValue(String optionValue, RecordCoreException exceptionToThrow) {
         optionValue = optionValue.strip();
         if (optionValue.startsWith(LuceneIndexOptions.DELIMITER_BETWEEN_ELEMENTS)
                 || optionValue.endsWith(LuceneIndexOptions.DELIMITER_BETWEEN_ELEMENTS)

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexQueryPlan.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexQueryPlan.java
@@ -48,8 +48,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.protobuf.Message;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -65,8 +64,8 @@ public class LuceneIndexQueryPlan extends RecordQueryIndexPlan implements PlanWi
     @Nullable
     private final List<KeyExpression> storedFields;
 
-    protected LuceneIndexQueryPlan(@Nonnull final PlanSerializationContext serializationContext,
-                                   @Nonnull final PLuceneIndexQueryPlan luceneIndexQueryPlanProto) {
+    protected LuceneIndexQueryPlan(final PlanSerializationContext serializationContext,
+                                   final PLuceneIndexQueryPlan luceneIndexQueryPlanProto) {
         super(serializationContext, Objects.requireNonNull(luceneIndexQueryPlanProto.getSuper()));
         this.planOrderingKey = null; // TODO
         Verify.verify(luceneIndexQueryPlanProto.hasHasStoredFields());
@@ -80,8 +79,8 @@ public class LuceneIndexQueryPlan extends RecordQueryIndexPlan implements PlanWi
         }
     }
 
-    protected LuceneIndexQueryPlan(@Nonnull String indexName, @Nonnull LuceneScanParameters scanParameters,
-                                   @Nonnull FetchIndexRecords fetchIndexRecords, boolean reverse,
+    protected LuceneIndexQueryPlan(String indexName, LuceneScanParameters scanParameters,
+                                   FetchIndexRecords fetchIndexRecords, boolean reverse,
                                    @Nullable PlanOrderingKey planOrderingKey, @Nullable List<KeyExpression> storedFields) {
         super(indexName, null, scanParameters, IndexFetchMethod.SCAN_AND_FETCH, fetchIndexRecords, reverse, false);
         this.planOrderingKey = planOrderingKey;
@@ -120,8 +119,7 @@ public class LuceneIndexQueryPlan extends RecordQueryIndexPlan implements PlanWi
         return resultBuilder.build();
     }
 
-    @Nonnull
-    private Set<Comparisons.Comparison> collectComparisons(@Nonnull final LuceneQueryClause queryClause) {
+    private Set<Comparisons.Comparison> collectComparisons(final LuceneQueryClause queryClause) {
         final var resultBuilder = ImmutableSet.<Comparisons.Comparison>builder();
 
         if (queryClause instanceof LuceneQueryFieldComparisonClause) {
@@ -147,8 +145,8 @@ public class LuceneIndexQueryPlan extends RecordQueryIndexPlan implements PlanWi
 
     @Override
     @SuppressWarnings("PMD.CompareObjectsWithEquals")
-    public void getStoredFields(@Nonnull List<KeyExpression> keyFields, @Nonnull List<KeyExpression> nonStoredFields,
-                                @Nonnull List<KeyExpression> otherFields) {
+    public void getStoredFields(List<KeyExpression> keyFields, List<KeyExpression> nonStoredFields,
+                                List<KeyExpression> otherFields) {
         int i = 0;
         while (i < nonStoredFields.size()) {
             KeyExpression origField = nonStoredFields.get(i);
@@ -178,7 +176,7 @@ public class LuceneIndexQueryPlan extends RecordQueryIndexPlan implements PlanWi
 
     // Unwrap functions that are just annotations.
     @SuppressWarnings("PMD.CompareObjectsWithEquals")
-    private static KeyExpression removeLuceneAnnotations(@Nonnull KeyExpression field) {
+    private static KeyExpression removeLuceneAnnotations(KeyExpression field) {
         if (field instanceof NestingKeyExpression) {
             KeyExpression origChild = ((NestingKeyExpression)field).getChild();
             KeyExpression child = removeLuceneAnnotations(origChild);
@@ -220,17 +218,15 @@ public class LuceneIndexQueryPlan extends RecordQueryIndexPlan implements PlanWi
         return Objects.hash(super.computeHashCodeWithoutChildren(), planOrderingKey, storedFields);
     }
 
-    @Nonnull
     @Override
-    protected RecordQueryIndexPlan withIndexScanParameters(@Nonnull final IndexScanParameters newIndexScanParameters) {
+    protected RecordQueryIndexPlan withIndexScanParameters(final IndexScanParameters newIndexScanParameters) {
         Verify.verify(newIndexScanParameters instanceof LuceneScanParameters);
         Verify.verify(newIndexScanParameters.getScanType().equals(LuceneScanTypes.BY_LUCENE));
         return new LuceneIndexQueryPlan(getIndexName(), (LuceneScanParameters)newIndexScanParameters, getFetchIndexRecords(), reverse, planOrderingKey, storedFields);
     }
 
-    @Nonnull
-    public static LuceneIndexQueryPlan of(@Nonnull final String indexName, @Nonnull final LuceneScanParameters scanParameters,
-                                          @Nonnull final FetchIndexRecords fetchIndexRecords, final boolean reverse,
+    public static LuceneIndexQueryPlan of(final String indexName, final LuceneScanParameters scanParameters,
+                                          final FetchIndexRecords fetchIndexRecords, final boolean reverse,
                                           @Nullable final PlanOrderingKey planOrderingKey, @Nullable final List<KeyExpression> storedFields) {
         if (scanParameters.getScanType().equals(LuceneScanTypes.BY_LUCENE)) {
             return new LuceneIndexQueryPlan(indexName, scanParameters, fetchIndexRecords, reverse, planOrderingKey, storedFields);
@@ -240,7 +236,6 @@ public class LuceneIndexQueryPlan extends RecordQueryIndexPlan implements PlanWi
         throw new RecordCoreException("unknown lucene scan warranted by caller");
     }
 
-    @Nonnull
     @Override
     public ExplainTokensWithPrecedence explain() {
         return ExplainTokensWithPrecedence.of(
@@ -249,14 +244,12 @@ public class LuceneIndexQueryPlan extends RecordQueryIndexPlan implements PlanWi
                         .addOptionalWhitespace().addClosingParen());
     }
 
-    @Nonnull
     @Override
-    public Message toProto(@Nonnull final PlanSerializationContext serializationContext) {
+    public Message toProto(final PlanSerializationContext serializationContext) {
         return toLuceneIndexPlanProto(serializationContext);
     }
 
-    @Nonnull
-    public PLuceneIndexQueryPlan toLuceneIndexPlanProto(@Nonnull final PlanSerializationContext serializationContext) {
+    public PLuceneIndexQueryPlan toLuceneIndexPlanProto(final PlanSerializationContext serializationContext) {
         final PLuceneIndexQueryPlan.Builder builder = PLuceneIndexQueryPlan.newBuilder()
                 .setSuper(toRecordQueryIndexPlanProto(serializationContext));
         builder.setHasStoredFields(storedFields != null);
@@ -269,19 +262,17 @@ public class LuceneIndexQueryPlan extends RecordQueryIndexPlan implements PlanWi
         return builder.build();
     }
 
-    @Nonnull
     @Override
-    public PRecordQueryPlan toRecordQueryPlanProto(@Nonnull final PlanSerializationContext serializationContext) {
+    public PRecordQueryPlan toRecordQueryPlanProto(final PlanSerializationContext serializationContext) {
         return PRecordQueryPlan.newBuilder()
                 .setAdditionalPlans(PlanSerialization.protoObjectToAny(serializationContext,
                         toLuceneIndexPlanProto(serializationContext)))
                 .build();
     }
 
-    @Nonnull
     @SuppressWarnings("unused")
-    public static LuceneIndexQueryPlan fromProto(@Nonnull final PlanSerializationContext serializationContext,
-                                                 @Nonnull final PLuceneIndexQueryPlan luceneIndexQueryPlanProto) {
+    public static LuceneIndexQueryPlan fromProto(final PlanSerializationContext serializationContext,
+                                                 final PLuceneIndexQueryPlan luceneIndexQueryPlanProto) {
         return new LuceneIndexQueryPlan(serializationContext, luceneIndexQueryPlanProto);
     }
 
@@ -290,16 +281,14 @@ public class LuceneIndexQueryPlan extends RecordQueryIndexPlan implements PlanWi
      */
     @AutoService(PlanDeserializer.class)
     public static class Deserializer implements PlanDeserializer<PLuceneIndexQueryPlan, LuceneIndexQueryPlan> {
-        @Nonnull
         @Override
         public Class<PLuceneIndexQueryPlan> getProtoMessageClass() {
             return PLuceneIndexQueryPlan.class;
         }
 
-        @Nonnull
         @Override
-        public LuceneIndexQueryPlan fromProto(@Nonnull final PlanSerializationContext serializationContext,
-                                              @Nonnull final PLuceneIndexQueryPlan luceneIndexQueryPlanProto) {
+        public LuceneIndexQueryPlan fromProto(final PlanSerializationContext serializationContext,
+                                              final PLuceneIndexQueryPlan luceneIndexQueryPlanProto) {
             return LuceneIndexQueryPlan.fromProto(serializationContext, luceneIndexQueryPlanProto);
         }
     }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexScrubbingToolsMissing.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexScrubbingToolsMissing.java
@@ -49,6 +49,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -58,7 +59,9 @@ import java.util.stream.Collectors;
  * have been indexed, but cannot be found in the segment index.
  */
 public class LuceneIndexScrubbingToolsMissing extends ValueIndexScrubbingToolsMissing {
+    @Nullable
     private Collection<RecordType> recordTypes = null;
+    @Nullable
     private Index index;
     private boolean isSynthetic;
 
@@ -99,7 +102,7 @@ public class LuceneIndexScrubbingToolsMissing extends ValueIndexScrubbingToolsMi
         }
 
         final FDBStoredRecord<Message> rec = result.get();
-        if (!shouldHandleItem(rec)) {
+        if (rec == null || !shouldHandleItem(rec)) {
             return CompletableFuture.completedFuture(null);
         }
 
@@ -121,7 +124,7 @@ public class LuceneIndexScrubbingToolsMissing extends ValueIndexScrubbingToolsMi
     }
 
     private boolean shouldHandleItem(FDBStoredRecord<Message> rec) {
-        if (rec == null || !recordTypes.contains(rec.getRecordType())) {
+        if (!Objects.requireNonNull(recordTypes, "presetParams was not called appropriately for this scrubbing tool").contains(rec.getRecordType())) {
             return false;
         }
         return indexMaintainer.maybeFilterRecord(rec) != null;
@@ -131,14 +134,15 @@ public class LuceneIndexScrubbingToolsMissing extends ValueIndexScrubbingToolsMi
     private CompletableFuture<Pair<MissingIndexReason, Tuple>> detectMissingIndexKeys(final FDBRecordStore store, FDBStoredRecord<Message> rec) {
         // Generate synthetic record (if applicable) and return the first detected missing (if any).
         final AtomicReference<Pair<MissingIndexReason, Tuple>> issue = new AtomicReference<>();
+        final Index nonNullIndex = Objects.requireNonNull(index, "presetParams was not called appropriately for this scrubbing tool");
 
         if (!isSynthetic) {
             return checkMissingIndexKey(rec, issue).thenApply(ignore -> issue.get());
         }
         final RecordQueryPlanner queryPlanner =
-                new RecordQueryPlanner(store.getRecordMetaData(), store.getRecordStoreState().withWriteOnlyIndexes(Collections.singletonList(index.getName())));
+                new RecordQueryPlanner(store.getRecordMetaData(), store.getRecordStoreState().withWriteOnlyIndexes(Collections.singletonList(nonNullIndex.getName())));
         final SyntheticRecordPlanner syntheticPlanner = new SyntheticRecordPlanner(store, queryPlanner);
-        SyntheticRecordFromStoredRecordPlan syntheticPlan = syntheticPlanner.forIndex(index);
+        SyntheticRecordFromStoredRecordPlan syntheticPlan = syntheticPlanner.forIndex(nonNullIndex);
         final RecordCursor<FDBSyntheticRecord> recordCursor = syntheticPlan.execute(store, rec);
 
         return AsyncUtil.whenAll(
@@ -152,7 +156,7 @@ public class LuceneIndexScrubbingToolsMissing extends ValueIndexScrubbingToolsMi
     private CompletableFuture<Void> checkMissingIndexKey(FDBIndexableRecord<Message> rec,
                                                          AtomicReference<Pair<MissingIndexReason, Tuple>> issue) {
         // Iterate grouping keys (if any) and detect missing index entry (if any)
-        final KeyExpression root = index.getRootExpression();
+        final KeyExpression root = Objects.requireNonNull(index, "presetParams was not called appropriately for this scrubbing tool").getRootExpression();
         final Map<Tuple, List<LuceneDocumentFromRecord.DocumentField>> recordFields = LuceneDocumentFromRecord.getRecordFields(root, rec);
         if (recordFields.isEmpty()) {
             // recordFields should not be an empty map
@@ -189,7 +193,7 @@ public class LuceneIndexScrubbingToolsMissing extends ValueIndexScrubbingToolsMi
     }
 
     @SuppressWarnings("PMD.CloseResource")
-    private boolean isMissingIndexKey(FDBIndexableRecord<Message> rec, Integer partitionId, Tuple groupingKey) {
+    private boolean isMissingIndexKey(FDBIndexableRecord<Message> rec, @Nullable Integer partitionId, Tuple groupingKey) {
         @Nullable final LucenePrimaryKeySegmentIndex segmentIndex = directoryManager.getDirectory(groupingKey, partitionId).getPrimaryKeySegmentIndex();
         if (segmentIndex == null) {
             // Here: internal error, getIndexScrubbingTools should have indicated that scrub missing is not supported.

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexScrubbingToolsMissing.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexScrubbingToolsMissing.java
@@ -95,8 +95,12 @@ public class LuceneIndexScrubbingToolsMissing extends ValueIndexScrubbingToolsMi
     }
 
     @Override
-    @Nullable
-    public CompletableFuture<Issue> handleOneItem(final FDBRecordStore store, final RecordCursorResult<FDBStoredRecord<Message>> result) {
+    // NullAway does not correctly resolve the nested generic nullability of the overridden
+    // ValueIndexScrubbingToolsMissing#handleOneItem (fdb-record-layer-core) across this module
+    // boundary; it reports that method as returning a bare CompletableFuture<Issue>, even though
+    // its actual, correct declaration (like this override) is CompletableFuture<@Nullable Issue>.
+    @SuppressWarnings("NullAway")
+    public CompletableFuture<@Nullable Issue> handleOneItem(final FDBRecordStore store, final RecordCursorResult<FDBStoredRecord<Message>> result) {
         if (recordTypes == null || index == null) {
             throw new IllegalStateException("presetParams was not called appropriately for this scrubbing tool");
         }
@@ -119,8 +123,17 @@ public class LuceneIndexScrubbingToolsMissing extends ValueIndexScrubbingToolsMi
                                     LogMessageKeys.GROUPING_KEY, missingIndexesKeys.getValue(),
                                     LogMessageKeys.REASON, missingIndexesKeys.getKey()),
                             FDBStoreTimer.Counts.INDEX_SCRUBBER_MISSING_ENTRIES,
-                            null);
+                            noRecordToIndex());
                 });
+    }
+
+    // Issue#recordToIndex is documented as nullable ("if non-null, let the indexer index this record"),
+    // but its constructor parameter is not itself annotated @Nullable. The Lucene missing-index scrubber
+    // does not support single-record repair, so this is always null; see the analogous
+    // ValueIndexScrubbingToolsMissing#allowRepairOrNull in fdb-record-layer-core.
+    @SuppressWarnings("NullAway")
+    private static FDBStoredRecord<Message> noRecordToIndex() {
+        return null;
     }
 
     private boolean shouldHandleItem(FDBStoredRecord<Message> rec) {

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexScrubbingToolsMissing.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexScrubbingToolsMissing.java
@@ -43,8 +43,7 @@ import com.apple.foundationdb.tuple.Tuple;
 import com.google.protobuf.Message;
 import org.apache.lucene.index.DirectoryReader;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
@@ -63,14 +62,11 @@ public class LuceneIndexScrubbingToolsMissing extends ValueIndexScrubbingToolsMi
     private Index index;
     private boolean isSynthetic;
 
-    @Nonnull
     private final LucenePartitioner partitioner;
-    @Nonnull
     private final FDBDirectoryManager directoryManager;
-    @Nonnull
     private final LuceneIndexMaintainer indexMaintainer;
 
-    public LuceneIndexScrubbingToolsMissing(@Nonnull LucenePartitioner partitioner, @Nonnull FDBDirectoryManager directoryManager, @Nonnull LuceneIndexMaintainer indexMaintainer) {
+    public LuceneIndexScrubbingToolsMissing(LucenePartitioner partitioner, FDBDirectoryManager directoryManager, LuceneIndexMaintainer indexMaintainer) {
         this.partitioner = partitioner;
         this.directoryManager = directoryManager;
         this.indexMaintainer = indexMaintainer;

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexSpellCheckQueryPlan.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexSpellCheckQueryPlan.java
@@ -44,8 +44,7 @@ import com.google.common.base.Verify;
 import com.google.common.collect.Iterables;
 import com.google.protobuf.Message;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.Function;
@@ -54,20 +53,19 @@ import java.util.function.Function;
  * Lucene query plan that allows to make spell-check suggestions.
  */
 public class LuceneIndexSpellCheckQueryPlan extends LuceneIndexQueryPlan {
-    protected LuceneIndexSpellCheckQueryPlan(@Nonnull final String indexName, @Nonnull final LuceneScanParameters scanParameters,
-                                             @Nonnull final FetchIndexRecords fetchIndexRecords, final boolean reverse,
+    protected LuceneIndexSpellCheckQueryPlan(final String indexName, final LuceneScanParameters scanParameters,
+                                             final FetchIndexRecords fetchIndexRecords, final boolean reverse,
                                              @Nullable final PlanOrderingKey planOrderingKey, @Nullable final List<KeyExpression> storedFields) {
         super(indexName, scanParameters, fetchIndexRecords, reverse, planOrderingKey, storedFields);
     }
 
     @SuppressWarnings("resource")
-    @Nonnull
     @Override
-    public <M extends Message> RecordCursor<FDBQueriedRecord<M>> fetchIndexRecords(@Nonnull final FDBRecordStoreBase<M> store,
-                                                                                   @Nonnull final EvaluationContext evaluationContext,
-                                                                                   @Nonnull final Function<byte[], RecordCursor<IndexEntry>> entryCursorFunction,
+    public <M extends Message> RecordCursor<FDBQueriedRecord<M>> fetchIndexRecords(final FDBRecordStoreBase<M> store,
+                                                                                   final EvaluationContext evaluationContext,
+                                                                                   final Function<byte[], RecordCursor<IndexEntry>> entryCursorFunction,
                                                                                    @Nullable final byte[] continuation,
-                                                                                   @Nonnull final ExecuteProperties executeProperties) {
+                                                                                   final ExecuteProperties executeProperties) {
         final RecordMetaData metaData = store.getRecordMetaData();
         final Index index = metaData.getIndex(indexName);
         final Collection<RecordType> recordTypes = metaData.recordTypesForIndex(index);
@@ -88,15 +86,13 @@ public class LuceneIndexSpellCheckQueryPlan extends LuceneIndexQueryPlan {
         return false;
     }
 
-    @Nonnull
     @Override
-    protected RecordQueryIndexPlan withIndexScanParameters(@Nonnull final IndexScanParameters newIndexScanParameters) {
+    protected RecordQueryIndexPlan withIndexScanParameters(final IndexScanParameters newIndexScanParameters) {
         Verify.verify(newIndexScanParameters instanceof LuceneScanParameters);
         Verify.verify(newIndexScanParameters.getScanType().equals(LuceneScanTypes.BY_LUCENE_SPELL_CHECK));
         return new LuceneIndexSpellCheckQueryPlan(getIndexName(), (LuceneScanParameters)newIndexScanParameters, getFetchIndexRecords(), reverse, getPlanOrderingKey(), getStoredFields());
     }
 
-    @Nonnull
     @Override
     public ExplainTokensWithPrecedence explain() {
         return ExplainTokensWithPrecedence.of(

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexSpellCheckQueryPlan.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexSpellCheckQueryPlan.java
@@ -64,7 +64,7 @@ public class LuceneIndexSpellCheckQueryPlan extends LuceneIndexQueryPlan {
     public <M extends Message> RecordCursor<FDBQueriedRecord<M>> fetchIndexRecords(final FDBRecordStoreBase<M> store,
                                                                                    final EvaluationContext evaluationContext,
                                                                                    final Function<byte[], RecordCursor<IndexEntry>> entryCursorFunction,
-                                                                                   @Nullable final byte[] continuation,
+                                                                                   final byte @Nullable [] continuation,
                                                                                    final ExecuteProperties executeProperties) {
         final RecordMetaData metaData = store.getRecordMetaData();
         final Index index = metaData.getIndex(indexName);
@@ -72,7 +72,11 @@ public class LuceneIndexSpellCheckQueryPlan extends LuceneIndexQueryPlan {
         final IndexScanType scanType = getScanType();
 
         final RecordType recordType = Iterables.getOnlyElement(recordTypes);
-        return entryCursorFunction.apply(continuation)
+        // entryCursorFunction's type is fixed by RecordQueryPlanWithIndex (unannotated core), whose own default
+        // implementation likewise applies a @Nullable continuation to this same Function<byte[], ...> type.
+        @SuppressWarnings("NullAway")
+        final RecordCursor<IndexEntry> entryCursor = entryCursorFunction.apply(continuation);
+        return entryCursor
                 .map(QueryPlanUtils.getCoveringIndexEntryToPartialRecordFunction(store, recordType.getName(), indexName,
                         LuceneIndexKeyValueToPartialRecordUtils.getToPartialRecord(index, recordType, scanType), false));
     }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexSpellCheckQueryPlan.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexSpellCheckQueryPlan.java
@@ -74,7 +74,7 @@ public class LuceneIndexSpellCheckQueryPlan extends LuceneIndexQueryPlan {
         final RecordType recordType = Iterables.getOnlyElement(recordTypes);
         // entryCursorFunction's type is fixed by RecordQueryPlanWithIndex (unannotated core), whose own default
         // implementation likewise applies a @Nullable continuation to this same Function<byte[], ...> type.
-        @SuppressWarnings("NullAway")
+        @SuppressWarnings({"NullAway", "PMD.CloseResource"})
         final RecordCursor<IndexEntry> entryCursor = entryCursorFunction.apply(continuation);
         return entryCursor
                 .map(QueryPlanUtils.getCoveringIndexEntryToPartialRecordFunction(store, recordType.getName(), indexName,

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexValidator.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneIndexValidator.java
@@ -31,7 +31,6 @@ import com.apple.foundationdb.record.metadata.MetaDataValidator;
 import com.apple.foundationdb.record.metadata.RecordType;
 import com.google.common.annotations.VisibleForTesting;
 
-import javax.annotation.Nonnull;
 import java.util.Map;
 
 /**
@@ -39,12 +38,12 @@ import java.util.Map;
  */
 @API(API.Status.EXPERIMENTAL)
 public class LuceneIndexValidator extends IndexValidator {
-    public LuceneIndexValidator(@Nonnull final Index index) {
+    public LuceneIndexValidator(final Index index) {
         super(index);
     }
 
     @Override
-    public void validate(@Nonnull MetaDataValidator metaDataValidator) {
+    public void validate(MetaDataValidator metaDataValidator) {
         super.validate(metaDataValidator);
         validateNotVersion();
         final var recordMetadata = metaDataValidator.getRecordMetaData();
@@ -56,7 +55,7 @@ public class LuceneIndexValidator extends IndexValidator {
     }
 
     @VisibleForTesting
-    public static void validateIndexOptions(@Nonnull Index index, @Nonnull RecordMetaData recordMetaData) {
+    public static void validateIndexOptions(Index index, RecordMetaData recordMetaData) {
         validateAnalyzerNamePerFieldOption(LuceneIndexOptions.LUCENE_ANALYZER_NAME_PER_FIELD_OPTION, index);
         validateAnalyzerNamePerFieldOption(LuceneIndexOptions.AUTO_COMPLETE_ANALYZER_NAME_PER_FIELD_OPTION, index);
         validatePartitionOptions(index);
@@ -66,7 +65,7 @@ public class LuceneIndexValidator extends IndexValidator {
         }
     }
 
-    private static void validatePartitionOptions(@Nonnull Index index) {
+    private static void validatePartitionOptions(Index index) {
         String lowWatermarkOption = index.getOption(LuceneIndexOptions.INDEX_PARTITION_LOW_WATERMARK);
         String highWatermarkOption = index.getOption(LuceneIndexOptions.INDEX_PARTITION_HIGH_WATERMARK);
         Integer highWatermark = null;
@@ -113,7 +112,7 @@ public class LuceneIndexValidator extends IndexValidator {
         }
     }
 
-    private static void validateAnalyzerNamePerFieldOption(@Nonnull String optionKey, @Nonnull Index index) {
+    private static void validateAnalyzerNamePerFieldOption(String optionKey, Index index) {
         String analyzerNamePerFieldOption = index.getOption(optionKey);
         if (analyzerNamePerFieldOption != null) {
             LuceneIndexOptions.validateKeyValuePairOptionValue(analyzerNamePerFieldOption,

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneLoggerInfoStream.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneLoggerInfoStream.java
@@ -24,8 +24,6 @@ import com.apple.foundationdb.record.logging.KeyValueLogMessage;
 import org.apache.lucene.util.InfoStream;
 import org.slf4j.Logger;
 
-import javax.annotation.Nonnull;
-
 /**
  * Record Layer's implementation of {@link InfoStream} that publishes messages as TRACE logs.
  */
@@ -33,7 +31,7 @@ import javax.annotation.Nonnull;
 public class LuceneLoggerInfoStream extends InfoStream {
     private final Logger loggerForStreamOutput;
 
-    public LuceneLoggerInfoStream(@Nonnull Logger loggerForStreamOutput) {
+    public LuceneLoggerInfoStream(Logger loggerForStreamOutput) {
         this.loggerForStreamOutput = loggerForStreamOutput;
     }
 

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneMetadataInfo.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneMetadataInfo.java
@@ -23,8 +23,7 @@ package com.apple.foundationdb.record.lucene;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.provider.foundationdb.IndexOperationResult;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -40,8 +39,8 @@ public class LuceneMetadataInfo extends IndexOperationResult {
     private List<LucenePartitionInfoProto.LucenePartitionInfo> partitionInfo;
     private Map<Integer, LuceneInfo> luceneInfo;
 
-    public LuceneMetadataInfo(@Nonnull final List<LucenePartitionInfoProto.LucenePartitionInfo> partitionInfo,
-                              @Nonnull final Map<Integer, LuceneInfo> luceneInfo) {
+    public LuceneMetadataInfo(final List<LucenePartitionInfoProto.LucenePartitionInfo> partitionInfo,
+                              final Map<Integer, LuceneInfo> luceneInfo) {
         this.partitionInfo = partitionInfo;
         this.luceneInfo = luceneInfo;
     }
@@ -85,13 +84,13 @@ public class LuceneMetadataInfo extends IndexOperationResult {
 
         public LuceneInfo(final int documentCount,
                           final int fieldInfoCount,
-                          @Nonnull final List<LuceneFileInfo> detailedFileInfos) {
+                          final List<LuceneFileInfo> detailedFileInfos) {
             this(documentCount, fieldInfoCount, detailedFileInfos, 0);
         }
 
         public LuceneInfo(final int documentCount,
                           final int fieldInfoCount,
-                          @Nonnull final List<LuceneFileInfo> detailedFileInfos,
+                          final List<LuceneFileInfo> detailedFileInfos,
                           final long pendingWritesQueueSize) {
             this.documentCount = documentCount;
             this.files = detailedFileInfos.stream().map(LuceneFileInfo::getName).collect(Collectors.toList());

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneNotQuery.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneNotQuery.java
@@ -33,7 +33,6 @@ import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.MatchAllDocsQuery;
 
-import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -49,27 +48,25 @@ import java.util.stream.Stream;
  */
 @API(API.Status.UNSTABLE)
 public class LuceneNotQuery extends LuceneBooleanQuery {
-    @Nonnull
     private final List<LuceneQueryClause> negatedChildren;
 
-    public LuceneNotQuery(@Nonnull final LuceneQueryType queryType,
-                          @Nonnull final List<LuceneQueryClause> children,
-                          @Nonnull final List<LuceneQueryClause> negatedChildren) {
+    public LuceneNotQuery(final LuceneQueryType queryType,
+                          final List<LuceneQueryClause> children,
+                          final List<LuceneQueryClause> negatedChildren) {
         super(queryType, children, BooleanClause.Occur.MUST);
         this.negatedChildren = negatedChildren;
     }
 
-    public LuceneNotQuery(@Nonnull final LuceneQueryType queryType, @Nonnull final LuceneQueryClause negatedChild) {
+    public LuceneNotQuery(final LuceneQueryType queryType, final LuceneQueryClause negatedChild) {
         this(queryType, Collections.emptyList(), Collections.singletonList(negatedChild));
     }
 
-    @Nonnull
     protected List<LuceneQueryClause> getNegatedChildren() {
         return negatedChildren;
     }
 
     @Override
-    public BoundQuery bind(@Nonnull FDBRecordStoreBase<?> store, @Nonnull Index index, @Nonnull EvaluationContext context) {
+    public BoundQuery bind(FDBRecordStoreBase<?> store, Index index, EvaluationContext context) {
         BooleanQuery.Builder builder = new BooleanQuery.Builder();
         Map<String, Set<String>> highlightingTermsMap = null;
         if (getChildren().isEmpty()) {
@@ -107,7 +104,7 @@ public class LuceneNotQuery extends LuceneBooleanQuery {
     }
 
     @Override
-    public void getPlannerGraphDetails(@Nonnull ImmutableList.Builder<String> detailsBuilder, @Nonnull ImmutableMap.Builder<String, Attribute> attributeMapBuilder) {
+    public void getPlannerGraphDetails(ImmutableList.Builder<String> detailsBuilder, ImmutableMap.Builder<String, Attribute> attributeMapBuilder) {
         super.getPlannerGraphDetails(detailsBuilder, attributeMapBuilder);
         for (LuceneQueryClause child : negatedChildren) {
             child.getPlannerGraphDetails(detailsBuilder, attributeMapBuilder);
@@ -115,7 +112,7 @@ public class LuceneNotQuery extends LuceneBooleanQuery {
     }
 
     @Override
-    public int planHash(@Nonnull final PlanHashMode mode) {
+    public int planHash(final PlanHashMode mode) {
         return super.planHash(mode) - PlanHashable.iterablePlanHash(mode, negatedChildren);
     }
 

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePartitioner.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePartitioner.java
@@ -77,8 +77,7 @@ import org.apache.lucene.search.SortField;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -91,6 +90,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
+
+import static com.apple.foundationdb.record.lucene.LucenePartitionInfoProto.LucenePartitionInfo;
 
 /**
  * Manage partitioning info for a <b>logical</b>, partitioned lucene index, in which each partition is a separate physical lucene index.
@@ -115,7 +116,7 @@ public class LucenePartitioner {
     private final LuceneRepartitionPlanner repartitionPlanner;
     private final LazyOpener<FDBDirectoryManager> directoryManagerSupplier;
 
-    public LucenePartitioner(@Nonnull IndexMaintainerState state) {
+    public LucenePartitioner(IndexMaintainerState state) {
         this.state = state;
         String partitionFieldName = state.index.getOption(LuceneIndexOptions.INDEX_PARTITION_BY_FIELD_NAME);
         this.partitioningEnabled = partitionFieldName != null;
@@ -180,9 +181,9 @@ public class LucenePartitioner {
      * @return partition id, or <code>null</code> if partitioning isn't enabled
      */
     @Nullable
-    public Integer selectQueryPartitionId(@Nonnull Tuple groupKey) {
+    public Integer selectQueryPartitionId(Tuple groupKey) {
         if (isPartitioningEnabled()) {
-            LucenePartitionInfoProto.LucenePartitionInfo partitionInfo = selectQueryPartition(groupKey, null).startPartition;
+            LucenePartitionInfo partitionInfo = selectQueryPartition(groupKey, null).startPartition;
             if (partitionInfo != null) {
                 return partitionInfo.getId();
             }
@@ -198,7 +199,7 @@ public class LucenePartitioner {
      * @return partition query hint, or <code>null</code> if partitioning isn't enabled or
      * no partitioning metadata exist for the given query
      */
-    public PartitionedQueryHint selectQueryPartition(@Nonnull Tuple groupKey, @Nullable LuceneScanQuery luceneScanQuery) {
+    public PartitionedQueryHint selectQueryPartition(Tuple groupKey, @Nullable LuceneScanQuery luceneScanQuery) {
         return LuceneConcurrency.asyncToSync(WAIT_LOAD_LUCENE_PARTITION_METADATA, selectQueryPartitionAsync(groupKey, luceneScanQuery), state.context);
     }
 
@@ -218,7 +219,7 @@ public class LucenePartitioner {
      * @return partition query hint, or <code>null</code> if partitioning isn't enabled or
      * no partitioning metadata exist for the given query
      */
-    public CompletableFuture<PartitionedQueryHint> selectQueryPartitionAsync(@Nonnull Tuple groupKey, @Nullable LuceneScanQuery luceneScanQuery) {
+    public CompletableFuture<PartitionedQueryHint> selectQueryPartitionAsync(Tuple groupKey, @Nullable LuceneScanQuery luceneScanQuery) {
         if (!isPartitioningEnabled()) {
             return CompletableFuture.completedFuture(new PartitionedQueryHint(true, null));
         }
@@ -232,7 +233,7 @@ public class LucenePartitioner {
         final Comparisons.Type comparisonType = partitionFieldPredicate == null ? null : partitionFieldPredicate.getComparisonType();
 
         if (comparisonType == null) {
-            CompletableFuture<LucenePartitionInfoProto.LucenePartitionInfo> noPredicatePartition = isAscending ?
+            CompletableFuture<LucenePartitionInfo> noPredicatePartition = isAscending ?
                                                                                                    getOldestPartition(groupKey) :
                                                                                                    getNewestPartition(groupKey, state.context, state.indexSubspace);
             return noPredicatePartition.thenApply(partition -> new PartitionedQueryHint(true, partition));
@@ -339,8 +340,7 @@ public class LucenePartitioner {
      * @param reverse reverse scan if <code>true</code>
      * @return future of <code>null</code> or matched partition info
      */
-    @Nonnull
-    private CompletableFuture<LucenePartitionInfoProto.LucenePartitionInfo> scanRange(Range range, boolean reverse) {
+    private CompletableFuture<LucenePartitionInfo> scanRange(Range range, boolean reverse) {
         final AsyncIterable<KeyValue> rangeIterable = state.context.ensureActive().getRange(range, 1, reverse, StreamingMode.WANT_ALL);
         return AsyncUtil.collect(rangeIterable, state.context.getExecutor())
                 .thenApply(targetPartitions -> targetPartitions.isEmpty() ? null : partitionInfoFromKV(targetPartitions.get(0)));
@@ -356,7 +356,7 @@ public class LucenePartitioner {
      * clauses, otherwise the predicate is returned
      */
     @Nullable
-    LuceneComparisonQuery checkQueryForPartitionFieldPredicate(final @Nonnull LuceneScanQuery luceneScanQuery) {
+    LuceneComparisonQuery checkQueryForPartitionFieldPredicate(final LuceneScanQuery luceneScanQuery) {
         Query query = luceneScanQuery.getQuery();
         if (isAPartitionFieldPredicate(query)) {
             return (LuceneComparisonQuery)query;
@@ -396,8 +396,7 @@ public class LucenePartitioner {
      * @param sort sort
      * @return PartitionedSortContext object
      */
-    @Nonnull
-    public PartitionedSortContext isSortedByPartitionField(@Nonnull Sort sort) {
+    public PartitionedSortContext isSortedByPartitionField(Sort sort) {
         boolean sortedByPartitioningKey = false;
         boolean isReverseSort = false;
         SortField[] updatedSortFields = null;
@@ -469,9 +468,8 @@ public class LucenePartitioner {
      * @param <M> message
      * @return partition id or <code>null</code> if partitioning isn't enabled on index
      */
-    @Nonnull
-    public <M extends Message> CompletableFuture<Integer> addToAndSavePartitionMetadata(@Nonnull FDBIndexableRecord<M> newRecord,
-                                                                                        @Nonnull Tuple groupingKey,
+    public <M extends Message> CompletableFuture<Integer> addToAndSavePartitionMetadata(FDBIndexableRecord<M> newRecord,
+                                                                                        Tuple groupingKey,
                                                                                         @Nullable Integer assignedPartitionId) {
         if (!isPartitioningEnabled()) {
             return CompletableFuture.completedFuture(null);
@@ -489,13 +487,12 @@ public class LucenePartitioner {
      * @param assignedPartitionIdOverride assigned partition override, if not null
      * @return assigned partition id
      */
-    @Nonnull
-    private CompletableFuture<Integer> addToAndSavePartitionMetadata(@Nonnull final Tuple groupingKey,
-                                                                     @Nonnull final Tuple partitioningKey,
+    private CompletableFuture<Integer> addToAndSavePartitionMetadata(final Tuple groupingKey,
+                                                                     final Tuple partitioningKey,
                                                                      @Nullable final Integer assignedPartitionIdOverride) {
         return state.context.doWithWriteLock(new LockIdentifier(partitionMetadataSubspace(groupingKey)),
                 () -> {
-                    final CompletableFuture<LucenePartitionInfoProto.LucenePartitionInfo> assignmentFuture;
+                    final CompletableFuture<LucenePartitionInfo> assignmentFuture;
                     if (assignedPartitionIdOverride != null) {
                         assignmentFuture = getPartitionMetaInfoById(assignedPartitionIdOverride, groupingKey);
                     } else {
@@ -503,7 +500,7 @@ public class LucenePartitioner {
                     }
                     return assignmentFuture.thenApply(assignedPartition -> {
                         // assignedPartition is not null, since a new one is created by the previous call if none exist
-                        LucenePartitionInfoProto.LucenePartitionInfo.Builder builder = Objects.requireNonNull(assignedPartition).toBuilder();
+                        LucenePartitionInfo.Builder builder = Objects.requireNonNull(assignedPartition).toBuilder();
                         builder.setCount(assignedPartition.getCount() + 1);
                         if (isOlderThan(partitioningKey, assignedPartition)) {
                             // clear the previous key
@@ -526,16 +523,15 @@ public class LucenePartitioner {
      * @param partitionKey partitioning key
      * @return partition metadata key
      */
-    @Nonnull
-    byte[] partitionMetadataKeyFromPartitioningValue(@Nonnull Tuple groupKey, @Nonnull Tuple partitionKey) {
+    byte[] partitionMetadataKeyFromPartitioningValue(Tuple groupKey, Tuple partitionKey) {
         return state.indexSubspace.pack(partitionMetadataKeyTuple(groupKey, partitionKey));
     }
 
-    Subspace partitionMetadataSubspace(@Nonnull Tuple groupKey) {
+    Subspace partitionMetadataSubspace(Tuple groupKey) {
         return state.indexSubspace.subspace(groupKey.add(PARTITION_META_SUBSPACE));
     }
 
-    private static Tuple partitionMetadataKeyTuple(final @Nonnull Tuple groupKey, @Nonnull Tuple partitionKey) {
+    private static Tuple partitionMetadataKeyTuple(final Tuple groupKey, Tuple partitionKey) {
         return groupKey.add(PARTITION_META_SUBSPACE).addAll(partitionKey);
     }
 
@@ -544,16 +540,15 @@ public class LucenePartitioner {
      *
      * @param builder builder instance
      */
-    void savePartitionMetadata(@Nonnull Tuple groupingKey,
-                               @Nonnull final LucenePartitionInfoProto.LucenePartitionInfo.Builder builder) {
-        LucenePartitionInfoProto.LucenePartitionInfo updatedPartition = builder.build();
+    void savePartitionMetadata(Tuple groupingKey,
+                               final LucenePartitionInfo.Builder builder) {
+        LucenePartitionInfo updatedPartition = builder.build();
         state.context.ensureActive().set(
                 partitionMetadataKeyFromPartitioningValue(groupingKey, getPartitionKey(updatedPartition)),
                 updatedPartition.toByteArray());
     }
 
-    @Nonnull
-    CompletableFuture<LucenePartitionInfoProto.LucenePartitionInfo> findPartitionInfo(@Nonnull Tuple groupingKey, @Nonnull Tuple partitioningKey) {
+    CompletableFuture<LucenePartitionInfo> findPartitionInfo(Tuple groupingKey, Tuple partitioningKey) {
         Range range = new Range(state.indexSubspace.subspace(groupingKey.add(PARTITION_META_SUBSPACE)).pack(),
                 state.indexSubspace.subspace(groupingKey.add(PARTITION_META_SUBSPACE).addAll(partitioningKey)).pack());
 
@@ -569,15 +564,14 @@ public class LucenePartitioner {
      * @param partitioningKey partitioning key
      * @return partition metadata future
      */
-    @Nonnull
-    private CompletableFuture<LucenePartitionInfoProto.LucenePartitionInfo> getOrCreatePartitionInfo(@Nonnull Tuple groupingKey, @Nonnull Tuple partitioningKey) {
+    private CompletableFuture<LucenePartitionInfo> getOrCreatePartitionInfo(Tuple groupingKey, Tuple partitioningKey) {
         return assignPartitionInternal(groupingKey, partitioningKey, true).thenCompose(assignedPartitionInfo -> {
             // optimization: if assigned partition is full and doc to be added is older than the partition's `from` value,
             // we create a new partition for it, in order to avoid unnecessary re-balancing later.
             if (assignedPartitionInfo.getCount() >= indexPartitionHighWatermark && isOlderThan(partitioningKey, assignedPartitionInfo)) {
                 return getAllPartitionMetaInfo(groupingKey).thenApply(partitionInfos -> {
                     int maxPartitionId = partitionInfos.stream()
-                            .map(LucenePartitionInfoProto.LucenePartitionInfo::getId)
+                            .map(LucenePartitionInfo::getId)
                             .max(Integer::compare)
                             .orElse(0);
                     return newPartitionMetadata(partitioningKey, maxPartitionId + 1);
@@ -596,10 +590,9 @@ public class LucenePartitioner {
      * @param <M> message
      * @return null future if no suitable partition exists, partition info otherwise
      */
-    @Nonnull
-    <M extends Message> CompletableFuture<LucenePartitionInfoProto.LucenePartitionInfo> tryGetPartitionInfo(
-            @Nonnull FDBIndexableRecord<M> record,
-            @Nonnull Tuple groupingKey) {
+    <M extends Message> CompletableFuture<LucenePartitionInfo> tryGetPartitionInfo(
+            FDBIndexableRecord<M> record,
+            Tuple groupingKey) {
         if (!isPartitioningEnabled()) {
             return CompletableFuture.completedFuture(null);
         }
@@ -613,7 +606,7 @@ public class LucenePartitioner {
      * @param amount amount to subtract from the doc count
      * @param partitionId the id of the partition to decrement
      */
-    CompletableFuture<Void> decrementCountAndSave(@Nonnull Tuple groupingKey,
+    CompletableFuture<Void> decrementCountAndSave(Tuple groupingKey,
                                                   int amount, final int partitionId) {
         return state.context.doWithWriteLock(new LockIdentifier(partitionMetadataSubspace(groupingKey)),
                 () -> getPartitionMetaInfoById(partitionId, groupingKey).thenAccept(serialized -> {
@@ -622,7 +615,7 @@ public class LucenePartitioner {
                                 .addLogInfo(LogMessageKeys.INDEX_NAME, state.index.getName())
                                 .addLogInfo(LogMessageKeys.INDEX_SUBSPACE, state.indexSubspace);
                     }
-                    LucenePartitionInfoProto.LucenePartitionInfo.Builder builder = Objects.requireNonNull(serialized).toBuilder();
+                    LucenePartitionInfo.Builder builder = Objects.requireNonNull(serialized).toBuilder();
                     // note that the to/from of the partition do not get updated, since that would require us to know
                     // what the next potential boundary value(s) are. The counts, nonetheless, remain valid.
                     builder.setCount(serialized.getCount() - amount);
@@ -645,9 +638,8 @@ public class LucenePartitioner {
      *                          inserting a document, and <code>false</code> when deleting.
      * @return partition metadata future
      */
-    @Nonnull
-    private CompletableFuture<LucenePartitionInfoProto.LucenePartitionInfo> assignPartitionInternal(@Nonnull Tuple groupingKey,
-                                                                                                    @Nonnull Tuple partitioningKey,
+    private CompletableFuture<LucenePartitionInfo> assignPartitionInternal(Tuple groupingKey,
+                                                                                                    Tuple partitioningKey,
                                                                                                     boolean createIfNotExists) {
 
         final Range range = TupleRange.toRange(
@@ -685,8 +677,7 @@ public class LucenePartitioner {
      * @return long if field is found
      * @throws RecordCoreException if no field of type <code>long</code> with given name is found
      */
-    @Nonnull
-    private <M extends Message> Object getPartitioningFieldValue(@Nonnull FDBIndexableRecord<M> rec) {
+    private <M extends Message> Object getPartitioningFieldValue(FDBIndexableRecord<M> rec) {
         Key.Evaluated evaluatedKey = partitioningKeyExpression.evaluateSingleton(rec);
         if (evaluatedKey.size() == 1) {
             Object value = evaluatedKey.getObject(0);
@@ -706,9 +697,8 @@ public class LucenePartitioner {
      * @param id partition id
      * @return partition metadata instance
      */
-    @Nonnull
-    private LucenePartitionInfoProto.LucenePartitionInfo newPartitionMetadata(@Nonnull final Tuple partitioningKey, int id) {
-        return LucenePartitionInfoProto.LucenePartitionInfo.newBuilder()
+    private LucenePartitionInfo newPartitionMetadata(final Tuple partitioningKey, int id) {
+        return LucenePartitionInfo.newBuilder()
                 .setCount(0)
                 .setTo(ByteString.copyFrom(partitioningKey.pack()))
                 .setFrom(ByteString.copyFrom(partitioningKey.pack()))
@@ -724,9 +714,8 @@ public class LucenePartitioner {
      * @param indexSubspace the index subspace; should generally be {@code state.indexSubspace}
      * @return partition metadata future
      */
-    @Nonnull
-    private static CompletableFuture<LucenePartitionInfoProto.LucenePartitionInfo> getNewestPartition(
-            @Nonnull Tuple groupKey, @Nonnull final FDBRecordContext context, @Nonnull final Subspace indexSubspace) {
+    private static CompletableFuture<LucenePartitionInfo> getNewestPartition(
+            Tuple groupKey, final FDBRecordContext context, final Subspace indexSubspace) {
         return getEdgePartition(groupKey, true, context, indexSubspace);
     }
 
@@ -736,8 +725,7 @@ public class LucenePartitioner {
      * @param groupKey group key
      * @return partition metadata future
      */
-    @Nonnull
-    private CompletableFuture<LucenePartitionInfoProto.LucenePartitionInfo> getOldestPartition(@Nonnull Tuple groupKey) {
+    private CompletableFuture<LucenePartitionInfo> getOldestPartition(Tuple groupKey) {
         return getEdgePartition(groupKey, false, state.context, state.indexSubspace);
     }
 
@@ -750,26 +738,24 @@ public class LucenePartitioner {
      * @param indexSubspace the index subspace; should generally be {@code state.indexSubspace}
      * @return partition metadata future
      */
-    @Nonnull
-    private static CompletableFuture<LucenePartitionInfoProto.LucenePartitionInfo> getEdgePartition(
-            @Nonnull Tuple groupKey, boolean reverse, @Nonnull final FDBRecordContext context,
-            @Nonnull final Subspace indexSubspace) {
+    private static CompletableFuture<LucenePartitionInfo> getEdgePartition(
+            Tuple groupKey, boolean reverse, final FDBRecordContext context,
+            final Subspace indexSubspace) {
         Range range = indexSubspace.subspace(groupKey.add(PARTITION_META_SUBSPACE)).range();
         final AsyncIterable<KeyValue> rangeIterable = context.ensureActive().getRange(range, 1, reverse, StreamingMode.WANT_ALL);
         return AsyncUtil.collect(rangeIterable, context.getExecutor()).thenApply(all -> all.isEmpty() ? null : partitionInfoFromKV(all.get(0)));
     }
 
     /**
-     * helper - parse an instance of {@link LucenePartitionInfoProto.LucenePartitionInfo}
+     * helper - parse an instance of {@link LucenePartitionInfo}
      * from a {@link KeyValue}.
      *
      * @param keyValue encoded key/value
      * @return partition metadata
      */
-    @Nonnull
-    static LucenePartitionInfoProto.LucenePartitionInfo partitionInfoFromKV(@Nonnull final KeyValue keyValue) {
+    static LucenePartitionInfo partitionInfoFromKV(final KeyValue keyValue) {
         try {
-            return LucenePartitionInfoProto.LucenePartitionInfo.parseFrom(keyValue.getValue());
+            return LucenePartitionInfo.parseFrom(keyValue.getValue());
         } catch (InvalidProtocolBufferException e) {
             throw new RecordCoreException(e);
         }
@@ -784,7 +770,6 @@ public class LucenePartitioner {
      * @param logMessages {@link com.apple.foundationdb.record.provider.foundationdb.FDBDatabaseRunner} additional log messages
      * @return a continuation at which to resume rebalancing in another call to {@code rebalancePartitions}
      */
-    @Nonnull
     public CompletableFuture<RecordCursorContinuation> rebalancePartitions(RecordCursorContinuation start, int documentCount, RepartitioningLogMessages logMessages) {
         // This function will iterate the grouping keys
         final KeyExpression rootExpression = state.index.getRootExpression();
@@ -852,8 +837,7 @@ public class LucenePartitioner {
      * @return future count of documents rebalanced in this group. If zero, no more re-balancing needed
      */
     @SuppressWarnings("PMD.AvoidBranchingStatementAsLastInLoop")
-    @Nonnull
-    public CompletableFuture<Integer> processPartitionRebalancing(@Nonnull final Tuple groupingKey,
+    public CompletableFuture<Integer> processPartitionRebalancing(final Tuple groupingKey,
                                                                   int repartitionDocumentCount,
                                                                   RepartitioningLogMessages logMessages) {
         if (repartitionDocumentCount <= 0) {
@@ -883,12 +867,12 @@ public class LucenePartitioner {
     }
 
     private CompletableFuture<Integer> processRebalancing(
-            List<LucenePartitionInfoProto.LucenePartitionInfo> partitionInfos,
+            List<LucenePartitionInfo> partitionInfos,
             Tuple groupingKey,
             int repartitionDocumentCount,
             RepartitioningLogMessages logMessages) {
         for (int i = 0; i < partitionInfos.size(); i++) {
-            LucenePartitionInfoProto.LucenePartitionInfo partitionInfo = partitionInfos.get(i);
+            LucenePartitionInfo partitionInfo = partitionInfos.get(i);
 
             LuceneRepartitionPlanner.RepartitioningContext repartitioningContext =
                     repartitionPlanner.determineRepartitioningAction(groupingKey, partitionInfos, i, repartitionDocumentCount);
@@ -918,8 +902,7 @@ public class LucenePartitioner {
      * @param logMessages log messages
      * @return future count of documents moved
      */
-    @Nonnull
-    private CompletableFuture<Integer> moveDocsFromPartitionThenLog(final @Nonnull LuceneRepartitionPlanner.RepartitioningContext repartitioningContext,
+    private CompletableFuture<Integer> moveDocsFromPartitionThenLog(final LuceneRepartitionPlanner.RepartitioningContext repartitioningContext,
                                                                     RepartitioningLogMessages logMessages) {
         logMessages
                 .setPartitionId(repartitioningContext.sourcePartition.getId())
@@ -935,9 +918,9 @@ public class LucenePartitioner {
     }
 
     private KeyValueLogMessage repartitionLogMessage(final String staticMessage,
-                                                     final @Nonnull Tuple groupingKey,
+                                                     final Tuple groupingKey,
                                                      final int repartitionDocumentCount,
-                                                     final @Nonnull LucenePartitionInfoProto.LucenePartitionInfo partitionInfo) {
+                                                     final LucenePartitionInfo partitionInfo) {
         return KeyValueLogMessage.build(staticMessage,
                 LogMessageKeys.INDEX_SUBSPACE, state.indexSubspace,
                 LuceneLogMessageKeys.GROUP, groupingKey,
@@ -956,9 +939,8 @@ public class LucenePartitioner {
      * @param count count of index entries to return
      * @return cursor over the N (or fewer) newest index entries
      */
-    @Nonnull
-    public LuceneRecordCursor getNewestNDocuments(@Nonnull final LucenePartitionInfoProto.LucenePartitionInfo partitionInfo,
-                                                  @Nonnull final Tuple groupingKey,
+    public LuceneRecordCursor getNewestNDocuments(final LucenePartitionInfo partitionInfo,
+                                                  final Tuple groupingKey,
                                                   int count) {
         return getEdgeNDocuments(partitionInfo, groupingKey, count, true);
     }
@@ -971,16 +953,14 @@ public class LucenePartitioner {
      * @param count count of index entries to return
      * @return cursor over the N (or fewer) oldest index entries
      */
-    @Nonnull
-    public LuceneRecordCursor getOldestNDocuments(@Nonnull final LucenePartitionInfoProto.LucenePartitionInfo partitionInfo,
-                                                  @Nonnull final Tuple groupingKey,
+    public LuceneRecordCursor getOldestNDocuments(final LucenePartitionInfo partitionInfo,
+                                                  final Tuple groupingKey,
                                                   int count) {
         return getEdgeNDocuments(partitionInfo, groupingKey, count, false);
     }
 
-    @Nonnull
-    private LuceneRecordCursor getEdgeNDocuments(@Nonnull final LucenePartitionInfoProto.LucenePartitionInfo partitionInfo,
-                                                 @Nonnull final Tuple groupingKey,
+    private LuceneRecordCursor getEdgeNDocuments(final LucenePartitionInfo partitionInfo,
+                                                 final Tuple groupingKey,
                                                  int count,
                                                  boolean newest) {
         final var fieldInfos = LuceneIndexExpressions.getDocumentFieldDerivations(state.index, state.store.getRecordMetaData());
@@ -1019,8 +999,7 @@ public class LucenePartitioner {
      * @param repartitioningContext context with data required for repartitioning, {@see RepartitionContext}
      * @return A future containing the amount of documents that were moved
      */
-    @Nonnull
-    private CompletableFuture<Integer> moveDocsFromPartition(@Nonnull final LuceneRepartitionPlanner.RepartitioningContext repartitioningContext) {
+    private CompletableFuture<Integer> moveDocsFromPartition(final LuceneRepartitionPlanner.RepartitioningContext repartitioningContext) {
         // sanity check
         if (repartitioningContext.countToMove <= 0) {
             if (LOGGER.isDebugEnabled()) {
@@ -1041,7 +1020,7 @@ public class LucenePartitioner {
                 repartitioningContext.action == LuceneRepartitionPlanner.RepartitioningAction.MERGE_INTO_BOTH ||
                 repartitioningContext.action == LuceneRepartitionPlanner.RepartitioningAction.OVERFLOW;
 
-        final LucenePartitionInfoProto.LucenePartitionInfo partitionInfo = repartitioningContext.sourcePartition;
+        final LucenePartitionInfo partitionInfo = repartitioningContext.sourcePartition;
         final Tuple groupingKey = repartitioningContext.groupingKey;
 
         LuceneRecordCursor cursor = removingOldest ?
@@ -1100,7 +1079,7 @@ public class LucenePartitioner {
                 });
                 timings.deleteNanos = System.nanoTime();
                 // update source partition's meta
-                LucenePartitionInfoProto.LucenePartitionInfo.Builder builder = partitionInfo.toBuilder()
+                LucenePartitionInfo.Builder builder = partitionInfo.toBuilder()
                         .setCount(partitionInfo.getCount() - records.size());
                 if (removingOldest) {
                     builder.setFrom(ByteString.copyFrom(Objects.requireNonNull(newBoundaryPartitionKey).pack()));
@@ -1114,7 +1093,7 @@ public class LucenePartitioner {
 
             // value of the "destination" partition's `from` value
             final Tuple overflowPartitioningKey = toPartitionKey(records.get(0));
-            LucenePartitionInfoProto.LucenePartitionInfo destinationPartition = removingOldest ?
+            LucenePartitionInfo destinationPartition = removingOldest ?
                                                                                 repartitioningContext.olderPartition
                                                                                                :
                                                                                 repartitioningContext.newerPartition;
@@ -1172,8 +1151,7 @@ public class LucenePartitioner {
      * @return 0 in case no operation was performed, 1 if the operation was successful
      */
     @VisibleForTesting
-    @Nonnull
-    int removeEmptyPartition(@Nonnull final LuceneRepartitionPlanner.RepartitioningContext repartitioningContext) {
+    int removeEmptyPartition(final LuceneRepartitionPlanner.RepartitioningContext repartitioningContext) {
         // sanity check
         if (repartitioningContext.countToMove != 0) {
             if (LOGGER.isWarnEnabled()) {
@@ -1213,16 +1191,16 @@ public class LucenePartitioner {
      * @param groupingKey the grouping key for the index
      * @return TRUE if the index is empty, FALSE otherwise
      */
-    private boolean verifyNoDocumentsInPartition(@Nonnull LucenePartitionInfoProto.LucenePartitionInfo partitionInfo, final Tuple groupingKey) throws IOException {
+    private boolean verifyNoDocumentsInPartition(LucenePartitionInfo partitionInfo, final Tuple groupingKey) throws IOException {
         return directoryManagerSupplier.get().getIndexReader(groupingKey, partitionInfo.getId()).numDocs() == 0;
     }
 
-    private void clearEmptyPartition(@Nonnull final LuceneRepartitionPlanner.RepartitioningContext repartitioningContext) {
+    private void clearEmptyPartition(final LuceneRepartitionPlanner.RepartitioningContext repartitioningContext) {
         RepartitionTimings timings = new RepartitionTimings();
         final StoreTimerSnapshot timerSnapshot = getStoreTimerSnapshot();
         timings.startNanos = System.nanoTime();
 
-        final LucenePartitionInfoProto.LucenePartitionInfo partitionInfo = repartitioningContext.sourcePartition;
+        final LucenePartitionInfo partitionInfo = repartitioningContext.sourcePartition;
         final Tuple groupingKey = repartitioningContext.groupingKey;
 
         // reset partition info for deleted partition
@@ -1236,13 +1214,13 @@ public class LucenePartitioner {
 
         if (repartitioningContext.olderPartition != null) {
             // update other partition's metadata (set "to" from deleted partition)
-            LucenePartitionInfoProto.LucenePartitionInfo.Builder builder = repartitioningContext.olderPartition.toBuilder();
+            LucenePartitionInfo.Builder builder = repartitioningContext.olderPartition.toBuilder();
             builder.setTo(partitionInfo.getTo());
             savePartitionMetadata(groupingKey, builder);
         } else {
             // no older partition - need to delete the newer partition data and set a new "from" ("from" is the key)
             state.context.ensureActive().clear(partitionMetadataKeyFromPartitioningValue(groupingKey, getPartitionKey(repartitioningContext.newerPartition)));
-            LucenePartitionInfoProto.LucenePartitionInfo.Builder builder = repartitioningContext.newerPartition.toBuilder();
+            LucenePartitionInfo.Builder builder = repartitioningContext.newerPartition.toBuilder();
             builder.setFrom(partitionInfo.getFrom());
             savePartitionMetadata(groupingKey, builder);
         }
@@ -1271,7 +1249,7 @@ public class LucenePartitioner {
      * @return future list of partition metadata
      */
     @VisibleForTesting
-    public CompletableFuture<List<LucenePartitionInfoProto.LucenePartitionInfo>> getAllPartitionMetaInfo(@Nonnull final Tuple groupingKey) {
+    public CompletableFuture<List<LucenePartitionInfo>> getAllPartitionMetaInfo(final Tuple groupingKey) {
         Range range = state.indexSubspace.subspace(groupingKey.add(PARTITION_META_SUBSPACE)).range();
         final AsyncIterable<KeyValue> rangeIterable = state.context.ensureActive().getRange(range, Integer.MAX_VALUE, true, StreamingMode.WANT_ALL);
         return AsyncUtil.collect(rangeIterable, state.context.getExecutor()).thenApply(all -> all.stream().map(LucenePartitioner::partitionInfoFromKV).collect(Collectors.toList()));
@@ -1284,8 +1262,7 @@ public class LucenePartitioner {
      * @param groupingKey grouping key
      * @return future of: partition info, or null if not found
      */
-    @Nonnull
-    public CompletableFuture<LucenePartitionInfoProto.LucenePartitionInfo> getPartitionMetaInfoById(int partitionId, @Nonnull final Tuple groupingKey) {
+    public CompletableFuture<LucenePartitionInfo> getPartitionMetaInfoById(int partitionId, final Tuple groupingKey) {
         return getAllPartitionMetaInfo(groupingKey)
                 .thenApply(partitionInfos -> partitionInfos.stream()
                         .filter(partition -> partition.getId() == partitionId)
@@ -1302,12 +1279,11 @@ public class LucenePartitioner {
      * @param indexSubspace index subspace
      * @return partition future
      */
-    @Nonnull
-    public static CompletableFuture<LucenePartitionInfoProto.LucenePartitionInfo> getNextOlderPartitionInfo(
-            @Nonnull final FDBRecordContext context,
-            @Nonnull final Tuple groupingKey,
+    public static CompletableFuture<LucenePartitionInfo> getNextOlderPartitionInfo(
+            final FDBRecordContext context,
+            final Tuple groupingKey,
             @Nullable final Tuple previousKey,
-            @Nonnull final Subspace indexSubspace) {
+            final Subspace indexSubspace) {
         if (previousKey == null) {
             return getNewestPartition(groupingKey, context, indexSubspace);
         } else {
@@ -1331,12 +1307,11 @@ public class LucenePartitioner {
      * @param indexSubspace index subspace
      * @return partition future
      */
-    @Nonnull
-    public static CompletableFuture<LucenePartitionInfoProto.LucenePartitionInfo> getNextNewerPartitionInfo(
-            @Nonnull final FDBRecordContext context,
-            @Nonnull final Tuple groupingKey,
+    public static CompletableFuture<LucenePartitionInfo> getNextNewerPartitionInfo(
+            final FDBRecordContext context,
+            final Tuple groupingKey,
             @Nullable final Tuple currentPartitionKey,
-            @Nonnull final Subspace indexSubspace) {
+            final Subspace indexSubspace) {
         if (currentPartitionKey == null) {
             return getNewestPartition(groupingKey, context, indexSubspace);
         }
@@ -1354,8 +1329,7 @@ public class LucenePartitioner {
      * @param <M> record message
      * @return partitioning key tuple
      */
-    @Nonnull
-    private <M extends Message> Tuple toPartitionKey(@Nonnull final FDBIndexableRecord<M> record) {
+    private <M extends Message> Tuple toPartitionKey(final FDBIndexableRecord<M> record) {
         return toPartitionKey(getPartitioningFieldValue(record), record.getPrimaryKey());
     }
 
@@ -1367,9 +1341,8 @@ public class LucenePartitioner {
      * @param primaryKey record primary key
      * @return partitioning key value tuple
      */
-    @Nonnull
-    public Tuple toPartitionKey(@Nonnull Object partitioningFieldValue,
-                                @Nonnull final Tuple primaryKey) {
+    public Tuple toPartitionKey(Object partitioningFieldValue,
+                                final Tuple primaryKey) {
         return Tuple.from(partitioningFieldValue).addAll(primaryKey);
     }
 
@@ -1381,11 +1354,11 @@ public class LucenePartitioner {
      * @param partitionInfo partitioning meta data
      * @return true if key is "older" than partitionInfo
      */
-    public static boolean isOlderThan(@Nonnull final Tuple key, @Nonnull final LucenePartitionInfoProto.LucenePartitionInfo partitionInfo) {
+    public static boolean isOlderThan(final Tuple key, final LucenePartitionInfo partitionInfo) {
         return key.compareTo(Tuple.fromBytes(partitionInfo.getFrom().toByteArray())) < 0;
     }
 
-    public static boolean isPrefixOlderThanPartition(@Nonnull final Tuple prefix, @Nonnull LucenePartitionInfoProto.LucenePartitionInfo partitionInfo) {
+    public static boolean isPrefixOlderThanPartition(final Tuple prefix, LucenePartitionInfo partitionInfo) {
         return ByteArrayUtil.compareUnsigned(getPartitionKey(partitionInfo).pack(), ByteArrayUtil.strinc(prefix.pack())) >= 0;
     }
 
@@ -1397,7 +1370,7 @@ public class LucenePartitioner {
      * @param partitionInfo partitioning meta data
      * @return true if key is "newer" than partitionInfo
      */
-    public static boolean isNewerThan(@Nonnull final Tuple key, @Nonnull final LucenePartitionInfoProto.LucenePartitionInfo partitionInfo) {
+    public static boolean isNewerThan(final Tuple key, final LucenePartitionInfo partitionInfo) {
         return key.compareTo(Tuple.fromBytes(partitionInfo.getTo().toByteArray())) > 0;
     }
 
@@ -1407,8 +1380,7 @@ public class LucenePartitioner {
      * @param partitionInfo partition metadata
      * @return partition key tuple
      */
-    @Nonnull
-    public static Tuple getPartitionKey(@Nonnull final LucenePartitionInfoProto.LucenePartitionInfo partitionInfo) {
+    public static Tuple getPartitionKey(final LucenePartitionInfo partitionInfo) {
         return Tuple.fromBytes(partitionInfo.getFrom().toByteArray());
     }
 
@@ -1418,8 +1390,7 @@ public class LucenePartitioner {
      * @param partitionInfo partition metadata
      * @return to tuple
      */
-    @Nonnull
-    public static Tuple getToTuple(@Nonnull final LucenePartitionInfoProto.LucenePartitionInfo partitionInfo) {
+    public static Tuple getToTuple(final LucenePartitionInfo partitionInfo) {
         return Tuple.fromBytes(partitionInfo.getTo().toByteArray());
     }
 
@@ -1461,14 +1432,14 @@ public class LucenePartitioner {
          * predicate that cannot be satisfied from any existing partition.
          */
         @Nullable
-        final LucenePartitionInfoProto.LucenePartitionInfo startPartition;
+        final LucenePartitionInfo startPartition;
         /**
          * <code>true</code> if the query <i>can</i> have matches in the given
          * starting partition (but doesn't necessarily have to).
          */
         final boolean canHaveMatches;
 
-        PartitionedQueryHint(boolean canHaveMatches, LucenePartitionInfoProto.LucenePartitionInfo startPartition) {
+        PartitionedQueryHint(boolean canHaveMatches, LucenePartitionInfo startPartition) {
             this.canHaveMatches = canHaveMatches;
             this.startPartition = startPartition;
         }
@@ -1489,12 +1460,11 @@ public class LucenePartitioner {
      * @param currentPartitionPosition current partition's position in the list
      * @return pair of left and right neighbors
      */
-    @Nonnull
-    public static Pair<LucenePartitionInfoProto.LucenePartitionInfo, LucenePartitionInfoProto.LucenePartitionInfo> getPartitionNeighbors(
-            @Nonnull final List<LucenePartitionInfoProto.LucenePartitionInfo> allPartitions,
+    public static Pair<LucenePartitionInfo, LucenePartitionInfo> getPartitionNeighbors(
+            final List<LucenePartitionInfo> allPartitions,
             int currentPartitionPosition) {
-        LucenePartitionInfoProto.LucenePartitionInfo leftPartition = currentPartitionPosition == 0 ? null : allPartitions.get(currentPartitionPosition - 1);
-        LucenePartitionInfoProto.LucenePartitionInfo rightPartition = currentPartitionPosition == allPartitions.size() - 1 ? null : allPartitions.get(currentPartitionPosition + 1);
+        LucenePartitionInfo leftPartition = currentPartitionPosition == 0 ? null : allPartitions.get(currentPartitionPosition - 1);
+        LucenePartitionInfo rightPartition = currentPartitionPosition == allPartitions.size() - 1 ? null : allPartitions.get(currentPartitionPosition + 1);
         return Pair.of(leftPartition, rightPartition);
     }
 

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePartitioner.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePartitioner.java
@@ -109,10 +109,10 @@ public class LucenePartitioner {
     public static final int PARTITION_DATA_SUBSPACE = 1;
     private final IndexMaintainerState state;
     private final boolean partitioningEnabled;
-    private final String partitionFieldNameInLucene;
+    private final @Nullable String partitionFieldNameInLucene;
     private final int indexPartitionHighWatermark;
     private final int indexPartitionLowWatermark;
-    private final KeyExpression partitioningKeyExpression;
+    private final @Nullable KeyExpression partitioningKeyExpression;
     private final LuceneRepartitionPlanner repartitionPlanner;
     private final LazyOpener<FDBDirectoryManager> directoryManagerSupplier;
 
@@ -120,7 +120,7 @@ public class LucenePartitioner {
         this.state = state;
         String partitionFieldName = state.index.getOption(LuceneIndexOptions.INDEX_PARTITION_BY_FIELD_NAME);
         this.partitioningEnabled = partitionFieldName != null;
-        if (partitioningEnabled && (partitionFieldName.isEmpty() || partitionFieldName.isBlank())) {
+        if (partitionFieldName != null && (partitionFieldName.isEmpty() || partitionFieldName.isBlank())) {
             throw new RecordCoreArgumentException("Invalid partition field name", LogMessageKeys.FIELD_NAME, partitionFieldName);
         }
         // partition field name in lucene, when nested, has `_` in place of `.`
@@ -200,7 +200,10 @@ public class LucenePartitioner {
      * no partitioning metadata exist for the given query
      */
     public PartitionedQueryHint selectQueryPartition(Tuple groupKey, @Nullable LuceneScanQuery luceneScanQuery) {
-        return LuceneConcurrency.asyncToSync(WAIT_LOAD_LUCENE_PARTITION_METADATA, selectQueryPartitionAsync(groupKey, luceneScanQuery), state.context);
+        // selectQueryPartitionAsync's future never completes with a null PartitionedQueryHint; asyncToSync's generic
+        // signature is just conservatively @Nullable.
+        return Objects.requireNonNull(
+                LuceneConcurrency.asyncToSync(WAIT_LOAD_LUCENE_PARTITION_METADATA, selectQueryPartitionAsync(groupKey, luceneScanQuery), state.context));
     }
 
     /**
@@ -426,8 +429,7 @@ public class LucenePartitioner {
      * @return <code>null</code> if primary field is already included in the sort fields,
      * otherwise the updated list of sort fields.
      */
-    @Nullable
-    private SortField[] ensurePrimaryKeyIsInSort(Sort sort) {
+    private SortField @Nullable [] ensurePrimaryKeyIsInSort(Sort sort) {
         // precondition: sort is by partition key (see LucenePartitioner.isSortedByPartitionField())
         // so, either partition field + primary key (explicitly) or just partition field.
         SortField[] fields = sort.getSort();
@@ -678,7 +680,8 @@ public class LucenePartitioner {
      * @throws RecordCoreException if no field of type <code>long</code> with given name is found
      */
     private <M extends Message> Object getPartitioningFieldValue(FDBIndexableRecord<M> rec) {
-        Key.Evaluated evaluatedKey = partitioningKeyExpression.evaluateSingleton(rec);
+        // Only called when partitioning is enabled, in which case partitioningKeyExpression is always set.
+        Key.Evaluated evaluatedKey = Objects.requireNonNull(partitioningKeyExpression).evaluateSingleton(rec);
         if (evaluatedKey.size() == 1) {
             Object value = evaluatedKey.getObject(0);
             if (value == null) {
@@ -804,7 +807,8 @@ public class LucenePartitioner {
             AtomicReference<RecordCursorContinuation> continuation = new AtomicReference<>(start);
             return AsyncUtil.whileTrue(() -> cursor.onNext().thenCompose(cursorResult -> {
                 if (cursorResult.hasNext()) {
-                    final Tuple groupingKey = Tuple.fromItems(cursorResult.get().getItems().subList(0, groupingCount));
+                    // get() is only @Nullable when hasNext() is false; it's guaranteed non-null here.
+                    final Tuple groupingKey = Tuple.fromItems(Objects.requireNonNull(cursorResult.get()).getItems().subList(0, groupingCount));
                     return processPartitionRebalancing(groupingKey, documentCount, logMessages)
                             .thenCompose(movedCount -> {
                                 if (movedCount > 0) {
@@ -1219,8 +1223,10 @@ public class LucenePartitioner {
             savePartitionMetadata(groupingKey, builder);
         } else {
             // no older partition - need to delete the newer partition data and set a new "from" ("from" is the key)
-            state.context.ensureActive().clear(partitionMetadataKeyFromPartitioningValue(groupingKey, getPartitionKey(repartitioningContext.newerPartition)));
-            LucenePartitionInfo.Builder builder = repartitioningContext.newerPartition.toBuilder();
+            // No older partition to update, so (per LuceneRepartitionPlanner's invariant) the newer partition must exist.
+            final LucenePartitionInfo newerPartition = Objects.requireNonNull(repartitioningContext.newerPartition);
+            state.context.ensureActive().clear(partitionMetadataKeyFromPartitioningValue(groupingKey, getPartitionKey(newerPartition)));
+            LucenePartitionInfo.Builder builder = newerPartition.toBuilder();
             builder.setFrom(partitionInfo.getFrom());
             savePartitionMetadata(groupingKey, builder);
         }
@@ -1410,10 +1416,9 @@ public class LucenePartitioner {
          * if the sort fields contain only the partition field, this will contain both the
          * partition field and, as the second item, the primary key {@link LuceneIndexMaintainer#PRIMARY_KEY_SEARCH_NAME}.
          */
-        @Nullable
-        SortField[] updatedSortFields;
+        SortField @Nullable [] updatedSortFields;
 
-        PartitionedSortContext(boolean isByPartitionField, boolean isReverse, @Nullable final SortField[] updatedSortFields) {
+        PartitionedSortContext(boolean isByPartitionField, boolean isReverse, final SortField @Nullable [] updatedSortFields) {
             this.isByPartitionField = isByPartitionField;
             this.isReverse = isReverse;
             this.updatedSortFields = updatedSortFields;
@@ -1439,7 +1444,7 @@ public class LucenePartitioner {
          */
         final boolean canHaveMatches;
 
-        PartitionedQueryHint(boolean canHaveMatches, LucenePartitionInfo startPartition) {
+        PartitionedQueryHint(boolean canHaveMatches, @Nullable LucenePartitionInfo startPartition) {
             this.canHaveMatches = canHaveMatches;
             this.startPartition = startPartition;
         }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePartitioner.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePartitioner.java
@@ -244,6 +244,10 @@ public class LucenePartitioner {
         }
 
 
+        // Tuple.from below intentionally accepts a null element here (an unannotated, external API
+        // conservatively treated by NullAway as requiring non-null); getComparand() may legitimately
+        // be null (e.g. for a null-comparison predicate), and Tuple supports a null tuple item.
+        @SuppressWarnings("NullAway")
         Tuple partitionField = Tuple.from(Objects.requireNonNull(partitionFieldPredicate).getComparand());
         // <
         byte[] lowEnd = state.indexSubspace.subspace(groupKey.add(PARTITION_META_SUBSPACE)).pack();

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePartitioner.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePartitioner.java
@@ -230,7 +230,8 @@ public class LucenePartitioner {
             return getNewestPartition(groupKey, state.context, state.indexSubspace).thenApply(newestPartition -> new PartitionedQueryHint(true, newestPartition));
         }
 
-        final PartitionedSortContext sortCriteria = luceneScanQuery.getSort() == null ? null : isSortedByPartitionField(luceneScanQuery.getSort());
+        final Sort sort = luceneScanQuery.getSort();
+        final PartitionedSortContext sortCriteria = sort == null ? null : isSortedByPartitionField(sort);
         final LuceneComparisonQuery partitionFieldPredicate = checkQueryForPartitionFieldPredicate(luceneScanQuery);
         final boolean isAscending = sortCriteria != null && sortCriteria.isByPartitionField && !sortCriteria.isReverse;
         final Comparisons.Type comparisonType = partitionFieldPredicate == null ? null : partitionFieldPredicate.getComparisonType();

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePlanner.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePlanner.java
@@ -256,8 +256,9 @@ public class LucenePlanner extends RecordQueryPlanner {
         }
         final var name = String.join("_", prefix);
         final var newFieldNames = luceneQueryComponent.getFields().stream().map(field -> name + "_" + field).collect(Collectors.toList());
-        final var newExplicitFieldNames = luceneQueryComponent.getExplicitFieldNames() == null
-                ? null : luceneQueryComponent.getExplicitFieldNames().stream().map(field -> name + "_" + field).collect(Collectors.toSet());
+        final var explicitFieldNames = luceneQueryComponent.getExplicitFieldNames();
+        final var newExplicitFieldNames = explicitFieldNames == null
+                ? null : explicitFieldNames.stream().map(field -> name + "_" + field).collect(Collectors.toSet());
         return luceneQueryComponent.withNewFields(newFieldNames, newExplicitFieldNames);
     }
 
@@ -299,9 +300,10 @@ public class LucenePlanner extends RecordQueryPlanner {
 
         switch (filter.getType()) {
             case AUTO_COMPLETE:
-                final var resolvedFields = filter.getExplicitFieldNames() == null
+                final var explicitFieldNames = filter.getExplicitFieldNames();
+                final var resolvedFields = explicitFieldNames == null
                                            ? filter.getFields()
-                                           : filter.getExplicitFieldNames();
+                                           : explicitFieldNames;
                 return new LuceneAutoCompleteQueryClause(filter.getQuery(), filter.isQueryIsParameter(), resolvedFields);
             case QUERY:
             case QUERY_HIGHLIGHT:

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePlanner.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePlanner.java
@@ -23,6 +23,7 @@ package com.apple.foundationdb.record.lucene;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.RecordStoreState;
+import com.apple.foundationdb.record.lucene.LuceneScanQueryParameters.LuceneQueryHighlightParameters;
 import com.apple.foundationdb.record.metadata.Index;
 import com.apple.foundationdb.record.metadata.RecordType;
 import com.apple.foundationdb.record.metadata.expressions.EmptyKeyExpression;
@@ -63,6 +64,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static com.apple.foundationdb.record.lucene.LuceneIndexExpressions.DocumentFieldDerivation;
@@ -126,8 +128,8 @@ public class LucenePlanner extends RecordQueryPlanner {
             groupingComparisons = ScanComparisons.EMPTY;
         }
 
-        LucenePlanState state = new LucenePlanState(index, groupingComparisons, filter);
-        state.documentFields = LuceneIndexExpressions.getDocumentFieldDerivations(index, metaData);
+        LucenePlanState state = new LucenePlanState(index, groupingComparisons, filter,
+                LuceneIndexExpressions.getDocumentFieldDerivations(index, metaData));
 
         QueryComponent queryComponent = state.groupingComparisons.isEmpty() ? state.filter : filterMask.getUnsatisfiedFilter();
         // Special scans like auto-complete cannot be combined with regular queries.
@@ -142,7 +144,7 @@ public class LucenePlanner extends RecordQueryPlanner {
                 return null;
             }
             getStoredFields(state);
-            LuceneScanQueryParameters.LuceneQueryHighlightParameters highlightParameters = getHighlightParameters(queryComponent);
+            LuceneQueryHighlightParameters highlightParameters = getHighlightParameters(queryComponent);
             scanParameters = new LuceneScanQueryParameters(groupingComparisons, query,
                     state.sort, state.storedFields, state.storedFieldTypes, highlightParameters);
         }
@@ -160,7 +162,8 @@ public class LucenePlanner extends RecordQueryPlanner {
                 state.repeated, false, false, null);
     }
 
-    private static LuceneScanQueryParameters.LuceneQueryHighlightParameters getHighlightParameters(QueryComponent queryComponent) {
+    @Nullable
+    private static LuceneQueryHighlightParameters getHighlightParameters(@Nullable QueryComponent queryComponent) {
         if (queryComponent instanceof LuceneQueryComponent) {
             LuceneQueryComponent luceneQueryComponent = (LuceneQueryComponent)queryComponent;
             return luceneQueryComponent.getLuceneQueryHighlightParameters();
@@ -168,7 +171,7 @@ public class LucenePlanner extends RecordQueryPlanner {
             return getHighlightParameters(((NestedField)queryComponent).getChild());
         } else if (queryComponent instanceof AndOrComponent) {
             for (QueryComponent child : ((AndOrComponent) queryComponent).getChildren()) {
-                LuceneScanQueryParameters.LuceneQueryHighlightParameters parameters = getHighlightParameters(child);
+                LuceneQueryHighlightParameters parameters = getHighlightParameters(child);
                 if (parameters != null) {
                     return parameters;
                 }
@@ -192,19 +195,21 @@ public class LucenePlanner extends RecordQueryPlanner {
         @Nullable
         PlanOrderingKey planOrderingKey;
 
-        Map<String, DocumentFieldDerivation> documentFields;
+        final Map<String, DocumentFieldDerivation> documentFields;
         boolean repeated;   // Matching a repeated field may introduce duplicates
 
-        LucenePlanState(final Index index, final ScanComparisons groupingComparisons, final QueryComponent filter) {
+        LucenePlanState(final Index index, final ScanComparisons groupingComparisons, final QueryComponent filter,
+                        final Map<String, DocumentFieldDerivation> documentFields) {
             this.index = index;
             this.groupingComparisons = groupingComparisons;
             this.filter = filter;
+            this.documentFields = documentFields;
         }
     }
 
     @Nullable
     @SuppressWarnings("PMD.CompareObjectsWithEquals")
-    private LuceneScanParameters getSpecialScan(LucenePlanState state, FilterSatisfiedMask filterMask, QueryComponent queryComponent) {
+    private LuceneScanParameters getSpecialScan(LucenePlanState state, FilterSatisfiedMask filterMask, @Nullable QueryComponent queryComponent) {
         QueryComponent component = queryComponent;
         final ImmutableList.Builder<String> prefixComponentsBuilder = ImmutableList.builder();
         // find the prefix of the special scan (if it exists)
@@ -236,7 +241,10 @@ public class LucenePlanner extends RecordQueryPlanner {
                         luceneQueryComponent.getQuery(), luceneQueryComponent.isQueryIsParameter());
 
         if (queryComponent != state.filter) {
-            filterMask = filterMask.getChild(queryComponent);
+            // component (derived from queryComponent above) was proven to be a LuceneQueryComponent, which is only
+            // possible if queryComponent itself is non-null (the instanceof checks above would have returned null
+            // immediately for a null queryComponent).
+            filterMask = filterMask.getChild(Objects.requireNonNull(queryComponent));
         }
         filterMask.setSatisfied(true);
         return scanParameters;
@@ -608,8 +616,10 @@ public class LucenePlanner extends RecordQueryPlanner {
                     final KeyExpression fieldExpression = fields.get(i);
                     if (recordFieldPathMatches(fieldExpression, documentField.getRecordFieldPath())) {
                         state.storedFields.set(i, documentField.getDocumentField());
-                        state.storedFieldTypes.set(i, documentField.getType());
-                        state.storedFieldExpressions.add(fieldExpression);
+                        // storedFieldTypes and storedFieldExpressions are always initialized together with
+                        // storedFields immediately above.
+                        Objects.requireNonNull(state.storedFieldTypes).set(i, documentField.getType());
+                        Objects.requireNonNull(state.storedFieldExpressions).add(fieldExpression);
                         break;
                     }
                 }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePlanner.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePlanner.java
@@ -84,10 +84,13 @@ public class LucenePlanner extends RecordQueryPlanner {
     @Override
     @Nullable
     protected ScoredPlan planOther(CandidateScan candidateScan,
-                                   Index index, QueryComponent filter,
+                                   Index index, @Nullable QueryComponent filter,
                                    @Nullable KeyExpression sort, boolean sortReverse,
                                    @Nullable KeyExpression commonPrimaryKey) {
-        if (index.getType().equals(LuceneIndexTypes.LUCENE)) {
+        // planLucene (below) is not designed to handle a null filter, so only take the Lucene-specific
+        // path when there is an actual filter to plan against; otherwise defer to the superclass, which
+        // already handles a null filter correctly.
+        if (filter != null && index.getType().equals(LuceneIndexTypes.LUCENE)) {
             return planLucene(candidateScan, index, filter, sort, sortReverse, commonPrimaryKey);
         } else {
             return super.planOther(candidateScan, index, filter, sort, sortReverse, commonPrimaryKey);

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePlanner.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePlanner.java
@@ -56,8 +56,7 @@ import org.apache.lucene.search.SortField;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -65,6 +64,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import static com.apple.foundationdb.record.lucene.LuceneIndexExpressions.DocumentFieldDerivation;
 
 /**
  * A planner to implement lucene query planning so that we can isolate the lucene functionality to
@@ -74,14 +75,14 @@ import java.util.stream.Collectors;
 public class LucenePlanner extends RecordQueryPlanner {
     private static final Logger logger = LoggerFactory.getLogger(LucenePlanner.class);
 
-    public LucenePlanner(@Nonnull final RecordMetaData metaData, @Nonnull final RecordStoreState recordStoreState, final PlannableIndexTypes indexTypes, final FDBStoreTimer timer) {
+    public LucenePlanner(final RecordMetaData metaData, final RecordStoreState recordStoreState, final PlannableIndexTypes indexTypes, final FDBStoreTimer timer) {
         super(metaData, recordStoreState, indexTypes, timer);
     }
 
     @Override
     @Nullable
-    protected ScoredPlan planOther(@Nonnull CandidateScan candidateScan,
-                                   @Nonnull Index index, @Nonnull QueryComponent filter,
+    protected ScoredPlan planOther(CandidateScan candidateScan,
+                                   Index index, QueryComponent filter,
                                    @Nullable KeyExpression sort, boolean sortReverse,
                                    @Nullable KeyExpression commonPrimaryKey) {
         if (index.getType().equals(LuceneIndexTypes.LUCENE)) {
@@ -92,8 +93,8 @@ public class LucenePlanner extends RecordQueryPlanner {
     }
 
     @Nullable
-    private ScoredPlan planLucene(@Nonnull CandidateScan candidateScan,
-                                  @Nonnull Index index, @Nonnull QueryComponent filter,
+    private ScoredPlan planLucene(CandidateScan candidateScan,
+                                  Index index, QueryComponent filter,
                                   @Nullable KeyExpression sort, boolean sortReverse,
                                   @Nullable KeyExpression commonPrimaryKey) {
         final RecordMetaData metaData = getRecordMetaData();
@@ -159,7 +160,7 @@ public class LucenePlanner extends RecordQueryPlanner {
                 state.repeated, false, false, null);
     }
 
-    private static LuceneScanQueryParameters.LuceneQueryHighlightParameters getHighlightParameters(@Nonnull QueryComponent queryComponent) {
+    private static LuceneScanQueryParameters.LuceneQueryHighlightParameters getHighlightParameters(QueryComponent queryComponent) {
         if (queryComponent instanceof LuceneQueryComponent) {
             LuceneQueryComponent luceneQueryComponent = (LuceneQueryComponent)queryComponent;
             return luceneQueryComponent.getLuceneQueryHighlightParameters();
@@ -177,11 +178,8 @@ public class LucenePlanner extends RecordQueryPlanner {
     }
 
     static class LucenePlanState {
-        @Nonnull
         final Index index;
-        @Nonnull
         final ScanComparisons groupingComparisons;
-        @Nonnull
         final QueryComponent filter;
         @Nullable
         Sort sort;
@@ -194,10 +192,10 @@ public class LucenePlanner extends RecordQueryPlanner {
         @Nullable
         PlanOrderingKey planOrderingKey;
 
-        Map<String, LuceneIndexExpressions.DocumentFieldDerivation> documentFields;
+        Map<String, DocumentFieldDerivation> documentFields;
         boolean repeated;   // Matching a repeated field may introduce duplicates
 
-        LucenePlanState(@Nonnull final Index index, @Nonnull final ScanComparisons groupingComparisons, @Nonnull final QueryComponent filter) {
+        LucenePlanState(final Index index, final ScanComparisons groupingComparisons, final QueryComponent filter) {
             this.index = index;
             this.groupingComparisons = groupingComparisons;
             this.filter = filter;
@@ -206,7 +204,7 @@ public class LucenePlanner extends RecordQueryPlanner {
 
     @Nullable
     @SuppressWarnings("PMD.CompareObjectsWithEquals")
-    private LuceneScanParameters getSpecialScan(@Nonnull LucenePlanState state, @Nonnull FilterSatisfiedMask filterMask, @Nonnull QueryComponent queryComponent) {
+    private LuceneScanParameters getSpecialScan(LucenePlanState state, FilterSatisfiedMask filterMask, QueryComponent queryComponent) {
         QueryComponent component = queryComponent;
         final ImmutableList.Builder<String> prefixComponentsBuilder = ImmutableList.builder();
         // find the prefix of the special scan (if it exists)
@@ -244,8 +242,7 @@ public class LucenePlanner extends RecordQueryPlanner {
         return scanParameters;
     }
 
-    @Nonnull
-    private LuceneQueryComponent prefixFieldNames(@Nonnull LuceneQueryComponent luceneQueryComponent, @Nonnull final List<String> prefix) {
+    private LuceneQueryComponent prefixFieldNames(LuceneQueryComponent luceneQueryComponent, final List<String> prefix) {
         if (prefix.isEmpty()) {
             return luceneQueryComponent;
         }
@@ -257,10 +254,10 @@ public class LucenePlanner extends RecordQueryPlanner {
     }
 
     @Nullable
-    private LuceneQueryClause getQueryForFilter(@Nonnull final LuceneQueryType queryType,
-                                                @Nonnull final LucenePlanState state,
-                                                @Nonnull final QueryComponent filter,
-                                                @Nonnull final List<String> parentFieldPath,
+    private LuceneQueryClause getQueryForFilter(final LuceneQueryType queryType,
+                                                final LucenePlanState state,
+                                                final QueryComponent filter,
+                                                final List<String> parentFieldPath,
                                                 @Nullable final FilterSatisfiedMask filterMask) {
         if (filter instanceof LuceneQueryComponent) {
             return getQueryForLuceneComponent(state, (LuceneQueryComponent)filter, parentFieldPath, filterMask);
@@ -279,8 +276,8 @@ public class LucenePlanner extends RecordQueryPlanner {
     }
 
     @Nullable
-    private LuceneQueryClause getQueryForLuceneComponent(@Nonnull LucenePlanState state, @Nonnull LuceneQueryComponent filter,
-                                                         @Nonnull List<String> parentFieldPath, @Nullable FilterSatisfiedMask filterMask) {
+    private LuceneQueryClause getQueryForLuceneComponent(LucenePlanState state, LuceneQueryComponent filter,
+                                                         List<String> parentFieldPath, @Nullable FilterSatisfiedMask filterMask) {
         filter = prefixFieldNames(filter, parentFieldPath);
 
         for (String field : filter.getFields()) {
@@ -313,8 +310,8 @@ public class LucenePlanner extends RecordQueryPlanner {
 
     @Nullable
     @SuppressWarnings({"java:S3776", "PMD.CompareObjectsWithEquals"})
-    private LuceneQueryClause getQueryForAndOr(@Nonnull final LuceneQueryType queryType, @Nonnull final LucenePlanState state,
-                                               @Nonnull final AndOrComponent filter, @Nonnull final List<String> parentFieldPath,
+    private LuceneQueryClause getQueryForAndOr(final LuceneQueryType queryType, final LucenePlanState state,
+                                               final AndOrComponent filter, final List<String> parentFieldPath,
                                                @Nullable final FilterSatisfiedMask filterMask) {
         final Iterator<FilterSatisfiedMask> subFilterMasks = filterMask != null ? filterMask.getChildren().iterator() : null;
         final List<QueryComponent> filters = filter.getChildren();
@@ -356,10 +353,10 @@ public class LucenePlanner extends RecordQueryPlanner {
     }
 
     @Nullable
-    private LuceneQueryClause getQueryForNot(@Nonnull final LuceneQueryType queryType,
-                                             @Nonnull final LucenePlanState state,
-                                             @Nonnull final NotComponent filter,
-                                             @Nonnull final List<String> parentFieldPath,
+    private LuceneQueryClause getQueryForNot(final LuceneQueryType queryType,
+                                             final LucenePlanState state,
+                                             final NotComponent filter,
+                                             final List<String> parentFieldPath,
                                              @Nullable final FilterSatisfiedMask filterMask) {
         final LuceneQueryClause childClause = getQueryForFilter(queryType, state, filter.getChild(), parentFieldPath,
                 filterMask == null ? null : filterMask.getChildren().get(0));
@@ -372,8 +369,7 @@ public class LucenePlanner extends RecordQueryPlanner {
         return negate(childClause);
     }
 
-    @Nonnull
-    private static LuceneQueryClause negate(@Nonnull LuceneQueryClause clause) {
+    private static LuceneQueryClause negate(LuceneQueryClause clause) {
         if (clause instanceof LuceneBooleanQuery) {
             final LuceneBooleanQuery booleanQuery = (LuceneBooleanQuery)clause;
             switch (booleanQuery.getOccur()) {
@@ -413,16 +409,16 @@ public class LucenePlanner extends RecordQueryPlanner {
     }
 
     @Nullable
-    private LuceneQueryClause getQueryForFieldWithComparison(@Nonnull final LuceneQueryType queryType,
-                                                             @Nonnull final LucenePlanState state,
-                                                             @Nonnull final FieldWithComparison filter,
-                                                             @Nonnull final List<String> fieldPath,
+    private LuceneQueryClause getQueryForFieldWithComparison(final LuceneQueryType queryType,
+                                                             final LucenePlanState state,
+                                                             final FieldWithComparison filter,
+                                                             final List<String> fieldPath,
                                                              @Nullable final FilterSatisfiedMask filterSatisfiedMask) {
         if (filterSatisfiedMask != null && filterSatisfiedMask.isSatisfied()) {
             return null;        // Already done as part of group comparisons
         }
         fieldPath.add(filter.getFieldName());
-        LuceneIndexExpressions.DocumentFieldDerivation fieldDerivation = findIndexField(state, fieldPath);
+        DocumentFieldDerivation fieldDerivation = findIndexField(state, fieldPath);
         fieldPath.remove(fieldPath.size() - 1);
         if (fieldDerivation == null) {
             return null;
@@ -450,11 +446,11 @@ public class LucenePlanner extends RecordQueryPlanner {
     }
 
     @Nullable
-    private LuceneQueryClause getQueryForNestedField(@Nonnull final LuceneQueryType queryType,
-                                                     @Nonnull final LucenePlanState state,
-                                                     @Nonnull final BaseField filter,
+    private LuceneQueryClause getQueryForNestedField(final LuceneQueryType queryType,
+                                                     final LucenePlanState state,
+                                                     final BaseField filter,
                                                      final boolean repeated,
-                                                     @Nonnull final List<String> fieldPath,
+                                                     final List<String> fieldPath,
                                                      @Nullable final FilterSatisfiedMask mask) {
         QueryComponent child = ((ComponentWithSingleChild)filter).getChild();
         fieldPath.add(filter.getFieldName());
@@ -472,15 +468,15 @@ public class LucenePlanner extends RecordQueryPlanner {
     }
 
     @Nullable
-    private LuceneIndexExpressions.DocumentFieldDerivation findIndexField(@Nonnull LucenePlanState state, @Nonnull List<String> fieldPath) {
+    private DocumentFieldDerivation findIndexField(LucenePlanState state, List<String> fieldPath) {
         if (fieldPath.size() == 1) {
             // Quickly check simple case by name to save looking through all document fields.
-            final LuceneIndexExpressions.DocumentFieldDerivation fieldDerivation = state.documentFields.get(fieldPath.get(0));
+            final DocumentFieldDerivation fieldDerivation = state.documentFields.get(fieldPath.get(0));
             if (fieldDerivation != null && fieldDerivation.getRecordFieldPath().equals(fieldPath)) {
                 return fieldDerivation;
             }
         }
-        for (LuceneIndexExpressions.DocumentFieldDerivation fieldDerivation : state.documentFields.values()) {
+        for (DocumentFieldDerivation fieldDerivation : state.documentFields.values()) {
             if (fieldDerivation.getRecordFieldPath().equals(fieldPath)) {
                 return fieldDerivation;
             }
@@ -488,9 +484,9 @@ public class LucenePlanner extends RecordQueryPlanner {
         return null;
     }
 
-    private boolean validateIndexField(@Nonnull LucenePlanState state, @Nonnull String field) {
+    private boolean validateIndexField(LucenePlanState state, String field) {
         // Can only check that the field name given corresponds to some top-level branch to an indexed field.
-        for (LuceneIndexExpressions.DocumentFieldDerivation fieldDerivation : state.documentFields.values()) {
+        for (DocumentFieldDerivation fieldDerivation : state.documentFields.values()) {
             if (fieldMatchesPath(fieldDerivation, field)) {
                 return true;
             }
@@ -498,7 +494,7 @@ public class LucenePlanner extends RecordQueryPlanner {
         return false;
     }
 
-    private boolean getSort(@Nonnull LucenePlanState state,
+    private boolean getSort(LucenePlanState state,
                             @Nullable KeyExpression sort, boolean sortReverse,
                             @Nullable KeyExpression commonPrimaryKey, @Nullable KeyExpression groupingKey) {
         final List<KeyExpression> sorts = new ArrayList<>();
@@ -534,7 +530,7 @@ public class LucenePlanner extends RecordQueryPlanner {
                 sortField = ((LuceneFunctionKeyExpression.LuceneSortBy)sortItem).isRelevance() ? SortField.FIELD_SCORE : SortField.FIELD_DOC;
                 hasBuiltInSort = true;
             } else {
-                for (LuceneIndexExpressions.DocumentFieldDerivation documentField : state.documentFields.values()) {
+                for (DocumentFieldDerivation documentField : state.documentFields.values()) {
                     if (documentField.isSorted() && recordFieldPathMatches(sortItem, documentField.getRecordFieldPath())) {
                         final SortField.Type type;
                         switch (documentField.getType()) {
@@ -599,9 +595,9 @@ public class LucenePlanner extends RecordQueryPlanner {
         return true;
     }
 
-    private void getStoredFields(@Nonnull LucenePlanState state) {
+    private void getStoredFields(LucenePlanState state) {
         final List<KeyExpression> fields = state.index.getRootExpression().normalizeKeyForPositions();
-        for (LuceneIndexExpressions.DocumentFieldDerivation documentField : state.documentFields.values()) {
+        for (DocumentFieldDerivation documentField : state.documentFields.values()) {
             if (documentField.isStored()) {
                 if (state.storedFields == null) {
                     state.storedFields = new ArrayList<>(Collections.nCopies(fields.size(), null));
@@ -621,7 +617,7 @@ public class LucenePlanner extends RecordQueryPlanner {
         }
     }
 
-    private boolean recordFieldPathMatches(@Nonnull KeyExpression keyExpression, @Nonnull List<String> recordFieldPath) {
+    private boolean recordFieldPathMatches(KeyExpression keyExpression, List<String> recordFieldPath) {
         int i = 0;
         while (true) {
             if (keyExpression instanceof FieldKeyExpression) {
@@ -643,8 +639,8 @@ public class LucenePlanner extends RecordQueryPlanner {
         }
     }
 
-    static boolean fieldMatchesPath(@Nonnull LuceneIndexExpressions.DocumentFieldDerivation fieldDerivation,
-                                    @Nonnull String field) {
+    static boolean fieldMatchesPath(DocumentFieldDerivation fieldDerivation,
+                                    String field) {
         StringBuilder path = null;
         for (String pathElement : fieldDerivation.getRecordFieldPath()) {
             if (path == null) {

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePrimaryKeySegmentIndex.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePrimaryKeySegmentIndex.java
@@ -26,8 +26,7 @@ import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.io.IOException;
 import java.util.List;
 
@@ -40,7 +39,7 @@ public interface LucenePrimaryKeySegmentIndex {
     List<List<Object>> readAllEntries();
 
     @SuppressWarnings("PMD.CloseResource")
-    List<String> findSegments(@Nonnull Tuple primaryKey) throws IOException;
+    List<String> findSegments(Tuple primaryKey) throws IOException;
 
     /**
      * Find document in index for direct delete.
@@ -53,7 +52,7 @@ public interface LucenePrimaryKeySegmentIndex {
      * @see IndexWriter#tryDeleteDocument
      */
     @Nullable
-    DocumentIndexEntry findDocument(@Nonnull DirectoryReader directoryReader, @Nonnull Tuple primaryKey) throws IOException;
+    DocumentIndexEntry findDocument(DirectoryReader directoryReader, Tuple primaryKey) throws IOException;
 
     /**
      * Add or delete the primary key/segment/docId from the index.
@@ -63,7 +62,7 @@ public interface LucenePrimaryKeySegmentIndex {
      * @param add whether to add ({@code true}) or delete ({@code false}) the entry
      * @param segmentName name associated with the segment, for logging
      */
-    void addOrDeletePrimaryKeyEntry(@Nonnull byte[] primaryKey, long segmentId, int docId, boolean add, String segmentName);
+    void addOrDeletePrimaryKeyEntry(byte[] primaryKey, long segmentId, int docId, boolean add, String segmentName);
 
     /**
      * Clears all the primary key entries for a given segment name.
@@ -77,18 +76,14 @@ public interface LucenePrimaryKeySegmentIndex {
      */
     // TODO: Can be a record.
     class DocumentIndexEntry {
-        @Nonnull
         public final Tuple primaryKey;
-        @Nonnull
         public final byte[] entryKey;
-        @Nonnull
         public final IndexReader indexReader;
-        @Nonnull
         public final String segmentName;
         public final int docId;
 
-        public DocumentIndexEntry(@Nonnull final Tuple primaryKey, @Nonnull final byte[] entryKey, @Nonnull final IndexReader indexReader,
-                                  @Nonnull String segmentName, final int docId) {
+        public DocumentIndexEntry(final Tuple primaryKey, final byte[] entryKey, final IndexReader indexReader,
+                                  String segmentName, final int docId) {
             this.primaryKey = primaryKey;
             this.entryKey = entryKey;
             this.indexReader = indexReader;

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePrimaryKeySegmentIndexV1.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePrimaryKeySegmentIndexV1.java
@@ -80,7 +80,8 @@ public class LucenePrimaryKeySegmentIndexV1 implements LucenePrimaryKeySegmentIn
     public List<List<Object>> readAllEntries() {
         AtomicReference<List<List<Object>>> list = new AtomicReference<>();
         directory.getAgilityContext().accept(aContext -> readAllEntries(aContext, list));
-        return list.get();
+        // The accept() call above runs synchronously, and readAllEntries() always populates list before returning.
+        return Objects.requireNonNull(list.get());
     }
 
     private void readAllEntries(FDBRecordContext aContext, AtomicReference<List<List<Object>>> list) {
@@ -90,7 +91,7 @@ public class LucenePrimaryKeySegmentIndexV1 implements LucenePrimaryKeySegmentIn
                 .setScanProperties(ScanProperties.FORWARD_SCAN)
                 .build();
                 RecordCursor<Tuple> entries = kvs.map(kv -> subspace.unpack(kv.getKey()))) {
-            tuples = LuceneConcurrency.asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_FIND_PRIMARY_KEY, entries.asList(), aContext);
+            tuples = Objects.requireNonNull(LuceneConcurrency.asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_FIND_PRIMARY_KEY, entries.asList(), aContext));
         }
         list.set(tuples.stream().map(t -> {
             List<Object> items = t.getItems();
@@ -114,7 +115,7 @@ public class LucenePrimaryKeySegmentIndexV1 implements LucenePrimaryKeySegmentIn
     @SuppressWarnings("PMD.CloseResource")
     public List<String> findSegments(Tuple primaryKey) throws IOException {
         try {
-            return directory.asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_FIND_PRIMARY_KEY,
+            return Objects.requireNonNull(directory.asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_FIND_PRIMARY_KEY,
                     directory.getAgilityContext().apply(context -> {
                         final Subspace keySubspace = subspace.subspace(primaryKey);
                         final KeyValueCursor kvs = KeyValueCursor.Builder.newBuilder(keySubspace)
@@ -131,7 +132,7 @@ public class LucenePrimaryKeySegmentIndexV1 implements LucenePrimaryKeySegmentIn
                                 return "#" + segid;
                             }
                         }).asList().whenComplete((result, err) -> kvs.close());
-                    }));
+                    })));
         } catch (RecordCoreException ex) {
             throw LuceneExceptions.toIoException(ex, null);
         }
@@ -174,8 +175,8 @@ public class LucenePrimaryKeySegmentIndexV1 implements LucenePrimaryKeySegmentIn
                     }
                     return null;
                 }).filter(Objects::nonNull)) {
-            doc.set(directory.asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_FIND_PRIMARY_KEY,
-                    documents.first()).orElse(null));
+            doc.set(Objects.requireNonNull(directory.asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_FIND_PRIMARY_KEY,
+                    documents.first())).orElse(null));
         }
     }
 
@@ -252,7 +253,7 @@ public class LucenePrimaryKeySegmentIndexV1 implements LucenePrimaryKeySegmentIn
                     final int maxDoc = mergeState.maxDocs[i];
                     for (int j = 0; j < maxDoc; j++) {
                         storedFieldsReader.visitDocument(j, visitor);
-                        final byte[] primaryKey = visitor.getPrimaryKey();
+                        final byte @Nullable [] primaryKey = visitor.getPrimaryKey();
                         if (primaryKey != null) {
                             if (liveDocs == null || liveDocs.get(j)) {
                                 int docId = docMap.get(j);
@@ -323,11 +324,9 @@ public class LucenePrimaryKeySegmentIndexV1 implements LucenePrimaryKeySegmentIn
      * After calling {@link StoredFieldsReader#visitDocument}, any primary key will be in {@link #getPrimaryKey}.
      */
     static class PrimaryKeyVisitor extends StoredFieldVisitor {
-        @Nullable
-        private byte[] primaryKey = null;
+        private byte @Nullable [] primaryKey = null;
 
-        @Nullable
-        public byte[] getPrimaryKey() {
+        public byte @Nullable [] getPrimaryKey() {
             return primaryKey;
         }
 

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePrimaryKeySegmentIndexV1.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePrimaryKeySegmentIndexV1.java
@@ -47,8 +47,7 @@ import org.apache.lucene.util.Bits;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
@@ -63,12 +62,10 @@ import java.util.stream.Collectors;
  */
 public class LucenePrimaryKeySegmentIndexV1 implements LucenePrimaryKeySegmentIndex {
     private static final Logger LOGGER = LoggerFactory.getLogger(LucenePrimaryKeySegmentIndexV1.class);
-    @Nonnull
     private final FDBDirectory directory;
-    @Nonnull
     private final Subspace subspace;
 
-    public LucenePrimaryKeySegmentIndexV1(@Nonnull FDBDirectory directory, @Nonnull Subspace subspace) {
+    public LucenePrimaryKeySegmentIndexV1(FDBDirectory directory, Subspace subspace) {
         this.directory = directory;
         this.subspace = subspace;
     }
@@ -115,7 +112,7 @@ public class LucenePrimaryKeySegmentIndexV1 implements LucenePrimaryKeySegmentIn
      */
     @Override
     @SuppressWarnings("PMD.CloseResource")
-    public List<String> findSegments(@Nonnull Tuple primaryKey) throws IOException {
+    public List<String> findSegments(Tuple primaryKey) throws IOException {
         try {
             return directory.asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_FIND_PRIMARY_KEY,
                     directory.getAgilityContext().apply(context -> {
@@ -142,7 +139,7 @@ public class LucenePrimaryKeySegmentIndexV1 implements LucenePrimaryKeySegmentIn
 
     @Override
     @Nullable
-    public DocumentIndexEntry findDocument(@Nonnull DirectoryReader directoryReader, @Nonnull Tuple primaryKey) throws IOException {
+    public DocumentIndexEntry findDocument(DirectoryReader directoryReader, Tuple primaryKey) throws IOException {
         try {
             final AtomicReference<DocumentIndexEntry> doc = new AtomicReference<>();
             directory.getAgilityContext().accept(aContext -> findDocument(aContext, doc, directoryReader, primaryKey));
@@ -153,7 +150,7 @@ public class LucenePrimaryKeySegmentIndexV1 implements LucenePrimaryKeySegmentIn
     }
 
     private void findDocument(FDBRecordContext aContext, AtomicReference<DocumentIndexEntry> doc,
-                              @Nonnull DirectoryReader directoryReader, @Nonnull Tuple primaryKey) {
+                              DirectoryReader directoryReader, Tuple primaryKey) {
         final SegmentInfos segmentInfos = ((StandardDirectoryReader)FilterDirectoryReader.unwrap(directoryReader)).getSegmentInfos();
         final Subspace keySubspace = subspace.subspace(primaryKey);
         try (KeyValueCursor kvs = KeyValueCursor.Builder.newBuilder(keySubspace)
@@ -196,22 +193,19 @@ public class LucenePrimaryKeySegmentIndexV1 implements LucenePrimaryKeySegmentIn
      * @return a wrapped writer
      * @throws IOException thrown by called methods
      */
-    @Nonnull
-    public StoredFieldsWriter wrapFieldsWriter(@Nonnull StoredFieldsWriter storedFieldsWriter, @Nonnull SegmentInfo si) throws IOException {
+    public StoredFieldsWriter wrapFieldsWriter(StoredFieldsWriter storedFieldsWriter, SegmentInfo si) throws IOException {
         final long segmentId = directory.primaryKeySegmentId(si.name, true);
         return new WrappedFieldsWriter(storedFieldsWriter, segmentId, si.name);
     }
 
     class WrappedFieldsWriter extends StoredFieldsWriter {
-        @Nonnull
         private final StoredFieldsWriter inner;
-        @Nonnull
         private final long segmentId;
         private final String segmentName;
 
         private int documentId;
 
-        WrappedFieldsWriter(@Nonnull StoredFieldsWriter inner, long segmentId, final String segmentName) {
+        WrappedFieldsWriter(StoredFieldsWriter inner, long segmentId, final String segmentName) {
             this.inner = inner;
             this.segmentId = segmentId;
             this.segmentName = segmentName;
@@ -305,7 +299,7 @@ public class LucenePrimaryKeySegmentIndexV1 implements LucenePrimaryKeySegmentIn
     }
 
     @Override
-    public void addOrDeletePrimaryKeyEntry(@Nonnull byte[] primaryKey, long segmentId, int docId, boolean add, String segmentName) {
+    public void addOrDeletePrimaryKeyEntry(byte[] primaryKey, long segmentId, int docId, boolean add, String segmentName) {
         if (LOGGER.isTraceEnabled()) {
             LOGGER.trace("pkey " + (add ? "Adding" : "Deling") + " #" + segmentId + "(" + segmentName + ")" +  Tuple.fromBytes(primaryKey));
         }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePrimaryKeySegmentIndexV1.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePrimaryKeySegmentIndexV1.java
@@ -52,6 +52,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
@@ -163,18 +164,18 @@ public class LucenePrimaryKeySegmentIndexV1 implements LucenePrimaryKeySegmentIn
                     final long segid = segdoc.getLong(0);
                     final String segmentName = directory.primaryKeySegmentName(segid);
                     if (segmentName == null) {
-                        return null;
+                        return Optional.<DocumentIndexEntry>empty();
                     }
                     for (int i = 0; i < segmentInfos.size(); i++) {
                         SegmentInfo segmentInfo = segmentInfos.info(i).info;
                         if (segmentInfo.name.equals(segmentName)) {
                             final int docid = (int)segdoc.getLong(1);
-                            return new DocumentIndexEntry(primaryKey, kv.getKey(),
-                                    directoryReader.leaves().get(i).reader(), segmentName, docid);
+                            return Optional.of(new DocumentIndexEntry(primaryKey, kv.getKey(),
+                                    directoryReader.leaves().get(i).reader(), segmentName, docid));
                         }
                     }
-                    return null;
-                }).filter(Objects::nonNull)) {
+                    return Optional.<DocumentIndexEntry>empty();
+                }).filter(Optional::isPresent).map(Optional::get)) {
             doc.set(Objects.requireNonNull(directory.asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_FIND_PRIMARY_KEY,
                     documents.first())).orElse(null));
         }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePrimaryKeySegmentIndexV2.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePrimaryKeySegmentIndexV2.java
@@ -67,7 +67,8 @@ public class LucenePrimaryKeySegmentIndexV2 implements LucenePrimaryKeySegmentIn
     public List<List<Object>> readAllEntries() {
         AtomicReference<List<List<Object>>> list = new AtomicReference<>();
         directory.getAgilityContext().accept(aContext -> readAllEntries(aContext, list));
-        return list.get();
+        // The accept() call above runs synchronously, and readAllEntries() always populates list before returning.
+        return Objects.requireNonNull(list.get());
     }
 
     private void readAllEntries(FDBRecordContext aContext, AtomicReference<List<List<Object>>> list) {
@@ -77,7 +78,7 @@ public class LucenePrimaryKeySegmentIndexV2 implements LucenePrimaryKeySegmentIn
                 .setScanProperties(ScanProperties.FORWARD_SCAN)
                 .build();
                  RecordCursor<Tuple> entries = kvs.map(kv -> subspace.unpack(kv.getKey()))) {
-            tuples = LuceneConcurrency.asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_FIND_PRIMARY_KEY, entries.asList(), aContext);
+            tuples = Objects.requireNonNull(LuceneConcurrency.asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_FIND_PRIMARY_KEY, entries.asList(), aContext));
         }
         list.set(tuples.stream().map(t -> {
             List<Object> items = t.getItems();
@@ -95,7 +96,7 @@ public class LucenePrimaryKeySegmentIndexV2 implements LucenePrimaryKeySegmentIn
     @SuppressWarnings("PMD.CloseResource")
     public List<String> findSegments(Tuple primaryKey) throws IOException {
         try {
-            return directory.asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_FIND_PRIMARY_KEY,
+            return Objects.requireNonNull(directory.asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_FIND_PRIMARY_KEY,
                     directory.getAgilityContext().apply(context -> {
                         final Subspace keySubspace = subspace.subspace(primaryKey);
                         final KeyValueCursor kvs = KeyValueCursor.Builder.newBuilder(keySubspace)
@@ -112,7 +113,7 @@ public class LucenePrimaryKeySegmentIndexV2 implements LucenePrimaryKeySegmentIn
                                 return "#" + segid;
                             }
                         }).asList().whenComplete((result, err) -> kvs.close());
-                    }));
+                    })));
         } catch (RecordCoreException ex) {
             throw LuceneExceptions.toIoException(ex, null);
         }
@@ -155,8 +156,8 @@ public class LucenePrimaryKeySegmentIndexV2 implements LucenePrimaryKeySegmentIn
                     }
                     return null;
                 }).filter(Objects::nonNull)) {
-            doc.set(directory.asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_FIND_PRIMARY_KEY,
-                    documents.first()).orElse(null));
+            doc.set(Objects.requireNonNull(directory.asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_FIND_PRIMARY_KEY,
+                    documents.first())).orElse(null));
         }
     }
 

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePrimaryKeySegmentIndexV2.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePrimaryKeySegmentIndexV2.java
@@ -40,8 +40,7 @@ import org.apache.lucene.index.StandardDirectoryReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
@@ -55,12 +54,10 @@ import java.util.stream.Collectors;
 public class LucenePrimaryKeySegmentIndexV2 implements LucenePrimaryKeySegmentIndex {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LucenePrimaryKeySegmentIndexV2.class);
-    @Nonnull
     private final FDBDirectory directory;
-    @Nonnull
     private final Subspace subspace;
 
-    public LucenePrimaryKeySegmentIndexV2(@Nonnull FDBDirectory directory, @Nonnull Subspace subspace) {
+    public LucenePrimaryKeySegmentIndexV2(FDBDirectory directory, Subspace subspace) {
         this.directory = directory;
         this.subspace = subspace;
     }
@@ -96,7 +93,7 @@ public class LucenePrimaryKeySegmentIndexV2 implements LucenePrimaryKeySegmentIn
 
     @Override
     @SuppressWarnings("PMD.CloseResource")
-    public List<String> findSegments(@Nonnull Tuple primaryKey) throws IOException {
+    public List<String> findSegments(Tuple primaryKey) throws IOException {
         try {
             return directory.asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_FIND_PRIMARY_KEY,
                     directory.getAgilityContext().apply(context -> {
@@ -123,7 +120,7 @@ public class LucenePrimaryKeySegmentIndexV2 implements LucenePrimaryKeySegmentIn
 
     @Override
     @Nullable
-    public DocumentIndexEntry findDocument(@Nonnull DirectoryReader directoryReader, @Nonnull Tuple primaryKey) throws IOException {
+    public DocumentIndexEntry findDocument(DirectoryReader directoryReader, Tuple primaryKey) throws IOException {
         try {
             final AtomicReference<DocumentIndexEntry> doc = new AtomicReference<>();
             directory.getAgilityContext().accept(aContext -> findDocument(aContext, doc, directoryReader, primaryKey));
@@ -134,7 +131,7 @@ public class LucenePrimaryKeySegmentIndexV2 implements LucenePrimaryKeySegmentIn
     }
 
     private void findDocument(FDBRecordContext aContext, AtomicReference<DocumentIndexEntry> doc,
-                                            @Nonnull DirectoryReader directoryReader, @Nonnull Tuple primaryKey) {
+                                            DirectoryReader directoryReader, Tuple primaryKey) {
         final SegmentInfos segmentInfos = ((StandardDirectoryReader)FilterDirectoryReader.unwrap(directoryReader)).getSegmentInfos();
         final Subspace keySubspace = subspace.subspace(primaryKey);
         try (KeyValueCursor kvs = KeyValueCursor.Builder.newBuilder(keySubspace)
@@ -164,7 +161,7 @@ public class LucenePrimaryKeySegmentIndexV2 implements LucenePrimaryKeySegmentIn
     }
 
     @Override
-    public void addOrDeletePrimaryKeyEntry(@Nonnull byte[] primaryKey, long segmentId, int docId, boolean add, String segmentName) {
+    public void addOrDeletePrimaryKeyEntry(byte[] primaryKey, long segmentId, int docId, boolean add, String segmentName) {
         if (LOGGER.isTraceEnabled()) {
             LOGGER.trace("pkey " + (add ? "Adding" : "Deling") + " #" + segmentId + "(" + segmentName + ")" +  Tuple.fromBytes(primaryKey));
         }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePrimaryKeySegmentIndexV2.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LucenePrimaryKeySegmentIndexV2.java
@@ -44,6 +44,7 @@ import org.jspecify.annotations.Nullable;
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
@@ -144,18 +145,18 @@ public class LucenePrimaryKeySegmentIndexV2 implements LucenePrimaryKeySegmentIn
                     final long segid = segdoc.getLong(0);
                     final String segmentName = directory.primaryKeySegmentName(segid);
                     if (segmentName == null) {
-                        return null;
+                        return Optional.<DocumentIndexEntry>empty();
                     }
                     for (int i = 0; i < segmentInfos.size(); i++) {
                         SegmentInfo segmentInfo = segmentInfos.info(i).info;
                         if (segmentInfo.name.equals(segmentName)) {
                             final int docid = (int)segdoc.getLong(1);
-                            return new DocumentIndexEntry(primaryKey, kv.getKey(),
-                                    directoryReader.leaves().get(i).reader(), segmentName, docid);
+                            return Optional.of(new DocumentIndexEntry(primaryKey, kv.getKey(),
+                                    directoryReader.leaves().get(i).reader(), segmentName, docid));
                         }
                     }
-                    return null;
-                }).filter(Objects::nonNull)) {
+                    return Optional.<DocumentIndexEntry>empty();
+                }).filter(Optional::isPresent).map(Optional::get)) {
             doc.set(Objects.requireNonNull(directory.asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_FIND_PRIMARY_KEY,
                     documents.first())).orElse(null));
         }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneQueryClause.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneQueryClause.java
@@ -49,8 +49,7 @@ import org.apache.lucene.search.spans.SpanOrQuery;
 import org.apache.lucene.search.spans.SpanQuery;
 import org.apache.lucene.search.spans.SpanTermQuery;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
@@ -61,24 +60,21 @@ import java.util.Set;
  */
 @API(API.Status.UNSTABLE)
 public abstract class LuceneQueryClause implements PlanHashable {
-    @Nonnull
     private final LuceneQueryType queryType;
 
-    protected LuceneQueryClause(@Nonnull final LuceneQueryType queryType) {
+    protected LuceneQueryClause(final LuceneQueryType queryType) {
         this.queryType = queryType;
     }
 
-    @Nonnull
     public LuceneQueryType getQueryType() {
         return queryType;
     }
 
-    public abstract BoundQuery bind(@Nonnull FDBRecordStoreBase<?> store, @Nonnull Index index, @Nonnull EvaluationContext context);
+    public abstract BoundQuery bind(FDBRecordStoreBase<?> store, Index index, EvaluationContext context);
 
-    public abstract void getPlannerGraphDetails(@Nonnull ImmutableList.Builder<String> detailsBuilder, @Nonnull ImmutableMap.Builder<String, Attribute> attributeMapBuilder);
+    public abstract void getPlannerGraphDetails(ImmutableList.Builder<String> detailsBuilder, ImmutableMap.Builder<String, Attribute> attributeMapBuilder);
 
-    @Nonnull
-    protected BoundQuery toBoundQuery(@Nonnull final Query luceneQuery) {
+    protected BoundQuery toBoundQuery(final Query luceneQuery) {
         return BoundQuery.ofLuceneQueryWithQueryType(luceneQuery, getQueryType());
     }
 
@@ -87,8 +83,7 @@ public abstract class LuceneQueryClause implements PlanHashable {
      * @param query lucene query to extract all terms from
      * @return a new highlighting terms map
      */
-    @Nonnull
-    protected static Map<String, Set<String>> getHighlightingTermsMap(@Nonnull final Query query) {
+    protected static Map<String, Set<String>> getHighlightingTermsMap(final Query query) {
         Map<String, Set<String>> highlightingTermsMap = Maps.newHashMap();
         if (query instanceof BooleanQuery) {
             BooleanQuery booleanQuery = (BooleanQuery) query;
@@ -158,9 +153,8 @@ public abstract class LuceneQueryClause implements PlanHashable {
     }
 
     @CanIgnoreReturnValue
-    @Nonnull
-    protected static Map<String, Set<String>> combineHighlightingTermsMaps(@Nonnull final Map<String, Set<String>> existingMap,
-                                                                           @Nonnull final Map<String, Set<String>> newMap) {
+    protected static Map<String, Set<String>> combineHighlightingTermsMaps(final Map<String, Set<String>> existingMap,
+                                                                           final Map<String, Set<String>> newMap) {
         newMap.forEach((field, newTerms) ->
                 existingMap.merge(field, newTerms, (o, n) -> {
                     final Set<String> terms = Sets.newHashSet(o);
@@ -174,21 +168,19 @@ public abstract class LuceneQueryClause implements PlanHashable {
      * Helper class to capture a bound query, i.e. a lucene query where all parameters have been resolved.
      */
     public static class BoundQuery {
-        @Nonnull
         private final Query luceneQuery;
         @Nullable
         private final Map<String, Set<String>> highlightingTermsMap;
 
-        public BoundQuery(@Nonnull final Query luceneQuery) {
+        public BoundQuery(final Query luceneQuery) {
             this(luceneQuery, null);
         }
 
-        public BoundQuery(@Nonnull final Query luceneQuery, @Nullable final Map<String, Set<String>> highlightingTermsMap) {
+        public BoundQuery(final Query luceneQuery, @Nullable final Map<String, Set<String>> highlightingTermsMap) {
             this.luceneQuery = luceneQuery;
             this.highlightingTermsMap = highlightingTermsMap;
         }
 
-        @Nonnull
         public Query getLuceneQuery() {
             return luceneQuery;
         }
@@ -198,7 +190,7 @@ public abstract class LuceneQueryClause implements PlanHashable {
             return highlightingTermsMap;
         }
 
-        public static BoundQuery ofLuceneQueryWithQueryType(@Nonnull Query luceneQuery, @Nonnull LuceneQueryType queryType) {
+        public static BoundQuery ofLuceneQueryWithQueryType(Query luceneQuery, LuceneQueryType queryType) {
             if (queryType == LuceneQueryType.QUERY_HIGHLIGHT) {
                 return new BoundQuery(luceneQuery, LuceneQueryClause.getHighlightingTermsMap(luceneQuery));
             }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneQueryComponent.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneQueryComponent.java
@@ -36,12 +36,13 @@ import com.google.common.collect.Iterables;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Supplier;
+
+import static com.apple.foundationdb.record.lucene.LuceneScanQueryParameters.LuceneQueryHighlightParameters;
 
 /**
  * A Query Component for Lucene that wraps the query supplied.
@@ -50,17 +51,14 @@ import java.util.function.Supplier;
 @API(API.Status.EXPERIMENTAL)
 public class LuceneQueryComponent implements QueryComponent, ComponentWithNoChildren {
 
-    @Nonnull
     private final LuceneQueryType type;
-    @Nonnull
     private final String query;
     private final boolean queryIsParameter;
 
-    @Nonnull
     private final List<String> fields;
 
     @Nullable
-    private final LuceneScanQueryParameters.LuceneQueryHighlightParameters luceneQueryHighlightParameters;
+    private final LuceneQueryHighlightParameters luceneQueryHighlightParameters;
 
     @Nullable
     private final Set<String> explicitFieldNames;
@@ -87,7 +85,7 @@ public class LuceneQueryComponent implements QueryComponent, ComponentWithNoChil
     }
 
     public LuceneQueryComponent(LuceneQueryType type, String query, boolean queryIsParameter, List<String> fields, boolean multiFieldSearch,
-                                @Nullable LuceneScanQueryParameters.LuceneQueryHighlightParameters luceneQueryHighlightParameters,
+                                @Nullable LuceneQueryHighlightParameters luceneQueryHighlightParameters,
                                 @Nullable Set<String> explicitFieldNames) {
         this.type = type;
         this.query = query;
@@ -105,32 +103,28 @@ public class LuceneQueryComponent implements QueryComponent, ComponentWithNoChil
         }
     }
 
-    @Nonnull
     @Override
-    public <M extends Message> Boolean evalMessage(@Nonnull final FDBRecordStoreBase<M> store, @Nonnull final EvaluationContext context, @Nullable final FDBRecord<M> rec, @Nullable final Message message) {
+    public <M extends Message> Boolean evalMessage(final FDBRecordStoreBase<M> store, final EvaluationContext context, @Nullable final FDBRecord<M> rec, @Nullable final Message message) {
         throw new RecordCoreException("Residual lucene components are not yet supported");
     }
 
     @Override
-    public void validate(@Nonnull final Descriptors.Descriptor descriptor) {
+    public void validate(final Descriptors.Descriptor descriptor) {
         // It's possible we could validate the fields that are being used with the fields that we've passed in.
     }
 
-    @Nonnull
     @Override
-    public GraphExpansion expand(@Nonnull final Quantifier.ForEach baseQuantifier,
-                                 @Nonnull final Supplier<Quantifier.ForEach> outerQuantifierSupplier,
-                                 @Nonnull final List<String> fieldNamePrefix) {
+    public GraphExpansion expand(final Quantifier.ForEach baseQuantifier,
+                                 final Supplier<Quantifier.ForEach> outerQuantifierSupplier,
+                                 final List<String> fieldNamePrefix) {
         // TODO do something here
         throw new UnsupportedOperationException();
     }
 
-    @Nonnull
     public LuceneQueryType getType() {
         return type;
     }
 
-    @Nonnull
     public String getQuery() {
         return query;
     }
@@ -139,7 +133,6 @@ public class LuceneQueryComponent implements QueryComponent, ComponentWithNoChil
         return queryIsParameter;
     }
 
-    @Nonnull
     public List<String> getFields() {
         return fields;
     }
@@ -149,7 +142,7 @@ public class LuceneQueryComponent implements QueryComponent, ComponentWithNoChil
     }
 
     @Nullable
-    public LuceneScanQueryParameters.LuceneQueryHighlightParameters getLuceneQueryHighlightParameters() {
+    public LuceneQueryHighlightParameters getLuceneQueryHighlightParameters() {
         return luceneQueryHighlightParameters;
     }
 
@@ -164,8 +157,7 @@ public class LuceneQueryComponent implements QueryComponent, ComponentWithNoChil
      * @param explicitFieldNames the new list of explicit field names
      * @return a new instance of {@link LuceneQueryComponent}.
      */
-    @Nonnull
-    public LuceneQueryComponent withNewFields(@Nonnull final List<String> fields, @Nullable Set<String> explicitFieldNames) {
+    public LuceneQueryComponent withNewFields(final List<String> fields, @Nullable Set<String> explicitFieldNames) {
         return new LuceneQueryComponent(type, query, queryIsParameter, fields, multiFieldSearch, luceneQueryHighlightParameters, explicitFieldNames);
     }
 
@@ -216,12 +208,11 @@ public class LuceneQueryComponent implements QueryComponent, ComponentWithNoChil
     }
 
     @Override
-    public int planHash(@Nonnull final PlanHashMode mode) {
+    public int planHash(final PlanHashMode mode) {
         return PlanHashable.objectsPlanHash(mode, type, query);
     }
 
     @Override
-    @Nonnull
     public String toString() {
         return "LuceneQuery(" + query + ")";
     }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneQueryFieldComparisonClause.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneQueryFieldComparisonClause.java
@@ -47,6 +47,7 @@ import org.apache.lucene.search.TermRangeQuery;
 
 import org.jspecify.annotations.Nullable;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Query clause using a {@link Comparisons.Comparison} against a document field.
@@ -182,11 +183,12 @@ public abstract class LuceneQueryFieldComparisonClause extends LuceneQueryClause
         }
     }
 
-    protected String applyFieldNameConversion(final boolean fieldNameOverride, final String field, final String namedFieldSuffix, final Object comparand) {
+    protected String applyFieldNameConversion(final boolean fieldNameOverride, final String field, @Nullable final String namedFieldSuffix, final Object comparand) {
         if ( ! fieldNameOverride) {
             return field;
         }
-        int location = field.lastIndexOf(namedFieldSuffix);
+        // If fieldNameOverride is true, the caller is required to supply a non-null suffix to convert.
+        int location = field.lastIndexOf(Objects.requireNonNull(namedFieldSuffix, "namedFieldSuffix must be set when fieldNameOverride is true"));
         if (location == -1) {
             throw new RecordCoreArgumentException("Cannot find the replacement suffix in Lucene field name")
                     .addLogInfo("fieldName", field)
@@ -313,10 +315,11 @@ public abstract class LuceneQueryFieldComparisonClause extends LuceneQueryClause
 
     static class IntQuery extends LuceneQueryFieldComparisonClause {
         private final boolean fieldNameOverride;
+        @Nullable
         private final String namedFieldSuffix;
 
         public IntQuery(final LuceneQueryType queryType, String field, LuceneIndexExpressions.DocumentFieldType fieldType, Comparisons.Comparison comparison,
-                        final boolean fieldNameOverride, final String namedFieldSuffix) {
+                        final boolean fieldNameOverride, @Nullable final String namedFieldSuffix) {
             super(queryType, field, fieldType, comparison);
             this.fieldNameOverride = fieldNameOverride;
             this.namedFieldSuffix = namedFieldSuffix;
@@ -361,10 +364,11 @@ public abstract class LuceneQueryFieldComparisonClause extends LuceneQueryClause
 
     static class LongQuery extends LuceneQueryFieldComparisonClause {
         private final boolean fieldNameOverride;
+        @Nullable
         private final String namedFieldSuffix;
 
         public LongQuery(final LuceneQueryType queryType, String field, LuceneIndexExpressions.DocumentFieldType fieldType, Comparisons.Comparison comparison,
-                         final boolean fieldNameOverride, final String namedFieldSuffix) {
+                         final boolean fieldNameOverride, @Nullable final String namedFieldSuffix) {
             super(queryType, field, fieldType, comparison);
             this.fieldNameOverride = fieldNameOverride;
             this.namedFieldSuffix = namedFieldSuffix;
@@ -433,10 +437,11 @@ public abstract class LuceneQueryFieldComparisonClause extends LuceneQueryClause
 
     static class DoubleQuery extends LuceneQueryFieldComparisonClause {
         private final boolean fieldNameOverride;
+        @Nullable
         private final String namedFieldSuffix;
 
         public DoubleQuery(final LuceneQueryType queryType, String field, LuceneIndexExpressions.DocumentFieldType fieldType, Comparisons.Comparison comparison,
-                           final boolean fieldNameOverride, final String namedFieldSuffix) {
+                           final boolean fieldNameOverride, @Nullable final String namedFieldSuffix) {
             super(queryType, field, fieldType, comparison);
             this.fieldNameOverride = fieldNameOverride;
             this.namedFieldSuffix = namedFieldSuffix;

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneQueryFieldComparisonClause.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneQueryFieldComparisonClause.java
@@ -45,8 +45,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TermRangeQuery;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.List;
 
 /**
@@ -54,37 +53,31 @@ import java.util.List;
  */
 @API(API.Status.UNSTABLE)
 public abstract class LuceneQueryFieldComparisonClause extends LuceneQueryClause {
-    @Nonnull
     protected final String field;
-    @Nonnull
     protected final LuceneIndexExpressions.DocumentFieldType fieldType;
-    @Nonnull
     protected final Comparisons.Comparison comparison;
 
-    protected LuceneQueryFieldComparisonClause(@Nonnull LuceneQueryType querType, @Nonnull String field, @Nonnull LuceneIndexExpressions.DocumentFieldType fieldType, @Nonnull Comparisons.Comparison comparison) {
+    protected LuceneQueryFieldComparisonClause(LuceneQueryType querType, String field, LuceneIndexExpressions.DocumentFieldType fieldType, Comparisons.Comparison comparison) {
         super(querType);
         this.field = field;
         this.fieldType = fieldType;
         this.comparison = comparison;
     }
 
-    @Nonnull
     public String getField() {
         return field;
     }
 
-    @Nonnull
     public LuceneIndexExpressions.DocumentFieldType getFieldType() {
         return fieldType;
     }
 
-    @Nonnull
     public Comparisons.Comparison getComparison() {
         return comparison;
     }
 
     @Override
-    public void getPlannerGraphDetails(@Nonnull final ImmutableList.Builder<String> detailsBuilder, @Nonnull final ImmutableMap.Builder<String, Attribute> attributeMapBuilder) {
+    public void getPlannerGraphDetails(final ImmutableList.Builder<String> detailsBuilder, final ImmutableMap.Builder<String, Attribute> attributeMapBuilder) {
         detailsBuilder.add("field: {{field}}");
         attributeMapBuilder.put("field", Attribute.gml(field));
         detailsBuilder.add("fieldType: {{fieldType}}");
@@ -96,7 +89,7 @@ public abstract class LuceneQueryFieldComparisonClause extends LuceneQueryClause
     }
 
     @Override
-    public int planHash(@Nonnull final PlanHashMode mode) {
+    public int planHash(final PlanHashMode mode) {
         return PlanHashable.objectsPlanHash(mode, field, fieldType, comparison);
     }
 
@@ -133,13 +126,12 @@ public abstract class LuceneQueryFieldComparisonClause extends LuceneQueryClause
         return result;
     }
 
-    @Nonnull
     @SuppressWarnings("fallthrough")
-    public static LuceneQueryFieldComparisonClause create(@Nonnull final LuceneQueryType queryType,
-                                                          @Nonnull final String field,
-                                                          @Nonnull final LuceneIndexExpressions.DocumentFieldType fieldType,
+    public static LuceneQueryFieldComparisonClause create(final LuceneQueryType queryType,
+                                                          final String field,
+                                                          final LuceneIndexExpressions.DocumentFieldType fieldType,
                                                           final boolean fieldNameOverride, @Nullable final String namedFieldSuffix,
-                                                          @Nonnull final Comparisons.Comparison comparison) {
+                                                          final Comparisons.Comparison comparison) {
         switch (comparison.getType()) {
             case NOT_NULL:
             case IS_NULL:
@@ -217,7 +209,7 @@ public abstract class LuceneQueryFieldComparisonClause extends LuceneQueryClause
         }
     }
 
-    protected static Query negate(@Nonnull Query query) {
+    protected static Query negate(Query query) {
         BooleanQuery.Builder builder = new BooleanQuery.Builder();
         builder.add(new MatchAllDocsQuery(), BooleanClause.Occur.MUST);
         builder.add(query, BooleanClause.Occur.MUST_NOT);
@@ -225,12 +217,12 @@ public abstract class LuceneQueryFieldComparisonClause extends LuceneQueryClause
     }
 
     static class NullQuery extends LuceneQueryFieldComparisonClause {
-        public NullQuery(@Nonnull final LuceneQueryType queryType, @Nonnull String field, @Nonnull LuceneIndexExpressions.DocumentFieldType fieldType, @Nonnull Comparisons.Comparison comparison) {
+        public NullQuery(final LuceneQueryType queryType, String field, LuceneIndexExpressions.DocumentFieldType fieldType, Comparisons.Comparison comparison) {
             super(queryType, field, fieldType, comparison);
         }
 
         @Override
-        public BoundQuery bind(@Nonnull FDBRecordStoreBase<?> store, @Nonnull Index index, @Nonnull EvaluationContext context) {
+        public BoundQuery bind(FDBRecordStoreBase<?> store, Index index, EvaluationContext context) {
             Query allValues = new TermRangeQuery(field, null, null, true, true);
             if (comparison.getType() == Comparisons.Type.NOT_NULL) {
                 return toBoundQuery(allValues);
@@ -243,13 +235,13 @@ public abstract class LuceneQueryFieldComparisonClause extends LuceneQueryClause
     }
 
     static class StringQuery extends LuceneQueryFieldComparisonClause {
-        public StringQuery(@Nonnull final LuceneQueryType queryType, @Nonnull String field, @Nonnull LuceneIndexExpressions.DocumentFieldType fieldType, @Nonnull Comparisons.Comparison comparison) {
+        public StringQuery(final LuceneQueryType queryType, String field, LuceneIndexExpressions.DocumentFieldType fieldType, Comparisons.Comparison comparison) {
             super(queryType, field, fieldType, comparison);
         }
 
         @Override
         @SuppressWarnings("unchecked")
-        public BoundQuery bind(@Nonnull FDBRecordStoreBase<?> store, @Nonnull Index index, @Nonnull EvaluationContext context) {
+        public BoundQuery bind(FDBRecordStoreBase<?> store, Index index, EvaluationContext context) {
             Object comparand = comparison.getComparand(store, context);
             if (comparand == null) {
                 return toBoundQuery(new MatchNoDocsQuery());
@@ -323,7 +315,7 @@ public abstract class LuceneQueryFieldComparisonClause extends LuceneQueryClause
         private final boolean fieldNameOverride;
         private final String namedFieldSuffix;
 
-        public IntQuery(@Nonnull final LuceneQueryType queryType, @Nonnull String field, @Nonnull LuceneIndexExpressions.DocumentFieldType fieldType, @Nonnull Comparisons.Comparison comparison,
+        public IntQuery(final LuceneQueryType queryType, String field, LuceneIndexExpressions.DocumentFieldType fieldType, Comparisons.Comparison comparison,
                         final boolean fieldNameOverride, final String namedFieldSuffix) {
             super(queryType, field, fieldType, comparison);
             this.fieldNameOverride = fieldNameOverride;
@@ -332,7 +324,7 @@ public abstract class LuceneQueryFieldComparisonClause extends LuceneQueryClause
 
         @Override
         @SuppressWarnings("unchecked")
-        public BoundQuery bind(@Nonnull FDBRecordStoreBase<?> store, @Nonnull Index index, @Nonnull EvaluationContext context) {
+        public BoundQuery bind(FDBRecordStoreBase<?> store, Index index, EvaluationContext context) {
             Object comparand = comparison.getComparand(store, context);
             if (comparand == null) {
                 return toBoundQuery(new MatchNoDocsQuery());
@@ -371,7 +363,7 @@ public abstract class LuceneQueryFieldComparisonClause extends LuceneQueryClause
         private final boolean fieldNameOverride;
         private final String namedFieldSuffix;
 
-        public LongQuery(@Nonnull final LuceneQueryType queryType, @Nonnull String field, @Nonnull LuceneIndexExpressions.DocumentFieldType fieldType, @Nonnull Comparisons.Comparison comparison,
+        public LongQuery(final LuceneQueryType queryType, String field, LuceneIndexExpressions.DocumentFieldType fieldType, Comparisons.Comparison comparison,
                          final boolean fieldNameOverride, final String namedFieldSuffix) {
             super(queryType, field, fieldType, comparison);
             this.fieldNameOverride = fieldNameOverride;
@@ -380,7 +372,7 @@ public abstract class LuceneQueryFieldComparisonClause extends LuceneQueryClause
 
         @Override
         @SuppressWarnings("unchecked")
-        public BoundQuery bind(@Nonnull FDBRecordStoreBase<?> store, @Nonnull Index index, @Nonnull EvaluationContext context) {
+        public BoundQuery bind(FDBRecordStoreBase<?> store, Index index, EvaluationContext context) {
             Object comparand = comparison.getComparand(store, context);
             if (comparand == null) {
                 return toBoundQuery(new MatchNoDocsQuery());
@@ -443,7 +435,7 @@ public abstract class LuceneQueryFieldComparisonClause extends LuceneQueryClause
         private final boolean fieldNameOverride;
         private final String namedFieldSuffix;
 
-        public DoubleQuery(@Nonnull final LuceneQueryType queryType, @Nonnull String field, @Nonnull LuceneIndexExpressions.DocumentFieldType fieldType, @Nonnull Comparisons.Comparison comparison,
+        public DoubleQuery(final LuceneQueryType queryType, String field, LuceneIndexExpressions.DocumentFieldType fieldType, Comparisons.Comparison comparison,
                            final boolean fieldNameOverride, final String namedFieldSuffix) {
             super(queryType, field, fieldType, comparison);
             this.fieldNameOverride = fieldNameOverride;
@@ -452,7 +444,7 @@ public abstract class LuceneQueryFieldComparisonClause extends LuceneQueryClause
 
         @Override
         @SuppressWarnings("unchecked")
-        public BoundQuery bind(@Nonnull FDBRecordStoreBase<?> store, @Nonnull Index index, @Nonnull EvaluationContext context) {
+        public BoundQuery bind(FDBRecordStoreBase<?> store, Index index, EvaluationContext context) {
             Object comparand = comparison.getComparand(store, context);
             if (comparand == null) {
                 return toBoundQuery(new MatchNoDocsQuery());

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneQueryMultiFieldSearchClause.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneQueryMultiFieldSearchClause.java
@@ -34,7 +34,6 @@ import com.google.common.collect.ImmutableMap;
 import org.apache.lucene.queryparser.classic.QueryParser;
 import org.apache.lucene.queryparser.flexible.standard.config.PointsConfig;
 
-import javax.annotation.Nonnull;
 import java.util.Map;
 
 /**
@@ -43,17 +42,15 @@ import java.util.Map;
  */
 @API(API.Status.UNSTABLE)
 public class LuceneQueryMultiFieldSearchClause extends LuceneQueryClause {
-    @Nonnull
     private final String search;
     private final boolean isParameter;
 
-    public LuceneQueryMultiFieldSearchClause(@Nonnull final LuceneQueryType queryType, @Nonnull final String search, final boolean isParameter) {
+    public LuceneQueryMultiFieldSearchClause(final LuceneQueryType queryType, final String search, final boolean isParameter) {
         super(queryType);
         this.search = search;
         this.isParameter = isParameter;
     }
 
-    @Nonnull
     public String getSearch() {
         return search;
     }
@@ -63,7 +60,7 @@ public class LuceneQueryMultiFieldSearchClause extends LuceneQueryClause {
     }
 
     @Override
-    public BoundQuery bind(@Nonnull FDBRecordStoreBase<?> store, @Nonnull Index index, @Nonnull EvaluationContext context) {
+    public BoundQuery bind(FDBRecordStoreBase<?> store, Index index, EvaluationContext context) {
         final var fieldInfos = LuceneIndexExpressions.getDocumentFieldDerivations(index, store.getRecordMetaData());
         final LuceneAnalyzerCombinationProvider analyzerSelector =
                 LuceneAnalyzerRegistryImpl.instance().getLuceneAnalyzerCombinationProvider(index, LuceneAnalyzerType.FULL_TEXT, fieldInfos);
@@ -81,7 +78,7 @@ public class LuceneQueryMultiFieldSearchClause extends LuceneQueryClause {
     }
 
     @Override
-    public void getPlannerGraphDetails(@Nonnull ImmutableList.Builder<String> detailsBuilder, @Nonnull ImmutableMap.Builder<String, Attribute> attributeMapBuilder) {
+    public void getPlannerGraphDetails(ImmutableList.Builder<String> detailsBuilder, ImmutableMap.Builder<String, Attribute> attributeMapBuilder) {
         if (isParameter) {
             detailsBuilder.add("param: {{param}}");
             attributeMapBuilder.put("param", Attribute.gml(search));
@@ -92,7 +89,7 @@ public class LuceneQueryMultiFieldSearchClause extends LuceneQueryClause {
     }
 
     @Override
-    public int planHash(@Nonnull final PlanHashMode mode) {
+    public int planHash(final PlanHashMode mode) {
         return PlanHashable.objectsPlanHash(mode, search, isParameter);
     }
 

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneQuerySearchClause.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneQuerySearchClause.java
@@ -34,7 +34,6 @@ import com.google.common.collect.ImmutableMap;
 import org.apache.lucene.queryparser.classic.QueryParser;
 import org.apache.lucene.queryparser.flexible.standard.config.PointsConfig;
 
-import javax.annotation.Nonnull;
 import java.util.Map;
 
 /**
@@ -44,30 +43,26 @@ import java.util.Map;
 public class LuceneQuerySearchClause extends LuceneQueryClause {
     public static final LuceneQueryClause MATCH_ALL_DOCS_QUERY = new LuceneQuerySearchClause(LuceneQueryType.QUERY, "*:*", false);
 
-    @Nonnull
     private final String defaultField;
-    @Nonnull
     private final String search;
     private final boolean isParameter;
 
     // TODO: Need better predicates for controlling field.
-    public LuceneQuerySearchClause(@Nonnull final LuceneQueryType queryType, @Nonnull final String search, final boolean isParameter) {
+    public LuceneQuerySearchClause(final LuceneQueryType queryType, final String search, final boolean isParameter) {
         this(queryType, LuceneIndexMaintainer.PRIMARY_KEY_SEARCH_NAME, search, isParameter);
     }
 
-    public LuceneQuerySearchClause(@Nonnull final LuceneQueryType queryType, @Nonnull final String defaultField, @Nonnull final String search, final boolean isParameter) {
+    public LuceneQuerySearchClause(final LuceneQueryType queryType, final String defaultField, final String search, final boolean isParameter) {
         super(queryType);
         this.defaultField = defaultField;
         this.search = search;
         this.isParameter = isParameter;
     }
 
-    @Nonnull
     public String getDefaultField() {
         return defaultField;
     }
 
-    @Nonnull
     public String getSearch() {
         return search;
     }
@@ -77,7 +72,7 @@ public class LuceneQuerySearchClause extends LuceneQueryClause {
     }
 
     @Override
-    public BoundQuery bind(@Nonnull FDBRecordStoreBase<?> store, @Nonnull Index index, @Nonnull EvaluationContext context) {
+    public BoundQuery bind(FDBRecordStoreBase<?> store, Index index, EvaluationContext context) {
         final var fieldInfos = LuceneIndexExpressions.getDocumentFieldDerivations(index, store.getRecordMetaData());
         final LuceneAnalyzerCombinationProvider analyzerSelector = LuceneAnalyzerRegistryImpl.instance().getLuceneAnalyzerCombinationProvider(index, LuceneAnalyzerType.FULL_TEXT, fieldInfos);
         final String searchString = isParameter ? (String)context.getBinding(search) : search;
@@ -93,7 +88,7 @@ public class LuceneQuerySearchClause extends LuceneQueryClause {
     }
 
     @Override
-    public void getPlannerGraphDetails(@Nonnull ImmutableList.Builder<String> detailsBuilder, @Nonnull ImmutableMap.Builder<String, Attribute> attributeMapBuilder) {
+    public void getPlannerGraphDetails(ImmutableList.Builder<String> detailsBuilder, ImmutableMap.Builder<String, Attribute> attributeMapBuilder) {
         if (!LuceneIndexMaintainer.PRIMARY_KEY_SEARCH_NAME.equals(defaultField)) {
             detailsBuilder.add("field: {{field}}");
             attributeMapBuilder.put("field", Attribute.gml(defaultField));
@@ -108,7 +103,7 @@ public class LuceneQuerySearchClause extends LuceneQueryClause {
     }
 
     @Override
-    public int planHash(@Nonnull final PlanHashMode mode) {
+    public int planHash(final PlanHashMode mode) {
         return PlanHashable.objectsPlanHash(mode, defaultField, search, isParameter);
     }
 

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneRecordCursor.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneRecordCursor.java
@@ -58,8 +58,7 @@ import org.apache.lucene.util.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
@@ -73,6 +72,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
 
 import static com.apple.foundationdb.record.RecordCursor.NoNextReason.SOURCE_EXHAUSTED;
+import static com.apple.foundationdb.record.lucene.LucenePartitionInfoProto.LucenePartitionInfo;
+import static com.apple.foundationdb.record.lucene.LuceneScanQueryParameters.LuceneQueryHighlightParameters;
 
 /**
  * This class is a Record Cursor implementation for Lucene queries.
@@ -83,11 +84,9 @@ public class LuceneRecordCursor implements BaseCursor<IndexEntry> {
     private static final Logger LOGGER = LoggerFactory.getLogger(LuceneRecordCursor.class);
     // pagination within single instance of record cursor for lucene queries.
     private final int pageSize;
-    @Nonnull
     private final Executor executor;
     @Nullable
     private final ExecutorService executorService;
-    @Nonnull
     private final CursorLimitManager limitManager;
     @Nullable
     private final FDBStoreTimer timer;
@@ -119,22 +118,18 @@ public class LuceneRecordCursor implements BaseCursor<IndexEntry> {
     Integer partitionId;
     @Nullable
     Tuple partitionKey;
-    @Nonnull
     LucenePartitioner partitioner;
     @Nullable
     private final List<String> storedFields;
-    @Nonnull
     private final Set<String> storedFieldsToReturn;
     @Nullable
     private final List<LuceneIndexExpressions.DocumentFieldType> storedFieldTypes;
 
     @Nullable
-    private final LuceneScanQueryParameters.LuceneQueryHighlightParameters luceneQueryHighlightParameters;
+    private final LuceneQueryHighlightParameters luceneQueryHighlightParameters;
     @Nullable
     private final Map<String, Set<String>> termMap;
-    @Nonnull
     private final LuceneAnalyzerCombinationProvider analyzerSelector;
-    @Nonnull
     private final LuceneAnalyzerCombinationProvider autoCompleteAnalyzerSelector;
     private boolean closed;
     /**
@@ -172,23 +167,23 @@ public class LuceneRecordCursor implements BaseCursor<IndexEntry> {
     //TODO: once we fix the available fields logic for lucene to take into account which fields are
     // stored there should be no need to pass in a list of fields, or we could only pass in the store field values.
     @SuppressWarnings("squid:S107")
-    LuceneRecordCursor(@Nonnull Executor executor,
+    LuceneRecordCursor(Executor executor,
                        @Nullable ExecutorService executorService,
-                       @Nonnull LucenePartitioner partitioner,
+                       LucenePartitioner partitioner,
                        int pageSize,
-                       @Nonnull ScanProperties scanProperties,
-                       @Nonnull final IndexMaintainerState state,
-                       @Nonnull Query query,
+                       ScanProperties scanProperties,
+                       final IndexMaintainerState state,
+                       Query query,
                        @Nullable Sort sort,
                        byte[] continuation,
                        @Nullable Tuple groupingKey,
-                       @Nullable LucenePartitionInfoProto.LucenePartitionInfo partitionInfo,
-                       @Nullable LuceneScanQueryParameters.LuceneQueryHighlightParameters luceneQueryHighlightParameters,
+                       @Nullable LucenePartitionInfo partitionInfo,
+                       @Nullable LuceneQueryHighlightParameters luceneQueryHighlightParameters,
                        @Nullable Map<String, Set<String>> termMap,
                        @Nullable final List<String> storedFields,
                        @Nullable final List<LuceneIndexExpressions.DocumentFieldType> storedFieldTypes,
-                       @Nonnull LuceneAnalyzerCombinationProvider analyzerSelector,
-                       @Nonnull LuceneAnalyzerCombinationProvider autoCompleteAnalyzerSelector) {
+                       LuceneAnalyzerCombinationProvider analyzerSelector,
+                       LuceneAnalyzerCombinationProvider autoCompleteAnalyzerSelector) {
         this.state = state;
         this.executor = executor;
         this.pageSize = pageSize;
@@ -271,7 +266,6 @@ public class LuceneRecordCursor implements BaseCursor<IndexEntry> {
         closed = false;
     }
 
-    @Nonnull
     @Override
     public CompletableFuture<RecordCursorResult<IndexEntry>> onNext() {
         if (nextResult != null && !nextResult.hasNext()) {
@@ -378,7 +372,7 @@ public class LuceneRecordCursor implements BaseCursor<IndexEntry> {
             return CompletableFuture.completedFuture(recordCursorResult);
         }
 
-        final CompletableFuture<LucenePartitionInfoProto.LucenePartitionInfo> nextPartitionFuture;
+        final CompletableFuture<LucenePartitionInfo> nextPartitionFuture;
         if (sortedByPartitioningKey && !isReverseSort) {
             // if we're in a partitioning-field-ascending-sort query, get the next more recent partition
             nextPartitionFuture = partitioner.getPartitionMetaInfoById(partitionId, groupingKey)
@@ -434,14 +428,13 @@ public class LuceneRecordCursor implements BaseCursor<IndexEntry> {
         return closed;
     }
 
-    @Nonnull
     @Override
     public Executor getExecutor() {
         return executor;
     }
 
     @Override
-    public boolean accept(@Nonnull RecordCursorVisitor visitor) {
+    public boolean accept(RecordCursorVisitor visitor) {
         visitor.visitEnter(this);
         return visitor.visitLeave(this);
     }
@@ -523,7 +516,7 @@ public class LuceneRecordCursor implements BaseCursor<IndexEntry> {
         return newTopDocs;
     }
 
-    private CompletableFuture<ScoreDocIndexEntry> buildIndexEntryFromScoreDocAsync(@Nonnull ScoreDoc scoreDoc) {
+    private CompletableFuture<ScoreDocIndexEntry> buildIndexEntryFromScoreDocAsync(ScoreDoc scoreDoc) {
         return CompletableFuture.supplyAsync(() -> {
             try {
                 Document document = searcher.doc(scoreDoc.doc, storedFieldsToReturn);
@@ -606,7 +599,7 @@ public class LuceneRecordCursor implements BaseCursor<IndexEntry> {
         private final Map<String, Set<String>> termMap;
         private final LuceneAnalyzerCombinationProvider analyzerSelector;
         private final LuceneAnalyzerCombinationProvider autoCompleteAnalyzerSelector;
-        private final LuceneScanQueryParameters.LuceneQueryHighlightParameters luceneQueryHighlightParameters;
+        private final LuceneQueryHighlightParameters luceneQueryHighlightParameters;
         private final KeyExpression indexKey;
 
         public ScoreDoc getScoreDoc() {
@@ -625,7 +618,7 @@ public class LuceneRecordCursor implements BaseCursor<IndexEntry> {
             return autoCompleteAnalyzerSelector;
         }
 
-        public LuceneScanQueryParameters.LuceneQueryHighlightParameters getLuceneQueryHighlightParameters() {
+        public LuceneQueryHighlightParameters getLuceneQueryHighlightParameters() {
             return luceneQueryHighlightParameters;
         }
 
@@ -633,11 +626,11 @@ public class LuceneRecordCursor implements BaseCursor<IndexEntry> {
             return indexKey;
         }
 
-        private ScoreDocIndexEntry(@Nonnull ScoreDoc scoreDoc, @Nonnull Index index, @Nonnull Tuple key,
-                                   @Nullable LuceneScanQueryParameters.LuceneQueryHighlightParameters luceneQueryHighlightParameters,
+        private ScoreDocIndexEntry(ScoreDoc scoreDoc, Index index, Tuple key,
+                                   @Nullable LuceneQueryHighlightParameters luceneQueryHighlightParameters,
                                    @Nullable final Map<String, Set<String>> termMap,
-                                   @Nonnull LuceneAnalyzerCombinationProvider analyzerSelector,
-                                   @Nonnull LuceneAnalyzerCombinationProvider autoCompleteAnalyzerSelector) {
+                                   LuceneAnalyzerCombinationProvider analyzerSelector,
+                                   LuceneAnalyzerCombinationProvider autoCompleteAnalyzerSelector) {
             super(index, key, TupleHelpers.EMPTY);
             this.scoreDoc = scoreDoc;
             this.luceneQueryHighlightParameters = luceneQueryHighlightParameters;

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneRecordCursor.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneRecordCursor.java
@@ -102,10 +102,14 @@ public class LuceneRecordCursor implements BaseCursor<IndexEntry> {
     @Nullable
     private RecordCursorResult<IndexEntry> nextResult;
     final IndexMaintainerState state;
+    @Nullable
     private IndexReader indexReader;
     private final Query query;
+    @Nullable
     private final Sort sort;
+    @Nullable
     private IndexSearcher searcher;
+    @Nullable
     private RecordCursor<IndexEntry> lookupResults = null;
     private int currentPosition = 0;
     private final List<KeyExpression> fields;
@@ -157,6 +161,7 @@ public class LuceneRecordCursor implements BaseCursor<IndexEntry> {
     /**
      * partitioning field value to search after.
      */
+    @Nullable
     private Tuple searchAfterPartitioningKey = null;
 
     /**
@@ -175,7 +180,7 @@ public class LuceneRecordCursor implements BaseCursor<IndexEntry> {
                        final IndexMaintainerState state,
                        Query query,
                        @Nullable Sort sort,
-                       byte[] continuation,
+                       byte @Nullable [] continuation,
                        @Nullable Tuple groupingKey,
                        @Nullable LucenePartitionInfo partitionInfo,
                        @Nullable LuceneQueryHighlightParameters luceneQueryHighlightParameters,
@@ -306,10 +311,12 @@ public class LuceneRecordCursor implements BaseCursor<IndexEntry> {
                         } catch (IOException ioException) {
                             throw LuceneExceptions.toRecordCoreException("Record Cursor failed", ioException, LogMessageKeys.QUERY, query);
                         }
-                        return lookupResults.onNext().thenCompose(this::switchToNextPartitionAndContinue);
+                        // maybePerformScan() always (re-)populates lookupResults before returning normally.
+                        return Objects.requireNonNull(lookupResults).onNext().thenCompose(this::switchToNextPartitionAndContinue);
                     }, executor).thenCompose(Function.identity());
                 }
-                return lookupResults.onNext().thenCompose(this::switchToNextPartitionAndContinue);
+                // The condition above being false implies lookupResults != null (De Morgan's on the `||`).
+                return Objects.requireNonNull(lookupResults).onNext().thenCompose(this::switchToNextPartitionAndContinue);
             });
         });
     }
@@ -322,8 +329,8 @@ public class LuceneRecordCursor implements BaseCursor<IndexEntry> {
         }
 
         // here: this is a continuation in a partitioned index, and we haven't yet "sanitized" the partition info
-        // with respect to the continuation, do that now:
-        return partitioner.getPartitionMetaInfoById(Objects.requireNonNull(partitionId), groupingKey).thenCompose(partitionInfo -> {
+        // with respect to the continuation, do that now: partitioning is enabled here, so groupingKey is present.
+        return partitioner.getPartitionMetaInfoById(Objects.requireNonNull(partitionId), Objects.requireNonNull(groupingKey)).thenCompose(partitionInfo -> {
             // the boundaries of the partition may have changed (due to re-balancing, explicit doc removal etc.)
             partitionKey = LucenePartitioner.getPartitionKey(partitionInfo);
 
@@ -339,7 +346,7 @@ public class LuceneRecordCursor implements BaseCursor<IndexEntry> {
                 dontResetSearchAfter = true;
 
                 // get the proper partition
-                getProperContinuationPartition = partitioner.findPartitionInfo(groupingKey, searchAfterPartitioningKey).thenCompose(properPartitionInfo -> {
+                getProperContinuationPartition = partitioner.findPartitionInfo(Objects.requireNonNull(groupingKey), searchAfterPartitioningKey).thenCompose(properPartitionInfo -> {
                     // if a "proper" partition no longer exists (e.g. there's no more records past the current continuation point in any partition),
                     // we keep the original partition info as is and let the normal "exhausted" condition be met.
                     if (properPartitionInfo != null) {
@@ -375,8 +382,8 @@ public class LuceneRecordCursor implements BaseCursor<IndexEntry> {
         final CompletableFuture<LucenePartitionInfo> nextPartitionFuture;
         if (sortedByPartitioningKey && !isReverseSort) {
             // if we're in a partitioning-field-ascending-sort query, get the next more recent partition
-            nextPartitionFuture = partitioner.getPartitionMetaInfoById(partitionId, groupingKey)
-                    .thenCompose(curPartition -> LucenePartitioner.getNextNewerPartitionInfo(state.context, groupingKey, partitioner.getPartitionKey(curPartition), state.indexSubspace));
+            nextPartitionFuture = partitioner.getPartitionMetaInfoById(Objects.requireNonNull(partitionId), Objects.requireNonNull(groupingKey))
+                    .thenCompose(curPartition -> LucenePartitioner.getNextNewerPartitionInfo(state.context, Objects.requireNonNull(groupingKey), partitioner.getPartitionKey(curPartition), state.indexSubspace));
         } else {
             // otherwise get the next older partition
             nextPartitionFuture = LucenePartitioner.getNextOlderPartitionInfo(
@@ -387,7 +394,8 @@ public class LuceneRecordCursor implements BaseCursor<IndexEntry> {
         }
 
         return nextPartitionFuture.thenCompose(nextPartition -> {
-            if (nextPartition != null && nextPartition.getId() != partitionId) {
+            // partitionKey != null (checked above) implies partitioning is active, so partitionId is also set.
+            if (nextPartition != null && nextPartition.getId() != Objects.requireNonNull(partitionId)) {
                 // reset scan params/state
                 exhausted = false;
                 this.partitionKey = partitioner.getPartitionKey(nextPartition);
@@ -404,7 +412,8 @@ public class LuceneRecordCursor implements BaseCursor<IndexEntry> {
                 }
                 try {
                     maybePerformScan();
-                    return lookupResults.onNext().thenCompose(this::switchToNextPartitionAndContinue);
+                    // maybePerformScan() always (re-)populates lookupResults before returning normally.
+                    return Objects.requireNonNull(lookupResults).onNext().thenCompose(this::switchToNextPartitionAndContinue);
                 } catch (IOException ioException) {
                     throw LuceneExceptions.toRecordCoreException(ioException.getMessage(), ioException, LogMessageKeys.QUERY, query);
                 }
@@ -468,8 +477,9 @@ public class LuceneRecordCursor implements BaseCursor<IndexEntry> {
                     } else if (exhausted) {
                         nextResult = RecordCursorResult.exhausted();
                     } else if (limitRemaining <= 0) {
+                        // exhausted is false here, so the scan matched at least `limit` docs and searchAfter was set.
                         RecordCursorContinuation continuationFromDoc = LuceneCursorContinuation.fromScoreDoc(
-                                searchAfter,
+                                Objects.requireNonNull(searchAfter),
                                 partitionId,
                                 partitionKey);
                         nextResult = RecordCursorResult.withoutNextValue(continuationFromDoc, NoNextReason.RETURN_LIMIT_REACHED);
@@ -478,8 +488,9 @@ public class LuceneRecordCursor implements BaseCursor<IndexEntry> {
                         if (stoppedReason.isEmpty()) {
                             throw new RecordCoreException("limit manager stopped LuceneRecordCursor but did not report a reason");
                         } else {
+                            // exhausted is false here, so the scan matched at least `limit` docs and searchAfter was set.
                             nextResult = RecordCursorResult.withoutNextValue(LuceneCursorContinuation.fromScoreDoc(
-                                    searchAfter,
+                                    Objects.requireNonNull(searchAfter),
                                     partitionId,
                                     partitionKey), stoppedReason.get());
                         }
@@ -519,7 +530,8 @@ public class LuceneRecordCursor implements BaseCursor<IndexEntry> {
     private CompletableFuture<ScoreDocIndexEntry> buildIndexEntryFromScoreDocAsync(ScoreDoc scoreDoc) {
         return CompletableFuture.supplyAsync(() -> {
             try {
-                Document document = searcher.doc(scoreDoc.doc, storedFieldsToReturn);
+                // searchForTopDocs() always sets searcher before the results it produced are processed here.
+                Document document = Objects.requireNonNull(searcher).doc(scoreDoc.doc, storedFieldsToReturn);
                 IndexableField primaryKey = document.getField(LuceneIndexMaintainer.PRIMARY_KEY_FIELD_NAME);
                 BytesRef pk = primaryKey.binaryValue();
                 if (LOGGER.isTraceEnabled()) {
@@ -540,14 +552,16 @@ public class LuceneRecordCursor implements BaseCursor<IndexEntry> {
                     }
                 }
                 if (storedFields != null) {
+                    // storedFieldTypes is always supplied alongside storedFields (see constructor), same length.
+                    final List<LuceneIndexExpressions.DocumentFieldType> fieldTypes = Objects.requireNonNull(storedFieldTypes);
                     for (int i = 0; i < storedFields.size(); i++) {
-                        if (storedFieldTypes.get(i) == null) {
+                        if (fieldTypes.get(i) == null) {
                             continue;
                         }
                         Object value = null;
                         IndexableField docField = document.getField(storedFields.get(i));
                         if (docField != null) {
-                            switch (storedFieldTypes.get(i)) {
+                            switch (fieldTypes.get(i)) {
                                 case STRING:
                                     value = docField.stringValue();
                                     break;
@@ -596,9 +610,11 @@ public class LuceneRecordCursor implements BaseCursor<IndexEntry> {
     public static final class ScoreDocIndexEntry extends IndexEntry {
         private final ScoreDoc scoreDoc;
 
+        @Nullable
         private final Map<String, Set<String>> termMap;
         private final LuceneAnalyzerCombinationProvider analyzerSelector;
         private final LuceneAnalyzerCombinationProvider autoCompleteAnalyzerSelector;
+        @Nullable
         private final LuceneQueryHighlightParameters luceneQueryHighlightParameters;
         private final KeyExpression indexKey;
 
@@ -606,6 +622,7 @@ public class LuceneRecordCursor implements BaseCursor<IndexEntry> {
             return scoreDoc;
         }
 
+        @Nullable
         public Map<String, Set<String>> getTermMap() {
             return termMap;
         }
@@ -618,6 +635,7 @@ public class LuceneRecordCursor implements BaseCursor<IndexEntry> {
             return autoCompleteAnalyzerSelector;
         }
 
+        @Nullable
         public LuceneQueryHighlightParameters getLuceneQueryHighlightParameters() {
             return luceneQueryHighlightParameters;
         }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneRepartitionPlanner.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneRepartitionPlanner.java
@@ -24,9 +24,10 @@ import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.util.pair.Pair;
 import com.apple.foundationdb.tuple.Tuple;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.List;
+
+import static com.apple.foundationdb.record.lucene.LucenePartitionInfoProto.LucenePartitionInfo;
 
 /**
  * Manage repartitioning details (merging small partitions and splitting large ones).
@@ -50,20 +51,19 @@ public class LuceneRepartitionPlanner {
      * @param repartitionDocumentCount max allowed documents to move per iteration
      * @return repartitioning context instance ({@link RepartitioningContext}
      */
-    @Nonnull
-    RepartitioningContext determineRepartitioningAction(@Nonnull final Tuple groupingKey,
-                                                        @Nonnull final List<LucenePartitionInfoProto.LucenePartitionInfo> allPartitions,
+    RepartitioningContext determineRepartitioningAction(final Tuple groupingKey,
+                                                        final List<LucenePartitionInfo> allPartitions,
                                                         int currentPartitionPosition,
                                                         int repartitionDocumentCount) {
-        int maxPartitionId = allPartitions.stream().mapToInt(LucenePartitionInfoProto.LucenePartitionInfo::getId).max().orElse(0);
-        LucenePartitionInfoProto.LucenePartitionInfo candidatePartition = allPartitions.get(currentPartitionPosition);
+        int maxPartitionId = allPartitions.stream().mapToInt(LucenePartitionInfo::getId).max().orElse(0);
+        LucenePartitionInfo candidatePartition = allPartitions.get(currentPartitionPosition);
 
-        Pair<LucenePartitionInfoProto.LucenePartitionInfo, LucenePartitionInfoProto.LucenePartitionInfo> neighborPartitions =
+        Pair<LucenePartitionInfo, LucenePartitionInfo> neighborPartitions =
                 LucenePartitioner.getPartitionNeighbors(allPartitions, currentPartitionPosition);
 
         // partitions sorted by key descending
-        LucenePartitionInfoProto.LucenePartitionInfo olderPartition = neighborPartitions.getRight();
-        LucenePartitionInfoProto.LucenePartitionInfo newerPartition = neighborPartitions.getLeft();
+        LucenePartitionInfo olderPartition = neighborPartitions.getRight();
+        LucenePartitionInfo newerPartition = neighborPartitions.getLeft();
 
         RepartitioningContext repartitioningContext = new RepartitioningContext(groupingKey,
                 maxPartitionId,
@@ -165,21 +165,21 @@ public class LuceneRepartitionPlanner {
      * Convenience collection of data needed for repartitioning.
      */
     public static class RepartitioningContext {
-        @Nonnull Tuple groupingKey;
-        @Nonnull final LucenePartitionInfoProto.LucenePartitionInfo sourcePartition;
-        @Nullable final LucenePartitionInfoProto.LucenePartitionInfo olderPartition;
-        @Nullable final LucenePartitionInfoProto.LucenePartitionInfo newerPartition;
+        Tuple groupingKey;
+        final LucenePartitionInfo sourcePartition;
+        @Nullable final LucenePartitionInfo olderPartition;
+        @Nullable final LucenePartitionInfo newerPartition;
         boolean emptyingPartition;
         int countToMove;
         int maxPartitionId;
         boolean newBoundaryRecordPresent;
         RepartitioningAction action;
 
-        RepartitioningContext(@Nonnull final Tuple groupingKey,
+        RepartitioningContext(final Tuple groupingKey,
                               int maxPartitionId,
-                              @Nonnull final LucenePartitionInfoProto.LucenePartitionInfo sourcePartition,
-                              @Nullable final LucenePartitionInfoProto.LucenePartitionInfo olderPartition,
-                              @Nullable final LucenePartitionInfoProto.LucenePartitionInfo newerPartition) {
+                              final LucenePartitionInfo sourcePartition,
+                              @Nullable final LucenePartitionInfo olderPartition,
+                              @Nullable final LucenePartitionInfo newerPartition) {
             this.groupingKey = groupingKey;
             this.maxPartitionId = maxPartitionId;
             this.sourcePartition = sourcePartition;

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanBounds.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanBounds.java
@@ -25,31 +25,25 @@ import com.apple.foundationdb.record.IndexScanType;
 import com.apple.foundationdb.record.provider.foundationdb.IndexScanBounds;
 import com.apple.foundationdb.tuple.Tuple;
 
-import javax.annotation.Nonnull;
-
 /**
  * Base class for {@link IndexScanBounds} used by {@code LUCENE} indexes.
  * Stores any group key prefix used to determine the directory location.
  */
 @API(API.Status.UNSTABLE)
 public abstract class LuceneScanBounds implements IndexScanBounds {
-    @Nonnull
     protected final IndexScanType scanType;
-    @Nonnull
     protected final Tuple groupKey;
 
-    protected LuceneScanBounds(@Nonnull IndexScanType scanType, @Nonnull Tuple groupKey) {
+    protected LuceneScanBounds(IndexScanType scanType, Tuple groupKey) {
         this.scanType = scanType;
         this.groupKey = groupKey;
     }
 
-    @Nonnull
     @Override
     public IndexScanType getScanType() {
         return scanType;
     }
 
-    @Nonnull
     public Tuple getGroupKey() {
         return groupKey;
     }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanParameters.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanParameters.java
@@ -40,8 +40,7 @@ import com.apple.foundationdb.tuple.TupleHelpers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -52,39 +51,33 @@ import java.util.Objects;
  */
 @API(API.Status.UNSTABLE)
 public abstract class LuceneScanParameters implements IndexScanParameters {
-    @Nonnull
     protected final IndexScanType scanType;
-    @Nonnull
     protected final ScanComparisons groupComparisons;
 
-    protected LuceneScanParameters(@Nonnull final PlanSerializationContext serializationContext,
-                                   @Nonnull final PLuceneScanParameters luceneScanParametersProto) {
+    protected LuceneScanParameters(final PlanSerializationContext serializationContext,
+                                   final PLuceneScanParameters luceneScanParametersProto) {
         this(IndexScanType.fromProto(serializationContext, Objects.requireNonNull(luceneScanParametersProto.getScanType())),
                 ScanComparisons.fromProto(serializationContext, Objects.requireNonNull(luceneScanParametersProto.getGroupComparisons())));
     }
 
-    protected LuceneScanParameters(@Nonnull final IndexScanType scanType, @Nonnull final ScanComparisons groupComparisons) {
+    protected LuceneScanParameters(final IndexScanType scanType, final ScanComparisons groupComparisons) {
         this.scanType = scanType;
         this.groupComparisons = groupComparisons;
     }
 
-    @Nonnull
     @Override
     public IndexScanType getScanType() {
         return scanType;
     }
 
-    @Nonnull
     @Override
-    public abstract LuceneScanBounds bind(@Nonnull FDBRecordStoreBase<?> store, @Nonnull Index index, @Nonnull EvaluationContext context);
+    public abstract LuceneScanBounds bind(FDBRecordStoreBase<?> store, Index index, EvaluationContext context);
 
-    @Nonnull
     public ScanComparisons getGroupComparisons() {
         return groupComparisons;
     }
 
-    @Nonnull
-    protected static List<String> indexTextFields(@Nonnull Index index, @Nonnull RecordMetaData metaData) {
+    protected static List<String> indexTextFields(Index index, RecordMetaData metaData) {
         final List<String> textFields = new ArrayList<>();
         for (RecordType recordType : metaData.recordTypesForIndex(index)) {
             for (LuceneIndexExpressions.DocumentFieldDerivation documentField : LuceneIndexExpressions.getDocumentFieldDerivations(index.getRootExpression(), recordType.getDescriptor()).values()) {
@@ -97,7 +90,7 @@ public abstract class LuceneScanParameters implements IndexScanParameters {
     }
 
     @Override
-    public boolean isUnique(@Nonnull Index index) {
+    public boolean isUnique(Index index) {
         return false;
     }
 
@@ -109,7 +102,6 @@ public abstract class LuceneScanParameters implements IndexScanParameters {
         }
     }
 
-    @Nonnull
     protected Tuple getGroupKey(@Nullable FDBRecordStoreBase<?> store, @Nullable EvaluationContext context) {
         TupleRange tupleRange = groupComparisons.toTupleRange(store, context);
         if (TupleRange.ALL.equals(tupleRange)) {
@@ -131,7 +123,7 @@ public abstract class LuceneScanParameters implements IndexScanParameters {
     }
 
     @Override
-    public void getPlannerGraphDetails(@Nonnull ImmutableList.Builder<String> detailsBuilder, @Nonnull ImmutableMap.Builder<String, Attribute> attributeMapBuilder) {
+    public void getPlannerGraphDetails(ImmutableList.Builder<String> detailsBuilder, ImmutableMap.Builder<String, Attribute> attributeMapBuilder) {
         detailsBuilder.add("scan type: {{scanType}}");
         attributeMapBuilder.put("scanType", Attribute.gml(scanType.toString()));
 
@@ -176,8 +168,7 @@ public abstract class LuceneScanParameters implements IndexScanParameters {
         return result;
     }
 
-    @Nonnull
-    public PLuceneScanParameters toLuceneScanParametersProto(@Nonnull final PlanSerializationContext serializationContext) {
+    public PLuceneScanParameters toLuceneScanParametersProto(final PlanSerializationContext serializationContext) {
         return PLuceneScanParameters.newBuilder()
                 .setScanType(scanType.toProto(serializationContext))
                 .setGroupComparisons(groupComparisons.toProto(serializationContext))

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanParameters.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanParameters.java
@@ -110,7 +110,8 @@ public abstract class LuceneScanParameters implements IndexScanParameters {
         if (!tupleRange.isEquals()) {
             throw new RecordCoreException("group comparisons did not result in equality");
         }
-        return tupleRange.getLow();
+        // An equality TupleRange always has a non-null low bound.
+        return Objects.requireNonNull(tupleRange.getLow());
     }
 
     @Nullable

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanQuery.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanQuery.java
@@ -26,18 +26,18 @@ import com.apple.foundationdb.tuple.Tuple;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Sort;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import static com.apple.foundationdb.record.lucene.LuceneScanQueryParameters.LuceneQueryHighlightParameters;
 
 /**
  * Scan a {@code LUCENE} index using a Lucene {@link Query}.
  */
 @API(API.Status.UNSTABLE)
 public class LuceneScanQuery extends LuceneScanBounds {
-    @Nonnull
     private final Query query;
     @Nullable
     private final Sort sort;
@@ -47,15 +47,15 @@ public class LuceneScanQuery extends LuceneScanBounds {
     private final List<LuceneIndexExpressions.DocumentFieldType> storedFieldTypes;
 
     @Nullable
-    private final LuceneScanQueryParameters.LuceneQueryHighlightParameters luceneQueryHighlightParameters;
+    private final LuceneQueryHighlightParameters luceneQueryHighlightParameters;
 
     @Nullable
     private final Map<String, Set<String>> termMap;
 
-    public LuceneScanQuery(@Nonnull final IndexScanType scanType, @Nonnull final Tuple groupKey,
-                           @Nonnull final Query query, @Nullable final Sort sort, @Nullable final List<String> storedFields,
+    public LuceneScanQuery(final IndexScanType scanType, final Tuple groupKey,
+                           final Query query, @Nullable final Sort sort, @Nullable final List<String> storedFields,
                            @Nullable final List<LuceneIndexExpressions.DocumentFieldType> storedFieldTypes,
-                           @Nullable final LuceneScanQueryParameters.LuceneQueryHighlightParameters luceneQueryHighlightParameters,
+                           @Nullable final LuceneQueryHighlightParameters luceneQueryHighlightParameters,
                            @Nullable final Map<String, Set<String>> termMap) {
         super(scanType, groupKey);
         this.query = query;
@@ -66,7 +66,6 @@ public class LuceneScanQuery extends LuceneScanBounds {
         this.termMap = termMap;
     }
 
-    @Nonnull
     public Query getQuery() {
         return query;
     }
@@ -87,7 +86,7 @@ public class LuceneScanQuery extends LuceneScanBounds {
     }
 
     @Nullable
-    public LuceneScanQueryParameters.LuceneQueryHighlightParameters getLuceneQueryHighlightParameters() {
+    public LuceneQueryHighlightParameters getLuceneQueryHighlightParameters() {
         return luceneQueryHighlightParameters;
     }
 

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanQueryParameters.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanQueryParameters.java
@@ -48,8 +48,7 @@ import com.google.common.collect.ImmutableSet;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Sort;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -61,7 +60,6 @@ import java.util.Set;
 public class LuceneScanQueryParameters extends LuceneScanParameters implements PlanSerializable {
     private static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("Lucene-Scan-Query");
 
-    @Nonnull
     final LuceneQueryClause query;
     @Nullable
     final Sort sort;
@@ -74,8 +72,8 @@ public class LuceneScanQueryParameters extends LuceneScanParameters implements P
     final LuceneQueryHighlightParameters luceneQueryHighlightParameters;
 
     @SpotBugsSuppressWarnings("NP_STORE_INTO_NONNULL_FIELD") // TODO remove this once we have a proper implementation
-    protected LuceneScanQueryParameters(@Nonnull final PlanSerializationContext serializationContext,
-                                        @Nonnull final PLuceneScanQueryParameters luceneScanQueryParametersProto) {
+    protected LuceneScanQueryParameters(final PlanSerializationContext serializationContext,
+                                        final PLuceneScanQueryParameters luceneScanQueryParametersProto) {
         super(serializationContext, Objects.requireNonNull(luceneScanQueryParametersProto.getSuper()));
         // TODO replace stub by extracting info out of the proto
         //noinspection DataFlowIssue
@@ -86,11 +84,11 @@ public class LuceneScanQueryParameters extends LuceneScanParameters implements P
         this.luceneQueryHighlightParameters = null;
     }
 
-    public LuceneScanQueryParameters(@Nonnull ScanComparisons groupComparisons, @Nonnull LuceneQueryClause query) {
+    public LuceneScanQueryParameters(ScanComparisons groupComparisons, LuceneQueryClause query) {
         this(groupComparisons, query, null, null, null, null);
     }
 
-    public LuceneScanQueryParameters(@Nonnull ScanComparisons groupComparisons, @Nonnull LuceneQueryClause query,
+    public LuceneScanQueryParameters(ScanComparisons groupComparisons, LuceneQueryClause query,
                                      @Nullable Sort sort,
                                      @Nullable List<String> storedFields, @Nullable List<LuceneIndexExpressions.DocumentFieldType> storedFieldTypes,
                                      @Nullable LuceneQueryHighlightParameters luceneQueryHighlightParameters) {
@@ -102,7 +100,6 @@ public class LuceneScanQueryParameters extends LuceneScanParameters implements P
         this.luceneQueryHighlightParameters = luceneQueryHighlightParameters;
     }
 
-    @Nonnull
     public LuceneQueryClause getQuery() {
         return query;
     }
@@ -123,7 +120,7 @@ public class LuceneScanQueryParameters extends LuceneScanParameters implements P
     }
 
     @Override
-    public int planHash(@Nonnull PlanHashMode mode) {
+    public int planHash(PlanHashMode mode) {
         return PlanHashable.objectsPlanHash(
                 mode,
                 BASE_HASH,
@@ -135,9 +132,8 @@ public class LuceneScanQueryParameters extends LuceneScanParameters implements P
                 storedFieldTypes);
     }
 
-    @Nonnull
     @Override
-    public LuceneScanQuery bind(@Nonnull FDBRecordStoreBase<?> store, @Nonnull Index index, @Nonnull EvaluationContext context) {
+    public LuceneScanQuery bind(FDBRecordStoreBase<?> store, Index index, EvaluationContext context) {
         final LuceneQueryClause.BoundQuery boundQuery = query.bind(store, index, context);
         if (luceneQueryHighlightParameters != null) {
             luceneQueryHighlightParameters.query = boundQuery.getLuceneQuery();
@@ -147,14 +143,13 @@ public class LuceneScanQueryParameters extends LuceneScanParameters implements P
                 sort, storedFields, storedFieldTypes, luceneQueryHighlightParameters, boundQuery.getHighlightingTermsMap());
     }
 
-    @Nonnull
     @Override
     public ExplainTokensWithPrecedence explain() {
         return ExplainTokensWithPrecedence.of(new ExplainTokens().addToString(getGroupScanDetails() + " " + query));
     }
 
     @Override
-    public void getPlannerGraphDetails(@Nonnull ImmutableList.Builder<String> detailsBuilder, @Nonnull ImmutableMap.Builder<String, Attribute> attributeMapBuilder) {
+    public void getPlannerGraphDetails(ImmutableList.Builder<String> detailsBuilder, ImmutableMap.Builder<String, Attribute> attributeMapBuilder) {
         super.getPlannerGraphDetails(detailsBuilder, attributeMapBuilder);
         query.getPlannerGraphDetails(detailsBuilder, attributeMapBuilder);
         if (sort != null) {
@@ -174,28 +169,25 @@ public class LuceneScanQueryParameters extends LuceneScanParameters implements P
         }
     }
 
-    @Nonnull
     @Override
-    public IndexScanParameters translateCorrelations(@Nonnull final TranslationMap translationMap,
+    public IndexScanParameters translateCorrelations(final TranslationMap translationMap,
                                                      final boolean shouldSimplifyValues) {
         return this;
     }
 
-    @Nonnull
     @Override
     public Set<CorrelationIdentifier> getCorrelatedTo() {
         return ImmutableSet.of();
     }
 
-    @Nonnull
     @Override
-    public IndexScanParameters rebase(@Nonnull final AliasMap translationMap) {
+    public IndexScanParameters rebase(final AliasMap translationMap) {
         return translateCorrelations(TranslationMap.rebaseWithAliasMap(translationMap), false);
     }
 
     @Override
     @SuppressWarnings("PMD.CompareObjectsWithEquals")
-    public boolean semanticEquals(@Nullable final Object other, @Nonnull final AliasMap aliasMap) {
+    public boolean semanticEquals(@Nullable final Object other, final AliasMap aliasMap) {
         if (this == other) {
             return true;
         }
@@ -235,27 +227,24 @@ public class LuceneScanQueryParameters extends LuceneScanParameters implements P
         return semanticHashCode();
     }
 
-    @Nonnull
     @Override
-    public PLuceneScanQueryParameters toProto(@Nonnull final PlanSerializationContext serializationContext) {
+    public PLuceneScanQueryParameters toProto(final PlanSerializationContext serializationContext) {
         // TODO replace stub
         return PLuceneScanQueryParameters.newBuilder()
                 .setSuper(toLuceneScanParametersProto(serializationContext))
                 .build();
     }
 
-    @Nonnull
     @Override
-    public PIndexScanParameters toIndexScanParametersProto(@Nonnull final PlanSerializationContext serializationContext) {
+    public PIndexScanParameters toIndexScanParametersProto(final PlanSerializationContext serializationContext) {
         return PIndexScanParameters.newBuilder()
                 .setAdditionalIndexScanParameters(PlanSerialization.protoObjectToAny(serializationContext, toProto(serializationContext)))
                 .build();
     }
 
-    @Nonnull
     @SuppressWarnings("unused")
-    public static LuceneScanQueryParameters fromProto(@Nonnull final PlanSerializationContext serializationContext,
-                                                      @Nonnull final PLuceneScanQueryParameters luceneScanQueryParametersProto) {
+    public static LuceneScanQueryParameters fromProto(final PlanSerializationContext serializationContext,
+                                                      final PLuceneScanQueryParameters luceneScanQueryParametersProto) {
         return new LuceneScanQueryParameters(serializationContext, luceneScanQueryParametersProto);
     }
 
@@ -309,16 +298,14 @@ public class LuceneScanQueryParameters extends LuceneScanParameters implements P
      */
     @AutoService(PlanDeserializer.class)
     public static class Deserializer implements PlanDeserializer<PLuceneScanQueryParameters, LuceneScanQueryParameters> {
-        @Nonnull
         @Override
         public Class<PLuceneScanQueryParameters> getProtoMessageClass() {
             return PLuceneScanQueryParameters.class;
         }
 
-        @Nonnull
         @Override
-        public LuceneScanQueryParameters fromProto(@Nonnull final PlanSerializationContext serializationContext,
-                                                   @Nonnull final PLuceneScanQueryParameters luceneScanQueryParametersProto) {
+        public LuceneScanQueryParameters fromProto(final PlanSerializationContext serializationContext,
+                                                   final PLuceneScanQueryParameters luceneScanQueryParametersProto) {
             return LuceneScanQueryParameters.fromProto(serializationContext, luceneScanQueryParametersProto);
         }
     }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanQueryParameters.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanQueryParameters.java
@@ -72,6 +72,7 @@ public class LuceneScanQueryParameters extends LuceneScanParameters implements P
     final LuceneQueryHighlightParameters luceneQueryHighlightParameters;
 
     @SpotBugsSuppressWarnings("NP_STORE_INTO_NONNULL_FIELD") // TODO remove this once we have a proper implementation
+    @SuppressWarnings("NullAway") // same as above: intentionally storing null into the non-null query field for now.
     protected LuceneScanQueryParameters(final PlanSerializationContext serializationContext,
                                         final PLuceneScanQueryParameters luceneScanQueryParametersProto) {
         super(serializationContext, Objects.requireNonNull(luceneScanQueryParametersProto.getSuper()));
@@ -158,11 +159,13 @@ public class LuceneScanQueryParameters extends LuceneScanParameters implements P
         }
         if (storedFields != null) {
             StringBuilder stored = new StringBuilder();
+            // storedFieldTypes is always supplied alongside storedFields (see constructor), same length.
+            final List<LuceneIndexExpressions.DocumentFieldType> fieldTypes = Objects.requireNonNull(storedFieldTypes);
             for (int i = 0; i < storedFields.size(); i++) {
                 if (i > 0) {
                     stored.append(", ");
                 }
-                stored.append(storedFields.get(i) + ":" + storedFieldTypes.get(i));
+                stored.append(storedFields.get(i) + ":" + fieldTypes.get(i));
             }
             detailsBuilder.add("stored: {{stored}}");
             attributeMapBuilder.put("stored", Attribute.gml(stored.toString()));
@@ -191,7 +194,7 @@ public class LuceneScanQueryParameters extends LuceneScanParameters implements P
         if (this == other) {
             return true;
         }
-        if (!super.equals(other)) {
+        if (other == null || !super.equals(other)) {
             return false;
         }
 
@@ -256,6 +259,7 @@ public class LuceneScanQueryParameters extends LuceneScanParameters implements P
 
         //the maximum number of times the query will be matched during summarization
         private final int maxMatchCount;
+        @Nullable
         private Query query;
 
         /**
@@ -270,12 +274,13 @@ public class LuceneScanQueryParameters extends LuceneScanParameters implements P
             this(snippetSize, maxMatchCount, null);
         }
 
-        public LuceneQueryHighlightParameters(int snippetSize, int maxMatchCount, Query theQuery) {
+        public LuceneQueryHighlightParameters(int snippetSize, int maxMatchCount, @Nullable Query theQuery) {
             this.snippedSize = snippetSize;
             this.maxMatchCount = maxMatchCount;
             this.query = theQuery;
         }
 
+        @Nullable
         public Query getQuery() {
             return query;
         }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanQueryParameters.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanQueryParameters.java
@@ -71,8 +71,7 @@ public class LuceneScanQueryParameters extends LuceneScanParameters implements P
     @Nullable
     final LuceneQueryHighlightParameters luceneQueryHighlightParameters;
 
-    @SpotBugsSuppressWarnings("NP_STORE_INTO_NONNULL_FIELD") // TODO remove this once we have a proper implementation
-    @SuppressWarnings("NullAway") // same as above: intentionally storing null into the non-null query field for now.
+    @SuppressWarnings("NullAway") // intentionally storing null into the non-null query field for now.
     protected LuceneScanQueryParameters(final PlanSerializationContext serializationContext,
                                         final PLuceneScanQueryParameters luceneScanQueryParametersProto) {
         super(serializationContext, Objects.requireNonNull(luceneScanQueryParametersProto.getSuper()));

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanSpellCheck.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanSpellCheck.java
@@ -24,7 +24,6 @@ import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.IndexScanType;
 import com.apple.foundationdb.tuple.Tuple;
 
-import javax.annotation.Nonnull;
 import java.util.List;
 
 /**
@@ -32,23 +31,19 @@ import java.util.List;
  */
 @API(API.Status.UNSTABLE)
 public class LuceneScanSpellCheck extends LuceneScanBounds {
-    @Nonnull
     final List<String> fields;
-    @Nonnull
     final String word;
 
-    public LuceneScanSpellCheck(@Nonnull IndexScanType scanType, @Nonnull Tuple groupKey, @Nonnull List<String> fields, @Nonnull String word) {
+    public LuceneScanSpellCheck(IndexScanType scanType, Tuple groupKey, List<String> fields, String word) {
         super(scanType, groupKey);
         this.fields = fields;
         this.word = word;
     }
 
-    @Nonnull
     public List<String> getFields() {
         return fields;
     }
 
-    @Nonnull
     public String getWord() {
         return word;
     }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanSpellCheckParameters.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanSpellCheckParameters.java
@@ -87,7 +87,9 @@ public class LuceneScanSpellCheckParameters extends LuceneScanParameters impleme
     @Override
     public LuceneScanSpellCheck bind(FDBRecordStoreBase<?> store, Index index, EvaluationContext context) {
         List<String> fields = indexTextFields(index, store.getRecordMetaData());
-        String wordToSpellCheck = isParameter ? (String)context.getBinding(key) : key;
+        String wordToSpellCheck = isParameter
+                ? Objects.requireNonNull((String)context.getBinding(key), () -> "No binding found for spellcheck parameter " + key)
+                : key;
         // TODO: Probably want more obvious syntax for this.
         if (wordToSpellCheck.contains(":")) {
             String[] fieldAndWord = wordToSpellCheck.split(":", 2);
@@ -142,7 +144,7 @@ public class LuceneScanSpellCheckParameters extends LuceneScanParameters impleme
         if (this == other) {
             return true;
         }
-        if (!super.equals(other)) {
+        if (other == null || !super.equals(other)) {
             return false;
         }
 

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanSpellCheckParameters.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneScanSpellCheckParameters.java
@@ -47,8 +47,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -62,33 +61,31 @@ import static com.apple.foundationdb.record.planprotos.LuceneRecordQueryPlanProt
 public class LuceneScanSpellCheckParameters extends LuceneScanParameters implements PlanSerializable {
     private static final ObjectPlanHash BASE_HASH = new ObjectPlanHash("Lucene-Scan-Spell-Check");
 
-    @Nonnull
     final String key;
     final boolean isParameter;
 
-    protected LuceneScanSpellCheckParameters(@Nonnull final PlanSerializationContext serializationContext,
-                                             @Nonnull final PLuceneScanSpellCheckParameters luceneScanSpellCheckParametersProto) {
+    protected LuceneScanSpellCheckParameters(final PlanSerializationContext serializationContext,
+                                             final PLuceneScanSpellCheckParameters luceneScanSpellCheckParametersProto) {
         super(serializationContext, Objects.requireNonNull(luceneScanSpellCheckParametersProto.getSuper()));
         // TODO replace stub by extracting info out of the proto
         this.key = "TODO";
         this.isParameter = false;
     }
 
-    protected LuceneScanSpellCheckParameters(@Nonnull ScanComparisons groupComparisons,
-                                             @Nonnull String key, boolean isParameter) {
+    protected LuceneScanSpellCheckParameters(ScanComparisons groupComparisons,
+                                             String key, boolean isParameter) {
         super(LuceneScanTypes.BY_LUCENE_SPELL_CHECK, groupComparisons);
         this.key = key;
         this.isParameter = isParameter;
     }
 
     @Override
-    public int planHash(@Nonnull PlanHashMode mode) {
+    public int planHash(PlanHashMode mode) {
         return PlanHashable.objectsPlanHash(mode, BASE_HASH, scanType, groupComparisons, key, isParameter);
     }
 
-    @Nonnull
     @Override
-    public LuceneScanSpellCheck bind(@Nonnull FDBRecordStoreBase<?> store, @Nonnull Index index, @Nonnull EvaluationContext context) {
+    public LuceneScanSpellCheck bind(FDBRecordStoreBase<?> store, Index index, EvaluationContext context) {
         List<String> fields = indexTextFields(index, store.getRecordMetaData());
         String wordToSpellCheck = isParameter ? (String)context.getBinding(key) : key;
         // TODO: Probably want more obvious syntax for this.
@@ -105,7 +102,6 @@ public class LuceneScanSpellCheckParameters extends LuceneScanParameters impleme
         return new LuceneScanSpellCheck(scanType, getGroupKey(store, context), fields, wordToSpellCheck);
     }
 
-    @Nonnull
     @Override
     public ExplainTokensWithPrecedence explain() {
         return ExplainTokensWithPrecedence.of(
@@ -113,7 +109,7 @@ public class LuceneScanSpellCheckParameters extends LuceneScanParameters impleme
     }
 
     @Override
-    public void getPlannerGraphDetails(@Nonnull ImmutableList.Builder<String> detailsBuilder, @Nonnull ImmutableMap.Builder<String, Attribute> attributeMapBuilder) {
+    public void getPlannerGraphDetails(ImmutableList.Builder<String> detailsBuilder, ImmutableMap.Builder<String, Attribute> attributeMapBuilder) {
         super.getPlannerGraphDetails(detailsBuilder, attributeMapBuilder);
         if (isParameter) {
             detailsBuilder.add("param: {{param}}");
@@ -124,28 +120,25 @@ public class LuceneScanSpellCheckParameters extends LuceneScanParameters impleme
         }
     }
 
-    @Nonnull
     @Override
-    public IndexScanParameters translateCorrelations(@Nonnull final TranslationMap translationMap,
+    public IndexScanParameters translateCorrelations(final TranslationMap translationMap,
                                                      final boolean shouldSimplifyValues) {
         return this;
     }
 
-    @Nonnull
     @Override
     public Set<CorrelationIdentifier> getCorrelatedTo() {
         return ImmutableSet.of();
     }
 
-    @Nonnull
     @Override
-    public IndexScanParameters rebase(@Nonnull final AliasMap translationMap) {
+    public IndexScanParameters rebase(final AliasMap translationMap) {
         return this;
     }
 
     @Override
     @SuppressWarnings("PMD.CompareObjectsWithEquals")
-    public boolean semanticEquals(@Nullable final Object other, @Nonnull final AliasMap aliasMap) {
+    public boolean semanticEquals(@Nullable final Object other, final AliasMap aliasMap) {
         if (this == other) {
             return true;
         }
@@ -186,27 +179,24 @@ public class LuceneScanSpellCheckParameters extends LuceneScanParameters impleme
         return semanticHashCode();
     }
 
-    @Nonnull
     @Override
-    public PLuceneScanSpellCheckParameters toProto(@Nonnull final PlanSerializationContext serializationContext) {
+    public PLuceneScanSpellCheckParameters toProto(final PlanSerializationContext serializationContext) {
         // TODO replace stub
         return PLuceneScanSpellCheckParameters.newBuilder()
                 .setSuper(toLuceneScanParametersProto(serializationContext))
                 .build();
     }
 
-    @Nonnull
     @Override
-    public PIndexScanParameters toIndexScanParametersProto(@Nonnull final PlanSerializationContext serializationContext) {
+    public PIndexScanParameters toIndexScanParametersProto(final PlanSerializationContext serializationContext) {
         return PIndexScanParameters.newBuilder()
                 .setExtension(luceneScanSpellCheckParameters, toProto(serializationContext))
                 .build();
     }
 
-    @Nonnull
     @SuppressWarnings("unused")
-    public static LuceneScanSpellCheckParameters fromProto(@Nonnull final PlanSerializationContext serializationContext,
-                                                           @Nonnull final PLuceneScanSpellCheckParameters luceneScanSpellCheckParametersProto) {
+    public static LuceneScanSpellCheckParameters fromProto(final PlanSerializationContext serializationContext,
+                                                           final PLuceneScanSpellCheckParameters luceneScanSpellCheckParametersProto) {
         return new LuceneScanSpellCheckParameters(serializationContext, luceneScanSpellCheckParametersProto);
     }
 
@@ -215,16 +205,14 @@ public class LuceneScanSpellCheckParameters extends LuceneScanParameters impleme
      */
     @AutoService(PlanDeserializer.class)
     public static class Deserializer implements PlanDeserializer<PLuceneScanSpellCheckParameters, LuceneScanSpellCheckParameters> {
-        @Nonnull
         @Override
         public Class<PLuceneScanSpellCheckParameters> getProtoMessageClass() {
             return PLuceneScanSpellCheckParameters.class;
         }
 
-        @Nonnull
         @Override
-        public LuceneScanSpellCheckParameters fromProto(@Nonnull final PlanSerializationContext serializationContext,
-                                                        @Nonnull final PLuceneScanSpellCheckParameters luceneScanSpellCheckParametersProto) {
+        public LuceneScanSpellCheckParameters fromProto(final PlanSerializationContext serializationContext,
+                                                        final PLuceneScanSpellCheckParameters luceneScanSpellCheckParametersProto) {
             return LuceneScanSpellCheckParameters.fromProto(serializationContext, luceneScanSpellCheckParametersProto);
         }
     }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneSpellCheckRecordCursor.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneSpellCheckRecordCursor.java
@@ -40,8 +40,7 @@ import org.apache.lucene.util.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -59,14 +58,10 @@ import static java.util.Comparator.comparing;
 public class LuceneSpellCheckRecordCursor implements BaseCursor<IndexEntry> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LuceneSpellCheckRecordCursor.class);
-    @Nonnull
     private final Executor executor;
-    @Nonnull
     private final IndexMaintainerState state;
     private final int limit;
-    @Nonnull
     private final String wordToSpellCheck;
-    @Nonnull
     private final DirectSpellChecker spellchecker;
     @Nullable
     private final FDBStoreTimer timer;
@@ -84,11 +79,11 @@ public class LuceneSpellCheckRecordCursor implements BaseCursor<IndexEntry> {
     private boolean closed;
 
 
-    public LuceneSpellCheckRecordCursor(@Nonnull List<String> fields,
-                                        @Nonnull String wordToSpellCheck,
-                                        @Nonnull final Executor executor,
+    public LuceneSpellCheckRecordCursor(List<String> fields,
+                                        String wordToSpellCheck,
+                                        final Executor executor,
                                         final ScanProperties scanProperties,
-                                        @Nonnull final IndexMaintainerState state,
+                                        final IndexMaintainerState state,
                                         @Nullable Tuple groupingKey,
                                         @Nullable Integer partitionId) {
         this.fields = fields;
@@ -105,7 +100,6 @@ public class LuceneSpellCheckRecordCursor implements BaseCursor<IndexEntry> {
         this.closed = false;
     }
 
-    @Nonnull
     @Override
     public CompletableFuture<RecordCursorResult<IndexEntry>> onNext() {
         CompletableFuture<IndexEntry> spellcheckResult = CompletableFuture.supplyAsync( () -> {
@@ -130,8 +124,7 @@ public class LuceneSpellCheckRecordCursor implements BaseCursor<IndexEntry> {
         });
     }
 
-    @Nonnull
-    private RecordCursorContinuation continuationHelper(@Nonnull IndexEntry lookupResult) {
+    private RecordCursorContinuation continuationHelper(IndexEntry lookupResult) {
         LuceneContinuationProto.LuceneSpellCheckIndexContinuation.Builder continuationBuilder =
                 LuceneContinuationProto.LuceneSpellCheckIndexContinuation.newBuilder().setValue(ByteString.copyFromUtf8(lookupResult.toString()));
         continuationBuilder.setLocation(currentPosition);
@@ -151,14 +144,13 @@ public class LuceneSpellCheckRecordCursor implements BaseCursor<IndexEntry> {
         return closed;
     }
 
-    @Nonnull
     @Override
     public Executor getExecutor() {
         return executor;
     }
 
     @Override
-    public boolean accept(@Nonnull final RecordCursorVisitor visitor) {
+    public boolean accept(final RecordCursorVisitor visitor) {
         visitor.visitEnter(this);
         return visitor.visitLeave(this);
     }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneSpellCheckRecordCursor.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/LuceneSpellCheckRecordCursor.java
@@ -45,6 +45,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.function.Function;
@@ -66,7 +67,7 @@ public class LuceneSpellCheckRecordCursor implements BaseCursor<IndexEntry> {
     @Nullable
     private final FDBStoreTimer timer;
 
-    private IndexReader indexReader;
+    private @Nullable IndexReader indexReader;
 
     @Nullable
     private List<IndexEntry> spellcheckSuggestions = null;
@@ -92,7 +93,7 @@ public class LuceneSpellCheckRecordCursor implements BaseCursor<IndexEntry> {
         this.state = state;
         this.limit = Math.min(
                 scanProperties.getExecuteProperties().getReturnedRowLimitOrMax(),
-                state.context.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_SPELLCHECK_SEARCH_UPPER_LIMIT));
+                Objects.requireNonNull(state.context.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_SPELLCHECK_SEARCH_UPPER_LIMIT)));
         this.groupingKey = groupingKey;
         this.partitionId = partitionId;
         this.spellchecker = new DirectSpellChecker();
@@ -110,16 +111,19 @@ public class LuceneSpellCheckRecordCursor implements BaseCursor<IndexEntry> {
                     throw LuceneExceptions.toRecordCoreException("Spellcheck suggestions lookup failure", e);
                 }
             }
-            return currentPosition < spellcheckSuggestions.size() ? spellcheckSuggestions.get(currentPosition) : null;
+            // spellcheck() always populates spellcheckSuggestions before returning normally.
+            final List<IndexEntry> suggestions = Objects.requireNonNull(spellcheckSuggestions);
+            return currentPosition < suggestions.size() ? suggestions.get(currentPosition) : null;
         }, executor);
         return spellcheckResult.thenApply(r -> {
             if (r == null) {
                 return RecordCursorResult.exhausted();
             } else {
+                final List<IndexEntry> suggestions = Objects.requireNonNull(spellcheckSuggestions);
                 if (LOGGER.isTraceEnabled()) {
-                    LOGGER.trace("Suggestion read as an index entry={}", spellcheckSuggestions.get(currentPosition));
+                    LOGGER.trace("Suggestion read as an index entry={}", suggestions.get(currentPosition));
                 }
-                return RecordCursorResult.withNextValue(r, continuationHelper(spellcheckSuggestions.get(currentPosition++)));
+                return RecordCursorResult.withNextValue(r, continuationHelper(suggestions.get(currentPosition++)));
             }
         });
     }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LazyOpener.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LazyOpener.java
@@ -25,7 +25,6 @@ import com.apple.foundationdb.record.lucene.LuceneExceptions;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.concurrent.CompletableFuture;
@@ -134,7 +133,6 @@ public class LazyOpener<T> {
      */
     @FunctionalInterface
     public interface Opener<T> {
-        @Nonnull
         T open() throws IOException;
     }
 }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LazyOpener.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LazyOpener.java
@@ -112,8 +112,9 @@ public class LazyOpener<T> {
                 // Try to unwrap the cause for the IOException
                 throw LuceneExceptions.toRecordCoreException(cause.getMessage(), (IOException)cause);
             } else {
-                // Otherwise, wrap with generic RecordCoreException
-                throw new RecordCoreException(cause);
+                // Otherwise, wrap with generic RecordCoreException. cause may legitimately be null if the
+                // ExecutionException itself was constructed without one.
+                throw new RecordCoreException("Unexpected exception while lazily opening resource", cause);
             }
         }
     }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LazyOpener.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LazyOpener.java
@@ -27,6 +27,7 @@ import com.google.common.base.Suppliers;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
@@ -82,7 +83,8 @@ public class LazyOpener<T> {
         } catch (ExecutionException e) {
             final Throwable outerCause = e.getCause();
             if (outerCause instanceof UncheckedIOException) {
-                final IOException innerCause = ((UncheckedIOException)outerCause).getCause();
+                // UncheckedIOException's constructors require a non-null IOException cause, so this is safe.
+                final IOException innerCause = Objects.requireNonNull(((UncheckedIOException)outerCause).getCause());
                 innerCause.addSuppressed(e);
                 throw innerCause;
             } else {

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedFieldInfosFormat.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedFieldInfosFormat.java
@@ -81,6 +81,9 @@ public class LuceneOptimizedFieldInfosFormat extends FieldInfosFormat {
     public FieldInfos read(final Directory directory, final String fileName) throws IOException {
         final FieldInfosStorage fieldInfosStorage = FDBDirectoryUtils.getFDBDirectory(directory).getFieldInfosStorage();
         final FDBLuceneFileReference fileReference = fieldInfosStorage.getFDBLuceneFileReference(fileName);
+        if (fileReference == null) {
+            throw new RecordCoreException("Reference not found").addLogInfo(LuceneLogMessageKeys.FILE_NAME, fileName);
+        }
         long id = fileReference.getFieldInfosId();
         final ByteString bitSetBytes = fileReference.getFieldInfosBitSet();
         if (bitSetBytes.isEmpty()) {
@@ -90,6 +93,9 @@ public class LuceneOptimizedFieldInfosFormat extends FieldInfosFormat {
         // There may be other fields in the protobuf that are not used in this segment
         BitSet bitSet = BitSet.valueOf(bitSetBytes.toByteArray());
         final LuceneFieldInfosProto.FieldInfos protobuf = fieldInfosStorage.readFieldInfos(id);
+        if (protobuf == null) {
+            throw new RecordCoreException("Field infos not found").addLogInfo(LuceneLogMessageKeys.FILE_NAME, fileName);
+        }
         List<FieldInfo> fieldInfos = new ArrayList<>();
         for (final LuceneFieldInfosProto.FieldInfo fieldInfo : protobuf.getFieldInfoList()) {
             if (bitSet.get(fieldInfo.getNumber())) {

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedFieldInfosFormat.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedFieldInfosFormat.java
@@ -40,7 +40,6 @@ import org.apache.lucene.index.SegmentInfo;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FilterDirectory;
 import org.apache.lucene.store.IOContext;
-import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -327,7 +326,6 @@ public class LuceneOptimizedFieldInfosFormat extends FieldInfosFormat {
     }
 
     @SuppressWarnings("PMD.CloseResource") // we are just unwrapping objects, not taking ownership
-    @Nullable
     private static String getFileName(final Directory directory, final SegmentInfo segmentInfo, final String segmentSuffix) {
         String fileName;
         final Directory unwrapped = FilterDirectory.unwrap(directory);

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedFieldInfosFormat.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedFieldInfosFormat.java
@@ -40,9 +40,8 @@ import org.apache.lucene.index.SegmentInfo;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FilterDirectory;
 import org.apache.lucene.store.IOContext;
+import org.jspecify.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.BitSet;
@@ -79,7 +78,6 @@ public class LuceneOptimizedFieldInfosFormat extends FieldInfosFormat {
     }
 
     @VisibleForTesting
-    @Nonnull
     public FieldInfos read(final Directory directory, final String fileName) throws IOException {
         final FieldInfosStorage fieldInfosStorage = FDBDirectoryUtils.getFDBDirectory(directory).getFieldInfosStorage();
         final FDBLuceneFileReference fileReference = fieldInfosStorage.getFDBLuceneFileReference(fileName);
@@ -198,8 +196,8 @@ public class LuceneOptimizedFieldInfosFormat extends FieldInfosFormat {
         fieldInfosStorage.setFieldInfoId(directory, fileName, id, bitSet);
     }
 
-    private boolean sameExceptAttributesOrdering(@Nonnull final LuceneFieldInfosProto.FieldInfo globalVersion,
-                                                 @Nonnull final LuceneFieldInfosProto.FieldInfo newVersion) {
+    private boolean sameExceptAttributesOrdering(final LuceneFieldInfosProto.FieldInfo globalVersion,
+                                                 final LuceneFieldInfosProto.FieldInfo newVersion) {
         if (protoToLucene(globalVersion.getAttributesList()).equals(protoToLucene(newVersion.getAttributesList()))) {
             // the only difference between this version and the new version is the ordering of the attributes
             return globalVersion.toBuilder().clearAttributes().build().equals(
@@ -317,7 +315,6 @@ public class LuceneOptimizedFieldInfosFormat extends FieldInfosFormat {
         }
     }
 
-    @Nonnull
     private static <T extends Enum<T>> RecordCoreException unexpectedEnumValue(final T enumValue) {
         return new RecordCoreException("Unexpected enum value")
                 .addLogInfo(LuceneLogMessageKeys.NAME, enumValue);

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedStoredFieldsFormat.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedStoredFieldsFormat.java
@@ -34,8 +34,8 @@ import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.SegmentInfo;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
+import org.jspecify.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.io.IOException;
 
 /**

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedStoredFieldsWriter.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedStoredFieldsWriter.java
@@ -63,6 +63,9 @@ public class LuceneOptimizedStoredFieldsWriter extends StoredFieldsWriter {
         this.directory = directory;
         this.docId = 0;
         this.segmentName = si.name;
+        // startDocument() always replaces this with a fresh builder before any document is actually written;
+        // initialize eagerly here just so the field is never null.
+        this.storedFields = LuceneStoredFieldsProto.LuceneStoredFields.newBuilder();
     }
 
     @Override

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/PrimaryKeyAndStoredFieldsWriter.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/PrimaryKeyAndStoredFieldsWriter.java
@@ -30,7 +30,6 @@ import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.SegmentInfo;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 
 class PrimaryKeyAndStoredFieldsWriter extends LuceneOptimizedStoredFieldsWriter {
@@ -40,7 +39,7 @@ class PrimaryKeyAndStoredFieldsWriter extends LuceneOptimizedStoredFieldsWriter 
     private int documentId;
 
     PrimaryKeyAndStoredFieldsWriter(SegmentInfo segmentInfo,
-                                    @Nonnull final FDBDirectory directory) throws IOException {
+                                    final FDBDirectory directory) throws IOException {
         super(directory, segmentInfo);
         this.segmentId = directory.primaryKeySegmentId(segmentInfo.name, true);
         this.lucenePrimaryKeySegmentIndex = directory.getPrimaryKeySegmentIndex();

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/PrimaryKeyAndStoredFieldsWriter.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/PrimaryKeyAndStoredFieldsWriter.java
@@ -31,6 +31,7 @@ import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.SegmentInfo;
 
 import java.io.IOException;
+import java.util.Objects;
 
 class PrimaryKeyAndStoredFieldsWriter extends LuceneOptimizedStoredFieldsWriter {
     private final LucenePrimaryKeySegmentIndex lucenePrimaryKeySegmentIndex;
@@ -42,7 +43,9 @@ class PrimaryKeyAndStoredFieldsWriter extends LuceneOptimizedStoredFieldsWriter 
                                     final FDBDirectory directory) throws IOException {
         super(directory, segmentInfo);
         this.segmentId = directory.primaryKeySegmentId(segmentInfo.name, true);
-        this.lucenePrimaryKeySegmentIndex = directory.getPrimaryKeySegmentIndex();
+        // This class is only constructed when PRIMARY_KEY_SEGMENT_INDEX_V2_ENABLED is set, in which case
+        // getPrimaryKeySegmentIndex() always returns a non-null LucenePrimaryKeySegmentIndexV2.
+        this.lucenePrimaryKeySegmentIndex = Objects.requireNonNull(directory.getPrimaryKeySegmentIndex());
     }
 
     @Override

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/package-info.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/codec/package-info.java
@@ -21,4 +21,7 @@
 /**
  * Common classes for optimization of lucene's codec.
  */
+@NullMarked
 package com.apple.foundationdb.record.lucene.codec;
+
+import org.jspecify.annotations.NullMarked;

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/AgileContext.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/AgileContext.java
@@ -31,12 +31,13 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContextConfi
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.locks.StampedLock;
 import java.util.function.Consumer;
 import java.util.function.Function;
+
+import static com.apple.foundationdb.record.provider.foundationdb.FDBRecordContextConfig.Builder;
 
 /**
  * A floating window (agile) context - create sub contexts and commit them as they reach their time/size quota.
@@ -44,7 +45,7 @@ import java.util.function.Function;
 @API(API.Status.INTERNAL)
 public class AgileContext implements AgilityContext {
     static final Logger LOGGER = LoggerFactory.getLogger(AgileContext.class);
-    private final FDBRecordContextConfig.Builder contextConfigBuilder;
+    private final Builder contextConfigBuilder;
     private final FDBDatabase database;
     private final FDBRecordContext callerContext; // for counters updates only
 
@@ -70,7 +71,7 @@ public class AgileContext implements AgilityContext {
     private Throwable lastException = null;
 
     @SuppressWarnings("this-escape")
-    protected AgileContext(FDBRecordContext callerContext, @Nullable FDBRecordContextConfig.Builder contextBuilder, final long timeQuotaMillis, final long sizeQuotaBytes) {
+    protected AgileContext(FDBRecordContext callerContext, @Nullable Builder contextBuilder, final long timeQuotaMillis, final long sizeQuotaBytes) {
         this.callerContext = callerContext;
         contextConfigBuilder = contextBuilder != null ? contextBuilder : callerContext.getConfig().toBuilder();
         contextConfigBuilder.setWeakReadSemantics(null); // We don't want all the transactions to use the same read-version
@@ -97,7 +98,6 @@ public class AgileContext implements AgilityContext {
     }
 
     @Override
-    @Nonnull
     public FDBRecordContext getCallerContext() {
         return callerContext;
     }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/AgileContext.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/AgileContext.java
@@ -32,6 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.jspecify.annotations.Nullable;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.locks.StampedLock;
 import java.util.function.Consumer;
@@ -49,6 +50,7 @@ public class AgileContext implements AgilityContext {
     private final FDBDatabase database;
     private final FDBRecordContext callerContext; // for counters updates only
 
+    @Nullable
     private FDBRecordContext currentContext;
     private long creationTime;
     private int currentWriteSize;
@@ -67,7 +69,9 @@ public class AgileContext implements AgilityContext {
     private boolean committingNow = false;
     private long prevCommitCheckTime;
     private boolean closed = false;
+    @Nullable
     private Function<FDBRecordContext, CompletableFuture<Void>> commitCheck;
+    @Nullable
     private Throwable lastException = null;
 
     @SuppressWarnings("this-escape")
@@ -214,7 +218,7 @@ public class AgileContext implements AgilityContext {
                 lock.unlock(stamp);
             }
         }
-        return function.apply(currentContext).whenComplete((result, exception) -> {
+        return function.apply(Objects.requireNonNull(currentContext)).whenComplete((result, exception) -> {
             lock.unlock(stamp);
             if (exception == null) {
                 commitIfNeeded();
@@ -255,7 +259,7 @@ public class AgileContext implements AgilityContext {
         final long stamp = lock.readLock();
         try {
             createIfNeeded();
-            function.accept(currentContext);
+            function.accept(Objects.requireNonNull(currentContext));
         } finally {
             lock.unlock(stamp);
         }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/AgilityContext.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/AgilityContext.java
@@ -25,16 +25,16 @@ import com.apple.foundationdb.Range;
 import com.apple.foundationdb.record.lucene.LuceneConcurrency;
 import com.apple.foundationdb.record.provider.common.StoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
-import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContextConfig;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.properties.RecordLayerPropertyKey;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.function.Function;
+
+import static com.apple.foundationdb.record.provider.foundationdb.FDBRecordContextConfig.Builder;
 
 /**
  * Create floating sub contexts from a caller context and commit when they reach time/write quota.
@@ -45,7 +45,7 @@ public interface AgilityContext {
         return new NonAgileContext(callerContext);
     }
 
-    static AgilityContext agile(FDBRecordContext callerContext, @Nullable FDBRecordContextConfig.Builder contextBuilder, final long timeQuotaMillis, final long sizeQuotaBytes) {
+    static AgilityContext agile(FDBRecordContext callerContext, @Nullable Builder contextBuilder, final long timeQuotaMillis, final long sizeQuotaBytes) {
         return new AgileContext(callerContext, contextBuilder, timeQuotaMillis, sizeQuotaBytes);
     }
 
@@ -53,7 +53,7 @@ public interface AgilityContext {
         return agile(callerContext, null, timeQuotaMillis, sizeQuotaBytes);
     }
 
-    static AgilityContext readOnlyNonAgile(FDBRecordContext callerContext, @Nullable FDBRecordContextConfig.Builder contextBuilder) {
+    static AgilityContext readOnlyNonAgile(FDBRecordContext callerContext, @Nullable Builder contextBuilder) {
         return new ReadOnlyNonAgileContext(callerContext, contextBuilder);
     }
 
@@ -127,7 +127,6 @@ public interface AgilityContext {
      * This function returns the caller's context. If called by external entities, it should only be used for testing.
      * @return caller's context
      */
-    @Nonnull
     FDBRecordContext getCallerContext();
 
     default <T> CompletableFuture<T> instrument(StoreTimer.Event event,
@@ -141,29 +140,29 @@ public interface AgilityContext {
         return getCallerContext().instrument(event, future, start);
     }
 
-    default void increment(@Nonnull StoreTimer.Count count) {
+    default void increment(StoreTimer.Count count) {
         getCallerContext().increment(count);
     }
 
-    default void increment(@Nonnull StoreTimer.Count count, int size) {
+    default void increment(StoreTimer.Count count, int size) {
         getCallerContext().increment(count, size);
     }
 
-    default void recordEvent(@Nonnull StoreTimer.Event event, long timeDelta) {
+    default void recordEvent(StoreTimer.Event event, long timeDelta) {
         getCallerContext().record(event, timeDelta);
     }
 
-    default void recordSize(@Nonnull StoreTimer.SizeEvent sizeEvent, long size) {
+    default void recordSize(StoreTimer.SizeEvent sizeEvent, long size) {
         getCallerContext().recordSize(sizeEvent, size);
     }
 
     @Nullable
-    default <T> T asyncToSync(StoreTimer.Wait event, @Nonnull CompletableFuture<T> async) {
+    default <T> T asyncToSync(StoreTimer.Wait event, CompletableFuture<T> async) {
         return LuceneConcurrency.asyncToSync(event, async, getCallerContext());
     }
 
     @Nullable
-    default <T> T getPropertyValue(@Nonnull RecordLayerPropertyKey<T> propertyKey) {
+    default <T> T getPropertyValue(RecordLayerPropertyKey<T> propertyKey) {
         return getCallerContext().getPropertyStorage().getPropertyValue(propertyKey);
     }
 
@@ -175,7 +174,7 @@ public interface AgilityContext {
      */
     void setCommitCheck(Function<FDBRecordContext, CompletableFuture<Void>> commitCheck);
 
-    default void commit(@Nonnull FDBRecordContext context) {
+    default void commit(FDBRecordContext context) {
         LuceneConcurrency.asyncToSync(FDBStoreTimer.Waits.WAIT_COMMIT, context.commitAsync(), context);
     }
 

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
@@ -263,6 +263,10 @@ public class FDBDirectory extends Directory {
         agilityContext.increment(LuceneEvents.Counts.LUCENE_BLOCK_CACHE_REMOVE);
     }
 
+    // NullAway/JSpecify does not reliably track @Nullable on array (byte[]) types; value is
+    // narrowed to non-null by the preceding null check before being passed to the unannotated
+    // Tuple.fromBytes.
+    @SuppressWarnings("NullAway")
     private long deserializeFileSequenceCounter(@Nullable byte[] value) {
         return value == null ? 0L : Tuple.fromBytes(value).getLong(0);
     }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
@@ -152,6 +152,7 @@ public class FDBDirectory extends Directory {
     private final int maxPendingWritesToReplay;
     private final int maxPendingQueueSize;
     private final int blockCacheMaximumSize;
+    @Nullable
     private Lock lastLock = null;
     private final int blockSize;
 
@@ -252,8 +253,10 @@ public class FDBDirectory extends Directory {
         this.sharedCachePending = sharedCacheManager != null && sharedCacheKey != null;
         this.fieldInfosStorage = new FieldInfosStorage(this);
         this.deferDeleteToCompoundFile = deferDeleteToCompoundFile;
-        this.maxPendingWritesToReplay = agilityContext.getPropertyValue(LuceneRecordContextProperties.LUCENE_MAX_PENDING_WRITES_REPLAYED_FOR_QUERY);
-        this.maxPendingQueueSize = agilityContext.getPropertyValue(LuceneRecordContextProperties.LUCENE_MAX_PENDING_QUEUE_SIZE);
+        this.maxPendingWritesToReplay = Objects.requireNonNullElse(
+                agilityContext.getPropertyValue(LuceneRecordContextProperties.LUCENE_MAX_PENDING_WRITES_REPLAYED_FOR_QUERY), PendingWriteQueue.DEFAULT_MAX_PENDING_ENTRIES_TO_REPLAY);
+        this.maxPendingQueueSize = Objects.requireNonNullElse(
+                agilityContext.getPropertyValue(LuceneRecordContextProperties.LUCENE_MAX_PENDING_QUEUE_SIZE), PendingWriteQueue.DEFAULT_MAX_PENDING_QUEUE_SIZE);
     }
 
     private void cacheRemovalCallback() {
@@ -369,9 +372,9 @@ public class FDBDirectory extends Directory {
     }
 
     Stream<NonnullPair<Long, byte[]>> getAllFieldInfosStream() {
-        return asyncToSync(
+        return Objects.requireNonNull(asyncToSync(
                 LuceneEvents.Waits.WAIT_LUCENE_READ_FIELD_INFOS,
-                agilityContext.apply(aContext -> aContext.ensureActive().getRange(fieldInfosSubspace.range()).asList()))
+                agilityContext.apply(aContext -> aContext.ensureActive().getRange(fieldInfosSubspace.range()).asList())))
                 .stream()
                 .map(keyValue -> NonnullPair.of(
                             fieldInfosSubspace.unpack(keyValue.getKey()).getLong(0),
@@ -533,14 +536,17 @@ public class FDBDirectory extends Directory {
                 if (sharedCache == null) {
                     return readData(id, block);
                 }
-                final byte[] fromShared = sharedCache.getBlockIfPresent(id, block);
+                // Capture a stable local reference; the field could theoretically change before the async
+                // continuation below runs, but sharedCache is only ever set once per directory instance.
+                final FDBDirectorySharedCache cache = sharedCache;
+                final byte @Nullable [] fromShared = cache.getBlockIfPresent(id, block);
                 if (fromShared != null) {
                     agilityContext.increment(LuceneEvents.Counts.LUCENE_SHARED_CACHE_HITS);
                     return CompletableFuture.completedFuture(fromShared);
                 } else {
                     agilityContext.increment(LuceneEvents.Counts.LUCENE_SHARED_CACHE_MISSES);
                     return readData(id, block).thenApply(data -> {
-                        sharedCache.putBlockIfAbsent(id, block, data);
+                        cache.putBlockIfAbsent(id, block, data);
                         return data;
                     });
                 }
@@ -567,7 +573,7 @@ public class FDBDirectory extends Directory {
             throw new RecordCoreStorageException("Could not find stored fields")
                     .addLogInfo(LuceneLogMessageKeys.SEGMENT, segmentName)
                     .addLogInfo(LuceneLogMessageKeys.DOC_ID, docId)
-                    .addLogInfo(LogMessageKeys.KEY, ByteArrayUtil2.loggable(key));
+                    .addLogInfo(LogMessageKeys.KEY, Objects.requireNonNull(ByteArrayUtil2.loggable(key)));
         }
         return Objects.requireNonNull(decodeFieldProtobuf(rawBytes));
     }
@@ -579,8 +585,8 @@ public class FDBDirectory extends Directory {
         if (list == null) {
             throw new RecordCoreStorageException("Could not find stored fields")
                     .addLogInfo(LuceneLogMessageKeys.SEGMENT, segmentName)
-                    .addLogInfo(LogMessageKeys.RANGE_START, ByteArrayUtil2.loggable(range.begin))
-                    .addLogInfo(LogMessageKeys.RANGE_END, ByteArrayUtil2.loggable(range.end));
+                    .addLogInfo(LogMessageKeys.RANGE_START, Objects.requireNonNull(ByteArrayUtil2.loggable(range.begin)))
+                    .addLogInfo(LogMessageKeys.RANGE_END, Objects.requireNonNull(ByteArrayUtil2.loggable(range.end)));
         }
         return list.stream().map(KeyValue::getValue).map(this::decodeFieldProtobuf).collect(Collectors.toList());
     }
@@ -688,23 +694,27 @@ public class FDBDirectory extends Directory {
         }
         if (sharedCachePending) {
             return loadFileSequenceCounter().thenCompose(vignore -> {
-                sharedCache = sharedCacheManager.getCache(sharedCacheKey, fileSequenceCounter.get());
+                // sharedCachePending is only ever true when both fields were set non-null at construction time.
+                sharedCache = Objects.requireNonNull(sharedCacheManager).getCache(Objects.requireNonNull(sharedCacheKey), fileSequenceCounter.get());
                 if (sharedCache == null) {
                     sharedCachePending = false;
                     return getFileReferenceCacheAsync();
                 }
-                Map<String, FDBLuceneFileReference> fromShared = sharedCache.getFileReferencesIfPresent();
+                // Capture a stable local reference so it can be used safely from the nested async continuation below.
+                final FDBDirectorySharedCache cache = sharedCache;
+                Map<String, FDBLuceneFileReference> fromShared = cache.getFileReferencesIfPresent();
                 if (fromShared != null) {
                     ConcurrentSkipListMap<String, FDBLuceneFileReference> copy = new ConcurrentSkipListMap<>(fromShared);
                     fileReferenceCache.compareAndSet(null, copy);
-                    fieldInfosStorage.initializeReferenceCount(sharedCache.getFieldInfosReferenceCount());
+                    fieldInfosStorage.initializeReferenceCount(cache.getFieldInfosReferenceCount());
                     sharedCachePending = false;
                     return CompletableFuture.completedFuture(fromShared);
                 }
                 return fileReferenceMapSupplier.get().thenApply(ignore -> {
-                    final ConcurrentSkipListMap<String, FDBLuceneFileReference> fromSupplier = fileReferenceCache.get();
-                    sharedCache.setFileReferencesIfAbsent(fromSupplier);
-                    sharedCache.setFieldInfosReferenceCount(getFieldInfosStorage().getReferenceCount());
+                    // fileReferenceMapSupplier.get() always populates fileReferenceCache before completing.
+                    final ConcurrentSkipListMap<String, FDBLuceneFileReference> fromSupplier = Objects.requireNonNull(fileReferenceCache.get());
+                    cache.setFileReferencesIfAbsent(fromSupplier);
+                    cache.setFieldInfosReferenceCount(getFieldInfosStorage().getReferenceCount());
                     sharedCachePending = false;
                     return fromSupplier;
                 });
@@ -740,7 +750,8 @@ public class FDBDirectory extends Directory {
             }
 
             if (isCompoundFile(name)) {
-                Map<String, FDBLuceneFileReference> cache = this.fileReferenceCache.get();
+                // getFileReferenceCacheAsync() (awaited above) always populates fileReferenceCache as a side effect.
+                Map<String, FDBLuceneFileReference> cache = Objects.requireNonNull(this.fileReferenceCache.get());
                 String primaryKeyName = name.substring(0, name.length() - DATA_EXTENSION.length()) + "pky";
                 deleteFileInternal(cache, primaryKeyName);
                 // TODO: If the segment is being deleted because it no longer has any live docs, it won't be merged
@@ -949,6 +960,9 @@ public class FDBDirectory extends Directory {
         try {
             if (FDBDirectory.isSegmentInfo(name) || FDBDirectory.isEntriesFile(name)) {
                 final FDBLuceneFileReference reference = getFDBLuceneFileReference(name);
+                if (reference == null) {
+                    throw new NoSuchFileException(name);
+                }
                 if (reference.getContent().isEmpty()) {
                     throw new RecordCoreException("File content is not stored in reference")
                             .addLogInfo(LuceneLogMessageKeys.FILE_NAME, name);
@@ -1242,28 +1256,32 @@ public class FDBDirectory extends Directory {
 
     private byte[] encodeFieldProtobuf(final byte[] bytes) {
         long startTime = System.nanoTime();
-        byte[] encoded = serializer.encodeFieldProtobuf(bytes);
+        // LuceneSerializer's encode methods only return null when given null input; bytes is non-null here.
+        byte[] encoded = Objects.requireNonNull(serializer.encodeFieldProtobuf(bytes));
         agilityContext.recordEvent(LuceneEvents.Waits.WAIT_LUCENE_SERIALIZE, System.nanoTime() - startTime);
         return encoded;
     }
 
     private byte[] decodeFieldProtobuf(final byte[] bytes) {
         long startTime = System.nanoTime();
-        final byte[] decoded = serializer.decodeFieldProtobuf(bytes);
+        // LuceneSerializer's decode methods only return null when given null input; bytes is non-null here.
+        final byte[] decoded = Objects.requireNonNull(serializer.decodeFieldProtobuf(bytes));
         agilityContext.recordEvent(LuceneEvents.Waits.WAIT_LUCENE_DESERIALIZE, System.nanoTime() - startTime);
         return decoded;
     }
 
     private byte[] encode(final byte[] bytes) {
         long startTime = System.nanoTime();
-        final byte[] encoded = serializer.encode(bytes);
+        // LuceneSerializer's encode methods only return null when given null input; bytes is non-null here.
+        final byte[] encoded = Objects.requireNonNull(serializer.encode(bytes));
         agilityContext.recordEvent(LuceneEvents.Waits.WAIT_LUCENE_SERIALIZE, System.nanoTime() - startTime);
         return encoded;
     }
 
     private byte[] decode(final byte[] bytes) {
         long startTime = System.nanoTime();
-        final byte[] decoded = serializer.decode(bytes);
+        // LuceneSerializer's decode methods only return null when given null input; bytes is non-null here.
+        final byte[] decoded = Objects.requireNonNull(serializer.decode(bytes));
         agilityContext.recordEvent(LuceneEvents.Waits.WAIT_LUCENE_DESERIALIZE, System.nanoTime() - startTime);
         return decoded;
     }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectory.java
@@ -73,8 +73,7 @@ import org.apache.lucene.store.LockFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 import java.io.IOException;
 import java.nio.file.NoSuchFileException;
@@ -137,7 +136,6 @@ public class FDBDirectory extends Directory {
     public static final int ONGOING_MERGE_INDICATOR_SUBSPACE = 9;
     public static final int PENDING_QUEUE_SIZE_SUBSPACE = 10;
     private final AtomicLong nextTempFileCounter = new AtomicLong();
-    @Nonnull
     private final Map<String, String> indexOptions;
     private final Subspace subspace;
     private final Subspace metaSubspace;
@@ -195,18 +193,18 @@ public class FDBDirectory extends Directory {
     private LucenePrimaryKeySegmentIndex primaryKeySegmentIndex;
 
     @VisibleForTesting
-    public FDBDirectory(@Nonnull Subspace subspace, @Nonnull FDBRecordContext context, @Nullable Map<String, String> indexOptions) {
+    public FDBDirectory(Subspace subspace, FDBRecordContext context, @Nullable Map<String, String> indexOptions) {
         this(subspace, indexOptions, null, null, true, AgilityContext.nonAgile(context));
     }
 
-    public FDBDirectory(@Nonnull Subspace subspace, @Nullable Map<String, String> indexOptions,
+    public FDBDirectory(Subspace subspace, @Nullable Map<String, String> indexOptions,
                         @Nullable FDBDirectorySharedCacheManager sharedCacheManager, @Nullable Tuple sharedCacheKey,
                         boolean deferDeleteToCompoundFile, AgilityContext agilityContext) {
         this(subspace, indexOptions, sharedCacheManager, sharedCacheKey, agilityContext, null,
                 DEFAULT_BLOCK_SIZE, DEFAULT_INITIAL_CAPACITY, DEFAULT_BLOCK_CACHE_MAXIMUM_SIZE, DEFAULT_CONCURRENCY_LEVEL, deferDeleteToCompoundFile);
     }
 
-    public FDBDirectory(@Nonnull Subspace subspace, @Nullable Map<String, String> indexOptions,
+    public FDBDirectory(Subspace subspace, @Nullable Map<String, String> indexOptions,
                         @Nullable FDBDirectorySharedCacheManager sharedCacheManager, @Nullable Tuple sharedCacheKey,
                         boolean deferDeleteToCompoundFile, AgilityContext agilityContext, @Nullable LockFactory lockFactory, int blockCacheMaximumSize) {
         this(subspace, indexOptions, sharedCacheManager, sharedCacheKey, agilityContext, lockFactory,
@@ -214,7 +212,7 @@ public class FDBDirectory extends Directory {
     }
 
     @SuppressWarnings("this-escape")
-    private FDBDirectory(@Nonnull Subspace subspace, @Nullable Map<String, String> indexOptions,
+    private FDBDirectory(Subspace subspace, @Nullable Map<String, String> indexOptions,
                          @Nullable FDBDirectorySharedCacheManager sharedCacheManager, @Nullable Tuple sharedCacheKey, AgilityContext agilityContext,
                          @Nullable LockFactory lockFactory,
                          int blockSize, final int initialCapacity, final int blockCacheMaximumSize, final int concurrencyLevel,
@@ -266,12 +264,10 @@ public class FDBDirectory extends Directory {
         return value == null ? 0L : Tuple.fromBytes(value).getLong(0);
     }
 
-    @Nonnull
     private byte[] serializeFileSequenceCounter(long value) {
         return Tuple.from(value).pack();
     }
 
-    @Nonnull
     private CompletableFuture<Void> loadFileSequenceCounter() {
         long originalValue = fileSequenceCounter.get();
         if (originalValue >= 0) {
@@ -327,8 +323,7 @@ public class FDBDirectory extends Directory {
      * @return FDBLuceneFileReference
      */
     @API(API.Status.INTERNAL)
-    @Nonnull
-    public CompletableFuture<FDBLuceneFileReference> getFDBLuceneFileReferenceAsync(@Nonnull final String name) {
+    public CompletableFuture<FDBLuceneFileReference> getFDBLuceneFileReferenceAsync(final String name) {
         if (LOGGER.isTraceEnabled()) {
             LOGGER.trace(getLogMessage("getFDBLuceneFileReferenceAsync",
                     LuceneLogMessageKeys.FILE_NAME, name));
@@ -338,7 +333,7 @@ public class FDBDirectory extends Directory {
 
     @API(API.Status.INTERNAL)
     @Nullable
-    public FDBLuceneFileReference getFDBLuceneFileReference(@Nonnull final String name) {
+    public FDBLuceneFileReference getFDBLuceneFileReference(final String name) {
         return asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_GET_FILE_REFERENCE, getFDBLuceneFileReferenceAsync(name));
     }
 
@@ -423,7 +418,7 @@ public class FDBDirectory extends Directory {
      * @param name name for the file reference
      * @param reference the file reference being inserted
      */
-    public void writeFDBLuceneFileReference(@Nonnull String name, @Nonnull FDBLuceneFileReference reference) {
+    public void writeFDBLuceneFileReference(String name, FDBLuceneFileReference reference) {
         final byte[] fileReferenceBytes = reference.getBytes();
         final byte[] encodedBytes = Objects.requireNonNull(encode(fileReferenceBytes));
         agilityContext.recordSize(LuceneEvents.SizeEvents.LUCENE_WRITE_FILE_REFERENCE, encodedBytes.length);
@@ -446,7 +441,7 @@ public class FDBDirectory extends Directory {
      * @param value the data to be stored
      * @return the actual data size written to database with potential compression and encryption applied
      */
-    public int writeData(final long id, final int block, @Nonnull final byte[] value) {
+    public int writeData(final long id, final int block, final byte[] value) {
         final byte[] encodedBytes = Objects.requireNonNull(encode(value));
         agilityContext.increment(LuceneEvents.Counts.LUCENE_BLOCK_WRITES);
         //This may not be correct transactionally
@@ -469,7 +464,7 @@ public class FDBDirectory extends Directory {
      * @param docID the document ID to write
      * @param rawBytes the bytes value of the stored fields
      */
-    public void writeStoredFields(@Nonnull String segmentName, int docID, @Nonnull final byte[] rawBytes) {
+    public void writeStoredFields(String segmentName, int docID, final byte[] rawBytes) {
         byte[] key = storedFieldsSubspace.pack(Tuple.from(segmentName, docID));
         byte[] value = encodeFieldProtobuf(rawBytes);
         agilityContext.recordSize(LuceneEvents.SizeEvents.LUCENE_WRITE_STORED_FIELDS, key.length + value.length);
@@ -486,7 +481,7 @@ public class FDBDirectory extends Directory {
      * @param segmentName the segment name to delete the fields from (all docs in the segment will be deleted)
      * @throws IOException if there is an issue reading metadata to do the delete
      */
-    public void deleteStoredFields(@Nonnull final String segmentName) throws IOException {
+    public void deleteStoredFields(final String segmentName) throws IOException {
         agilityContext.increment(LuceneEvents.Counts.LUCENE_DELETE_STORED_FIELDS);
         if (LOGGER.isTraceEnabled()) {
             LOGGER.trace(getLogMessage("Delete Stored Fields Data",
@@ -511,17 +506,15 @@ public class FDBDirectory extends Directory {
      * @throws RecordCoreArgumentException if a reference with that id hasn't been written yet.
      */
     @API(API.Status.INTERNAL)
-    @Nonnull
-    public CompletableFuture<byte[]> readBlock(@Nonnull IndexInput requestingInput,
-                                               @Nonnull String fileName,
-                                               @Nonnull CompletableFuture<FDBLuceneFileReference> referenceFuture,
+    public CompletableFuture<byte[]> readBlock(IndexInput requestingInput,
+                                               String fileName,
+                                               CompletableFuture<FDBLuceneFileReference> referenceFuture,
                                                int block) {
         return referenceFuture.thenCompose(reference -> readBlock(requestingInput, fileName, reference, block));
     }
 
-    @Nonnull
     @SuppressWarnings("PMD.PreserveStackTrace")
-    private CompletableFuture<byte[]> readBlock(@Nonnull IndexInput requestingInput, @Nonnull String fileName,
+    private CompletableFuture<byte[]> readBlock(IndexInput requestingInput, String fileName,
                                                 @Nullable FDBLuceneFileReference reference, int block) {
         if (LOGGER.isTraceEnabled()) {
             LOGGER.trace(getLogMessage("readBlock",
@@ -565,7 +558,6 @@ public class FDBDirectory extends Directory {
                         .thenApply(this::decode));
     }
 
-    @Nonnull
     public byte[] readStoredFields(String segmentName, int docId) {
         final byte[] key = storedFieldsSubspace.pack(Tuple.from(segmentName, docId));
         final byte[] rawBytes = asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_GET_STORED_FIELDS,
@@ -580,7 +572,6 @@ public class FDBDirectory extends Directory {
         return Objects.requireNonNull(decodeFieldProtobuf(rawBytes));
     }
 
-    @Nonnull
     public List<byte[]> readAllStoredFields(String segmentName) {
         final Range range = storedFieldsSubspace.range(Tuple.from(segmentName));
         final List<KeyValue> list = asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_GET_ALL_STORED_FIELDS,
@@ -602,7 +593,6 @@ public class FDBDirectory extends Directory {
      * @return String list of names of lucene file references
      */
     @Override
-    @Nonnull
     public String[] listAll() throws IOException {
         long startTime = System.nanoTime();
         try {
@@ -691,7 +681,6 @@ public class FDBDirectory extends Directory {
                 LuceneLogMessageKeys.FILE_ACTUAL_TOTAL_SIZE, actualTotalSize);
     }
 
-    @Nonnull
     @VisibleForTesting
     public CompletableFuture<Map<String, FDBLuceneFileReference>> getFileReferenceCacheAsync() {
         if (fileReferenceCache.get() != null) {
@@ -726,7 +715,6 @@ public class FDBDirectory extends Directory {
         return fileReferenceMapSupplier.get().thenApply(ignore -> fileReferenceCache.get());
     }
 
-    @Nonnull
     private Map<String, FDBLuceneFileReference> getFileReferenceCache() {
         return Objects.requireNonNull(asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_LOAD_FILE_CACHE, getFileReferenceCacheAsync()));
     }
@@ -736,7 +724,7 @@ public class FDBDirectory extends Directory {
      * @param name the name for the file reference
      */
     @Override
-    public void deleteFile(@Nonnull String name) throws IOException {
+    public void deleteFile(String name) throws IOException {
         if (LOGGER.isTraceEnabled()) {
             LOGGER.trace(getLogMessage("deleteFile",
                     LuceneLogMessageKeys.FILE_NAME, name));
@@ -767,7 +755,7 @@ public class FDBDirectory extends Directory {
     }
 
     @VisibleForTesting
-    protected boolean deleteFileInternal(@Nonnull Map<String, FDBLuceneFileReference> cache, @Nonnull String name) throws IOException {
+    protected boolean deleteFileInternal(Map<String, FDBLuceneFileReference> cache, String name) throws IOException {
         // TODO make this transactional or ensure that it is deleted in the right order
         FDBLuceneFileReference fileReference = cache.remove(name);
         if (fileReference == null) {
@@ -815,7 +803,7 @@ public class FDBDirectory extends Directory {
      * @throws NoSuchFileException if the file reference doesn't exist.
      */
     @Override
-    public long fileLength(@Nonnull String name) throws IOException {
+    public long fileLength(String name) throws IOException {
         if (LOGGER.isTraceEnabled()) {
             LOGGER.trace(getLogMessage("fileLength",
                     LuceneLogMessageKeys.FILE_NAME, name));
@@ -841,9 +829,8 @@ public class FDBDirectory extends Directory {
      * @return IndexOutput FDB Backed Index Output FDBIndexOutput
      */
     @Override
-    @Nonnull
     @SuppressWarnings("java:S2093")
-    public IndexOutput createOutput(@Nonnull final String name, @Nullable final IOContext ioContext) throws IOException {
+    public IndexOutput createOutput(final String name, @Nullable final IOContext ioContext) throws IOException {
         if (LOGGER.isTraceEnabled()) {
             LOGGER.trace(getLogMessage("createOutput",
                     LuceneLogMessageKeys.FILE_NAME, name));
@@ -884,8 +871,7 @@ public class FDBDirectory extends Directory {
      * @return IndexOutput
      */
     @Override
-    @Nonnull
-    public IndexOutput createTempOutput(@Nonnull final String prefix, @Nonnull final String suffix, @Nonnull final IOContext ioContext) throws IOException {
+    public IndexOutput createTempOutput(final String prefix, final String suffix, final IOContext ioContext) throws IOException {
         if (LOGGER.isTraceEnabled()) {
             LOGGER.trace(getLogMessage("createTempOutput",
                     LuceneLogMessageKeys.FILE_PREFIX, prefix,
@@ -894,13 +880,12 @@ public class FDBDirectory extends Directory {
         return createOutput(getTempFileName(prefix, suffix, this.nextTempFileCounter.getAndIncrement()), ioContext);
     }
 
-    @Nonnull
-    protected static String getTempFileName(@Nonnull String prefix, @Nonnull String suffix, long counter) {
+    protected static String getTempFileName(String prefix, String suffix, long counter) {
         return IndexFileNames.segmentFileName(prefix, suffix + "_" + Long.toString(counter, 36), "tmp");
     }
 
     @Override
-    public void sync(@Nonnull final Collection<String> collection) {
+    public void sync(final Collection<String> collection) {
         if (LOGGER.isTraceEnabled()) {
             LOGGER.trace(getLogMessage("sync",
                     LuceneLogMessageKeys.FILE_NAME, String.join(", ", collection)));
@@ -921,7 +906,7 @@ public class FDBDirectory extends Directory {
      * @param dest desc
      */
     @Override
-    public void rename(@Nonnull final String source, @Nonnull final String dest) throws IOException {
+    public void rename(final String source, final String dest) throws IOException {
         if (LOGGER.isTraceEnabled()) {
             LOGGER.trace(getLogMessage("rename",
                     LogMessageKeys.SOURCE_FILE, source,
@@ -956,8 +941,7 @@ public class FDBDirectory extends Directory {
     }
 
     @Override
-    @Nonnull
-    public IndexInput openInput(@Nonnull final String name, @Nonnull final IOContext ioContext) throws IOException {
+    public IndexInput openInput(final String name, final IOContext ioContext) throws IOException {
         if (LOGGER.isTraceEnabled()) {
             LOGGER.trace(getLogMessage("openInput",
                     LuceneLogMessageKeys.FILE_NAME, name));
@@ -985,8 +969,7 @@ public class FDBDirectory extends Directory {
     }
 
     @Override
-    @Nonnull
-    public Lock obtainLock(@Nonnull final String lockName) throws IOException {
+    public Lock obtainLock(final String lockName) throws IOException {
         if (LOGGER.isTraceEnabled()) {
             LOGGER.trace(getLogMessage("obtainLock",
                     LuceneLogMessageKeys.LOCK_NAME, lockName));
@@ -1092,7 +1075,6 @@ public class FDBDirectory extends Directory {
      * @return Emtpy set of strings
      */
     @Override
-    @Nonnull
     public Set<String> getPendingDeletions() {
         if (LOGGER.isTraceEnabled()) {
             LOGGER.trace(getLogMessage("getPendingDeletions"));
@@ -1115,7 +1097,7 @@ public class FDBDirectory extends Directory {
     }
 
     @Nullable
-    public <T> T asyncToSync(@Nonnull StoreTimer.Wait event, @Nonnull CompletableFuture<T> async) {
+    public <T> T asyncToSync(StoreTimer.Wait event, CompletableFuture<T> async) {
         return agilityContext.asyncToSync(event, async);
     }
 
@@ -1128,12 +1110,11 @@ public class FDBDirectory extends Directory {
         return subspace;
     }
 
-    @Nonnull
-    private String getLogMessage(@Nonnull String staticMsg, @Nullable final Object... keysAndValues) {
+    private String getLogMessage(String staticMsg, @Nullable final Object... keysAndValues) {
         return getKeyValueLogMessage(staticMsg, keysAndValues).toString();
     }
 
-    private KeyValueLogMessage getKeyValueLogMessage(final @Nonnull String staticMsg, final Object... keysAndValues) {
+    private KeyValueLogMessage getKeyValueLogMessage(final String staticMsg, final Object... keysAndValues) {
         return KeyValueLogMessage.build(staticMsg, keysAndValues)
                 .addKeyAndValue(LogMessageKeys.SUBSPACE, subspace)
                 .addKeyAndValue(LuceneLogMessageKeys.COMPRESSION_SUPPOSED, serializer.isCompressionEnabled())
@@ -1188,7 +1169,7 @@ public class FDBDirectory extends Directory {
 
     // Map segment name to integer id.
     // TODO: Could store this elsewhere, such as inside compound file.
-    public long primaryKeySegmentId(@Nonnull String segmentName, boolean create) throws IOException {
+    public long primaryKeySegmentId(String segmentName, boolean create) throws IOException {
         try {
             final String fileName = IndexFileNames.segmentFileName(segmentName, "", "pky");
             FDBLuceneFileReference ref = getFDBLuceneFileReference(fileName);
@@ -1231,7 +1212,7 @@ public class FDBDirectory extends Directory {
      * @param defaultValue the value to use when the option is not set
      * @return the index option value, or the default value if not found
      */
-    public boolean getBooleanIndexOption(@Nonnull String key, boolean defaultValue) {
+    public boolean getBooleanIndexOption(String key, boolean defaultValue) {
         final String option = getIndexOption(key);
         if (option == null) {
             return defaultValue;
@@ -1246,7 +1227,7 @@ public class FDBDirectory extends Directory {
      * @return the index option value, null if not found
      */
     @Nullable
-    public String getIndexOption(@Nonnull String key) {
+    public String getIndexOption(String key) {
         return indexOptions.get(key);
     }
 
@@ -1255,7 +1236,6 @@ public class FDBDirectory extends Directory {
      * @param agilityContext the agility context to use for the factory
      * @return the created lock factory
      */
-    @Nonnull
     private FDBDirectoryLockFactory defaultLockFactory(final AgilityContext agilityContext) {
         return new FDBDirectoryLockFactory(this, Objects.requireNonNullElse(agilityContext.getPropertyValue(LuceneRecordContextProperties.LUCENE_FILE_LOCK_TIME_WINDOW_MILLISECONDS), 0));
     }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryLockFactory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryLockFactory.java
@@ -39,6 +39,7 @@ import org.apache.lucene.store.LockFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.jspecify.annotations.Nullable;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.UUID;

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryLockFactory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryLockFactory.java
@@ -133,11 +133,19 @@ public final class FDBDirectoryLockFactory extends LockFactory {
             return Tuple.from(selfStampUuid, timeStampMillis).pack();
         }
 
+        // NullAway/JSpecify does not reliably track @Nullable on array (byte[]) types; value is
+        // narrowed to non-null by the preceding null check before being passed to the unannotated
+        // Tuple.fromBytes.
+        @SuppressWarnings("NullAway")
         private static long fileLockValueToTimestamp(@Nullable byte[] value) {
             return value == null ? 0 :
                    Tuple.fromBytes(value).getLong(1);
         }
 
+        // NullAway/JSpecify does not reliably track @Nullable on array (byte[]) types; value is
+        // narrowed to non-null by the preceding null check before being passed to the unannotated
+        // Tuple.fromBytes.
+        @SuppressWarnings("NullAway")
         @Nullable
         private static UUID fileLockValueToUuid(@Nullable byte[] value) {
             return value == null ? null :

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryLockFactory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryLockFactory.java
@@ -89,6 +89,7 @@ public final class FDBDirectoryLockFactory extends LockFactory {
          * When closing this lock, we set this to the current context, so that when the pre-commit hook runs we won't
          * fail to heartbeat, as it will expect the lock to be deleted.
          */
+        @Nullable
         private FDBRecordContext closingContext = null;
         private final Object fileLockSetLock = new Object();
 
@@ -131,12 +132,13 @@ public final class FDBDirectoryLockFactory extends LockFactory {
             return Tuple.from(selfStampUuid, timeStampMillis).pack();
         }
 
-        private static long fileLockValueToTimestamp(byte[] value) {
+        private static long fileLockValueToTimestamp(@Nullable byte[] value) {
             return value == null ? 0 :
                    Tuple.fromBytes(value).getLong(1);
         }
 
-        private static UUID fileLockValueToUuid(byte[] value) {
+        @Nullable
+        private static UUID fileLockValueToUuid(@Nullable byte[] value) {
             return value == null ? null :
                    Tuple.fromBytes(value).getUUID(0);
         }
@@ -173,7 +175,7 @@ public final class FDBDirectoryLockFactory extends LockFactory {
                     });
         }
 
-        private void fileLockCheckHeartBeat(byte[] val) {
+        private void fileLockCheckHeartBeat(@Nullable byte[] val) {
             long existingTimeStamp = fileLockValueToTimestamp(val);
             UUID existingUuid = fileLockValueToUuid(val);
             if (existingTimeStamp == 0 || existingUuid == null) {
@@ -184,7 +186,7 @@ public final class FDBDirectoryLockFactory extends LockFactory {
             }
         }
 
-        private void fileLockCheckNewLock(byte[] val, long nowMillis) {
+        private void fileLockCheckNewLock(@Nullable byte[] val, long nowMillis) {
             long existingTimeStamp = fileLockValueToTimestamp(val);
             UUID existingUuid = fileLockValueToUuid(val);
             if (existingUuid == null || existingTimeStamp <= 0) {

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryLockFactory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryLockFactory.java
@@ -39,7 +39,6 @@ import org.apache.lucene.store.LockFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.UUID;
@@ -292,7 +291,7 @@ public final class FDBDirectoryLockFactory extends LockFactory {
      */
     @SuppressWarnings("serial")
     public static class FDBDirectoryLockException extends LoggableException {
-        public FDBDirectoryLockException(@Nonnull final String msg) {
+        public FDBDirectoryLockException(final String msg) {
             super(msg);
         }
     }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryManager.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryManager.java
@@ -143,7 +143,10 @@ public class FDBDirectoryManager implements AutoCloseable {
         return analyzerSelector;
     }
 
-    @SuppressWarnings("PMD.CloseResource")
+    // NullAway/JSpecify does not currently track @Nullable on the array (byte[]) continuation
+    // parameter of ChainedCursor's constructor (out of scope to fix here); null intentionally
+    // means "start from the beginning".
+    @SuppressWarnings({"PMD.CloseResource", "NullAway"})
     public CompletableFuture<Void> mergeIndex(LucenePartitioner partitioner) {
         // This function will iterate the grouping keys and explicitly merge each
 
@@ -322,7 +325,10 @@ public class FDBDirectoryManager implements AutoCloseable {
                 }));
     }
 
-    @SuppressWarnings("PMD.CloseResource")
+    // NullAway/JSpecify does not currently track @Nullable on array (byte[])
+    // parameters of KeyValueCursorBase.Builder#setContinuation (out of
+    // scope to fix here); null intentionally means "start from the beginning".
+    @SuppressWarnings({"PMD.CloseResource", "NullAway"})
     public static CompletableFuture<Optional<Tuple>> nextTuple(FDBRecordContext context,
                                                                Subspace subspace,
                                                                KeyRange range,

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryManager.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryManager.java
@@ -401,7 +401,7 @@ public class FDBDirectoryManager implements AutoCloseable {
     }
 
     private int getBlockCacheMaximumSize() {
-        return state.context.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_BLOCK_CACHE_MAXIMUM_SIZE);
+        return Objects.requireNonNull(state.context.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_BLOCK_CACHE_MAXIMUM_SIZE));
     }
 
     private static Tuple getDirectoryKey(final @Nullable Tuple groupingKey, final @Nullable Integer partitionId) {

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryManager.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryManager.java
@@ -61,8 +61,7 @@ import org.apache.lucene.index.IndexWriter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.IdentityHashMap;
@@ -91,20 +90,16 @@ import java.util.stream.Collectors;
 @API(API.Status.INTERNAL)
 public class FDBDirectoryManager implements AutoCloseable {
     private static final Logger LOGGER = LoggerFactory.getLogger(FDBDirectoryManager.class);
-    @Nonnull
     private final IndexMaintainerState state;
-    @Nonnull
     private final Map<Tuple, FDBDirectoryWrapper> createdDirectories;
     private final int mergeDirectoryCount;
-    @Nonnull
     protected final LuceneAnalyzerWrapper writerAnalyzer;
-    @Nonnull
     private final LuceneAnalyzerCombinationProvider analyzerSelector;
     @Nullable
     protected final Exception exceptionAtCreation;
     private boolean closed = false;
 
-    protected FDBDirectoryManager(@Nonnull IndexMaintainerState state) {
+    protected FDBDirectoryManager(IndexMaintainerState state) {
         this.state = state;
         this.createdDirectories = new ConcurrentHashMap<>();
         this.mergeDirectoryCount = getMergeDirectoryCount(state);
@@ -144,13 +139,12 @@ public class FDBDirectoryManager implements AutoCloseable {
         }
     }
 
-    @Nonnull
     public LuceneAnalyzerCombinationProvider getAnalyzerSelector() {
         return analyzerSelector;
     }
 
     @SuppressWarnings("PMD.CloseResource")
-    public CompletableFuture<Void> mergeIndex(@Nonnull LucenePartitioner partitioner) {
+    public CompletableFuture<Void> mergeIndex(LucenePartitioner partitioner) {
         // This function will iterate the grouping keys and explicitly merge each
 
         final ScanProperties scanProperties = ScanProperties.FORWARD_SCAN.with(
@@ -195,7 +189,7 @@ public class FDBDirectoryManager implements AutoCloseable {
     }
 
     private CompletableFuture<Void> mergeIndex(Tuple groupingKey,
-                                               @Nonnull LucenePartitioner partitioner, final AgilityContext agileContext) {
+                                               LucenePartitioner partitioner, final AgilityContext agileContext) {
         // Note: We always flush before calls to `mergeIndexNow` because we won't come back to get the next partition
         // or group until after the merge which could be many seconds later, in which case the current transaction would
         // no longer be valid. It may make sense to have AgilityContext.Agile commit periodically regardless of activity
@@ -253,9 +247,9 @@ public class FDBDirectoryManager implements AutoCloseable {
                 });
     }
 
-    public void mergeIndexWithContext(@Nonnull final Tuple groupingKey,
+    public void mergeIndexWithContext(final Tuple groupingKey,
                                       @Nullable final Integer partitionId,
-                                      @Nonnull final AgilityContext agilityContext) {
+                                      final AgilityContext agilityContext) {
         try (FDBDirectoryWrapper directoryWrapper = createDirectoryWrapper(groupingKey, partitionId, agilityContext)) {
             try {
                 directoryWrapper.setOngoingMergeIndicator();
@@ -279,9 +273,9 @@ public class FDBDirectoryManager implements AutoCloseable {
     }
 
     @SuppressWarnings("PMD.CloseResource")
-    public CompletableFuture<Void> drainPendingQueue(@Nonnull final Tuple groupingKey,
+    public CompletableFuture<Void> drainPendingQueue(final Tuple groupingKey,
                                                      @Nullable final Integer partitionId,
-                                                     @Nonnull final AgilityContext agilityContext) {
+                                                     final AgilityContext agilityContext) {
         final FDBDirectoryWrapper directoryWrapper = createDirectoryWrapper(groupingKey, partitionId, agilityContext);
         return directoryWrapper.drainPendingQueue(groupingKey, partitionId)
                 .whenComplete((v, e) -> {
@@ -329,11 +323,11 @@ public class FDBDirectoryManager implements AutoCloseable {
     }
 
     @SuppressWarnings("PMD.CloseResource")
-    public static CompletableFuture<Optional<Tuple>> nextTuple(@Nonnull FDBRecordContext context,
-                                                               @Nonnull Subspace subspace,
-                                                               @Nonnull KeyRange range,
-                                                               @Nonnull Optional<Tuple> lastTuple,
-                                                               @Nonnull ScanProperties scanProperties,
+    public static CompletableFuture<Optional<Tuple>> nextTuple(FDBRecordContext context,
+                                                               Subspace subspace,
+                                                               KeyRange range,
+                                                               Optional<Tuple> lastTuple,
+                                                               ScanProperties scanProperties,
                                                                int groupingCount) {
         KeyValueCursor.Builder cursorBuilder =
                 KeyValueCursor.Builder.withSubspace(subspace)
@@ -366,7 +360,7 @@ public class FDBDirectoryManager implements AutoCloseable {
      * Invalidate directories from the cache if their grouping key begins with a specified prefix.
      * @param prefix the prefix of grouping keys to remove from the cache
      */
-    public void invalidatePrefix(@Nonnull Tuple prefix) {
+    public void invalidatePrefix(Tuple prefix) {
         final Iterator<Map.Entry<Tuple, FDBDirectoryWrapper>> iterator = createdDirectories.entrySet().iterator();
         while (iterator.hasNext()) {
             Map.Entry<Tuple, FDBDirectoryWrapper> item = iterator.next();
@@ -401,7 +395,7 @@ public class FDBDirectoryManager implements AutoCloseable {
         return createNewDirectoryWrapper(state, getDirectoryKey(groupingKey, partitionId), mergeDirectoryCount, agilityContext, getBlockCacheMaximumSize());
     }
 
-    protected @Nonnull FDBDirectoryWrapper createNewDirectoryWrapper(final IndexMaintainerState state, final Tuple key, final int mergeDirectoryCount, final AgilityContext agilityContext, final int blockCacheMaximumSize) {
+    protected FDBDirectoryWrapper createNewDirectoryWrapper(final IndexMaintainerState state, final Tuple key, final int mergeDirectoryCount, final AgilityContext agilityContext, final int blockCacheMaximumSize) {
         return new FDBDirectoryWrapper(state, key, mergeDirectoryCount, agilityContext, blockCacheMaximumSize,
                 writerAnalyzer, exceptionAtCreation);
     }
@@ -447,7 +441,6 @@ public class FDBDirectoryManager implements AutoCloseable {
         }
     }
 
-    @Nonnull
     public FDBDirectory getDirectory(@Nullable Tuple groupingKey, @Nullable Integer partitionId) {
         return getDirectoryWrapper(groupingKey, partitionId).getDirectory();
     }
@@ -456,12 +449,10 @@ public class FDBDirectoryManager implements AutoCloseable {
         return getDirectoryWrapper(groupingKey, partitionId).getReader();
     }
 
-    @Nonnull
     public IndexWriter getIndexWriter(@Nullable Tuple groupingKey, @Nullable Integer partitionId) throws IOException {
         return getDirectoryWrapper(groupingKey, partitionId).getWriter();
     }
 
-    @Nonnull
     public IndexReader getIndexReaderWithReplayedQueue(@Nullable Tuple groupingKey, @Nullable Integer partitionId) throws IOException {
         return getDirectoryWrapper(groupingKey, partitionId).getIndexReaderWithReplayedQueue();
     }
@@ -474,13 +465,12 @@ public class FDBDirectoryManager implements AutoCloseable {
         return getDirectoryWrapper(groupingKey, partititonId).getWriterReader(refresh);
     }
 
-    @Nonnull
-    public static FDBDirectoryManager getManager(@Nonnull IndexMaintainerState state) {
+    public static FDBDirectoryManager getManager(IndexMaintainerState state) {
         return getOrCreateManager(state, () -> new FDBDirectoryManager(state));
     }
 
     @SuppressWarnings("PMD.CloseResource")
-    protected static @Nonnull FDBDirectoryManager getOrCreateManager(final @Nonnull IndexMaintainerState state, Supplier<FDBDirectoryManager> managerSupplier) {
+    protected static FDBDirectoryManager getOrCreateManager(final IndexMaintainerState state, Supplier<FDBDirectoryManager> managerSupplier) {
         synchronized (state.context) {
             FDBRecordContext context = state.context;
             FDBDirectoryManager existing = context.getInSession(state.indexSubspace, FDBDirectoryManager.class);
@@ -522,7 +512,7 @@ public class FDBDirectoryManager implements AutoCloseable {
         }
     }
 
-    private int getMergeDirectoryCount(@Nonnull IndexMaintainerState state) {
+    private int getMergeDirectoryCount(IndexMaintainerState state) {
         return Math.toIntExact(state.store
                 .getRecordMetaData()
                 .getAllIndexes()

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectorySharedCache.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectorySharedCache.java
@@ -26,8 +26,7 @@ import com.apple.foundationdb.tuple.Tuple;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
@@ -41,18 +40,14 @@ import java.util.concurrent.atomic.AtomicReference;
 @ThreadSafe
 public class FDBDirectorySharedCache {
 
-    @Nonnull
     private final Tuple key;
     private final long sequenceNumber;
-    @Nonnull
     private final AtomicReference<Map<String, FDBLuceneFileReference>> fileReferences;
 
-    @Nonnull
     private final AtomicReference<ConcurrentMap<Long, AtomicInteger>> fieldInfosReferenceCount = new AtomicReference<>();
-    @Nonnull
     private final Cache<Pair<Long, Integer>, byte[]> blocks;
 
-    public FDBDirectorySharedCache(@Nonnull Tuple key, long sequenceNumber,
+    public FDBDirectorySharedCache(Tuple key, long sequenceNumber,
                                    int maximumSize, int concurrencyLevel, int initialCapacity) {
         this.key = key;
         this.sequenceNumber = sequenceNumber;
@@ -70,7 +65,6 @@ public class FDBDirectorySharedCache {
      * The key is relative to the record store root, so including the index subspace prefix and any grouping keys.
      * @return the key for this directory cache
      */
-    @Nonnull
     public Tuple getKey() {
         return key;
     }
@@ -97,7 +91,7 @@ public class FDBDirectorySharedCache {
      * Add set of file references to the cache.
      * @param fileReferences the file references for the associated directory as of the sequence number
      */
-    public void setFileReferencesIfAbsent(@Nonnull Map<String, FDBLuceneFileReference> fileReferences) {
+    public void setFileReferencesIfAbsent(Map<String, FDBLuceneFileReference> fileReferences) {
         this.fileReferences.compareAndSet(null, fileReferences);
     }
 
@@ -118,7 +112,7 @@ public class FDBDirectorySharedCache {
      * @param blockNumber block number in the file
      * @param block the block to be cached
      */
-    public void putBlockIfAbsent(long id, int blockNumber, @Nonnull byte[] block) {
+    public void putBlockIfAbsent(long id, int blockNumber, byte[] block) {
         blocks.asMap().putIfAbsent(Pair.of(id, blockNumber), block);
     }
 

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectorySharedCache.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectorySharedCache.java
@@ -101,8 +101,7 @@ public class FDBDirectorySharedCache {
      * @param blockNumber block number in the file
      * @return the cached block or {@code null} if not cached
      */
-    @Nullable
-    public byte[] getBlockIfPresent(long id, int blockNumber) {
+    public byte @Nullable [] getBlockIfPresent(long id, int blockNumber) {
         return blocks.getIfPresent(Pair.of(id, blockNumber));
     }
 
@@ -116,10 +115,11 @@ public class FDBDirectorySharedCache {
         blocks.asMap().putIfAbsent(Pair.of(id, blockNumber), block);
     }
 
-    public void setFieldInfosReferenceCount(final ConcurrentMap<Long, AtomicInteger> fieldInfosReferenceCount) {
+    public void setFieldInfosReferenceCount(@Nullable final ConcurrentMap<Long, AtomicInteger> fieldInfosReferenceCount) {
         this.fieldInfosReferenceCount.compareAndSet(null, fieldInfosReferenceCount);
     }
 
+    @Nullable
     public ConcurrentMap<Long, AtomicInteger> getFieldInfosReferenceCount() {
         return this.fieldInfosReferenceCount.get();
     }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectorySharedCacheManager.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectorySharedCacheManager.java
@@ -127,6 +127,7 @@ public class FDBDirectorySharedCacheManager {
      * Builder for {@code FDBDirectorySharedCacheManager}.
      */
     public static class Builder {
+        @Nullable
         private Subspace subspace;
         private int maximumSize = 1024;
         private int concurrencyLevel = 16;
@@ -135,7 +136,7 @@ public class FDBDirectorySharedCacheManager {
         protected Builder() {
         }
 
-        public Builder setSubspace(final Subspace subspace) {
+        public Builder setSubspace(@Nullable final Subspace subspace) {
             this.subspace = subspace;
             return this;
         }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectorySharedCacheManager.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectorySharedCacheManager.java
@@ -25,8 +25,7 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 import com.apple.foundationdb.subspace.Subspace;
 import com.apple.foundationdb.tuple.Tuple;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -44,7 +43,6 @@ import java.util.concurrent.ConcurrentHashMap;
 @ThreadSafe
 public class FDBDirectorySharedCacheManager {
     public static final Object SHARED_CACHE_CONTEXT_KEY = new Object();
-    @Nonnull
     private final Map<Tuple, FDBDirectorySharedCache> caches;
     @Nullable
     private final Subspace subspace;
@@ -79,7 +77,7 @@ public class FDBDirectorySharedCacheManager {
      * @see #setForContext
      */
     @Nullable
-    public static FDBDirectorySharedCacheManager forContext(@Nonnull FDBRecordContext context) {
+    public static FDBDirectorySharedCacheManager forContext(FDBRecordContext context) {
         return context.getInSession(SHARED_CACHE_CONTEXT_KEY, FDBDirectorySharedCacheManager.class);
     }
 
@@ -87,7 +85,7 @@ public class FDBDirectorySharedCacheManager {
      * Set the given shared cache manager in the given context.
      * @param context the record context in which to put the shared cache manager
      */
-    public void setForContext(@Nonnull FDBRecordContext context) {
+    public void setForContext(FDBRecordContext context) {
         context.putInSessionIfAbsent(SHARED_CACHE_CONTEXT_KEY, this);
     }
 
@@ -106,7 +104,7 @@ public class FDBDirectorySharedCacheManager {
      * @return a shared cache of {@code null} if the sequence number is too old
      */
     @Nullable
-    public FDBDirectorySharedCache getCache(@Nonnull Tuple key, long sequenceNumber) {
+    public FDBDirectorySharedCache getCache(Tuple key, long sequenceNumber) {
         FDBDirectorySharedCache storedCache = caches.compute(key, (ckey, cache) -> {
             if (cache == null || cache.getSequenceNumber() < sequenceNumber) {
                 cache = new FDBDirectorySharedCache(ckey, sequenceNumber,

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryUtils.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryUtils.java
@@ -26,8 +26,6 @@ import com.apple.foundationdb.record.lucene.codec.LuceneOptimizedCompoundReader;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FilterDirectory;
 
-import javax.annotation.Nonnull;
-
 /**
  * Utilities for standardizing some interactions with {@link FDBDirectory}.
  */
@@ -37,8 +35,7 @@ public class FDBDirectoryUtils {
     }
 
     @SuppressWarnings("PMD.CloseResource")
-    @Nonnull
-    public static FDBDirectory getFDBDirectory(@Nonnull Directory directory) {
+    public static FDBDirectory getFDBDirectory(Directory directory) {
         final Directory unwrapped = FilterDirectory.unwrap(directory);
         if (unwrapped instanceof FDBDirectory) {
             return ((FDBDirectory)unwrapped);
@@ -51,8 +48,7 @@ public class FDBDirectoryUtils {
     }
 
     @SuppressWarnings("PMD.CloseResource")
-    @Nonnull
-    public static FDBDirectory getFDBDirectoryNotCompound(@Nonnull Directory directory) {
+    public static FDBDirectory getFDBDirectoryNotCompound(Directory directory) {
         final Directory unwrapped = FilterDirectory.unwrap(directory);
         if (unwrapped instanceof FDBDirectory) {
             return ((FDBDirectory)unwrapped);

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryWrapper.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryWrapper.java
@@ -68,6 +68,7 @@ import org.jspecify.annotations.Nullable;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -191,13 +192,13 @@ public class FDBDirectoryWrapper implements AutoCloseable {
         pendingWriteQueue = LazyOpener.supply(() -> directory.createPendingWritesQueue());
     }
 
-    private IndexWriter createIndexWriter(final Exception exceptionAtCreation) throws IOException {
+    private IndexWriter createIndexWriter(@Nullable final Exception exceptionAtCreation) throws IOException {
         useWriter = true;
         IndexWriterConfig indexWriterConfig = createIndexWriterConfig(exceptionAtCreation);
         return new IndexWriter(this.directory, indexWriterConfig);
     }
 
-    private IndexWriterConfig createIndexWriterConfig(final Exception exceptionAtCreation) {
+    private IndexWriterConfig createIndexWriterConfig(@Nullable final Exception exceptionAtCreation) {
         final IndexDeferredMaintenanceControl mergeControl = this.state.store.getIndexDeferredMaintenanceControl();
         final MergePolicy mergePolicy;
         if (mergeControl.shouldAutoMergeDuringCommit() || mergeControl.isExplicitMergePath()) {
@@ -205,8 +206,8 @@ public class FDBDirectoryWrapper implements AutoCloseable {
             // merge policy, and avoid requesting a deferred merge
             mergePolicy = new FDBTieredMergePolicy(mergeControl, this.agilityContext,
                     this.state.indexSubspace, this.key, exceptionAtCreation)
-                    .setMaxMergedSegmentMB(this.state.context.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_MERGE_MAX_SIZE))
-                    .setSegmentsPerTier(this.state.context.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_MERGE_SEGMENTS_PER_TIER));
+                    .setMaxMergedSegmentMB(Objects.requireNonNull(this.state.context.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_MERGE_MAX_SIZE)))
+                    .setSegmentsPerTier(Objects.requireNonNull(this.state.context.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_MERGE_SEGMENTS_PER_TIER)));
         } else {
             // Here: Not a merge path, optimize by using a "no merge" policy and request a deferred merge
             mergePolicy = NoMergePolicy.INSTANCE;
@@ -246,8 +247,8 @@ public class FDBDirectoryWrapper implements AutoCloseable {
 
     protected FDBDirectory createFDBDirectory(final Subspace subspace,
                                                        final Map<String, String> options,
-                                                       final FDBDirectorySharedCacheManager sharedCacheManager,
-                                                       final Tuple sharedCacheKey,
+                                                       @Nullable final FDBDirectorySharedCacheManager sharedCacheManager,
+                                                       @Nullable final Tuple sharedCacheKey,
                                                        final boolean useCompoundFile, final AgilityContext agilityContext,
                                                        final @Nullable LockFactory lockFactory,
                                                        final int blockCacheMaximumSize) {
@@ -270,7 +271,7 @@ public class FDBDirectoryWrapper implements AutoCloseable {
         } else {
             return StandardDirectoryReaderOptimization.open(directory, null, null,
                     state.context.getExecutor(),
-                    state.context.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_OPEN_PARALLELISM));
+                    Objects.requireNonNull(state.context.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_OPEN_PARALLELISM)));
         }
     }
 
@@ -292,15 +293,15 @@ public class FDBDirectoryWrapper implements AutoCloseable {
         } else {
             PendingWriteQueue queue = getPendingWriteQueue();
             // Use the regular context to find out if the queue has anything
-            final Boolean queueIsEmpty = LuceneConcurrency.asyncToSync(
+            final Boolean queueIsEmpty = Objects.requireNonNull(LuceneConcurrency.asyncToSync(
                     LuceneEvents.Waits.WAIT_LUCENE_READ_PENDING_QUEUE,
                     queue.isQueueEmpty(state.context),
-                    state.context);
+                    state.context));
             if (queueIsEmpty) {
                 // Use the regular reader in case there is nothing in the queue
                 return StandardDirectoryReaderOptimization.open(directory, null, null,
                         state.context.getExecutor(),
-                        state.context.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_OPEN_PARALLELISM));
+                        Objects.requireNonNull(state.context.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_OPEN_PARALLELISM)));
             } else {
                 // create a reader from a writer that has the queue elements replayed
                 return DirectoryReader.open(replayedQueueIndexWriter.get());
@@ -383,7 +384,7 @@ public class FDBDirectoryWrapper implements AutoCloseable {
         @Override
         public synchronized void merge(final MergeSource mergeSource, final MergeTrigger trigger) throws IOException {
             long startTime = System.nanoTime();
-            if (state.context.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_MULTIPLE_MERGE_OPTIMIZATION_ENABLED) && trigger == MergeTrigger.FULL_FLUSH) {
+            if (Objects.requireNonNull(state.context.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_MULTIPLE_MERGE_OPTIMIZATION_ENABLED)) && trigger == MergeTrigger.FULL_FLUSH) {
                 if (ThreadLocalRandom.current().nextInt(mergeDirectoryCount) == 0) {
                     if (mergeSource.hasPendingMerges()) {
                         MergeUtils.logExecutingMerge(LOGGER, "Executing Merge based on probability", agilityContext, state.indexSubspace, key, trigger);
@@ -451,7 +452,7 @@ public class FDBDirectoryWrapper implements AutoCloseable {
         @Override
         public synchronized void merge(final MergeSource mergeSource, final MergeTrigger trigger) throws IOException {
             long startTime = System.nanoTime();
-            if (state.context.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_MULTIPLE_MERGE_OPTIMIZATION_ENABLED) && trigger == MergeTrigger.FULL_FLUSH) {
+            if (Objects.requireNonNull(state.context.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_MULTIPLE_MERGE_OPTIMIZATION_ENABLED)) && trigger == MergeTrigger.FULL_FLUSH) {
                 if (ThreadLocalRandom.current().nextInt(mergeDirectoryCount) == 0) {
                     if (mergeSource.hasPendingMerges()) {
                         MergeUtils.logExecutingMerge(LOGGER, "Executing Merge Concurrently based on probability", agilityContext, state.indexSubspace, key, trigger);

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryWrapper.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryWrapper.java
@@ -64,8 +64,7 @@ import org.apache.lucene.util.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Map;
@@ -97,7 +96,6 @@ public class FDBDirectoryWrapper implements AutoCloseable {
     private final int mergeDirectoryCount;
     private final AgilityContext agilityContext;
     private final Tuple key;
-    @Nonnull
     private final LuceneAnalyzerWrapper analyzerWrapper;
     private final int blockCacheMaximumSize;
     /**
@@ -145,12 +143,12 @@ public class FDBDirectoryWrapper implements AutoCloseable {
      */
     private LazyOpener<PendingWriteQueue> pendingWriteQueue;
 
-    FDBDirectoryWrapper(@Nonnull final IndexMaintainerState state,
-                        @Nonnull final Tuple key,
+    FDBDirectoryWrapper(final IndexMaintainerState state,
+                        final Tuple key,
                         int mergeDirectoryCount,
-                        @Nonnull final AgilityContext agilityContext,
+                        final AgilityContext agilityContext,
                         final int blockCacheMaximumSize,
-                        @Nonnull final LuceneAnalyzerWrapper analyzerWrapper,
+                        final LuceneAnalyzerWrapper analyzerWrapper,
                         @Nullable final Exception exceptionAtCreation) {
         this.state = state;
         this.key = key;
@@ -170,12 +168,12 @@ public class FDBDirectoryWrapper implements AutoCloseable {
 
     @VisibleForTesting
     @SuppressWarnings("this-escape")
-    public FDBDirectoryWrapper(@Nonnull final IndexMaintainerState state,
-                               @Nonnull final FDBDirectory directory,
-                               @Nonnull final Tuple key,
+    public FDBDirectoryWrapper(final IndexMaintainerState state,
+                               final FDBDirectory directory,
+                               final Tuple key,
                                int mergeDirectoryCount,
-                               @Nonnull final AgilityContext agilityContext,
-                               @Nonnull final LuceneAnalyzerWrapper analyzerWrapper,
+                               final AgilityContext agilityContext,
+                               final LuceneAnalyzerWrapper analyzerWrapper,
                                @Nullable final Exception exceptionAtCreation) {
         this.state = state;
         this.key = key;
@@ -193,14 +191,12 @@ public class FDBDirectoryWrapper implements AutoCloseable {
         pendingWriteQueue = LazyOpener.supply(() -> directory.createPendingWritesQueue());
     }
 
-    @Nonnull
     private IndexWriter createIndexWriter(final Exception exceptionAtCreation) throws IOException {
         useWriter = true;
         IndexWriterConfig indexWriterConfig = createIndexWriterConfig(exceptionAtCreation);
         return new IndexWriter(this.directory, indexWriterConfig);
     }
 
-    @Nonnull
     private IndexWriterConfig createIndexWriterConfig(final Exception exceptionAtCreation) {
         final IndexDeferredMaintenanceControl mergeControl = this.state.store.getIndexDeferredMaintenanceControl();
         final MergePolicy mergePolicy;
@@ -226,7 +222,6 @@ public class FDBDirectoryWrapper implements AutoCloseable {
                 .setInfoStream(new LuceneLoggerInfoStream(LOGGER));
     }
 
-    @Nonnull
     protected FDBDirectory createFDBDirectory(final IndexMaintainerState state,
                                               final Tuple key,
                                               final AgilityContext agilityContext,
@@ -249,7 +244,7 @@ public class FDBDirectoryWrapper implements AutoCloseable {
                 agilityContext, lockFactory, blockCacheMaximumSize);
     }
 
-    protected @Nonnull FDBDirectory createFDBDirectory(final Subspace subspace,
+    protected FDBDirectory createFDBDirectory(final Subspace subspace,
                                                        final Map<String, String> options,
                                                        final FDBDirectorySharedCacheManager sharedCacheManager,
                                                        final Tuple sharedCacheKey,
@@ -289,7 +284,6 @@ public class FDBDirectoryWrapper implements AutoCloseable {
      * and will be rolled back once the directory is closed.
      * This object should be closed by callers.
      */
-    @Nonnull
     @SuppressWarnings("PMD.CloseResource")
     public IndexReader getIndexReaderWithReplayedQueue() throws IOException {
         if (useWriter) {
@@ -314,7 +308,6 @@ public class FDBDirectoryWrapper implements AutoCloseable {
         }
     }
 
-    @Nonnull
     @SuppressWarnings("PMD.CloseResource")
     private IndexWriter createIndexWriterWithReplayedQueue() throws IOException {
         final AgilityContext agilityContextReadOnly = replayedQueueContext.get().getAgilityContext();
@@ -332,7 +325,6 @@ public class FDBDirectoryWrapper implements AutoCloseable {
         return readOnlyIndexWriter;
     }
 
-    @Nonnull
     private CloseableReadOnlyAgilityContext createReadOnlyContext() {
         AgilityContext readOnlyContext = AgilityContext.readOnlyNonAgile(agilityContext.getCallerContext(), null);
         return new CloseableReadOnlyAgilityContext(readOnlyContext);
@@ -370,17 +362,14 @@ public class FDBDirectoryWrapper implements AutoCloseable {
          * This class is temporarily duplicating FDBDirectoryMergeScheduler.
          * TODO: After verified, either delete FDBDirectoryMergeScheduler or delete FDBDirectorySerialMergeScheduler.
          */
-        @Nonnull
         private final IndexMaintainerState state;
         private final int mergeDirectoryCount;
-        @Nonnull
         private final AgilityContext agilityContext;
-        @Nonnull
         private final Tuple key;
 
-        private FDBDirectorySerialMergeScheduler(@Nonnull IndexMaintainerState state, int mergeDirectoryCount,
-                                           @Nonnull final AgilityContext agilityContext,
-                                           @Nonnull final Tuple key) {
+        private FDBDirectorySerialMergeScheduler(IndexMaintainerState state, int mergeDirectoryCount,
+                                           final AgilityContext agilityContext,
+                                           final Tuple key) {
             this.state = state;
             this.mergeDirectoryCount = mergeDirectoryCount;
             this.agilityContext = agilityContext;
@@ -441,17 +430,14 @@ public class FDBDirectoryWrapper implements AutoCloseable {
     }
 
     private static class FDBDirectoryMergeScheduler extends ConcurrentMergeScheduler {
-        @Nonnull
         private final IndexMaintainerState state;
         private final int mergeDirectoryCount;
-        @Nonnull
         private final AgilityContext agilityContext;
-        @Nonnull
         private final Tuple key;
 
-        private FDBDirectoryMergeScheduler(@Nonnull IndexMaintainerState state, int mergeDirectoryCount,
-                                           @Nonnull final AgilityContext agilityContext,
-                                           @Nonnull final Tuple key) {
+        private FDBDirectoryMergeScheduler(IndexMaintainerState state, int mergeDirectoryCount,
+                                           final AgilityContext agilityContext,
+                                           final Tuple key) {
             this.state = state;
             this.mergeDirectoryCount = mergeDirectoryCount;
             this.agilityContext = agilityContext;
@@ -495,10 +481,10 @@ public class FDBDirectoryWrapper implements AutoCloseable {
         }
     }
 
-    private MergeScheduler getMergeScheduler(@Nonnull IndexMaintainerState state,
+    private MergeScheduler getMergeScheduler(IndexMaintainerState state,
                                              int mergeDirectoryCount,
-                                             @Nonnull final AgilityContext agilityContext,
-                                             @Nonnull final Tuple key) {
+                                             final AgilityContext agilityContext,
+                                             final Tuple key) {
         final Boolean useConcurrent = state.context.getPropertyStorage().getPropertyValue(LuceneRecordContextProperties.LUCENE_USE_CONCURRENT_MERGE_SCHEDULER);
         return Boolean.TRUE.equals(useConcurrent) ?
                new FDBDirectoryMergeScheduler(state, mergeDirectoryCount, agilityContext, key) :
@@ -506,7 +492,6 @@ public class FDBDirectoryWrapper implements AutoCloseable {
 
     }
 
-    @Nonnull
     @SuppressWarnings("PMD.CloseResource")
     public IndexWriter getWriter() throws IOException {
         return writer.get();
@@ -552,7 +537,7 @@ public class FDBDirectoryWrapper implements AutoCloseable {
         return getDirectory().clearOngoingMergeIndicatorIfQueueEmptyAsync();
     }
 
-    public CompletableFuture<Void> drainPendingQueue(@Nonnull final Tuple groupingKey,
+    public CompletableFuture<Void> drainPendingQueue(final Tuple groupingKey,
                                                      @Nullable final Integer partitionId) {
         if (LOGGER.isInfoEnabled()) {
             LOGGER.info(KeyValueLogMessage.of("Drain pending queue",
@@ -591,7 +576,7 @@ public class FDBDirectoryWrapper implements AutoCloseable {
     }
 
     @SuppressWarnings("PMD.CloseResource")
-    private CompletableFuture<Void> drainPendingQueueNow(@Nonnull final Tuple groupingKey,
+    private CompletableFuture<Void> drainPendingQueueNow(final Tuple groupingKey,
                                                          @Nullable final Integer partitionId) {
         // Note - since this directory wrapper was already created, agility context should be unused in the next line's path
         final PendingWriteQueue writeQueue = getPendingWriteQueue();
@@ -614,7 +599,7 @@ public class FDBDirectoryWrapper implements AutoCloseable {
 
     private CursorFactory<PendingWriteQueue.QueueEntry> cursorFactory(PendingWriteQueue pendingWriteQueue,
                                                                       @Nullable Function<FDBRecordStore, CompletableFuture<Void>> preCommitCallback) {
-        return (@Nonnull FDBRecordStore store, @Nullable RecordCursorResult<PendingWriteQueue.QueueEntry> lastResult, int rowLimit) -> {
+        return (FDBRecordStore store, @Nullable RecordCursorResult<PendingWriteQueue.QueueEntry> lastResult, int rowLimit) -> {
             if (preCommitCallback != null) {
                 store.getContext().getOrCreateCommitCheck(DRAIN_PRE_COMMIT_HOOK + state.index.getName(),
                         name -> () -> preCommitCallback.apply(store));
@@ -628,7 +613,7 @@ public class FDBDirectoryWrapper implements AutoCloseable {
     }
 
     private ItemHandler<PendingWriteQueue.QueueEntry> handleOneItemFactory(PendingWriteQueue pendingWriteQueue,
-                                                                           @Nonnull final Tuple groupingKey,
+                                                                           final Tuple groupingKey,
                                                                            @Nullable final Integer partitionId) {
         return (store, lastResult, quotamanager) -> {
             final PendingWriteQueue.QueueEntry queueEntry = lastResult.get();
@@ -676,7 +661,7 @@ public class FDBDirectoryWrapper implements AutoCloseable {
             super("Pending queue drain had failed", cause);
         }
 
-        public PendingQueueDrainException(@Nonnull final String msg, @Nullable final Object... keyValues) {
+        public PendingQueueDrainException(final String msg, @Nullable final Object... keyValues) {
             super(msg, keyValues);
         }
     }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryWrapper.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryWrapper.java
@@ -23,6 +23,7 @@ package com.apple.foundationdb.record.lucene.directory;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.record.RecordCoreException;
+import com.apple.foundationdb.record.RecordCursor;
 import com.apple.foundationdb.record.RecordCursorResult;
 import com.apple.foundationdb.record.ScanProperties;
 import com.apple.foundationdb.record.logging.KeyValueLogMessage;
@@ -234,10 +235,11 @@ public class FDBDirectoryWrapper implements AutoCloseable {
         if (sharedCacheManager == null) {
             sharedCacheKey = null;
         } else {
-            if (sharedCacheManager.getSubspace() == null) {
+            final Subspace sharedManagerSubspace = sharedCacheManager.getSubspace();
+            if (sharedManagerSubspace == null) {
                 sharedCacheKey = state.store.getSubspace().unpack(subspace.pack());
             } else {
-                sharedCacheKey = sharedCacheManager.getSubspace().unpack(subspace.pack());
+                sharedCacheKey = sharedManagerSubspace.unpack(subspace.pack());
             }
         }
         return createFDBDirectory(
@@ -598,18 +600,29 @@ public class FDBDirectoryWrapper implements AutoCloseable {
                 });
     }
 
+    // Implemented as an explicit anonymous class (rather than a lambda) so that createCursor's own @Nullable
+    // lastResult parameter keeps its correct formal-parameter index in the compiled bytecode. javac's lambda
+    // desugaring prepends captured variables (pendingWriteQueue, preCommitCallback) to the synthetic method's
+    // parameter list without re-indexing the lambda's own parameter type annotations to match, which previously
+    // misattributed lastResult's @Nullable annotation onto the captured pendingWriteQueue parameter and made
+    // SpotBugs (incorrectly) report NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE on pendingWriteQueue.
     private CursorFactory<PendingWriteQueue.QueueEntry> cursorFactory(PendingWriteQueue pendingWriteQueue,
                                                                       @Nullable Function<FDBRecordStore, CompletableFuture<Void>> preCommitCallback) {
-        return (FDBRecordStore store, @Nullable RecordCursorResult<PendingWriteQueue.QueueEntry> lastResult, int rowLimit) -> {
-            if (preCommitCallback != null) {
-                store.getContext().getOrCreateCommitCheck(DRAIN_PRE_COMMIT_HOOK + state.index.getName(),
-                        name -> () -> preCommitCallback.apply(store));
+        return new CursorFactory<PendingWriteQueue.QueueEntry>() {
+            @Override
+            public RecordCursor<PendingWriteQueue.QueueEntry> createCursor(FDBRecordStore store,
+                                                                             @Nullable RecordCursorResult<PendingWriteQueue.QueueEntry> lastResult,
+                                                                             int rowLimit) {
+                if (preCommitCallback != null) {
+                    store.getContext().getOrCreateCommitCheck(DRAIN_PRE_COMMIT_HOOK + state.index.getName(),
+                            name -> () -> preCommitCallback.apply(store));
+                }
+                byte[] continuation = lastResult == null ? null : lastResult.getContinuation().toBytes();
+                ScanProperties scanProperties = ScanProperties.FORWARD_SCAN.with(executeProperties -> executeProperties.setReturnedRowLimit(rowLimit));
+                // Note: null could have been used instead of continuation as the preceding items should have been deleted. However,
+                // using a continuation will prevent an infinite loop in case of a bug that doesn't clear items.
+                return pendingWriteQueue.getQueueCursor(store.getContext(), scanProperties, continuation);
             }
-            byte[] continuation = lastResult == null ? null : lastResult.getContinuation().toBytes();
-            ScanProperties scanProperties = ScanProperties.FORWARD_SCAN.with(executeProperties -> executeProperties.setReturnedRowLimit(rowLimit));
-            // Note: null could have been used instead of continuation as the preceding items should have been deleted. However,
-            // using a continuation will prevent an infinite loop in case of a bug that doesn't clear items.
-            return pendingWriteQueue.getQueueCursor(store.getContext(), scanProperties, continuation);
         };
     }
 

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBIndexInput.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBIndexInput.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 import org.jspecify.annotations.Nullable;
 import java.io.EOFException;
 import java.io.IOException;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 import static com.google.common.base.Verify.verify;
@@ -53,12 +54,14 @@ public final class FDBIndexInput extends IndexInput {
      * Position within the current block
      */
     private long position;
+    @Nullable
     private CompletableFuture<byte[]> currentData;
     private int currentBlock;
     private final long initialOffset;
     private int numberOfSeeks = 0;
     // These actual values are added to remove a hotspot during byte reads.
-    private byte[] actualCurrentData;
+    private byte @Nullable [] actualCurrentData;
+    @Nullable
     private FDBLuceneFileReference actualReference;
 
     /**
@@ -125,7 +128,9 @@ public final class FDBIndexInput extends IndexInput {
 
     private byte[] getCurrentData() {
         if (actualCurrentData == null) {
-            actualCurrentData = fdbDirectory.asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_GET_DATA_BLOCK, currentData);
+            // currentData is always set by the constructor or readBlock() before this is called; the eventual
+            // result never resolves to null either.
+            actualCurrentData = Objects.requireNonNull(fdbDirectory.asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_GET_DATA_BLOCK, Objects.requireNonNull(currentData)));
         }
         return actualCurrentData;
     }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBIndexInput.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBIndexInput.java
@@ -31,8 +31,7 @@ import org.apache.lucene.store.IndexInput;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.io.EOFException;
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
@@ -72,7 +71,7 @@ public final class FDBIndexInput extends IndexInput {
      * @param fdbDirectory FDB directory mapping
      * @throws IOException exception
      */
-    public FDBIndexInput(@Nonnull final String fileName, @Nonnull final FDBDirectory fdbDirectory) throws IOException {
+    public FDBIndexInput(final String fileName, final FDBDirectory fdbDirectory) throws IOException {
         this(fileName, fileName, fdbDirectory, fdbDirectory.getFDBLuceneFileReferenceAsync(fileName), 0L,
                 0L, 0, null);
     }
@@ -90,8 +89,8 @@ public final class FDBIndexInput extends IndexInput {
      * @param currentData future with CurrentData Fetch
      * @throws IOException exception
      */
-    public FDBIndexInput(@Nonnull final String resourceDescription, @Nonnull final String fileName, @Nonnull final FDBDirectory fdbDirectory,
-                         @Nonnull CompletableFuture<FDBLuceneFileReference> reference, long initialOffset, long position,
+    public FDBIndexInput(final String resourceDescription, final String fileName, final FDBDirectory fdbDirectory,
+                         CompletableFuture<FDBLuceneFileReference> reference, long initialOffset, long position,
                          int currentBlock, @Nullable CompletableFuture<byte[]> currentData) throws IOException {
         super(resourceDescription);
         if (LOGGER.isTraceEnabled()) {
@@ -113,7 +112,6 @@ public final class FDBIndexInput extends IndexInput {
         }
     }
 
-    @Nonnull
     private FDBLuceneFileReference getFileReference() {
         if (actualReference == null) {
             actualReference = fdbDirectory.asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_GET_FILE_REFERENCE, reference);
@@ -215,8 +213,7 @@ public final class FDBIndexInput extends IndexInput {
      * @throws IOException exception
      */
     @Override
-    @Nonnull
-    public IndexInput slice(@Nonnull String sliceDescription, long offset, long length) throws IOException {
+    public IndexInput slice(String sliceDescription, long offset, long length) throws IOException {
         if (LOGGER.isTraceEnabled()) {
             LOGGER.trace(getLogMessage("slice",
                     LogMessageKeys.DESCRIPTION, sliceDescription,
@@ -293,7 +290,7 @@ public final class FDBIndexInput extends IndexInput {
      * @param length length
      */
     @Override
-    public void readBytes(@Nonnull final byte[] bytes, final int offset, final int length) throws IOException {
+    public void readBytes(final byte[] bytes, final int offset, final int length) throws IOException {
         try {
             int bytesRead = 0;
             final FDBLuceneFileReference fileReference = getFileReference();
@@ -337,8 +334,7 @@ public final class FDBIndexInput extends IndexInput {
         return (int) ( (position + initialOffset) / getFileReference().getBlockSize());
     }
 
-    @Nonnull
-    private String getLogMessage(@Nonnull String staticMsg, @Nullable final Object... keysAndValues) {
+    private String getLogMessage(String staticMsg, @Nullable final Object... keysAndValues) {
         return KeyValueLogMessage.build(staticMsg, keysAndValues)
                 .addKeyAndValue(LogMessageKeys.SUBSPACE, fdbDirectory.getSubspace())
                 .addKeyAndValue(LuceneLogMessageKeys.RESOURCE, fileName)

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBIndexOutput.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBIndexOutput.java
@@ -32,8 +32,7 @@ import org.apache.lucene.store.IndexOutput;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.zip.CRC32;
@@ -66,7 +65,7 @@ public final class FDBIndexOutput extends IndexOutput {
      * @param name name of resource
      * @param fdbDirectory existing FDBDirectory
      */
-    public FDBIndexOutput(@Nonnull String name, @Nonnull FDBDirectory fdbDirectory) throws IOException {
+    public FDBIndexOutput(String name, FDBDirectory fdbDirectory) throws IOException {
         this(name, name, fdbDirectory);
     }
 
@@ -77,7 +76,7 @@ public final class FDBIndexOutput extends IndexOutput {
      * @param name name of resource
      * @param fdbDirectory existing FDBDirectory
      */
-    public FDBIndexOutput(@Nonnull String resourceDescription, @Nonnull String name, @Nonnull FDBDirectory fdbDirectory) throws IOException {
+    public FDBIndexOutput(String resourceDescription, String name, FDBDirectory fdbDirectory) throws IOException {
         super(resourceDescription, name);
         if (LOGGER.isTraceEnabled()) {
             LOGGER.trace(KeyValueLogMessage.of("init",
@@ -150,12 +149,12 @@ public final class FDBIndexOutput extends IndexOutput {
      * @param input input to setExpectedBytes
      * @param numBytes expected number of bytes
      */
-    void setExpectedBytes(@Nonnull final PrefetchableBufferedChecksumIndexInput input, final long numBytes) {
+    void setExpectedBytes(final PrefetchableBufferedChecksumIndexInput input, final long numBytes) {
         input.setExpectedBytes(numBytes);
     }
 
     @Override
-    public void copyBytes(@Nonnull final DataInput input, final long numBytes) throws IOException {
+    public void copyBytes(final DataInput input, final long numBytes) throws IOException {
         try {
             if (LOGGER.isTraceEnabled()) {
                 LOGGER.trace(getLogMessage("copy bytes",
@@ -181,7 +180,7 @@ public final class FDBIndexOutput extends IndexOutput {
      * @param length length
      */
     @Override
-    public void writeBytes(@Nonnull final byte[] bytes, final int offset, final int length) throws IOException {
+    public void writeBytes(final byte[] bytes, final int offset, final int length) throws IOException {
         if (LOGGER.isTraceEnabled()) {
             LOGGER.trace(getLogMessage("writeBytes()",
                     LuceneLogMessageKeys.OFFSET, offset,
@@ -225,8 +224,7 @@ public final class FDBIndexOutput extends IndexOutput {
         }
     }
 
-    @Nonnull
-    private String getLogMessage(@Nonnull String staticMsg, @Nullable final Object... keysAndValues) {
+    private String getLogMessage(String staticMsg, @Nullable final Object... keysAndValues) {
         return KeyValueLogMessage.build(staticMsg, keysAndValues)
                 .addKeyAndValue(LogMessageKeys.SUBSPACE, fdbDirectory.getSubspace())
                 .addKeyAndValue(LuceneLogMessageKeys.RESOURCE, resourceDescription)

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBIndexOutput.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBIndexOutput.java
@@ -96,8 +96,9 @@ public final class FDBIndexOutput extends IndexOutput {
      * Close the directory which writes the FileReference.
      */
     @Override
-    @SuppressWarnings("NullAway") // buffer = null below is intentional: writes after close() should fail fast
-                                   // with an NPE rather than silently writing to a stale buffer.
+    // buffer = null below is intentional: writes after close() should fail fast with an NPE
+    // rather than silently writing to a stale buffer.
+    @SuppressWarnings("NullAway")
     public void close() throws IOException {
         if (LOGGER.isTraceEnabled()) {
             LOGGER.trace(getLogMessage("close()",

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBIndexOutput.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBIndexOutput.java
@@ -96,6 +96,8 @@ public final class FDBIndexOutput extends IndexOutput {
      * Close the directory which writes the FileReference.
      */
     @Override
+    @SuppressWarnings("NullAway") // buffer = null below is intentional: writes after close() should fail fast
+                                   // with an NPE rather than silently writing to a stale buffer.
     public void close() throws IOException {
         if (LOGGER.isTraceEnabled()) {
             LOGGER.trace(getLogMessage("close()",

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBLuceneFileReference.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBLuceneFileReference.java
@@ -28,8 +28,7 @@ import com.apple.foundationdb.record.lucene.LuceneLogMessageKeys;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 
 
 /**
@@ -42,15 +41,13 @@ public class FDBLuceneFileReference {
     private final long size;
     private final long actualSize;
     private final long blockSize;
-    @Nonnull
     private final ByteString content;
 
     private long fieldInfosId;
-    @Nonnull
     private ByteString fieldInfosBitSet;
 
     @SuppressWarnings("deprecation")
-    private static ByteString getContentFromProto(@Nonnull LuceneFileSystemProto.LuceneFileReference protoMessage) {
+    private static ByteString getContentFromProto(LuceneFileSystemProto.LuceneFileReference protoMessage) {
         if (protoMessage.getColumnBitSetWordsCount() != 0 || protoMessage.hasEntries() || protoMessage.hasSegmentInfo()) {
             throw new RecordCoreException("FileReference has old file content")
                     .addLogInfo(LuceneLogMessageKeys.REF_ID, protoMessage.getId());
@@ -58,7 +55,7 @@ public class FDBLuceneFileReference {
         return protoMessage.getContent();
     }
 
-    private FDBLuceneFileReference(@Nonnull LuceneFileSystemProto.LuceneFileReference protoMessage) {
+    private FDBLuceneFileReference(LuceneFileSystemProto.LuceneFileReference protoMessage) {
         this(protoMessage.getId(), protoMessage.getSize(), protoMessage.getActualSize(), protoMessage.getBlockSize(),
                 getContentFromProto(protoMessage), protoMessage.getFieldInfosId(), protoMessage.getFieldInfosBitset());
     }
@@ -73,7 +70,7 @@ public class FDBLuceneFileReference {
     }
 
     private FDBLuceneFileReference(long id, long size, long actualSize, long blockSize,
-                                   @Nonnull ByteString content, final long fieldInfosId, final @Nonnull ByteString fieldInfosBitSet) {
+                                   ByteString content, final long fieldInfosId, final ByteString fieldInfosBitSet) {
         this.id = id;
         this.size = size;
         this.actualSize = actualSize;
@@ -103,7 +100,6 @@ public class FDBLuceneFileReference {
         return content;
     }
 
-    @Nonnull
     public byte[] getBytes() {
         final LuceneFileSystemProto.LuceneFileReference.Builder builder = LuceneFileSystemProto.LuceneFileReference.newBuilder();
         builder.setId(this.id);
@@ -148,7 +144,6 @@ public class FDBLuceneFileReference {
         this.fieldInfosBitSet = bitSet;
     }
 
-    @Nonnull
     public ByteString getFieldInfosBitSet() {
         return fieldInfosBitSet;
     }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBTieredMergePolicy.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBTieredMergePolicy.java
@@ -66,6 +66,7 @@ class FDBTieredMergePolicy extends TieredMergePolicy {
     }
 
     @Override
+    @Nullable
     @SuppressWarnings("checkstyle:VariableDeclarationUsageDistance")
     public MergeSpecification findMerges(MergeTrigger mergeTrigger, SegmentInfos infos, MergeContext mergeContext) throws IOException {
         if (mergeControl == null) {

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBTieredMergePolicy.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FDBTieredMergePolicy.java
@@ -30,8 +30,7 @@ import org.apache.lucene.index.TieredMergePolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.io.IOException;
 
@@ -41,17 +40,15 @@ class FDBTieredMergePolicy extends TieredMergePolicy {
     private static final Logger LOGGER = LoggerFactory.getLogger(FDBTieredMergePolicy.class);
     @Nullable private final IndexDeferredMaintenanceControl mergeControl;
     private final AgilityContext context;
-    @Nonnull
     private final Subspace indexSubspace;
-    @Nonnull
     private final Tuple key;
     @Nullable
     private final Exception exceptionAtCreation;
 
     public FDBTieredMergePolicy(@Nullable IndexDeferredMaintenanceControl mergeControl,
-                                @Nonnull AgilityContext context,
-                                @Nonnull Subspace indexSubspace,
-                                @Nonnull final Tuple key,
+                                AgilityContext context,
+                                Subspace indexSubspace,
+                                final Tuple key,
                                 @Nullable final Exception exceptionAtCreation) {
         this.mergeControl = mergeControl;
         this.context = context;

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FieldInfosStorage.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/FieldInfosStorage.java
@@ -22,7 +22,7 @@ package com.apple.foundationdb.record.lucene.directory;
 
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.lucene.LuceneExceptions;
-import com.apple.foundationdb.record.lucene.LuceneFieldInfosProto;
+import com.apple.foundationdb.record.lucene.LuceneFieldInfosProto.FieldInfos;
 import com.apple.foundationdb.record.lucene.LuceneLogMessageKeys;
 import com.apple.foundationdb.record.lucene.codec.LazyOpener;
 import com.apple.foundationdb.record.util.pair.Pair;
@@ -31,6 +31,7 @@ import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import org.apache.lucene.store.Directory;
 
+import org.jspecify.annotations.Nullable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.BitSet;
@@ -50,7 +51,7 @@ import java.util.stream.Collectors;
 public class FieldInfosStorage {
 
     public static final long GLOBAL_FIELD_INFOS_ID = -2;
-    private final LazyOpener<Map<Long, LuceneFieldInfosProto.FieldInfos>> allFieldInfosSupplier;
+    private final LazyOpener<Map<Long, FieldInfos>> allFieldInfosSupplier;
     private final FDBDirectory directory;
     private final AtomicReference<ConcurrentMap<Long, AtomicInteger>> referenceCount;
 
@@ -61,7 +62,7 @@ public class FieldInfosStorage {
                                 Pair::getLeft,
                                 pair -> {
                                     try {
-                                        return LuceneFieldInfosProto.FieldInfos.parseFrom(pair.getRight());
+                                        return FieldInfos.parseFrom(pair.getRight());
                                     } catch (InvalidProtocolBufferException e) {
                                         throw new UncheckedIOException(e);
                                     }
@@ -72,19 +73,19 @@ public class FieldInfosStorage {
     }
 
     @VisibleForTesting
-    public Map<Long, LuceneFieldInfosProto.FieldInfos> getAllFieldInfos() throws IOException {
+    public Map<Long, FieldInfos> getAllFieldInfos() throws IOException {
         return allFieldInfosSupplier.get();
     }
 
-    public LuceneFieldInfosProto.FieldInfos readGlobalFieldInfos() throws IOException {
+    public @Nullable FieldInfos readGlobalFieldInfos() throws IOException {
         return readFieldInfos(GLOBAL_FIELD_INFOS_ID);
     }
 
-    public LuceneFieldInfosProto.FieldInfos readFieldInfos(long id) throws IOException {
+    public @Nullable FieldInfos readFieldInfos(long id) throws IOException {
         return getAllFieldInfos().get(id);
     }
 
-    public long writeFieldInfos(LuceneFieldInfosProto.FieldInfos value) throws IOException {
+    public long writeFieldInfos(FieldInfos value) throws IOException {
         try {
             long id;
             if (Boolean.TRUE.equals(getAllFieldInfos().isEmpty())) {
@@ -99,7 +100,7 @@ public class FieldInfosStorage {
         }
     }
 
-    private void writeFieldInfos(final long id, final LuceneFieldInfosProto.FieldInfos value) throws IOException {
+    private void writeFieldInfos(final long id, final FieldInfos value) throws IOException {
         try {
             directory.writeFieldInfos(id, value.toByteArray());
             getAllFieldInfos().put(id, value);
@@ -108,10 +109,11 @@ public class FieldInfosStorage {
         }
     }
 
-    public void updateGlobalFieldInfos(LuceneFieldInfosProto.FieldInfos value) throws IOException {
+    public void updateGlobalFieldInfos(FieldInfos value) throws IOException {
         writeFieldInfos(GLOBAL_FIELD_INFOS_ID, value);
     }
 
+    @Nullable
     public FDBLuceneFileReference getFDBLuceneFileReference(String fileName) {
         return directory.getFDBLuceneFileReference(fileName);
     }
@@ -134,17 +136,20 @@ public class FieldInfosStorage {
         }
     }
 
-    void initializeReferenceCount(final ConcurrentMap<Long, AtomicInteger> fieldInfosCount) {
+    void initializeReferenceCount(@Nullable final ConcurrentMap<Long, AtomicInteger> fieldInfosCount) {
         referenceCount.compareAndSet(null, fieldInfosCount);
     }
 
+    @Nullable
     public ConcurrentMap<Long, AtomicInteger> getReferenceCount() {
         return referenceCount.get();
     }
 
     public void addReference(final FDBLuceneFileReference reference) {
         if (reference.getFieldInfosId() != 0) {
-            referenceCount.get()
+            // writeFDBLuceneFileReference() always populates the file reference cache (which in turn initializes
+            // referenceCount) before calling this method.
+            Objects.requireNonNull(referenceCount.get(), "fieldInfosReferenceCache")
                     .computeIfAbsent(reference.getFieldInfosId(), key -> new AtomicInteger(0))
                     .incrementAndGet();
         }
@@ -152,8 +157,8 @@ public class FieldInfosStorage {
 
     public boolean delete(final long id) throws IOException {
         if (id != 0 &&
-                Objects.requireNonNull(referenceCount.get(), "fieldInfosReferenceCache")
-                        .get(id).decrementAndGet() == 0) {
+                Objects.requireNonNull(Objects.requireNonNull(referenceCount.get(), "fieldInfosReferenceCache")
+                        .get(id), "no reference count entry for id").decrementAndGet() == 0) {
             getAllFieldInfos().remove(id);
             return true;
         }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/LuceneSerializer.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/LuceneSerializer.java
@@ -40,6 +40,7 @@ import javax.crypto.Cipher;
 import javax.crypto.spec.IvParameterSpec;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
+import java.util.Objects;
 
 /**
  * Serialize a Lucene directory block to/from an FDB key-value byte array.
@@ -84,11 +85,14 @@ public class LuceneSerializer {
         return keyManager;
     }
 
-    @Nullable
-    public byte[] encode(@Nullable byte[] data) {
+    public byte @Nullable [] encode(@Nullable byte[] data) {
         if (data == null) {
             return null;
         }
+        // NullAway's array-type checking doesn't reliably narrow a @Nullable array parameter to non-null via a
+        // preceding null check when the value is later passed to another non-null byte[] parameter. data is
+        // definitely non-null here (checked above); Objects.requireNonNull is just used as a type-narrowing no-op.
+        final byte[] nonNullData = Objects.requireNonNull(data);
 
         final CompressedAndEncryptedSerializerState state = new CompressedAndEncryptedSerializerState();
         long prefix = 0;
@@ -112,7 +116,7 @@ public class LuceneSerializer {
             // Placeholder for the code byte at beginning, will be modified in output byte array if needed
             decodedDataOutput.writeVLong(prefix);
             final int prefixLength = (int)decodedDataOutput.size();
-            encoded = compressIfNeeded(state, decodedDataOutput, data, prefixLength);
+            encoded = compressIfNeeded(state, decodedDataOutput, nonNullData, prefixLength);
             encoded = encryptIfNeeded(state, encoded, prefixLength);
         } catch (IOException | GeneralSecurityException ex) {
             throw new RecordCoreException("Lucene data encoding failure", ex);
@@ -124,15 +128,14 @@ public class LuceneSerializer {
                     LuceneLogMessageKeys.ENCRYPTION_SUPPOSED, encryptionEnabled,
                     LuceneLogMessageKeys.COMPRESSED_EVENTUALLY, state.isCompressed(),
                     LuceneLogMessageKeys.ENCRYPTED_EVENTUALLY, state.isEncrypted(),
-                    LuceneLogMessageKeys.ORIGINAL_DATA_SIZE, data.length,
+                    LuceneLogMessageKeys.ORIGINAL_DATA_SIZE, nonNullData.length,
                     LuceneLogMessageKeys.ENCODED_DATA_SIZE, encoded.length));
         }
 
         return encoded;
     }
 
-    @Nullable
-    public byte[] decode(@Nullable byte[] data) {
+    public byte @Nullable [] decode(@Nullable byte[] data) {
         if (data == null) {
             return null;
         }
@@ -230,6 +233,10 @@ public class LuceneSerializer {
             return encoded;
         }
 
+        if (keyManager == null) {
+            throw new RecordCoreException("cannot encrypt Lucene blocks without keys");
+        }
+
         final byte[] encrypted;
         final byte[] ivData = new byte[CipherPool.IV_SIZE];
         keyManager.getRandom(state.getKeyNumber()).nextBytes(ivData);
@@ -276,25 +283,31 @@ public class LuceneSerializer {
         encodedDataInput.reset(decrypted);
     }
 
-    @Nullable
-    public byte[] encodeFieldProtobuf(@Nullable byte[] bytes) {
+    public byte @Nullable [] encodeFieldProtobuf(@Nullable byte[] bytes) {
         if (fieldProtobufPrefixEnabled) {
             return encode(bytes);
         } else {
-            return bytes;
+            // NullAway's array-type checking treats the @Nullable byte[] parameter and the byte @Nullable[] return
+            // type as mismatched "type parameter" nullability even though they mean the same thing; both are
+            // genuinely nullable here (bytes is returned unchanged).
+            @SuppressWarnings("NullAway")
+            final byte @Nullable [] result = bytes;
+            return result;
         }
     }
 
-    @Nullable
-    public byte[] decodeFieldProtobuf(@Nullable byte[] bytes) {
+    public byte @Nullable [] decodeFieldProtobuf(@Nullable byte[] bytes) {
         if (bytes == null) {
             return null;
         }
+        // See encode()'s comment: data is definitely non-null here (checked above); Objects.requireNonNull is
+        // just used as a type-narrowing no-op to work around NullAway's unreliable array-type flow narrowing.
+        final byte[] nonNullBytes = Objects.requireNonNull(bytes);
 
-        if (isProtobufMessageWithoutPrefix(bytes)) {
-            return bytes;
+        if (isProtobufMessageWithoutPrefix(nonNullBytes)) {
+            return nonNullBytes;
         }
-        return decode(bytes);
+        return decode(nonNullBytes);
     }
 
     // This can be removed once it is guaranteed that all indexes are using the encoded format.

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/LuceneSerializer.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/LuceneSerializer.java
@@ -35,8 +35,7 @@ import org.apache.lucene.util.BytesRef;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import javax.crypto.Cipher;
 import javax.crypto.spec.IvParameterSpec;
 import java.io.IOException;
@@ -173,9 +172,8 @@ public class LuceneSerializer {
         return decoded;
     }
 
-    @Nonnull
-    private static byte[] compressIfNeeded(@Nonnull CompressedAndEncryptedSerializerState state, @Nonnull ByteBuffersDataOutput encodedDataOutput,
-                                           @Nonnull byte[] uncompressedData, int prefixLength)
+    private static byte[] compressIfNeeded(CompressedAndEncryptedSerializerState state, ByteBuffersDataOutput encodedDataOutput,
+                                           byte[] uncompressedData, int prefixLength)
             throws IOException {
         if (!state.isCompressed()) {
             return fallBackToUncompressed(state, uncompressedData, encodedDataOutput.toArrayCopy(), prefixLength);
@@ -197,8 +195,8 @@ public class LuceneSerializer {
         }
     }
 
-    private static byte[] fallBackToUncompressed(@Nonnull CompressedAndEncryptedSerializerState state, @Nonnull byte[] originalData,
-                                                 @Nonnull byte[] encodedData, int prefixLength) {
+    private static byte[] fallBackToUncompressed(CompressedAndEncryptedSerializerState state, byte[] originalData,
+                                                 byte[] encodedData, int prefixLength) {
         final byte[] encoded = new byte[originalData.length + prefixLength];
         System.arraycopy(encodedData, 0, encoded, 0, prefixLength);
         // This bit is always in the lowest (first) byte, even if the prefix is longer.
@@ -208,7 +206,7 @@ public class LuceneSerializer {
         return encoded;
     }
 
-    private void decompressIfNeeded(@Nonnull CompressedAndEncryptedSerializerState state, @Nonnull ByteArrayDataInput encodedDataInput)
+    private void decompressIfNeeded(CompressedAndEncryptedSerializerState state, ByteArrayDataInput encodedDataInput)
             throws IOException {
         if (!state.isCompressed()) {
             return;
@@ -227,7 +225,7 @@ public class LuceneSerializer {
         encodedDataInput.reset(ref.bytes, ref.offset, ref.length);
     }
 
-    private byte[] encryptIfNeeded(@Nonnull CompressedAndEncryptedSerializerState state, @Nonnull byte[] encoded, int prefixLength) throws GeneralSecurityException {
+    private byte[] encryptIfNeeded(CompressedAndEncryptedSerializerState state, byte[] encoded, int prefixLength) throws GeneralSecurityException {
         if (!state.isEncrypted()) {
             return encoded;
         }
@@ -251,7 +249,7 @@ public class LuceneSerializer {
         return withIv;
     }
 
-    private void decryptIfNeeded(@Nonnull CompressedAndEncryptedSerializerState state, @Nonnull ByteArrayDataInput encodedDataInput)
+    private void decryptIfNeeded(CompressedAndEncryptedSerializerState state, ByteArrayDataInput encodedDataInput)
             throws GeneralSecurityException {
         if (!state.isEncrypted()) {
             return;
@@ -302,7 +300,7 @@ public class LuceneSerializer {
     // This can be removed once it is guaranteed that all indexes are using the encoded format.
     // Only works for Protobuf messages all of whose fields are themselves length-delimited,
     // such as LuceneStoredFields (StoredField or bytes) or FieldInfos (FieldInfo).
-    private boolean isProtobufMessageWithoutPrefix(@Nonnull byte[] bytes) {
+    private boolean isProtobufMessageWithoutPrefix(byte[] bytes) {
         if (bytes.length < 1) {
             return true;    // No room for prefix; empty message.
         }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/MergeUtils.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/MergeUtils.java
@@ -25,13 +25,13 @@ import com.apple.foundationdb.record.logging.LogMessageKeys;
 import com.apple.foundationdb.record.lucene.LuceneLogMessageKeys;
 import com.apple.foundationdb.subspace.Subspace;
 import com.apple.foundationdb.tuple.Tuple;
-import org.apache.lucene.index.MergePolicy;
 import org.apache.lucene.index.MergeTrigger;
 import org.slf4j.Logger;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.stream.Collectors;
+
+import static org.apache.lucene.index.MergePolicy.MergeSpecification;
 
 /**
  * Utility class for helping {@link FDBTieredMergePolicy} and {@code FDBDirectoryMergeScheduler}.
@@ -39,25 +39,25 @@ import java.util.stream.Collectors;
 class MergeUtils {
 
 
-    public static void logExecutingMerge(@Nonnull final Logger logger,
-                                         @Nonnull final String staticMessage,
-                                         @Nonnull final AgilityContext agilityContext,
-                                         @Nonnull final Subspace indexSubspace,
+    public static void logExecutingMerge(final Logger logger,
+                                         final String staticMessage,
+                                         final AgilityContext agilityContext,
+                                         final Subspace indexSubspace,
                                          @Nullable final Tuple key,
-                                         @Nonnull final MergeTrigger mergeTrigger) {
+                                         final MergeTrigger mergeTrigger) {
         if (logger.isDebugEnabled()) {
             final KeyValueLogMessage message = baseLogMessage(staticMessage, agilityContext, indexSubspace, key, mergeTrigger);
             logWithExceptionIfNotAgile(logger, agilityContext, message);
         }
     }
 
-    static void logFoundMerges(@Nonnull final Logger logger,
-                               @Nonnull final String staticMessage,
-                               @Nonnull final AgilityContext context,
-                               @Nonnull final Subspace indexSubspace,
+    static void logFoundMerges(final Logger logger,
+                               final String staticMessage,
+                               final AgilityContext context,
+                               final Subspace indexSubspace,
                                @Nullable final Tuple key,
-                               @Nonnull final MergeTrigger mergeTrigger,
-                               @Nullable final MergePolicy.MergeSpecification merges,
+                               final MergeTrigger mergeTrigger,
+                               @Nullable final MergeSpecification merges,
                                @Nullable final Exception exceptionAtCreation) {
         if (merges != null && logger.isDebugEnabled()) {
             final KeyValueLogMessage message = baseLogMessage(staticMessage, context, indexSubspace, key, mergeTrigger);
@@ -68,13 +68,13 @@ class MergeUtils {
     }
 
     @SuppressWarnings("PMD.GuardLogStatement") // method is only called in a guard for isDebugEnabled
-    private static void logWithCreationMessageIfNotAgile(final @Nonnull Logger logger,
-                                                         final @Nonnull String staticMessage,
-                                                         final @Nonnull AgilityContext context,
-                                                         final @Nonnull Subspace indexSubspace,
+    private static void logWithCreationMessageIfNotAgile(final Logger logger,
+                                                         final String staticMessage,
+                                                         final AgilityContext context,
+                                                         final Subspace indexSubspace,
                                                          final @Nullable Tuple key,
-                                                         final @Nonnull MergeTrigger mergeTrigger,
-                                                         final @Nonnull MergePolicy.MergeSpecification merges,
+                                                         final MergeTrigger mergeTrigger,
+                                                         final MergeSpecification merges,
                                                          final @Nullable Exception exceptionAtCreation) {
         if (!(context instanceof AgileContext)) {
             final KeyValueLogMessage message = baseLogMessage(staticMessage, context, indexSubspace, key, mergeTrigger);
@@ -84,7 +84,7 @@ class MergeUtils {
     }
 
     @SuppressWarnings("PMD.GuardLogStatement") // method is only called in a guard for isDebugEnabled
-    private static void logWithExceptionIfNotAgile(final @Nonnull Logger logger, final @Nonnull AgilityContext context, final KeyValueLogMessage message) {
+    private static void logWithExceptionIfNotAgile(final Logger logger, final AgilityContext context, final KeyValueLogMessage message) {
         if (context instanceof AgileContext) {
             logger.debug(message.toString());
         } else {
@@ -92,8 +92,7 @@ class MergeUtils {
         }
     }
 
-    @Nonnull
-    private static KeyValueLogMessage baseLogMessage(final @Nonnull String staticMessage, final @Nonnull AgilityContext context, final @Nonnull Subspace indexSubspace, final @Nullable Tuple key, final @Nonnull MergeTrigger mergeTrigger) {
+    private static KeyValueLogMessage baseLogMessage(final String staticMessage, final AgilityContext context, final Subspace indexSubspace, final @Nullable Tuple key, final MergeTrigger mergeTrigger) {
         return KeyValueLogMessage.build(staticMessage,
                 LogMessageKeys.INDEX_SUBSPACE, indexSubspace,
                 LogMessageKeys.KEY, key,
@@ -101,7 +100,7 @@ class MergeUtils {
                 LogMessageKeys.AGILITY_CONTEXT, context.getClass().getSimpleName());
     }
 
-    private static String simpleSpec(@Nonnull final MergePolicy.MergeSpecification merges) {
+    private static String simpleSpec(final MergeSpecification merges) {
         return merges.merges.stream().map(merge ->
                         merge.segments.stream().map(segment -> segment.info.name)
                                 .collect(Collectors.joining(",", "", "")))

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/NonAgileContext.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/NonAgileContext.java
@@ -24,7 +24,6 @@ import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.RecordCoreStorageException;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 
-import javax.annotation.Nonnull;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -65,7 +64,6 @@ public class NonAgileContext implements AgilityContext {
     }
 
     @Override
-    @Nonnull
     public FDBRecordContext getCallerContext() {
         return callerContext;
     }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/PendingWriteQueue.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/PendingWriteQueue.java
@@ -59,6 +59,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -198,7 +199,7 @@ public class PendingWriteQueue {
     public RecordCursor<QueueEntry> getQueueCursor(
             FDBRecordContext context,
             ScanProperties scanProperties,
-            @Nullable byte[] continuation) {
+            byte @Nullable [] continuation) {
         // Force snapshot isolation on the inner cursor (the only component that issues FDB reads) so the drain
         // never installs a read-conflict range over the queue subspace. The unsplitter still receives the
         // original scanProperties, so the caller's row/byte/skip limits are honored (it issues no reads itself,
@@ -308,7 +309,8 @@ public class PendingWriteQueue {
         // There is no need to replay with a continuation as all the replayed items need to make it into the
         // current writer in the given transaction to be queried
         return getQueueCursor(context, scanProperties, null).forEachResult(entry -> {
-            replayOperation(entry.get(), indexWriter, index);
+            // forEachResult only invokes this for results where hasNext() is true, so get() is non-null.
+            replayOperation(Objects.requireNonNull(entry.get()), indexWriter, index);
         }).thenAccept(lastResult -> {
             if (lastResult.getNoNextReason().equals(RecordCursor.NoNextReason.RETURN_LIMIT_REACHED)) {
                 // Reached the row limit
@@ -385,7 +387,8 @@ public class PendingWriteQueue {
                          ? Tuple.from(incarnation, recordVersion.toVersionstamp())
                          : Tuple.from(recordVersion.toVersionstamp());
         long startTime = System.nanoTime();
-        byte[] value = serializer.encode(builder.build().toByteArray());
+        // serializer.encode() only returns null when given null input; the encoded bytes are non-null here.
+        byte[] value = Objects.requireNonNull(serializer.encode(builder.build().toByteArray()));
         context.record(LuceneEvents.Waits.WAIT_LUCENE_SERIALIZE, System.nanoTime() - startTime);
         // save with splits
         SplitHelper.saveWithSplit(context, queueSubspace, keyTuple, value, null, true, false, false, null, null);
@@ -464,6 +467,7 @@ public class PendingWriteQueue {
         return ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN).putLong(count).array();
     }
 
+    @Nullable
     private Long decodeQueueSize(@Nullable byte[] bytes) {
         return bytes == null ? null : ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN).getLong();
     }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/PendingWriteQueue.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/PendingWriteQueue.java
@@ -456,7 +456,8 @@ public class PendingWriteQueue {
                     if (size == null) {
                         return null;
                     } else {
-                        final Long actualSize = decodeQueueSize(size);
+                        // decodeQueueSize() only returns null when given null bytes; size is non-null here.
+                        final Long actualSize = Objects.requireNonNull(decodeQueueSize(size));
                         context.recordSize(LuceneEvents.SizeEvents.LUCENE_QUEUE_SIZE, actualSize);
                         return actualSize;
                     }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/PendingWriteQueue.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/PendingWriteQueue.java
@@ -54,8 +54,7 @@ import org.apache.lucene.index.IndexWriter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -127,7 +126,7 @@ public class PendingWriteQueue {
      * @param allowIncarnation whether to prefix queue keys with an incarnation value, ensuring entries from newer
      * incarnations sort after older ones. See {@link FDBRecordStore#getIncarnation()}
      */
-    public PendingWriteQueue(@Nonnull Subspace queueSubspace, @Nonnull Subspace queueSizeSubspace, int maxEntriesToReplay, int maxQueueSize, LuceneSerializer serializer, boolean allowIncarnation) {
+    public PendingWriteQueue(Subspace queueSubspace, Subspace queueSizeSubspace, int maxEntriesToReplay, int maxQueueSize, LuceneSerializer serializer, boolean allowIncarnation) {
         this.queueSubspace = queueSubspace;
         this.queueSizeSubspace = queueSizeSubspace;
         this.maxEntriesToReplay = maxEntriesToReplay;
@@ -145,9 +144,9 @@ public class PendingWriteQueue {
      * @param incarnationValue the incarnation value to prefix queue keys with (see {@link FDBRecordStore#getIncarnation()})
      */
     public void enqueueInsert(
-            @Nonnull FDBRecordContext context,
-            @Nonnull Tuple primaryKey,
-            @Nonnull List<LuceneDocumentFromRecord.DocumentField> fields,
+            FDBRecordContext context,
+            Tuple primaryKey,
+            List<LuceneDocumentFromRecord.DocumentField> fields,
             int incarnationValue) {
 
         enqueueOperationInternal(
@@ -166,8 +165,8 @@ public class PendingWriteQueue {
      * @param incarnationValue the incarnation value to prefix queue keys with (see {@link FDBRecordStore#getIncarnation()})
      */
     public void enqueueDelete(
-            @Nonnull FDBRecordContext context,
-            @Nonnull Tuple primaryKey,
+            FDBRecordContext context,
+            Tuple primaryKey,
             int incarnationValue) {
 
         enqueueOperationInternal(
@@ -197,8 +196,8 @@ public class PendingWriteQueue {
      */
     @SuppressWarnings("PMD.CloseResource")
     public RecordCursor<QueueEntry> getQueueCursor(
-            @Nonnull FDBRecordContext context,
-            @Nonnull ScanProperties scanProperties,
+            FDBRecordContext context,
+            ScanProperties scanProperties,
             @Nullable byte[] continuation) {
         // Force snapshot isolation on the inner cursor (the only component that issues FDB reads) so the drain
         // never installs a read-conflict range over the queue subspace. The unsplitter still receives the
@@ -250,7 +249,7 @@ public class PendingWriteQueue {
      * @param context the context to use
      * @param entry the entry to remove
      */
-    public void clearEntry(@Nonnull FDBRecordContext context, @Nonnull QueueEntry entry) {
+    public void clearEntry(FDBRecordContext context, QueueEntry entry) {
         // Install a read-conflict range over the keys this entry occupies. Clears are blind writes that do not
         // conflict with each other, so without this two transactions could concurrently clear the same entry and
         // each decrement the size counter, making it drift. The read conflict ensures at most one clear of
@@ -277,8 +276,7 @@ public class PendingWriteQueue {
      * @param context the record context
      * @return a future that resolves to {@code true} if the queue is empty, {@code false} otherwise
      */
-    @Nonnull
-    public CompletableFuture<Boolean> isQueueEmpty(@Nonnull FDBRecordContext context) {
+    public CompletableFuture<Boolean> isQueueEmpty(FDBRecordContext context) {
         // This is using direct count as it is still efficient, and is accurate in all cases, even when the counter is
         // uninitialized or has drifted
         // Return true if empty
@@ -296,7 +294,6 @@ public class PendingWriteQueue {
      *
      * @return CompletableFuture that completes when all operations have been replayed
      */
-    @Nonnull
     public CompletableFuture<Void> replayQueuedOperations(FDBRecordContext context, IndexWriter indexWriter, Index index) {
         ScanProperties scanProperties = ScanProperties.FORWARD_SCAN;
         if (maxEntriesToReplay > 0) {
@@ -323,7 +320,7 @@ public class PendingWriteQueue {
     /**
      * Replay a single queued operation directly to the IndexWriter.
      */
-    private void replayOperation(@Nonnull QueueEntry entry, @Nonnull IndexWriter indexWriter, @Nonnull Index index) {
+    private void replayOperation(QueueEntry entry, IndexWriter indexWriter, Index index) {
         LucenePendingWriteQueueProto.PendingWriteItem.OperationType opType = entry.getOperationType();
 
         try {
@@ -354,9 +351,9 @@ public class PendingWriteQueue {
     }
 
     private void enqueueOperationInternal(
-            @Nonnull FDBRecordContext context,
-            @Nonnull LucenePendingWriteQueueProto.PendingWriteItem.OperationType operationType,
-            @Nonnull Tuple primaryKey,
+            FDBRecordContext context,
+            LucenePendingWriteQueueProto.PendingWriteItem.OperationType operationType,
+            Tuple primaryKey,
             @Nullable List<LuceneDocumentFromRecord.DocumentField> fields,
             int incarnation) {
 
@@ -408,7 +405,7 @@ public class PendingWriteQueue {
         }
     }
 
-    private KeyValueLogMessage getLogMessage(final @Nonnull String staticMsg) {
+    private KeyValueLogMessage getLogMessage(final String staticMsg) {
         return KeyValueLogMessage.build(staticMsg)
                 .addKeyAndValue(LogMessageKeys.SUBSPACE, queueSubspace);
     }
@@ -421,7 +418,7 @@ public class PendingWriteQueue {
      * @param context the context to use
      * @param amount the amount by which to mutate the counter
      */
-    private void mutateQueueSizeCounter(final @Nonnull FDBRecordContext context, final int amount) {
+    private void mutateQueueSizeCounter(final FDBRecordContext context, final int amount) {
         context.ensureActive().mutate(MutationType.ADD, queueSizeSubspace.pack(), encodeQueueSize(amount));
     }
 
@@ -450,8 +447,7 @@ public class PendingWriteQueue {
      *
      * @return a future that resolves to the queue size, or {@code null} if the counter does not exist
      */
-    @Nonnull
-    public CompletableFuture<Long> getQueueSize(@Nonnull FDBRecordContext context) {
+    public CompletableFuture<Long> getQueueSize(FDBRecordContext context) {
         return context.readTransaction(true).get(queueSizeSubspace.pack())
                 .thenApply(size -> {
                     if (size == null) {

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/PendingWriteQueue.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/PendingWriteQueue.java
@@ -195,7 +195,10 @@ public class PendingWriteQueue {
      *
      * @return a record cursor that iterates through the elements of the queue, in order
      */
-    @SuppressWarnings("PMD.CloseResource")
+    // NullAway/JSpecify does not currently track @Nullable on array (byte[])
+    // parameters of KeyValueCursorBase.Builder#setContinuation (out of
+    // scope to fix here); null intentionally means "start from the beginning".
+    @SuppressWarnings({"PMD.CloseResource", "NullAway"})
     public RecordCursor<QueueEntry> getQueueCursor(
             FDBRecordContext context,
             ScanProperties scanProperties,

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/PendingWritesQueueHelper.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/PendingWritesQueueHelper.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 @API(API.Status.INTERNAL)
 public final class PendingWritesQueueHelper {
@@ -73,16 +74,16 @@ public final class PendingWritesQueueHelper {
                 builder.setStringValue((String)value);
                 break;
             case INT:
-                builder.setIntValue((Integer)value);
+                builder.setIntValue(Objects.requireNonNull((Integer)value));
                 break;
             case LONG:
-                builder.setLongValue((Long)value);
+                builder.setLongValue(Objects.requireNonNull((Long)value));
                 break;
             case DOUBLE:
-                builder.setDoubleValue((Double)value);
+                builder.setDoubleValue(Objects.requireNonNull((Double)value));
                 break;
             case BOOLEAN:
-                builder.setBooleanValue((Boolean)value);
+                builder.setBooleanValue(Objects.requireNonNull((Boolean)value));
                 break;
             default:
                 throw new IllegalArgumentException("Unsupported field type: " + field.getType() + " for field " + field.getFieldName());

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/PendingWritesQueueHelper.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/PendingWritesQueueHelper.java
@@ -26,7 +26,6 @@ import com.apple.foundationdb.record.lucene.LuceneDocumentFromRecord;
 import com.apple.foundationdb.record.lucene.LuceneIndexExpressions;
 import com.apple.foundationdb.record.lucene.LucenePendingWriteQueueProto;
 
-import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -37,7 +36,7 @@ public final class PendingWritesQueueHelper {
     /**
      * Convert DocumentField to protobuf DocumentField.
      */
-    public static LucenePendingWriteQueueProto.DocumentField toProtoField(@Nonnull LuceneDocumentFromRecord.DocumentField field) {
+    public static LucenePendingWriteQueueProto.DocumentField toProtoField(LuceneDocumentFromRecord.DocumentField field) {
 
         LucenePendingWriteQueueProto.DocumentField.Builder builder =
                 LucenePendingWriteQueueProto.DocumentField.newBuilder()
@@ -96,7 +95,7 @@ public final class PendingWritesQueueHelper {
      * Convert protobuf DocumentField list back to LuceneDocumentFromRecord.DocumentField list.
      */
     public static List<LuceneDocumentFromRecord.DocumentField> fromProtoFields(
-            @Nonnull List<LucenePendingWriteQueueProto.DocumentField> protoFields) {
+            List<LucenePendingWriteQueueProto.DocumentField> protoFields) {
 
         List<LuceneDocumentFromRecord.DocumentField> fields = new ArrayList<>();
         for (LucenePendingWriteQueueProto.DocumentField protoField : protoFields) {

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/ReadOnlyNonAgileContext.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/ReadOnlyNonAgileContext.java
@@ -27,11 +27,12 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContextConfig;
 import com.apple.foundationdb.record.provider.foundationdb.PreventCommitCheck;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.function.Function;
+
+import static com.apple.foundationdb.record.provider.foundationdb.FDBRecordContextConfig.Builder;
 
 /**
  * A non-agile context that creates a read-only transaction.
@@ -45,10 +46,10 @@ class ReadOnlyNonAgileContext implements AgilityContext {
     private final FDBRecordContext readOnlyContext;
     private boolean closed = false;
 
-    public ReadOnlyNonAgileContext(final FDBRecordContext callerContext, @Nullable FDBRecordContextConfig.Builder contextBuilder) {
+    public ReadOnlyNonAgileContext(final FDBRecordContext callerContext, @Nullable Builder contextBuilder) {
         this.callerContext = callerContext;
 
-        FDBRecordContextConfig.Builder contextConfigBuilder = contextBuilder != null ? contextBuilder : callerContext.getConfig().toBuilder();
+        Builder contextConfigBuilder = contextBuilder != null ? contextBuilder : callerContext.getConfig().toBuilder();
         final FDBRecordContextConfig contextConfig = contextConfigBuilder.build();
         readOnlyContext = callerContext.getDatabase().openContext(contextConfig);
         // Use the same read version for the new context
@@ -82,7 +83,6 @@ class ReadOnlyNonAgileContext implements AgilityContext {
     }
 
     @Override
-    @Nonnull
     public FDBRecordContext getCallerContext() {
         return callerContext;
     }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/package-info.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/directory/package-info.java
@@ -21,4 +21,7 @@
 /**
  * Common classes for lucene index queries.
  */
+@NullMarked
 package com.apple.foundationdb.record.lucene.directory;
+
+import org.jspecify.annotations.NullMarked;

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/exact/ExactTokenAnalyzerFactory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/exact/ExactTokenAnalyzerFactory.java
@@ -27,8 +27,6 @@ import com.apple.foundationdb.record.lucene.LuceneAnalyzerWrapper;
 import com.apple.foundationdb.record.metadata.Index;
 import com.google.auto.service.AutoService;
 
-import javax.annotation.Nonnull;
-
 /**
  * Constructs a new instance of {@link ExactTokenAnalyzer}.
  */
@@ -40,23 +38,19 @@ public class ExactTokenAnalyzerFactory implements LuceneAnalyzerFactory  {
     public static final String UNIQUE_NAME = "query_only_exact_analyzer";
 
 
-    @Nonnull
     @Override
     public String getName() {
         return NAME;
     }
 
-    @Nonnull
     @Override
     public LuceneAnalyzerType getType() {
         return LuceneAnalyzerType.FULL_TEXT;
     }
 
-    @Nonnull
     @Override
-    public AnalyzerChooser getIndexAnalyzerChooser(@Nonnull Index ignored) {
+    public AnalyzerChooser getIndexAnalyzerChooser(Index ignored) {
         return new AnalyzerChooser() {
-            @Nonnull
             @Override
             public LuceneAnalyzerWrapper chooseAnalyzer() {
                 return new LuceneAnalyzerWrapper(UNIQUE_NAME, new ExactTokenAnalyzer());
@@ -64,11 +58,9 @@ public class ExactTokenAnalyzerFactory implements LuceneAnalyzerFactory  {
         };
     }
 
-    @Nonnull
     @Override
-    public AnalyzerChooser getQueryAnalyzerChooser(@Nonnull Index ignored, @Nonnull AnalyzerChooser alsoIgnored) {
+    public AnalyzerChooser getQueryAnalyzerChooser(Index ignored, AnalyzerChooser alsoIgnored) {
         return new AnalyzerChooser() {
-            @Nonnull
             @Override
             public LuceneAnalyzerWrapper chooseAnalyzer() {
                 return new LuceneAnalyzerWrapper(UNIQUE_NAME, new ExactTokenAnalyzer());

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/exact/package-info.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/exact/package-info.java
@@ -21,4 +21,7 @@
 /**
  * Contains classes for analyzing stored and sorted fields.
  */
+@NullMarked
 package com.apple.foundationdb.record.lucene.exact;
+
+import org.jspecify.annotations.NullMarked;

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/filter/package-info.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/filter/package-info.java
@@ -21,4 +21,7 @@
 /**
  * Contains filter classes.
  */
+@NullMarked
 package com.apple.foundationdb.record.lucene.filter;
+
+import org.jspecify.annotations.NullMarked;

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/highlight/LuceneHighlighting.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/highlight/LuceneHighlighting.java
@@ -49,6 +49,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -118,7 +119,7 @@ public class LuceneHighlighting {
         }
 
         return highlightedTermsForMessage(queriedRecord, queriedRecord.getRecord(), nestedName,
-                docIndexEntry.getIndexKey(), docIndexEntry.getTermMap(), docIndexEntry.getAnalyzerSelector(), docIndexEntry.getLuceneQueryHighlightParameters());
+                docIndexEntry.getIndexKey(), Objects.requireNonNullElse(docIndexEntry.getTermMap(), Collections.emptyMap()), docIndexEntry.getAnalyzerSelector(), docIndexEntry.getLuceneQueryHighlightParameters());
     }
 
     // Modify the Lucene fields of a record message with highlighting the terms from the given termMap

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/highlight/LuceneHighlighting.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/highlight/LuceneHighlighting.java
@@ -39,9 +39,8 @@ import com.apple.foundationdb.util.StringUtils;
 import com.google.protobuf.Message;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.search.uhighlight.UnifiedHighlighter;
+import org.jspecify.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.text.BreakIterator;
 import java.util.ArrayList;
@@ -60,7 +59,7 @@ public class LuceneHighlighting {
     private LuceneHighlighting() {
     }
 
-    private static Set<String> getPrefixTerms(@Nonnull Set<String> terms) {
+    private static Set<String> getPrefixTerms(Set<String> terms) {
         Set<String> result = Collections.emptySet();
         Iterator<String> iter = terms.iterator();
         while (iter.hasNext()) {
@@ -77,7 +76,7 @@ public class LuceneHighlighting {
         return result;
     }
 
-    private static boolean isMatch(@Nonnull String candidate, @Nonnull Set<String> terms, @Nonnull Set<String> prefixes) {
+    private static boolean isMatch(String candidate, Set<String> terms, Set<String> prefixes) {
         for (String term : terms) {
             if (StringUtils.containsIgnoreCase(candidate, term)) {
                 return true;
@@ -91,8 +90,7 @@ public class LuceneHighlighting {
         return false;
     }
 
-    @Nonnull
-    private static Set<String> getFieldTerms(@Nonnull Map<String, Set<String>> termMap, @Nonnull String fieldName) {
+    private static Set<String> getFieldTerms(Map<String, Set<String>> termMap, String fieldName) {
         final Set<String> terms = new HashSet<>();
         final Set<String> forField = termMap.get(fieldName);
         if (forField != null) {
@@ -105,7 +103,6 @@ public class LuceneHighlighting {
         return terms;
     }
 
-    @Nonnull
     public static <M extends Message> List<HighlightedTerm> highlightedTermsForMessage(@Nullable FDBQueriedRecord<M> queriedRecord,
                                                                                        @Nullable String nestedName) {
         if (queriedRecord == null) {
@@ -126,13 +123,12 @@ public class LuceneHighlighting {
 
     // Modify the Lucene fields of a record message with highlighting the terms from the given termMap
 
-    @Nonnull
-    public static <M extends Message> List<HighlightedTerm> highlightedTermsForMessage(@Nonnull FDBRecord<M> rec, M message,
+    public static <M extends Message> List<HighlightedTerm> highlightedTermsForMessage(FDBRecord<M> rec, M message,
                                                                                        @Nullable String nestedName,
-                                                                                       @Nonnull KeyExpression expression,
-                                                                                       @Nonnull Map<String, Set<String>> termMap,
-                                                                                       @Nonnull LuceneAnalyzerCombinationProvider analyzerSelector,
-                                                                                       @Nonnull LuceneScanQueryParameters.LuceneQueryHighlightParameters luceneQueryHighlightParameters) {
+                                                                                       KeyExpression expression,
+                                                                                       Map<String, Set<String>> termMap,
+                                                                                       LuceneAnalyzerCombinationProvider analyzerSelector,
+                                                                                       LuceneScanQueryParameters.LuceneQueryHighlightParameters luceneQueryHighlightParameters) {
         if (nestedName != null) {
             expression = getNestedFields(expression, nestedName);
             if (expression == null) {
@@ -165,8 +161,8 @@ public class LuceneHighlighting {
     }
 
     @Nullable
-    private static Object highlight(final @Nonnull LuceneAnalyzerCombinationProvider analyzerSelector,
-                                    final @Nonnull LuceneScanQueryParameters.LuceneQueryHighlightParameters luceneQueryHighlightParameters,
+    private static Object highlight(final LuceneAnalyzerCombinationProvider analyzerSelector,
+                                    final LuceneScanQueryParameters.LuceneQueryHighlightParameters luceneQueryHighlightParameters,
                                     final String fieldName,
                                     final String value,
                                     final String termName) {
@@ -180,7 +176,7 @@ public class LuceneHighlighting {
     }
 
     @Nullable
-    private static KeyExpression getNestedFields(@Nonnull KeyExpression expression, @Nonnull String nestedName) {
+    private static KeyExpression getNestedFields(KeyExpression expression, String nestedName) {
         if (expression instanceof GroupingKeyExpression) {
             expression = ((GroupingKeyExpression)expression).getGroupedSubKey();
         }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/highlight/package-info.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/highlight/package-info.java
@@ -21,4 +21,7 @@
 /**
  * Highlighting of matched terms found in using record-layer lucene integration.
  */
+@NullMarked
 package com.apple.foundationdb.record.lucene.highlight;
+
+import org.jspecify.annotations.NullMarked;

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/idformat/LuceneIndexKeySerializer.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/idformat/LuceneIndexKeySerializer.java
@@ -24,9 +24,8 @@ import com.apple.foundationdb.record.RecordCoreArgumentException;
 import com.apple.foundationdb.record.lucene.LuceneIndexMaintainer;
 import com.apple.foundationdb.tuple.Tuple;
 import org.apache.lucene.document.BinaryPoint;
+import org.jspecify.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -90,7 +89,7 @@ public class LuceneIndexKeySerializer {
      * @param key the key to serialize
      * @return the serialized key
      */
-    public byte[] asPackedByteArray(@Nonnull final Tuple key) {
+    public byte[] asPackedByteArray(final Tuple key) {
         return key.pack();
     }
 
@@ -100,7 +99,7 @@ public class LuceneIndexKeySerializer {
      * @param key the key to serialize
      * @return the split (BinaryPoint) style serialized key
      */
-    public byte[][] asPackedBinaryPoint(@Nonnull final Tuple key) {
+    public byte[][] asPackedBinaryPoint(final Tuple key) {
         // We might use a different dimension size here
         List<byte[]> splitBytes = split(key.pack(), BINARY_POINT_DIMENSION_SIZE);
         return splitBytes.toArray(new byte[splitBytes.size()][]);
@@ -114,7 +113,7 @@ public class LuceneIndexKeySerializer {
      * @return the formatted serialized key
      * @throws RecordCoreFormatException in case there is no format or the format failed to parse or validate
      */
-    public byte[][] asFormattedBinaryPoint(@Nonnull final Tuple key) throws RecordCoreFormatException {
+    public byte[][] asFormattedBinaryPoint(final Tuple key) throws RecordCoreFormatException {
         if (format == null) {
             throw new RecordCoreFormatException("Missing format, cannot format to a BinaryPoint");
         }
@@ -186,7 +185,7 @@ public class LuceneIndexKeySerializer {
      * @return the formatted key as a BinaryPoint
      * @throws RecordCoreArgumentException in case the format failed to verify or the key did nto match
      */
-    private List<byte[]> applyFormat(@Nonnull RecordIdFormat.TupleElement format, @Nonnull Tuple key) throws RecordCoreArgumentException {
+    private List<byte[]> applyFormat(RecordIdFormat.TupleElement format, Tuple key) throws RecordCoreArgumentException {
         List<RecordIdFormat.FormatElement> formatElements = format.getChildren();
         if (key.size() != formatElements.size()) {
             throw new RecordCoreFormatException("Key tuple and format have different sizes, format cannot be applied")
@@ -218,8 +217,7 @@ public class LuceneIndexKeySerializer {
     }
 
     @SuppressWarnings("java:S3776")
-    @Nullable
-    private byte[] applyFormat(final RecordIdFormat.FormatElementType formatElement, final Object tupleElement) {
+    private @Nullable byte[] applyFormat(final RecordIdFormat.FormatElementType formatElement, final Object tupleElement) {
         byte[] value;
         switch (formatElement) {
             case NONE:

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/idformat/LuceneIndexKeySerializer.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/idformat/LuceneIndexKeySerializer.java
@@ -216,7 +216,10 @@ public class LuceneIndexKeySerializer {
         return result;
     }
 
-    @SuppressWarnings("java:S3776")
+    // Tuple.from below (case NULL) intentionally accepts a null element here (an unannotated,
+    // external API conservatively treated by NullAway as requiring non-null); a null tuple item
+    // is the deliberate encoding for this format element.
+    @SuppressWarnings({"java:S3776", "NullAway"})
     private byte @Nullable [] applyFormat(final RecordIdFormat.FormatElementType formatElement, final Object tupleElement) {
         byte[] value;
         switch (formatElement) {

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/idformat/LuceneIndexKeySerializer.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/idformat/LuceneIndexKeySerializer.java
@@ -217,7 +217,7 @@ public class LuceneIndexKeySerializer {
     }
 
     @SuppressWarnings("java:S3776")
-    private @Nullable byte[] applyFormat(final RecordIdFormat.FormatElementType formatElement, final Object tupleElement) {
+    private byte @Nullable [] applyFormat(final RecordIdFormat.FormatElementType formatElement, final Object tupleElement) {
         byte[] value;
         switch (formatElement) {
             case NONE:

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/idformat/LuceneIndexKeySerializer.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/idformat/LuceneIndexKeySerializer.java
@@ -202,7 +202,7 @@ public class LuceneIndexKeySerializer {
                 result.addAll(applyFormat((RecordIdFormat.TupleElement)formatElement, verifyTuple(keyElement)));
             } else if (formatElement instanceof RecordIdFormat.FormatElementType) {
                 // Recursion termination condition
-                byte[] byteArray = applyFormat((RecordIdFormat.FormatElementType)formatElement, keyElement);
+                @Nullable byte[] byteArray = applyFormat((RecordIdFormat.FormatElementType)formatElement, keyElement);
                 // Skip if null (e.g. NONE element)
                 if (byteArray != null) {
                     result.add(byteArray);

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/idformat/RecordCoreFormatException.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/idformat/RecordCoreFormatException.java
@@ -23,8 +23,6 @@ package com.apple.foundationdb.record.lucene.idformat;
 import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.RecordCoreException;
 
-import javax.annotation.Nonnull;
-
 /**
  * Exception thrown when encountering issues serializing IDs using {@link LuceneIndexKeySerializer}.
  */
@@ -32,11 +30,11 @@ import javax.annotation.Nonnull;
 public class RecordCoreFormatException extends RecordCoreException {
     private static final long serialVersionUID = 1;
 
-    public RecordCoreFormatException(@Nonnull String msg, @Nonnull Object... keyValue) {
+    public RecordCoreFormatException(String msg, Object... keyValue) {
         super(msg, keyValue);
     }
 
-    public RecordCoreFormatException(@Nonnull String msg, @Nonnull Throwable cause) {
+    public RecordCoreFormatException(String msg, Throwable cause) {
         super(msg, cause);
     }
 }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/idformat/RecordCoreSizeException.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/idformat/RecordCoreSizeException.java
@@ -20,19 +20,17 @@
 
 package com.apple.foundationdb.record.lucene.idformat;
 
-import javax.annotation.Nonnull;
-
 /**
  * Exception thrown when the RecordIdFormat size exceeds the maximum.
  */
 public class RecordCoreSizeException extends RecordCoreFormatException {
     private static final long serialVersionUID = 1;
 
-    public RecordCoreSizeException(@Nonnull final String msg, @Nonnull final Object... keyValue) {
+    public RecordCoreSizeException(final String msg, final Object... keyValue) {
         super(msg, keyValue);
     }
 
-    public RecordCoreSizeException(@Nonnull final String msg, @Nonnull final Throwable cause) {
+    public RecordCoreSizeException(final String msg, final Throwable cause) {
         super(msg, cause);
     }
 }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/idformat/RecordIdFormat.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/idformat/RecordIdFormat.java
@@ -22,7 +22,6 @@ package com.apple.foundationdb.record.lucene.idformat;
 
 import com.apple.foundationdb.tuple.Tuple;
 
-import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -69,10 +68,9 @@ public class RecordIdFormat {
         }
     }
 
-    @Nonnull
     private final TupleElement element;
 
-    public RecordIdFormat(@Nonnull final TupleElement element) {
+    public RecordIdFormat(final TupleElement element) {
         this.element = element;
     }
 
@@ -80,7 +78,6 @@ public class RecordIdFormat {
         return new RecordIdFormat(TupleElement.of(elements));
     }
 
-    @Nonnull
     public TupleElement getElement() {
         return element;
     }
@@ -117,22 +114,19 @@ public class RecordIdFormat {
      * A collection of elements matching a Tuple structure in the key.
      */
     public static class TupleElement implements FormatElement {
-        @Nonnull
         private final List<FormatElement> children;
 
-        public TupleElement(@Nonnull final List<FormatElement> children) {
+        public TupleElement(final List<FormatElement> children) {
             if (children.isEmpty()) {
                 throw new RecordCoreFormatException("Tuple element cannot be empty");
             }
             this.children = children;
         }
 
-        @Nonnull
         public List<FormatElement> getChildren() {
             return children;
         }
 
-        @Nonnull
         public static TupleElement of(FormatElement... children) {
             return new TupleElement(List.of(children));
         }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/idformat/RecordIdFormatParser.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/idformat/RecordIdFormatParser.java
@@ -20,11 +20,13 @@
 
 package com.apple.foundationdb.record.lucene.idformat;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static com.apple.foundationdb.record.lucene.idformat.RecordIdFormat.FormatElementType;
 
 /**
  * A simple parser for the string that represents the {@link RecordIdFormat}.
@@ -65,18 +67,16 @@ public class RecordIdFormatParser {
      * @return the constructed format
      * @throws RecordCoreFormatException in case of parse failure
      */
-    @Nonnull
     public static RecordIdFormat parse(final String formatString) throws RecordCoreFormatException {
         // top level element is actually a tuple
         RecordIdFormat.TupleElement tupleElement = parseTuple(formatString.trim());
         return new RecordIdFormat(tupleElement);
     }
 
-    @Nonnull
     private static RecordIdFormat.FormatElement parseElement(final String s) throws RecordCoreFormatException {
         String trimmed = s.trim();
         // Try to parse as a format type enum
-        RecordIdFormat.FormatElementType formatElementType = parseType(trimmed);
+        FormatElementType formatElementType = parseType(trimmed);
         if (formatElementType != null) {
             return formatElementType;
         } else {
@@ -85,7 +85,6 @@ public class RecordIdFormatParser {
         }
     }
 
-    @Nonnull
     private static RecordIdFormat.TupleElement parseTuple(final String s) {
         if ((!s.startsWith(BEGIN_TUPLE_STR)) || (!s.endsWith(END_TUPLE_STR))) {
             throw new RecordCoreFormatException("Format error: syntax error")
@@ -102,9 +101,9 @@ public class RecordIdFormatParser {
     }
 
     @Nullable
-    private static RecordIdFormat.FormatElementType parseType(final String s) {
+    private static FormatElementType parseType(final String s) {
         try {
-            return RecordIdFormat.FormatElementType.valueOf(s);
+            return FormatElementType.valueOf(s);
         } catch (IllegalArgumentException ex) {
             // not a match
             return null;

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/idformat/package-info.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/idformat/package-info.java
@@ -21,4 +21,7 @@
 /**
  * Common classes for lucene's ngram tokenizing.
  */
+@NullMarked
 package com.apple.foundationdb.record.lucene.idformat;
+
+import org.jspecify.annotations.NullMarked;

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/ngram/NgramAnalyzer.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/ngram/NgramAnalyzer.java
@@ -39,9 +39,8 @@ import org.apache.lucene.analysis.en.EnglishAnalyzer;
 import org.apache.lucene.analysis.ngram.EdgeNGramTokenFilter;
 import org.apache.lucene.analysis.ngram.NGramTokenFilter;
 import org.apache.lucene.analysis.standard.UAX29URLEmailTokenizer;
+import org.jspecify.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -88,22 +87,19 @@ public class NgramAnalyzer extends StopwordAnalyzerBase {
     public static class NgramAnalyzerFactory implements LuceneAnalyzerFactory {
         public static final String ANALYZER_FACTORY_NAME = "NGRAM";
 
-        @Nonnull
         @Override
         public String getName() {
             return ANALYZER_FACTORY_NAME;
         }
 
-        @Nonnull
         @Override
         public LuceneAnalyzerType getType() {
             return LuceneAnalyzerType.FULL_TEXT;
         }
 
         @SuppressWarnings("deprecation")
-        @Nonnull
         @Override
-        public AnalyzerChooser getIndexAnalyzerChooser(@Nonnull Index index) {
+        public AnalyzerChooser getIndexAnalyzerChooser(Index index) {
             try {
                 final String minLengthString = Optional.ofNullable(index.getOption(IndexOptions.TEXT_TOKEN_MIN_SIZE)).orElse(DEFAULT_MINIMUM_NGRAM_TOKEN_LENGTH);
                 final String maxLengthString = Optional.ofNullable(index.getOption(IndexOptions.TEXT_TOKEN_MAX_SIZE)).orElse(DEFAULT_MAXIMUM_NGRAM_TOKEN_LENGTH);

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/ngram/package-info.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/ngram/package-info.java
@@ -21,4 +21,7 @@
 /**
  * Common classes for lucene's ngram tokenizing.
  */
+@NullMarked
 package com.apple.foundationdb.record.lucene.ngram;
+
+import org.jspecify.annotations.NullMarked;

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/package-info.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/package-info.java
@@ -59,4 +59,7 @@
  * @see com.apple.foundationdb.record.lucene.LuceneFunctionNames
  *
  */
+@NullMarked
 package com.apple.foundationdb.record.lucene;
+
+import org.jspecify.annotations.NullMarked;

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/query/BitSetQuery.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/query/BitSetQuery.java
@@ -34,6 +34,7 @@ import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.ScorerSupplier;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.DocIdSetBuilder;
+import org.apache.lucene.util.DocIdSetBuilder.BulkAdder;
 import org.apache.lucene.util.FixedBitSet;
 import org.apache.lucene.util.NumericUtils;
 
@@ -93,7 +94,7 @@ public class BitSetQuery extends Query {
                 return new PointValues.IntersectVisitor() {
 
                     @Nullable
-                    DocIdSetBuilder.BulkAdder adder;
+                    BulkAdder adder;
 
                     @Override
                     public void grow(int count) {

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/query/BitSetQuery.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/query/BitSetQuery.java
@@ -37,6 +37,7 @@ import org.apache.lucene.util.DocIdSetBuilder;
 import org.apache.lucene.util.FixedBitSet;
 import org.apache.lucene.util.NumericUtils;
 
+import org.jspecify.annotations.Nullable;
 import java.io.IOException;
 import java.util.Objects;
 
@@ -91,6 +92,7 @@ public class BitSetQuery extends Query {
             private PointValues.IntersectVisitor getIntersectVisitor(DocIdSetBuilder result) {
                 return new PointValues.IntersectVisitor() {
 
+                    @Nullable
                     DocIdSetBuilder.BulkAdder adder;
 
                     @Override
@@ -100,7 +102,8 @@ public class BitSetQuery extends Query {
 
                     @Override
                     public void visit(int docID) {
-                        adder.add(docID);
+                        // grow() is always called before visit() per the IntersectVisitor contract.
+                        Objects.requireNonNull(adder).add(docID);
                     }
 
                     @Override
@@ -164,6 +167,7 @@ public class BitSetQuery extends Query {
 
             @SuppressWarnings("PMD.CloseResource")
             @Override
+            @Nullable
             public ScorerSupplier scorerSupplier(final LeafReaderContext context) throws IOException {
                 LeafReader reader = context.reader();
                 PointValues values = reader.getPointValues(field);
@@ -207,6 +211,7 @@ public class BitSetQuery extends Query {
             }
 
             @Override
+            @Nullable
             public Scorer scorer(LeafReaderContext context) throws IOException {
                 ScorerSupplier scorerSupplier = scorerSupplier(context);
                 if (scorerSupplier == null) {

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/query/package-info.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/query/package-info.java
@@ -21,4 +21,7 @@
 /**
  * Common classes for handling bitsets.
  */
+@NullMarked
 package com.apple.foundationdb.record.lucene.query;
+
+import org.jspecify.annotations.NullMarked;

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/ConfigAwareQueryParser.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/ConfigAwareQueryParser.java
@@ -116,6 +116,9 @@ public interface ConfigAwareQueryParser {
         }
 
         final var cfg = Objects.requireNonNull(getPointsConfig()).get(field);
+        if (cfg == null) {
+            throw new ParseException("No points config found for field " + field);
+        }
         if (!Long.class.equals(cfg.getType())) {
             throw new ParseException("Cannot parse a BITSET_CONTAINS on a non-long data type");
         }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/ConfigAwareQueryParser.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/ConfigAwareQueryParser.java
@@ -37,7 +37,6 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.spans.SpanNearQuery;
 import org.apache.lucene.search.spans.SpanQuery;
 
-import javax.annotation.Nonnull;
 import java.text.NumberFormat;
 import java.util.Map;
 import java.util.Objects;
@@ -48,17 +47,13 @@ import java.util.Objects;
  */
 public interface ConfigAwareQueryParser {
 
-    @Nonnull
     Map<String, PointsConfig> getPointsConfig();
 
-    @Nonnull
     Query constructFieldWithoutPointsConfig(String field, String queryText, boolean quoted) throws ParseException;
 
-    @Nonnull
     Token nextToken();
 
     @SuppressWarnings("PMD.PreserveStackTrace") //it isn't possible with Lucene's exception API
-    @Nonnull
     default Query attemptConstructFieldQueryWithPointsConfig(final String field, String queryText, final boolean quoted) throws ParseException {
         final var pointsConfig = getPointsConfig();
         PointsConfig cfg = pointsConfig.get(field);
@@ -107,9 +102,8 @@ public interface ConfigAwareQueryParser {
         }
     }
 
-    @Nonnull
     @SuppressWarnings("PMD.PreserveStackTrace") //it isn't possible with Lucene's exception API
-    private Query constructBitSetQuery(@Nonnull final String field) throws ParseException {
+    private Query constructBitSetQuery(final String field) throws ParseException {
         //look for the next token
         if (!"(".equals(nextToken().toString())) {
             throw new ParseException("Missing ( from BITSET_CONTAINS");
@@ -136,7 +130,6 @@ public interface ConfigAwareQueryParser {
         return new BitSetQuery(field, bitMask);
     }
 
-    @Nonnull
     Query constructRangeQueryWithoutPointsConfig(String field,
                                                  String part1,
                                                  String part2,
@@ -144,7 +137,6 @@ public interface ConfigAwareQueryParser {
                                                  boolean endInclusive) throws ParseException;
 
     @SuppressWarnings("PMD.PreserveStackTrace") //it isn't possible with Lucene's exception API
-    @Nonnull
     default Query attemptConstructRangeQueryWithPointsConfig(final String field,
                                                              final String part1,
                                                              final String part2,
@@ -193,7 +185,6 @@ public interface ConfigAwareQueryParser {
     }
 
     @SpotBugsSuppressWarnings(value = "FE_FLOATING_POINT_EQUALITY", justification = "Floating point values are special sentinel values")
-    @Nonnull
     private Query newFloatRangeQuery(final String field, final boolean startInclusive, final boolean endInclusive, final Number start, final Number end) throws ParseException {
         float s = start.floatValue();
         float e = end.floatValue();
@@ -222,7 +213,6 @@ public interface ConfigAwareQueryParser {
     }
 
     @SpotBugsSuppressWarnings(value = "FE_FLOATING_POINT_EQUALITY", justification = "Floating point values are special sentinel values")
-    @Nonnull
     private Query newDoubleRangeQuery(final String field, final boolean startInclusive, final boolean endInclusive, final Number start, final Number end) throws ParseException {
         double s = start.doubleValue();
         double e = end.doubleValue();
@@ -249,7 +239,6 @@ public interface ConfigAwareQueryParser {
         return DoublePoint.newRangeQuery(field, s, e);
     }
 
-    @Nonnull
     private Query newLongRangeQuery(final String field, final boolean startInclusive, final boolean endInclusive, final Number start, final Number end) throws ParseException {
         long s = start.longValue();
         long e = end.longValue();
@@ -286,7 +275,6 @@ public interface ConfigAwareQueryParser {
         return LongPoint.newRangeQuery(field, s, e);
     }
 
-    @Nonnull
     private Query newIntegerRangeQuery(final String field, final boolean startInclusive, final boolean endInclusive, final Number start, final Number end) throws ParseException {
         int s = start.intValue();
         int e = end.intValue();
@@ -313,7 +301,6 @@ public interface ConfigAwareQueryParser {
         return IntPoint.newRangeQuery(field, s, e);
     }
 
-    @Nonnull
     default Query addSlop(Query q, int slop) {
         if (q instanceof PhraseQuery) {
             PhraseQuery.Builder builder = new PhraseQuery.Builder();

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/LuceneOptimizedIndexSearcher.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/LuceneOptimizedIndexSearcher.java
@@ -41,11 +41,13 @@ import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.ThreadInterruptedException;
 
+import org.jspecify.annotations.Nullable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
@@ -66,7 +68,7 @@ public class LuceneOptimizedIndexSearcher extends IndexSearcher {
         super(r);
     }
 
-    public LuceneOptimizedIndexSearcher(final IndexReader r, final Executor executor) {
+    public LuceneOptimizedIndexSearcher(final IndexReader r, @Nullable final Executor executor) {
         super(r, executor);
     }
 
@@ -220,7 +222,8 @@ public class LuceneOptimizedIndexSearcher extends IndexSearcher {
             dependencies.stream().map(CompletableFuture::join).collect(Collectors.toList())
                     .forEach((Pair<LeafReaderContext, Pair<LeafCollector, BulkScorer>> result) -> {
                         final Pair<LeafCollector, BulkScorer> scorer = result.getRight();
-                        final LeafReaderContext ctx = result.getLeft();
+                        // Always constructed with a non-null ctx as the pair's left element (see the map() above).
+                        final LeafReaderContext ctx = Objects.requireNonNull(result.getLeft());
                         if (scorer != null && scorer.getLeft() != null && scorer.getRight() != null) {
                             try {
                                 scorer.getRight().score(scorer.getLeft(), ctx.reader().getLiveDocs());

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/LuceneOptimizedIndexSearcher.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/LuceneOptimizedIndexSearcher.java
@@ -41,7 +41,6 @@ import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.ThreadInterruptedException;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -174,14 +173,12 @@ public class LuceneOptimizedIndexSearcher extends IndexSearcher {
      */
     private static class WrapperException extends RuntimeException {
         private static final long serialVersionUID = 1L;
-        @Nonnull
         private final IOException ioe;
 
-        WrapperException(@Nonnull final IOException ioe) {
+        WrapperException(final IOException ioe) {
             this.ioe = ioe;
         }
 
-        @Nonnull
         public IOException unwrap() {
             return ioe;
         }
@@ -203,9 +200,8 @@ public class LuceneOptimizedIndexSearcher extends IndexSearcher {
      * caught and ignored. For more information about this please have a look at the implementation of the above method,
      * and read the documentation of {@link CollectionTerminatedException}.
      */
-    @Nonnull
     @SuppressWarnings({"PMD.EmptyCatchBlock"})
-    private <C extends Collector> CompletableFuture<C> searchOptimized(@Nonnull final Executor executor, @Nonnull final Weight weight, @Nonnull final List<LeafReaderContext> leaves, @Nonnull final C collector) {
+    private <C extends Collector> CompletableFuture<C> searchOptimized(final Executor executor, final Weight weight, final List<LeafReaderContext> leaves, final C collector) {
         // 1. spawn a list of parallel tasks that interact with the DB for better throughput.
         final List<CompletableFuture<Pair<LeafReaderContext, Pair<LeafCollector, BulkScorer>>>> dependencies = leaves.stream().map(ctx -> CompletableFuture.supplyAsync(() -> {
             try {

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/LuceneOptimizedMultiFieldQueryParser.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/LuceneOptimizedMultiFieldQueryParser.java
@@ -29,7 +29,6 @@ import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.spans.SpanNearQuery;
 
-import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -44,10 +43,9 @@ import java.util.Map;
  */
 public class LuceneOptimizedMultiFieldQueryParser extends MultiFieldQueryParser implements ConfigAwareQueryParser {
 
-    @Nonnull
     private final Map<String, PointsConfig> pointsConfig;
 
-    public LuceneOptimizedMultiFieldQueryParser(String[] fields, Analyzer analyzer, @Nonnull final Map<String, PointsConfig> pointsConfig) {
+    public LuceneOptimizedMultiFieldQueryParser(String[] fields, Analyzer analyzer, final Map<String, PointsConfig> pointsConfig) {
         super(fields, analyzer);
         this.pointsConfig = pointsConfig;
     }
@@ -98,25 +96,21 @@ public class LuceneOptimizedMultiFieldQueryParser extends MultiFieldQueryParser 
     }
 
 
-    @Nonnull
     @Override
     public Map<String, PointsConfig> getPointsConfig() {
         return pointsConfig;
     }
 
-    @Nonnull
     @Override
-    public Query constructFieldWithoutPointsConfig(final @Nonnull String field, final @Nonnull String queryText, final boolean quoted) throws ParseException {
+    public Query constructFieldWithoutPointsConfig(final String field, final String queryText, final boolean quoted) throws ParseException {
         return super.getFieldQuery(field, queryText, quoted);
     }
 
-    @Nonnull
     @Override
-    public Query constructRangeQueryWithoutPointsConfig(final @Nonnull String field, final @Nonnull String part1, final @Nonnull String part2, final boolean startInclusive, final boolean endInclusive) throws ParseException {
+    public Query constructRangeQueryWithoutPointsConfig(final String field, final String part1, final String part2, final boolean startInclusive, final boolean endInclusive) throws ParseException {
         return super.getRangeQuery(field, part1, part2, startInclusive, endInclusive);
     }
 
-    @Nonnull
     @Override
     public final Token nextToken() {
         return getNextToken();

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/LuceneOptimizedMultiFieldQueryParser.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/LuceneOptimizedMultiFieldQueryParser.java
@@ -29,6 +29,7 @@ import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.spans.SpanNearQuery;
 
+import org.jspecify.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -51,6 +52,7 @@ public class LuceneOptimizedMultiFieldQueryParser extends MultiFieldQueryParser 
     }
 
     @Override
+    @Nullable
     protected Query getFieldQuery(String field, String queryText, int slop) throws ParseException {
         if (field == null) {
             List<Query> clauses = new ArrayList<>();

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/LuceneOptimizedMultiFieldStopWordsQueryParser.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/LuceneOptimizedMultiFieldStopWordsQueryParser.java
@@ -27,7 +27,6 @@ import org.apache.lucene.queryparser.flexible.standard.config.PointsConfig;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.Query;
 
-import javax.annotation.Nonnull;
 import java.util.Map;
 
 /**
@@ -42,10 +41,9 @@ import java.util.Map;
  */
 @SuppressWarnings({"java:S110"})
 public class LuceneOptimizedMultiFieldStopWordsQueryParser extends LuceneOptimizedMultiFieldQueryParser {
-    @Nonnull
     private final CharArraySet stopWords;
 
-    public LuceneOptimizedMultiFieldStopWordsQueryParser(final String[] fields, final Analyzer analyzer, @Nonnull final Map<String, PointsConfig> pointsConfig, @Nonnull CharArraySet stopWords) {
+    public LuceneOptimizedMultiFieldStopWordsQueryParser(final String[] fields, final Analyzer analyzer, final Map<String, PointsConfig> pointsConfig, CharArraySet stopWords) {
         super(fields, analyzer, pointsConfig);
         this.stopWords = stopWords;
     }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/LuceneOptimizedQueryParser.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/LuceneOptimizedQueryParser.java
@@ -28,7 +28,6 @@ import org.apache.lucene.queryparser.flexible.standard.config.PointsConfig;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.spans.SpanNearQuery;
 
-import javax.annotation.Nonnull;
 import java.util.Map;
 
 /**
@@ -37,10 +36,9 @@ import java.util.Map;
  */
 public class LuceneOptimizedQueryParser extends QueryParser implements ConfigAwareQueryParser {
 
-    @Nonnull
     private final Map<String, PointsConfig> pointsConfig;
 
-    public LuceneOptimizedQueryParser(String field, Analyzer analyzer, @Nonnull final Map<String, PointsConfig> pointsConfig) {
+    public LuceneOptimizedQueryParser(String field, Analyzer analyzer, final Map<String, PointsConfig> pointsConfig) {
         super(field, analyzer);
         this.pointsConfig = pointsConfig;
     }
@@ -63,25 +61,21 @@ public class LuceneOptimizedQueryParser extends QueryParser implements ConfigAwa
         return attemptConstructRangeQueryWithPointsConfig(field, part1, part2, startInclusive, endInclusive);
     }
 
-    @Nonnull
     @Override
     public Map<String, PointsConfig> getPointsConfig() {
         return pointsConfig;
     }
 
-    @Nonnull
     @Override
-    public Query constructFieldWithoutPointsConfig(final @Nonnull String field, final @Nonnull String queryText, final boolean quoted) throws ParseException {
+    public Query constructFieldWithoutPointsConfig(final String field, final String queryText, final boolean quoted) throws ParseException {
         return super.getFieldQuery(field, queryText, quoted);
     }
 
-    @Nonnull
     @Override
-    public Query constructRangeQueryWithoutPointsConfig(final @Nonnull String field, final @Nonnull String part1, final @Nonnull String part2, final boolean startInclusive, final boolean endInclusive) throws ParseException {
+    public Query constructRangeQueryWithoutPointsConfig(final String field, final String part1, final String part2, final boolean startInclusive, final boolean endInclusive) throws ParseException {
         return super.getRangeQuery(field, part1, part2, startInclusive, endInclusive);
     }
 
-    @Nonnull
     @Override
     public final Token nextToken() {
         return getNextToken();

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/LuceneOptimizedStopWordsQueryParser.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/LuceneOptimizedStopWordsQueryParser.java
@@ -27,7 +27,6 @@ import org.apache.lucene.queryparser.flexible.standard.config.PointsConfig;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.Query;
 
-import javax.annotation.Nonnull;
 import java.util.Map;
 
 /**
@@ -41,10 +40,9 @@ import java.util.Map;
  * the stop words removal, so this is not necessary here.
  */
 public class LuceneOptimizedStopWordsQueryParser extends LuceneOptimizedQueryParser {
-    @Nonnull
     private final CharArraySet stopWords;
 
-    public LuceneOptimizedStopWordsQueryParser(final String field, final Analyzer analyzer, @Nonnull final Map<String, PointsConfig> pointsConfig, @Nonnull CharArraySet stopWords) {
+    public LuceneOptimizedStopWordsQueryParser(final String field, final Analyzer analyzer, final Map<String, PointsConfig> pointsConfig, CharArraySet stopWords) {
         super(field, analyzer, pointsConfig);
         this.stopWords = stopWords;
     }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/LuceneQueryParserFactory.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/LuceneQueryParserFactory.java
@@ -25,7 +25,6 @@ import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.queryparser.classic.QueryParser;
 import org.apache.lucene.queryparser.flexible.standard.config.PointsConfig;
 
-import javax.annotation.Nonnull;
 import java.util.Map;
 
 /**
@@ -34,7 +33,7 @@ import java.util.Map;
  * This class is meant to be implemented and provided through a {@link AutoService} extension: see {@link LuceneQueryParserFactoryProvider}.
  */
 public interface LuceneQueryParserFactory {
-    QueryParser createQueryParser(String field, Analyzer analyzer, @Nonnull Map<String, PointsConfig> pointsConfig);
+    QueryParser createQueryParser(String field, Analyzer analyzer, Map<String, PointsConfig> pointsConfig);
 
-    QueryParser createMultiFieldQueryParser(String[] fields, Analyzer analyzer, @Nonnull Map<String, PointsConfig> pointsConfig);
+    QueryParser createMultiFieldQueryParser(String[] fields, Analyzer analyzer, Map<String, PointsConfig> pointsConfig);
 }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/LuceneQueryParserFactoryProvider.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/LuceneQueryParserFactoryProvider.java
@@ -29,7 +29,6 @@ import org.apache.lucene.analysis.en.EnglishAnalyzer;
 import org.apache.lucene.queryparser.classic.QueryParser;
 import org.apache.lucene.queryparser.flexible.standard.config.PointsConfig;
 
-import javax.annotation.Nonnull;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -44,24 +43,20 @@ public class LuceneQueryParserFactoryProvider {
     private static final Supplier<LuceneQueryParserFactoryProvider> INSTANCE = Suppliers.memoize(LuceneQueryParserFactoryProvider::new);
 
     // The parser factory that was found (or the default one if none was found)
-    @Nonnull
     private final LuceneQueryParserFactory parserFactory;
 
     private LuceneQueryParserFactoryProvider() {
         parserFactory = initRegistry();
     }
 
-    @Nonnull
     public static LuceneQueryParserFactoryProvider instance() {
         return INSTANCE.get();
     }
 
-    @Nonnull
     public LuceneQueryParserFactory getParserFactory() {
         return parserFactory;
     }
 
-    @Nonnull
     private static LuceneQueryParserFactory initRegistry() {
         LuceneQueryParserFactory first = null;
         for (LuceneQueryParserFactory factory : ServiceLoaderProvider.load(LuceneQueryParserFactory.class)) {
@@ -85,19 +80,17 @@ public class LuceneQueryParserFactoryProvider {
      */
     public static class DefaultParserFactory implements LuceneQueryParserFactory {
         @Override
-        public QueryParser createQueryParser(final String field, final Analyzer analyzer, @Nonnull final Map<String, PointsConfig> pointsConfig) {
+        public QueryParser createQueryParser(final String field, final Analyzer analyzer, final Map<String, PointsConfig> pointsConfig) {
             return new LuceneOptimizedStopWordsQueryParser(field, analyzer, pointsConfig, getStopWords());
         }
 
-        @Nonnull
         @Override
-        public QueryParser createMultiFieldQueryParser(String[] fields, Analyzer analyzer, @Nonnull final Map<String, PointsConfig> pointsConfig) {
+        public QueryParser createMultiFieldQueryParser(String[] fields, Analyzer analyzer, final Map<String, PointsConfig> pointsConfig) {
             QueryParser parser = new LuceneOptimizedMultiFieldStopWordsQueryParser(fields, analyzer, pointsConfig, getStopWords());
             parser.setDefaultOperator(QueryParser.Operator.OR);
             return parser;
         }
 
-        @Nonnull
         protected CharArraySet getStopWords() {
             return EnglishAnalyzer.ENGLISH_STOP_WORDS_SET;
         }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/QueryParserUtils.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/QueryParserUtils.java
@@ -24,9 +24,7 @@ import org.apache.lucene.analysis.CharArraySet;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.PrefixQuery;
 import org.apache.lucene.search.Query;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Utilities for use in using query parsers.
@@ -40,8 +38,7 @@ public class QueryParserUtils {
      * @param stopWords the list of stop words
      * @return the modifier, modified if it should be relaxed
      */
-    @Nonnull
-    public static BooleanClause.Occur relaxOccur(@Nonnull final Query q, @Nonnull final BooleanClause.Occur occur, @Nonnull final CharArraySet stopWords) {
+    public static BooleanClause.Occur relaxOccur(final Query q, final BooleanClause.Occur occur, final CharArraySet stopWords) {
         BooleanClause.Occur modifiableOccur = occur;
 
         CharSequence term = getTerm(q);

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/package-info.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/search/package-info.java
@@ -21,4 +21,7 @@
 /**
  * Common classes for parallel execution of search.
  */
+@NullMarked
 package com.apple.foundationdb.record.lucene.search;
+
+import org.jspecify.annotations.NullMarked;

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/synonym/SynonymAnalyzer.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/synonym/SynonymAnalyzer.java
@@ -37,21 +37,18 @@ import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.analysis.standard.UAX29URLEmailTokenizer;
 import org.apache.lucene.analysis.synonym.SynonymGraphFilter;
 import org.apache.lucene.analysis.synonym.SynonymMap;
+import org.jspecify.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.Objects;
 
 /**
  * The analyzer for index with synonym enabled.
  */
 public class SynonymAnalyzer extends StopwordAnalyzerBase {
-    @Nonnull
     private final String name;
 
     private int maxTokenLength = StandardAnalyzer.DEFAULT_MAX_TOKEN_LENGTH;
 
-    @Nonnull
     public String getName() {
         return name;
     }
@@ -69,12 +66,12 @@ public class SynonymAnalyzer extends StopwordAnalyzerBase {
         return this.maxTokenLength;
     }
 
-    public SynonymAnalyzer(@Nullable CharArraySet stopwords, @Nonnull String name) {
+    public SynonymAnalyzer(@Nullable CharArraySet stopwords, String name) {
         super(stopwords);
         this.name = name;
     }
 
-    public SynonymAnalyzer(@Nullable CharArraySet stopwords, @Nonnull String name, int maxTokenLength) {
+    public SynonymAnalyzer(@Nullable CharArraySet stopwords, String name, int maxTokenLength) {
         super(stopwords);
         this.name = name;
         this.maxTokenLength = maxTokenLength;
@@ -100,7 +97,6 @@ public class SynonymAnalyzer extends StopwordAnalyzerBase {
         return new LowerCaseFilter(in);
     }
 
-    @Nonnull
     private SynonymMap getSynonymMap() {
         return SynonymMapRegistryImpl.instance().getSynonymMap(name);
     }
@@ -113,29 +109,25 @@ public class SynonymAnalyzer extends StopwordAnalyzerBase {
     public static class QueryOnlySynonymAnalyzerFactory implements LuceneAnalyzerFactory {
         public static final String ANALYZER_FACTORY_NAME = "SYNONYM";
 
-        @Nonnull
         @Override
         public String getName() {
             return ANALYZER_FACTORY_NAME;
         }
 
-        @Nonnull
         @Override
         public LuceneAnalyzerType getType() {
             return LuceneAnalyzerType.FULL_TEXT;
         }
 
         @SuppressWarnings("deprecation")
-        @Nonnull
         @Override
-        public AnalyzerChooser getIndexAnalyzerChooser(@Nonnull Index index) {
+        public AnalyzerChooser getIndexAnalyzerChooser(Index index) {
             return LuceneAnalyzerWrapper::getStandardAnalyzerWrapper;
         }
 
         @SuppressWarnings("deprecation")
-        @Nonnull
         @Override
-        public AnalyzerChooser getQueryAnalyzerChooser(@Nonnull Index index, @Nonnull AnalyzerChooser indexAnalyzerChooser) {
+        public AnalyzerChooser getQueryAnalyzerChooser(Index index, AnalyzerChooser indexAnalyzerChooser) {
             final String name = Objects.requireNonNullElse(index.getOption(LuceneIndexOptions.TEXT_SYNONYM_SET_NAME_OPTION),
                     EnglishSynonymMapConfig.ExpandedEnglishSynonymMapConfig.CONFIG_NAME);
             return () -> new LuceneAnalyzerWrapper(ANALYZER_FACTORY_NAME,
@@ -151,22 +143,19 @@ public class SynonymAnalyzer extends StopwordAnalyzerBase {
     public static class AuthoritativeSynonymOnlyAnalyzerFactory implements LuceneAnalyzerFactory {
         public static final String ANALYZER_FACTORY_NAME = "INDEX_ONLY_SYNONYM";
 
-        @Nonnull
         @Override
         public String getName() {
             return ANALYZER_FACTORY_NAME;
         }
 
-        @Nonnull
         @Override
         public LuceneAnalyzerType getType() {
             return LuceneAnalyzerType.FULL_TEXT;
         }
 
         @SuppressWarnings("deprecation")
-        @Nonnull
         @Override
-        public AnalyzerChooser getIndexAnalyzerChooser(@Nonnull Index index) {
+        public AnalyzerChooser getIndexAnalyzerChooser(Index index) {
             final String name = Objects.requireNonNullElse(index.getOption(LuceneIndexOptions.TEXT_SYNONYM_SET_NAME_OPTION),
                     EnglishSynonymMapConfig.AuthoritativeOnlyEnglishSynonymMapConfig.CONFIG_NAME);
             return () -> new LuceneAnalyzerWrapper(ANALYZER_FACTORY_NAME,
@@ -174,9 +163,8 @@ public class SynonymAnalyzer extends StopwordAnalyzerBase {
         }
 
         @SuppressWarnings("deprecation")
-        @Nonnull
         @Override
-        public AnalyzerChooser getQueryAnalyzerChooser(@Nonnull Index index, @Nonnull AnalyzerChooser indexAnalyzerChooser) {
+        public AnalyzerChooser getQueryAnalyzerChooser(Index index, AnalyzerChooser indexAnalyzerChooser) {
             return indexAnalyzerChooser;
         }
     }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/synonym/SynonymMapConfig.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/synonym/SynonymMapConfig.java
@@ -24,7 +24,6 @@ import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.RecordCoreException;
 import com.apple.foundationdb.record.lucene.LuceneLogMessageKeys;
 
-import javax.annotation.Nonnull;
 import java.io.InputStream;
 
 /**
@@ -51,8 +50,7 @@ public interface SynonymMapConfig {
      */
     boolean expand();
 
-    @Nonnull
-    static InputStream openFile(@Nonnull String file) {
+    static InputStream openFile(String file) {
         InputStream stream = Thread.currentThread().getContextClassLoader().getResourceAsStream(file);
         if (stream == null) {
             throw new RecordCoreException("Synonym file not found").addLogInfo(LuceneLogMessageKeys.FILE_NAME, file);

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/synonym/SynonymMapRegistry.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/synonym/SynonymMapRegistry.java
@@ -24,8 +24,6 @@ import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.metadata.MetaDataException;
 import org.apache.lucene.analysis.synonym.SynonymMap;
 
-import javax.annotation.Nonnull;
-
 /**
  * Registry for {@link SynonymAnalyzer}s.
  */
@@ -38,6 +36,5 @@ public interface SynonymMapRegistry {
      * @return the analyzer over the given set of synonyms
      * @throws MetaDataException if no such tokenizer exists
      */
-    @Nonnull
-    SynonymMap getSynonymMap(@Nonnull String name);
+    SynonymMap getSynonymMap(String name);
 }

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/synonym/SynonymMapRegistryImpl.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/synonym/SynonymMapRegistryImpl.java
@@ -36,7 +36,6 @@ import org.apache.lucene.analysis.synonym.SynonymMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
@@ -48,25 +47,21 @@ import java.util.Map;
  * Registry for {@link SynonymMap}s.
  */
 public class SynonymMapRegistryImpl implements SynonymMapRegistry {
-    @Nonnull
     private static final Logger LOGGER = LoggerFactory.getLogger(SynonymMapRegistryImpl.class);
     private static final SynonymMapRegistryImpl INSTANCE = new SynonymMapRegistryImpl();
 
-    @Nonnull
     private final Map<String, SynonymMap> registry;
 
     private SynonymMapRegistryImpl() {
         registry = initRegistry();
     }
 
-    @Nonnull
     public static SynonymMapRegistry instance() {
         return INSTANCE;
     }
 
-    @Nonnull
     @Override
-    public SynonymMap getSynonymMap(@Nonnull final String name) {
+    public SynonymMap getSynonymMap(final String name) {
         final SynonymMap map = registry.get(name);
         if (map == null) {
             throw new MetaDataException("unrecognized synonym map", LogMessageKeys.SYNONYM_NAME, name);
@@ -74,7 +69,6 @@ public class SynonymMapRegistryImpl implements SynonymMapRegistry {
         return map;
     }
 
-    @Nonnull
     private static Map<String, SynonymMap> initRegistry() {
         final Map<String, SynonymMap> registry = new HashMap<>();
         for (SynonymMapConfig config : ServiceLoaderProvider.load(SynonymMapConfig.class)) {

--- a/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/synonym/package-info.java
+++ b/fdb-record-layer-lucene/src/main/java/com/apple/foundationdb/record/lucene/synonym/package-info.java
@@ -21,4 +21,7 @@
 /**
  * Common classes for lucene's synonym tokenizing.
  */
+@NullMarked
 package com.apple.foundationdb.record.lucene.synonym;
+
+import org.jspecify.annotations.NullMarked;

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneIndexFailureTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneIndexFailureTest.java
@@ -47,7 +47,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -591,7 +590,7 @@ public class FDBLuceneIndexFailureTest extends FDBLuceneTestBase {
     private class UnknownRecordCoreException extends RecordCoreException {
         private static final long serialVersionUID = 0L;
 
-        public UnknownRecordCoreException(@Nonnull final String msg) {
+        public UnknownRecordCoreException(final String msg) {
             super(msg, new Exception(msg));
         }
     }
@@ -599,7 +598,7 @@ public class FDBLuceneIndexFailureTest extends FDBLuceneTestBase {
     private class UnknownRuntimeException extends RuntimeException {
         private static final long serialVersionUID = 0L;
 
-        public UnknownRuntimeException(@Nonnull final String msg) {
+        public UnknownRuntimeException(final String msg) {
             super(msg);
         }
     }
@@ -607,7 +606,7 @@ public class FDBLuceneIndexFailureTest extends FDBLuceneTestBase {
     private class UnknownLoggableException extends LoggableException {
         private static final long serialVersionUID = 0L;
 
-        public UnknownLoggableException(@Nonnull final Throwable cause) {
+        public UnknownLoggableException(final Throwable cause) {
             super(cause);
         }
     }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneIndexFailureTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneIndexFailureTest.java
@@ -94,6 +94,9 @@ public class FDBLuceneIndexFailureTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @BooleanSource
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void basicGroupedPartitionedTest(boolean useLegacyAsyncToSync) {
         final RecordLayerPropertyStorage contextProps = RecordLayerPropertyStorage.newBuilder()
                 .addProp(LuceneRecordContextProperties.LUCENE_USE_LEGACY_ASYNC_TO_SYNC, useLegacyAsyncToSync)
@@ -121,6 +124,9 @@ public class FDBLuceneIndexFailureTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @BooleanSource
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void basicNonGroupedPartitionedTest(boolean useLegacyAsyncToSync) {
         final RecordLayerPropertyStorage contextProps = RecordLayerPropertyStorage.newBuilder()
                 .addProp(LuceneRecordContextProperties.LUCENE_USE_LEGACY_ASYNC_TO_SYNC, useLegacyAsyncToSync)
@@ -553,8 +559,10 @@ public class FDBLuceneIndexFailureTest extends FDBLuceneTestBase {
      */
     private void rebuildIndexMetaData(final FDBRecordContext context, final String document, final Index index) {
         Pair<FDBRecordStore, QueryPlanner> pair = LuceneIndexTestUtils.rebuildIndexMetaData(context, Objects.requireNonNull(path), document, index, isUseCascadesPlanner(), registry);
-        this.recordStore = pair.getLeft();
-        this.planner = pair.getRight();
+        // Pair#getLeft/getRight are @Nullable in general (a Pair may hold nulls), but
+        // rebuildIndexMetaData always constructs its result from the non-null store/planner it builds.
+        this.recordStore = Objects.requireNonNull(pair.getLeft());
+        this.planner = Objects.requireNonNull(pair.getRight());
         this.recordStore.getIndexDeferredMaintenanceControl().setAutoMergeDuringCommit(true);
     }
 

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneIndexFailureTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneIndexFailureTest.java
@@ -27,7 +27,7 @@ import com.apple.foundationdb.record.lucene.directory.InjectedFailureRepository;
 import com.apple.foundationdb.record.lucene.directory.MockedLuceneIndexMaintainerFactory;
 import com.apple.foundationdb.record.lucene.directory.TestingIndexMaintainerRegistry;
 import com.apple.foundationdb.record.metadata.Index;
-import com.apple.foundationdb.record.provider.common.StoreTimer;
+import com.apple.foundationdb.record.provider.common.StoreTimer.Event;
 import com.apple.foundationdb.record.provider.foundationdb.FDBExceptions;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStore;
@@ -46,6 +46,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -54,6 +55,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
@@ -533,9 +535,9 @@ public class FDBLuceneIndexFailureTest extends FDBLuceneTestBase {
         }
     }
 
-    private RuntimeException mapExceptions(Throwable throwable, StoreTimer.Event event) {
+    private RuntimeException mapExceptions(Throwable throwable, @Nullable Event event) {
         if (throwable instanceof ExecutionException) {
-            throwable = throwable.getCause();
+            throwable = Objects.requireNonNull(throwable.getCause());
         }
         return new UnknownLoggableException(throwable);
     }
@@ -550,7 +552,7 @@ public class FDBLuceneIndexFailureTest extends FDBLuceneTestBase {
      * @param index the index to use
      */
     private void rebuildIndexMetaData(final FDBRecordContext context, final String document, final Index index) {
-        Pair<FDBRecordStore, QueryPlanner> pair = LuceneIndexTestUtils.rebuildIndexMetaData(context, path, document, index, isUseCascadesPlanner(), registry);
+        Pair<FDBRecordStore, QueryPlanner> pair = LuceneIndexTestUtils.rebuildIndexMetaData(context, Objects.requireNonNull(path), document, index, isUseCascadesPlanner(), registry);
         this.recordStore = pair.getLeft();
         this.planner = pair.getRight();
         this.recordStore.getIndexDeferredMaintenanceControl().setAutoMergeDuringCommit(true);

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneMapQueryTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneMapQueryTest.java
@@ -57,6 +57,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.jspecify.annotations.Nullable;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
@@ -140,6 +141,7 @@ public class FDBLuceneMapQueryTest extends FDBRecordStoreQueryTestBase {
 
     private static final List<TestRecordsTextProto.MapDocument> mapDocuments = createMapDocuments();
 
+    @Nullable
     private ExecutorService executorService = null;
 
     @Override
@@ -152,7 +154,7 @@ public class FDBLuceneMapQueryTest extends FDBRecordStoreQueryTestBase {
                     Sets.newHashSet(LuceneIndexTypes.LUCENE)
             );
         }
-        planner = new LucenePlanner(recordStore.getRecordMetaData(), recordStore.getRecordStoreState(), indexTypes, recordStore.getTimer());
+        planner = new LucenePlanner(recordStore.getRecordMetaData(), recordStore.getRecordStoreState(), indexTypes, Objects.requireNonNull(recordStore.getTimer()));
     }
 
     @Override
@@ -204,28 +206,28 @@ public class FDBLuceneMapQueryTest extends FDBRecordStoreQueryTestBase {
                                 Pair.of("Blah", false),
                                 Pair.of("c", false))
                         .map(pair ->
-                                Arguments.of(Query.field("stringToLongMap").matches(Query.field("values").oneOfThem().matches(Query.field("key").equalsValue(pair.getLeft()))),
+                                Arguments.of(Query.field("stringToLongMap").matches(Query.field("values").oneOfThem().matches(Query.field("key").equalsValue(Objects.requireNonNull(pair.getLeft())))),
                                         pair.getRight(),
                                         "MapField$string2long")),
                 Stream.of(Pair.of("c", true),
                                 Pair.of("Blah", false),
                                 Pair.of("d", false))
                         .map(pair ->
-                                Arguments.of(Query.field("stringWrapperToLongMap").matches(Query.field("values").oneOfThem().matches(Query.field("key").matches(Query.field("value").equalsValue(pair.getLeft())))),
+                                Arguments.of(Query.field("stringWrapperToLongMap").matches(Query.field("values").oneOfThem().matches(Query.field("key").matches(Query.field("value").equalsValue(Objects.requireNonNull(pair.getLeft()))))),
                                         pair.getRight(),
                                         "MapField$stringWrapper2long")),
                 Stream.of(Pair.of("f", true),
                                 Pair.of("Blah", false),
                                 Pair.of("d", false))
                         .map(pair ->
-                                Arguments.of(Query.field("stringToIntMap").matches(Query.field("values").oneOfThem().matches(Query.field("key").equalsValue(pair.getLeft()))),
+                                Arguments.of(Query.field("stringToIntMap").matches(Query.field("values").oneOfThem().matches(Query.field("key").equalsValue(Objects.requireNonNull(pair.getLeft())))),
                                         pair.getRight(),
                                         "MapField$string2int")),
                 Stream.of(Pair.of("g", true),
                                 Pair.of("Blah", false),
                                 Pair.of("a", false))
                         .map(pair ->
-                                Arguments.of(Query.field("stringToDoubleMap").matches(Query.field("values").oneOfThem().matches(Query.field("key").equalsValue(pair.getLeft()))),
+                                Arguments.of(Query.field("stringToDoubleMap").matches(Query.field("values").oneOfThem().matches(Query.field("key").equalsValue(Objects.requireNonNull(pair.getLeft())))),
                                         pair.getRight(),
                                         "MapField$string2double"))
         ).flatMap(Function.identity());

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneMapQueryTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneMapQueryTest.java
@@ -54,8 +54,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
@@ -330,7 +329,6 @@ public class FDBLuceneMapQueryTest extends FDBRecordStoreQueryTestBase {
     }
 
 
-    @Nonnull
     private static List<TestRecordsTextProto.MapDocument> createMapDocuments() {
         List<TestRecordsTextProto.MapDocument> result = IntStream.range(0, textSamples.size() / 2)
                 .mapToObj(i -> TestRecordsTextProto.MapDocument.newBuilder()
@@ -364,7 +362,6 @@ public class FDBLuceneMapQueryTest extends FDBRecordStoreQueryTestBase {
         return result;
     }
 
-    @Nonnull
     private static TestRecordsTextProto.MapDocument.String2Long.Builder getStringToLongMap(final int i, final String value) {
         TestRecordsTextProto.MapDocument.String2Long.Builder builder = TestRecordsTextProto.MapDocument.String2Long.newBuilder()
                 .addValues(TestRecordsTextProto.MapDocument.String2LongPair.newBuilder()
@@ -378,7 +375,6 @@ public class FDBLuceneMapQueryTest extends FDBRecordStoreQueryTestBase {
         return builder;
     }
 
-    @Nonnull
     private static TestRecordsTextProto.MapDocument.StringWrapper2Long.Builder getStringWrapperToLongMap(final int i, final String value) {
         TestRecordsTextProto.MapDocument.StringWrapper2Long.Builder builder = TestRecordsTextProto.MapDocument.StringWrapper2Long.newBuilder()
                 .addValues(TestRecordsTextProto.MapDocument.StringWrapper2LongPair.newBuilder()
@@ -396,7 +392,6 @@ public class FDBLuceneMapQueryTest extends FDBRecordStoreQueryTestBase {
         return builder;
     }
 
-    @Nonnull
     private static TestRecordsTextProto.MapDocument.String2Int.Builder getStringToIntMap(final int i, final String value) {
         TestRecordsTextProto.MapDocument.String2Int.Builder builder = TestRecordsTextProto.MapDocument.String2Int.newBuilder()
                 .addValues(TestRecordsTextProto.MapDocument.String2IntPair.newBuilder()
@@ -411,7 +406,6 @@ public class FDBLuceneMapQueryTest extends FDBRecordStoreQueryTestBase {
     }
 
 
-    @Nonnull
     private static TestRecordsTextProto.MapDocument.String2Double.Builder getStringToDoubleMap(final int i, final String value) {
         TestRecordsTextProto.MapDocument.String2Double.Builder builder = TestRecordsTextProto.MapDocument.String2Double.newBuilder()
                 .addValues(TestRecordsTextProto.MapDocument.String2DoublePair.newBuilder()

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneMapQueryTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneMapQueryTest.java
@@ -302,8 +302,14 @@ public class FDBLuceneMapQueryTest extends FDBRecordStoreQueryTestBase {
                     .build();
             RecordQueryPlan plan = planQuery(query);
             assertTrue(plan.getUsedIndexes().contains(expectedIndex));
-            try (RecordCursor<QueryResult> recordCursor = recordStore.executeQuery(plan, null, EvaluationContext.forBinding("$param", value), ExecuteProperties.SERIAL_EXECUTE)) {
-                List<Long> primaryKeys = recordCursor.map(QueryResult::getQueriedRecord).map(FDBQueriedRecord::getPrimaryKey).map(t -> t.getLong(0)).asList().get();
+            // Passes a null continuation into FDBRecordStoreBase#executeQuery; NullAway does not
+            // reliably recognize @Nullable on that array (byte[]) parameter.
+            @SuppressWarnings("NullAway")
+            RecordCursor<QueryResult> recordCursor = recordStore.executeQuery(plan, null, EvaluationContext.forBinding("$param", value), ExecuteProperties.SERIAL_EXECUTE);
+            try (recordCursor) {
+                // getQueriedRecord() is @Nullable in general, but this query always returns real
+                // documents, so the queried record is always present here.
+                List<Long> primaryKeys = recordCursor.map(qr -> Objects.requireNonNull(qr.getQueriedRecord())).map(FDBQueriedRecord::getPrimaryKey).map(t -> t.getLong(0)).asList().get();
                 final Set<Long> expected = found ? Set.of(0L, 1L, 2L) : Set.of();
                 assertEquals(expected, Set.copyOf(primaryKeys));
             }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneQueryTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneQueryTest.java
@@ -76,8 +76,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -479,7 +478,6 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
         }
     }
 
-    @Nonnull
     private static String quote(final boolean quotes, final String term) {
         return "text:" + (quotes ? "\"" + term + "\"" : term);
     }
@@ -927,7 +925,7 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
     @ParameterizedTest(name = "threadedLuceneScanDoesntBreakPlannerAndSearch-PoolThreadCount={0}")
     @MethodSource("threadCount")
     @SuperSlow
-    void threadedLuceneScanDoesntBreakPlannerAndSearch(@Nonnull Integer value) throws Exception {
+    void threadedLuceneScanDoesntBreakPlannerAndSearch(Integer value) throws Exception {
         final FDBDatabaseFactory factory = dbExtension.getDatabaseFactory();
         // limit the FJP size to try and force the # segments to exceed the # threads
         factory.setExecutor(new ForkJoinPool(PARALLELISM,
@@ -973,7 +971,7 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
         final ThreadFactory delegate = Executors.defaultThreadFactory();
 
         @Override
-        public Thread newThread(@Nonnull Runnable r) {
+        public Thread newThread(Runnable r) {
             return delegate.newThread(() -> {
                 threadCounts.merge(Thread.currentThread().getName(), 1, Integer::sum);
                 r.run();

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneQueryTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneQueryTest.java
@@ -209,7 +209,9 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
 
     private static final Index COMPLEX_TEXT_BY_GROUP = new Index("Complex$text_by_group", function(LuceneFunctionNames.LUCENE_TEXT, field("text")).groupBy(field("group")), LuceneIndexTypes.LUCENE);
 
+    @Nullable
     private ExecutorService executorService = null;
+    @Nullable
     private SerializationKeyManager keyManager;
 
     @Override
@@ -225,7 +227,7 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
                         Sets.newHashSet(LuceneIndexTypes.LUCENE)
                 );
             }
-            planner = new LucenePlanner(recordStore.getRecordMetaData(), recordStore.getRecordStoreState(), indexTypes, recordStore.getTimer());
+            planner = new LucenePlanner(recordStore.getRecordMetaData(), recordStore.getRecordStoreState(), indexTypes, Objects.requireNonNull(recordStore.getTimer()));
         }
     }
 
@@ -272,7 +274,7 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
         }, SIMPLE_TEXT_SUFFIXES);
     }
 
-    protected void openRecordStore(FDBRecordContext context, RecordMetaDataHook hook, Index simpleDocIndex) {
+    protected void openRecordStore(FDBRecordContext context, RecordMetaDataHook hook, @Nullable Index simpleDocIndex) {
         RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder().setRecords(TestRecordsTextProto.getDescriptor());
         metaDataBuilder.getRecordType(TextIndexTestUtils.COMPLEX_DOC).setPrimaryKey(concatenateFields("group", "doc_id"));
         if (simpleDocIndex != null) {
@@ -1397,7 +1399,7 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
             do {
                 try (RecordCursor<FDBQueriedRecord<Message>> recordCursor = recordStore.executeQuery(plan, continuation, executeProperties)) {
                     primaryKeys.addAll(recordCursor.map(FDBQueriedRecord::getPrimaryKey).map(t -> t.getLong(0)).asList(holder).get());
-                    continuation = holder.get().getContinuation().toBytes();
+                    continuation = Objects.requireNonNull(holder.get()).getContinuation().toBytes();
                 }
             } while (continuation != null);
             if (sorted) {

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneQueryTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneQueryTest.java
@@ -1380,6 +1380,9 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
 
     @ParameterizedTest(name = "continuations[sorted={0}]")
     @BooleanSource
+    // Passes a null/@Nullable continuation into FDBRecordStoreBase#executeQuery; NullAway does not
+    // reliably recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void continuations(boolean sorted) throws Exception {
         initializeFlat();
         try (FDBRecordContext context = openContext()) {
@@ -1394,7 +1397,7 @@ public class FDBLuceneQueryTest extends FDBRecordStoreQueryTestBase {
             RecordQueryPlan plan = planQuery(query.build());
             ExecuteProperties executeProperties = ExecuteProperties.newBuilder().setReturnedRowLimit(2).build();
             List<Long> primaryKeys = new ArrayList<>();
-            byte[] continuation = null;
+            byte @Nullable [] continuation = null;
             AtomicReference<RecordCursorResult<Long>> holder = new AtomicReference<>();
             do {
                 try (RecordCursor<FDBQueriedRecord<Message>> recordCursor = recordStore.executeQuery(plan, continuation, executeProperties)) {

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneQueuedDocQueryTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneQueuedDocQueryTest.java
@@ -172,6 +172,9 @@ public class FDBLuceneQueuedDocQueryTest extends FDBRecordStoreTestBase {
     }
 
     @Test
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void tooManyPendingWritesInQueue() throws Exception {
         final RecordLayerPropertyStorage contextProps = RecordLayerPropertyStorage.newBuilder()
                 .addProp(LuceneRecordContextProperties.LUCENE_MAX_PENDING_WRITES_REPLAYED_FOR_QUERY, 1)
@@ -190,6 +193,9 @@ public class FDBLuceneQueuedDocQueryTest extends FDBRecordStoreTestBase {
     }
 
     @Test
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void saveToQueueAfterTransactionCreated() throws Exception {
         // Save an item to the queue after the transaction that performs the search is created
         // Since the search is done with the same GRV as the original transaction, no docs will be replayed
@@ -219,6 +225,9 @@ public class FDBLuceneQueuedDocQueryTest extends FDBRecordStoreTestBase {
     }
 
     @Test
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void saveToIndexWithinTransaction() throws Exception {
         // Save an item to the index after the transaction that performs the search is created
         // This should return a reader that can see the changes
@@ -247,6 +256,9 @@ public class FDBLuceneQueuedDocQueryTest extends FDBRecordStoreTestBase {
     }
 
     @Test
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void saveToQueueWithinTransaction() throws Exception {
         // Save an item to the queue after the transaction that performs the search is created
         // Query should not see the changes since the writes are not replayed from the regular transaction to the read-only one
@@ -338,6 +350,9 @@ public class FDBLuceneQueuedDocQueryTest extends FDBRecordStoreTestBase {
         }
     }
 
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     private void scanAndCompareDocs(Index index, String searchTerm, Set<Long> expectedPKs) throws Exception {
         try (FDBRecordContext context = openContext()) {
             openRecordStore(context, index);

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneQueuedDocQueryTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneQueuedDocQueryTest.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -401,7 +402,7 @@ public class FDBLuceneQueuedDocQueryTest extends FDBRecordStoreTestBase {
     }
 
     protected FDBRecordStore openRecordStore(FDBRecordContext context, Index index) {
-        recordStore = LuceneIndexTestUtils.openRecordStore(context, path, mdb -> {
+        recordStore = LuceneIndexTestUtils.openRecordStore(context, Objects.requireNonNull(path), mdb -> {
             if (index != null) {
                 mdb.removeIndex("SimpleDocument$text");
                 mdb.addIndex(TextIndexTestUtils.SIMPLE_DOC, index);

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneTestBase.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneTestBase.java
@@ -38,7 +38,6 @@ import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.search.Sort;
 import org.junit.jupiter.api.Assertions;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -85,7 +84,7 @@ public abstract class FDBLuceneTestBase extends FDBRecordStoreTestBase {
             INDEX_PARTITION_HIGH_WATERMARK, "10"));
 
 
-    protected StoreTimer.Counter getCounter(@Nonnull final FDBRecordContext recordContext, @Nonnull final StoreTimer.Event event) {
+    protected StoreTimer.Counter getCounter(final FDBRecordContext recordContext, final StoreTimer.Event event) {
         return Verify.verifyNotNull(recordContext.getTimer()).getCounter(event);
     }
 
@@ -111,7 +110,6 @@ public abstract class FDBLuceneTestBase extends FDBRecordStoreTestBase {
         return manager.getIndexReader(groupingKey, partitionId);
     }
 
-    @Nonnull
     protected LuceneIndexMaintainer getIndexMaintainer(final Index index) {
         return (LuceneIndexMaintainer)recordStore.getIndexMaintainer(index);
     }
@@ -141,7 +139,6 @@ public abstract class FDBLuceneTestBase extends FDBRecordStoreTestBase {
         }
     }
 
-    @Nonnull
     protected static Index complexPartitionedIndex(final Map<String, String> options) {
         return new Index("Complex$partitioned",
                 concat(function(LuceneFunctionNames.LUCENE_TEXT, field("text")),
@@ -150,7 +147,6 @@ public abstract class FDBLuceneTestBase extends FDBRecordStoreTestBase {
                 options);
     }
 
-    @Nonnull
     protected static Index getJoinedIndex(final Map<String, String> options) {
         return new Index("joinNestedConcat",
                 concat(
@@ -161,7 +157,6 @@ public abstract class FDBLuceneTestBase extends FDBRecordStoreTestBase {
                 options);
     }
 
-    @Nonnull
     protected static Index complexPartitionedIndexNoGroup(final Map<String, String> options) {
         return new Index("Complex$partitioned_noGroup",
                 concat(function(LuceneFunctionNames.LUCENE_TEXT, field("text")),

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneTestBase.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/FDBLuceneTestBase.java
@@ -32,17 +32,18 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreTestBase;
 import com.apple.foundationdb.record.provider.foundationdb.properties.RecordLayerPropertyStorage;
 import com.apple.foundationdb.tuple.Tuple;
-import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableMap;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.search.Sort;
 import org.junit.jupiter.api.Assertions;
+import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -85,7 +86,7 @@ public abstract class FDBLuceneTestBase extends FDBRecordStoreTestBase {
 
 
     protected StoreTimer.Counter getCounter(final FDBRecordContext recordContext, final StoreTimer.Event event) {
-        return Verify.verifyNotNull(recordContext.getTimer()).getCounter(event);
+        return Objects.requireNonNull(Objects.requireNonNull(recordContext.getTimer()).getCounter(event));
     }
 
     protected List<LucenePartitionInfoProto.LucenePartitionInfo> getPartitionMeta(Index index,
@@ -169,7 +170,7 @@ public abstract class FDBLuceneTestBase extends FDBRecordStoreTestBase {
         return groupedSortedTextSearch(index, search, null, group);
     }
 
-    protected LuceneScanBounds groupedSortedTextSearch(Index index, String search, Sort sort, Object group) {
+    protected LuceneScanBounds groupedSortedTextSearch(Index index, String search, @Nullable Sort sort, Object group) {
         return LuceneIndexTestValidator.groupedSortedTextSearch(recordStore, index, search, sort, group);
     }
 

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneAnalyzerTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneAnalyzerTest.java
@@ -32,7 +32,6 @@ import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.Collection;
@@ -91,7 +90,7 @@ public class LuceneAnalyzerTest {
         Assertions.assertEquals(ImmutableSet.of("hello", "rl"), result);
     }
 
-    private static void tokenizeWithAnalyzer(Collection<String> result, @Nonnull String input, Analyzer analyzer) throws IOException {
+    private static void tokenizeWithAnalyzer(Collection<String> result, String input, Analyzer analyzer) throws IOException {
         try (TokenStream stream = analyzer.tokenStream("field", new StringReader(input))) {
             stream.reset();
             while (stream.incrementToken()) {

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneAutoCompletedMatchesTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneAutoCompletedMatchesTest.java
@@ -28,8 +28,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
@@ -114,11 +113,11 @@ class LuceneAutoCompletedMatchesTest {
         assertComputeAllMatches("Hello World ", List.of("hello", "world"), ImmutableSet.of(), text, numAdditionalTokens, expected);
     }
 
-    private static void assertComputeAllMatches(@Nonnull final String queryString, @Nonnull final List<String> expectedTokens,
+    private static void assertComputeAllMatches(final String queryString, final List<String> expectedTokens,
                                                 @Nullable final Set<String> expectedPrefixTokens,
-                                                @Nonnull final String text,
+                                                final String text,
                                                 final int numAdditionalTokens,
-                                                @Nonnull final List<String> expectedMatches) {
+                                                final List<String> expectedMatches) {
         final Analyzer analyzer = getTestAnalyzer();
         LuceneAutoCompleteHelpers.AutoCompleteTokens tokens = LuceneAutoCompleteHelpers.getQueryTokens(analyzer, queryString);
         assertEquals(expectedTokens, tokens.getQueryTokens());
@@ -162,12 +161,12 @@ class LuceneAutoCompletedMatchesTest {
         assertComputeAllMatchesForPhrase("Good Mor", List.of("good"), "mor", text, numAdditionalTokens, expected);
     }
 
-    private static void assertComputeAllMatchesForPhrase(@Nonnull final String queryString,
-                                                         @Nonnull final List<String> expectedTokens,
+    private static void assertComputeAllMatchesForPhrase(final String queryString,
+                                                         final List<String> expectedTokens,
                                                          @Nullable final String expectedPrefixToken,
-                                                         @Nonnull final String text,
+                                                         final String text,
                                                          final int numAdditionalTokens,
-                                                         @Nonnull final List<String> expectedMatches) {
+                                                         final List<String> expectedMatches) {
         final Analyzer analyzer = getTestAnalyzer();
         LuceneAutoCompleteHelpers.AutoCompleteTokens tokens = LuceneAutoCompleteHelpers.getQueryTokens(analyzer, queryString);
         assertEquals(expectedTokens, tokens.getQueryTokens());

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneDocumentFromRecordTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneDocumentFromRecordTest.java
@@ -36,8 +36,7 @@ import org.apache.lucene.index.Term;
 import org.apache.lucene.search.TermQuery;
 import org.junit.jupiter.api.Test;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -670,7 +669,7 @@ class LuceneDocumentFromRecordTest {
 
     private static LuceneDocumentFromRecord.DocumentField documentField(String name, @Nullable Object value, LuceneIndexExpressions.DocumentFieldType type,
                                                                         boolean stored, boolean sorted,
-                                                                        @Nonnull Map<String, Object> fieldConfigs) {
+                                                                        Map<String, Object> fieldConfigs) {
         return new LuceneDocumentFromRecord.DocumentField(name, value, type, stored, sorted, fieldConfigs);
     }
 

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexGetMetadataInfoTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexGetMetadataInfoTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.jspecify.annotations.Nullable;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -77,7 +78,7 @@ public class LuceneIndexGetMetadataInfoTest extends FDBRecordStoreTestBase {
                 assertEquals(Map.of(), result.getLuceneInfo());
             } else {
                 assertEquals(Set.of(0), result.getLuceneInfo().keySet());
-                final LuceneMetadataInfo.LuceneInfo luceneInfo = result.getLuceneInfo().get(0);
+                final LuceneMetadataInfo.LuceneInfo luceneInfo = Objects.requireNonNull(result.getLuceneInfo().get(0));
                 assertEquals(dataModel.primaryKeys(groupingKey).size(), luceneInfo.getDocumentCount());
                 // When we save, we save all records for a group in a single transaction, so that will result in a
                 // single segment, but when the index is not grouped we have 5 transactions, which results in 5
@@ -123,7 +124,7 @@ public class LuceneIndexGetMetadataInfoTest extends FDBRecordStoreTestBase {
             } else {
                 assertEquals(Set.copyOf(partitionIds), result.getLuceneInfo().keySet());
                 for (final Integer partitionId : partitionIds) {
-                    final LuceneMetadataInfo.LuceneInfo luceneInfo = result.getLuceneInfo().get(partitionId);
+                    final LuceneMetadataInfo.LuceneInfo luceneInfo = Objects.requireNonNull(result.getLuceneInfo().get(partitionId));
                     assertEquals(10, luceneInfo.getDocumentCount());
                     assertThat(luceneInfo.getFiles(), Matchers.hasSize(segmentCountToFileCount(1)));
                     assertThat(luceneInfo.getDetailedFileInfos(), Matchers.hasSize(segmentCountToFileCount(1)));
@@ -180,7 +181,7 @@ public class LuceneIndexGetMetadataInfoTest extends FDBRecordStoreTestBase {
                 .map(LucenePartitionInfoProto.LucenePartitionInfo::getId)
                 .findFirst().orElseThrow();
         for (final Integer partitionId : partitionIds) {
-            final LuceneMetadataInfo.LuceneInfo luceneInfo = result.getLuceneInfo().get(partitionId);
+            final LuceneMetadataInfo.LuceneInfo luceneInfo = Objects.requireNonNull(result.getLuceneInfo().get(partitionId));
             if (partitionId == smallerPartition) {
                 assertEquals(9, luceneInfo.getDocumentCount());
                 // one extra file for the `.liv`
@@ -286,7 +287,7 @@ public class LuceneIndexGetMetadataInfoTest extends FDBRecordStoreTestBase {
 
         // Queue has pending entries - metadata should report a non-zero queue size
         final LuceneMetadataInfo result = getLuceneMetadataInfo(false, Tuple.from(), dataModel, null);
-        assertThat(result.getLuceneInfo().get(0).getPendingWritesQueueSize(), Matchers.equalTo(3L));
+        assertThat(Objects.requireNonNull(result.getLuceneInfo().get(0)).getPendingWritesQueueSize(), Matchers.equalTo(3L));
 
         // Merge drains the queue
         try (FDBRecordContext context = openContext()) {
@@ -295,7 +296,7 @@ public class LuceneIndexGetMetadataInfoTest extends FDBRecordStoreTestBase {
 
         // After merge the queue is empty - metadata should report zero
         final LuceneMetadataInfo result2 = getLuceneMetadataInfo(false, Tuple.from(), dataModel, null);
-        assertEquals(0L, result2.getLuceneInfo().get(0).getPendingWritesQueueSize());
+        assertEquals(0L, Objects.requireNonNull(result2.getLuceneInfo().get(0)).getPendingWritesQueueSize());
     }
 
     private static void assertPartitionInfosHaveCorrectFromTo(

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexGetMetadataInfoTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexGetMetadataInfoTest.java
@@ -32,8 +32,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -317,8 +316,8 @@ public class LuceneIndexGetMetadataInfoTest extends FDBRecordStoreTestBase {
     }
 
     private LuceneMetadataInfo getLuceneMetadataInfo(final boolean justPartitionInfo,
-                                                     @Nonnull final Tuple groupingKey,
-                                                     @Nonnull final LuceneIndexTestDataModel dataModel,
+                                                     final Tuple groupingKey,
+                                                     final LuceneIndexTestDataModel dataModel,
                                                      @Nullable final Integer partitionId) {
         try (FDBRecordContext context = openContext()) {
             final FDBRecordStore store = dataModel.schemaSetup.apply(context);

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
@@ -542,7 +542,7 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
         Index index = complexPartitionedIndex(options);
         final KeySpacePath path = pathManager.createPath(TestKeySpace.RECORD_STORE);
         Function<FDBRecordContext, FDBRecordStore> schemaSetup = context ->
-                LuceneIndexTestUtils.rebuildIndexMetaData(context, path, TestRecordsTextProto.ComplexDocument.getDescriptor().getName(), index, useCascadesPlanner).getLeft();
+                Objects.requireNonNull(LuceneIndexTestUtils.rebuildIndexMetaData(context, path, TestRecordsTextProto.ComplexDocument.getDescriptor().getName(), index, useCascadesPlanner).getLeft());
 
         final RecordLayerPropertyStorage contextProps = RecordLayerPropertyStorage.newBuilder()
                 .addProp(LuceneRecordContextProperties.LUCENE_REPARTITION_DOCUMENT_COUNT, 8)
@@ -561,7 +561,8 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
             // subspace for (group 1, partition data subspace, partition 0, file lock subspace)
             Subspace subspace = recordStore.indexSubspace(index).subspace(Tuple.from(1, LucenePartitioner.PARTITION_DATA_SUBSPACE, 0, FDBDirectory.FILE_LOCK_SUBSPACE));
             byte[] fileLockKey = subspace.pack(Tuple.from("write.lock"));
-            FDBDirectoryLockFactory lockFactory = new FDBDirectoryLockFactory(null, 10_000);
+            final FDBDirectory directory = getIndexMaintainer(recordStore, index).getDirectoryManager().getDirectory(Tuple.from(1), 0);
+            FDBDirectoryLockFactory lockFactory = new FDBDirectoryLockFactory(directory, 10_000);
 
             Lock testLock = lockFactory.obtainLock(new NonAgileContext(context), fileLockKey, "write.lock");
             testLock.ensureValid();
@@ -575,7 +576,7 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
             try (RecordCursor<IndexEntry> cursor = recordStore.scanIndex(
                     index,
                     LuceneIndexTestValidator.groupedSortedTextSearch(recordStore, index, "text:word", null, 1), null, ScanProperties.FORWARD_SCAN)) {
-                List<Tuple> primaryKeys = LuceneConcurrency.asyncToSync(FDBStoreTimer.Waits.WAIT_ADVANCE_CURSOR, cursor.asList(), context)
+                List<Tuple> primaryKeys = Objects.requireNonNull(LuceneConcurrency.asyncToSync(FDBStoreTimer.Waits.WAIT_ADVANCE_CURSOR, cursor.asList(), context))
                         .stream()
                         .map(IndexEntry::getPrimaryKey)
                         .collect(Collectors.toList());
@@ -615,7 +616,7 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
         Index index = complexPartitionedIndex(options);
         final KeySpacePath path = pathManager.createPath(TestKeySpace.RECORD_STORE);
         Function<FDBRecordContext, FDBRecordStore> schemaSetup = context ->
-                LuceneIndexTestUtils.rebuildIndexMetaData(context, path, TestRecordsTextProto.ComplexDocument.getDescriptor().getName(), index, useCascadesPlanner).getLeft();
+                Objects.requireNonNull(LuceneIndexTestUtils.rebuildIndexMetaData(context, path, TestRecordsTextProto.ComplexDocument.getDescriptor().getName(), index, useCascadesPlanner).getLeft());
 
         assertNotNull(index);
 
@@ -657,7 +658,7 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
                             try (RecordCursor<IndexEntry> cursor = recordStore.scanIndex(
                                     index,
                                     LuceneIndexTestValidator.groupedSortedTextSearch(recordStore, index, "text:word", null, 1), null, ScanProperties.FORWARD_SCAN)) {
-                                List<IndexEntry> matches = LuceneConcurrency.asyncToSync(FDBStoreTimer.Waits.WAIT_ADVANCE_CURSOR, cursor.asList(), context);
+                                List<IndexEntry> matches = Objects.requireNonNull(LuceneConcurrency.asyncToSync(FDBStoreTimer.Waits.WAIT_ADVANCE_CURSOR, cursor.asList(), context));
                                 assertFalse(matches.isEmpty());
                             }
 
@@ -748,7 +749,7 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
         Index index = complexPartitionedIndex(options);
         final KeySpacePath path = pathManager.createPath(TestKeySpace.RECORD_STORE);
         Function<FDBRecordContext, FDBRecordStore> schemaSetup = context ->
-                LuceneIndexTestUtils.rebuildIndexMetaData(context, path, TestRecordsTextProto.ComplexDocument.getDescriptor().getName(), index, useCascadesPlanner).getLeft();
+                Objects.requireNonNull(LuceneIndexTestUtils.rebuildIndexMetaData(context, path, TestRecordsTextProto.ComplexDocument.getDescriptor().getName(), index, useCascadesPlanner).getLeft());
         final RecordLayerPropertyStorage contextProps = RecordLayerPropertyStorage.newBuilder()
                 .addProp(LuceneRecordContextProperties.LUCENE_REPARTITION_DOCUMENT_COUNT, 8)
                 .build();
@@ -799,7 +800,7 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
         Index index = complexPartitionedIndex(options);
         final KeySpacePath path = pathManager.createPath(TestKeySpace.RECORD_STORE);
         Function<FDBRecordContext, FDBRecordStore> schemaSetup = context ->
-                LuceneIndexTestUtils.rebuildIndexMetaData(context, path, TestRecordsTextProto.ComplexDocument.getDescriptor().getName(), index, useCascadesPlanner).getLeft();
+                Objects.requireNonNull(LuceneIndexTestUtils.rebuildIndexMetaData(context, path, TestRecordsTextProto.ComplexDocument.getDescriptor().getName(), index, useCascadesPlanner).getLeft());
 
         final RecordLayerPropertyStorage contextProps = RecordLayerPropertyStorage.newBuilder()
                 .addProp(LuceneRecordContextProperties.LUCENE_REPARTITION_DOCUMENT_COUNT, 8)
@@ -985,7 +986,7 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
         try (FDBRecordContext context = openContext(contextProps)) {
             final FDBRecordStore recordStore = dataModel.createOrOpenRecordStore(context);
             dataModel.groupingKeys().forEach(groupingKey -> {
-                List<Tuple> sortedPartitionKeys = dataModel.groupingKeyToPrimaryKeyToPartitionKey.get(groupingKey)
+                List<Tuple> sortedPartitionKeys = Objects.requireNonNull(dataModel.groupingKeyToPrimaryKeyToPartitionKey.get(groupingKey))
                         .values().stream().sorted().collect(Collectors.toList());
                 // delete enough docs to empty partition
                 Set<Tuple> partitionKeysToDelete = new HashSet<>(sortedPartitionKeys.subList(start, end));
@@ -1297,9 +1298,10 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
         final RecordLayerPropertyStorage contextProps2 = contextPropsBuilder.build();
         IOException ioException = assertThrows(IOException.class,
                 () -> dataModel.validate(() -> openContext(contextProps2)));
-        assertThat(ioException.getCause(), instanceOf(RecordCoreException.class));
+        final Throwable cause = Objects.requireNonNull(ioException.getCause());
+        assertThat(cause, instanceOf(RecordCoreException.class));
         // Possible failures: (1) does not decrypt; (2) decrypts to garbage with bad compression level; (3) does not decompress.
-        assertThat(ioException.getCause().getMessage(), anyOf(
+        assertThat(cause.getMessage(), anyOf(
                 containsString("Lucene data decoding failure"),
                 containsString("Un-supported compression version")));
     }
@@ -1665,6 +1667,7 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
         }
     }
 
+    @Nullable
     private static LoggableKeysAndValues<? extends Exception> findTimeoutException(final RecordCoreException e) {
         Map<Throwable, String> visited = new IdentityHashMap<>();
         ArrayDeque<Throwable> toVisit = new ArrayDeque<>();

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
@@ -534,6 +534,9 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
 
     // Lock a directory, and commit, then try to update a record, or save a record, or do a search, and assert that nothing
     // is corrupted (or that the user request fails)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     @Test
     void lockCommitThenValidateTest() throws IOException {
         final Map<String, String> options = Map.of(
@@ -608,6 +611,9 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
 
     // A chaos test of two threads, one constantly trying to merge, and one trying to update a record, or save a new record or do a search.
     // At the end the index should be validated for consistency.
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     @Test
     void chaosMergeAndUpdateTest() throws InterruptedException, IOException {
         final Map<String, String> options = Map.of(

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexMaintenanceTest.java
@@ -79,8 +79,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import javax.crypto.SecretKey;
 import java.io.IOException;
 import java.time.Duration;
@@ -850,8 +849,8 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
     static class InvalidLockTestFDBDirectory extends FDBDirectory {
         private final int percentFailure;
 
-        public InvalidLockTestFDBDirectory(@Nonnull Subspace subspace,
-                                           @Nonnull FDBRecordContext context,
+        public InvalidLockTestFDBDirectory(Subspace subspace,
+                                           FDBRecordContext context,
                                            @Nullable Map<String, String> indexOptions,
                                            final int percentFailure) {
             super(subspace, context, indexOptions);
@@ -859,8 +858,7 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
         }
 
         @Override
-        @Nonnull
-        public Lock obtainLock(@Nonnull final String lockName) throws IOException {
+        public Lock obtainLock(final String lockName) throws IOException {
             final Lock lock = super.obtainLock(lockName);
             return new Lock() {
                 @Override
@@ -1692,7 +1690,6 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
         return null;
     }
 
-    @Nonnull
     public static Index complexPartitionedIndex(final Map<String, String> options) {
         return new Index("Complex$partitioned",
                 concat(function(LuceneFunctionNames.LUCENE_TEXT, field("text")),
@@ -1746,7 +1743,6 @@ public class LuceneIndexMaintenanceTest extends FDBRecordStoreConcurrentTestBase
         return ignored -> { };
     }
 
-    @Nonnull
     protected LuceneIndexMaintainer getIndexMaintainer(FDBRecordStore store, Index index) {
         return (LuceneIndexMaintainer)store.getIndexMaintainer(index);
     }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexScrubbingTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexScrubbingTest.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Stream;
 
 import static com.apple.foundationdb.record.lucene.LuceneIndexTestUtils.SIMPLE_TEXT_SUFFIXES_WITH_PRIMARY_KEY_SEGMENT_INDEX;
@@ -59,7 +60,7 @@ class LuceneIndexScrubbingTest extends FDBLuceneTestBase {
     }
 
     private void rebuildIndexMetaData(final FDBRecordContext context, final String document, final Index index) {
-        Pair<FDBRecordStore, QueryPlanner> pair = LuceneIndexTestUtils.rebuildIndexMetaData(context, path, document, index, isUseCascadesPlanner());
+        Pair<FDBRecordStore, QueryPlanner> pair = LuceneIndexTestUtils.rebuildIndexMetaData(context, Objects.requireNonNull(path), document, index, isUseCascadesPlanner());
         this.recordStore = pair.getLeft();
         this.planner = pair.getRight();
     }
@@ -246,7 +247,7 @@ class LuceneIndexScrubbingTest extends FDBLuceneTestBase {
 
         try (final FDBRecordContext context = openContext()) {
             // Overwrite + add records without updating the index
-            Pair<FDBRecordStore, QueryPlanner> pair = LuceneIndexTestUtils.rebuildIndexMetaData(context, path, SIMPLE_DOC, index, isUseCascadesPlanner(), registry);
+            Pair<FDBRecordStore, QueryPlanner> pair = LuceneIndexTestUtils.rebuildIndexMetaData(context, Objects.requireNonNull(path), SIMPLE_DOC, index, isUseCascadesPlanner(), registry);
             this.recordStore = pair.getLeft();
             this.planner = pair.getRight();
             injectedFailures.setFlag(LUCENE_MAINTAINER_SKIP_INDEX_UPDATE);

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexScrubbingTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexScrubbingTest.java
@@ -38,7 +38,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import javax.annotation.Nonnull;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -72,10 +71,9 @@ class LuceneIndexScrubbingTest extends FDBLuceneTestBase {
                                 .map(isGrouped -> Arguments.of(isSynthetic, isGrouped, isPartitioned))));
     }
 
-    @Nonnull
-    protected FDBRecordStore.Builder getStoreBuilderWithRegistry(@Nonnull FDBRecordContext context,
-                                                                 @Nonnull RecordMetaDataProvider metaData,
-                                                                 @Nonnull final KeySpacePath path) {
+    protected FDBRecordStore.Builder getStoreBuilderWithRegistry(FDBRecordContext context,
+                                                                 RecordMetaDataProvider metaData,
+                                                                 final KeySpacePath path) {
         return super.getStoreBuilder(context, metaData, path).setIndexMaintainerRegistry(registry);
     }
 

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexScrubbingTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexScrubbingTest.java
@@ -61,8 +61,10 @@ class LuceneIndexScrubbingTest extends FDBLuceneTestBase {
 
     private void rebuildIndexMetaData(final FDBRecordContext context, final String document, final Index index) {
         Pair<FDBRecordStore, QueryPlanner> pair = LuceneIndexTestUtils.rebuildIndexMetaData(context, Objects.requireNonNull(path), document, index, isUseCascadesPlanner());
-        this.recordStore = pair.getLeft();
-        this.planner = pair.getRight();
+        // Pair#getLeft/getRight are @Nullable in general (a Pair may hold nulls), but
+        // rebuildIndexMetaData always constructs its result from the non-null store/planner it builds.
+        this.recordStore = Objects.requireNonNull(pair.getLeft());
+        this.planner = Objects.requireNonNull(pair.getRight());
     }
 
     private static Stream<Arguments> threeBooleanArgs() {
@@ -248,8 +250,10 @@ class LuceneIndexScrubbingTest extends FDBLuceneTestBase {
         try (final FDBRecordContext context = openContext()) {
             // Overwrite + add records without updating the index
             Pair<FDBRecordStore, QueryPlanner> pair = LuceneIndexTestUtils.rebuildIndexMetaData(context, Objects.requireNonNull(path), SIMPLE_DOC, index, isUseCascadesPlanner(), registry);
-            this.recordStore = pair.getLeft();
-            this.planner = pair.getRight();
+            // Pair#getLeft/getRight are @Nullable in general (a Pair may hold nulls), but
+            // rebuildIndexMetaData always constructs its result from the non-null store/planner it builds.
+            this.recordStore = Objects.requireNonNull(pair.getLeft());
+            this.planner = Objects.requireNonNull(pair.getRight());
             injectedFailures.setFlag(LUCENE_MAINTAINER_SKIP_INDEX_UPDATE);
             recordStore.saveRecord(createSimpleDocument(1623L, ENGINEER_JOKE, 2));
             recordStore.saveRecord(createSimpleDocument(7771547L, WAYLON, 1));

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
@@ -54,6 +54,7 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBQueriedRecord;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStore;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase;
+import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreBase.RecordExistenceCheck;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreTestBase;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoreTimer;
 import com.apple.foundationdb.record.provider.foundationdb.FDBStoredRecord;
@@ -230,13 +231,25 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
     private static final Logger LOGGER = LoggerFactory.getLogger(LuceneIndexTest.class);
     private static final String LUCENE_INDEX_MAP_PARAMS = "com.apple.foundationdb.record.lucene.LuceneIndexTestUtils#luceneIndexMapParams";
 
-    private Tuple createComplexRecordJoinedToSimple(int group, long docIdSimple, long docIdComplex, String text, String text2, boolean isSeen, long timestamp, Integer score) {
+    private Tuple createComplexRecordJoinedToSimple(int group, long docIdSimple, long docIdComplex, @Nullable String text, String text2, boolean isSeen, long timestamp, @Nullable Integer score) {
         return createComplexRecordJoinedToSimple(group, docIdSimple, docIdComplex, text, text2, isSeen, timestamp, score, null);
     }
 
-    private Tuple createComplexRecordJoinedToSimple(int group, long docIdSimple, long docIdComplex, String text, String text2, boolean isSeen, long timestamp, Integer score, FDBRecordStoreBase.RecordExistenceCheck existenceCheck) {
+    private Tuple createComplexRecordJoinedToSimple(int group, long docIdSimple, long docIdComplex, @Nullable String text, String text2, boolean isSeen, long timestamp, @Nullable Integer score, @Nullable RecordExistenceCheck existenceCheck) {
         TestRecordsTextProto.SimpleDocument simpleDocument = text != null ? createSimpleDocument(docIdSimple, text, group) : createSimpleDocument(docIdSimple, group);
-        ComplexDocument complexDocument = createComplexDocument(docIdComplex, "", text2, group, score, isSeen, timestamp);
+        // Not using LuceneIndexTestUtils.createComplexDocument(..., Integer score, ...) here because that overload
+        // requires a non-null score, whereas this method intentionally allows callers to omit the score field.
+        ComplexDocument.Builder complexDocumentBuilder = ComplexDocument.newBuilder()
+                .setDocId(docIdComplex)
+                .setText("")
+                .setText2(text2)
+                .setGroup(group)
+                .setIsSeen(isSeen)
+                .setTime(timestamp);
+        if (score != null) {
+            complexDocumentBuilder.setScore(score);
+        }
+        ComplexDocument complexDocument = complexDocumentBuilder.build();
         Tuple syntheticRecordTypeKey = recordStore.getRecordMetaData()
                 .getSyntheticRecordType("luceneSyntheticComplexJoinedToSimple")
                 .getRecordTypeKeyTuple();
@@ -358,7 +371,7 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
                 Sets.newHashSet(IndexTypes.TEXT),
                 Sets.newHashSet(LuceneIndexTypes.LUCENE)
         );
-        planner = new LucenePlanner(recordStore.getRecordMetaData(), recordStore.getRecordStoreState(), indexTypes, recordStore.getTimer());
+        planner = new LucenePlanner(recordStore.getRecordMetaData(), recordStore.getRecordStoreState(), indexTypes, Objects.requireNonNull(recordStore.getTimer()));
         planner.setConfiguration(planner.getConfiguration()
                 .asBuilder()
                 .setPlanOtherAttemptWholeFilter(false)
@@ -494,7 +507,7 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
             recordStore.saveRecord(createComplexDocument(9999L, "hello world!", 1, Instant.now().plus(2, ChronoUnit.DAYS).toEpochMilli()));
             context.commit();
 
-            final FDBStoreTimer timer = context.getTimer();
+            final FDBStoreTimer timer = Objects.requireNonNull(context.getTimer());
             assertTrue(timer.getCount(LuceneEvents.Counts.LUCENE_BLOCK_CACHE_REMOVE) > 0);
         }
     }
@@ -513,7 +526,7 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
             recordStore.saveRecord(createComplexDocument(9999L, "hello world!", 1, Instant.now().plus(2, ChronoUnit.DAYS).toEpochMilli()));
             context.commit();
 
-            final FDBStoreTimer timer = context.getTimer();
+            final FDBStoreTimer timer = Objects.requireNonNull(context.getTimer());
             assertEquals(timer.getCount(LuceneEvents.Counts.LUCENE_BLOCK_CACHE_REMOVE), 0);
             assertTrue(timer.getCount(LuceneEvents.Waits.WAIT_LUCENE_GET_DATA_BLOCK) > 0);
         }
@@ -526,8 +539,8 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
     @ParameterizedTest
     @MethodSource(value = {"dualGroupModeIndexProvider"})
     void repartitionGroupedTest(Pair<Index, Tuple> indexAndGroupingKey) throws IOException {
-        Index index = indexAndGroupingKey.getLeft();
-        Tuple groupingKey = indexAndGroupingKey.getRight();
+        Index index = Objects.requireNonNull(indexAndGroupingKey.getLeft());
+        Tuple groupingKey = Objects.requireNonNull(indexAndGroupingKey.getRight());
         final RecordLayerPropertyStorage contextProps = RecordLayerPropertyStorage.newBuilder()
                 .addProp(LuceneRecordContextProperties.LUCENE_REPARTITION_DOCUMENT_COUNT, 6)
                 .build();
@@ -759,8 +772,8 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
     @ParameterizedTest
     @MethodSource(value = {"dualGroupModeIndexProvider"})
     void optimizedPartitionInsertionTest(Pair<Index, Tuple> indexAndGroupingKey) throws IOException {
-        Index index = indexAndGroupingKey.getLeft();
-        Tuple groupingKey = indexAndGroupingKey.getRight();
+        Index index = Objects.requireNonNull(indexAndGroupingKey.getLeft());
+        Tuple groupingKey = Objects.requireNonNull(indexAndGroupingKey.getRight());
         final RecordLayerPropertyStorage contextProps = RecordLayerPropertyStorage.newBuilder()
                 .addProp(LuceneRecordContextProperties.LUCENE_REPARTITION_DOCUMENT_COUNT, 6)
                 .build();
@@ -910,8 +923,8 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
                 INDEX_PARTITION_BY_FIELD_NAME, isSynthetic ? "complex.timestamp" : "timestamp",
                 INDEX_PARTITION_HIGH_WATERMARK, String.valueOf(10));
         Pair<Index, Consumer<FDBRecordContext>> indexConsumerPair = setupIndex(options, isGrouped, isSynthetic);
-        final Index index = indexConsumerPair.getLeft();
-        Consumer<FDBRecordContext> schemaSetup = indexConsumerPair.getRight();
+        final Index index = Objects.requireNonNull(indexConsumerPair.getLeft());
+        Consumer<FDBRecordContext> schemaSetup = Objects.requireNonNull(indexConsumerPair.getRight());
 
         final RecordLayerPropertyStorage contextProps = RecordLayerPropertyStorage.newBuilder()
                 .addProp(LuceneRecordContextProperties.LUCENE_REPARTITION_DOCUMENT_COUNT, 6)
@@ -1149,8 +1162,8 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
                 INDEX_PARTITION_BY_FIELD_NAME, "timestamp",
                 INDEX_PARTITION_HIGH_WATERMARK, String.valueOf(highWaterMark));
         Pair<Index, Consumer<FDBRecordContext>> indexConsumerPair = setupIndex(options, true, false);
-        final Index index = indexConsumerPair.getLeft();
-        Consumer<FDBRecordContext> schemaSetup = indexConsumerPair.getRight();
+        final Index index = Objects.requireNonNull(indexConsumerPair.getLeft());
+        Consumer<FDBRecordContext> schemaSetup = Objects.requireNonNull(indexConsumerPair.getRight());
 
         final RecordLayerPropertyStorage contextProps = RecordLayerPropertyStorage.newBuilder()
                 .addProp(LuceneRecordContextProperties.LUCENE_REPARTITION_DOCUMENT_COUNT, docCountPerTxn)
@@ -1224,7 +1237,7 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
             int totalExpectedRepartitionCallCount = 0;
 
             for (final GroupSpec groupSpec : groupSpecs) {
-                List<LucenePartitionInfoProto.LucenePartitionInfo> groupPartitionInfos = partitionInfos.get(groupSpec.value);
+                List<LucenePartitionInfoProto.LucenePartitionInfo> groupPartitionInfos = Objects.requireNonNull(partitionInfos.get(groupSpec.value));
 
                 Pair<int[], Integer> spreadAndCallCount = calculateAndValidateRepartitioningExpectations(
                         groupPartitionInfos,
@@ -1233,16 +1246,16 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
                         docCountPerTxn,
                         maxCountPerRepartitionCall,
                         -1);
-                totalExpectedRepartitionCallCount += spreadAndCallCount.getRight();
-                int[] docDistribution = spreadAndCallCount.getLeft();
+                totalExpectedRepartitionCallCount += Objects.requireNonNull(spreadAndCallCount.getRight());
+                int[] docDistribution = Objects.requireNonNull(spreadAndCallCount.getLeft());
                 int edge = groupSpec.docCount - docDistribution[0];
 
                 // validate content of partition 0 (original)
-                validateDocsInPartition(index, 0, groupSpec.groupTuple, Set.copyOf(primaryKeys.get(groupSpec.value).subList(edge, groupSpec.docCount)), luceneSearch);
+                validateDocsInPartition(index, 0, groupSpec.groupTuple, Set.copyOf(Objects.requireNonNull(primaryKeys.get(groupSpec.value)).subList(edge, groupSpec.docCount)), luceneSearch);
 
                 // validate content of rest of partitions
                 for (int i = docDistribution.length - 1; i > 0; i--) {
-                    validateDocsInPartition(index, i, groupSpec.groupTuple, Set.copyOf(primaryKeys.get(groupSpec.value).subList(edge - docDistribution[i], edge)), luceneSearch);
+                    validateDocsInPartition(index, i, groupSpec.groupTuple, Set.copyOf(Objects.requireNonNull(primaryKeys.get(groupSpec.value)).subList(edge - docDistribution[i], edge)), luceneSearch);
                     edge = edge - docDistribution[i];
                 }
             }
@@ -1281,7 +1294,7 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
         if (isSynthetic) {
             queryComponents.add(Query.field("complex").matches(Query.field("group").equalsParameter("group_value")));
             if (comparisonType != Type.NOT_EQUALS) {
-                queryComponents.add(Query.field("complex").matches(comparisonToQueryFunction.get(comparisonType).apply(Query.field(partitionFieldName), predicateComparand)));
+                queryComponents.add(Query.field("complex").matches(Objects.requireNonNull(comparisonToQueryFunction.get(comparisonType)).apply(Query.field(partitionFieldName), predicateComparand)));
             }
             if (luceneSearch != null) {
                 queryComponents.add(new LuceneQueryComponent(luceneSearch, List.of("simple_text")));
@@ -1300,7 +1313,7 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
         } else {
             queryComponents.add(Query.field("group").equalsParameter("group_value"));
             if (comparisonType != Type.NOT_EQUALS) {
-                queryComponents.add(comparisonToQueryFunction.get(comparisonType).apply(Query.field(partitionFieldName), predicateComparand));
+                queryComponents.add(Objects.requireNonNull(comparisonToQueryFunction.get(comparisonType)).apply(Query.field(partitionFieldName), predicateComparand));
             }
             if (luceneSearch != null) {
                 queryComponents.add(new LuceneQueryComponent(luceneSearch, List.of("text")));
@@ -1318,7 +1331,7 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
                     .build();
         }
 
-        LucenePlanner planner = new LucenePlanner(recordStore.getRecordMetaData(), recordStore.getRecordStoreState(), PlannableIndexTypes.DEFAULT, recordStore.getTimer());
+        LucenePlanner planner = new LucenePlanner(recordStore.getRecordMetaData(), recordStore.getRecordStoreState(), PlannableIndexTypes.DEFAULT, Objects.requireNonNull(recordStore.getTimer()));
         RecordQueryPlan plan = planner.plan(recordQuery);
         assertTrue(plan instanceof LuceneIndexQueryPlan);
         LuceneIndexQueryPlan luceneIndexQueryPlan = (LuceneIndexQueryPlan) plan;
@@ -1333,8 +1346,8 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
                 INDEX_PARTITION_BY_FIELD_NAME, isSynthetic ? "complex.timestamp" : "timestamp",
                 INDEX_PARTITION_HIGH_WATERMARK, String.valueOf(8));
         Pair<Index, Consumer<FDBRecordContext>> indexConsumerPair = setupIndex(options, true, isSynthetic);
-        final Index index = indexConsumerPair.getLeft();
-        Consumer<FDBRecordContext> schemaSetup = indexConsumerPair.getRight();
+        final Index index = Objects.requireNonNull(indexConsumerPair.getLeft());
+        Consumer<FDBRecordContext> schemaSetup = Objects.requireNonNull(indexConsumerPair.getRight());
 
         final RecordLayerPropertyStorage contextProps = RecordLayerPropertyStorage.newBuilder()
                 .addProp(LuceneRecordContextProperties.LUCENE_REPARTITION_DOCUMENT_COUNT, 8)
@@ -1379,8 +1392,8 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
                 INDEX_PARTITION_BY_FIELD_NAME, isSynthetic ? "complex.timestamp" : "timestamp",
                 INDEX_PARTITION_HIGH_WATERMARK, String.valueOf(8));
         Pair<Index, Consumer<FDBRecordContext>> indexConsumerPair = setupIndex(options, true, isSynthetic);
-        final Index index = indexConsumerPair.getLeft();
-        Consumer<FDBRecordContext> schemaSetup = indexConsumerPair.getRight();
+        final Index index = Objects.requireNonNull(indexConsumerPair.getLeft());
+        Consumer<FDBRecordContext> schemaSetup = Objects.requireNonNull(indexConsumerPair.getRight());
 
         final RecordLayerPropertyStorage contextProps = RecordLayerPropertyStorage.newBuilder()
                 .addProp(LuceneRecordContextProperties.LUCENE_REPARTITION_DOCUMENT_COUNT, 8)
@@ -1526,8 +1539,8 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
                 INDEX_PARTITION_BY_FIELD_NAME, isSynthetic ? "complex.timestamp" : "timestamp",
                 INDEX_PARTITION_HIGH_WATERMARK, String.valueOf(3));
         Pair<Index, Consumer<FDBRecordContext>> indexConsumerPair = setupIndex(options, true, isSynthetic);
-        final Index index = indexConsumerPair.getLeft();
-        Consumer<FDBRecordContext> schemaSetup = indexConsumerPair.getRight();
+        final Index index = Objects.requireNonNull(indexConsumerPair.getLeft());
+        Consumer<FDBRecordContext> schemaSetup = Objects.requireNonNull(indexConsumerPair.getRight());
 
         final RecordLayerPropertyStorage contextProps = RecordLayerPropertyStorage.newBuilder()
                 .addProp(LuceneRecordContextProperties.LUCENE_REPARTITION_DOCUMENT_COUNT, 8)
@@ -1650,8 +1663,8 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
                 INDEX_PARTITION_LOW_WATERMARK, String.valueOf(lowWatermark),
                 INDEX_PARTITION_HIGH_WATERMARK, String.valueOf(highWatermark));
         Pair<Index, Consumer<FDBRecordContext>> indexConsumerPair = setupIndex(options, true, isSynthetic);
-        final Index index = indexConsumerPair.getLeft();
-        Consumer<FDBRecordContext> schemaSetup = indexConsumerPair.getRight();
+        final Index index = Objects.requireNonNull(indexConsumerPair.getLeft());
+        Consumer<FDBRecordContext> schemaSetup = Objects.requireNonNull(indexConsumerPair.getRight());
 
         final RecordLayerPropertyStorage contextProps = RecordLayerPropertyStorage.newBuilder()
                 .addProp(LuceneRecordContextProperties.LUCENE_REPARTITION_DOCUMENT_COUNT, repartitionDocCount)
@@ -1817,8 +1830,8 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
                 INDEX_PARTITION_LOW_WATERMARK, String.valueOf(lowWatermark)
                 );
         Pair<Index, Consumer<FDBRecordContext>> indexConsumerPair = setupIndex(options, true, isSynthetic);
-        Index index = indexConsumerPair.getLeft();
-        Consumer<FDBRecordContext> schemaSetup = indexConsumerPair.getRight();
+        Index index = Objects.requireNonNull(indexConsumerPair.getLeft());
+        Consumer<FDBRecordContext> schemaSetup = Objects.requireNonNull(indexConsumerPair.getRight());
 
         final RecordLayerPropertyStorage contextProps = RecordLayerPropertyStorage.newBuilder()
                 .addProp(LuceneRecordContextProperties.LUCENE_REPARTITION_DOCUMENT_COUNT, repartitionCount)
@@ -1891,8 +1904,8 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
                 INDEX_PARTITION_BY_FIELD_NAME, isSynthetic ? "complex.timestamp" : "timestamp",
                 INDEX_PARTITION_HIGH_WATERMARK, String.valueOf(8));
         Pair<Index, Consumer<FDBRecordContext>> indexConsumerPair = setupIndex(options, true, isSynthetic);
-        final Index index = indexConsumerPair.getLeft();
-        Consumer<FDBRecordContext> schemaSetup = indexConsumerPair.getRight();
+        final Index index = Objects.requireNonNull(indexConsumerPair.getLeft());
+        Consumer<FDBRecordContext> schemaSetup = Objects.requireNonNull(indexConsumerPair.getRight());
 
         final RecordLayerPropertyStorage contextProps = RecordLayerPropertyStorage.newBuilder()
                 .addProp(LuceneRecordContextProperties.LUCENE_REPARTITION_DOCUMENT_COUNT, 8)
@@ -2019,7 +2032,7 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
                             assertTrue((sortType == SortType.ASCENDING && selectedPartitionInfo.getId() == 0)
                                     || selectedPartitionInfo.getId() == 3);
                         } else {
-                            assertEquals(startingPartitionExpectation.get(predicateComparand).get(comparisonType).get(sortType), selectedPartitionInfo == null ? -1 : selectedPartitionInfo.getId());
+                            assertEquals(Objects.requireNonNull(Objects.requireNonNull(startingPartitionExpectation.get(predicateComparand)).get(comparisonType)).get(sortType), selectedPartitionInfo == null ? -1 : selectedPartitionInfo.getId());
                         }
                     }
                 }
@@ -2602,7 +2615,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
                 rebuildIndexMetaData(context, SIMPLE_DOC, index);
                 recordStore.saveRecord(createSimpleDocument(1623L, ENGINEER_JOKE, 2));
                 recordStore.saveRecord(createSimpleDocument(1547L, ENGINEER_JOKE, 1));
-                recordStore.saveRecord(createSimpleDocument(1548L, ENGINEER_JOKE, null));
+                // Not using LuceneIndexTestUtils.createSimpleDocument(..., Integer group) here because that overload
+                // requires a non-null group, whereas this document intentionally has no group set.
+                recordStore.saveRecord(TestRecordsTextProto.SimpleDocument.newBuilder().setDocId(1548L).setText(ENGINEER_JOKE).build());
 
                 assertIndexEntryPrimaryKeys(Set.of(1623L),
                         recordStore.scanIndex(index, fullTextSearch(index, "\"propose a Vision\" AND group:2"), null, ScanProperties.FORWARD_SCAN));
@@ -3473,8 +3488,8 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
                 if (primaryKeySegmentIndexEnabled) {
                     // TODO: Is there a more stable way to check this?
-                    final LucenePrimaryKeySegmentIndex primaryKeySegmentIndex = getDirectory(index, Tuple.from())
-                            .getPrimaryKeySegmentIndex();
+                    final LucenePrimaryKeySegmentIndex primaryKeySegmentIndex = Objects.requireNonNull(getDirectory(index, Tuple.from())
+                            .getPrimaryKeySegmentIndex());
                     assertEquals(new ArrayList<>(Arrays.asList(
                                     new ArrayList<>(Arrays.asList(-1L, new ArrayList<>(Arrays.asList(3015L, 1000L)), new ArrayList<>(Arrays.asList(1000L)), "_q", 2)),
                                     new ArrayList<>(Arrays.asList(-1L, new ArrayList<>(Arrays.asList(3016L, 1001L)), new ArrayList<>(Arrays.asList(1001L)), "_q", 0)),
@@ -3495,7 +3510,12 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
                     var existenceCheck = i < 5
                                          ? FDBRecordStoreBase.RecordExistenceCheck.ERROR_IF_EXISTS
                                          : FDBRecordStoreBase.RecordExistenceCheck.ERROR_IF_NOT_EXISTS;
-                    final TestRecordsTextProto.SimpleDocument record = createSimpleDocument(1000L + i % 5, numbersText(i + 1), null);
+                    // Not using LuceneIndexTestUtils.createSimpleDocument(..., Integer group) here because that
+                    // overload requires a non-null group, whereas this document intentionally has no group set.
+                    final TestRecordsTextProto.SimpleDocument record = TestRecordsTextProto.SimpleDocument.newBuilder()
+                            .setDocId(1000L + i % 5)
+                            .setText(numbersText(i + 1))
+                            .build();
                     primaryKeys.add(recordStore.saveRecord(record, existenceCheck).getPrimaryKey());
                     context.commit();
                 }
@@ -3522,8 +3542,8 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
                 if (primaryKeySegmentIndexEnabled) {
                     // TODO: Is there a more stable way to check this?
-                    final LucenePrimaryKeySegmentIndex primaryKeySegmentIndex = getDirectory(index, Tuple.from())
-                            .getPrimaryKeySegmentIndex();
+                    final LucenePrimaryKeySegmentIndex primaryKeySegmentIndex = Objects.requireNonNull(getDirectory(index, Tuple.from())
+                            .getPrimaryKeySegmentIndex());
                     assertEquals(List.of(
                                     List.of(1000L, "_q", 2),
                                     List.of(1001L, "_q", 0),
@@ -3624,14 +3644,14 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
     void fullDeleteSegmentIndex(IndexedType indexedType) throws Exception {
         fullDeleteHelper(indexMaintainer -> {
-            final LucenePrimaryKeySegmentIndex primaryKeySegmentIndex1 = indexMaintainer
+            final LucenePrimaryKeySegmentIndex primaryKeySegmentIndex1 = Objects.requireNonNull(indexMaintainer
                     .getDirectory(Tuple.from(), null)
-                    .getPrimaryKeySegmentIndex();
+                    .getPrimaryKeySegmentIndex());
             assertEquals(List.of(), primaryKeySegmentIndex1.readAllEntries());
         }, indexMaintainer -> {
-            final LucenePrimaryKeySegmentIndex primaryKeySegmentIndex = indexMaintainer
+            final LucenePrimaryKeySegmentIndex primaryKeySegmentIndex = Objects.requireNonNull(indexMaintainer
                     .getDirectory(Tuple.from(), null)
-                    .getPrimaryKeySegmentIndex();
+                    .getPrimaryKeySegmentIndex());
             assertNotEquals(List.of(), primaryKeySegmentIndex.readAllEntries());
         },
                 indexedType);
@@ -5434,7 +5454,7 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
                     ))
                     .build();
 
-            LucenePlanner planner = new LucenePlanner(recordStore.getRecordMetaData(), recordStore.getRecordStoreState(), PlannableIndexTypes.DEFAULT, recordStore.getTimer());
+            LucenePlanner planner = new LucenePlanner(recordStore.getRecordMetaData(), recordStore.getRecordStoreState(), PlannableIndexTypes.DEFAULT, Objects.requireNonNull(recordStore.getTimer()));
             RecordQueryPlan plan = planner.plan(recordQuery);
             assertThat(plan, indexScan(allOf(
                     indexName(index.getName()),
@@ -5448,7 +5468,7 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
                     plan.execute(recordStore, EvaluationContext.forBinding("group_value", zeroGroupDoc.getGroup()))
                             .map(r -> {
                                 if (indexedType.isSynthetic()) {
-                                    return r.getConstituent("complex").getRecord();
+                                    return Objects.requireNonNull(r.getConstituent("complex")).getRecord();
                                 } else {
                                     return r.getRecord();
                                 }
@@ -5460,7 +5480,7 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
                     plan.execute(recordStore, EvaluationContext.forBinding("group_value", oneGroupDoc.getGroup()))
                             .map(r -> {
                                 if (indexedType.isSynthetic()) {
-                                    return r.getConstituent("complex").getRecord();
+                                    return Objects.requireNonNull(r.getConstituent("complex")).getRecord();
                                 } else {
                                     return r.getRecord();
                                 }
@@ -6006,7 +6026,7 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
         final Set<Long> allFieldInfos = assertDoesNotThrow(() -> directory.getFieldInfosStorage().getAllFieldInfos().keySet());
         int segmentCount = 0;
         for (String file : allFiles) {
-            final FDBLuceneFileReference fileReference = directory.getFDBLuceneFileReference(file);
+            final FDBLuceneFileReference fileReference = Objects.requireNonNull(directory.getFDBLuceneFileReference(file));
             if (FDBDirectory.isEntriesFile(file) || FDBDirectory.isSegmentInfo(file) || FDBDirectory.isFieldInfoFile(file)
                     || file.endsWith(".pky")) {
                 assertFalse(fileReference.getContent().isEmpty(), "fileName=" + file);
@@ -6035,7 +6055,7 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
         if (FDBDirectory.isFieldInfoFile(file) || FDBDirectory.isEntriesFile(file)) {
             assertNotEquals(0, fileReference.getFieldInfosId());
             assertNotEquals(ByteString.EMPTY, fileReference.getFieldInfosBitSet());
-            final LuceneFieldInfosProto.FieldInfos fieldInfos = assertDoesNotThrow(() -> directory.getFieldInfosStorage().readFieldInfos(fileReference.getFieldInfosId()));
+            final LuceneFieldInfosProto.FieldInfos fieldInfos = assertDoesNotThrow(() -> Objects.requireNonNull(directory.getFieldInfosStorage().readFieldInfos(fileReference.getFieldInfosId())));
             final BitSet bitSet = BitSet.valueOf(fileReference.getFieldInfosBitSet().toByteArray());
             final Set<Integer> fieldNumbers = fieldInfos.getFieldInfoList().stream()
                     .map(LuceneFieldInfosProto.FieldInfo::getNumber)
@@ -6187,7 +6207,7 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
     }
 
     private void rebuildIndexMetaData(final FDBRecordContext context, final String document, final Index index) {
-        Pair<FDBRecordStore, QueryPlanner> pair = LuceneIndexTestUtils.rebuildIndexMetaData(context, path, document, index, isUseCascadesPlanner());
+        Pair<FDBRecordStore, QueryPlanner> pair = LuceneIndexTestUtils.rebuildIndexMetaData(context, Objects.requireNonNull(path), document, index, isUseCascadesPlanner());
         this.recordStore = pair.getLeft();
         this.planner = pair.getRight();
         this.recordStore.getIndexDeferredMaintenanceControl().setAutoMergeDuringCommit(true);
@@ -6278,7 +6298,7 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     private void testConflictWithLockAgileSet(AgilityContext agile1, Tuple conflictTuple) {
         agile1.accept(aContext -> {
-            byte [] conflictKey = path.toSubspace(aContext).pack(conflictTuple);
+            byte [] conflictKey = Objects.requireNonNull(path).toSubspace(aContext).pack(conflictTuple);
             final Transaction tr = aContext.ensureActive();
             tr.get(conflictKey).join();
             tr.set(conflictKey, Tuple.from(100, 20).pack());
@@ -6287,7 +6307,7 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     private void testConflictWithLockCauseConflict(Tuple conflictTuple) {
         try (final FDBRecordContext context = fdb.openContext()) {
-            byte [] conflictKey = path.toSubspace(context).pack(conflictTuple);
+            byte [] conflictKey = Objects.requireNonNull(path).toSubspace(context).pack(conflictTuple);
             final Transaction tr = context.ensureActive();
             tr.get(conflictKey).join();
             tr.set(conflictKey, Tuple.from(100, 10).pack());

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
@@ -437,6 +437,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
     // ==================== PARTITIONED INDEX TESTS =====================
 
     @Test
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void basicGroupedPartitionedTest() {
         try (FDBRecordContext context = openContext()) {
             rebuildIndexMetaData(context, COMPLEX_DOC, COMPLEX_PARTITIONED);
@@ -469,6 +472,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
     }
 
     @Test
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void basicNonGroupedPartitionedTest() {
         try (FDBRecordContext context = openContext()) {
             rebuildIndexMetaData(context, COMPLEX_DOC, COMPLEX_PARTITIONED_NOGROUP);
@@ -914,6 +920,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest(name = "isGrouped: {0}, isSynthetic: {1}, with unique timestamps: {2}, sort type: {3}")
     @MethodSource
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void continuationDuringRepartitioningTest(boolean isGrouped,
                                               boolean isSynthetic,
                                               boolean uniqueTimestamps,
@@ -1531,6 +1540,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void functionalPartitionFieldPredicateTest(long seed) {
         Random random = new Random(seed);
         boolean isSynthetic = false;
@@ -1875,6 +1887,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
     }
 
     @Test
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void simpleCrossPartitionQuery() {
         try (FDBRecordContext context = openContext()) {
             rebuildIndexMetaData(context, COMPLEX_DOC, COMPLEX_PARTITIONED);
@@ -2044,6 +2059,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
      * test LIMIT spanning partitions.
      */
     @Test
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void testPartitionedLimit() {
         try (FDBRecordContext context = openContext()) {
             rebuildIndexMetaData(context, COMPLEX_DOC, COMPLEX_PARTITIONED);
@@ -2061,6 +2079,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
      * test SKIP spanning partitions.
      */
     @Test
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void testPartitionedSkip() {
         try (FDBRecordContext context = openContext()) {
             rebuildIndexMetaData(context, COMPLEX_DOC, COMPLEX_PARTITIONED);
@@ -2078,6 +2099,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
      * test skip with limit spanning partitions.
      */
     @Test
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void testPartitionedSkipWithLimit() {
         try (FDBRecordContext context = openContext()) {
             rebuildIndexMetaData(context, COMPLEX_DOC, COMPLEX_PARTITIONED);
@@ -2095,6 +2119,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
      * test limit with continuation spanning partitions.
      */
     @Test
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void testPartitionedLimitWithContinuation() throws ExecutionException, InterruptedException, InvalidProtocolBufferException {
         try (FDBRecordContext context = openContext()) {
             rebuildIndexMetaData(context, COMPLEX_DOC, COMPLEX_PARTITIONED);
@@ -2134,6 +2161,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
      * test cross partition limit query with multiple scans.
      */
     @Test
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void testPartitionedLimitNeedsMultipleScans() {
         try (FDBRecordContext context = openContext()) {
             rebuildIndexMetaData(context, COMPLEX_DOC, COMPLEX_PARTITIONED);
@@ -2153,6 +2183,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
      * test cross partition skip over max page size.
      */
     @Test
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void testPartitionedSkipOverMaxPageSize() {
         try (FDBRecordContext context = openContext()) {
             rebuildIndexMetaData(context, COMPLEX_DOC, COMPLEX_PARTITIONED);
@@ -2168,6 +2201,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
     }
 
     @Test
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void testPartitionedSorted() {
         try (FDBRecordContext context = openContext()) {
             rebuildIndexMetaData(context, COMPLEX_DOC, COMPLEX_PARTITIONED);
@@ -2276,6 +2312,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
     // ==================== NON-PARTITIONED TESTS =====================
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void simpleInsertAndSearch(IndexedType indexedType) {
         final Index index = indexedType.getIndex(SIMPLE_TEXT_SUFFIXES_KEY);
         try (FDBRecordContext context = openContext()) {
@@ -2301,6 +2340,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void largeMetadataTest(LuceneIndexTestUtils.IndexedType indexedType) {
         // Test a document with many fields, where the field metadata is larger than a data block
 
@@ -2335,6 +2377,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
      */
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void differentFieldSearch(IndexedType indexedType) {
         final Index index = indexedType.getIndex(MANY_FIELDS_INDEX_KEY);
         try (FDBRecordContext context = openContext()) {
@@ -2377,6 +2422,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
      */
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void differentFieldSearchNoOverlap(IndexedType indexedType) {
         final Index index = indexedType.getIndex(MANY_FIELDS_INDEX_KEY);
         try (FDBRecordContext context = openContext()) {
@@ -2424,6 +2472,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource({"specialCharacterParams"})
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void insertAndSearchWithSpecialCharacters(IndexedType indexedType, String specialCharacter) {
         final Index index = indexedType.getIndex(SIMPLE_TEXT_SUFFIXES_KEY);
         try (FDBRecordContext context = openContext()) {
@@ -2450,6 +2501,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void searchTextQueryWithBooleanEquals(IndexedType indexedType) {
         /*
          * Check that a point query on a number type and a text match together return the correct result
@@ -2479,6 +2533,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void searchTextQueryWithBooleanNotEquals(IndexedType indexedType) {
         /*
          * Check that a point query on a number type and a text match together return the correct result
@@ -2508,6 +2565,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void searchTextQueryWithBooleanRange(IndexedType indexedType) {
         /*
          * Check that a point query on a number type and a text match together return the correct result
@@ -2538,6 +2598,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void searchTextQueryWithBooleanBoth(IndexedType indexedType) {
         /*
          * Check that a point query on a number type and a text match together return the correct result
@@ -2567,6 +2630,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void searchTextQueryWithBooleanEither(IndexedType indexedType) {
         /*
          * Check that a point query on a number type and a text match together return the correct result
@@ -2597,6 +2663,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void searchTextQueryWithNumberEquals(IndexedType indexedType) {
         /*
          * Check that a point query on a number type and a text match together return the correct result
@@ -2630,6 +2699,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void searchTextWithEmailPrefix(IndexedType indexedType) {
         /*
          * Check that a prefix query with an email in it will return the email
@@ -2655,6 +2727,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void searchTextQueryWithNumberRange(IndexedType indexedType) {
         /*
          * Check that a range query on a number type and a text match together return the correct result
@@ -2684,6 +2759,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void searchTextWithNumberRangeInfinite(IndexedType indexedType) {
         /*
          * Check that a range query returns empty if you feed it a range that is logically empty (i.e. (Long.MAX_VALUE,...)
@@ -2746,6 +2824,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource("bitsetParams")
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void bitset(IndexedType indexedType, int mask, List<Long> expectedResult, Set<Tuple> syntheticExpectedResult) {
         /*
          * Check that a bitset_contains query returns the right result given a certain mask
@@ -2823,6 +2904,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource("bitsetOrParams")
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void bitsetOr(IndexedType indexedType, int mask1, int mask2, List<Long> expectedResult, Set<Tuple> syntheticExpectedResult) {
         /*
          * Check that a bitset_contains query returns the right result given a certain mask
@@ -2859,6 +2943,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void simpleEmptyIndex(IndexedType indexedType) {
         final Index index = indexedType.getIndex(SIMPLE_TEXT_SUFFIXES_KEY);
         try (FDBRecordContext context = openContext()) {
@@ -2875,6 +2962,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void simpleEmptyAutoComplete(IndexedType indexedType) {
         final Index index = indexedType.getIndex(SIMPLE_TEXT_WITH_AUTO_COMPLETE_KEY);
         try (FDBRecordContext context = openContext()) {
@@ -2893,6 +2983,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void simpleInsertAndSearchNumFDBFetches(IndexedType indexedType) {
         final Index index = indexedType.getIndex(SIMPLE_TEXT_SUFFIXES_KEY);
         try (FDBRecordContext context = openContext()) {
@@ -2954,6 +3047,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void testNullValue(IndexedType indexedType) {
         final Index index = indexedType.getIndex(SIMPLE_TEXT_SUFFIXES_KEY);
         try (FDBRecordContext context = openContext()) {
@@ -2980,6 +3076,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void testLimit(IndexedType indexedType) {
         final Index index = indexedType.getIndex(SIMPLE_TEXT_SUFFIXES_KEY);
         try (FDBRecordContext context = openContext()) {
@@ -3004,6 +3103,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void testSkip(IndexedType indexedType) {
         final Index index = indexedType.getIndex(SIMPLE_TEXT_SUFFIXES_KEY);
         try (FDBRecordContext context = openContext()) {
@@ -3028,6 +3130,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void testSkipWithLimit(IndexedType indexedType) {
         final Index index = indexedType.getIndex(SIMPLE_TEXT_SUFFIXES_KEY);
         try (FDBRecordContext context = openContext()) {
@@ -3081,6 +3186,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void testLimitNeedsMultipleScans(IndexedType indexedType) {
         final RecordLayerPropertyStorage.Builder storageBuilder = RecordLayerPropertyStorage.newBuilder()
                 .addProp(LuceneRecordContextProperties.LUCENE_INDEX_CURSOR_PAGE_SIZE, 201);
@@ -3110,6 +3218,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void testSkipOverMultipleScans(IndexedType indexedType) {
         final RecordLayerPropertyStorage.Builder storageBuilder = RecordLayerPropertyStorage.newBuilder()
                 .addProp(LuceneRecordContextProperties.LUCENE_INDEX_CURSOR_PAGE_SIZE, 201);
@@ -3140,6 +3251,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void testNestedFieldSearch(IndexedType indexedType) {
         final Index index = indexedType.getIndex(MAP_ON_VALUE_INDEX_KEY);
         try (FDBRecordContext context = openContext()) {
@@ -3173,6 +3287,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void testGroupedRecordSearch(IndexedType indexedType) {
         final Index index = indexedType.getIndex(MAP_ON_VALUE_INDEX_KEY);
         try (FDBRecordContext context = openContext()) {
@@ -3204,6 +3321,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void testMultipleFieldSearch(IndexedType indexedType) {
         final Index index = indexedType.getIndex(COMPLEX_MULTIPLE_TEXT_INDEXES_KEY);
         try (FDBRecordContext context = openContext()) {
@@ -3227,6 +3347,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void testFuzzySearchWithDefaultEdit2(IndexedType indexedType) {
         final Index index = indexedType.getIndex(COMPLEX_MULTIPLE_TEXT_INDEXES_KEY);
         try (FDBRecordContext context = openContext()) {
@@ -3251,6 +3374,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void simpleInsertDeleteAndSearch(IndexedType indexedType) {
         final Index index = indexedType.getIndex(SIMPLE_TEXT_SUFFIXES_KEY);
         try (FDBRecordContext context = openContext()) {
@@ -3284,6 +3410,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void simpleInsertAndSearchSingleTransaction(IndexedType indexedType) {
         final Index index = indexedType.getIndex(SIMPLE_TEXT_SUFFIXES_KEY);
         try {
@@ -3316,6 +3445,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void testCommit(IndexedType indexedType) {
         Index index = indexedType.getIndex(SIMPLE_TEXT_SUFFIXES_KEY);
         Tuple primaryKey1 = null;
@@ -3355,6 +3487,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void testRollback(IndexedType indexedType) {
         final Index index = indexedType.getIndex(SIMPLE_TEXT_SUFFIXES_KEY);
         Tuple primaryKey1;
@@ -3446,6 +3581,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource("primaryKeySegmentIndexEnabledParams")
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void testSimpleUpdate(IndexedType indexedType, boolean primaryKeySegmentIndexEnabled) throws IOException {
         final Index index = indexedType.getIndex(primaryKeySegmentIndexEnabled ? SIMPLE_TEXT_SUFFIXES_WITH_PRIMARY_KEY_SEGMENT_INDEX_KEY : SIMPLE_TEXT_SUFFIXES_KEY);
         final RecordLayerPropertyStorage contextProps = RecordLayerPropertyStorage.newBuilder()
@@ -3561,6 +3699,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void simpleDeleteSegmentIndex(IndexedType indexedType) {
         final Index index = indexedType.getIndex(SIMPLE_TEXT_SUFFIXES_WITH_PRIMARY_KEY_SEGMENT_INDEX_KEY);
         final RecordLayerPropertyStorage contextProps = RecordLayerPropertyStorage.newBuilder()
@@ -3892,6 +4033,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void testGroupedMultipleUpdate(IndexedType indexedType) {
         final Index index = indexedType.getIndex(COMPLEX_GROUPED_WITH_PRIMARY_KEY_SEGMENT_INDEX_KEY);
         final RecordLayerPropertyStorage contextProps = RecordLayerPropertyStorage.newBuilder()
@@ -3982,6 +4126,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void scanWithQueryOnlySynonymIndex(IndexedType indexedType) {
         final Index index = indexedType.getIndex(QUERY_ONLY_SYNONYM_LUCENE_INDEX_KEY);
         try (FDBRecordContext context = openContext()) {
@@ -4031,6 +4178,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void scanWithAuthoritativeSynonymOnlyIndex(IndexedType indexedType) {
         final Index index = indexedType.getIndex(AUTHORITATIVE_SYNONYM_ONLY_LUCENE_INDEX_KEY);
         try (FDBRecordContext context = openContext()) {
@@ -4086,6 +4236,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void phraseSearchBasedOnQueryOnlySynonymIndex(IndexedType indexedType) {
         final Index index = indexedType.getIndex(QUERY_ONLY_SYNONYM_LUCENE_INDEX_KEY);
         try (FDBRecordContext context = openContext()) {
@@ -4185,6 +4338,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void phraseSearchBasedOnAuthoritativeSynonymOnlyIndex(IndexedType indexedType) {
         final Index index = indexedType.getIndex(AUTHORITATIVE_SYNONYM_ONLY_LUCENE_INDEX_KEY);
         try (FDBRecordContext context = openContext()) {
@@ -4323,6 +4479,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void scanWithCombinedSetsSynonymIndex(IndexedType indexedType) {
         // The COMBINED_SYNONYM_SETS adds this extra line to our synonym set:
         // 'synonym', 'nonsynonym'
@@ -4353,6 +4512,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void proximitySearchOnMultiFieldWithMultiWordSynonym(IndexedType indexedType) {
         final Index index = indexedType.getIndex(QUERY_ONLY_SYNONYM_LUCENE_INDEX_KEY);
         try (FDBRecordContext context = openContext()) {
@@ -4376,6 +4538,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void proximitySearchOnSpecificFieldWithMultiWordSynonym(IndexedType indexedType) {
         final Index index = indexedType.getIndex(QUERY_ONLY_SYNONYM_LUCENE_INDEX_KEY);
         try (FDBRecordContext context = openContext()) {
@@ -4397,6 +4562,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
     }
 
     @Test
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void scanWithNgramIndex() {
         try (FDBRecordContext context = openContext()) {
             rebuildIndexMetaData(context, SIMPLE_DOC, NGRAM_LUCENE_INDEX);
@@ -4445,6 +4613,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
      */
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void searchForAutoCompleteWithLoadingNoRecords(IndexedType indexedType) {
         final Index index = indexedType.getIndex(SIMPLE_TEXT_WITH_AUTO_COMPLETE_KEY);
         try (FDBRecordContext context = openContext()) {
@@ -4465,9 +4636,12 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
         }
     }
 
-    @SuppressWarnings("UnstableApiUsage")
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex/executeQuery (and, in one case,
+    // Tuple.from(null, ...)); NullAway does not reliably recognize @Nullable on the array (byte[])
+    // continuation parameter, and Tuple.from is an unannotated external API.
+    @SuppressWarnings({"UnstableApiUsage", "NullAway"})
     void searchForAutoCompleteAcrossMultipleFields(IndexedType indexedType) throws Exception {
         final Index index = indexedType.getIndex(COMPLEX_MULTIPLE_TEXT_INDEXES_WITH_AUTO_COMPLETE_KEY);
         try (FDBRecordContext context = openContext()) {
@@ -4571,6 +4745,10 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex/executeQuery (and, in one case,
+    // Tuple.from(null, ...)); NullAway does not reliably recognize @Nullable on the array (byte[])
+    // continuation parameter, and Tuple.from is an unannotated external API.
+    @SuppressWarnings("NullAway")
     void searchForAutoCompleteWithContinueTyping(IndexedType indexedType) throws Exception {
         final Index index = indexedType.getIndex(SIMPLE_TEXT_WITH_AUTO_COMPLETE_KEY);
         try (FDBRecordContext context = openContext()) {
@@ -4621,6 +4799,10 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex/executeQuery (and, in one case,
+    // Tuple.from(null, ...)); NullAway does not reliably recognize @Nullable on the array (byte[])
+    // continuation parameter, and Tuple.from is an unannotated external API.
+    @SuppressWarnings("NullAway")
     void searchForAutoCompleteForGroupedRecord(IndexedType indexedType) throws Exception {
         final Index index = indexedType.getIndex(MAP_ON_VALUE_INDEX_WITH_AUTO_COMPLETE_KEY);
         try (FDBRecordContext context = openContext()) {
@@ -4684,6 +4866,10 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex/executeQuery (and, in one case,
+    // Tuple.from(null, ...)); NullAway does not reliably recognize @Nullable on the array (byte[])
+    // continuation parameter, and Tuple.from is an unannotated external API.
+    @SuppressWarnings("NullAway")
     void searchForAutoCompleteExcludedFieldsForGroupedRecord(IndexedType indexedType) throws Exception {
         final Index index = indexedType.getIndex(MAP_ON_VALUE_INDEX_WITH_AUTO_COMPLETE_EXCLUDED_FIELDS_KEY);
         try (FDBRecordContext context = openContext()) {
@@ -4867,6 +5053,10 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex/executeQuery (and, in one case,
+    // Tuple.from(null, ...)); NullAway does not reliably recognize @Nullable on the array (byte[])
+    // continuation parameter, and Tuple.from is an unannotated external API.
+    @SuppressWarnings("NullAway")
     void testAutoCompleteSearchMultipleResultsSingleDocument(IndexedType indexedType) throws Exception {
         final Index index = indexedType.getIndex(COMPLEX_MULTIPLE_TEXT_INDEXES_WITH_AUTO_COMPLETE_KEY);
         try (FDBRecordContext context = openContext()) {
@@ -5113,6 +5303,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void searchForSpellCheck(IndexedType indexedType) throws Exception {
         final Index index = indexedType.getIndex(SPELLCHECK_INDEX_KEY);
         try (FDBRecordContext context = openContext()) {
@@ -5159,6 +5352,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void searchForSpellcheckForGroupedRecord(IndexedType indexedType) throws Exception {
         final Index index = indexedType.getIndex(MAP_ON_VALUE_INDEX_KEY);
         try (FDBRecordContext context = openContext()) {
@@ -5207,6 +5403,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
         }
     }
 
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     private void spellCheckHelper(final Index index, String query, List<Pair<String, String>> expectedSuggestions) throws ExecutionException, InterruptedException {
         List<IndexEntry> suggestions = recordStore.scanIndex(index,
                 spellCheck(index, query),
@@ -5516,6 +5715,10 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex/executeQuery (and, in one case,
+    // Tuple.from(null, ...)); NullAway does not reliably recognize @Nullable on the array (byte[])
+    // continuation parameter, and Tuple.from is an unannotated external API.
+    @SuppressWarnings("NullAway")
     void testDeleteWhereAutoComplete(IndexedType indexedType) throws Exception {
         final Index index = indexedType.getIndex(COMPLEX_MULTI_GROUPED_WITH_AUTO_COMPLETE_KEY);
         final String groupField = indexedType.isSynthetic() ? "score" : "group";
@@ -5641,6 +5844,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
     }
 
     @Test
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void analyzerPerField() {
         try (FDBRecordContext context = openContext()) {
             rebuildIndexMetaData(context, COMPLEX_DOC, MULTIPLE_ANALYZER_LUCENE_INDEX);
@@ -5662,6 +5868,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void testSimpleAutoComplete(IndexedType indexedType) {
         final Index index = indexedType.getIndex(AUTO_COMPLETE_SIMPLE_LUCENE_INDEX_KEY);
         try (FDBRecordContext context = openContext()) {
@@ -5683,6 +5892,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void basicLuceneCursorTest(IndexedType indexedType) {
         final Index index = indexedType.getIndex(SIMPLE_TEXT_SUFFIXES_KEY);
         try (FDBRecordContext context = openContext()) {
@@ -5710,6 +5922,10 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex/executeQuery (and, in one case,
+    // Tuple.from(null, ...)); NullAway does not reliably recognize @Nullable on the array (byte[])
+    // continuation parameter, and Tuple.from is an unannotated external API.
+    @SuppressWarnings("NullAway")
     void luceneCursorTestWithMultiplePages(IndexedType indexedType) throws Exception {
         final Index index = indexedType.getIndex(SIMPLE_TEXT_SUFFIXES_KEY);
         // Configure page size as 10
@@ -5745,6 +5961,10 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex/executeQuery (and, in one case,
+    // Tuple.from(null, ...)); NullAway does not reliably recognize @Nullable on the array (byte[])
+    // continuation parameter, and Tuple.from is an unannotated external API.
+    @SuppressWarnings("NullAway")
     void luceneCursorTestWith3rdPage(IndexedType indexedType) throws Exception {
         final Index index = indexedType.getIndex(SIMPLE_TEXT_SUFFIXES_KEY);
         // Configure page size as 10
@@ -5780,6 +6000,10 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex/executeQuery (and, in one case,
+    // Tuple.from(null, ...)); NullAway does not reliably recognize @Nullable on the array (byte[])
+    // continuation parameter, and Tuple.from is an unannotated external API.
+    @SuppressWarnings("NullAway")
     void luceneCursorTestWithMultiplePagesWithSkip(IndexedType indexedType) throws Exception {
         final Index index = indexedType.getIndex(SIMPLE_TEXT_SUFFIXES_KEY);
         // Configure page size as 10
@@ -5816,6 +6040,10 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex/executeQuery (and, in one case,
+    // Tuple.from(null, ...)); NullAway does not reliably recognize @Nullable on the array (byte[])
+    // continuation parameter, and Tuple.from is an unannotated external API.
+    @SuppressWarnings("NullAway")
     void luceneCursorTestWithLimit(IndexedType indexedType) throws Exception {
         final Index index = indexedType.getIndex(SIMPLE_TEXT_SUFFIXES_KEY);
         // Configure page size as 10
@@ -5872,6 +6100,10 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex/executeQuery (and, in one case,
+    // Tuple.from(null, ...)); NullAway does not reliably recognize @Nullable on the array (byte[])
+    // continuation parameter, and Tuple.from is an unannotated external API.
+    @SuppressWarnings("NullAway")
     void luceneCursorTestWithLimitAndSkip(IndexedType indexedType) throws Exception {
         final Index index = indexedType.getIndex(SIMPLE_TEXT_SUFFIXES_KEY);
         // Configure page size as 10
@@ -5934,6 +6166,10 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource(LUCENE_INDEX_MAP_PARAMS)
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex/executeQuery (and, in one case,
+    // Tuple.from(null, ...)); NullAway does not reliably recognize @Nullable on the array (byte[])
+    // continuation parameter, and Tuple.from is an unannotated external API.
+    @SuppressWarnings("NullAway")
     void luceneCursorTestAllMatchesSkipped(IndexedType indexedType) throws Exception {
         final Index index = indexedType.getIndex(SIMPLE_TEXT_SUFFIXES_KEY);
         // Configure page size as 10
@@ -5971,6 +6207,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     @ParameterizedTest
     @MethodSource("primaryKeySegmentIndexEnabledParams")
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void manySegmentsParallelOpen(IndexedType indexedType, boolean primaryKeySegmentIndexEnabled) throws IOException {
         final Index index = indexedType.getIndex(primaryKeySegmentIndexEnabled ? SIMPLE_TEXT_SUFFIXES_WITH_PRIMARY_KEY_SEGMENT_INDEX_KEY : SIMPLE_TEXT_SUFFIXES_KEY);
         for (int i = 0; i < 20; i++) {
@@ -6074,6 +6313,10 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
         return fileReference.getFieldInfosId();
     }
 
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex/executeQuery (and, in one case,
+    // Tuple.from(null, ...)); NullAway does not reliably recognize @Nullable on the array (byte[])
+    // continuation parameter, and Tuple.from is an unannotated external API.
+    @SuppressWarnings("NullAway")
     private void searchForAutoCompleteAndAssert(IndexedType indexedType, String query, boolean matches, boolean highlight, int planHash) throws Exception {
         final Index index = indexedType.getIndex(SIMPLE_TEXT_WITH_AUTO_COMPLETE_KEY);
         try (FDBRecordContext context = openContext()) {
@@ -6173,7 +6416,10 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
         }
     }
 
-    @SuppressWarnings("UnusedReturnValue")
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex/executeQuery (and, in one case,
+    // Tuple.from(null, ...)); NullAway does not reliably recognize @Nullable on the array (byte[])
+    // continuation parameter, and Tuple.from is an unannotated external API.
+    @SuppressWarnings({"UnusedReturnValue", "NullAway"})
     private void queryAndAssertAutoCompleteSuggestionsReturned(Index index, boolean isSynthetic, @Nullable String queriedConstituent, List<KeyExpression> storedFields,
                                                                String queriedField,
                                                                String searchKey, List<String> expectedSuggestions) throws Exception {
@@ -6208,8 +6454,10 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
 
     private void rebuildIndexMetaData(final FDBRecordContext context, final String document, final Index index) {
         Pair<FDBRecordStore, QueryPlanner> pair = LuceneIndexTestUtils.rebuildIndexMetaData(context, Objects.requireNonNull(path), document, index, isUseCascadesPlanner());
-        this.recordStore = pair.getLeft();
-        this.planner = pair.getRight();
+        // Pair#getLeft/getRight are @Nullable in general (a Pair may hold nulls), but
+        // rebuildIndexMetaData always constructs its result from the non-null store/planner it builds.
+        this.recordStore = Objects.requireNonNull(pair.getLeft());
+        this.planner = Objects.requireNonNull(pair.getRight());
         this.recordStore.getIndexDeferredMaintenanceControl().setAutoMergeDuringCommit(true);
     }
 

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTest.java
@@ -110,8 +110,7 @@ import org.opentest4j.AssertionFailedError;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.SequenceInputStream;
@@ -314,7 +313,6 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
             INDEX_PARTITION_BY_FIELD_NAME, "complex.timestamp",
             INDEX_PARTITION_HIGH_WATERMARK, "10"));
 
-    @Nonnull
     private static Index getJoinedIndexNoGroup(final Map<String, String> options) {
         return new Index("joinNestedConcat",
                 concat(
@@ -329,7 +327,7 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
     private long timestamp29DaysAgo;
     private long yesterday;
 
-    private static Index getMapOnValueIndexWithOption(@Nonnull String name, @Nonnull ImmutableMap<String, String> options) {
+    private static Index getMapOnValueIndexWithOption(String name, ImmutableMap<String, String> options) {
         return new Index(
                 name,
                 new GroupingKeyExpression(field("entry", KeyExpression.FanType.FanOut).nest(concat(keys)), 3),
@@ -381,33 +379,29 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
         return scan.bind(recordStore, index, EvaluationContext.EMPTY);
     }
 
-    @Nonnull
     @SuppressWarnings("unused")
-    private LuceneScanBounds groupedAutoCompleteBounds(@Nonnull final Index index, @Nonnull final String search,
-                                                       @Nonnull final Object group, @Nonnull final Iterable<String> fields) {
+    private LuceneScanBounds groupedAutoCompleteBounds(final Index index, final String search,
+                                                       final Object group, final Iterable<String> fields) {
         LuceneScanParameters scan = groupedAutoCompleteScanParams(search, group, fields);
         return scan.bind(recordStore, index, EvaluationContext.EMPTY);
     }
 
-    @Nonnull
-    protected static LuceneScanParameters groupedAutoCompleteScanParams(@Nonnull final String search,
-                                                                        @Nonnull final Object group,
-                                                                        @Nonnull final Iterable<String> fields) {
+    protected static LuceneScanParameters groupedAutoCompleteScanParams(final String search,
+                                                                        final Object group,
+                                                                        final Iterable<String> fields) {
         return new LuceneScanQueryParameters(
                 Verify.verifyNotNull(ScanComparisons.from(new Comparisons.SimpleComparison(Comparisons.Type.EQUALS, group))),
                 new LuceneAutoCompleteQueryClause(search, false, fields));
     }
 
-    @Nonnull
-    private LuceneScanBounds autoCompleteBounds(@Nonnull final Index index, @Nonnull final String search,
-                                                @Nonnull final Iterable<String> fields) {
+    private LuceneScanBounds autoCompleteBounds(final Index index, final String search,
+                                                final Iterable<String> fields) {
         LuceneScanParameters scan = autoCompleteScanParams(search, fields);
         return scan.bind(recordStore, index, EvaluationContext.EMPTY);
     }
 
-    @Nonnull
-    private LuceneScanParameters autoCompleteScanParams(@Nonnull final String search,
-                                                        @Nonnull final Iterable<String> fields) {
+    private LuceneScanParameters autoCompleteScanParams(final String search,
+                                                        final Iterable<String> fields) {
         return new LuceneScanQueryParameters(
                 Verify.verifyNotNull(ScanComparisons.EMPTY),
                 new LuceneAutoCompleteQueryClause(search, false, fields));
@@ -816,15 +810,15 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
         }
     }
 
-    private static void joinedPartitionedLuceneIndexMetadataHook(@Nonnull final RecordMetaDataBuilder metaDataBuilder) {
+    private static void joinedPartitionedLuceneIndexMetadataHook(final RecordMetaDataBuilder metaDataBuilder) {
         metaDataBuilder.addIndex(joinedMetadataHook(metaDataBuilder), JOINED_INDEX);
     }
 
-    private static void joinedPartitionedUngroupedLuceneIndexMetadataHook(@Nonnull final RecordMetaDataBuilder metaDataBuilder) {
+    private static void joinedPartitionedUngroupedLuceneIndexMetadataHook(final RecordMetaDataBuilder metaDataBuilder) {
         metaDataBuilder.addIndex(joinedMetadataHook(metaDataBuilder), JOINED_INDEX_NOGROUP);
     }
 
-    private static JoinedRecordTypeBuilder joinedMetadataHook(@Nonnull final RecordMetaDataBuilder metaDataBuilder) {
+    private static JoinedRecordTypeBuilder joinedMetadataHook(final RecordMetaDataBuilder metaDataBuilder) {
         //set up the joined index
         final JoinedRecordTypeBuilder joined = metaDataBuilder.addJoinedRecordType("luceneJoinedPartitionedIdx");
         joined.addConstituent("complex", "ComplexDocument");
@@ -2411,7 +2405,6 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
                         param2 -> Arguments.of(indexedType, param2)));
     }
 
-    @Nonnull
     private String specialCharacterText(String specialCharacter) {
         return "Do we match special characters like " + specialCharacter + ", even when its mashed together like " + specialCharacter + "noSpaces?";
     }
@@ -3644,7 +3637,6 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
                 indexedType);
     }
 
-    @Nonnull
     private Index fullDeleteHelper(final TestHelpers.DangerousConsumer<LuceneIndexMaintainer> assertEmpty,
                                    final TestHelpers.DangerousConsumer<LuceneIndexMaintainer> assertNotEmpty,
                                    final IndexedType indexedType) throws Exception {
@@ -3760,7 +3752,7 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
                 indexedType);
     }
 
-    private static @Nonnull String listAll(final LuceneIndexMaintainer indexMaintainer) {
+    private static String listAll(final LuceneIndexMaintainer indexMaintainer) {
         try {
             return String.join(", ", indexMaintainer.getDirectory(Tuple.from(), null).listAll());
         } catch (IOException e) {
@@ -5195,7 +5187,7 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
         }
     }
 
-    private void spellCheckHelper(final Index index, @Nonnull String query, List<Pair<String, String>> expectedSuggestions) throws ExecutionException, InterruptedException {
+    private void spellCheckHelper(final Index index, String query, List<Pair<String, String>> expectedSuggestions) throws ExecutionException, InterruptedException {
         List<IndexEntry> suggestions = recordStore.scanIndex(index,
                 spellCheck(index, query),
                 null,
@@ -5991,11 +5983,11 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
         }
     }
 
-    private static void assertAutoCompleteEntriesAndSegmentInfoStoredInCompoundFile(Index index, @Nonnull Subspace subspace, @Nonnull FDBRecordContext context, @Nonnull String segment) {
+    private static void assertAutoCompleteEntriesAndSegmentInfoStoredInCompoundFile(Index index, Subspace subspace, FDBRecordContext context, String segment) {
         validateSegmentAndIndexIntegrity(index, subspace, context, segment);
     }
 
-    private static void validateSegmentAndIndexIntegrity(Index index, @Nonnull Subspace subspace, @Nonnull FDBRecordContext context, @Nonnull String segmentFile) {
+    private static void validateSegmentAndIndexIntegrity(Index index, Subspace subspace, FDBRecordContext context, String segmentFile) {
         try (final FDBDirectory directory = new FDBDirectory(subspace, context, index.getOptions())) {
             final FDBLuceneFileReference reference = directory.getFDBLuceneFileReference(segmentFile);
             assertNotNull(reference);
@@ -6007,7 +5999,7 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
         }
     }
 
-    private static void validateIndexIntegrity(Index index, @Nonnull Subspace subspace, @Nonnull FDBRecordContext context, @Nullable FDBDirectory fdbDirectory, @Nullable String segmentName) throws IOException {
+    private static void validateIndexIntegrity(Index index, Subspace subspace, FDBRecordContext context, @Nullable FDBDirectory fdbDirectory, @Nullable String segmentName) throws IOException {
         final FDBDirectory directory = fdbDirectory == null ? new FDBDirectory(subspace, context, index.getOptions()) : fdbDirectory;
         String[] allFiles = directory.listAll();
         Set<Long> usedFieldInfos = new HashSet<>();
@@ -6143,7 +6135,7 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
             "There is a country called Armenia"
     );
 
-    private void addIndexAndSaveRecordForAutoComplete(@Nonnull FDBRecordContext context, Index index, boolean isSynthetic, List<String> autoCompletes) {
+    private void addIndexAndSaveRecordForAutoComplete(FDBRecordContext context, Index index, boolean isSynthetic, List<String> autoCompletes) {
         if (isSynthetic) {
             openRecordStore(context, metaDataBuilder -> metaDataHookSyntheticRecordComplexJoinedToSimple(metaDataBuilder, index));
             for (int i = 0; i < autoCompletes.size(); i++) {
@@ -6162,9 +6154,9 @@ public class LuceneIndexTest extends FDBLuceneTestBase {
     }
 
     @SuppressWarnings("UnusedReturnValue")
-    private void queryAndAssertAutoCompleteSuggestionsReturned(@Nonnull Index index, boolean isSynthetic, @Nullable String queriedConstituent, @Nonnull List<KeyExpression> storedFields,
-                                                               @Nonnull String queriedField,
-                                                               @Nonnull String searchKey, @Nonnull List<String> expectedSuggestions) throws Exception {
+    private void queryAndAssertAutoCompleteSuggestionsReturned(Index index, boolean isSynthetic, @Nullable String queriedConstituent, List<KeyExpression> storedFields,
+                                                               String queriedField,
+                                                               String searchKey, List<String> expectedSuggestions) throws Exception {
         final RecordQueryPlan luceneIndexPlan =
                 LuceneIndexQueryPlan.of(index.getName(),
                         autoCompleteScanParams(searchKey, ImmutableSet.of(isSynthetic ? queriedConstituent + "_" + queriedField : queriedField)),

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTestDataModel.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTestDataModel.java
@@ -46,8 +46,7 @@ import com.apple.foundationdb.record.test.TestKeySpacePathManagerExtension;
 import com.apple.foundationdb.tuple.Tuple;
 import com.google.protobuf.Message;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -98,8 +97,8 @@ public class LuceneIndexTestDataModel {
     private long start;
     private boolean reverseSaveOrder = false;
 
-    private LuceneIndexTestDataModel(@Nonnull final Builder builder,
-                                     @Nonnull final Function<FDBRecordContext, FDBRecordStore> schemaSetup) {
+    private LuceneIndexTestDataModel(final Builder builder,
+                                     final Function<FDBRecordContext, FDBRecordStore> schemaSetup) {
         random = builder.random;
         textGenerator = builder.textGenerator;
         isGrouped = builder.isGrouped;
@@ -152,7 +151,6 @@ public class LuceneIndexTestDataModel {
         return returnValue;
     }
 
-    @Nonnull
     public FDBRecordStore createOrOpenRecordStore(final FDBRecordContext context) {
         return Objects.requireNonNull(schemaSetup.apply(context));
     }
@@ -163,7 +161,7 @@ public class LuceneIndexTestDataModel {
     }
 
     void saveManyRecords(final int minDocumentCount,
-                         @Nonnull final Supplier<FDBRecordContext> openContext,
+                         final Supplier<FDBRecordContext> openContext,
                          final int transactionCount) {
         final long start = Instant.now().toEpochMilli();
         int i = 0;
@@ -256,7 +254,6 @@ public class LuceneIndexTestDataModel {
                 });
     }
 
-    @Nonnull
     private static Tuple createSyntheticPrimaryKey(final FDBRecordStore recordStore, final Tuple parentPrimaryKey, final Tuple childPrimaryKey) {
         final Tuple syntheticRecordTypeKey = recordStore.getRecordMetaData()
                 .getSyntheticRecordType("JoinChildren")
@@ -266,7 +263,6 @@ public class LuceneIndexTestDataModel {
                 childPrimaryKey.getItems());
     }
 
-    @Nonnull
     private CompletableFuture<Tuple> saveParentRecord(final boolean withContent, final FDBRecordStore recordStore,
                                                       final int group, final int uniqueCounter, final long timestamp) {
         var parentBuilder = TestRecordsGroupedParentChildProto.MyParentRecord.newBuilder()
@@ -285,7 +281,6 @@ public class LuceneIndexTestDataModel {
     }
 
 
-    @Nonnull
     private CompletableFuture<Tuple> saveChildRecord(final boolean withContent, final FDBRecordStore recordStore, final int group, final int countInGroup) {
         var childBuilder = TestRecordsGroupedParentChildProto.MyChildRecord.newBuilder()
                 .setGroup(group)
@@ -321,7 +316,6 @@ public class LuceneIndexTestDataModel {
         return validator;
     }
 
-    @Nonnull
     static Index addIndex(final boolean isSynthetic, final KeyExpression rootExpression,
                           final Map<String, String> options, final RecordMetaDataBuilder metaDataBuilder,
                           @Nullable IndexPredicate predicate) {
@@ -343,7 +337,6 @@ public class LuceneIndexTestDataModel {
         return index;
     }
 
-    @Nonnull
     static KeyExpression createRootExpression(final boolean isGrouped, final boolean isSynthetic) {
         ThenKeyExpression baseExpression;
         KeyExpression groupingExpression;
@@ -380,12 +373,10 @@ public class LuceneIndexTestDataModel {
         return rootExpression;
     }
 
-    @Nonnull
     static Tuple calculateGroupTuple(final boolean isGrouped, final int group) {
         return isGrouped ? Tuple.from(group) : Tuple.from();
     }
 
-    @Nonnull
     static RecordMetaDataBuilder createBaseMetaDataBuilder() {
         RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder()
                 .setRecords(TestRecordsGroupedParentChildProto.getDescriptor());
@@ -416,7 +407,7 @@ public class LuceneIndexTestDataModel {
      * @param groupingKey the grouping key for the partition, or {@code null} for non-grouped indexes
      * @param partitionId the partition id, or {@code null} for non-partitioned indexes
      */
-    public void setOngoingMergeIndicator(@Nonnull final FDBRecordContext context,
+    public void setOngoingMergeIndicator(final FDBRecordContext context,
                                          @Nullable final Tuple groupingKey,
                                          @Nullable final Integer partitionId) {
         FDBRecordStore store = Objects.requireNonNull(schemaSetup.apply(context));
@@ -559,7 +550,6 @@ public class LuceneIndexTestDataModel {
             return new LuceneIndexTestDataModel(this, schemaSetup);
         }
 
-        @Nonnull
         private Map<String, String> getOptions() {
             final Map<String, String> options = new HashMap<>();
             options.put(LuceneIndexOptions.PRIMARY_KEY_SEGMENT_INDEX_V2_ENABLED, String.valueOf(primaryKeySegmentIndexEnabled));
@@ -580,8 +570,8 @@ public class LuceneIndexTestDataModel {
      */
     @FunctionalInterface
     public interface StoreBuilderSupplier {
-        FDBRecordStore.Builder get(@Nonnull FDBRecordContext context, @Nonnull RecordMetaData metaData,
-                                   @Nonnull final KeySpacePath path);
+        FDBRecordStore.Builder get(FDBRecordContext context, RecordMetaData metaData,
+                                   final KeySpacePath path);
     }
 
 
@@ -607,14 +597,11 @@ public class LuceneIndexTestDataModel {
     }
 
     private class ParentRecord implements RecordUnderTest {
-        @Nonnull
         final Tuple groupingKey;
-        @Nonnull
         final Tuple primaryKey;
-        @Nonnull
         private final Tuple partitioningKey;
 
-        private ParentRecord(@Nonnull final Tuple groupingKey, @Nonnull final Tuple primaryKey, final long timestamp) {
+        private ParentRecord(final Tuple groupingKey, final Tuple primaryKey, final long timestamp) {
             this.groupingKey = groupingKey;
             this.primaryKey = primaryKey;
             partitioningKey = Tuple.from(timestamp).addAll(primaryKey);
@@ -650,19 +637,14 @@ public class LuceneIndexTestDataModel {
     }
 
     private class SyntheticRecord implements RecordUnderTest {
-        @Nonnull
         final Tuple groupingKey;
-        @Nonnull
         final Tuple parentPrimaryKey;
-        @Nonnull
         private final Tuple childPrimaryKey;
-        @Nonnull
         private final Tuple syntheticPrimaryKey;
-        @Nonnull
         private final Tuple partitioningKey;
 
-        private SyntheticRecord(@Nonnull final Tuple groupingKey, @Nonnull final Tuple primaryKey,
-                                @Nonnull final Tuple childPrimaryKey, @Nonnull final Tuple syntheticPrimaryKey, final long timestamp) {
+        private SyntheticRecord(final Tuple groupingKey, final Tuple primaryKey,
+                                final Tuple childPrimaryKey, final Tuple syntheticPrimaryKey, final long timestamp) {
             this.groupingKey = groupingKey;
             this.parentPrimaryKey = primaryKey;
             this.childPrimaryKey = childPrimaryKey;

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTestDataModel.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTestDataModel.java
@@ -428,6 +428,9 @@ public class LuceneIndexTestDataModel {
         }
     }
 
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     public List<IndexEntry> findAllRecordsByQuery(final FDBRecordContext context, int group) {
         LuceneQueryClause search = LuceneQuerySearchClause.MATCH_ALL_DOCS_QUERY;
 

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTestDataModel.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTestDataModel.java
@@ -92,6 +92,7 @@ public class LuceneIndexTestDataModel {
     final ConcurrentMap<Tuple, ConcurrentMap<Tuple, Tuple>> groupingKeyToPrimaryKeyToPartitionKey;
     private final ConcurrentMap<Tuple, RecordUnderTest> recordsUnderTest;
     final ConcurrentMap<Tuple, AtomicInteger> nextRecNoInGroup;
+    @Nullable
     private LuceneIndexTestValidator validator;
     // A "start" timestamp to make the partitioning field look more like a timestamp
     private long start;
@@ -100,12 +101,12 @@ public class LuceneIndexTestDataModel {
     private LuceneIndexTestDataModel(final Builder builder,
                                      final Function<FDBRecordContext, FDBRecordStore> schemaSetup) {
         random = builder.random;
-        textGenerator = builder.textGenerator;
+        textGenerator = Objects.requireNonNull(builder.textGenerator);
         isGrouped = builder.isGrouped;
         isSynthetic = builder.isSynthetic;
         primaryKeySegmentIndexEnabled = builder.primaryKeySegmentIndexEnabled;
         partitionHighWatermark = builder.partitionHighWatermark;
-        index = builder.index;
+        index = Objects.requireNonNull(builder.index);
         this.schemaSetup = schemaSetup;
         groupingKeyToPrimaryKeyToPartitionKey = new ConcurrentHashMap<>();
         recordsUnderTest = new ConcurrentHashMap<>();
@@ -129,7 +130,7 @@ public class LuceneIndexTestDataModel {
     }
 
     public Set<Tuple> primaryKeys(Tuple groupingKey) {
-        return groupingKeyToPrimaryKeyToPartitionKey.get(groupingKey).keySet();
+        return Objects.requireNonNull(groupingKeyToPrimaryKeyToPartitionKey.get(groupingKey)).keySet();
     }
 
     public List<RecordUnderTest> recordsUnderTest() {
@@ -219,8 +220,8 @@ public class LuceneIndexTestDataModel {
 
     private Tuple saveRecordToSync(final boolean withContent, final FDBRecordStore recordStore,
                                    final int group) {
-        return recordStore.getContext().asyncToSync(FDBStoreTimer.Waits.WAIT_SAVE_RECORD,
-                saveRecordAsync(withContent, recordStore, group));
+        return Objects.requireNonNull(recordStore.getContext().asyncToSync(FDBStoreTimer.Waits.WAIT_SAVE_RECORD,
+                saveRecordAsync(withContent, recordStore, group)));
     }
 
     public CompletableFuture<Tuple> saveRecordAsync(final boolean withContent, final FDBRecordStore recordStore, final int group) {
@@ -295,8 +296,7 @@ public class LuceneIndexTestDataModel {
     }
 
     public void validate(final Supplier<FDBRecordContext> openContext) throws IOException {
-        getValidator(openContext);
-        validator.validate(index, groupingKeyToPrimaryKeyToPartitionKey, isSynthetic ? CHILD_SEARCH_TERM : PARENT_SEARCH_TERM);
+        getValidator(openContext).validate(index, groupingKeyToPrimaryKeyToPartitionKey, isSynthetic ? CHILD_SEARCH_TERM : PARENT_SEARCH_TERM);
     }
 
     public Map<Tuple, List<Integer>> getPartitionCounts(final Supplier<FDBRecordContext> openContext) {
@@ -460,6 +460,7 @@ public class LuceneIndexTestDataModel {
         private final Random random;
         private final StoreBuilderSupplier storeBuilderSupplier;
         private final TestKeySpacePathManagerExtension pathManager;
+        @Nullable
         private RandomTextGenerator textGenerator;
         boolean isGrouped;
         boolean isSynthetic;
@@ -543,7 +544,7 @@ public class LuceneIndexTestDataModel {
                 this.metadata = metaDataBuilder.build();
             }
             final Function<FDBRecordContext, FDBRecordStore> schemaSetup = context -> {
-                final FDBRecordStore store = storeBuilderSupplier.get(context, metadata, path).createOrOpen();
+                final FDBRecordStore store = storeBuilderSupplier.get(context, Objects.requireNonNull(metadata), path).createOrOpen();
                 store.getIndexDeferredMaintenanceControl().setAutoMergeDuringCommit(false);
                 return store;
             };
@@ -629,7 +630,7 @@ public class LuceneIndexTestDataModel {
 
         @Override
         public CompletableFuture<Void> deleteRecord(FDBRecordStore recordStore) {
-            groupingKeyToPrimaryKeyToPartitionKey.get(groupingKey).remove(primaryKey);
+            Objects.requireNonNull(groupingKeyToPrimaryKeyToPartitionKey.get(groupingKey)).remove(primaryKey);
             recordsUnderTest.remove(primaryKey);
             return recordStore.deleteRecordAsync(primaryKey)
                     .thenAccept(wasDeleted -> assertTrue(wasDeleted, () -> primaryKey + " should have been deletable"));
@@ -675,7 +676,7 @@ public class LuceneIndexTestDataModel {
 
         @Override
         public CompletableFuture<Void> deleteRecord(FDBRecordStore recordStore) {
-            groupingKeyToPrimaryKeyToPartitionKey.get(groupingKey).remove(syntheticPrimaryKey);
+            Objects.requireNonNull(groupingKeyToPrimaryKeyToPartitionKey.get(groupingKey)).remove(syntheticPrimaryKey);
             recordsUnderTest.remove(parentPrimaryKey);
             return recordStore.deleteRecordAsync(parentPrimaryKey)
                     .thenAccept(wasDeleted -> assertTrue(wasDeleted, () -> parentPrimaryKey + " should have been deletable"))

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTestUtils.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTestUtils.java
@@ -60,6 +60,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Random;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
@@ -630,12 +631,12 @@ public class LuceneIndexTestUtils {
                         Sets.newHashSet(LuceneIndexTypes.LUCENE)
                 );
             }
-            planner = new LucenePlanner(recordStore.getRecordMetaData(), recordStore.getRecordStoreState(), indexTypes, recordStore.getTimer());
+            planner = new LucenePlanner(recordStore.getRecordMetaData(), recordStore.getRecordStoreState(), indexTypes, Objects.requireNonNull(recordStore.getTimer()));
         }
         return planner;
     }
 
-    public static LuceneScanBounds fullSortTextSearch(FDBRecordStore recordStore, Index index, String search, Sort sort) {
+    public static LuceneScanBounds fullSortTextSearch(FDBRecordStore recordStore, Index index, String search, @Nullable Sort sort) {
         LuceneScanParameters scan = new LuceneScanQueryParameters(
                 ScanComparisons.EMPTY,
                 new LuceneQueryMultiFieldSearchClause(LuceneQueryType.QUERY, search, false),
@@ -896,7 +897,7 @@ public class LuceneIndexTestUtils {
         }
 
         public Index getIndex(final String key) {
-            return indexes.get(key);
+            return Objects.requireNonNull(indexes.get(key));
         }
 
         public boolean isSynthetic() {

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTestUtils.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTestUtils.java
@@ -55,8 +55,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import org.apache.lucene.search.Sort;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -132,7 +131,6 @@ public class LuceneIndexTestUtils {
 
     public static final Index SIMPLE_TEXT_SUFFIXES = simpleTextSuffixesIndex(options -> { });
 
-    @Nonnull
     public static Index simpleTextSuffixesIndex(Consumer<Map<String, String>> optionsBuilder) {
         final Map<String, String> options = new HashMap<>();
         options.put(IndexOptions.TEXT_TOKENIZER_NAME_OPTION, AllSuffixesTextTokenizer.NAME);
@@ -253,7 +251,6 @@ public class LuceneIndexTestUtils {
 
     public static final Index TEXT_AND_STORED_COMPLEX = textAndStoredComplexIndex(options -> { });
 
-    @Nonnull
     public static Index textAndStoredComplexIndex(final Consumer<Map<String, String>> optionsBuilder) {
         Map<String, String> options = new HashMap<>();
         options.put(IndexOptions.TEXT_TOKENIZER_NAME_OPTION, AllSuffixesTextTokenizer.NAME);
@@ -530,7 +527,7 @@ public class LuceneIndexTestUtils {
         return Stream.of(IndexedType.values());
     }
 
-    protected static Index getMapOnValueIndexWithOption(@Nonnull String name, @Nonnull ImmutableMap<String, String> options) {
+    protected static Index getMapOnValueIndexWithOption(String name, ImmutableMap<String, String> options) {
         return new Index(
                 name,
                 new GroupingKeyExpression(field("entry", KeyExpression.FanType.FanOut).nest(concat(keys)), 3),
@@ -583,13 +580,13 @@ public class LuceneIndexTestUtils {
     }
 
     public static FDBRecordStore openRecordStore(FDBRecordContext context,
-                                          @Nonnull KeySpacePath path,
+                                          KeySpacePath path,
                                           FDBRecordStoreTestBase.RecordMetaDataHook hook) {
         return openRecordStore(context, path, hook, null);
     }
 
     public static FDBRecordStore openRecordStore(FDBRecordContext context,
-                                          @Nonnull KeySpacePath path,
+                                          KeySpacePath path,
                                           FDBRecordStoreTestBase.RecordMetaDataHook hook,
                                           @Nullable IndexMaintainerFactoryRegistry indexMaintainerRegistry) {
         RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder().setRecords(TestRecordsTextProto.getDescriptor());
@@ -600,10 +597,9 @@ public class LuceneIndexTestUtils {
                 .createOrOpen();
     }
 
-    @Nonnull
-    private static FDBRecordStore.Builder getStoreBuilder(@Nonnull FDBRecordContext context,
-                                                          @Nonnull KeySpacePath path,
-                                                          @Nonnull RecordMetaData metaData,
+    private static FDBRecordStore.Builder getStoreBuilder(FDBRecordContext context,
+                                                          KeySpacePath path,
+                                                          RecordMetaData metaData,
                                                           @Nullable IndexMaintainerFactoryRegistry indexMaintainerRegistry) {
         final FDBRecordStore.Builder builder = FDBRecordStore.newBuilder()
                 .setFormatVersion(FormatVersion.getMaximumSupportedVersion()) // set to max to test newest features (unsafe for real deployments)
@@ -616,7 +612,7 @@ public class LuceneIndexTestUtils {
         return builder;
     }
 
-    static QueryPlanner setupPlanner(@Nonnull FDBRecordStore recordStore,
+    static QueryPlanner setupPlanner(FDBRecordStore recordStore,
                                      @Nullable PlannableIndexTypes indexTypes, boolean useRewritePlanner) {
         QueryPlanner planner;
         if (useRewritePlanner) {

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTestValidator.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTestValidator.java
@@ -55,6 +55,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -153,7 +154,7 @@ public class LuceneIndexTestValidator {
             validateDocsInPartition(recordStore, index, null, groupingKey, Set.copyOf(records), universalSearch);
             validatePrimaryKeySegmentIndex(recordStore, index, groupingKey, null,
                     Set.copyOf(records), allowDuplicatePrimaryKeys);
-            Set.copyOf(records).forEach(primaryKey -> missingDocuments.get(groupingKey).remove(primaryKey));
+            Set.copyOf(records).forEach(primaryKey -> Objects.requireNonNull(missingDocuments.get(groupingKey)).remove(primaryKey));
             // check for dangling blocks
             final FDBDirectoryManager directoryManager = getDirectoryManager(recordStore, index);
             final FDBDirectory directory = directoryManager.getDirectory(groupingKey, null);
@@ -198,7 +199,7 @@ public class LuceneIndexTestValidator {
                 visitedCount += partitionInfo.getCount();
                 validatePrimaryKeySegmentIndex(recordStore, index, groupingKey, partitionInfo.getId(),
                         expectedPrimaryKeys, allowDuplicatePrimaryKeys);
-                expectedPrimaryKeys.forEach(primaryKey -> missingDocuments.get(groupingKey).remove(primaryKey));
+                expectedPrimaryKeys.forEach(primaryKey -> Objects.requireNonNull(missingDocuments.get(groupingKey)).remove(primaryKey));
                 // check for dangling blocks
                 final FDBDirectory directory = directoryManager.getDirectory(groupingKey, partitionInfo.getId());
                 if (LOGGER.isTraceEnabled()) {
@@ -211,7 +212,7 @@ public class LuceneIndexTestValidator {
 
     private Tuple validatePartition(final Tuple groupingKey, final int partitionLowWatermark, final int partitionHighWatermark,
                                     final List<LucenePartitionInfoProto.LucenePartitionInfo> partitionInfos, final int partitionIndex,
-                                    final Set<Integer> usedPartitionIds, Tuple previousToTuple) {
+                                    final Set<Integer> usedPartitionIds, @Nullable Tuple previousToTuple) {
         final LucenePartitionInfoProto.LucenePartitionInfo partitionInfo = partitionInfos.get(partitionIndex);
         assertTrue(isPartitionCountWithinBounds(partitionInfos, partitionIndex, partitionLowWatermark, partitionHighWatermark),
                 () -> partitionMessage(groupingKey, partitionLowWatermark, partitionHighWatermark, partitionInfos, partitionIndex));
@@ -362,11 +363,11 @@ public class LuceneIndexTestValidator {
         return FDBDirectoryManager.getManager(state);
     }
 
-    public static LuceneScanBounds groupedSortedTextSearch(final FDBRecordStoreBase<?> recordStore, Index index, String search, Sort sort, Object group) {
+    public static LuceneScanBounds groupedSortedTextSearch(final FDBRecordStoreBase<?> recordStore, Index index, String search, @Nullable Sort sort, Object group) {
         return groupedSortedTextSearch(recordStore, index, new LuceneQuerySearchClause(LuceneQueryType.QUERY, search, false), sort, group);
     }
 
-    public static LuceneScanBounds groupedSortedTextSearch(final FDBRecordStoreBase<?> recordStore, Index index, LuceneQueryClause search, Sort sort, Object group) {
+    public static LuceneScanBounds groupedSortedTextSearch(final FDBRecordStoreBase<?> recordStore, Index index, LuceneQueryClause search, @Nullable Sort sort, Object group) {
         LuceneScanParameters scan = new LuceneScanQueryParameters(
                 Verify.verifyNotNull(ScanComparisons.from(new Comparisons.SimpleComparison(Comparisons.Type.EQUALS, group))),
                 search,

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTestValidator.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexTestValidator.java
@@ -47,8 +47,7 @@ import org.junit.jupiter.api.Assertions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -210,7 +209,6 @@ public class LuceneIndexTestValidator {
         }
     }
 
-    @Nonnull
     private Tuple validatePartition(final Tuple groupingKey, final int partitionLowWatermark, final int partitionHighWatermark,
                                     final List<LucenePartitionInfoProto.LucenePartitionInfo> partitionInfos, final int partitionIndex,
                                     final Set<Integer> usedPartitionIds, Tuple previousToTuple) {
@@ -227,7 +225,6 @@ public class LuceneIndexTestValidator {
         return lastToTuple;
     }
 
-    @Nonnull
     private static String partitionMessage(final Tuple groupingKey, final int partitionLowWatermark, final int partitionHighWatermark,
                                            final List<LucenePartitionInfoProto.LucenePartitionInfo> partitionInfos, final int partitionIndex) {
         final String allCounts = partitionInfos.stream()
@@ -287,7 +284,7 @@ public class LuceneIndexTestValidator {
         }
     }
 
-    boolean isPartitionCountWithinBounds(@Nonnull final List<LucenePartitionInfoProto.LucenePartitionInfo> partitionInfos,
+    boolean isPartitionCountWithinBounds(final List<LucenePartitionInfoProto.LucenePartitionInfo> partitionInfos,
                                          int currentPartitionIndex,
                                          int lowWatermark,
                                          int highWatermark) {
@@ -360,7 +357,6 @@ public class LuceneIndexTestValidator {
         return manager.getIndexReader(groupingKey, partitionId);
     }
 
-    @Nonnull
     private static FDBDirectoryManager getDirectoryManager(final FDBRecordStore recordStore, final Index index) {
         IndexMaintainerState state = new IndexMaintainerState(recordStore, index, recordStore.getIndexMaintenanceFilter());
         return FDBDirectoryManager.getManager(state);
@@ -382,11 +378,11 @@ public class LuceneIndexTestValidator {
         return scan.bind(recordStore, index, EvaluationContext.EMPTY);
     }
 
-    public static void validatePrimaryKeySegmentIndex(@Nonnull FDBRecordStore recordStore,
-                                                      @Nonnull Index index,
-                                                      @Nonnull Tuple groupingKey,
+    public static void validatePrimaryKeySegmentIndex(FDBRecordStore recordStore,
+                                                      Index index,
+                                                      Tuple groupingKey,
                                                       @Nullable Integer partitionId,
-                                                      @Nonnull Set<Tuple> expectedPrimaryKeys,
+                                                      Set<Tuple> expectedPrimaryKeys,
                                                       final boolean allowDuplicates) throws IOException {
         final FDBDirectoryManager directoryManager = getDirectoryManager(recordStore, index);
         final LucenePrimaryKeySegmentIndex primaryKeySegmentIndex = directoryManager.getDirectory(groupingKey, partitionId)

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexValidatorTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneIndexValidatorTest.java
@@ -28,7 +28,6 @@ import com.apple.foundationdb.record.provider.foundationdb.indexes.TextIndexTest
 import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
 
-import javax.annotation.Nonnull;
 import java.util.Map;
 import java.util.Set;
 
@@ -74,7 +73,7 @@ public class LuceneIndexValidatorTest {
                 () -> validateIndexOptions(options7));
     }
 
-    void validateIndexOptions(@Nonnull Map<String, String> indexOptions) {
+    void validateIndexOptions(Map<String, String> indexOptions) {
         Index index = new Index("Complex$text_index",
                 concat(function(LuceneFunctionNames.LUCENE_TEXT, field("text")), function(LuceneFunctionNames.LUCENE_TEXT, field("text2"))),
                 LuceneIndexTypes.LUCENE,

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneLockFailureTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneLockFailureTest.java
@@ -48,6 +48,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Map;
+import java.util.Objects;
 
 import static com.apple.foundationdb.record.lucene.LuceneIndexOptions.INDEX_PARTITION_BY_FIELD_NAME;
 import static com.apple.foundationdb.record.lucene.LuceneIndexOptions.INDEX_PARTITION_HIGH_WATERMARK;
@@ -318,14 +319,14 @@ class LuceneLockFailureTest extends FDBRecordStoreTestBase {
 
     // Open the store with the type and index
     private void rebuildIndexMetaData(final FDBRecordContext context, final String document, final Index index) {
-        Pair<FDBRecordStore, QueryPlanner> pair = LuceneIndexTestUtils.rebuildIndexMetaData(context, path, document, index, useCascadesPlanner);
+        Pair<FDBRecordStore, QueryPlanner> pair = LuceneIndexTestUtils.rebuildIndexMetaData(context, Objects.requireNonNull(path), document, index, useCascadesPlanner);
         this.recordStore = pair.getLeft();
         this.planner = pair.getRight();
     }
 
     // Open the store for the type and index, and set the prefixes for the type such that deleteWhere can be run
     private void openStoreWithPrefixes(final FDBRecordContext context, final String document, final Index index) {
-        this.recordStore = openRecordStore(context, path, metaDataBuilder -> {
+        this.recordStore = openRecordStore(context, Objects.requireNonNull(path), metaDataBuilder -> {
             TextIndexTestUtils.addRecordTypePrefix(metaDataBuilder);
             metaDataBuilder.removeIndex(TextIndexTestUtils.SIMPLE_DEFAULT_NAME);
             metaDataBuilder.addIndex(document, index);

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneLockFailureTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneLockFailureTest.java
@@ -320,8 +320,10 @@ class LuceneLockFailureTest extends FDBRecordStoreTestBase {
     // Open the store with the type and index
     private void rebuildIndexMetaData(final FDBRecordContext context, final String document, final Index index) {
         Pair<FDBRecordStore, QueryPlanner> pair = LuceneIndexTestUtils.rebuildIndexMetaData(context, Objects.requireNonNull(path), document, index, useCascadesPlanner);
-        this.recordStore = pair.getLeft();
-        this.planner = pair.getRight();
+        // Pair#getLeft/getRight are @Nullable in general (a Pair may hold nulls), but
+        // rebuildIndexMetaData always constructs its result from the non-null store/planner it builds.
+        this.recordStore = Objects.requireNonNull(pair.getLeft());
+        this.planner = Objects.requireNonNull(pair.getRight());
     }
 
     // Open the store for the type and index, and set the prefixes for the type such that deleteWhere can be run

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneOnlineIndexingTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneOnlineIndexingTest.java
@@ -73,7 +73,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1072,21 +1071,18 @@ class LuceneOnlineIndexingTest extends FDBRecordStoreTestBase {
 
     @AutoService(IndexMaintainerFactory.class)
     public static class TerribleMergingIndexMaintainerFactory implements IndexMaintainerFactory {
-        @Nonnull
         @Override
         public Iterable<String> getIndexTypes() {
             return Collections.singletonList("terribleMerger");
         }
 
-        @Nonnull
         @Override
         public IndexValidator getIndexValidator(Index index) {
             return new IndexValidator(index);
         }
 
-        @Nonnull
         @Override
-        public IndexMaintainer getIndexMaintainer(@Nonnull IndexMaintainerState state) {
+        public IndexMaintainer getIndexMaintainer(IndexMaintainerState state) {
             return new TerribleMergingIndexMaintainer(state);
         }
     }
@@ -1138,21 +1134,18 @@ class LuceneOnlineIndexingTest extends FDBRecordStoreTestBase {
 
     @AutoService(IndexMaintainerFactory.class)
     public static class Terrible2MergingIndexMaintainerFactory implements IndexMaintainerFactory {
-        @Nonnull
         @Override
         public Iterable<String> getIndexTypes() {
             return Collections.singletonList("terrible2Merger");
         }
 
-        @Nonnull
         @Override
         public IndexValidator getIndexValidator(Index index) {
             return new IndexValidator(index);
         }
 
-        @Nonnull
         @Override
-        public IndexMaintainer getIndexMaintainer(@Nonnull IndexMaintainerState state) {
+        public IndexMaintainer getIndexMaintainer(IndexMaintainerState state) {
             return new Terrible2MergingIndexMaintainer(state);
         }
     }
@@ -1294,21 +1287,18 @@ class LuceneOnlineIndexingTest extends FDBRecordStoreTestBase {
 
     @AutoService(IndexMaintainerFactory.class)
     public static class TerribleRebalanceIndexMaintainerFactory implements IndexMaintainerFactory {
-        @Nonnull
         @Override
         public Iterable<String> getIndexTypes() {
             return Collections.singletonList("terribleRebalance");
         }
 
-        @Nonnull
         @Override
         public IndexValidator getIndexValidator(Index index) {
             return new IndexValidator(index);
         }
 
-        @Nonnull
         @Override
-        public IndexMaintainer getIndexMaintainer(@Nonnull IndexMaintainerState state) {
+        public IndexMaintainer getIndexMaintainer(IndexMaintainerState state) {
             return new TerribleRebalanceIndexMaintainer(state);
         }
     }
@@ -1368,21 +1358,18 @@ class LuceneOnlineIndexingTest extends FDBRecordStoreTestBase {
 
     @AutoService(IndexMaintainerFactory.class)
     public static class Terriblerebalnce2ndChanceIndexMaintainerFactory implements IndexMaintainerFactory {
-        @Nonnull
         @Override
         public Iterable<String> getIndexTypes() {
             return Collections.singletonList("terribleRebalance2ndChance");
         }
 
-        @Nonnull
         @Override
         public IndexValidator getIndexValidator(Index index) {
             return new IndexValidator(index);
         }
 
-        @Nonnull
         @Override
-        public IndexMaintainer getIndexMaintainer(@Nonnull IndexMaintainerState state) {
+        public IndexMaintainer getIndexMaintainer(IndexMaintainerState state) {
             return new Terriblerebalnce2ndChanceIndexMaintainer(state);
         }
     }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneOnlineIndexingTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneOnlineIndexingTest.java
@@ -122,8 +122,10 @@ class LuceneOnlineIndexingTest extends FDBRecordStoreTestBase {
 
     private void rebuildIndexMetaData(final FDBRecordContext context, final String document, final Index index) {
         Pair<FDBRecordStore, QueryPlanner> pair = LuceneIndexTestUtils.rebuildIndexMetaData(context, Objects.requireNonNull(path), document, index, isUseCascadesPlanner());
-        this.recordStore = pair.getLeft();
-        this.planner = pair.getRight();
+        // Pair#getLeft/getRight are @Nullable in general (a Pair may hold nulls), but
+        // rebuildIndexMetaData always constructs its result from the non-null store/planner it builds.
+        this.recordStore = Objects.requireNonNull(pair.getLeft());
+        this.planner = Objects.requireNonNull(pair.getRight());
     }
 
     private void disableIndex(Index index, String document) {
@@ -170,8 +172,10 @@ class LuceneOnlineIndexingTest extends FDBRecordStoreTestBase {
         assertTrue(allFiles.length < 12);
     }
 
-    @SuppressWarnings("checkstyle:VariableDeclarationUsageDistance")
     @Test
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings({"checkstyle:VariableDeclarationUsageDistance", "NullAway"})
     void luceneOnlineIndexingTestWithRecordUpdates() throws IOException {
         final Map<String, String> options = Map.of(
                 INDEX_PARTITION_BY_FIELD_NAME, "timestamp",
@@ -325,6 +329,9 @@ class LuceneOnlineIndexingTest extends FDBRecordStoreTestBase {
             3416978384487730594L, // this one failed reliably when most seeds passed
             6096618498708109618L // this one failed too
     })
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void luceneOnlineIndexingTestWithAllRecordUpdates(long seed) {
         final Map<String, String> options = Map.of(
                 INDEX_PARTITION_BY_FIELD_NAME, "timestamp",

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneOnlineIndexingTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneOnlineIndexingTest.java
@@ -80,6 +80,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
@@ -120,7 +121,7 @@ class LuceneOnlineIndexingTest extends FDBRecordStoreTestBase {
 
 
     private void rebuildIndexMetaData(final FDBRecordContext context, final String document, final Index index) {
-        Pair<FDBRecordStore, QueryPlanner> pair = LuceneIndexTestUtils.rebuildIndexMetaData(context, path, document, index, isUseCascadesPlanner());
+        Pair<FDBRecordStore, QueryPlanner> pair = LuceneIndexTestUtils.rebuildIndexMetaData(context, Objects.requireNonNull(path), document, index, isUseCascadesPlanner());
         this.recordStore = pair.getLeft();
         this.planner = pair.getRight();
     }
@@ -580,14 +581,14 @@ class LuceneOnlineIndexingTest extends FDBRecordStoreTestBase {
             TextIndexTestUtils.addRecordTypePrefix(metaDataBuilder);
         };
         try (final FDBRecordContext context = openContext()) {
-            recordStore = LuceneIndexTestUtils.openRecordStore(context, path, hook);
+            recordStore = LuceneIndexTestUtils.openRecordStore(context, Objects.requireNonNull(path), hook);
             for (Index index: indexes) {
                 recordStore.markIndexDisabled(index).join();
             }
             context.commit();
         }
         try (final FDBRecordContext context = openContext()) {
-            recordStore = LuceneIndexTestUtils.openRecordStore(context, path, hook);
+            recordStore = LuceneIndexTestUtils.openRecordStore(context, Objects.requireNonNull(path), hook);
             for (int i = 0; i < numRecords; i ++) {
                 long docId = docIds[i];
                 recordStore.saveRecord(createSimpleDocument(docId, randomText(rn), randomGroup(rn)));
@@ -596,7 +597,7 @@ class LuceneOnlineIndexingTest extends FDBRecordStoreTestBase {
         }
         // overwrite some records (to enforce merge), write others as new
         try (final FDBRecordContext context = openContext()) {
-            recordStore = LuceneIndexTestUtils.openRecordStore(context, path, hook);
+            recordStore = LuceneIndexTestUtils.openRecordStore(context, Objects.requireNonNull(path), hook);
             for (int i = 0; i < middle; i ++) {
                 long docId = docIds[i];
                 recordStore.saveRecord(createSimpleDocument(docId, randomText(rn), randomGroup(rn)));
@@ -609,7 +610,7 @@ class LuceneOnlineIndexingTest extends FDBRecordStoreTestBase {
         }
         // build the index ..
         try (final FDBRecordContext context = openContext()) {
-            recordStore = LuceneIndexTestUtils.openRecordStore(context, path, hook);
+            recordStore = LuceneIndexTestUtils.openRecordStore(context, Objects.requireNonNull(path), hook);
             try (OnlineIndexer indexBuilder = OnlineIndexer.newBuilder()
                     .setRecordStore(recordStore)
                     .setTargetIndexes(indexes)
@@ -623,7 +624,7 @@ class LuceneOnlineIndexingTest extends FDBRecordStoreTestBase {
         }
         // .. and assert readable mode
         try (final FDBRecordContext context = openContext()) {
-            recordStore = LuceneIndexTestUtils.openRecordStore(context, path, hook);
+            recordStore = LuceneIndexTestUtils.openRecordStore(context, Objects.requireNonNull(path), hook);
             for (Index index: indexes) {
                 assertTrue(recordStore.getIndexState(index).isReadable());
             }
@@ -1250,7 +1251,7 @@ class LuceneOnlineIndexingTest extends FDBRecordStoreTestBase {
             commit(context);
         }
         newLength = listFiles(index).length;
-        final int timeCommitCount = timer.getCounter(LuceneEvents.Counts.LUCENE_AGILE_COMMITS_TIME_QUOTA).getCount();
+        final int timeCommitCount = Objects.requireNonNull(timer.getCounter(LuceneEvents.Counts.LUCENE_AGILE_COMMITS_TIME_QUOTA)).getCount();
         LOGGER.debug("Merge test: number of files: old=" + oldLength + " new=" + newLength +
                      " needMerge=" + recordStore.getIndexDeferredMaintenanceControl().getMergeRequiredIndexes() +
                      " timeCommitCount: " + timeCommitCount);

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LucenePartitionerTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LucenePartitionerTest.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 @Tag(Tags.RequiresFDB)
 public class LucenePartitionerTest extends FDBRecordStoreConcurrentTestBase {
@@ -210,7 +211,7 @@ public class LucenePartitionerTest extends FDBRecordStoreConcurrentTestBase {
             dataModel.groupingKeyToPrimaryKeyToPartitionKey.keySet().forEach(groupingKey -> {
                 final List<LucenePartitionInfoProto.LucenePartitionInfo> partitions =
                         partitioner.getAllPartitionMetaInfo(groupingKey).join();
-                Assertions.assertThat(partitions).anyMatch(partition -> partition.getId() == partitionsWithZeroCount.get(groupingKey));
+                Assertions.assertThat(partitions).anyMatch(partition -> partition.getId() == Objects.requireNonNull(partitionsWithZeroCount.get(groupingKey)));
             });
         }
     }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LucenePlanMatchers.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LucenePlanMatchers.java
@@ -27,22 +27,20 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 
-import javax.annotation.Nonnull;
-
 /**
  * Test plan matchers for Lucene plan elements.
  */
 public class LucenePlanMatchers {
 
-    public static Matcher<RecordQueryIndexPlan> scanParams(@Nonnull Matcher<IndexScanParameters> scanMatcher) {
+    public static Matcher<RecordQueryIndexPlan> scanParams(Matcher<IndexScanParameters> scanMatcher) {
         return new ScanParamsMatcher(scanMatcher);
     }
 
-    public static Matcher<IndexScanParameters> query(@Nonnull Matcher<LuceneQueryClause> queryMatcher) {
+    public static Matcher<IndexScanParameters> query(Matcher<LuceneQueryClause> queryMatcher) {
         return new QueryMatcher(queryMatcher);
     }
 
-    public static Matcher<IndexScanParameters> group(@Nonnull Matcher<ScanComparisons> boundsMatcher) {
+    public static Matcher<IndexScanParameters> group(Matcher<ScanComparisons> boundsMatcher) {
         return new GroupBoundsMatcher(boundsMatcher);
     }
 
@@ -50,15 +48,14 @@ public class LucenePlanMatchers {
      * Match {@link IndexScanParameters}.
      */
     public static class ScanParamsMatcher extends TypeSafeMatcher<RecordQueryIndexPlan> {
-        @Nonnull
         private final Matcher<IndexScanParameters> scanMatcher;
 
-        public ScanParamsMatcher(@Nonnull Matcher<IndexScanParameters> scanMatcher) {
+        public ScanParamsMatcher(Matcher<IndexScanParameters> scanMatcher) {
             this.scanMatcher = scanMatcher;
         }
 
         @Override
-        public boolean matchesSafely(@Nonnull RecordQueryIndexPlan plan) {
+        public boolean matchesSafely(RecordQueryIndexPlan plan) {
             return scanMatcher.matches(plan.getScanParameters());
         }
 
@@ -74,15 +71,14 @@ public class LucenePlanMatchers {
      * Match {@link LuceneQueryClause}.
      */
     public static class QueryMatcher extends TypeSafeMatcher<IndexScanParameters> {
-        @Nonnull
         private final Matcher<LuceneQueryClause> queryMatcher;
 
-        public QueryMatcher(@Nonnull Matcher<LuceneQueryClause> queryMatcher) {
+        public QueryMatcher(Matcher<LuceneQueryClause> queryMatcher) {
             this.queryMatcher = queryMatcher;
         }
 
         @Override
-        public boolean matchesSafely(@Nonnull IndexScanParameters scan) {
+        public boolean matchesSafely(IndexScanParameters scan) {
             return scan instanceof LuceneScanQueryParameters && queryMatcher.matches(((LuceneScanQueryParameters)scan).getQuery());
         }
 
@@ -99,15 +95,14 @@ public class LucenePlanMatchers {
      * Each group is a separate Lucene index.
      */
     public static class GroupBoundsMatcher extends TypeSafeMatcher<IndexScanParameters> {
-        @Nonnull
         private final Matcher<ScanComparisons> boundsMatcher;
 
-        public GroupBoundsMatcher(@Nonnull Matcher<ScanComparisons> boundsMatcher) {
+        public GroupBoundsMatcher(Matcher<ScanComparisons> boundsMatcher) {
             this.boundsMatcher = boundsMatcher;
         }
 
         @Override
-        public boolean matchesSafely(@Nonnull IndexScanParameters scan) {
+        public boolean matchesSafely(IndexScanParameters scan) {
             return scan instanceof LuceneScanQueryParameters && boundsMatcher.matches(((LuceneScanQueryParameters)scan).getGroupComparisons());
         }
 

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LucenePlannerTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LucenePlannerTest.java
@@ -49,6 +49,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 import static com.apple.foundationdb.record.lucene.LucenePlanMatchers.query;
 import static com.apple.foundationdb.record.lucene.LucenePlanMatchers.scanParams;
@@ -267,7 +268,7 @@ public class LucenePlannerTest extends FDBRecordStoreTestBase {
     }
 
     protected void setPlannerWholeFilterConfig(boolean isTrue) {
-        planner = new LucenePlanner(recordStore.getRecordMetaData(), recordStore.getRecordStoreState(), PlannableIndexTypes.DEFAULT, recordStore.getTimer());
+        planner = new LucenePlanner(recordStore.getRecordMetaData(), recordStore.getRecordStoreState(), PlannableIndexTypes.DEFAULT, Objects.requireNonNull(recordStore.getTimer()));
         planner.setConfiguration(planner.getConfiguration()
                 .asBuilder()
                 .setPlanOtherAttemptWholeFilter(isTrue)

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LucenePrimaryKeySegmentIndexTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LucenePrimaryKeySegmentIndexTest.java
@@ -42,6 +42,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.IntStream;
@@ -306,12 +307,12 @@ public class LucenePrimaryKeySegmentIndexTest extends FDBRecordStoreTestBase {
                 () -> {
                     timer.reset();
                     assertNull(timer.getCounter(LuceneEvents.Events.LUCENE_DELETE_DOCUMENT_BY_QUERY),
-                            () -> "Count: " + timer.getCounter(LuceneEvents.Events.LUCENE_DELETE_DOCUMENT_BY_QUERY).getCount());
+                            () -> "Count: " + Objects.requireNonNull(timer.getCounter(LuceneEvents.Events.LUCENE_DELETE_DOCUMENT_BY_QUERY)).getCount());
                     idCounter -= 3;
                     createDocuments(index, 3);
                     assertNull(timer.getCounter(LuceneEvents.Events.LUCENE_DELETE_DOCUMENT_BY_QUERY),
-                            () -> "Count: " + timer.getCounter(LuceneEvents.Events.LUCENE_DELETE_DOCUMENT_BY_QUERY).getCount());
-                    assertEquals(3, timer.getCounter(LuceneEvents.Events.LUCENE_DELETE_DOCUMENT_BY_PRIMARY_KEY).getCount());
+                            () -> "Count: " + Objects.requireNonNull(timer.getCounter(LuceneEvents.Events.LUCENE_DELETE_DOCUMENT_BY_QUERY)).getCount());
+                    assertEquals(3, Objects.requireNonNull(timer.getCounter(LuceneEvents.Events.LUCENE_DELETE_DOCUMENT_BY_PRIMARY_KEY)).getCount());
                 });
         // retrying the merge should cleanup any extraneous mappings
         try (FDBRecordContext context = openContext()) {
@@ -347,7 +348,7 @@ public class LucenePrimaryKeySegmentIndexTest extends FDBRecordStoreTestBase {
     }
 
     private void rebuildIndexMetaData(final FDBRecordContext context, final String document, final Index index) {
-        Pair<FDBRecordStore, QueryPlanner> pair = LuceneIndexTestUtils.rebuildIndexMetaData(context, path, document, index, isUseCascadesPlanner());
+        Pair<FDBRecordStore, QueryPlanner> pair = LuceneIndexTestUtils.rebuildIndexMetaData(context, Objects.requireNonNull(path), document, index, isUseCascadesPlanner());
         this.recordStore = pair.getLeft();
         this.planner = pair.getRight();
         recordStore.getIndexDeferredMaintenanceControl().setAutoMergeDuringCommit(autoMerge);

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LucenePrimaryKeySegmentIndexTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LucenePrimaryKeySegmentIndexTest.java
@@ -37,7 +37,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -335,7 +334,6 @@ public class LucenePrimaryKeySegmentIndexTest extends FDBRecordStoreTestBase {
         return super.openContext(contextProps);
     }
 
-    @Nonnull
     private Set<Tuple> createDocuments(final Index index, int count) {
         Set<Tuple> primaryKeys = new HashSet<>();
         try (FDBRecordContext context = openContext()) {

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LucenePrimaryKeySegmentIndexTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LucenePrimaryKeySegmentIndexTest.java
@@ -349,8 +349,10 @@ public class LucenePrimaryKeySegmentIndexTest extends FDBRecordStoreTestBase {
 
     private void rebuildIndexMetaData(final FDBRecordContext context, final String document, final Index index) {
         Pair<FDBRecordStore, QueryPlanner> pair = LuceneIndexTestUtils.rebuildIndexMetaData(context, Objects.requireNonNull(path), document, index, isUseCascadesPlanner());
-        this.recordStore = pair.getLeft();
-        this.planner = pair.getRight();
+        // Pair#getLeft/getRight are @Nullable in general (a Pair may hold nulls), but
+        // rebuildIndexMetaData always constructs its result from the non-null store/planner it builds.
+        this.recordStore = Objects.requireNonNull(pair.getLeft());
+        this.planner = Objects.requireNonNull(pair.getRight());
         recordStore.getIndexDeferredMaintenanceControl().setAutoMergeDuringCommit(autoMerge);
     }
 

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneQueryIntegrationTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneQueryIntegrationTest.java
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneQueryIntegrationTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneQueryIntegrationTest.java
@@ -43,6 +43,7 @@ import org.junit.jupiter.api.Test;
 import org.jspecify.annotations.Nullable;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import static com.apple.foundationdb.record.metadata.Key.Expressions.concat;
@@ -88,7 +89,7 @@ public class LuceneQueryIntegrationTest extends FDBRecordStoreQueryTestBase {
                 );
             }
 
-            planner = new LucenePlanner(recordStore.getRecordMetaData(), recordStore.getRecordStoreState(), indexTypes, recordStore.getTimer());
+            planner = new LucenePlanner(recordStore.getRecordMetaData(), recordStore.getRecordStoreState(), indexTypes, Objects.requireNonNull(recordStore.getTimer()));
         }
     }
 

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneScanAllEntriesTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneScanAllEntriesTest.java
@@ -55,7 +55,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import javax.annotation.Nonnull;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -290,10 +289,9 @@ public class LuceneScanAllEntriesTest extends FDBRecordStoreConcurrentTestBase {
         }
     }
 
-    @Nonnull
-    private FDBRecordStore.Builder getStoreBuilderFilterOddRecNo(@Nonnull FDBRecordContext context,
-                                                                   @Nonnull RecordMetaDataProvider metaData,
-                                                                   @Nonnull final KeySpacePath path) {
+    private FDBRecordStore.Builder getStoreBuilderFilterOddRecNo(FDBRecordContext context,
+                                                                   RecordMetaDataProvider metaData,
+                                                                   final KeySpacePath path) {
         // Create an index maintenance filter that only indexes records with even recNo
         IndexMaintenanceFilter evenRecNoFilter = (index, rec) -> {
             Descriptors.FieldDescriptor recNoField =
@@ -386,10 +384,9 @@ public class LuceneScanAllEntriesTest extends FDBRecordStoreConcurrentTestBase {
         assertEquals("Lucene does not support this kind of filtering", exception.getMessage());
     }
 
-    @Nonnull
-    private FDBRecordStore.Builder getStoreBuilderWithSomeFilter(@Nonnull FDBRecordContext context,
-                                                                 @Nonnull RecordMetaDataProvider metaData,
-                                                                 @Nonnull final KeySpacePath path) {
+    private FDBRecordStore.Builder getStoreBuilderWithSomeFilter(FDBRecordContext context,
+                                                                 RecordMetaDataProvider metaData,
+                                                                 final KeySpacePath path) {
         // Create an index maintenance filter that returns SOME
         // This should trigger an exception since Lucene doesn't support partial indexing
         IndexMaintenanceFilter someFilter = (index, rec) -> IndexMaintenanceFilter.IndexValues.SOME;
@@ -424,10 +421,9 @@ public class LuceneScanAllEntriesTest extends FDBRecordStoreConcurrentTestBase {
         }
     }
 
-    @Nonnull
-    private FDBRecordStore.Builder getStoreBuilderWithFailingFilterFor1002L(@Nonnull FDBRecordContext context,
-                                                                            @Nonnull RecordMetaDataProvider metaData,
-                                                                            @Nonnull final KeySpacePath path) {
+    private FDBRecordStore.Builder getStoreBuilderWithFailingFilterFor1002L(FDBRecordContext context,
+                                                                            RecordMetaDataProvider metaData,
+                                                                            final KeySpacePath path) {
         // Create an index maintenance filter that throws an exception for specific record with recNo 1002L
         // This can be used to tests error handling when the filter itself fails
         IndexMaintenanceFilter failingFilter = (index, rec) -> {
@@ -487,10 +483,9 @@ public class LuceneScanAllEntriesTest extends FDBRecordStoreConcurrentTestBase {
         }
     }
 
-    @Nonnull
-    private FDBRecordStore.Builder getStoreBuilderFilterOddRecNoSynthetic(@Nonnull FDBRecordContext context,
-                                                                          @Nonnull RecordMetaDataProvider metaData,
-                                                                          @Nonnull final KeySpacePath path) {
+    private FDBRecordStore.Builder getStoreBuilderFilterOddRecNoSynthetic(FDBRecordContext context,
+                                                                          RecordMetaDataProvider metaData,
+                                                                          final KeySpacePath path) {
         // Create an index maintenance filter that only indexes synthetic records with even parent rec_no
         IndexMaintenanceFilter evenRecNoFilter = (index, rec) -> {
             // For synthetic records, we need to access the parent constituent

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneScanAllEntriesTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneScanAllEntriesTest.java
@@ -55,8 +55,10 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import org.jspecify.annotations.Nullable;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.LongPredicate;
 import java.util.stream.Collectors;
@@ -127,7 +129,7 @@ public class LuceneScanAllEntriesTest extends FDBRecordStoreConcurrentTestBase {
     }
 
     private Set<Tuple> expectedResults(final boolean matchAllDocs, final boolean isGrouped, final boolean includeEmptyDoc,
-                                       final Tuple group1ContentDoc, final Tuple group2ContentDoc, final Tuple group2EmptyDoc) {
+                                       final Tuple group1ContentDoc, final Tuple group2ContentDoc, @Nullable final Tuple group2EmptyDoc) {
         // Synthetic record does not change the expected results - it just creates a record with a compound
         // key, so not needed for this method.
         Set<Tuple> result = new HashSet<>();
@@ -174,7 +176,7 @@ public class LuceneScanAllEntriesTest extends FDBRecordStoreConcurrentTestBase {
 
             // Run the scan with the given query and assert the results
             final Tuple groupTuple = LuceneIndexTestDataModel.calculateGroupTuple(isGrouped, 2);
-            final Set<Tuple> expectedKeys = dataModel.groupingKeyToPrimaryKeyToPartitionKey.get(groupTuple).keySet();
+            final Set<Tuple> expectedKeys = Objects.requireNonNull(dataModel.groupingKeyToPrimaryKeyToPartitionKey.get(groupTuple)).keySet();
             assertEquals(500, expectedKeys.size());
             assertIndexEntryPrimaryKeyTuples(expectedKeys,
                     store.scanIndex(dataModel.index, scanBounds, null, ScanProperties.FORWARD_SCAN));
@@ -219,7 +221,7 @@ public class LuceneScanAllEntriesTest extends FDBRecordStoreConcurrentTestBase {
                     });
             // Run the scan with the given query and assert the results
             final Tuple groupTuple = LuceneIndexTestDataModel.calculateGroupTuple(isGrouped, 2);
-            final Set<Tuple> expectedKeys = dataModel.groupingKeyToPrimaryKeyToPartitionKey.get(groupTuple).keySet();
+            final Set<Tuple> expectedKeys = Objects.requireNonNull(dataModel.groupingKeyToPrimaryKeyToPartitionKey.get(groupTuple)).keySet();
             assertEquals(500, expectedKeys.size());
             assertIndexEntryPrimaryKeyTuples(expectedKeys, cursor);
         }
@@ -412,7 +414,7 @@ public class LuceneScanAllEntriesTest extends FDBRecordStoreConcurrentTestBase {
         try (FDBRecordContext context = openContext()) {
             RecordCoreException exception = Assertions.assertThrows(RecordCoreException.class, () -> dataModel.saveRecords(1, context, 2));
 
-            Assertions.assertTrue(exception.getMessage().startsWith("Filter failed for recNo:"),
+            Assertions.assertTrue(Objects.requireNonNull(exception.getMessage()).startsWith("Filter failed for recNo:"),
                     "Exception message should indicate filter failure");
             Assertions.assertEquals(1002L, exception.getLogInfo().get("rec_no"),
                     "Exception should log the rec_no that caused the failure");

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneScanAllEntriesTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneScanAllEntriesTest.java
@@ -85,6 +85,9 @@ public class LuceneScanAllEntriesTest extends FDBRecordStoreConcurrentTestBase {
 
     @ParameterizedTest(name = "indexScanTest({argumentsWithNames})")
     @MethodSource("scanArguments")
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     public void indexScanTest(boolean isSynthetic, boolean matchAllDocs, boolean isGrouped, boolean includeEmptyDoc) throws Exception {
         final long seed = 5363275763521L;
         final LuceneIndexTestDataModel dataModel = new LuceneIndexTestDataModel.Builder(seed, this::getStoreBuilder, pathManager)
@@ -150,6 +153,9 @@ public class LuceneScanAllEntriesTest extends FDBRecordStoreConcurrentTestBase {
 
     @ParameterizedTest
     @BooleanSource
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     public void scanLargeIndexTest(boolean isGrouped) throws Exception {
         final long seed = 6437286L;
         final boolean isSynthetic = false;

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneSerializerTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneSerializerTest.java
@@ -39,7 +39,9 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import org.jspecify.annotations.Nullable;
 import javax.crypto.SecretKey;
+import java.util.Objects;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Stream;
@@ -60,7 +62,7 @@ class LuceneSerializerTest {
                 .setContent(content)
                 .build();
         final byte[] originalValue = reference.toByteArray();
-        final byte[] encodedValue = serializer.encode(originalValue);
+        final byte[] encodedValue = Objects.requireNonNull(serializer.encode(originalValue));
         final byte[] decodedValue = serializer.decode(encodedValue);
 
         final byte[] expectedEncodedValue = new byte[originalValue.length + 1];
@@ -91,7 +93,7 @@ class LuceneSerializerTest {
                 .setContent(ByteString.copyFromUtf8(content))
                 .build();
         final byte[] value = reference.toByteArray();
-        final byte[] encodedValue = serializer.encode(value);
+        final byte[] encodedValue = Objects.requireNonNull(serializer.encode(value));
         final byte[] decodedValue = serializer.decode(encodedValue);
 
         // The encoded value's size is smaller than the original one due to compression
@@ -127,7 +129,7 @@ class LuceneSerializerTest {
                 .setContent(content)
                 .build();
         final byte[] value = reference.toByteArray();
-        final byte[] encodedValue = serializer.encode(value);
+        final byte[] encodedValue = Objects.requireNonNull(serializer.encode(value));
         final byte[] decodedValue = serializer.decode(encodedValue);
         Assertions.assertArrayEquals(value, decodedValue);
         final LuceneFileSystemProto.LuceneFileReference decryptedReference = LuceneFileSystemProto.LuceneFileReference.parseFrom(decodedValue);
@@ -223,15 +225,15 @@ class LuceneSerializerTest {
         final LuceneSerializer serializer = getSerializer(encode, compress, encrypt, random);
         final Message built = build.build();
         final byte[] value = built.toByteArray();
-        final byte[] encodedValue = serializer.encodeFieldProtobuf(value);
-        final byte[] decodedValue = serializer.decodeFieldProtobuf(encodedValue);
+        final byte[] encodedValue = Objects.requireNonNull(serializer.encodeFieldProtobuf(value));
+        final byte[] decodedValue = Objects.requireNonNull(serializer.decodeFieldProtobuf(encodedValue));
         Assertions.assertArrayEquals(value, decodedValue);
         final Message parsed = parse.parse(decodedValue);
         Assertions.assertEquals(built, parsed);
     }
 
     private LuceneSerializer getSerializer(boolean encodeFieldProtobuf, boolean compress,
-                                           boolean encrypt, Random randomIfEncrypting) {
+                                           boolean encrypt, @Nullable Random randomIfEncrypting) {
         final SerializationKeyManager keyManager;
         if (encrypt) {
             SecretKey key = RandomSecretUtil.randomSecretKey(randomIfEncrypting);

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneSerializerTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneSerializerTest.java
@@ -236,7 +236,7 @@ class LuceneSerializerTest {
                                            boolean encrypt, @Nullable Random randomIfEncrypting) {
         final SerializationKeyManager keyManager;
         if (encrypt) {
-            SecretKey key = RandomSecretUtil.randomSecretKey(randomIfEncrypting);
+            SecretKey key = RandomSecretUtil.randomSecretKey(Objects.requireNonNull(randomIfEncrypting, "random must be provided when encrypting"));
             keyManager = new FixedZeroKeyManager(key, null, randomIfEncrypting);
         } else {
             keyManager = null;

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneSharedCacheTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneSharedCacheTest.java
@@ -45,6 +45,7 @@ import org.junit.jupiter.api.Test;
 import org.jspecify.annotations.Nullable;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import static com.apple.foundationdb.record.metadata.Key.Expressions.concatenateFields;
@@ -82,7 +83,7 @@ public class LuceneSharedCacheTest extends FDBRecordStoreQueryTestBase {
                     Set.of(IndexTypes.TEXT),
                     Set.of(LuceneIndexTypes.LUCENE)
             );
-            planner = new LucenePlanner(recordStore.getRecordMetaData(), recordStore.getRecordStoreState(), indexTypes, recordStore.getTimer());
+            planner = new LucenePlanner(recordStore.getRecordMetaData(), recordStore.getRecordStoreState(), indexTypes, Objects.requireNonNull(recordStore.getTimer()));
         }
     }
 

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneSharedCacheTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneSharedCacheTest.java
@@ -42,8 +42,7 @@ import com.apple.test.Tags;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -87,7 +86,7 @@ public class LuceneSharedCacheTest extends FDBRecordStoreQueryTestBase {
         }
     }
 
-    protected void openRecordStore(@Nonnull FDBRecordContext context) {
+    protected void openRecordStore(FDBRecordContext context) {
         RecordMetaDataBuilder metaDataBuilder = RecordMetaData.newBuilder().setRecords(TestRecordsTextProto.getDescriptor());
         metaDataBuilder.getRecordType(TextIndexTestUtils.COMPLEX_DOC).setPrimaryKey(concatenateFields("group", "doc_id"));
         metaDataBuilder.removeIndex("SimpleDocument$text");
@@ -108,7 +107,7 @@ public class LuceneSharedCacheTest extends FDBRecordStoreQueryTestBase {
         }
     }
 
-    protected Set<Long> groupQueryForPrimaryKeys(@Nonnull RecordQuery query, long group) throws Exception {
+    protected Set<Long> groupQueryForPrimaryKeys(RecordQuery query, long group) throws Exception {
         RecordQueryPlan plan = planner.plan(query);
         EvaluationContext context = EvaluationContext.forBinding("g", group);
         List<Long> primaryKeys = plan.execute(recordStore, context)

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneStoredFieldsTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneStoredFieldsTest.java
@@ -47,6 +47,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -127,8 +128,8 @@ public class LuceneStoredFieldsTest extends FDBRecordStoreTestBase {
             try (FDBDirectory directory = new FDBDirectory(recordStore.indexSubspace(index), context, index.getOptions())) {
                 if (type.usesOptimizedStoredFields) {
                     assertDocCountPerSegment(directory, List.of("_0"), List.of(3));
-                    assertTrue(timer.getCounter(LuceneEvents.Waits.WAIT_LUCENE_GET_STORED_FIELDS).getCount() > 1);
-                    assertTrue(timer.getCounter(LuceneEvents.SizeEvents.LUCENE_WRITE_STORED_FIELDS).getCount() >= 3);
+                    assertTrue(Objects.requireNonNull(timer.getCounter(LuceneEvents.Waits.WAIT_LUCENE_GET_STORED_FIELDS)).getCount() > 1);
+                    assertTrue(Objects.requireNonNull(timer.getCounter(LuceneEvents.SizeEvents.LUCENE_WRITE_STORED_FIELDS)).getCount() >= 3);
                 } else {
                     assertTotalDocCountInSegments(0, segments, directory);
                 }
@@ -172,8 +173,8 @@ public class LuceneStoredFieldsTest extends FDBRecordStoreTestBase {
                 // TODO: Find a way to force a merge and make sure the old segments are gone
                 if (type.usesOptimizedStoredFields) {
                     assertDocCountPerSegment(directory, List.of("_0", "_1", "_2", "_3"), List.of(1, 1, 1, 0));
-                    assertTrue(timer.getCounter(LuceneEvents.Waits.WAIT_LUCENE_GET_STORED_FIELDS).getCount() > 1);
-                    assertTrue(timer.getCounter(LuceneEvents.SizeEvents.LUCENE_WRITE_STORED_FIELDS).getCount() >= 3);
+                    assertTrue(Objects.requireNonNull(timer.getCounter(LuceneEvents.Waits.WAIT_LUCENE_GET_STORED_FIELDS)).getCount() > 1);
+                    assertTrue(Objects.requireNonNull(timer.getCounter(LuceneEvents.SizeEvents.LUCENE_WRITE_STORED_FIELDS)).getCount() >= 3);
                 } else {
                     assertTotalDocCountInSegments(0, segments, directory);
                 }
@@ -227,7 +228,7 @@ public class LuceneStoredFieldsTest extends FDBRecordStoreTestBase {
                 // After a merge, all tombstones are removed and one document remains
                 if (type.usesOptimizedStoredFields) {
                     assertTotalDocCountInSegments(1, segments, directory);
-                    assertTrue(timer.getCounter(LuceneEvents.Counts.LUCENE_DELETE_STORED_FIELDS).getCount() > 0);
+                    assertTrue(Objects.requireNonNull(timer.getCounter(LuceneEvents.Counts.LUCENE_DELETE_STORED_FIELDS)).getCount() > 0);
                 } else {
                     assertTotalDocCountInSegments(0, segments, directory);
                 }
@@ -320,7 +321,7 @@ public class LuceneStoredFieldsTest extends FDBRecordStoreTestBase {
                 // After a merge, all tombstones are removed and 3 documents remain
                 if (type.usesOptimizedStoredFields) {
                     assertTotalDocCountInSegments(3, segments, directory);
-                    assertTrue(timer.getCounter(LuceneEvents.Counts.LUCENE_DELETE_STORED_FIELDS).getCount() > 0);
+                    assertTrue(Objects.requireNonNull(timer.getCounter(LuceneEvents.Counts.LUCENE_DELETE_STORED_FIELDS)).getCount() > 0);
                 } else {
                     assertTotalDocCountInSegments(0, segments, directory);
                 }
@@ -368,7 +369,7 @@ public class LuceneStoredFieldsTest extends FDBRecordStoreTestBase {
                 if (type.usesOptimizedStoredFields) {
                     // When deleting all docs from the index, the first segment (_0) was merged away and the last segment (_1) gets removed
                     assertDocCountPerSegment(directory, List.of("_0", "_1"), List.of(0, 0));
-                    assertTrue(timer.getCounter(LuceneEvents.Counts.LUCENE_DELETE_STORED_FIELDS).getCount() > 0);
+                    assertTrue(Objects.requireNonNull(timer.getCounter(LuceneEvents.Counts.LUCENE_DELETE_STORED_FIELDS)).getCount() > 0);
                 } else {
                     assertTotalDocCountInSegments(0, segments, directory);
                 }
@@ -424,8 +425,8 @@ public class LuceneStoredFieldsTest extends FDBRecordStoreTestBase {
             try (FDBDirectory directory = new FDBDirectory(recordStore.indexSubspace(index), context, index.getOptions())) {
                 if (type.usesOptimizedStoredFields) {
                     assertDocCountPerSegment(directory, List.of("_0"), List.of(3));
-                    assertTrue(timer.getCounter(LuceneEvents.Waits.WAIT_LUCENE_GET_STORED_FIELDS).getCount() > 5);
-                    assertTrue(timer.getCounter(LuceneEvents.SizeEvents.LUCENE_WRITE_STORED_FIELDS).getCount() >= 3);
+                    assertTrue(Objects.requireNonNull(timer.getCounter(LuceneEvents.Waits.WAIT_LUCENE_GET_STORED_FIELDS)).getCount() > 5);
+                    assertTrue(Objects.requireNonNull(timer.getCounter(LuceneEvents.SizeEvents.LUCENE_WRITE_STORED_FIELDS)).getCount() >= 3);
                 } else {
                     assertTotalDocCountInSegments(0, segments, directory);
                 }
@@ -473,12 +474,12 @@ public class LuceneStoredFieldsTest extends FDBRecordStoreTestBase {
     }
 
     private Object toFieldValue(final FDBQueriedRecord<Message> record, final String fieldName) {
-        final Message storedRecord = record.getStoredRecord().getRecord();
+        final Message storedRecord = Objects.requireNonNull(record.getStoredRecord()).getRecord();
         return storedRecord.getField(storedRecord.getDescriptorForType().findFieldByName(fieldName));
     }
 
     private Tuple toPrimaryKey(final FDBQueriedRecord<Message> record) {
-        return record.getIndexEntry().getPrimaryKey();
+        return Objects.requireNonNull(record.getIndexEntry()).getPrimaryKey();
     }
 
     private void validatePrimaryKeySegmentIndex(final Index index, final Set<Tuple> primaryKeys, final String documentType) throws IOException {
@@ -523,7 +524,7 @@ public class LuceneStoredFieldsTest extends FDBRecordStoreTestBase {
     }
 
     private void rebuildIndexMetaData(final FDBRecordContext context, final String document, final Index index) {
-        Pair<FDBRecordStore, QueryPlanner> pair = LuceneIndexTestUtils.rebuildIndexMetaData(context, path, document, index, isUseCascadesPlanner());
+        Pair<FDBRecordStore, QueryPlanner> pair = LuceneIndexTestUtils.rebuildIndexMetaData(context, Objects.requireNonNull(path), document, index, isUseCascadesPlanner());
         this.recordStore = pair.getLeft();
         this.planner = pair.getRight();
         recordStore.getIndexDeferredMaintenanceControl().setAutoMergeDuringCommit(false);

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneStoredFieldsTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneStoredFieldsTest.java
@@ -525,8 +525,10 @@ public class LuceneStoredFieldsTest extends FDBRecordStoreTestBase {
 
     private void rebuildIndexMetaData(final FDBRecordContext context, final String document, final Index index) {
         Pair<FDBRecordStore, QueryPlanner> pair = LuceneIndexTestUtils.rebuildIndexMetaData(context, Objects.requireNonNull(path), document, index, isUseCascadesPlanner());
-        this.recordStore = pair.getLeft();
-        this.planner = pair.getRight();
+        // Pair#getLeft/getRight are @Nullable in general (a Pair may hold nulls), but
+        // rebuildIndexMetaData always constructs its result from the non-null store/planner it builds.
+        this.recordStore = Objects.requireNonNull(pair.getLeft());
+        this.planner = Objects.requireNonNull(pair.getRight());
         recordStore.getIndexDeferredMaintenanceControl().setAutoMergeDuringCommit(false);
     }
 }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneSyntheticPlannerTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneSyntheticPlannerTest.java
@@ -38,7 +38,6 @@ import com.google.common.collect.Sets;
 import org.hamcrest.Matcher;
 import org.junit.jupiter.api.Test;
 
-import javax.annotation.Nonnull;
 import java.util.List;
 
 import static com.apple.foundationdb.record.lucene.LucenePlanMatchers.query;
@@ -78,7 +77,7 @@ public class LuceneSyntheticPlannerTest extends FDBRecordStoreTestBase {
                 .build());
     }
 
-    private static void metadataHook(@Nonnull final RecordMetaDataBuilder metaDataBuilder) {
+    private static void metadataHook(final RecordMetaDataBuilder metaDataBuilder) {
         metaDataBuilder.getRecordType("CustomerWithHeader")
                 .setPrimaryKey(Key.Expressions.concat(field("___header").nest("z_key"), field("___header").nest("rec_id")));
         metaDataBuilder.getRecordType("OrderWithHeader")

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneSyntheticPlannerTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/LuceneSyntheticPlannerTest.java
@@ -39,6 +39,7 @@ import org.hamcrest.Matcher;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Objects;
 
 import static com.apple.foundationdb.record.lucene.LucenePlanMatchers.query;
 import static com.apple.foundationdb.record.lucene.LucenePlanMatchers.scanParams;
@@ -70,7 +71,7 @@ public class LuceneSyntheticPlannerTest extends FDBRecordStoreTestBase {
                     Sets.newHashSet(IndexTypes.TEXT),
                     Sets.newHashSet(LuceneIndexTypes.LUCENE)
             );
-        planner = new LucenePlanner(recordStore.getRecordMetaData(), recordStore.getRecordStoreState(), indexTypes, recordStore.getTimer());
+        planner = new LucenePlanner(recordStore.getRecordMetaData(), recordStore.getRecordStoreState(), indexTypes, Objects.requireNonNull(recordStore.getTimer()));
         planner.setConfiguration(planner.getConfiguration()
                 .asBuilder()
                 .setPlanOtherAttemptWholeFilter(attemptWholeFilter)

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/LazyCloseableTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/LazyCloseableTest.java
@@ -27,7 +27,6 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Isolated;
 
-import javax.annotation.Nonnull;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -57,8 +56,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @Isolated // To avoid contention on the thread pool with other tests running in parallel
 class LazyCloseableTest {
 
-    @Nonnull
-    static <T> Deque<T> collectFromMultipleThreads(int concurrency, @Nonnull Supplier<T> supplier) throws InterruptedException {
+    static <T> Deque<T> collectFromMultipleThreads(int concurrency, Supplier<T> supplier) throws InterruptedException {
         // Set up one thread for each concurrent creation we want to execute
         final List<Thread> threads = new ArrayList<>(concurrency);
         final CountDownLatch latch = new CountDownLatch(concurrency);
@@ -265,7 +263,6 @@ class LazyCloseableTest {
         assertDoesNotThrow(opener::close);
     }
 
-    @Nonnull
     private static LazyCloseable<Closeable> failingOpener(final IOException thrownException) {
         return LazyCloseable.supply(() -> {
             throw thrownException;

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedFieldInfosFormatTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedFieldInfosFormatTest.java
@@ -52,7 +52,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -436,7 +435,6 @@ class LuceneOptimizedFieldInfosFormatTest extends FDBRecordStoreTestBase {
         return Stream.of(Map.of(), Map.of("box", "car"), Map.of("run", "far", "walk", "slow"));
     }
 
-    @Nonnull
     private static FieldInfos singleFieldInfos(final String name, final int number) {
         return new FieldInfos(new FieldInfo[] {simpleFieldInfo(name, number)});
     }
@@ -500,7 +498,6 @@ class LuceneOptimizedFieldInfosFormatTest extends FDBRecordStoreTestBase {
         format.write(directory, segment.create(directory), "", fieldInfos, ioContext);
     }
 
-    @Nonnull
     private static FieldInfo fieldInfoA(final boolean storeTermVector, final boolean omitNorms, final boolean storePayloads) {
         // Note: FieldInfo will ignore all these booleans if IndexOptions == NONE
         return new FieldInfo("aField", 1, storeTermVector, omitNorms, storePayloads,
@@ -508,26 +505,22 @@ class LuceneOptimizedFieldInfosFormatTest extends FDBRecordStoreTestBase {
                 0, 0, 0, false);
     }
 
-    @Nonnull
     private static FieldInfo fieldInfoB(final IndexOptions indexOptions, final DocValuesType docValuesType, final int dvGen, final Map<String, String> attributes) {
         return new FieldInfo("aField", 1, false, false, false,
                 indexOptions, docValuesType, dvGen, attributes,
                 0, 0, 0, false);
     }
 
-    @Nonnull
     private static FieldInfo fieldInfoC(final int pointDimensionCount, final int pointIndexDimensionCount, final int pointNumBytes, final boolean softDeletesField) {
         return new FieldInfo("aField", 1, false, false, false,
                 IndexOptions.DOCS_AND_FREQS_AND_POSITIONS_AND_OFFSETS, DocValuesType.NUMERIC, 1, Map.of(),
                 pointDimensionCount, pointIndexDimensionCount, pointNumBytes, softDeletesField);
     }
 
-    @Nonnull
     private static FieldInfo simpleFieldInfo(final String name, final int number) {
         return fieldInfo(name, number, Map.of());
     }
 
-    @Nonnull
     private static FieldInfo fieldInfo(final String name, final int number, final Map<String, String> attributes) {
         return new FieldInfo(name, number, false, false, false,
                 IndexOptions.DOCS, DocValuesType.NUMERIC, 1, attributes, 0, 0, 0, false);

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedFieldInfosFormatTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/LuceneOptimizedFieldInfosFormatTest.java
@@ -59,6 +59,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -322,8 +323,8 @@ class LuceneOptimizedFieldInfosFormatTest extends FDBRecordStoreTestBase {
                 },
                 directory -> {
                     final FieldInfosStorage fieldInfoStorage = directory.getFieldInfosStorage();
-                    final LuceneFieldInfosProto.FieldInfos global = fieldInfoStorage
-                            .readFieldInfos(FieldInfosStorage.GLOBAL_FIELD_INFOS_ID);
+                    final LuceneFieldInfosProto.FieldInfos global = Objects.requireNonNull(fieldInfoStorage
+                            .readFieldInfos(FieldInfosStorage.GLOBAL_FIELD_INFOS_ID));
                     final LuceneFieldInfosProto.FieldInfos.Builder builder = global.toBuilder();
                     final LuceneFieldInfosProto.FieldInfo.Builder fieldInfoBuilder = builder.getFieldInfoBuilder(0);
                     final List<LuceneFieldInfosProto.Attribute> reversedAttributes = new ArrayList<>();
@@ -339,8 +340,8 @@ class LuceneOptimizedFieldInfosFormatTest extends FDBRecordStoreTestBase {
                 },
                 directory -> {
                     final FieldInfosStorage fieldInfoStorage = directory.getFieldInfosStorage();
-                    final LuceneFieldInfosProto.FieldInfos global = fieldInfoStorage
-                            .readFieldInfos(FieldInfosStorage.GLOBAL_FIELD_INFOS_ID);
+                    final LuceneFieldInfosProto.FieldInfos global = Objects.requireNonNull(fieldInfoStorage
+                            .readFieldInfos(FieldInfosStorage.GLOBAL_FIELD_INFOS_ID));
                     assertEquals(
                             global.getFieldInfo(0).getAttributesList().stream()
                                     .map(LuceneFieldInfosProto.Attribute::getKey)
@@ -356,8 +357,8 @@ class LuceneOptimizedFieldInfosFormatTest extends FDBRecordStoreTestBase {
                             directory.getFieldInfosCount()));
 
                     final FieldInfosStorage fieldInfoStorage = directory.getFieldInfosStorage();
-                    final LuceneFieldInfosProto.FieldInfos global = fieldInfoStorage
-                            .readFieldInfos(FieldInfosStorage.GLOBAL_FIELD_INFOS_ID);
+                    final LuceneFieldInfosProto.FieldInfos global = Objects.requireNonNull(fieldInfoStorage
+                            .readFieldInfos(FieldInfosStorage.GLOBAL_FIELD_INFOS_ID));
                     assertEquals(
                             global.getFieldInfo(0).getAttributesList().stream()
                                     .map(LuceneFieldInfosProto.Attribute::getKey)
@@ -391,13 +392,13 @@ class LuceneOptimizedFieldInfosFormatTest extends FDBRecordStoreTestBase {
         sameOrMultiTransaction(oneTransaction,
                 directory -> {
                     for (Pair<LightSegmentInfo, FieldInfo> pair : fieldInfos) {
-                        write(directory, pair.getLeft(), new FieldInfos(new FieldInfo[] {pair.getRight()}));
+                        write(directory, Objects.requireNonNull(pair.getLeft()), new FieldInfos(new FieldInfo[] {pair.getRight()}));
                     }
                 },
                 directory -> {
                     for (Pair<LightSegmentInfo, FieldInfo> pair : fieldInfos) {
                         assertFieldInfosEqual(new FieldInfos(new FieldInfo[] { pair.getRight() }),
-                                read(directory, pair.getLeft()));
+                                read(directory, Objects.requireNonNull(pair.getLeft())));
                     }
                 });
     }
@@ -553,7 +554,7 @@ class LuceneOptimizedFieldInfosFormatTest extends FDBRecordStoreTestBase {
     }
 
     private FDBDirectory createDirectory(final FDBRecordContext context) {
-        return new FDBDirectory(path.toSubspace(context), context,
+        return new FDBDirectory(Objects.requireNonNull(path).toSubspace(context), context,
                 Map.of(LuceneIndexOptions.PRIMARY_KEY_SEGMENT_INDEX_V2_ENABLED, "true"));
     }
 

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/TestFDBDirectory.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/TestFDBDirectory.java
@@ -39,9 +39,8 @@ import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
+import org.jspecify.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -131,9 +130,8 @@ public class TestFDBDirectory extends FDBDirectory {
         previousStoredFields.set(null);
     }
 
-    @Nonnull
     @Override
-    public IndexInput openInput(@Nonnull final String name, @Nonnull final IOContext ioContext) throws IOException {
+    public IndexInput openInput(final String name, final IOContext ioContext) throws IOException {
         final IndexInput indexInput = super.openInput(name, ioContext);
         if (fullBufferToSurviveDeletes) {
             assertThat("Avoid buffering more than 10MB",
@@ -178,9 +176,8 @@ public class TestFDBDirectory extends FDBDirectory {
         return indexInput;
     }
 
-    @Nonnull
     @Override
-    public IndexOutput createOutput(@Nonnull final String name, @Nullable final IOContext ioContext) throws IOException {
+    public IndexOutput createOutput(final String name, @Nullable final IOContext ioContext) throws IOException {
         final IndexOutput indexOutput = super.createOutput(name, ioContext);
         if (allowAddIndexes) {
             if (isStacktraceCopySegmentAsIs()) {

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/TestFDBDirectory.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/codec/TestFDBDirectory.java
@@ -157,9 +157,9 @@ public class TestFDBDirectory extends FDBDirectory {
                         name.endsWith("." + LuceneOptimizedStoredFieldsFormat.STORED_FIELDS_EXTENSION)) {
                     final String segmentName = IndexFileNames.parseSegmentName(name);
                     final byte[] key = storedFieldsSubspace.pack(Tuple.from(segmentName));
-                    final List<KeyValue> rawStoredFields = asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_GET_STORED_FIELDS,
+                    final List<KeyValue> rawStoredFields = Objects.requireNonNull(asyncToSync(LuceneEvents.Waits.WAIT_LUCENE_GET_STORED_FIELDS,
                             getAgilityContext().instrument(LuceneEvents.Events.LUCENE_READ_STORED_FIELDS,
-                                    getAgilityContext().getRange(key, ByteArrayUtil.strinc(key))));
+                                    getAgilityContext().getRange(key, ByteArrayUtil.strinc(key)))));
                     final Map<Long, byte[]> storedFields = rawStoredFields.stream().collect(Collectors.toMap(
                             keyValue -> storedFieldsSubspace.unpack(keyValue.getKey()).getLong(1),
                             keyValue -> Objects.requireNonNull(Objects.requireNonNull(getSerializer()).decodeFieldProtobuf(keyValue.getValue()))
@@ -187,7 +187,7 @@ public class TestFDBDirectory extends FDBDirectory {
                         @Override
                         public void close() throws IOException {
                             super.close();
-                            final NonnullPair<String, FieldInfos> previous = previousFieldInfos.get();
+                            final NonnullPair<String, FieldInfos> previous = Objects.requireNonNull(previousFieldInfos.get());
                             FIELD_INFOS_FORMAT.write(TestFDBDirectory.this, previous.getRight(), name);
 
                             previousFieldInfos.compareAndSet(previous, null);
@@ -197,7 +197,7 @@ public class TestFDBDirectory extends FDBDirectory {
 
                 if (name.endsWith("." + LuceneOptimizedCompoundFormat.DATA_EXTENSION) ||
                         name.endsWith("." + LuceneOptimizedStoredFieldsFormat.STORED_FIELDS_EXTENSION)) {
-                    final NonnullPair<String, Map<Long, byte[]>> previous = previousStoredFields.get();
+                    final NonnullPair<String, Map<Long, byte[]>> previous = Objects.requireNonNull(previousStoredFields.get());
                     final String segmentName = IndexFileNames.parseSegmentName(name);
                     for (final Map.Entry<Long, byte[]> storedFields : previous.getRight().entrySet()) {
                         writeStoredFields(segmentName, storedFields.getKey().intValue(), storedFields.getValue());

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/AgilityContextTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/AgilityContextTest.java
@@ -150,13 +150,13 @@ class AgilityContextTest extends FDBRecordStoreTestBase {
      */
     private Subspace getSubspace(final AgilityContext agilityContext) {
         return agilityContext
-                .apply(context -> CompletableFuture.completedFuture(path.toSubspace(context)))
+                .apply(context -> CompletableFuture.completedFuture(Objects.requireNonNull(path).toSubspace(context)))
                 .join();
     }
 
     private void assertLoopThreadsValues() {
         try (FDBRecordContext context = fdb.openContext()) {
-            final Subspace subspace = path.toSubspace(context);
+            final Subspace subspace = Objects.requireNonNull(path).toSubspace(context);
             for (int loop = 0; loop < loopCount; loop++) {
                 final AgilityContext agilityContext = getAgilityContext(context, AgilityContextType.NON_AGILE);
                 for (int i = 0; i < threadCount; i++) {
@@ -173,7 +173,7 @@ class AgilityContextTest extends FDBRecordStoreTestBase {
 
     private void assertLoopNoValues() {
         try (FDBRecordContext context = fdb.openContext()) {
-            final Subspace subspace = path.toSubspace(context);
+            final Subspace subspace = Objects.requireNonNull(path).toSubspace(context);
             for (int loop = 0; loop < loopCount; loop++) {
                 final AgilityContext agilityContext = getAgilityContext(context, AgilityContextType.NON_AGILE);
                 for (int i = 0; i < threadCount; i++) {
@@ -286,7 +286,7 @@ class AgilityContextTest extends FDBRecordStoreTestBase {
                         "To where it bent in the undergrowth;" ;
 
         try (FDBRecordContext context = useProp ? openContext(insertProps) : openContext()) {
-            final Subspace subspace = path.toSubspace(context);
+            final Subspace subspace = Objects.requireNonNull(path).toSubspace(context);
             final AgilityContext agilityContext =
                     useProp ? getAgilityContextAgileProp(context) : AgilityContext.agile(context, timeLimit, sizeLimit);
             for (int i = 0; i < loopCount; i++) {
@@ -327,7 +327,7 @@ class AgilityContextTest extends FDBRecordStoreTestBase {
             assertThat(timer.getCount(limitType.timerEvent), Matchers.greaterThan(0));
         }
         try (FDBRecordContext context = openContext(insertProps)) {
-            final Subspace subspace = path.toSubspace(context);
+            final Subspace subspace = Objects.requireNonNull(path).toSubspace(context);
             final AgilityContext agilityContext = getAgilityContext(context, AgilityContextType.NON_AGILE);
             for (int i = 0; i < loopCount; i++) {
                 byte[] key = subspace.pack(Tuple.from(2023, i));
@@ -364,7 +364,7 @@ class AgilityContextTest extends FDBRecordStoreTestBase {
                         "To where it bent in the undergrowth;" ;
 
         try (FDBRecordContext context = useProp ? openContext(insertProps) : openContext()) {
-            final Subspace subspace = path.toSubspace(context);
+            final Subspace subspace = Objects.requireNonNull(path).toSubspace(context);
             final AgilityContext agilityContext =
                     useProp ? getAgilityContextAgileProp(context) : AgilityContext.agile(context, timeLimit, sizeLimit);
             final byte[] unwritableKey = new byte[] { (byte)0xff };
@@ -466,7 +466,7 @@ class AgilityContextTest extends FDBRecordStoreTestBase {
 
             IntStream.rangeClosed(0, threadCount).parallel().forEach(threadNum -> {
                 try (FDBRecordContext context = openContext(insertProps)) {
-                    final Subspace subspace = path.toSubspace(context);
+                    final Subspace subspace = Objects.requireNonNull(path).toSubspace(context);
                     final AgilityContext agilityContext = getAgilityContext(context, contextType);
                     for (int i = 1700; i < 1900; i += 17) {
                         final long iFinal = i;
@@ -511,7 +511,7 @@ class AgilityContextTest extends FDBRecordStoreTestBase {
         byte[] packedValue = value.pack();
         try (FDBRecordContext context = openContext()) {
             final AgilityContext agilityContext = getAgilityContext(context, AgilityContextType.AGILE);
-            final Subspace subspace = path.toSubspace(context);
+            final Subspace subspace = Objects.requireNonNull(path).toSubspace(context);
             keyAborted = subspace.pack(Tuple.from(2023, 3));
             agilityContext.set(keyAborted, packedValue);
             agilityContext.abortAndClose();
@@ -545,7 +545,7 @@ class AgilityContextTest extends FDBRecordStoreTestBase {
         byte[] packedValue = value.pack();
         try (FDBRecordContext context = openContext()) {
             final AgilityContext agilityContext = getAgilityContext(context, AgilityContextType.AGILE);
-            final Subspace subspace = path.toSubspace(context);
+            final Subspace subspace = Objects.requireNonNull(path).toSubspace(context);
             byte[] keyAborted = subspace.pack(abortedTuple);
             byte[] keySucceeds = subspace.pack(successTuple);
             byte[] keyFails = subspace.pack(failTuple);
@@ -572,7 +572,7 @@ class AgilityContextTest extends FDBRecordStoreTestBase {
             context.commit();
         }
         try (FDBRecordContext context = openContext()) {
-            final Subspace subspace = path.toSubspace(context);
+            final Subspace subspace = Objects.requireNonNull(path).toSubspace(context);
             byte[] keyAborted = subspace.pack(abortedTuple);
             byte[] keySucceeds = subspace.pack(successTuple);
             byte[] keyFails = subspace.pack(failTuple);
@@ -601,7 +601,7 @@ class AgilityContextTest extends FDBRecordStoreTestBase {
 
         try (FDBRecordContext context = openContext()) {
             final AgilityContext agilityContext = getAgilityContext(context, AgilityContextType.READ_ONLY);
-            final Subspace subspace = path.toSubspace(context);
+            final Subspace subspace = Objects.requireNonNull(path).toSubspace(context);
             written = subspace.pack(Tuple.from("Written"));
             notWritten = subspace.pack(Tuple.from("NotWritten"));
 
@@ -626,7 +626,7 @@ class AgilityContextTest extends FDBRecordStoreTestBase {
         byte[] key;
 
         FDBRecordContext earlyContext = openContext();
-        final Subspace subspace = path.toSubspace(earlyContext);
+        final Subspace subspace = Objects.requireNonNull(path).toSubspace(earlyContext);
         key = subspace.pack(Tuple.from("something"));
 
         try (FDBRecordContext laterContext = openContext()) {
@@ -649,7 +649,7 @@ class AgilityContextTest extends FDBRecordStoreTestBase {
         byte[] key;
 
         try (FDBRecordContext context = openContext()) {
-            final Subspace subspace = path.toSubspace(context);
+            final Subspace subspace = Objects.requireNonNull(path).toSubspace(context);
             key = subspace.pack(Tuple.from("something"));
 
             final AgilityContext agilityContext = getAgilityContext(context, AgilityContextType.READ_ONLY);
@@ -734,7 +734,7 @@ class AgilityContextTest extends FDBRecordStoreTestBase {
                 return CompletableFuture.completedFuture(null);
             });
             // call set to create transaction
-            byte[] key = this.path.toSubspace(context).pack(Tuple.from(prefix, "a").pack());
+            byte[] key = Objects.requireNonNull(path).toSubspace(context).pack(Tuple.from(prefix, "a").pack());
             agilityContext.set(key, "Hello".getBytes());
             // commit the agility context
             try {
@@ -757,7 +757,7 @@ class AgilityContextTest extends FDBRecordStoreTestBase {
     void testCloseOnCommitFailure() {
         final byte[] key;
         try (FDBRecordContext context = openContext()) {
-            key = this.path.toSubspace(context).pack(Tuple.from(prefix, "a").pack());
+            key = Objects.requireNonNull(path).toSubspace(context).pack(Tuple.from(prefix, "a").pack());
             context.ensureActive().set(key, Tuple.from(1).pack());
             context.commit();
         }
@@ -788,7 +788,7 @@ class AgilityContextTest extends FDBRecordStoreTestBase {
     void testAutoCommitVersionStampOuterSleep() throws InterruptedException {
         final byte[] key;
         try (FDBRecordContext userContext = openContext()) {
-            key = this.path.toSubspace(userContext).pack(Tuple.from(prefix, "a").pack());
+            key = Objects.requireNonNull(path).toSubspace(userContext).pack(Tuple.from(prefix, "a").pack());
             final AgilityContext agilityContext = AgilityContext.agile(userContext, 2, 10000);
             AtomicReference<FDBRecordContext> firstOperation = new AtomicReference<>();
             agilityContext.accept(context -> {
@@ -805,7 +805,7 @@ class AgilityContextTest extends FDBRecordStoreTestBase {
                 secondOperation.set(context);
             });
             agilityContext.flush();
-            MatcherAssert.assertThat(secondOperation.get().getCommittedVersion(), Matchers.greaterThan(firstOperation.get().getCommittedVersion()));
+            MatcherAssert.assertThat(Objects.requireNonNull(secondOperation.get()).getCommittedVersion(), Matchers.greaterThan(Objects.requireNonNull(firstOperation.get()).getCommittedVersion()));
         }
     }
 
@@ -814,7 +814,7 @@ class AgilityContextTest extends FDBRecordStoreTestBase {
         int timeQuota = 10;
         final byte[] key;
         try (FDBRecordContext userContext = openContext()) {
-            key = this.path.toSubspace(userContext).pack(Tuple.from(prefix, "a").pack());
+            key = Objects.requireNonNull(path).toSubspace(userContext).pack(Tuple.from(prefix, "a").pack());
             final AgilityContext agilityContext = AgilityContext.agile(userContext, timeQuota, 10000);
             AtomicReference<FDBRecordContext> firstOperation = new AtomicReference<>();
             AtomicInteger timeCommit = new AtomicInteger(0);
@@ -843,7 +843,7 @@ class AgilityContextTest extends FDBRecordStoreTestBase {
                         return oldVal;
                     })).join();
             agilityContext.flush();
-            MatcherAssert.assertThat(secondOperation.get().getCommittedVersion(), Matchers.greaterThan(firstOperation.get().getCommittedVersion()));
+            MatcherAssert.assertThat(Objects.requireNonNull(secondOperation.get()).getCommittedVersion(), Matchers.greaterThan(Objects.requireNonNull(firstOperation.get()).getCommittedVersion()));
         }
     }
 
@@ -851,7 +851,7 @@ class AgilityContextTest extends FDBRecordStoreTestBase {
     void testAutoCommitVersionStampInnerSleep() {
         final byte[] key;
         try (FDBRecordContext userContext = openContext()) {
-            key = this.path.toSubspace(userContext).pack(Tuple.from(prefix, "a").pack());
+            key = Objects.requireNonNull(path).toSubspace(userContext).pack(Tuple.from(prefix, "a").pack());
             final AgilityContext agilityContext = AgilityContext.agile(userContext, 2, 10000);
             AtomicReference<FDBRecordContext> firstOperation = new AtomicReference<>();
             agilityContext.accept(context -> {
@@ -870,7 +870,7 @@ class AgilityContextTest extends FDBRecordStoreTestBase {
                 secondOperation.set(context);
             });
             agilityContext.flush();
-            MatcherAssert.assertThat(secondOperation.get().getCommittedVersion(), Matchers.greaterThan(firstOperation.get().getCommittedVersion()));
+            MatcherAssert.assertThat(Objects.requireNonNull(secondOperation.get()).getCommittedVersion(), Matchers.greaterThan(Objects.requireNonNull(firstOperation.get()).getCommittedVersion()));
         }
     }
 
@@ -878,7 +878,7 @@ class AgilityContextTest extends FDBRecordStoreTestBase {
     void testAutoCommitVersionStampInnerSleepUseApply() {
         final byte[] key;
         try (FDBRecordContext userContext = openContext()) {
-            key = this.path.toSubspace(userContext).pack(Tuple.from(prefix, "a").pack());
+            key = Objects.requireNonNull(path).toSubspace(userContext).pack(Tuple.from(prefix, "a").pack());
             final AgilityContext agilityContext = AgilityContext.agile(userContext, 2, 10000);
             AtomicReference<FDBRecordContext> firstOperation = new AtomicReference<>();
             agilityContext.apply(context -> context.ensureActive()
@@ -901,7 +901,7 @@ class AgilityContextTest extends FDBRecordStoreTestBase {
                         return oldVal;
                     })).join();
             agilityContext.flush();
-            MatcherAssert.assertThat(secondOperation.get().getCommittedVersion(), Matchers.greaterThan(firstOperation.get().getCommittedVersion()));
+            MatcherAssert.assertThat(Objects.requireNonNull(secondOperation.get()).getCommittedVersion(), Matchers.greaterThan(Objects.requireNonNull(firstOperation.get()).getCommittedVersion()));
         }
     }
 

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryBaseTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryBaseTest.java
@@ -36,7 +36,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import javax.annotation.Nonnull;
 import java.util.Map;
 import java.util.Random;
 
@@ -67,7 +66,7 @@ public abstract class FDBDirectoryBaseTest {
         directory = createDirectory(subspace, context, null);
     }
 
-    protected @Nonnull FDBDirectory createDirectory(final Subspace subspace, final FDBRecordContext context, final Map<String, String> indexOptions) {
+    protected FDBDirectory createDirectory(final Subspace subspace, final FDBRecordContext context, final Map<String, String> indexOptions) {
         return new FDBDirectory(subspace, context, indexOptions);
     }
 

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryBaseTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryBaseTest.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import org.jspecify.annotations.Nullable;
 import java.util.Map;
 import java.util.Random;
 
@@ -66,7 +67,7 @@ public abstract class FDBDirectoryBaseTest {
         directory = createDirectory(subspace, context, null);
     }
 
-    protected FDBDirectory createDirectory(final Subspace subspace, final FDBRecordContext context, final Map<String, String> indexOptions) {
+    protected FDBDirectory createDirectory(final Subspace subspace, final FDBRecordContext context, @Nullable final Map<String, String> indexOptions) {
         return new FDBDirectory(subspace, context, indexOptions);
     }
 

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryFailuresTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryFailuresTest.java
@@ -33,7 +33,6 @@ import com.apple.test.Tags;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.nio.file.NoSuchFileException;
 import java.util.Map;
@@ -240,7 +239,6 @@ public class FDBDirectoryFailuresTest extends FDBDirectoryBaseTest {
     /*
      * Override default behavior to create a mocked directory.
      */
-    @Nonnull
     @Override
     protected FDBDirectory createDirectory(final Subspace subspace, final FDBRecordContext context, final Map<String, String> indexOptions) {
         injectedFailures = new InjectedFailureRepository();

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryFailuresTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryFailuresTest.java
@@ -33,9 +33,11 @@ import com.apple.test.Tags;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import org.jspecify.annotations.Nullable;
 import java.io.IOException;
 import java.nio.file.NoSuchFileException;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
@@ -58,6 +60,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 @Tag(Tags.RequiresFDB)
 public class FDBDirectoryFailuresTest extends FDBDirectoryBaseTest {
+    @Nullable
     private InjectedFailureRepository injectedFailures;
 
     @Test
@@ -120,7 +123,9 @@ public class FDBDirectoryFailuresTest extends FDBDirectoryBaseTest {
         assertTrue(ex.getCause() instanceof TimeoutException);
 
         directory.getCallerContext().commit();
-        assertCorrectMetricSize(LuceneEvents.SizeEvents.LUCENE_WRITE, 1, directory.getSerializer().encode(data).length);
+        final LuceneSerializer serializer = Objects.requireNonNull(directory.getSerializer());
+        final byte[] encoded = Objects.requireNonNull(serializer.encode(data));
+        assertCorrectMetricSize(LuceneEvents.SizeEvents.LUCENE_WRITE, 1, encoded.length);
     }
 
     @Test
@@ -240,7 +245,7 @@ public class FDBDirectoryFailuresTest extends FDBDirectoryBaseTest {
      * Override default behavior to create a mocked directory.
      */
     @Override
-    protected FDBDirectory createDirectory(final Subspace subspace, final FDBRecordContext context, final Map<String, String> indexOptions) {
+    protected FDBDirectory createDirectory(final Subspace subspace, final FDBRecordContext context, @Nullable final Map<String, String> indexOptions) {
         injectedFailures = new InjectedFailureRepository();
         final MockedFDBDirectory directory = new MockedFDBDirectory(subspace, context, indexOptions);
         directory.setInjectedFailures(injectedFailures);
@@ -248,10 +253,10 @@ public class FDBDirectoryFailuresTest extends FDBDirectoryBaseTest {
     }
 
     private void addFailure(final InjectedFailureRepository.Methods method, final Exception exception, final int count) {
-        injectedFailures.addFailure(method, exception, count);
+        Objects.requireNonNull(injectedFailures).addFailure(method, exception, count);
     }
 
     private void removeFailure(final InjectedFailureRepository.Methods method) {
-        injectedFailures.removeFailure(method);
+        Objects.requireNonNull(injectedFailures).removeFailure(method);
     }
 }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryLockTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryLockTest.java
@@ -40,7 +40,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -235,7 +234,7 @@ class FDBDirectoryLockTest {
         }
     }
 
-    private @Nonnull FDBDirectory createDirectory(final AgilityContext agilityContext) {
+    private FDBDirectory createDirectory(final AgilityContext agilityContext) {
         return new FDBDirectory(subspace, null, null, null, true, agilityContext);
     }
 }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryLockTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryLockTest.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -81,7 +82,7 @@ class FDBDirectoryLockTest {
             final Lock lock1 = directory.obtainLock(lockName);
             lock1.ensureValid();
             LockObtainFailedException e = assertThrows(LockObtainFailedException.class, () -> directory.obtainLock(lockName));
-            assertTrue(e.getMessage().contains(alreadyLockedMessage));
+            assertTrue(Objects.requireNonNull(e.getMessage()).contains(alreadyLockedMessage));
             lock1.ensureValid();
             lock1.close();
 
@@ -89,7 +90,7 @@ class FDBDirectoryLockTest {
             final Lock lock2 = directory.obtainLock(lockName);
             lock2.ensureValid();
             e = assertThrows(LockObtainFailedException.class, () -> directory.obtainLock(lockName));
-            assertTrue(e.getMessage().contains(alreadyLockedMessage));
+            assertTrue(Objects.requireNonNull(e.getMessage()).contains(alreadyLockedMessage));
             lock2.ensureValid();
             lock2.close();
         }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBDirectoryTest.java
@@ -49,6 +49,7 @@ import java.nio.file.NoSuchFileException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.stream.Collectors;
@@ -139,9 +140,9 @@ public class FDBDirectoryTest extends FDBDirectoryBaseTest {
         FDBLuceneFileReference luceneFileReference = directory.getFDBLuceneFileReference("test1");
         assertNotNull(luceneFileReference, "fileReference should exist");
 
-        LuceneSerializer serializer = directory.getSerializer();
+        LuceneSerializer serializer = Objects.requireNonNull(directory.getSerializer());
         assertCorrectMetricSize(LuceneEvents.SizeEvents.LUCENE_WRITE_FILE_REFERENCE, 2,
-                serializer.encode(reference1.getBytes()).length + serializer.encode(reference2.getBytes()).length);
+                Objects.requireNonNull(serializer.encode(reference1.getBytes())).length + Objects.requireNonNull(serializer.encode(reference2.getBytes())).length);
     }
 
     @Test
@@ -170,7 +171,9 @@ public class FDBDirectoryTest extends FDBDirectoryBaseTest {
                 directory.getFDBLuceneFileReferenceAsync("testReference2"), 1).get(), "seek data should exist");
 
         directory.getCallerContext().commit();
-        assertCorrectMetricSize(LuceneEvents.SizeEvents.LUCENE_WRITE, 1, directory.getSerializer().encode(data).length);
+        final LuceneSerializer serializer = Objects.requireNonNull(directory.getSerializer());
+        final byte[] encoded = Objects.requireNonNull(serializer.encode(data));
+        assertCorrectMetricSize(LuceneEvents.SizeEvents.LUCENE_WRITE, 1, encoded.length);
     }
 
     @Test
@@ -408,7 +411,8 @@ public class FDBDirectoryTest extends FDBDirectoryBaseTest {
                             () -> newDirectory.clearOngoingMergeIndicatorIfQueueEmptyAsync().join(),
                             "clearUseQueueFailIfNonEmpty should throw when queue is not empty");
             assertThat(completionException.getCause(), Matchers.instanceOf(RecordCoreException.class));
-            assertThat(completionException.getCause().getMessage(),
+            final Throwable cause = Objects.requireNonNull(completionException.getCause());
+            assertThat(cause.getMessage(),
                     Matchers.containsString("pending write queue is not empty"));
 
             // Indicator should still be set

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBIndexOutputTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBIndexOutputTest.java
@@ -29,7 +29,6 @@ import org.apache.lucene.store.IndexInput;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
@@ -89,7 +88,6 @@ public class FDBIndexOutputTest extends FDBDirectoryBaseTest {
         assertEquals(BLOCK_ARRAY_100.length, directory.getFDBLuceneFileReference(FILE_NAME_TWO).getSize());
     }
 
-    @Nonnull
     private List<ComparablePair<Long, Integer>> directoryCacheKeys() {
         return directory.getBlockCache().asMap().keySet().stream().sorted().collect(Collectors.toList());
     }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBIndexOutputTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/FDBIndexOutputTest.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Random;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -64,7 +65,7 @@ public class FDBIndexOutputTest extends FDBDirectoryBaseTest {
         random.nextBytes(data);
         output.writeBytes(data, data.length);
         output.close();
-        assertEquals(data.length, directory.getFDBLuceneFileReference(FILE_NAME).getSize());
+        assertEquals(data.length, Objects.requireNonNull(directory.getFDBLuceneFileReference(FILE_NAME)).getSize());
     }
     
     @Test
@@ -72,7 +73,7 @@ public class FDBIndexOutputTest extends FDBDirectoryBaseTest {
         FDBIndexOutput output = new FDBIndexOutput(FILE_NAME, directory);
         output.writeByte((byte) 0);
         output.close();
-        assertEquals(1, directory.getFDBLuceneFileReference(FILE_NAME).getSize());
+        assertEquals(1, Objects.requireNonNull(directory.getFDBLuceneFileReference(FILE_NAME)).getSize());
     }
 
     @Test
@@ -80,12 +81,12 @@ public class FDBIndexOutputTest extends FDBDirectoryBaseTest {
         FDBIndexOutput output = new FDBIndexOutput(FILE_NAME, directory);
         output.writeBytes(BLOCK_ARRAY_100, BLOCK_ARRAY_100.length);
         output.close();
-        assertEquals(BLOCK_ARRAY_100.length, directory.getFDBLuceneFileReference(FILE_NAME).getSize());
+        assertEquals(BLOCK_ARRAY_100.length, Objects.requireNonNull(directory.getFDBLuceneFileReference(FILE_NAME)).getSize());
         IndexInput blocks = directory.openInput(FILE_NAME, IOContext.READONCE);
         output = new FDBIndexOutput(FILE_NAME_TWO, directory);
         output.copyBytes(blocks, blocks.length());
         output.close();
-        assertEquals(BLOCK_ARRAY_100.length, directory.getFDBLuceneFileReference(FILE_NAME_TWO).getSize());
+        assertEquals(BLOCK_ARRAY_100.length, Objects.requireNonNull(directory.getFDBLuceneFileReference(FILE_NAME_TWO)).getSize());
     }
 
     private List<ComparablePair<Long, Integer>> directoryCacheKeys() {
@@ -97,7 +98,7 @@ public class FDBIndexOutputTest extends FDBDirectoryBaseTest {
         FDBIndexOutput output = new FDBIndexOutput(FILE_NAME, directory);
         output.writeBytes(BLOCK_ARRAY_100, BLOCK_ARRAY_100.length);
         output.close();
-        assertEquals(BLOCK_ARRAY_100.length, directory.getFDBLuceneFileReference(FILE_NAME).getSize());
+        assertEquals(BLOCK_ARRAY_100.length, Objects.requireNonNull(directory.getFDBLuceneFileReference(FILE_NAME)).getSize());
         IndexInput blocks = directory.openChecksumInput(FILE_NAME, IOContext.READONCE);
         output = new FDBIndexOutput(FILE_NAME_TWO, directory);
         output.setExpectedBytes((PrefetchableBufferedChecksumIndexInput) blocks, 2 * FDBDirectory.DEFAULT_BLOCK_SIZE);
@@ -109,7 +110,7 @@ public class FDBIndexOutputTest extends FDBDirectoryBaseTest {
         FDBIndexOutput output = new FDBIndexOutput(FILE_NAME, directory);
         output.writeBytes(BLOCK_ARRAY_100, BLOCK_ARRAY_100.length);
         output.close();
-        assertEquals(BLOCK_ARRAY_100.length, directory.getFDBLuceneFileReference(FILE_NAME).getSize());
+        assertEquals(BLOCK_ARRAY_100.length, Objects.requireNonNull(directory.getFDBLuceneFileReference(FILE_NAME)).getSize());
         IndexInput blocks = directory.openChecksumInput(FILE_NAME, IOContext.READONCE);
         output = new FDBIndexOutput(FILE_NAME_TWO, directory);
         output.setExpectedBytes((PrefetchableBufferedChecksumIndexInput) blocks, 50 * FDBDirectory.DEFAULT_BLOCK_SIZE);
@@ -134,7 +135,7 @@ public class FDBIndexOutputTest extends FDBDirectoryBaseTest {
         FDBIndexOutput output = new FDBIndexOutput(FILE_NAME, directory);
         output.writeBytes(BLOCK_ARRAY_100, BLOCK_ARRAY_100.length);
         output.close();
-        assertEquals(BLOCK_ARRAY_100.length, directory.getFDBLuceneFileReference(FILE_NAME).getSize());
+        assertEquals(BLOCK_ARRAY_100.length, Objects.requireNonNull(directory.getFDBLuceneFileReference(FILE_NAME)).getSize());
         IndexInput blocks = directory.openChecksumInput(FILE_NAME, IOContext.READONCE);
         output = new FDBIndexOutput(FILE_NAME_TWO, directory);
         output.setExpectedBytes((PrefetchableBufferedChecksumIndexInput) blocks, 50 * FDBDirectory.DEFAULT_BLOCK_SIZE);
@@ -148,7 +149,7 @@ public class FDBIndexOutputTest extends FDBDirectoryBaseTest {
         FDBIndexOutput output = new FDBIndexOutput(FILE_NAME, directory);
         output.writeBytes(BLOCK_ARRAY_100, BLOCK_ARRAY_100.length);
         output.close();
-        assertEquals(BLOCK_ARRAY_100.length, directory.getFDBLuceneFileReference(FILE_NAME).getSize());
+        assertEquals(BLOCK_ARRAY_100.length, Objects.requireNonNull(directory.getFDBLuceneFileReference(FILE_NAME)).getSize());
         IndexInput blocks = directory.openChecksumInput(FILE_NAME, IOContext.READONCE);
         output = new FDBIndexOutput(FILE_NAME_TWO, directory);
         output.setExpectedBytes((PrefetchableBufferedChecksumIndexInput) blocks, 50 * FDBDirectory.DEFAULT_BLOCK_SIZE);
@@ -162,7 +163,7 @@ public class FDBIndexOutputTest extends FDBDirectoryBaseTest {
         FDBIndexOutput output = new FDBIndexOutput(FILE_NAME, directory);
         output.writeBytes(BLOCK_ARRAY_100, BLOCK_ARRAY_100.length);
         output.close();
-        assertEquals(BLOCK_ARRAY_100.length, directory.getFDBLuceneFileReference(FILE_NAME).getSize());
+        assertEquals(BLOCK_ARRAY_100.length, Objects.requireNonNull(directory.getFDBLuceneFileReference(FILE_NAME)).getSize());
         IndexInput blocks = directory.openChecksumInput(FILE_NAME, IOContext.READONCE);
         output = new FDBIndexOutput(FILE_NAME_TWO, directory);
         output.setExpectedBytes((PrefetchableBufferedChecksumIndexInput) blocks, (long)(2.5 * 160 * 1024));
@@ -176,7 +177,7 @@ public class FDBIndexOutputTest extends FDBDirectoryBaseTest {
         FDBIndexOutput output = new FDBIndexOutput(FILE_NAME, directory);
         output.writeBytes(BLOCK_ARRAY_100, BLOCK_ARRAY_100.length);
         output.close();
-        assertEquals(BLOCK_ARRAY_100.length, directory.getFDBLuceneFileReference(FILE_NAME).getSize());
+        assertEquals(BLOCK_ARRAY_100.length, Objects.requireNonNull(directory.getFDBLuceneFileReference(FILE_NAME)).getSize());
         IndexInput blocks = directory.openChecksumInput(FILE_NAME, IOContext.READONCE);
         output = new FDBIndexOutput(FILE_NAME_TWO, directory);
         output.setExpectedBytes((PrefetchableBufferedChecksumIndexInput) blocks, (100L * FDBDirectory.DEFAULT_BLOCK_SIZE));

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/InjectedFailureRepository.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/InjectedFailureRepository.java
@@ -22,7 +22,6 @@ package com.apple.foundationdb.record.lucene.directory;
 
 import com.apple.foundationdb.record.RecordCoreException;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.EnumMap;
 import java.util.Optional;
@@ -57,11 +56,11 @@ public class InjectedFailureRepository {
     private EnumMap<Methods, AtomicLong> invocationCounts = new EnumMap<>(Methods.class);
     private EnumMap<Flags, Boolean> flagsMap = new EnumMap<>(Flags.class);
 
-    public void addFailure(@Nonnull Methods method, @Nonnull Exception exception, long count) {
+    public void addFailure(Methods method, Exception exception, long count) {
         failureDescriptions.put(method, new FailureDescription(method, exception, count));
     }
 
-    public void removeFailure(@Nonnull Methods method) {
+    public void removeFailure(Methods method) {
         failureDescriptions.remove(method);
         invocationCounts.remove(method);
     }
@@ -71,19 +70,19 @@ public class InjectedFailureRepository {
         invocationCounts.clear();
     }
 
-    public void setFlag(@Nonnull Flags flag) {
+    public void setFlag(Flags flag) {
         setFlag(flag, true);
     }
 
-    public void setFlag(@Nonnull Flags flag, Boolean value) {
+    public void setFlag(Flags flag, Boolean value) {
         flagsMap.put(flag, value);
     }
 
-    public boolean hasFlag(@Nonnull Flags flag) {
+    public boolean hasFlag(Flags flag) {
         return Optional.ofNullable(flagsMap.get(flag)).orElse(false);
     }
 
-    public void checkFailureForIoException(@Nonnull final Methods method) throws IOException {
+    public void checkFailureForIoException(final Methods method) throws IOException {
         try {
             checkFailure(method);
         } catch (IOException ex) {
@@ -93,7 +92,7 @@ public class InjectedFailureRepository {
         }
     }
 
-    public void checkFailureForCoreException(@Nonnull final Methods method) throws RecordCoreException {
+    public void checkFailureForCoreException(final Methods method) throws RecordCoreException {
         try {
             checkFailure(method);
         } catch (RecordCoreException ex) {
@@ -103,7 +102,7 @@ public class InjectedFailureRepository {
         }
     }
 
-    private void checkFailure(@Nonnull final Methods method) throws Exception {
+    private void checkFailure(final Methods method) throws Exception {
         // Local definitions have precedence over global ones
         FailureDescription failureDescription = failureDescriptions.get(method);
         if (failureDescription != null) {
@@ -119,9 +118,7 @@ public class InjectedFailureRepository {
      * A Failure description is the definition of the failure to be injected.
      */
     public static class FailureDescription {
-        @Nonnull
         private final Methods method;
-        @Nonnull
         private final Exception exception;
         private final long count;
 
@@ -131,18 +128,16 @@ public class InjectedFailureRepository {
          * @param exception the exception to throw
          * @param count the number of "clean" executions to allow before starting to throw the exception
          */
-        public FailureDescription(@Nonnull final Methods method, @Nonnull final Exception exception, final long count) {
+        public FailureDescription(final Methods method, final Exception exception, final long count) {
             this.method = method;
             this.exception = exception;
             this.count = count;
         }
 
-        @Nonnull
         public Methods getMethod() {
             return method;
         }
 
-        @Nonnull
         public Exception getException() {
             return exception;
         }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/MockedFDBDirectory.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/MockedFDBDirectory.java
@@ -51,7 +51,7 @@ import static com.apple.foundationdb.record.lucene.directory.InjectedFailureRepo
 public class MockedFDBDirectory extends FDBDirectory {
     private InjectedFailureRepository injectedFailures;
 
-    public MockedFDBDirectory(final Subspace subspace, final Map<String, String> options, final FDBDirectorySharedCacheManager sharedCacheManager, final Tuple sharedCacheKey, final boolean useCompoundFile, final AgilityContext agilityContext, @Nullable LockFactory lockFactory, final int blockCacheMaximumSize) {
+    public MockedFDBDirectory(final Subspace subspace, final Map<String, String> options, @Nullable final FDBDirectorySharedCacheManager sharedCacheManager, @Nullable final Tuple sharedCacheKey, final boolean useCompoundFile, final AgilityContext agilityContext, @Nullable LockFactory lockFactory, final int blockCacheMaximumSize) {
         super(subspace, options, sharedCacheManager, sharedCacheKey, useCompoundFile, agilityContext, lockFactory, blockCacheMaximumSize);
     }
 

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/MockedFDBDirectory.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/MockedFDBDirectory.java
@@ -28,8 +28,7 @@ import com.apple.foundationdb.tuple.Tuple;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.LockFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -56,7 +55,7 @@ public class MockedFDBDirectory extends FDBDirectory {
         super(subspace, options, sharedCacheManager, sharedCacheKey, useCompoundFile, agilityContext, lockFactory, blockCacheMaximumSize);
     }
 
-    public MockedFDBDirectory(@Nonnull final Subspace subspace, @Nonnull final FDBRecordContext context, @Nullable final Map<String, String> indexOptions) {
+    public MockedFDBDirectory(final Subspace subspace, final FDBRecordContext context, @Nullable final Map<String, String> indexOptions) {
         super(subspace, context, indexOptions);
     }
 
@@ -66,9 +65,8 @@ public class MockedFDBDirectory extends FDBDirectory {
         return super.getIncrement();
     }
 
-    @Nonnull
     @Override
-    public CompletableFuture<FDBLuceneFileReference> getFDBLuceneFileReferenceAsync(@Nonnull final String name) {
+    public CompletableFuture<FDBLuceneFileReference> getFDBLuceneFileReferenceAsync(final String name) {
         return super.getFDBLuceneFileReferenceAsync(name)
                 .thenApply(ref -> {
                     injectedFailures.checkFailureForCoreException(LUCENE_GET_FDB_LUCENE_FILE_REFERENCE_ASYNC);
@@ -76,9 +74,8 @@ public class MockedFDBDirectory extends FDBDirectory {
                 });
     }
 
-    @Nonnull
     @Override
-    public CompletableFuture<byte[]> readBlock(@Nonnull final IndexInput requestingInput, @Nonnull final String fileName, @Nonnull final CompletableFuture<FDBLuceneFileReference> referenceFuture, final int block) {
+    public CompletableFuture<byte[]> readBlock(final IndexInput requestingInput, final String fileName, final CompletableFuture<FDBLuceneFileReference> referenceFuture, final int block) {
         return super.readBlock(requestingInput, fileName, referenceFuture, block)
                 .thenApply(bytes -> {
                     injectedFailures.checkFailureForCoreException(LUCENE_READ_BLOCK);
@@ -86,14 +83,12 @@ public class MockedFDBDirectory extends FDBDirectory {
                 });
     }
 
-    @Nonnull
     @Override
     public String[] listAll() throws IOException {
         injectedFailures.checkFailureForIoException(LUCENE_LIST_ALL);
         return super.listAll();
     }
 
-    @Nonnull
     @Override
     public CompletableFuture<Map<String, FDBLuceneFileReference>> getFileReferenceCacheAsync() {
         return super.getFileReferenceCacheAsync()
@@ -104,7 +99,7 @@ public class MockedFDBDirectory extends FDBDirectory {
     }
 
     @Override
-    protected boolean deleteFileInternal(@Nonnull final Map<String, FDBLuceneFileReference> cache, @Nonnull final String name) throws IOException {
+    protected boolean deleteFileInternal(final Map<String, FDBLuceneFileReference> cache, final String name) throws IOException {
         injectedFailures.checkFailureForCoreException(LUCENE_DELETE_FILE_INTERNAL);
         return super.deleteFileInternal(cache, name);
     }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/MockedFDBDirectory.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/MockedFDBDirectory.java
@@ -31,6 +31,7 @@ import org.apache.lucene.store.LockFactory;
 import org.jspecify.annotations.Nullable;
 import java.io.IOException;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
@@ -49,6 +50,7 @@ import static com.apple.foundationdb.record.lucene.directory.InjectedFailureRepo
  * exception is the exception that should be throws and count is the number of "clean" invocation to allow before starting to fail.
  */
 public class MockedFDBDirectory extends FDBDirectory {
+    @Nullable
     private InjectedFailureRepository injectedFailures;
 
     public MockedFDBDirectory(final Subspace subspace, final Map<String, String> options, @Nullable final FDBDirectorySharedCacheManager sharedCacheManager, @Nullable final Tuple sharedCacheKey, final boolean useCompoundFile, final AgilityContext agilityContext, @Nullable LockFactory lockFactory, final int blockCacheMaximumSize) {
@@ -61,7 +63,7 @@ public class MockedFDBDirectory extends FDBDirectory {
 
     @Override
     public long getIncrement() throws IOException {
-        injectedFailures.checkFailureForIoException(LUCENE_GET_INCREMENT);
+        Objects.requireNonNull(injectedFailures).checkFailureForIoException(LUCENE_GET_INCREMENT);
         return super.getIncrement();
     }
 
@@ -69,7 +71,7 @@ public class MockedFDBDirectory extends FDBDirectory {
     public CompletableFuture<FDBLuceneFileReference> getFDBLuceneFileReferenceAsync(final String name) {
         return super.getFDBLuceneFileReferenceAsync(name)
                 .thenApply(ref -> {
-                    injectedFailures.checkFailureForCoreException(LUCENE_GET_FDB_LUCENE_FILE_REFERENCE_ASYNC);
+                    Objects.requireNonNull(injectedFailures).checkFailureForCoreException(LUCENE_GET_FDB_LUCENE_FILE_REFERENCE_ASYNC);
                     return ref;
                 });
     }
@@ -78,14 +80,14 @@ public class MockedFDBDirectory extends FDBDirectory {
     public CompletableFuture<byte[]> readBlock(final IndexInput requestingInput, final String fileName, final CompletableFuture<FDBLuceneFileReference> referenceFuture, final int block) {
         return super.readBlock(requestingInput, fileName, referenceFuture, block)
                 .thenApply(bytes -> {
-                    injectedFailures.checkFailureForCoreException(LUCENE_READ_BLOCK);
+                    Objects.requireNonNull(injectedFailures).checkFailureForCoreException(LUCENE_READ_BLOCK);
                     return bytes;
                 });
     }
 
     @Override
     public String[] listAll() throws IOException {
-        injectedFailures.checkFailureForIoException(LUCENE_LIST_ALL);
+        Objects.requireNonNull(injectedFailures).checkFailureForIoException(LUCENE_LIST_ALL);
         return super.listAll();
     }
 
@@ -93,27 +95,27 @@ public class MockedFDBDirectory extends FDBDirectory {
     public CompletableFuture<Map<String, FDBLuceneFileReference>> getFileReferenceCacheAsync() {
         return super.getFileReferenceCacheAsync()
                 .thenApply(cache -> {
-                    injectedFailures.checkFailureForCoreException(LUCENE_GET_FILE_REFERENCE_CACHE_ASYNC);
+                    Objects.requireNonNull(injectedFailures).checkFailureForCoreException(LUCENE_GET_FILE_REFERENCE_CACHE_ASYNC);
                     return cache;
                 });
     }
 
     @Override
     protected boolean deleteFileInternal(final Map<String, FDBLuceneFileReference> cache, final String name) throws IOException {
-        injectedFailures.checkFailureForCoreException(LUCENE_DELETE_FILE_INTERNAL);
+        Objects.requireNonNull(injectedFailures).checkFailureForCoreException(LUCENE_DELETE_FILE_INTERNAL);
         return super.deleteFileInternal(cache, name);
     }
 
     @Nullable
     @Override
     public LucenePrimaryKeySegmentIndex getPrimaryKeySegmentIndex() {
-        injectedFailures.checkFailureForCoreException(LUCENE_GET_PRIMARY_KEY_SEGMENT_INDEX);
+        Objects.requireNonNull(injectedFailures).checkFailureForCoreException(LUCENE_GET_PRIMARY_KEY_SEGMENT_INDEX);
         return super.getPrimaryKeySegmentIndex();
     }
 
     @Override
     Stream<NonnullPair<Long, byte[]>> getAllFieldInfosStream() {
-        injectedFailures.checkFailureForCoreException(LUCENE_GET_ALL_FIELDS_INFO_STREAM);
+        Objects.requireNonNull(injectedFailures).checkFailureForCoreException(LUCENE_GET_ALL_FIELDS_INFO_STREAM);
         return super.getAllFieldInfosStream();
     }
 

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/MockedFDBDirectoryManager.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/MockedFDBDirectoryManager.java
@@ -23,10 +23,14 @@ package com.apple.foundationdb.record.lucene.directory;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerState;
 import com.apple.foundationdb.tuple.Tuple;
 
+import org.jspecify.annotations.Nullable;
+import java.util.Objects;
+
 /**
  * A Testing-focused {@link FDBDirectoryManager} that allows a mocked-FDBDirectory to be injected into the system.
  */
 public class MockedFDBDirectoryManager extends FDBDirectoryManager {
+    @Nullable
     private InjectedFailureRepository injectedFailures;
 
     public MockedFDBDirectoryManager(final IndexMaintainerState state) {
@@ -38,7 +42,7 @@ public class MockedFDBDirectoryManager extends FDBDirectoryManager {
                                                             final int mergeDirectoryCount, final AgilityContext agilityContext,
                                                             final int blockCacheMaximumSize) {
         return new MockedFDBDirectoryWrapper(state, key, mergeDirectoryCount, agilityContext, blockCacheMaximumSize,
-                injectedFailures, writerAnalyzer, exceptionAtCreation);
+                Objects.requireNonNull(injectedFailures), writerAnalyzer, exceptionAtCreation);
     }
 
     /**

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/MockedFDBDirectoryManager.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/MockedFDBDirectoryManager.java
@@ -23,19 +23,16 @@ package com.apple.foundationdb.record.lucene.directory;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerState;
 import com.apple.foundationdb.tuple.Tuple;
 
-import javax.annotation.Nonnull;
-
 /**
  * A Testing-focused {@link FDBDirectoryManager} that allows a mocked-FDBDirectory to be injected into the system.
  */
 public class MockedFDBDirectoryManager extends FDBDirectoryManager {
     private InjectedFailureRepository injectedFailures;
 
-    public MockedFDBDirectoryManager(@Nonnull final IndexMaintainerState state) {
+    public MockedFDBDirectoryManager(final IndexMaintainerState state) {
         super(state);
     }
 
-    @Nonnull
     @Override
     protected FDBDirectoryWrapper createNewDirectoryWrapper(final IndexMaintainerState state, final Tuple key,
                                                             final int mergeDirectoryCount, final AgilityContext agilityContext,
@@ -49,9 +46,8 @@ public class MockedFDBDirectoryManager extends FDBDirectoryManager {
      * @param state the state to use for the manager
      * @return a cached instance of the manager if one exists, create a new one otherwise
      */
-    @Nonnull
     @SuppressWarnings("PMD.CloseResource")
-    public static FDBDirectoryManager getManager(@Nonnull IndexMaintainerState state) {
+    public static FDBDirectoryManager getManager(IndexMaintainerState state) {
         return getOrCreateManager(state, () -> new MockedFDBDirectoryManager(state));
     }
 

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/MockedFDBDirectoryWrapper.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/MockedFDBDirectoryWrapper.java
@@ -49,8 +49,8 @@ public class MockedFDBDirectoryWrapper extends FDBDirectoryWrapper {
 
     @Override
     protected FDBDirectory createFDBDirectory(final Subspace subspace, final Map<String, String> options,
-                                              final FDBDirectorySharedCacheManager sharedCacheManager,
-                                              final Tuple sharedCacheKey, final boolean useCompoundFile,
+                                              @Nullable final FDBDirectorySharedCacheManager sharedCacheManager,
+                                              @Nullable final Tuple sharedCacheKey, final boolean useCompoundFile,
                                               final AgilityContext agilityContext,
                                               final @Nullable LockFactory lockFactory,
                                               final int blockCacheMaximumSize) {

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/MockedFDBDirectoryWrapper.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/MockedFDBDirectoryWrapper.java
@@ -26,21 +26,20 @@ import com.apple.foundationdb.subspace.Subspace;
 import com.apple.foundationdb.tuple.Tuple;
 import org.apache.lucene.store.LockFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.Map;
 
 /**
  * A Testing-focused {@link FDBDirectoryWrapper} that allows a mocked-FDBDirectory to be injected into the system.
  */
 public class MockedFDBDirectoryWrapper extends FDBDirectoryWrapper {
-    MockedFDBDirectoryWrapper(@Nonnull final IndexMaintainerState state,
-                              @Nonnull final Tuple key,
+    MockedFDBDirectoryWrapper(final IndexMaintainerState state,
+                              final Tuple key,
                               final int mergeDirectoryCount,
-                              @Nonnull final AgilityContext agilityContext,
+                              final AgilityContext agilityContext,
                               final int blockCacheMaximumSize,
-                              @Nonnull final InjectedFailureRepository injectedFailures,
-                              @Nonnull final LuceneAnalyzerWrapper writerAnalyzer,
+                              final InjectedFailureRepository injectedFailures,
+                              final LuceneAnalyzerWrapper writerAnalyzer,
                               @Nullable final Exception exceptionAtCreation) {
         super(state, key, mergeDirectoryCount, agilityContext, blockCacheMaximumSize, writerAnalyzer, exceptionAtCreation);
         // Set the injectedFailures at the end of the constructor since createDirectory() is called from the constructor
@@ -48,7 +47,6 @@ public class MockedFDBDirectoryWrapper extends FDBDirectoryWrapper {
         ((MockedFDBDirectory)getDirectory()).setInjectedFailures(injectedFailures);
     }
 
-    @Nonnull
     @Override
     protected FDBDirectory createFDBDirectory(final Subspace subspace, final Map<String, String> options,
                                               final FDBDirectorySharedCacheManager sharedCacheManager,

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/MockedLuceneIndexMaintainer.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/MockedLuceneIndexMaintainer.java
@@ -26,8 +26,7 @@ import com.apple.foundationdb.record.provider.foundationdb.FDBIndexableRecord;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerState;
 import com.google.protobuf.Message;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
@@ -40,7 +39,7 @@ public class MockedLuceneIndexMaintainer extends LuceneIndexMaintainer {
     final InjectedFailureRepository injectedFailures;
 
     @SuppressWarnings("this-escape")
-    public MockedLuceneIndexMaintainer(@Nonnull final IndexMaintainerState state, @Nonnull final Executor executor, final InjectedFailureRepository injectedFailures) {
+    public MockedLuceneIndexMaintainer(final IndexMaintainerState state, final Executor executor, final InjectedFailureRepository injectedFailures) {
         super(state, executor);
         this.injectedFailures = injectedFailures;
         // Setting failures has to be done here rather than via a constructor param since createDirectoryManager is called
@@ -48,7 +47,6 @@ public class MockedLuceneIndexMaintainer extends LuceneIndexMaintainer {
         ((MockedFDBDirectoryManager)getDirectoryManager()).setInjectedFailures(injectedFailures);
     }
 
-    @Nonnull
     @Override
     public <M extends Message> CompletableFuture<Void> update(@Nullable final FDBIndexableRecord<M> oldRecord, @Nullable final FDBIndexableRecord<M> newRecord) {
         if (injectedFailures.hasFlag(InjectedFailureRepository.Flags.LUCENE_MAINTAINER_SKIP_INDEX_UPDATE)) {
@@ -57,9 +55,8 @@ public class MockedLuceneIndexMaintainer extends LuceneIndexMaintainer {
         return super.update(oldRecord, newRecord);
     }
 
-    @Nonnull
     @Override
-    protected FDBDirectoryManager createDirectoryManager(@Nonnull final IndexMaintainerState state) {
+    protected FDBDirectoryManager createDirectoryManager(final IndexMaintainerState state) {
         // Use the mocked manager static factory method to create/return the right type
         return MockedFDBDirectoryManager.getManager(state);
     }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/MockedLuceneIndexMaintainerFactory.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/MockedLuceneIndexMaintainerFactory.java
@@ -24,8 +24,6 @@ import com.apple.foundationdb.record.lucene.LuceneIndexMaintainerFactory;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainer;
 import com.apple.foundationdb.record.provider.foundationdb.IndexMaintainerState;
 
-import javax.annotation.Nonnull;
-
 /**
  * A mocked version of {@link LuceneIndexMaintainerFactory}.
  * This allows for the injection of a mocked index maintainer (and eventually, mock FDBDirectory) through the
@@ -38,9 +36,8 @@ public class MockedLuceneIndexMaintainerFactory extends LuceneIndexMaintainerFac
         this.injectedFailures = injectedFailures;
     }
 
-    @Nonnull
     @Override
-    public IndexMaintainer getIndexMaintainer(@Nonnull final IndexMaintainerState state) {
+    public IndexMaintainer getIndexMaintainer(final IndexMaintainerState state) {
         return new MockedLuceneIndexMaintainer(state, state.context.getExecutor(), injectedFailures);
     }
 }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/PendingWriteQueueIntegrationTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/PendingWriteQueueIntegrationTest.java
@@ -52,8 +52,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -1147,12 +1146,10 @@ public class PendingWriteQueueIntegrationTest extends FDBRecordStoreTestBase {
         }
     }
 
-    @Nonnull
     private static LuceneIndexMaintainer getIndexMaintainer(FDBRecordStore store, Index index) {
         return (LuceneIndexMaintainer)store.getIndexMaintainer(index);
     }
 
-    @Nonnull
     public static Index complexPartitionedIndex(final Map<String, String> options) {
         return new Index("Complex$partitioned",
                 concat(function(LuceneFunctionNames.LUCENE_TEXT, field("text")),

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/PendingWriteQueueIntegrationTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/PendingWriteQueueIntegrationTest.java
@@ -625,6 +625,9 @@ public class PendingWriteQueueIntegrationTest extends FDBRecordStoreTestBase {
     }
 
     @Test
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     void testQueryTransactionNotClosed() {
         // This test runs a query with queue elements replayed but does not commit the transaction
         // The DirectoryManager listens to close hooks to figure out that it needs to close all resources
@@ -1105,6 +1108,9 @@ public class PendingWriteQueueIntegrationTest extends FDBRecordStoreTestBase {
         verifyExpectedDocIds(schemaSetup, index, "*:*", null, expectedDocIds);
     }
 
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     private void verifyExpectedDocIds(Function<FDBRecordContext, FDBRecordStore> schemaSetup, Index index,
                                       String query, @Nullable Object group, Set<Long> expectedDocIds) {
         // location of the doc_id within the Tuple returned from the cursor

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/PendingWriteQueueIntegrationTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/PendingWriteQueueIntegrationTest.java
@@ -95,9 +95,9 @@ public class PendingWriteQueueIntegrationTest extends FDBRecordStoreTestBase {
         final Index index = SIMPLE_TEXT_SUFFIXES;
         final KeySpacePath path = pathManager.createPath(TestKeySpace.RECORD_STORE);
         final Function<FDBRecordContext, FDBRecordStore> schemaSetup = context ->
-                LuceneIndexTestUtils.rebuildIndexMetaData(context, path,
+                Objects.requireNonNull(LuceneIndexTestUtils.rebuildIndexMetaData(context, path,
                         TestRecordsTextProto.SimpleDocument.getDescriptor().getName(),
-                        index, useCascadesPlanner).getLeft();
+                        index, useCascadesPlanner).getLeft());
 
         // Set "ongoing merge" indicator
         setOngoingMergeIndicator(schemaSetup, index, null, null);
@@ -134,9 +134,9 @@ public class PendingWriteQueueIntegrationTest extends FDBRecordStoreTestBase {
         final Index index = SIMPLE_TEXT_SUFFIXES;
         final KeySpacePath path = pathManager.createPath(TestKeySpace.RECORD_STORE);
         final Function<FDBRecordContext, FDBRecordStore> schemaSetup = context ->
-                LuceneIndexTestUtils.rebuildIndexMetaData(context, path,
+                Objects.requireNonNull(LuceneIndexTestUtils.rebuildIndexMetaData(context, path,
                         TestRecordsTextProto.SimpleDocument.getDescriptor().getName(),
-                        index, useCascadesPlanner).getLeft();
+                        index, useCascadesPlanner).getLeft());
 
         // Set ongoing merge indicator
         setOngoingMergeIndicator(schemaSetup, index, null, null);
@@ -184,9 +184,9 @@ public class PendingWriteQueueIntegrationTest extends FDBRecordStoreTestBase {
         final Index index = SIMPLE_TEXT_SUFFIXES;
         final KeySpacePath path = pathManager.createPath(TestKeySpace.RECORD_STORE);
         final Function<FDBRecordContext, FDBRecordStore> schemaSetup = context ->
-                LuceneIndexTestUtils.rebuildIndexMetaData(context, path,
+                Objects.requireNonNull(LuceneIndexTestUtils.rebuildIndexMetaData(context, path,
                         TestRecordsTextProto.SimpleDocument.getDescriptor().getName(),
-                        index, useCascadesPlanner).getLeft();
+                        index, useCascadesPlanner).getLeft());
 
 
         // Write multiple records
@@ -257,9 +257,9 @@ public class PendingWriteQueueIntegrationTest extends FDBRecordStoreTestBase {
         final Index index = complexPartitionedIndex(options);
         final KeySpacePath path = pathManager.createPath(TestKeySpace.RECORD_STORE);
         final Function<FDBRecordContext, FDBRecordStore> schemaSetup = context ->
-                LuceneIndexTestUtils.rebuildIndexMetaData(context, path,
+                Objects.requireNonNull(LuceneIndexTestUtils.rebuildIndexMetaData(context, path,
                         TestRecordsTextProto.ComplexDocument.getDescriptor().getName(),
-                        index, useCascadesPlanner).getLeft();
+                        index, useCascadesPlanner).getLeft());
 
         // Insert a few documents when "ongoing merge" indicator is clear.
         try (FDBRecordContext context = openContext()) {
@@ -351,9 +351,9 @@ public class PendingWriteQueueIntegrationTest extends FDBRecordStoreTestBase {
         final Index index = complexPartitionedIndex(options);
         final KeySpacePath path = pathManager.createPath(TestKeySpace.RECORD_STORE);
         final Function<FDBRecordContext, FDBRecordStore> schemaSetup = context ->
-                LuceneIndexTestUtils.rebuildIndexMetaData(context, path,
+                Objects.requireNonNull(LuceneIndexTestUtils.rebuildIndexMetaData(context, path,
                         TestRecordsTextProto.ComplexDocument.getDescriptor().getName(),
-                        index, useCascadesPlanner).getLeft();
+                        index, useCascadesPlanner).getLeft());
 
         final Tuple groupingKey = Tuple.from(1L);
         final int numPartitions = 5; // if changed, other parts of the test should be modified
@@ -395,7 +395,7 @@ public class PendingWriteQueueIntegrationTest extends FDBRecordStoreTestBase {
             FDBRecordStore recordStore = Objects.requireNonNull(schemaSetup.apply(context));
             for (int partition = 0; partition < numPartitions; partition++) {
                 // Delete first document from each partition
-                recordStore.deleteRecord(partitionPrimaryKeys.get(partition).get(0));
+                recordStore.deleteRecord(Objects.requireNonNull(partitionPrimaryKeys.get(partition)).get(0));
             }
             commit(context);
         }
@@ -454,9 +454,9 @@ public class PendingWriteQueueIntegrationTest extends FDBRecordStoreTestBase {
         final Index index = complexPartitionedIndex(options);
         final KeySpacePath path = pathManager.createPath(TestKeySpace.RECORD_STORE);
         final Function<FDBRecordContext, FDBRecordStore> schemaSetup = context ->
-                LuceneIndexTestUtils.rebuildIndexMetaData(context, path,
+                Objects.requireNonNull(LuceneIndexTestUtils.rebuildIndexMetaData(context, path,
                         TestRecordsTextProto.ComplexDocument.getDescriptor().getName(),
-                        index, useCascadesPlanner).getLeft();
+                        index, useCascadesPlanner).getLeft());
 
         final Tuple groupingKey = Tuple.from(1L);
         final Integer partition0 = 0;
@@ -487,8 +487,8 @@ public class PendingWriteQueueIntegrationTest extends FDBRecordStoreTestBase {
         // Delete one document from each partition (will be queued)
         try (FDBRecordContext context = openContext()) {
             FDBRecordStore recordStore = Objects.requireNonNull(schemaSetup.apply(context));
-            recordStore.deleteRecord(primaryKeys.get(2001L)); // Delete from partition 0
-            recordStore.deleteRecord(primaryKeys.get(3001L)); // Delete from partition 1
+            recordStore.deleteRecord(Objects.requireNonNull(primaryKeys.get(2001L))); // Delete from partition 0
+            recordStore.deleteRecord(Objects.requireNonNull(primaryKeys.get(3001L))); // Delete from partition 1
             commit(context);
         }
 
@@ -525,9 +525,9 @@ public class PendingWriteQueueIntegrationTest extends FDBRecordStoreTestBase {
         final Index index = SIMPLE_TEXT_SUFFIXES;
         final KeySpacePath path = pathManager.createPath(TestKeySpace.RECORD_STORE);
         final Function<FDBRecordContext, FDBRecordStore> schemaSetup = context ->
-                LuceneIndexTestUtils.rebuildIndexMetaData(context, path,
+                Objects.requireNonNull(LuceneIndexTestUtils.rebuildIndexMetaData(context, path,
                         TestRecordsTextProto.SimpleDocument.getDescriptor().getName(),
-                        index, useCascadesPlanner).getLeft();
+                        index, useCascadesPlanner).getLeft());
 
         // Insert document before queue is enabled
         try (FDBRecordContext context = openContext()) {
@@ -576,9 +576,9 @@ public class PendingWriteQueueIntegrationTest extends FDBRecordStoreTestBase {
         final Index index = SIMPLE_TEXT_SUFFIXES;
         final KeySpacePath path = pathManager.createPath(TestKeySpace.RECORD_STORE);
         final Function<FDBRecordContext, FDBRecordStore> schemaSetup = context ->
-                LuceneIndexTestUtils.rebuildIndexMetaData(context, path,
+                Objects.requireNonNull(LuceneIndexTestUtils.rebuildIndexMetaData(context, path,
                         TestRecordsTextProto.SimpleDocument.getDescriptor().getName(),
-                        index, useCascadesPlanner).getLeft();
+                        index, useCascadesPlanner).getLeft());
 
         // Mark "ongoing merge" indicator
         setOngoingMergeIndicator(schemaSetup, index, null, null);
@@ -632,9 +632,9 @@ public class PendingWriteQueueIntegrationTest extends FDBRecordStoreTestBase {
         final Index index = SIMPLE_TEXT_SUFFIXES;
         final KeySpacePath path = pathManager.createPath(TestKeySpace.RECORD_STORE);
         final Function<FDBRecordContext, FDBRecordStore> schemaSetup = context ->
-                LuceneIndexTestUtils.rebuildIndexMetaData(context, path,
+                Objects.requireNonNull(LuceneIndexTestUtils.rebuildIndexMetaData(context, path,
                         TestRecordsTextProto.SimpleDocument.getDescriptor().getName(),
-                        index, useCascadesPlanner).getLeft();
+                        index, useCascadesPlanner).getLeft());
 
         // Mark "ongoing merge" indicator
         setOngoingMergeIndicator(schemaSetup, index, null, null);
@@ -667,9 +667,9 @@ public class PendingWriteQueueIntegrationTest extends FDBRecordStoreTestBase {
         final Index index = SIMPLE_TEXT_SUFFIXES;
         final KeySpacePath path = pathManager.createPath(TestKeySpace.RECORD_STORE);
         final Function<FDBRecordContext, FDBRecordStore> schemaSetup = context ->
-                LuceneIndexTestUtils.rebuildIndexMetaData(context, path,
+                Objects.requireNonNull(LuceneIndexTestUtils.rebuildIndexMetaData(context, path,
                         TestRecordsTextProto.SimpleDocument.getDescriptor().getName(),
-                        index, useCascadesPlanner).getLeft();
+                        index, useCascadesPlanner).getLeft());
 
         // Enable queue
         setOngoingMergeIndicator(schemaSetup, index, null, null);
@@ -715,9 +715,9 @@ public class PendingWriteQueueIntegrationTest extends FDBRecordStoreTestBase {
         final Index index = SIMPLE_TEXT_SUFFIXES;
         final KeySpacePath path = pathManager.createPath(TestKeySpace.RECORD_STORE);
         final Function<FDBRecordContext, FDBRecordStore> schemaSetup = context ->
-                LuceneIndexTestUtils.rebuildIndexMetaData(context, path,
+                Objects.requireNonNull(LuceneIndexTestUtils.rebuildIndexMetaData(context, path,
                         TestRecordsTextProto.SimpleDocument.getDescriptor().getName(),
-                        index, useCascadesPlanner).getLeft();
+                        index, useCascadesPlanner).getLeft());
 
         // Insert without queue indicator - should request deferred merge
         try (FDBRecordContext context = openContext()) {
@@ -768,9 +768,9 @@ public class PendingWriteQueueIntegrationTest extends FDBRecordStoreTestBase {
         final Index index = SIMPLE_TEXT_SUFFIXES;
         final KeySpacePath path = pathManager.createPath(TestKeySpace.RECORD_STORE);
         final Function<FDBRecordContext, FDBRecordStore> schemaSetup = context ->
-                LuceneIndexTestUtils.rebuildIndexMetaData(context, path,
+                Objects.requireNonNull(LuceneIndexTestUtils.rebuildIndexMetaData(context, path,
                         TestRecordsTextProto.SimpleDocument.getDescriptor().getName(),
-                        index, useCascadesPlanner).getLeft();
+                        index, useCascadesPlanner).getLeft());
 
         // Setup: Create initial records before queue mode
         try (FDBRecordContext context = openContext()) {
@@ -891,9 +891,9 @@ public class PendingWriteQueueIntegrationTest extends FDBRecordStoreTestBase {
         final Index index = SIMPLE_TEXT_SUFFIXES;
         final KeySpacePath path = pathManager.createPath(TestKeySpace.RECORD_STORE);
         final Function<FDBRecordContext, FDBRecordStore> schemaSetup = context ->
-                LuceneIndexTestUtils.rebuildIndexMetaData(context, path,
+                Objects.requireNonNull(LuceneIndexTestUtils.rebuildIndexMetaData(context, path,
                         TestRecordsTextProto.SimpleDocument.getDescriptor().getName(),
-                        index, useCascadesPlanner).getLeft();
+                        index, useCascadesPlanner).getLeft());
 
         // 1. Set ongoing merge indicator
         setOngoingMergeIndicator(schemaSetup, index, null, null);
@@ -904,7 +904,12 @@ public class PendingWriteQueueIntegrationTest extends FDBRecordStoreTestBase {
             FDBRecordStore recordStore = Objects.requireNonNull(schemaSetup.apply(context));
             Subspace subspace = recordStore.indexSubspace(index).subspace(Tuple.from(FDBDirectory.FILE_LOCK_SUBSPACE));
             byte[] fileLockKey = subspace.pack(Tuple.from(IndexWriter.WRITE_LOCK_NAME));
-            lockFactory = new FDBDirectoryLockFactory(null, 10_000);
+            // The directory is unused by the obtainLock(AgilityContext, byte[], String) overload below,
+            // but the constructor requires a non-null value.
+            IndexMaintainerState state = new IndexMaintainerState(recordStore, index,
+                    recordStore.getIndexMaintenanceFilter());
+            FDBDirectory directory = FDBDirectoryManager.getManager(state).getDirectory(null, null);
+            lockFactory = new FDBDirectoryLockFactory(directory, 10_000);
             lockFactory.obtainLock(new NonAgileContext(context), fileLockKey, IndexWriter.WRITE_LOCK_NAME);
             commit(context);
         }
@@ -932,9 +937,9 @@ public class PendingWriteQueueIntegrationTest extends FDBRecordStoreTestBase {
                 options.put(LuceneIndexOptions.PENDING_WRITE_QUEUE_INCARNATION_ENABLED, Boolean.toString(incarnationEnabled)));
         final KeySpacePath path = pathManager.createPath(TestKeySpace.RECORD_STORE);
         final Function<FDBRecordContext, FDBRecordStore> schemaSetup = context ->
-                LuceneIndexTestUtils.rebuildIndexMetaData(context, path,
+                Objects.requireNonNull(LuceneIndexTestUtils.rebuildIndexMetaData(context, path,
                         TestRecordsTextProto.SimpleDocument.getDescriptor().getName(),
-                        index, useCascadesPlanner).getLeft();
+                        index, useCascadesPlanner).getLeft());
 
         // Set "ongoing merge" indicator so the queue is used
         setOngoingMergeIndicator(schemaSetup, index, null, null);
@@ -977,9 +982,9 @@ public class PendingWriteQueueIntegrationTest extends FDBRecordStoreTestBase {
         final Index index = SIMPLE_TEXT_SUFFIXES;
         final KeySpacePath path = pathManager.createPath(TestKeySpace.RECORD_STORE);
         final Function<FDBRecordContext, FDBRecordStore> schemaSetup = context ->
-                LuceneIndexTestUtils.rebuildIndexMetaData(context, path,
+                Objects.requireNonNull(LuceneIndexTestUtils.rebuildIndexMetaData(context, path,
                         TestRecordsTextProto.SimpleDocument.getDescriptor().getName(),
-                        index, useCascadesPlanner).getLeft();
+                        index, useCascadesPlanner).getLeft());
 
         // Set "ongoing merge" indicator so writes go to queue
         setOngoingMergeIndicator(schemaSetup, index, null, null);

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/PendingWriteQueueSerializationTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/PendingWriteQueueSerializationTest.java
@@ -165,6 +165,9 @@ class PendingWriteQueueSerializationTest extends FDBRecordStoreTestBase {
         assertComplexRecordsIdenticalExceptIds(schemaSetup);
     }
 
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     private void assertComplexRecordsIdenticalExceptIds(Function<FDBRecordContext, FDBRecordStore> schemaSetup) {
         try (FDBRecordContext context = openContext()) {
             FDBRecordStore recordStore = Objects.requireNonNull(schemaSetup.apply(context));
@@ -227,6 +230,9 @@ class PendingWriteQueueSerializationTest extends FDBRecordStoreTestBase {
         }
     }
 
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     private void assertRecordsIdenticalExceptIds(Function<FDBRecordContext, FDBRecordStore> schemaSetup,
                                                  Index index) {
         try (FDBRecordContext context = openContext()) {
@@ -256,6 +262,9 @@ class PendingWriteQueueSerializationTest extends FDBRecordStoreTestBase {
         }
     }
 
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     private void assertQueryFindsRecords(Function<FDBRecordContext, FDBRecordStore> schemaSetup, Index index,
                                          List<String> searchTerms, List<Long> expectedDocIds, boolean isComplex) {
         for (String searchTerm: searchTerms) {

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/PendingWriteQueueSerializationTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/PendingWriteQueueSerializationTest.java
@@ -67,9 +67,9 @@ class PendingWriteQueueSerializationTest extends FDBRecordStoreTestBase {
         final Index index = SIMPLE_TEXT_SUFFIXES;
         final KeySpacePath path = pathManager.createPath(TestKeySpace.RECORD_STORE);
         final Function<FDBRecordContext, FDBRecordStore> schemaSetup = context ->
-                LuceneIndexTestUtils.rebuildIndexMetaData(context, path,
+                Objects.requireNonNull(LuceneIndexTestUtils.rebuildIndexMetaData(context, path,
                         TestRecordsTextProto.SimpleDocument.getDescriptor().getName(),
-                        index, useCascadesPlanner).getLeft();
+                        index, useCascadesPlanner).getLeft());
 
         final long directRecordId = 1001L;
         final long queuedRecordId = 2002L;
@@ -117,7 +117,7 @@ class PendingWriteQueueSerializationTest extends FDBRecordStoreTestBase {
         final Index index = TEXT_AND_STORED_COMPLEX;
         final KeySpacePath path = pathManager.createPath(TestKeySpace.RECORD_STORE);
         final Function<FDBRecordContext, FDBRecordStore> schemaSetup = context ->
-                LuceneIndexTestUtils.rebuildIndexMetaData(context, path, COMPLEX_DOC, index, useCascadesPlanner).getLeft();
+                Objects.requireNonNull(LuceneIndexTestUtils.rebuildIndexMetaData(context, path, COMPLEX_DOC, index, useCascadesPlanner).getLeft());
 
         final long directRecordId = 1001L;
         final long queuedRecordId = 2002L;

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/PendingWriteQueueSerializationTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/PendingWriteQueueSerializationTest.java
@@ -41,8 +41,7 @@ import com.apple.test.Tags;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -304,7 +303,6 @@ class PendingWriteQueueSerializationTest extends FDBRecordStoreTestBase {
         }
     }
 
-    @Nonnull
     private static LuceneIndexMaintainer getLuceneIndexMaintainer(FDBRecordStore store, Index index) {
         return (LuceneIndexMaintainer) store.getIndexMaintainer(index);
     }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/PendingWriteQueueSizeIntegrationTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/PendingWriteQueueSizeIntegrationTest.java
@@ -339,6 +339,9 @@ class PendingWriteQueueSizeIntegrationTest extends FDBRecordStoreTestBase {
         verifyExpectedDocIds(index, "*:*", null, expectedDocIds, simpleMetadataHook());
     }
 
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     private void verifyExpectedDocIds(Index index, String query, @Nullable Object group, Set<Long> expectedDocIds, final RecordMetaDataHook hook) {
         // location of the doc_id within the Tuple returned from the cursor
         int pkLocation = (group == null) ? 0 : 1;

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/PendingWriteQueueSizeIntegrationTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/PendingWriteQueueSizeIntegrationTest.java
@@ -46,8 +46,7 @@ import com.apple.test.Tags;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -381,7 +380,6 @@ class PendingWriteQueueSizeIntegrationTest extends FDBRecordStoreTestBase {
         }
     }
 
-    @Nonnull
     private LuceneIndexMaintainer getIndexMaintainer(FDBRecordStore store, Index index) {
         return (LuceneIndexMaintainer)store.getIndexMaintainer(index);
     }
@@ -400,7 +398,6 @@ class PendingWriteQueueSizeIntegrationTest extends FDBRecordStoreTestBase {
         };
     }
 
-    @Nonnull
     public Index complexPartitionedIndex(int highWatermark) {
         final Map<String, String> options = Map.of(
                 ENABLE_PENDING_WRITE_QUEUE_DURING_MERGE, "true",
@@ -411,7 +408,6 @@ class PendingWriteQueueSizeIntegrationTest extends FDBRecordStoreTestBase {
         return complexPartitionedIndex(options);
     }
 
-    @Nonnull
     public Index complexPartitionedIndex(final Map<String, String> options) {
         return new Index("Complex$partitioned",
                 concat(function(LuceneFunctionNames.LUCENE_TEXT, field("text")),

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/PendingWriteQueueSizeIntegrationTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/PendingWriteQueueSizeIntegrationTest.java
@@ -51,6 +51,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -84,7 +85,7 @@ class PendingWriteQueueSizeIntegrationTest extends FDBRecordStoreTestBase {
         // Write too many records in a single transaction
         final int maxQueueSize = 5;
         try (FDBRecordContext context = openContext(getContextProperties(maxQueueSize))) {
-            FDBRecordStore recordStore = LuceneIndexTestUtils.openRecordStore(context, path, simpleMetadataHook());
+            FDBRecordStore recordStore = LuceneIndexTestUtils.openRecordStore(context, Objects.requireNonNull(path), simpleMetadataHook());
             for (int i = 0; i < maxQueueSize; i++) {
                 recordStore.saveRecord(LuceneIndexTestUtils.createSimpleDocument(100L + i, "test document", 1));
             }
@@ -102,7 +103,7 @@ class PendingWriteQueueSizeIntegrationTest extends FDBRecordStoreTestBase {
 
         final int maxQueueSize = 5;
         try (FDBRecordContext context = openContext(getContextProperties(maxQueueSize))) {
-            FDBRecordStore recordStore = LuceneIndexTestUtils.openRecordStore(context, path, simpleMetadataHook());
+            FDBRecordStore recordStore = LuceneIndexTestUtils.openRecordStore(context, Objects.requireNonNull(path), simpleMetadataHook());
             for (int i = 0; i < maxQueueSize; i++) {
                 recordStore.saveRecord(LuceneIndexTestUtils.createSimpleDocument(100L + i, "test document", 1));
             }
@@ -110,7 +111,7 @@ class PendingWriteQueueSizeIntegrationTest extends FDBRecordStoreTestBase {
         }
 
         try (FDBRecordContext context = openContext(getContextProperties(maxQueueSize))) {
-            FDBRecordStore recordStore = LuceneIndexTestUtils.openRecordStore(context, path, simpleMetadataHook());
+            FDBRecordStore recordStore = LuceneIndexTestUtils.openRecordStore(context, Objects.requireNonNull(path), simpleMetadataHook());
             assertThrows(PendingWriteQueue.PendingWritesQueueTooLargeException.class,
                     () -> recordStore.saveRecord(LuceneIndexTestUtils.createSimpleDocument(999L, "test document", 1)));
             // The index is now in an inconsistent state, do don't commit
@@ -125,7 +126,7 @@ class PendingWriteQueueSizeIntegrationTest extends FDBRecordStoreTestBase {
 
         final int maxQueueSize = 5;
         try (FDBRecordContext context = openContext(getContextProperties(maxQueueSize))) {
-            FDBRecordStore recordStore = LuceneIndexTestUtils.openRecordStore(context, path, simpleMetadataHook());
+            FDBRecordStore recordStore = LuceneIndexTestUtils.openRecordStore(context, Objects.requireNonNull(path), simpleMetadataHook());
             for (int i = 0; i < maxQueueSize; i++) {
                 recordStore.saveRecord(LuceneIndexTestUtils.createSimpleDocument(100L + i, "test document", 1));
             }
@@ -138,7 +139,7 @@ class PendingWriteQueueSizeIntegrationTest extends FDBRecordStoreTestBase {
         setOngoingMergeIndicator(index, null, null, simpleMetadataHook());
 
         try (FDBRecordContext context = openContext(getContextProperties(maxQueueSize))) {
-            FDBRecordStore recordStore = LuceneIndexTestUtils.openRecordStore(context, path, simpleMetadataHook());
+            FDBRecordStore recordStore = LuceneIndexTestUtils.openRecordStore(context, Objects.requireNonNull(path), simpleMetadataHook());
             recordStore.saveRecord(LuceneIndexTestUtils.createSimpleDocument(999L, "test document", 1));
             commit(context);
         }
@@ -156,7 +157,7 @@ class PendingWriteQueueSizeIntegrationTest extends FDBRecordStoreTestBase {
         // Write 5 records
         final int maxQueueSize = 5;
         try (FDBRecordContext context = openContext(getContextProperties(maxQueueSize))) {
-            FDBRecordStore recordStore = LuceneIndexTestUtils.openRecordStore(context, path, simpleMetadataHook());
+            FDBRecordStore recordStore = LuceneIndexTestUtils.openRecordStore(context, Objects.requireNonNull(path), simpleMetadataHook());
             for (int i = 0; i < maxQueueSize; i++) {
                 recordStore.saveRecord(LuceneIndexTestUtils.createSimpleDocument(100L + i, "test document", 1));
             }
@@ -168,7 +169,7 @@ class PendingWriteQueueSizeIntegrationTest extends FDBRecordStoreTestBase {
 
         // Update 3 documents, third update fails
         try (FDBRecordContext context = openContext(getContextProperties(maxQueueSize))) {
-            FDBRecordStore recordStore = LuceneIndexTestUtils.openRecordStore(context, path, simpleMetadataHook());
+            FDBRecordStore recordStore = LuceneIndexTestUtils.openRecordStore(context, Objects.requireNonNull(path), simpleMetadataHook());
             recordStore.saveRecord(LuceneIndexTestUtils.createSimpleDocument(100L, "test document updated", 1));
             recordStore.saveRecord(LuceneIndexTestUtils.createSimpleDocument(101L, "test document updated", 1));
             assertThrows(PendingWriteQueue.PendingWritesQueueTooLargeException.class, () ->
@@ -201,7 +202,7 @@ class PendingWriteQueueSizeIntegrationTest extends FDBRecordStoreTestBase {
         final int someDocsCount = 3;
         // Insert a few documents when "ongoing merge" indicator is clear.
         try (FDBRecordContext context = openContext(getContextProperties(maxQueueSize))) {
-            FDBRecordStore recordStore = LuceneIndexTestUtils.openRecordStore(context, path, hook);
+            FDBRecordStore recordStore = LuceneIndexTestUtils.openRecordStore(context, Objects.requireNonNull(path), hook);
             for (int i = 0; i < 6; i++) {
                 recordStore.saveRecord(LuceneIndexTestUtils.createComplexDocument(2000L + i, "document foo", 1L, 30L + i));
             }
@@ -221,7 +222,7 @@ class PendingWriteQueueSizeIntegrationTest extends FDBRecordStoreTestBase {
 
         // Insert documents when "ongoing merge" indicator is set.
         try (FDBRecordContext context = openContext(getContextProperties(maxQueueSize))) {
-            FDBRecordStore recordStore = LuceneIndexTestUtils.openRecordStore(context, path, hook);
+            FDBRecordStore recordStore = LuceneIndexTestUtils.openRecordStore(context, Objects.requireNonNull(path), hook);
             // Put 3 docs in each partition
             for (int i = 0; i < someDocsCount; i++) {
                 // save record to new partition (queued)
@@ -237,13 +238,13 @@ class PendingWriteQueueSizeIntegrationTest extends FDBRecordStoreTestBase {
             commit(context);
         }
         try (FDBRecordContext context = openContext(getContextProperties(maxQueueSize))) {
-            FDBRecordStore recordStore = LuceneIndexTestUtils.openRecordStore(context, path, hook);
+            FDBRecordStore recordStore = LuceneIndexTestUtils.openRecordStore(context, Objects.requireNonNull(path), hook);
             // additional doc fails on new queue
             assertThrows(PendingWriteQueue.PendingWritesQueueTooLargeException.class, () ->
                     recordStore.saveRecord(LuceneIndexTestUtils.createComplexDocument(999, "second document", 1L, 100L + 9)));
         }
         try (FDBRecordContext context = openContext(getContextProperties(maxQueueSize))) {
-            FDBRecordStore recordStore = LuceneIndexTestUtils.openRecordStore(context, path, hook);
+            FDBRecordStore recordStore = LuceneIndexTestUtils.openRecordStore(context, Objects.requireNonNull(path), hook);
             // additional docs succeed on old queue
             for (int i = someDocsCount; i < maxQueueSize; i++) {
                 recordStore.saveRecord(LuceneIndexTestUtils.createComplexDocument(200L + i, "second document", 1L, 30L - i));
@@ -251,7 +252,7 @@ class PendingWriteQueueSizeIntegrationTest extends FDBRecordStoreTestBase {
             commit(context);
         }
         try (FDBRecordContext context = openContext(getContextProperties(maxQueueSize))) {
-            FDBRecordStore recordStore = LuceneIndexTestUtils.openRecordStore(context, path, hook);
+            FDBRecordStore recordStore = LuceneIndexTestUtils.openRecordStore(context, Objects.requireNonNull(path), hook);
             // additional docs fail on both queues
             assertThrows(PendingWriteQueue.PendingWritesQueueTooLargeException.class, () ->
                     recordStore.saveRecord(LuceneIndexTestUtils.createComplexDocument(999, "second document", 1L, 100L + 9)));
@@ -274,7 +275,7 @@ class PendingWriteQueueSizeIntegrationTest extends FDBRecordStoreTestBase {
 
     private void verifyClearedQueueAndIndicator(Index index, @Nullable Tuple groupingKey, @Nullable Integer partitionId, final RecordMetaDataHook hook) {
         try (FDBRecordContext context = openContext()) {
-            FDBRecordStore recordStore = LuceneIndexTestUtils.openRecordStore(context, path, hook);
+            FDBRecordStore recordStore = LuceneIndexTestUtils.openRecordStore(context, Objects.requireNonNull(path), hook);
             IndexMaintainerState state = new IndexMaintainerState(recordStore, index,
                     recordStore.getIndexMaintenanceFilter());
             FDBDirectoryManager directoryManager = FDBDirectoryManager.getManager(state);
@@ -294,7 +295,7 @@ class PendingWriteQueueSizeIntegrationTest extends FDBRecordStoreTestBase {
     private void verifyExpectedQueueAndIndicator(Index index, @Nullable Tuple groupingKey, @Nullable Integer partitionId,
                                                  List<LucenePendingWriteQueueProto.PendingWriteItem.OperationType> expectedOperations, final RecordMetaDataHook hook) {
         try (FDBRecordContext context = openContext()) {
-            FDBRecordStore recordStore = LuceneIndexTestUtils.openRecordStore(context, path, hook);
+            FDBRecordStore recordStore = LuceneIndexTestUtils.openRecordStore(context, Objects.requireNonNull(path), hook);
             IndexMaintainerState state = new IndexMaintainerState(recordStore, index,
                     recordStore.getIndexMaintenanceFilter());
             FDBDirectoryManager directoryManager = FDBDirectoryManager.getManager(state);
@@ -319,7 +320,7 @@ class PendingWriteQueueSizeIntegrationTest extends FDBRecordStoreTestBase {
 
     private void verifyPartitionCount(Index index, @Nullable Tuple groupingKey, List<Integer> expectedCount, final RecordMetaDataHook hook) {
         try (FDBRecordContext context = openContext()) {
-            FDBRecordStore recordStore = LuceneIndexTestUtils.openRecordStore(context, path, hook);
+            FDBRecordStore recordStore = LuceneIndexTestUtils.openRecordStore(context, Objects.requireNonNull(path), hook);
             final LuceneIndexMaintainer indexMaintainer = (LuceneIndexMaintainer)recordStore.getIndexMaintainer(index);
             final LucenePartitioner partitioner = indexMaintainer.getPartitioner();
 
@@ -343,7 +344,7 @@ class PendingWriteQueueSizeIntegrationTest extends FDBRecordStoreTestBase {
         int pkLocation = (group == null) ? 0 : 1;
 
         try (FDBRecordContext context = openContext()) {
-            FDBRecordStore recordStore = LuceneIndexTestUtils.openRecordStore(context, path, hook);
+            FDBRecordStore recordStore = LuceneIndexTestUtils.openRecordStore(context, Objects.requireNonNull(path), hook);
             LuceneScanBounds scanBounds = LuceneIndexTestUtils.fullTextSearch(recordStore, index, query, false, 0, group);
 
             try (RecordCursor<IndexEntry> cursor = recordStore.scanIndex(index, scanBounds, null, ScanProperties.FORWARD_SCAN)) {
@@ -361,7 +362,7 @@ class PendingWriteQueueSizeIntegrationTest extends FDBRecordStoreTestBase {
 
     private void setOngoingMergeIndicator(Index index, @Nullable Tuple groupingKey, @Nullable Integer partitionId, final RecordMetaDataHook hook) {
         try (FDBRecordContext context = openContext()) {
-            FDBRecordStore recordStore = LuceneIndexTestUtils.openRecordStore(context, path, hook);
+            FDBRecordStore recordStore = LuceneIndexTestUtils.openRecordStore(context, Objects.requireNonNull(path), hook);
             // Get directory and set ongoing merge indicator
             IndexMaintainerState state = new IndexMaintainerState(recordStore, index, recordStore.getIndexMaintenanceFilter());
             FDBDirectoryManager directoryManager = FDBDirectoryManager.getManager(state);
@@ -373,7 +374,7 @@ class PendingWriteQueueSizeIntegrationTest extends FDBRecordStoreTestBase {
 
     private void mergeIndexNow(Index index, final RecordMetaDataHook hook) {
         try (FDBRecordContext context = openContext()) {
-            FDBRecordStore recordStore = LuceneIndexTestUtils.openRecordStore(context, path, hook);
+            FDBRecordStore recordStore = LuceneIndexTestUtils.openRecordStore(context, Objects.requireNonNull(path), hook);
             final LuceneIndexMaintainer indexMaintainer = getIndexMaintainer(recordStore, index);
             indexMaintainer.mergeIndex().join();
             commit(context);

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/PendingWriteQueueSizeTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/PendingWriteQueueSizeTest.java
@@ -25,6 +25,7 @@ import com.apple.foundationdb.record.lucene.LuceneDocumentFromRecord;
 import com.apple.foundationdb.record.lucene.LuceneIndexExpressions;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreTestBase;
+import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpacePath;
 import com.apple.foundationdb.subspace.Subspace;
 import com.apple.foundationdb.tuple.Tuple;
 import com.apple.test.Tags;
@@ -34,6 +35,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -176,7 +178,7 @@ class PendingWriteQueueSizeTest extends FDBRecordStoreTestBase {
                     () -> queue.enqueueInsert(context, Tuple.from(999), createSingleField(), 0)
             );
             assertNotNull(exception);
-            assertTrue(exception.getMessage().contains("Queue size too large"));
+            assertTrue(Objects.requireNonNull(exception.getMessage()).contains("Queue size too large"));
         }
     }
 
@@ -279,8 +281,9 @@ class PendingWriteQueueSizeTest extends FDBRecordStoreTestBase {
     }
 
     private PendingWriteQueue getQueue(FDBRecordContext context, int maxQueueSize) {
-        Subspace queueSpace = path.toSubspace(context).subspace(Tuple.from("queue"));
-        Subspace counterSpace = path.toSubspace(context).subspace(Tuple.from("counter"));
+        final KeySpacePath nonNullPath = Objects.requireNonNull(path);
+        Subspace queueSpace = nonNullPath.toSubspace(context).subspace(Tuple.from("queue"));
+        Subspace counterSpace = nonNullPath.toSubspace(context).subspace(Tuple.from("counter"));
         return new PendingWriteQueue(queueSpace, counterSpace,
                 PendingWriteQueue.DEFAULT_MAX_PENDING_ENTRIES_TO_REPLAY, maxQueueSize, serializer, true);
     }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/PendingWriteQueueTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/PendingWriteQueueTest.java
@@ -36,6 +36,7 @@ import com.apple.foundationdb.record.lucene.LucenePendingWriteQueueProto;
 import com.apple.foundationdb.record.provider.foundationdb.FDBExceptions;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordContext;
 import com.apple.foundationdb.record.provider.foundationdb.FDBRecordStoreTestBase;
+import com.apple.foundationdb.record.provider.foundationdb.keyspace.KeySpacePath;
 import com.apple.foundationdb.subspace.Subspace;
 import com.apple.foundationdb.tuple.Tuple;
 import com.apple.foundationdb.tuple.Versionstamp;
@@ -61,6 +62,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -152,7 +154,7 @@ class PendingWriteQueueTest extends FDBRecordStoreTestBase {
             docs.forEach(doc -> {
                 queue.enqueueInsert(context, doc.getPrimaryKey(), doc.getFields(), incarnationValue);
             });
-            assertEquals(docs.size(), context.getTimer().getCount(LuceneEvents.Counts.LUCENE_PENDING_QUEUE_WRITE));
+            assertEquals(docs.size(), Objects.requireNonNull(context.getTimer()).getCount(LuceneEvents.Counts.LUCENE_PENDING_QUEUE_WRITE));
             commit(context);
         }
 
@@ -165,7 +167,7 @@ class PendingWriteQueueTest extends FDBRecordStoreTestBase {
         // Delete the 3rd entry
         try (FDBRecordContext context = openContext()) {
             queue.clearEntry(context, entries.get(2));
-            assertEquals(1, context.getTimer().getCount(LuceneEvents.Counts.LUCENE_PENDING_QUEUE_CLEAR));
+            assertEquals(1, Objects.requireNonNull(context.getTimer()).getCount(LuceneEvents.Counts.LUCENE_PENDING_QUEUE_CLEAR));
             commit(context);
         }
 
@@ -385,7 +387,7 @@ class PendingWriteQueueTest extends FDBRecordStoreTestBase {
 
     /** Key backing the marker that models {@code FDBDirectory}'s ongoing-merge indicator (subspace index 2). */
     private byte[] markerKey(FDBRecordContext context) {
-        return path.toSubspace(context).subspace(Tuple.from(2)).pack();
+        return Objects.requireNonNull(path).toSubspace(context).subspace(Tuple.from(2)).pack();
     }
 
     private void setMarker(FDBRecordContext context) {
@@ -916,8 +918,9 @@ class PendingWriteQueueTest extends FDBRecordStoreTestBase {
     }
 
     private PendingWriteQueue getQueue(FDBRecordContext context, LuceneSerializer serializer, boolean allowIncarnation) {
-        Subspace queueSpace = path.toSubspace(context).subspace(Tuple.from(0));
-        Subspace counterSpace = path.toSubspace(context).subspace(Tuple.from(1));
+        final KeySpacePath nonNullPath = Objects.requireNonNull(path);
+        Subspace queueSpace = nonNullPath.toSubspace(context).subspace(Tuple.from(0));
+        Subspace counterSpace = nonNullPath.toSubspace(context).subspace(Tuple.from(1));
         return new PendingWriteQueue(queueSpace, counterSpace,
                 PendingWriteQueue.DEFAULT_MAX_PENDING_ENTRIES_TO_REPLAY,
                 PendingWriteQueue.DEFAULT_MAX_PENDING_QUEUE_SIZE,
@@ -1001,9 +1004,8 @@ class PendingWriteQueueTest extends FDBRecordStoreTestBase {
                 assertTrue(entryField.hasTextValue());
                 return entryField.getTextValue();
             default:
-                fail("Unknown type");
+                return fail("Unknown type");
         }
-        return null;
     }
 
     private List<TestDocument> createTestDocuments() {
@@ -1079,15 +1081,13 @@ class PendingWriteQueueTest extends FDBRecordStoreTestBase {
             super(true, false, null, true);
         }
 
-        @Nullable
         @Override
-        public byte[] encode(@Nullable final byte[] data) {
+        public byte @Nullable [] encode(final byte @Nullable [] data) {
             throw new RecordCoreInternalException("Failing to encode");
         }
 
-        @Nullable
         @Override
-        public byte[] decode(@Nullable final byte[] data) {
+        public byte @Nullable [] decode(final byte @Nullable [] data) {
             throw new RecordCoreInternalException("Failing to decode");
         }
     }
@@ -1097,15 +1097,13 @@ class PendingWriteQueueTest extends FDBRecordStoreTestBase {
             super(true, false, null, true);
         }
 
-        @Nullable
         @Override
-        public byte[] encode(@Nullable final byte[] data) {
+        public byte @Nullable [] encode(final byte @Nullable [] data) {
             return data;
         }
 
-        @Nullable
         @Override
-        public byte[] decode(@Nullable final byte[] data) {
+        public byte @Nullable [] decode(final byte @Nullable [] data) {
             return data;
         }
     }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/PendingWriteQueueTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/PendingWriteQueueTest.java
@@ -55,8 +55,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -385,16 +384,15 @@ class PendingWriteQueueTest extends FDBRecordStoreTestBase {
     }
 
     /** Key backing the marker that models {@code FDBDirectory}'s ongoing-merge indicator (subspace index 2). */
-    @Nonnull
-    private byte[] markerKey(@Nonnull FDBRecordContext context) {
+    private byte[] markerKey(FDBRecordContext context) {
         return path.toSubspace(context).subspace(Tuple.from(2)).pack();
     }
 
-    private void setMarker(@Nonnull FDBRecordContext context) {
+    private void setMarker(FDBRecordContext context) {
         context.ensureActive().set(markerKey(context), new byte[] {1});
     }
 
-    private boolean markerExists(@Nonnull FDBRecordContext context) {
+    private boolean markerExists(FDBRecordContext context) {
         return context.ensureActive().get(markerKey(context)).join() != null;
     }
 
@@ -402,7 +400,7 @@ class PendingWriteQueueTest extends FDBRecordStoreTestBase {
      * Mirrors {@code FDBDirectory.clearOngoingMergeIndicatorIfQueueEmptyAsync}: clears the marker only if the
      * queue is empty, otherwise throws so the caller drains more and retries.
      */
-    private void clearMarkerIfQueueEmpty(@Nonnull FDBRecordContext context, @Nonnull PendingWriteQueue queue) {
+    private void clearMarkerIfQueueEmpty(FDBRecordContext context, PendingWriteQueue queue) {
         if (!queue.isQueueEmpty(context).join()) {
             throw new RecordCoreException("Cannot clear queue usage indicator: pending write queue is not empty");
         }
@@ -899,7 +897,6 @@ class PendingWriteQueueTest extends FDBRecordStoreTestBase {
         }
     }
 
-    @Nonnull
     private TestDocument createHugeDocument(Random random) {
         StringBuilder builder = new StringBuilder();
         for (int i = 0 ; i < 500_000 ; i++) {
@@ -1040,7 +1037,6 @@ class PendingWriteQueueTest extends FDBRecordStoreTestBase {
         return List.of(docWithNoFields, docWithOneFields, docWithMultipleFields, hugeDoc, docWithAllFieldTypes);
     }
 
-    @Nonnull
     private static Tuple primaryKey(String text) {
         return Tuple.from(text, System.nanoTime());
     }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/TestingIndexMaintainerRegistry.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/directory/TestingIndexMaintainerRegistry.java
@@ -31,7 +31,6 @@ import com.apple.foundationdb.record.util.ServiceLoaderProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -40,19 +39,16 @@ import java.util.Map;
  * This can be used in place of the production registry
  */
 public class TestingIndexMaintainerRegistry implements IndexMaintainerFactoryRegistry {
-    @Nonnull
     private static final Logger LOGGER = LoggerFactory.getLogger(TestingIndexMaintainerRegistry.class);
 
-    @Nonnull
     private final Map<String, IndexMaintainerFactory> registry = new HashMap<>();
 
     public TestingIndexMaintainerRegistry() {
         initRegistry();
     }
 
-    @Nonnull
     @Override
-    public IndexMaintainerFactory getIndexMaintainerFactory(@Nonnull final Index index) {
+    public IndexMaintainerFactory getIndexMaintainerFactory(final Index index) {
         final IndexMaintainerFactory factory = registry.get(index.getType());
         if (factory == null) {
             throw new MetaDataException("Unknown index type for " + index);

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/highlight/FDBLuceneHighlightingTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/highlight/FDBLuceneHighlightingTest.java
@@ -54,6 +54,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static com.apple.foundationdb.record.lucene.LuceneIndexTestUtils.NGRAM_LUCENE_INDEX;
@@ -381,7 +382,7 @@ public class FDBLuceneHighlightingTest extends FDBRecordStoreTestBase {
 
     @SuppressWarnings("SameParameterValue") //deliberately placed here to make it easier to add new tests
     private void rebuildIndexMetaData(final FDBRecordContext context, final String document, final Index index) {
-        Pair<FDBRecordStore, QueryPlanner> pair = LuceneIndexTestUtils.rebuildIndexMetaData(context, path, document, index, isUseCascadesPlanner());
+        Pair<FDBRecordStore, QueryPlanner> pair = LuceneIndexTestUtils.rebuildIndexMetaData(context, Objects.requireNonNull(path), document, index, isUseCascadesPlanner());
         this.recordStore = pair.getLeft();
         this.planner = pair.getRight();
     }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/highlight/FDBLuceneHighlightingTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/highlight/FDBLuceneHighlightingTest.java
@@ -79,6 +79,9 @@ public class FDBLuceneHighlightingTest extends FDBRecordStoreTestBase {
         SynonymMapRegistryImpl.instance().getSynonymMap(EnglishSynonymMapConfig.ExpandedEnglishSynonymMapConfig.CONFIG_NAME);
     }
 
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     @Test
     void highlightedPrefix() {
         try (FDBRecordContext context = openContext()) {
@@ -95,6 +98,9 @@ public class FDBLuceneHighlightingTest extends FDBRecordStoreTestBase {
         }
     }
 
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     @Test
     void highlightedBitsetQuery() {
         try (FDBRecordContext context = openContext()) {
@@ -111,6 +117,9 @@ public class FDBLuceneHighlightingTest extends FDBRecordStoreTestBase {
         }
     }
 
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     @Test
     void highlightedNumberRangeQuery() {
         try (FDBRecordContext context = openContext()) {
@@ -147,6 +156,9 @@ public class FDBLuceneHighlightingTest extends FDBRecordStoreTestBase {
         }
     }
 
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     @Test
     void highlightedBooleanRangeQuery() {
         try (FDBRecordContext context = openContext()) {
@@ -167,6 +179,9 @@ public class FDBLuceneHighlightingTest extends FDBRecordStoreTestBase {
         }
     }
 
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     @Test
     void highlightedTermRangeQuery() {
         try (FDBRecordContext context = openContext()) {
@@ -178,6 +193,9 @@ public class FDBLuceneHighlightingTest extends FDBRecordStoreTestBase {
         }
     }
 
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     @Test
     void highlightedTermQuery() {
         try (FDBRecordContext context = openContext()) {
@@ -194,6 +212,9 @@ public class FDBLuceneHighlightingTest extends FDBRecordStoreTestBase {
         }
     }
 
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     @Test
     void highlightedSynonymIndex() {
         final String original = "peanut butter and jelly sandwich";
@@ -220,6 +241,9 @@ public class FDBLuceneHighlightingTest extends FDBRecordStoreTestBase {
     }
 
 
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     @Test
     void highlightedNgramIndex() {
         try (FDBRecordContext context = openContext()) {
@@ -240,6 +264,9 @@ public class FDBLuceneHighlightingTest extends FDBRecordStoreTestBase {
         }
     }
 
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     @Test
     void highlightingWithSnippets() {
         try (FDBRecordContext context = openContext()) {
@@ -383,8 +410,10 @@ public class FDBLuceneHighlightingTest extends FDBRecordStoreTestBase {
     @SuppressWarnings("SameParameterValue") //deliberately placed here to make it easier to add new tests
     private void rebuildIndexMetaData(final FDBRecordContext context, final String document, final Index index) {
         Pair<FDBRecordStore, QueryPlanner> pair = LuceneIndexTestUtils.rebuildIndexMetaData(context, Objects.requireNonNull(path), document, index, isUseCascadesPlanner());
-        this.recordStore = pair.getLeft();
-        this.planner = pair.getRight();
+        // Pair#getLeft/getRight are @Nullable in general (a Pair may hold nulls), but
+        // rebuildIndexMetaData always constructs its result from the non-null store/planner it builds.
+        this.recordStore = Objects.requireNonNull(pair.getLeft());
+        this.planner = Objects.requireNonNull(pair.getRight());
     }
 
     private void assertRecordHighlights(List<String> texts, RecordCursor<FDBIndexedRecord<Message>> cursor) {

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/highlight/LuceneHighlighterTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/highlight/LuceneHighlighterTest.java
@@ -548,9 +548,8 @@ public class LuceneHighlighterTest {
             Assertions.assertTrue(result instanceof HighlightedTerm, "Did not return a string!");
             return (HighlightedTerm)result;
         } catch (ParseException e) {
-            Assertions.fail("Failed to parse Lucene query");
+            return Assertions.fail("Failed to parse Lucene query");
         }
-        return null;
     }
 
     private void assertHighlightCorrect(HighlightedTerm expected, HighlightedTerm actual) {

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/highlight/LuceneHighlighterTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/highlight/LuceneHighlighterTest.java
@@ -57,7 +57,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -377,8 +376,7 @@ public class LuceneHighlighterTest {
         }
     }
 
-    @Nonnull
-    private String specialCharacterText(@Nonnull String specialCharacter) {
+    private String specialCharacterText(String specialCharacter) {
         return "Do we match special characters like " + specialCharacter + " even when its mashed together like " + specialCharacter + "noSpaces?";
     }
 

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/highlight/LuceneLocaleTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/highlight/LuceneLocaleTest.java
@@ -90,6 +90,9 @@ public class LuceneLocaleTest extends FDBRecordStoreTestBase {
         }
     }
 
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     private void assertSearchMatches(String search) {
         Assertions.assertEquals(List.of(1623L),
                 recordStore.fetchIndexRecords(
@@ -99,6 +102,9 @@ public class LuceneLocaleTest extends FDBRecordStoreTestBase {
                         .asList().join());
     }
 
+    // Passes a null continuation into FDBRecordStoreBase#scanIndex; NullAway does not reliably
+    // recognize @Nullable on that array (byte[]) parameter.
+    @SuppressWarnings("NullAway")
     private void assertHighlightMatches(final String search) {
         assertRecordHighlights(List.of("Hello {record} layer"),
                 recordStore.fetchIndexRecords(
@@ -112,8 +118,10 @@ public class LuceneLocaleTest extends FDBRecordStoreTestBase {
     @SuppressWarnings("SameParameterValue") //deliberately placed here to make it easier to add new tests
     private void rebuildIndexMetaData(final FDBRecordContext context, final String document, final Index index) {
         Pair<FDBRecordStore, QueryPlanner> pair = LuceneIndexTestUtils.rebuildIndexMetaData(context, Objects.requireNonNull(path), document, index, isUseCascadesPlanner());
-        this.recordStore = pair.getLeft();
-        this.planner = pair.getRight();
+        // Pair#getLeft/getRight are @Nullable in general (a Pair may hold nulls), but
+        // rebuildIndexMetaData always constructs its result from the non-null store/planner it builds.
+        this.recordStore = Objects.requireNonNull(pair.getLeft());
+        this.planner = Objects.requireNonNull(pair.getRight());
     }
 
     private void assertRecordHighlights(List<String> texts, RecordCursor<FDBIndexedRecord<Message>> cursor) {

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/highlight/LuceneLocaleTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/highlight/LuceneLocaleTest.java
@@ -43,6 +43,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 
 import static com.apple.foundationdb.record.lucene.LuceneIndexTestUtils.TEXT_AND_STORED_COMPLEX;
 import static com.apple.foundationdb.record.provider.foundationdb.indexes.TextIndexTestUtils.COMPLEX_DOC;
@@ -110,7 +111,7 @@ public class LuceneLocaleTest extends FDBRecordStoreTestBase {
 
     @SuppressWarnings("SameParameterValue") //deliberately placed here to make it easier to add new tests
     private void rebuildIndexMetaData(final FDBRecordContext context, final String document, final Index index) {
-        Pair<FDBRecordStore, QueryPlanner> pair = LuceneIndexTestUtils.rebuildIndexMetaData(context, path, document, index, isUseCascadesPlanner());
+        Pair<FDBRecordStore, QueryPlanner> pair = LuceneIndexTestUtils.rebuildIndexMetaData(context, Objects.requireNonNull(path), document, index, isUseCascadesPlanner());
         this.recordStore = pair.getLeft();
         this.planner = pair.getRight();
     }

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/highlight/LuceneScaleTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/highlight/LuceneScaleTest.java
@@ -243,7 +243,7 @@ public class LuceneScaleTest extends FDBRecordStoreTestBase {
     protected void clear() {
         if (Config.CLEAR_BEFORE_RUN) {
             fdb.run(context -> {
-                path.deleteAllData(context);
+                Objects.requireNonNull(path).deleteAllData(context);
                 return null;
             });
         }
@@ -263,7 +263,7 @@ public class LuceneScaleTest extends FDBRecordStoreTestBase {
                 );
             }
 
-            planner = new LucenePlanner(recordStore.getRecordMetaData(), recordStore.getRecordStoreState(), indexTypes, recordStore.getTimer());
+            planner = new LucenePlanner(recordStore.getRecordMetaData(), recordStore.getRecordStoreState(), indexTypes, Objects.requireNonNull(recordStore.getTimer()));
         }
     }
 
@@ -514,8 +514,8 @@ public class LuceneScaleTest extends FDBRecordStoreTestBase {
         private void disableIndex() {
             try (FDBRecordContext context = openContext()) {
                 final FDBRecordStore store = openStore(context);
-                maxDocId = LuceneConcurrency.asyncToSync(FDBStoreTimer.Waits.WAIT_LOAD_SYSTEM_KEY,
-                        store.scanRecords(TupleRange.ALL, null, ScanProperties.FORWARD_SCAN).getCount(), context);
+                maxDocId = Objects.requireNonNull(LuceneConcurrency.asyncToSync(FDBStoreTimer.Waits.WAIT_LOAD_SYSTEM_KEY,
+                        store.scanRecords(TupleRange.ALL, null, ScanProperties.FORWARD_SCAN).getCount(), context));
                 continuing = maxDocId > 0;
                 logger.info("Disabling index");
                 store.markIndexDisabled(INDEX.getName());
@@ -527,8 +527,8 @@ public class LuceneScaleTest extends FDBRecordStoreTestBase {
             OnlineIndexer.Builder indexBuilder = null;
             try (FDBRecordContext context = openContext()) {
                 final FDBRecordStore store = openStore(context);
-                maxDocId = LuceneConcurrency.asyncToSync(FDBStoreTimer.Waits.WAIT_LOAD_SYSTEM_KEY,
-                        store.scanRecords(TupleRange.ALL, null, ScanProperties.FORWARD_SCAN).getCount(), context);
+                maxDocId = Objects.requireNonNull(LuceneConcurrency.asyncToSync(FDBStoreTimer.Waits.WAIT_LOAD_SYSTEM_KEY,
+                        store.scanRecords(TupleRange.ALL, null, ScanProperties.FORWARD_SCAN).getCount(), context));
                 continuing = maxDocId > 0;
                 if (!store.getIndexState(INDEX.getName()).isReadable()) {
                     indexBuilder = OnlineIndexer.newBuilder()
@@ -587,7 +587,7 @@ public class LuceneScaleTest extends FDBRecordStoreTestBase {
         }
 
         private FDBRecordStore openStore(final FDBRecordContext context) {
-            final Pair<FDBRecordStore, QueryPlanner> res = LuceneIndexTestUtils.rebuildIndexMetaData(context, path, TextIndexTestUtils.COMPLEX_DOC, INDEX, false);
+            final Pair<FDBRecordStore, QueryPlanner> res = LuceneIndexTestUtils.rebuildIndexMetaData(context, Objects.requireNonNull(path), TextIndexTestUtils.COMPLEX_DOC, INDEX, false);
             recordStore = res.getLeft();
             planner = res.getRight();
             return recordStore;
@@ -639,7 +639,7 @@ public class LuceneScaleTest extends FDBRecordStoreTestBase {
 
         private Message getRandomRecord(final FDBRecordStore store) {
             // TODO randomly get a record, but skew it towards more recent ones...
-            return store.loadRecord(Tuple.from(1, random.nextInt(maxDocId))).getRecord();
+            return Objects.requireNonNull(store.loadRecord(Tuple.from(1, random.nextInt(maxDocId)))).getRecord();
         }
 
         public void search() throws ExecutionException, InterruptedException {

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/highlight/LuceneScaleTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/highlight/LuceneScaleTest.java
@@ -66,9 +66,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.jspecify.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
@@ -449,13 +448,11 @@ public class LuceneScaleTest extends FDBRecordStoreTestBase {
     }
 
 
-    @Nonnull
     private static PrintStream createJson(final String name) throws FileNotFoundException {
         final String filename = ".out/LuceneScaleTest." + Config.ISOLATION_ID + "." + name + ".json";
         return new PrintStream(new FileOutputStream(filename, false), true);
     }
 
-    @Nonnull
     private static PrintStream createCsv(final String name, final boolean append) throws FileNotFoundException {
         final String filename = ".out/LuceneScaleTest." + Config.ISOLATION_ID + "." + name + ".csv";
         boolean writeHeader = !append || !new File(filename).exists();
@@ -640,7 +637,6 @@ public class LuceneScaleTest extends FDBRecordStoreTestBase {
             }
         }
 
-        @Nonnull
         private Message getRandomRecord(final FDBRecordStore store) {
             // TODO randomly get a record, but skew it towards more recent ones...
             return store.loadRecord(Tuple.from(1, random.nextInt(maxDocId))).getRecord();

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/highlight/LuceneScaleTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/highlight/LuceneScaleTest.java
@@ -240,6 +240,10 @@ public class LuceneScaleTest extends FDBRecordStoreTestBase {
     }
 
     @BeforeEach
+    // fdb.run(context -> { ...; return null; }): FDBDatabase#run's unbounded <T> type parameter
+    // is treated as @NonNull, so the implicit Void "return null" trips NullAway even though there
+    // is no real value to return.
+    @SuppressWarnings("NullAway")
     protected void clear() {
         if (Config.CLEAR_BEFORE_RUN) {
             fdb.run(context -> {
@@ -511,6 +515,9 @@ public class LuceneScaleTest extends FDBRecordStoreTestBase {
             }
         }
 
+        // Passes a null continuation into FDBRecordStoreBase#scanRecords; NullAway does not reliably
+        // recognize @Nullable on that array (byte[]) parameter.
+        @SuppressWarnings("NullAway")
         private void disableIndex() {
             try (FDBRecordContext context = openContext()) {
                 final FDBRecordStore store = openStore(context);
@@ -523,6 +530,9 @@ public class LuceneScaleTest extends FDBRecordStoreTestBase {
             }
         }
 
+        // Passes a null continuation into FDBRecordStoreBase#scanRecords; NullAway does not reliably
+        // recognize @Nullable on that array (byte[]) parameter.
+        @SuppressWarnings("NullAway")
         private void buildIndex() {
             OnlineIndexer.Builder indexBuilder = null;
             try (FDBRecordContext context = openContext()) {
@@ -588,8 +598,10 @@ public class LuceneScaleTest extends FDBRecordStoreTestBase {
 
         private FDBRecordStore openStore(final FDBRecordContext context) {
             final Pair<FDBRecordStore, QueryPlanner> res = LuceneIndexTestUtils.rebuildIndexMetaData(context, Objects.requireNonNull(path), TextIndexTestUtils.COMPLEX_DOC, INDEX, false);
-            recordStore = res.getLeft();
-            planner = res.getRight();
+            // Pair#getLeft/getRight are @Nullable in general (a Pair may hold nulls), but
+            // rebuildIndexMetaData always constructs its result from the non-null store/planner it builds.
+            recordStore = Objects.requireNonNull(res.getLeft());
+            planner = Objects.requireNonNull(res.getRight());
             return recordStore;
         }
 
@@ -618,7 +630,10 @@ public class LuceneScaleTest extends FDBRecordStoreTestBase {
                     }
                 }
                 context.commit();
-                return store.getIndexDeferredMaintenanceControl().getMergeRequiredIndexes();
+                // getMergeRequiredIndexes() is declared to return a non-null Set<Index> (see
+                // IndexDeferredMaintenanceControl, fdb-record-layer-core); it is only seen as @Nullable
+                // here because it is unannotated from this module's NullAway perspective.
+                return Objects.requireNonNull(store.getIndexDeferredMaintenanceControl().getMergeRequiredIndexes());
             }
         }
 
@@ -633,7 +648,7 @@ public class LuceneScaleTest extends FDBRecordStoreTestBase {
                     store.saveRecord(builder.build());
                 }
                 context.commit();
-                return store.getIndexDeferredMaintenanceControl().getMergeRequiredIndexes();
+                return Objects.requireNonNull(store.getIndexDeferredMaintenanceControl().getMergeRequiredIndexes());
             }
         }
 

--- a/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/idformat/LuceneIndexKeySerializerTest.java
+++ b/fdb-record-layer-lucene/src/test/java/com/apple/foundationdb/record/lucene/idformat/LuceneIndexKeySerializerTest.java
@@ -130,6 +130,10 @@ public class LuceneIndexKeySerializerTest {
     }
 
     @Test
+    // Tuple.from below intentionally accepts null elements here (an unannotated, external API
+    // conservatively treated by NullAway as requiring non-null); this test specifically exercises
+    // the *_OR_NULL format elements.
+    @SuppressWarnings("NullAway")
     void testNullableInteger() {
         Tuple key = Tuple.from(null, 45L, null);
         LuceneIndexKeySerializer classUnderTest = LuceneIndexKeySerializer.fromStringFormat("[INT64_OR_NULL, INT64, INT32_OR_NULL]");


### PR DESCRIPTION
10th of a 14-PR stack adopting jspecify + NullAway null-checking, stacked on #4582 (`fdb-record-layer-spatial`). Same treatment applied to `fdb-record-layer-lucene`, split into two independently-worked chunks then merged. See inline comments for specific findings.