### PR TITLE
Adopt jspecify + NullAway null-checking on fdb-relational-server

### DIFF
--- a/fdb-relational-server/fdb-relational-server.gradle
+++ b/fdb-relational-server/fdb-relational-server.gradle
@@ -22,6 +22,7 @@ plugins {
     id 'java-test-fixtures'
     id 'application'
     alias(libs.plugins.shadow)
+    alias(libs.plugins.errorprone)
 }
 
 apply from: rootProject.file('gradle/publishing.gradle')
@@ -96,6 +97,7 @@ dependencies {
     implementation project(":fdb-relational-api")
     implementation project(":fdb-relational-core")
     implementation project(":fdb-relational-grpc")
+    compileOnly(libs.jspecify)
     implementation(libs.grpc.inprocess)
     implementation(libs.grpc.netty)
     implementation(libs.grpc.protobuf)
@@ -113,6 +115,9 @@ dependencies {
     runtimeOnly(libs.log4j.slf4jBinding)
     runtimeOnly(libs.log4j.core)
 
+    errorprone(libs.errorprone.core)
+    errorprone(libs.nullaway)
+
     testFixturesImplementation(project(":fdb-java-annotations")) {
         exclude(group: "com.squareup", module: "javapoet")
     }
@@ -127,6 +132,20 @@ dependencies {
     testCompileOnly(libs.bundles.test.compileOnly)
     testImplementation(libs.grpc.testing)
     testImplementation(libs.apache.httpclient)
+}
+
+// jspecify + NullAway, scoped to this module only. See @NullMarked package-info.java files in
+// com.apple.foundationdb.relational.server / .server.jdbc.v1 (the latter is a subpackage of the
+// former so is covered by the same AnnotatedPackages prefix). Companion change to the
+// fdb-relational-grpc and fdb-relational-jdbc null-checking adoption.
+tasks.withType(JavaCompile).configureEach {
+    options.errorprone {
+        disableAllChecks = true
+        error("NullAway")
+        option("NullAway:AnnotatedPackages", "com.apple.foundationdb.relational.server")
+        option("NullAway:JSpecifyMode", "true")
+        option("NullAway:AcknowledgeRestrictiveAnnotations", "true")
+    }
 }
 
 application {

--- a/fdb-relational-server/src/main/java/com/apple/foundationdb/relational/server/FRL.java
+++ b/fdb-relational-server/src/main/java/com/apple/foundationdb/relational/server/FRL.java
@@ -53,8 +53,8 @@ import com.apple.foundationdb.relational.recordlayer.ddl.RecordLayerMetadataOper
 import com.apple.foundationdb.relational.recordlayer.query.cache.RelationalPlanCache;
 import com.apple.foundationdb.relational.recordlayer.util.ExceptionUtil;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import java.net.URI;
 import java.sql.Array;
 import java.sql.DriverManager;
@@ -87,15 +87,15 @@ public class FRL implements AutoCloseable {
         this(Options.NONE, null);
     }
 
-    public FRL(@Nonnull Options options) throws RelationalException {
+    public FRL(Options options) throws RelationalException {
         this(options, null);
     }
 
-    public FRL(@Nonnull Options options, @Nullable String clusterFile) throws RelationalException {
+    public FRL(Options options, @Nullable String clusterFile) throws RelationalException {
         this(options, clusterFile, true);
     }
 
-    public FRL(@Nonnull Options options, @Nullable String clusterFile, boolean registerDriver) throws RelationalException {
+    public FRL(Options options, @Nullable String clusterFile, boolean registerDriver) throws RelationalException {
         final FDBDatabase fdbDb = FDBDatabaseFactory.instance().getDatabase(clusterFile);
         final Long asyncToSyncTimeout = options.getOption(Options.Name.ASYNC_OPERATIONS_TIMEOUT_MILLIS);
         if (asyncToSyncTimeout > 0) {
@@ -163,7 +163,7 @@ public class FRL implements AutoCloseable {
             this.rowCount = rowCount;
         }
 
-        public static Response query(@Nonnull ResultSet resultSet) {
+        public static Response query(ResultSet resultSet) {
             return new Response(resultSet, -1);
         }
 
@@ -198,8 +198,7 @@ public class FRL implements AutoCloseable {
      * @return Returns A Response with either a ResultSet or a Row count, depending on the type of query issued
      * @throws SQLException For all sorts of reasons.
      */
-    @Nonnull
-    public Response execute(String database, String schema, String sql, List<Parameter> parameters, Options options)
+    public Response execute(String database, String schema, String sql, @Nullable List<Parameter> parameters, Options options)
             throws SQLException {
         // Down inside connect, it calls RecordLayerStorageCluster.loadDatabase which internally creates a Transaction
         // to RecordLayerStorageCluster.loadDatabase and which, internal to loadDatabase, it then closes.
@@ -218,8 +217,8 @@ public class FRL implements AutoCloseable {
         return Objects.requireNonNull(driver.connect(URI.create(createEmbeddedJDBCURI(database, schema)), options));
     }
 
-    private Response executeInternal(@Nonnull RelationalConnection connection,
-                                     @Nonnull String sql,
+    private Response executeInternal(RelationalConnection connection,
+                                     String sql,
                                      @Nullable List<Parameter> parameters,
                                      @Nullable Options options) throws SQLException {
         ResultSet resultSet;
@@ -262,8 +261,8 @@ public class FRL implements AutoCloseable {
         }
     }
 
-    private static void addPreparedStatementParameter(@Nonnull RelationalPreparedStatement relationalPreparedStatement,
-                                                      @Nonnull Parameter parameter, int index) throws SQLException {
+    private static void addPreparedStatementParameter(RelationalPreparedStatement relationalPreparedStatement,
+                                                      Parameter parameter, int index) throws SQLException {
         final var oneOfValue = parameter.getParameter();
         if (oneOfValue.hasString()) {
             relationalPreparedStatement.setString(index, oneOfValue.getString());
@@ -347,46 +346,45 @@ public class FRL implements AutoCloseable {
         return new TransactionalToken(transactionalConnection);
     }
 
-    @Nonnull
-    public Response transactionalExecute(TransactionalToken token, String sql, List<Parameter> parameters, @Nullable Options options)
+    public Response transactionalExecute(@Nullable TransactionalToken token, String sql, List<Parameter> parameters, @Nullable Options options)
             throws SQLException {
-        assertValidToken(token);
-        return executeInternal(token.getConnection(), sql, parameters, options);
+        return executeInternal(requireValidToken(token).getConnection(), sql, parameters, options);
     }
 
-    public int transactionalInsert(TransactionalToken token, String tableName, List<RelationalStruct> data)
+    public int transactionalInsert(@Nullable TransactionalToken token, String tableName, List<RelationalStruct> data)
             throws SQLException {
-        assertValidToken(token);
-        try (Statement statement = token.getConnection().createStatement()) {
+        try (Statement statement = requireValidToken(token).getConnection().createStatement()) {
             try (RelationalStatement relationalStatement = statement.unwrap(RelationalStatement.class)) {
                 return relationalStatement.executeInsert(tableName, data, Options.NONE);
             }
         }
     }
 
-    public void transactionalCommit(TransactionalToken token) throws SQLException {
-        assertValidToken(token);
-        token.getConnection().commit();
+    public void transactionalCommit(@Nullable TransactionalToken token) throws SQLException {
+        requireValidToken(token).getConnection().commit();
     }
 
-    public void transactionalRollback(TransactionalToken token) throws SQLException {
-        assertValidToken(token);
-        token.getConnection().rollback();
+    public void transactionalRollback(@Nullable TransactionalToken token) throws SQLException {
+        requireValidToken(token).getConnection().rollback();
     }
 
-    public void enableAutoCommit(TransactionalToken token) throws SQLException {
-        assertValidToken(token);
-        token.getConnection().setAutoCommit(true);
+    public void enableAutoCommit(@Nullable TransactionalToken token) throws SQLException {
+        requireValidToken(token).getConnection().setAutoCommit(true);
     }
 
-    public void transactionalClose(TransactionalToken token) throws SQLException {
+    public void transactionalClose(@Nullable TransactionalToken token) throws SQLException {
         if (token != null && !token.expired()) {
             token.close();
         }
 
     }
 
-    private void assertValidToken(TransactionalToken token) throws SQLException {
+    /**
+     * Check that <code>token</code> is non-null and not expired.
+     * @return <code>token</code>, narrowed to non-null, for convenient chaining at call sites.
+     * @throws SQLException if <code>token</code> is null or expired.
+     */
+    private TransactionalToken requireValidToken(@Nullable TransactionalToken token) throws SQLException {
         if (token == null) {
             // TODO: non SQLException exception?
             throw new SQLException("Transaction was not initialized");
@@ -394,6 +392,7 @@ public class FRL implements AutoCloseable {
         if (token.expired()) {
             throw new SQLException("Transaction had expired");
         }
+        return token;
     }
 
     @Override

--- a/fdb-relational-server/src/main/java/com/apple/foundationdb/relational/server/InProcessRelationalServer.java
+++ b/fdb-relational-server/src/main/java/com/apple/foundationdb/relational/server/InProcessRelationalServer.java
@@ -29,7 +29,8 @@ import com.apple.foundationdb.relational.server.jdbc.v1.JDBCService;
 import io.grpc.Server;
 import io.grpc.inprocess.InProcessServerBuilder;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InterruptedIOException;
@@ -45,7 +46,9 @@ import java.time.Instant;
 @SuppressWarnings({"PMD.SystemPrintln", "PMD.DoNotCallSystemExit"})
 @API(API.Status.EXPERIMENTAL)
 public class InProcessRelationalServer implements Closeable {
+    @Nullable
     private Server grpcInProcessServer;
+    @Nullable
     private FRL frl;
     private final String serverName;
     @Nullable
@@ -92,7 +95,9 @@ public class InProcessRelationalServer implements Closeable {
                 // Use stderr here since the logger may have been reset by its JVM shutdown hook.
                 System.err.println(Instant.now() + " Waiting on in-process Server " + getServerName() + " termination");
                 try {
-                    InProcessRelationalServer.this.grpcInProcessServer.shutdown();
+                    if (InProcessRelationalServer.this.grpcInProcessServer != null) {
+                        InProcessRelationalServer.this.grpcInProcessServer.shutdown();
+                    }
                     InProcessRelationalServer.this.awaitTermination();
                 } catch (InterruptedIOException e) {
                     throw new RuntimeException(e);

--- a/fdb-relational-server/src/main/java/com/apple/foundationdb/relational/server/RelationalServer.java
+++ b/fdb-relational-server/src/main/java/com/apple/foundationdb/relational/server/RelationalServer.java
@@ -48,11 +48,13 @@ import org.apache.commons.cli.ParseException;
 import org.apache.commons.cli.help.HelpFormatter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.jspecify.annotations.Nullable;
 
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.time.Instant;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
@@ -78,31 +80,35 @@ public class RelationalServer implements Closeable {
     private static final Logger logger = LogManager.getLogger(RelationalServer.class.getName());
     private static final int DEFAULT_HTTP_PORT = GrpcConstants.DEFAULT_SERVER_PORT + 1;
 
+    @Nullable
     private Server grpcServer;
     private final int grpcPort;
     private final int httpPort;
+    @Nullable
     private FRL frl;
     private final CollectorRegistry collectorRegistry;
+    @Nullable
     private final String clusterFile;
 
     // Visible for the test fixture only so it can pass a CollectorRegistry.
 
     @VisibleForTesting
-    RelationalServer(int grpcPort, int httpPort, CollectorRegistry collectorRegistry, String clusterFile) {
+    RelationalServer(int grpcPort, int httpPort, CollectorRegistry collectorRegistry, @Nullable String clusterFile) {
         this.grpcPort = grpcPort;
         this.httpPort = httpPort;
         this.collectorRegistry = collectorRegistry;
         this.clusterFile = clusterFile;
     }
 
-    public RelationalServer(int grpcPort, int httpPort, String clusterFile) {
+    public RelationalServer(int grpcPort, int httpPort, @Nullable String clusterFile) {
         this(grpcPort, httpPort, CollectorRegistry.defaultRegistry, clusterFile);
     }
 
     @Override
     public String toString() {
-        return "listening=" + this.grpcServer.getListenSockets() +
-                ", services=" + this.grpcServer.getServices().stream().map(m -> m.getServiceDescriptor().getName())
+        Server server = requireStartedGrpcServer();
+        return "listening=" + server.getListenSockets() +
+                ", services=" + server.getServices().stream().map(m -> m.getServiceDescriptor().getName())
                 .collect(Collectors.toList()) +
                 ", httpPort=" + this.httpPort;
     }
@@ -113,7 +119,17 @@ public class RelationalServer implements Closeable {
      * @return The port GRPC is listening on
      */
     public int getGrpcPort() {
-        return this.grpcServer.getPort();
+        return requireStartedGrpcServer().getPort();
+    }
+
+    /**
+     * Narrow {@link #grpcServer} to non-null.
+     * @return {@link #grpcServer}, narrowed to non-null.
+     * @throws NullPointerException if called before {@link #start()} completes; see the javadoc on
+     * {@link #getGrpcPort()} and {@link #toString()}.
+     */
+    private Server requireStartedGrpcServer() {
+        return Objects.requireNonNull(this.grpcServer, "RelationalServer has not been started");
     }
 
     /**
@@ -180,7 +196,9 @@ public class RelationalServer implements Closeable {
                 // Use stderr here since the logger may have been reset by its JVM shutdown hook.
                 System.err.println(Instant.now() + " Waiting on Server termination");
                 try {
-                    RelationalServer.this.grpcServer.shutdown();
+                    if (RelationalServer.this.grpcServer != null) {
+                        RelationalServer.this.grpcServer.shutdown();
+                    }
                     RelationalServer.this.awaitTermination();
                 } catch (InterruptedIOException e) {
                     throw new RuntimeException(e);
@@ -258,20 +276,22 @@ public class RelationalServer implements Closeable {
                 .desc("Path to the cluster file; default=null.").get();
         options.addOption(clusterFileOption);
         CommandLineParser parser = new DefaultParser();
-        CommandLine cli = null;
+        @Nullable CommandLine parsedCli = null;
         try {
-            cli = parser.parse(options, args);
+            parsedCli = parser.parse(options, args);
         } catch (ParseException pe) {
             System.err.println("Parse of command-line failed: " + pe.getMessage());
             System.exit(1);
         }
+        // System.exit() above does not return, but the compiler/NullAway can't know that.
+        final CommandLine cli = Objects.requireNonNull(parsedCli);
         if (cli.hasOption(help.getOpt())) {
             HelpFormatter formatter = HelpFormatter.builder().get();
             formatter.printHelp("relational", null, options, null, true);
             return;
         }
 
-        final String clusterFile;
+        final @Nullable String clusterFile;
         if (cli.hasOption(clusterFileOption)) {
             clusterFile = cli.getOptionValue(clusterFileOption);
         } else {

--- a/fdb-relational-server/src/main/java/com/apple/foundationdb/relational/server/TransactionalToken.java
+++ b/fdb-relational-server/src/main/java/com/apple/foundationdb/relational/server/TransactionalToken.java
@@ -22,9 +22,12 @@ package com.apple.foundationdb.relational.server;
 
 import com.apple.foundationdb.relational.api.RelationalConnection;
 
+import org.jspecify.annotations.Nullable;
+
 import java.sql.SQLException;
 
 public class TransactionalToken {
+    @Nullable
     private RelationalConnection transactionalConnection;
 
     TransactionalToken(final RelationalConnection transactionalConnection) {
@@ -32,6 +35,9 @@ public class TransactionalToken {
     }
 
     public RelationalConnection getConnection() {
+        if (transactionalConnection == null) {
+            throw new IllegalStateException("Cannot get connection of an expired TransactionalToken");
+        }
         return transactionalConnection;
     }
 
@@ -40,7 +46,7 @@ public class TransactionalToken {
     }
 
     public void close() throws SQLException {
-        if (!expired()) {
+        if (transactionalConnection != null) {
             transactionalConnection.close();
             transactionalConnection = null;
         }

--- a/fdb-relational-server/src/main/java/com/apple/foundationdb/relational/server/jdbc/v1/JDBCService.java
+++ b/fdb-relational-server/src/main/java/com/apple/foundationdb/relational/server/jdbc/v1/JDBCService.java
@@ -47,6 +47,7 @@ import io.grpc.protobuf.StatusProto;
 import io.grpc.stub.StreamObserver;
 
 import java.sql.SQLException;
+import java.util.Objects;
 
 /**
  * Field the Relational JDBC Service.
@@ -202,7 +203,7 @@ public class JDBCService extends JDBCServiceGrpc.JDBCServiceImplBase {
         }
         try (RelationalResultSet rs = frl.get(request.getDatabase(), request.getSchema(), request.getTableName(),
                     TypeConversion.fromProtobuf(request.getKeySet()), TypeConversion.fromProtobuf(request.getOptions()))) {
-            GetResponse getResponse = GetResponse.newBuilder().setResultSet(TypeConversion.toProtobuf(rs)).build();
+            GetResponse getResponse = GetResponse.newBuilder().setResultSet(Objects.requireNonNull(TypeConversion.toProtobuf(rs))).build();
             responseObserver.onNext(getResponse);
             responseObserver.onCompleted();
         } catch (SQLException e) {
@@ -248,7 +249,7 @@ public class JDBCService extends JDBCServiceGrpc.JDBCServiceImplBase {
         }
         try (RelationalResultSet rs = this.frl.scan(request.getDatabase(), request.getSchema(), request.getTableName(),
                     TypeConversion.fromProtobuf(request.getKeySet()), TypeConversion.fromProtobuf(request.getOptions()))) {
-            ScanResponse scanResponse = ScanResponse.newBuilder().setResultSet(TypeConversion.toProtobuf(rs)).build();
+            ScanResponse scanResponse = ScanResponse.newBuilder().setResultSet(Objects.requireNonNull(TypeConversion.toProtobuf(rs))).build();
             responseObserver.onNext(scanResponse);
             responseObserver.onCompleted();
         } catch (SQLException e) {

--- a/fdb-relational-server/src/main/java/com/apple/foundationdb/relational/server/jdbc/v1/TransactionRequestHandler.java
+++ b/fdb-relational-server/src/main/java/com/apple/foundationdb/relational/server/jdbc/v1/TransactionRequestHandler.java
@@ -39,6 +39,7 @@ import com.apple.foundationdb.relational.server.TransactionalToken;
 import com.google.protobuf.Any;
 import com.google.rpc.Status;
 import io.grpc.stub.StreamObserver;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,6 +58,7 @@ public class TransactionRequestHandler implements StreamObserver<TransactionalRe
 
     private final StreamObserver<TransactionalResponse> responseObserver;
     private final FRL frl;
+    @Nullable
     private TransactionalToken transactionalToken;
 
     public TransactionRequestHandler(final StreamObserver<TransactionalResponse> responseObserver, final FRL frl) {

--- a/fdb-relational-server/src/main/java/com/apple/foundationdb/relational/server/jdbc/v1/package-info.java
+++ b/fdb-relational-server/src/main/java/com/apple/foundationdb/relational/server/jdbc/v1/package-info.java
@@ -22,4 +22,7 @@
  * JDBC server implementation. Includes implementation for gRPC services used to power a database
  * server accessible via a JDBC client.
  */
+@NullMarked
 package com.apple.foundationdb.relational.server.jdbc.v1;
+
+import org.jspecify.annotations.NullMarked;

--- a/fdb-relational-server/src/main/java/com/apple/foundationdb/relational/server/package-info.java
+++ b/fdb-relational-server/src/main/java/com/apple/foundationdb/relational/server/package-info.java
@@ -23,4 +23,7 @@
  * {@link com.apple.foundationdb.relational.server.RelationalServer} stands up a GRPC Server hosting GRPC Services
  * Relational JDBC Service and GRPC Health Service.
  */
+@NullMarked
 package com.apple.foundationdb.relational.server;
+
+import org.jspecify.annotations.NullMarked;

--- a/fdb-relational-server/src/test/java/com/apple/foundationdb/relational/server/RelationalServerTest.java
+++ b/fdb-relational-server/src/test/java/com/apple/foundationdb/relational/server/RelationalServerTest.java
@@ -48,7 +48,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -129,6 +130,7 @@ public class RelationalServerTest {
             update(stub, sysDbPath, RelationalKeyspaceProvider.CATALOG, "create database \"" + testdb + "\"");
             update(stub, sysDbPath, RelationalKeyspaceProvider.CATALOG, "create schema \"" + testdb + "/test_schema\" with template test_template");
             ResultSet resultSet = execute(stub, sysDbPath, RelationalKeyspaceProvider.CATALOG, "select * from databases");
+            Assertions.assertNotNull(resultSet);
             Assertions.assertEquals(2, resultSet.getRowCount());
             Assertions.assertEquals(1, resultSet.getRow(0).getColumns().getColumnCount());
             Assertions.assertEquals(1, resultSet.getRow(1).getColumns().getColumnCount());

--- a/fdb-relational-server/src/testFixtures/java/com/apple/foundationdb/relational/server/ServerTestUtil.java
+++ b/fdb-relational-server/src/testFixtures/java/com/apple/foundationdb/relational/server/ServerTestUtil.java
@@ -25,6 +25,7 @@ import com.apple.foundationdb.test.FDBTestEnvironment;
 import io.prometheus.client.CollectorRegistry;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
 import java.net.BindException;
@@ -59,10 +60,11 @@ public final class ServerTestUtil {
     /**
      * Create and start a RelationalServer with a specific cluster file.
      * @param preferredPort The preferred port to start on
-     * @param clusterFile The cluster file to use for FDB connection
+     * @param clusterFile The cluster file to use for FDB connection, or {@code null} to use the default
+     *     cluster file
      * @return Return a started {@link RelationalServer}
      */
-    public static RelationalServer createAndStartRelationalServer(int preferredPort, String clusterFile) throws IOException {
+    public static RelationalServer createAndStartRelationalServer(int preferredPort, @Nullable String clusterFile) throws IOException {
         RelationalServer relationalServer = null;
         for (int port = preferredPort; port <= (preferredPort + PORT_RETRY_MAX); port += 2) {
             // Create a CollectorRegistry when a test fixture else "java.lang.IllegalArgumentException:

--- a/fdb-relational-server/src/testFixtures/java/com/apple/foundationdb/relational/server/ServerTestUtil.java
+++ b/fdb-relational-server/src/testFixtures/java/com/apple/foundationdb/relational/server/ServerTestUtil.java
@@ -76,9 +76,10 @@ public final class ServerTestUtil {
             } catch (IOException ioe) {
                 // GRPC throws an IOE w/ a message that begins with the below when BindException.
                 // HTTPServer will throw a BindException. Handle both.
+                final String message = ioe.getMessage();
                 if (ioe instanceof BindException ||
                         (ioe.getCause() != null && ioe.getCause() instanceof  BindException) ||
-                        ioe.getMessage().contains("Failed to bind to address")) {
+                        (message != null && message.contains("Failed to bind to address"))) {
                     final int portToLog = port;
                     logger.info("BindException on port={}, trying the next port", portToLog, ioe);
                     relationalServer.close();
@@ -87,6 +88,10 @@ public final class ServerTestUtil {
                 }
                 throw ioe;
             }
+        }
+        if (relationalServer == null) {
+            throw new IOException("Could not start RelationalServer on any port in [" + preferredPort + ", "
+                    + (preferredPort + PORT_RETRY_MAX) + "]");
         }
         return relationalServer;
     }

--- a/fdb-relational-server/src/testFixtures/java/com/apple/foundationdb/relational/server/package-info.java
+++ b/fdb-relational-server/src/testFixtures/java/com/apple/foundationdb/relational/server/package-info.java
@@ -21,4 +21,7 @@
 /**
  * Test Utility for downstream modules.
  */
+@NullMarked
 package com.apple.foundationdb.relational.server;
+
+import org.jspecify.annotations.NullMarked;


### PR DESCRIPTION
13th of a 14-PR stack adopting jspecify + NullAway null-checking, stacked on #4585 (`fdb-relational-core`). Same treatment applied to `fdb-relational-server`. See inline comments for specific findings.