### PR TITLE
Adopt jspecify + NullAway null-checking on yaml-tests

### DIFF
--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/AbstractAggregateResultSet.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/AbstractAggregateResultSet.java
@@ -26,6 +26,7 @@ import com.apple.foundationdb.relational.api.RelationalResultSetMetaData;
 import com.apple.foundationdb.relational.api.RelationalStruct;
 import com.apple.foundationdb.relational.api.exceptions.ErrorCode;
 
+import org.jspecify.annotations.Nullable;
 import java.sql.SQLException;
 import java.util.UUID;
 
@@ -38,6 +39,7 @@ import java.util.UUID;
 public abstract class AbstractAggregateResultSet implements RelationalResultSet {
     private boolean isClosed = false;
     private final RelationalResultSetMetaData metadata;
+    @Nullable
     protected RelationalResultSet currentRow;
 
     protected AbstractAggregateResultSet(RelationalResultSetMetaData metadata) {
@@ -46,6 +48,7 @@ public abstract class AbstractAggregateResultSet implements RelationalResultSet 
 
     protected abstract boolean hasNext();
 
+    @Nullable
     protected abstract RelationalResultSet advanceRow() throws SQLException;
 
     @Override
@@ -61,140 +64,117 @@ public abstract class AbstractAggregateResultSet implements RelationalResultSet 
 
     @Override
     public boolean wasNull() throws SQLException {
-        checkCurrentRow();
-        return currentRow.wasNull();
+        return checkCurrentRow().wasNull();
     }
 
     @Override
     public String getString(int columnIndex) throws SQLException {
-        checkCurrentRow();
-        return currentRow.getString(columnIndex);
+        return checkCurrentRow().getString(columnIndex);
     }
 
     @Override
     public boolean getBoolean(int columnIndex) throws SQLException {
-        checkCurrentRow();
-        return currentRow.getBoolean(columnIndex);
+        return checkCurrentRow().getBoolean(columnIndex);
     }
 
     @Override
     public int getInt(int columnIndex) throws SQLException {
-        checkCurrentRow();
-        return currentRow.getInt(columnIndex);
+        return checkCurrentRow().getInt(columnIndex);
     }
 
     @Override
     public long getLong(int columnIndex) throws SQLException {
-        checkCurrentRow();
-        return currentRow.getLong(columnIndex);
+        return checkCurrentRow().getLong(columnIndex);
     }
 
     @Override
     public float getFloat(int columnIndex) throws SQLException {
-        checkCurrentRow();
-        return currentRow.getFloat(columnIndex);
+        return checkCurrentRow().getFloat(columnIndex);
     }
 
     @Override
     public double getDouble(int columnIndex) throws SQLException {
-        checkCurrentRow();
-        return currentRow.getDouble(columnIndex);
+        return checkCurrentRow().getDouble(columnIndex);
     }
 
     @Override
     public byte[] getBytes(int columnIndex) throws SQLException {
-        checkCurrentRow();
-        return currentRow.getBytes(columnIndex);
+        return checkCurrentRow().getBytes(columnIndex);
     }
 
     @Override
     public Object getObject(int columnIndex) throws SQLException {
-        checkCurrentRow();
-        return currentRow.getObject(columnIndex);
+        return checkCurrentRow().getObject(columnIndex);
     }
 
     @Override
     public RelationalStruct getStruct(int oneBasedPosition) throws SQLException {
-        checkCurrentRow();
-        return currentRow.getStruct(oneBasedPosition);
+        return checkCurrentRow().getStruct(oneBasedPosition);
     }
 
     @Override
     public RelationalArray getArray(int oneBasedPosition) throws SQLException {
-        checkCurrentRow();
-        return currentRow.getArray(oneBasedPosition);
+        return checkCurrentRow().getArray(oneBasedPosition);
     }
 
     @Override
     public UUID getUUID(int oneBasedPosition) throws SQLException {
-        checkCurrentRow();
-        return currentRow.getUUID(oneBasedPosition);
+        return checkCurrentRow().getUUID(oneBasedPosition);
     }
 
     @Override
     public String getString(String columnLabel) throws SQLException {
-        checkCurrentRow();
-        return currentRow.getString(columnLabel);
+        return checkCurrentRow().getString(columnLabel);
     }
 
     @Override
     public boolean getBoolean(String columnLabel) throws SQLException {
-        checkCurrentRow();
-        return currentRow.getBoolean(columnLabel);
+        return checkCurrentRow().getBoolean(columnLabel);
     }
 
     @Override
     public int getInt(String columnLabel) throws SQLException {
-        checkCurrentRow();
-        return currentRow.getInt(columnLabel);
+        return checkCurrentRow().getInt(columnLabel);
     }
 
     @Override
     public long getLong(String columnLabel) throws SQLException {
-        checkCurrentRow();
-        return currentRow.getLong(columnLabel);
+        return checkCurrentRow().getLong(columnLabel);
     }
 
     @Override
     public float getFloat(String columnLabel) throws SQLException {
-        checkCurrentRow();
-        return currentRow.getFloat(columnLabel);
+        return checkCurrentRow().getFloat(columnLabel);
     }
 
     @Override
     public double getDouble(String columnLabel) throws SQLException {
-        checkCurrentRow();
-        return currentRow.getDouble(columnLabel);
+        return checkCurrentRow().getDouble(columnLabel);
     }
 
     @Override
     public byte[] getBytes(String columnLabel) throws SQLException {
-        checkCurrentRow();
-        return currentRow.getBytes(columnLabel);
+        return checkCurrentRow().getBytes(columnLabel);
     }
 
     @Override
     public Object getObject(String columnLabel) throws SQLException {
-        checkCurrentRow();
-        return currentRow.getObject(columnLabel);
+        return checkCurrentRow().getObject(columnLabel);
     }
 
     @Override
     public RelationalStruct getStruct(String fieldName) throws SQLException {
-        checkCurrentRow();
-        return currentRow.getStruct(fieldName);
+        return checkCurrentRow().getStruct(fieldName);
     }
 
     @Override
     public RelationalArray getArray(String fieldName) throws SQLException {
-        checkCurrentRow();
-        return currentRow.getArray(fieldName);
+        return checkCurrentRow().getArray(fieldName);
     }
 
     @Override
     public UUID getUUID(String fieldName) throws SQLException {
-        checkCurrentRow();
-        return currentRow.getUUID(fieldName);
+        return checkCurrentRow().getUUID(fieldName);
     }
 
     @Override
@@ -207,9 +187,10 @@ public abstract class AbstractAggregateResultSet implements RelationalResultSet 
         return isClosed;
     }
 
-    private void checkCurrentRow() throws SQLException {
+    private RelationalResultSet checkCurrentRow() throws SQLException {
         if ((currentRow == null) || isClosed()) {
             throw new SQLException("ResultSet exhausted", ErrorCode.INVALID_CURSOR_STATE.getErrorCode());
         }
+        return currentRow;
     }
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/AggregateResultSet.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/AggregateResultSet.java
@@ -26,7 +26,7 @@ import com.apple.foundationdb.relational.api.RelationalResultSetMetaData;
 import com.apple.foundationdb.relational.api.exceptions.ErrorCode;
 import org.junit.jupiter.api.Assertions;
 
-import javax.annotation.Nonnull;
+import org.jspecify.annotations.Nullable;
 import java.sql.SQLException;
 import java.util.Iterator;
 
@@ -53,6 +53,7 @@ public class AggregateResultSet extends AbstractAggregateResultSet {
     }
 
     @Override
+    @Nullable
     protected RelationalResultSet advanceRow() throws SQLException {
         if (!hasNext()) {
             return null;
@@ -65,7 +66,6 @@ public class AggregateResultSet extends AbstractAggregateResultSet {
         return rowIterator.next();
     }
 
-    @Nonnull
     @Override
     public Continuation getContinuation() throws SQLException {
         if (hasNext()) {

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/ConnectionTarget.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/ConnectionTarget.java
@@ -20,7 +20,6 @@
 
 package com.apple.foundationdb.relational.yamltests;
 
-import javax.annotation.Nonnull;
 import java.net.URI;
 
 /**
@@ -42,16 +41,14 @@ import java.net.URI;
  * </ul>
  */
 public class ConnectionTarget {
-    @Nonnull
     private final URI uri;
     private final int clusterIndex;
 
-    public ConnectionTarget(@Nonnull URI uri, int clusterIndex) {
+    public ConnectionTarget(URI uri, int clusterIndex) {
         this.uri = uri;
         this.clusterIndex = clusterIndex;
     }
 
-    @Nonnull
     public URI getUri() {
         return uri;
     }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/CustomYamlConstructor.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/CustomYamlConstructor.java
@@ -37,7 +37,6 @@ import org.yaml.snakeyaml.constructor.SafeConstructor;
 import org.yaml.snakeyaml.nodes.Node;
 import org.yaml.snakeyaml.nodes.ScalarNode;
 
-import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -126,7 +125,6 @@ public class CustomYamlConstructor extends SafeConstructor {
                             Map.Entry::getValue));
         }
 
-        @Nonnull
         public Object getObject() {
             return object;
         }
@@ -135,7 +133,7 @@ public class CustomYamlConstructor extends SafeConstructor {
             return lineNumber;
         }
 
-        public static LinedObject cast(@Nonnull Object obj, @Nonnull Supplier<String> msg) {
+        public static LinedObject cast(Object obj, Supplier<String> msg) {
             Assert.thatUnchecked(obj instanceof LinedObject, ErrorCode.INTERNAL_ERROR, msg);
             return (LinedObject) obj;
         }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/GitMetricsFileFinder.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/GitMetricsFileFinder.java
@@ -27,8 +27,7 @@ import com.google.common.collect.ImmutableSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -59,10 +58,9 @@ public final class GitMetricsFileFinder {
      * @return set of paths to changed metrics YAML files
      * @throws RelationalException if git command fails or repository is not valid
      */
-    @Nonnull
-    public static Set<Path> findChangedMetricsYamlFiles(@Nonnull final String baseRef,
-                                                        @Nonnull final String headRef,
-                                                        @Nonnull final Path repositoryRoot) throws RelationalException {
+    public static Set<Path> findChangedMetricsYamlFiles(final String baseRef,
+                                                        final String headRef,
+                                                        final Path repositoryRoot) throws RelationalException {
         final List<String> changedFiles = getChangedFiles(baseRef, headRef, repositoryRoot);
         final ImmutableSet.Builder<Path> metricsFiles = ImmutableSet.builder();
 
@@ -84,10 +82,9 @@ public final class GitMetricsFileFinder {
      * @return list of relative file paths that have changed
      * @throws RelationalException if git command fails
      */
-    @Nonnull
-    private static List<String> getChangedFiles(@Nonnull final String baseRef,
-                                                @Nonnull final String headRef,
-                                                @Nonnull final Path repositoryRoot) throws RelationalException {
+    private static List<String> getChangedFiles(final String baseRef,
+                                                final String headRef,
+                                                final Path repositoryRoot) throws RelationalException {
         final var command = List.of("git", "diff", "--name-only", baseRef + "..." + headRef);
         try {
             if (logger.isDebugEnabled()) {
@@ -130,7 +127,7 @@ public final class GitMetricsFileFinder {
      * @param filePath the file path to check
      * @return true if the file is a metrics file
      */
-    private static boolean isMetricsYamlFile(@Nonnull final String filePath) {
+    private static boolean isMetricsYamlFile(final String filePath) {
         return filePath.endsWith(".metrics.yaml");
     }
 
@@ -149,9 +146,9 @@ public final class GitMetricsFileFinder {
      * @throws RelationalException if git command fails
      */
     @Nullable
-    public static Path getFileAtReference(@Nonnull final String filePath,
-                                          @Nonnull final String gitRef,
-                                          @Nonnull final Path repositoryRoot) throws RelationalException {
+    public static Path getFileAtReference(final String filePath,
+                                          final String gitRef,
+                                          final Path repositoryRoot) throws RelationalException {
         try {
             final var tempFile = Files.createTempFile("metrics-diff-", gitRef + ".metrics.yaml");
             final var command = List.of("git", "show", gitRef + ":" + filePath);

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/Matchers.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/Matchers.java
@@ -44,8 +44,7 @@ import com.google.protobuf.Message;
 import org.yaml.snakeyaml.nodes.ScalarNode;
 import org.yaml.snakeyaml.nodes.SequenceNode;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -60,91 +59,85 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 public class Matchers {
 
-    @Nonnull
-    public static List<?> arrayList(@Nonnull final Object obj) {
+    public static List<?> arrayList(final Object obj) {
         return arrayList(obj, obj.toString());
     }
 
-    @Nonnull
-    public static List<?> arrayList(@Nonnull final Object obj, @Nonnull final String desc) {
+    public static List<?> arrayList(final Object obj, final String desc) {
         if (obj instanceof List) {
             return (List<?>) obj;
         }
         return fail(String.format(Locale.ROOT, "Expecting '%s' to be of type '%s'", desc, List.class.getSimpleName()));
     }
 
-    @Nonnull
-    public static Map<?, ?> map(@Nonnull final Object obj) {
+    public static Map<?, ?> map(final Object obj) {
         return map(obj, obj.toString());
     }
 
-    @Nonnull
-    public static Map<?, ?> map(@Nonnull final Object obj, @Nonnull final String desc) {
+    public static Map<?, ?> map(@Nullable final Object obj, final String desc) {
         if (obj instanceof Map<?, ?>) {
             return (Map<?, ?>) obj;
         }
         return fail(String.format(Locale.ROOT, "Expecting %s to be of type %s", desc, Map.class.getSimpleName()));
     }
 
-    public static Map.Entry<?, ?> mapEntry(@Nonnull final Object obj, @Nonnull final String desc) {
+    public static Map.Entry<?, ?> mapEntry(final Object obj, final String desc) {
         if (obj instanceof Map.Entry<?, ?>) {
             return (Map.Entry<?, ?>) obj;
         }
-        fail(String.format(Locale.ROOT, "Expecting %s to be of type %s", desc, Map.Entry.class.getSimpleName()));
-        return null;
+        return fail(String.format(Locale.ROOT, "Expecting %s to be of type %s", desc, Map.Entry.class.getSimpleName()));
     }
 
-    public static Object first(@Nonnull final List<?> obj) {
+    public static Object first(final List<?> obj) {
         return first(obj, obj.toString());
     }
 
-    public static Object first(@Nonnull final List<?> obj, @Nonnull final String desc) {
+    public static Object first(final List<?> obj, final String desc) {
         if (obj.isEmpty()) {
             fail(String.format(Locale.ROOT, "Expecting %s to contain at least one element, however it is empty", desc));
         }
         return obj.get(0);
     }
 
-    public static Object second(@Nonnull final List<?> obj) {
+    public static Object second(final List<?> obj) {
         if (obj.size() <= 1) {
             fail(String.format(Locale.ROOT, "Expecting %s to contain at least two elements, however it contains %s element", obj, obj.size()));
         }
         return obj.get(1);
     }
 
-    public static Object third(@Nonnull final List<?> obj) {
+    public static Object third(final List<?> obj) {
         if (obj.size() <= 2) {
             fail(String.format(Locale.ROOT, "Expecting %s to contain at least three elements, however it contains %s element", obj, obj.size()));
         }
         return obj.get(2);
     }
 
-    public static String string(@Nonnull final Object obj, @Nonnull final String desc) {
+    public static String string(@Nullable final Object obj, final String desc) {
         if (obj instanceof String) {
             // <NULL> should return null maybe?
             return (String) obj;
         }
-        fail(String.format(Locale.ROOT, "Expecting %s to be of type %s, however it is of type %s", desc, String.class.getSimpleName(), obj.getClass().getSimpleName()));
-        return null;
+        return fail(String.format(Locale.ROOT, "Expecting %s to be of type %s, however it is of type %s", desc, String.class.getSimpleName(), obj == null ? "null" : obj.getClass().getSimpleName()));
     }
 
-    public static boolean matches(@Nonnull final Object expected, @Nonnull final Object actual) {
+    public static boolean matches(@Nullable final Object expected, @Nullable final Object actual) {
         return Objects.equals(expected, actual);
     }
 
-    public static String string(@Nonnull final Object obj) {
+    public static String string(final Object obj) {
         return string(obj, obj.toString());
     }
 
-    public static boolean isString(@Nonnull final Object obj) {
+    public static boolean isString(final Object obj) {
         return obj instanceof String;
     }
 
-    public static boolean isBoolean(@Nonnull final Object obj) {
+    public static boolean isBoolean(final Object obj) {
         return obj instanceof Boolean;
     }
 
-    public static boolean bool(@Nonnull final Object obj) {
+    public static boolean bool(final Object obj) {
         if (obj instanceof Boolean) {
             // <NULL> should return null maybe?
             return (Boolean) obj;
@@ -153,11 +146,11 @@ public class Matchers {
         return false; // never reached.
     }
 
-    public static boolean isLong(@Nonnull final Object obj) {
+    public static boolean isLong(final Object obj) {
         return obj instanceof Long;
     }
 
-    public static long longValue(@Nonnull final Object obj) {
+    public static long longValue(final Object obj) {
         if (obj instanceof Long) {
             return (Long) obj;
         }
@@ -168,11 +161,11 @@ public class Matchers {
         return -1; // never reached.
     }
 
-    public static boolean isInt(@Nonnull final Object obj) {
+    public static boolean isInt(final Object obj) {
         return obj instanceof Integer;
     }
 
-    public static int intValue(@Nonnull final Object obj) {
+    public static int intValue(final Object obj) {
         if (obj instanceof Integer) {
             return (Integer) obj;
         }
@@ -180,11 +173,11 @@ public class Matchers {
         return -1; // never reached.
     }
 
-    public static boolean isDouble(@Nonnull final Object object) {
+    public static boolean isDouble(final Object object) {
         return object instanceof Double;
     }
 
-    public static double doubleValue(@Nonnull final Object obj) {
+    public static double doubleValue(final Object obj) {
         if (obj instanceof Double) {
             return (Double) obj;
         }
@@ -192,11 +185,11 @@ public class Matchers {
         return -1; // never reached.
     }
 
-    public static boolean isArray(@Nonnull final Object object) {
+    public static boolean isArray(final Object object) {
         return object instanceof List;
     }
 
-    public static boolean isMap(@Nonnull final Object obj) {
+    public static boolean isMap(final Object obj) {
         return obj instanceof Map<?, ?>;
     }
 
@@ -204,32 +197,28 @@ public class Matchers {
         return obj == null;
     }
 
-    @Nonnull
-    public static Message message(@Nonnull final Object obj) {
+    public static Message message(final Object obj) {
         if (obj instanceof Message) {
             return (Message) obj;
         }
         return fail(String.format(Locale.ROOT, "Expecting %s to be of type %s, however it is of type %s.", obj, Message.class.getSimpleName(), obj.getClass().getSimpleName()));
     }
 
-    @Nonnull
-    public static <T> T notNull(@Nullable final T object, @Nonnull final String desc) {
+    public static <T> T notNull(@Nullable final T object, final String desc) {
         if (object == null) {
-            fail(String.format(Locale.ROOT, "unexpected %s to be null", desc));
+            return fail(String.format(Locale.ROOT, "unexpected %s to be null", desc));
         }
         return object;
     }
 
-    @Nonnull
-    public static Map.Entry<?, ?> firstEntry(@Nonnull final Object obj, @Nonnull final String desc) {
+    public static Map.Entry<?, ?> firstEntry(final Object obj, final String desc) {
         if (obj instanceof Map) {
             return ((Map<?, ?>) obj).entrySet().iterator().next();
         }
         return fail(String.format(Locale.ROOT, "Expecting %s to be of type %s, however it is of type %s.", desc, Map.class.getSimpleName(), obj.getClass().getSimpleName()));
     }
 
-    @Nonnull
-    public static Map.Entry<?, ?> onlyEntry(@Nonnull final Object obj, @Nonnull final String desc) {
+    public static Map.Entry<?, ?> onlyEntry(final Object obj, final String desc) {
         if (obj instanceof Map) {
             final var map = ((Map<?, ?>) obj);
             if (map.size() != 1) {
@@ -240,59 +229,50 @@ public class Matchers {
         return fail(String.format(Locale.ROOT, "Expecting %s to be of type %s, however it is of type %s.", desc, Map.class.getSimpleName(), obj.getClass().getSimpleName()));
     }
 
-    @Nonnull
-    public static Object valueElseKey(@Nonnull final Map.Entry<?, ?> entry) {
+    public static Object valueElseKey(final Map.Entry<?, ?> entry) {
         if (isNull(entry.getKey()) && isNull(entry.getValue())) {
             fail(String.format(Locale.ROOT, "encountered YAML-style 'null' which is not supported, consider using '%s' instead", IsNullTag.usage()));
         }
         return entry.getValue() == null ? entry.getKey() : entry.getValue();
     }
 
-    @Nonnull
-    public static Function<Integer, Object> valueByIndex(@Nonnull final RelationalResultSet resultSet) {
+    public static Function<Integer, Object> valueByIndex(final RelationalResultSet resultSet) {
         return i -> {
             try {
                 return resultSet.getObject(i);
             } catch (SQLException e) {
-                fail(e.getMessage(), e);
+                return fail(e.getMessage(), e);
             }
-            return null;
         };
     }
 
-    @Nonnull
-    public static Function<Integer, Object> valueByIndex(@Nonnull final RelationalStruct resultSet) {
+    public static Function<Integer, Object> valueByIndex(final RelationalStruct resultSet) {
         return i -> {
             try {
                 return resultSet.getObject(i);
             } catch (SQLException e) {
-                fail(e.getMessage(), e);
+                return fail(e.getMessage(), e);
             }
-            return null;
         };
     }
 
-    @Nonnull
-    public static Function<String, Object> valueByName(@Nonnull final RelationalResultSet resultSet) {
+    public static Function<String, Object> valueByName(final RelationalResultSet resultSet) {
         return i -> {
             try {
                 return resultSet.getObject(i);
             } catch (SQLException e) {
-                fail(e.getMessage(), e);
+                return fail(e.getMessage(), e);
             }
-            return null;
         };
     }
 
-    @Nonnull
-    public static Function<String, Object> valueByName(@Nonnull final RelationalStruct resultSet) {
+    public static Function<String, Object> valueByName(final RelationalStruct resultSet) {
         return i -> {
             try {
                 return resultSet.getObject(i);
             } catch (SQLException e) {
-                fail(e.getMessage(), e);
+                return fail(e.getMessage(), e);
             }
-            return null;
         };
     }
 
@@ -323,7 +303,7 @@ public class Matchers {
             return SUCCESS;
         }
 
-        public static ResultSetMatchResult fail(@Nonnull final String explanation) {
+        public static ResultSetMatchResult fail(final String explanation) {
             return new ResultSetMatchResult(false, explanation);
         }
 
@@ -354,7 +334,6 @@ public class Matchers {
 
     public static class ResultSetPrettyPrinter {
 
-        @Nonnull
         private final List<List<String>> resultSet;
 
         public ResultSetPrettyPrinter() {
@@ -403,8 +382,7 @@ public class Matchers {
          * @param rows the rows to render, each a list of already-stringified cell values
          * @return the rendered table
          */
-        @Nonnull
-        private static String renderTable(@Nonnull final List<List<String>> rows) {
+        private static String renderTable(final List<List<String>> rows) {
             final int columnCount = rows.stream().mapToInt(List::size).max().orElse(0);
             final int[] columnWidths = new int[columnCount];
             for (final var row : rows) {
@@ -428,8 +406,7 @@ public class Matchers {
          * @param columnWidths the rendered width of each column, excluding cell padding
          * @return the rule line, terminated with a newline
          */
-        @Nonnull
-        private static String buildRule(@Nonnull final int[] columnWidths) {
+        private static String buildRule(final int[] columnWidths) {
             final var sb = new StringBuilder();
             for (final int width : columnWidths) {
                 sb.append('+').append("-".repeat(width + 2));
@@ -445,8 +422,7 @@ public class Matchers {
          * @param columnWidths the rendered width of each column, excluding cell padding
          * @return the row line, terminated with a newline
          */
-        @Nonnull
-        private static String buildRow(@Nonnull final List<String> row, @Nonnull final int[] columnWidths) {
+        private static String buildRow(final List<String> row, final int[] columnWidths) {
             final var sb = new StringBuilder();
             for (int i = 0; i < columnWidths.length; i++) {
                 final String cell = i < row.size() ? row.get(i) : "";
@@ -467,7 +443,7 @@ public class Matchers {
         return input;
     }
 
-    public static Pair<ResultSetMatchResult, ResultSetPrettyPrinter> matchResultSet(final Object expected, final RelationalResultSet actual, final boolean isExpectedOrdered) throws SQLException {
+    public static Pair<ResultSetMatchResult, ResultSetPrettyPrinter> matchResultSet(@Nullable final Object expected, @Nullable final RelationalResultSet actual, final boolean isExpectedOrdered) throws SQLException {
         if (expected instanceof IgnoreTag) {
             return ImmutablePair.of(ResultSetMatchResult.success(), null);
         }
@@ -518,7 +494,7 @@ public class Matchers {
         return ImmutablePair.of(ResultSetMatchResult.success(), null);
     }
 
-    private static ImmutablePair<ResultSetMatchResult, ResultSetPrettyPrinter> matchUnorderedResultSet(final RelationalResultSet actual, final @Nonnull Multiset<?> expectedAsMultiSet) throws SQLException {
+    private static ImmutablePair<ResultSetMatchResult, ResultSetPrettyPrinter> matchUnorderedResultSet(final RelationalResultSet actual, final Multiset<?> expectedAsMultiSet) throws SQLException {
         final ResultSetPrettyPrinter resultSetPrettyPrinter = new ResultSetPrettyPrinter();
         final var expectedRowCount = expectedAsMultiSet.size();
         var actualRowsCounter = 1;
@@ -556,7 +532,7 @@ public class Matchers {
         return ImmutablePair.of(ResultSetMatchResult.success(), null);
     }
 
-    public static void printCurrentAndRemaining(@Nonnull final RelationalResultSet resultSet, @Nonnull final ResultSetPrettyPrinter printer) throws SQLException {
+    public static void printCurrentAndRemaining(final RelationalResultSet resultSet, final ResultSetPrettyPrinter printer) throws SQLException {
         final var colCount = resultSet.getMetaData().getColumnCount();
         printer.newRow();
         for (int i = 1; i <= colCount; i++) {
@@ -565,7 +541,7 @@ public class Matchers {
         printRemaining(resultSet, printer);
     }
 
-    public static boolean printRemaining(@Nonnull final RelationalResultSet resultSet, @Nonnull final ResultSetPrettyPrinter printer) throws SQLException {
+    public static boolean printRemaining(final RelationalResultSet resultSet, final ResultSetPrettyPrinter printer) throws SQLException {
         boolean thereWasRemainingRows = false;
         final var colCount = resultSet.getMetaData().getColumnCount();
         while (resultSet.next()) {
@@ -578,11 +554,10 @@ public class Matchers {
         return thereWasRemainingRows;
     }
 
-    @Nonnull
-    private static ResultSetMatchResult matchRow(@Nonnull final Map<?, ?> expected,
+    private static ResultSetMatchResult matchRow(final Map<?, ?> expected,
                                                  final int actualEntriesCount,
-                                                 @Nonnull final Function<String, Object> entryByNameAccessor,
-                                                 @Nonnull final Function<Integer, Object> entryByNumberAccessor,
+                                                 final Function<String, Object> entryByNameAccessor,
+                                                 final Function<Integer, Object> entryByNumberAccessor,
                                                  int rowNumber) throws SQLException {
         final var expectedColCount = expected.entrySet().size();
         if (actualEntriesCount != expectedColCount) {
@@ -591,13 +566,12 @@ public class Matchers {
         return matchMap(expected, actualEntriesCount, entryByNameAccessor, entryByNumberAccessor, rowNumber, "");
     }
 
-    @Nonnull
-    private static ResultSetMatchResult matchMap(@Nonnull final Map<?, ?> expected,
+    private static ResultSetMatchResult matchMap(final Map<?, ?> expected,
                                                  final int actualEntriesCount,
-                                                 @Nonnull final Function<String, Object> entryByNameAccessor,
-                                                 @Nonnull final Function<Integer, Object> entryByNumberAccessor,
+                                                 final Function<String, Object> entryByNameAccessor,
+                                                 final Function<Integer, Object> entryByNumberAccessor,
                                                  int rowNumber,
-                                                 @Nonnull String cellRef) throws SQLException {
+                                                 String cellRef) throws SQLException {
         int counter = 1;
         final var expectedColCount = expected.entrySet().size();
         if (actualEntriesCount != expectedColCount) {
@@ -620,9 +594,9 @@ public class Matchers {
     }
 
     private static ResultSetMatchResult matchField(@Nullable final Object expected,
-                                                   @Nullable final Object actual,
+                                                   @Nullable Object actual,
                                                    int rowNumber,
-                                                   @Nonnull String cellRef) throws SQLException {
+                                                   String cellRef) throws SQLException {
         if (expected instanceof IgnoreTag.IgnoreMatcher) {
             return ResultSetMatchResult.success();
         }
@@ -640,6 +614,10 @@ public class Matchers {
         if (expected instanceof Matchable) {
             return ((Matchable)expected).matches(actual, rowNumber, cellRef);
         }
+
+        // expected is not an IsNullTag.IsNullMatcher (it would have been caught by the Matchable branch
+        // above), so per the check above, actual is guaranteed non-null from here on.
+        actual = Objects.requireNonNull(actual);
 
         // (nested) message
         if (expected instanceof Map<?, ?>) {
@@ -740,8 +718,7 @@ public class Matchers {
      * @param actual actual value.
      * @return {@code true} if {@code expected} matches {@code actual}, otherwise {@code false}.
      */
-    @Nonnull
-    private static ResultSetMatchResult matchIntField(@Nonnull final Integer expected, @Nonnull final Object actual, int rowNumber, @Nonnull String cellRef) {
+    private static ResultSetMatchResult matchIntField(final Integer expected, final Object actual, int rowNumber, String cellRef) {
         if (actual instanceof Integer) {
             if (Objects.equals(expected, actual)) {
                 return ResultSetMatchResult.success();
@@ -761,8 +738,7 @@ public class Matchers {
      * @param actual actual value.
      * @return success if {@code expected} matches {@code actual}, otherwise fail.
      */
-    @Nonnull
-    private static ResultSetMatchResult matchFloatField(@Nonnull final Float expected, @Nonnull final Object actual, int rowNumber, @Nonnull String cellRef) {
+    private static ResultSetMatchResult matchFloatField(final Float expected, final Object actual, int rowNumber, String cellRef) {
         if (actual instanceof Float) {
             if (Objects.equals(expected, actual)) {
                 return ResultSetMatchResult.success();
@@ -776,8 +752,7 @@ public class Matchers {
         return ResultSetMatchResult.fail(String.format(Locale.ROOT, "cell mismatch at row: %d cellRef: %s%n expected 🟢 does not match 🟡.%n🟢 %s (Float) %n🟡 %s (%s)", rowNumber, cellRef, expected, actual, actual.getClass().getSimpleName()));
     }
 
-    @Nonnull
-    public static RealVector constructVectorFromString(int precision, @Nonnull final SequenceNode yamlElementsNode) {
+    public static RealVector constructVectorFromString(int precision, final SequenceNode yamlElementsNode) {
         final var elements = yamlElementsNode.getValue().stream().map(v -> Assert.castUnchecked(v, ScalarNode.class).getValue())
                 .collect(ImmutableList.toImmutableList());
 
@@ -811,8 +786,7 @@ public class Matchers {
         }
     }
 
-    @Nonnull
-    public static String constructRandomString(@Nonnull final ScalarNode yamlElementsNode) {
+    public static String constructRandomString(final ScalarNode yamlElementsNode) {
         return RandomStringParser.parse(yamlElementsNode.getValue());
     }
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/MetricsDiffAnalyzer.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/MetricsDiffAnalyzer.java
@@ -35,8 +35,7 @@ import com.google.protobuf.Descriptors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -44,6 +43,7 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeMap;
 
 /**
@@ -54,11 +54,8 @@ import java.util.TreeMap;
 public final class MetricsDiffAnalyzer {
     private static final Logger logger = LogManager.getLogger(MetricsDiffAnalyzer.class);
 
-    @Nonnull
     private final String baseRef;
-    @Nonnull
     private final String headRef;
-    @Nonnull
     private final Path repositoryRoot;
     @Nullable
     private final String urlBase;
@@ -77,21 +74,24 @@ public final class MetricsDiffAnalyzer {
         public String repositoryRoot = ".";
 
         @Parameter(names = {"--output", "-o"}, description = "Output file path (writes to stdout if not specified)", order = 2)
+        @Nullable
         public String outputPath;
 
         @Parameter(names = {"--outlier-queries"}, description = "Output file path to specifically list data for outlier queries", order = 5)
+        @Nullable
         public String outlierQueryPath;
 
         @Parameter(names = {"--url-base"}, description = "Base of the URL to use for linking to queries", order = 6)
+        @Nullable
         public String urlBase;
 
         @Parameter(names = {"--help", "-h"}, description = "Show help message", help = true, order = 4)
         public boolean help;
     }
 
-    public MetricsDiffAnalyzer(@Nonnull final String baseRef,
-                               @Nonnull final String headRef,
-                               @Nonnull final Path repositoryRoot,
+    public MetricsDiffAnalyzer(final String baseRef,
+                               final String headRef,
+                               final Path repositoryRoot,
                                @Nullable final String urlBase) {
         this.baseRef = baseRef;
         this.headRef = headRef;
@@ -122,7 +122,6 @@ public final class MetricsDiffAnalyzer {
             commander.usage();
             return;
         }
-
 
         try {
             final Path repositoryRoot = arguments.repositoryRoot == null ? Paths.get(".") : Paths.get(arguments.repositoryRoot);
@@ -167,7 +166,6 @@ public final class MetricsDiffAnalyzer {
      * @return analysis results
      * @throws RelationalException if analysis fails
      */
-    @Nonnull
     public MetricsAnalysisResult analyze() throws RelationalException {
         if (logger.isInfoEnabled()) {
             logger.info(KeyValueLogMessage.of("Starting metrics diff analysis",
@@ -195,8 +193,8 @@ public final class MetricsDiffAnalyzer {
     /**
      * Analyzes a single metrics file for changes.
      */
-    private void analyzeYamlFile(@Nonnull final Path yamlPath,
-                                 @Nonnull final MetricsAnalysisResult.Builder analysisBuilder) throws RelationalException {
+    private void analyzeYamlFile(final Path yamlPath,
+                                 final MetricsAnalysisResult.Builder analysisBuilder) throws RelationalException {
         if (logger.isDebugEnabled()) {
             logger.debug(KeyValueLogMessage.of("Analyzing YAML metrics file",
                     "path", yamlPath));
@@ -217,8 +215,7 @@ public final class MetricsDiffAnalyzer {
         compareMetrics(baseMetrics, headMetrics, yamlPath, analysisBuilder);
     }
 
-    @Nonnull
-    private Map<PlannerMetricsProto.Identifier, MetricsInfo> loadMetricsAtRef(@Nonnull Path yamlPath, @Nonnull String ref) throws RelationalException {
+    private Map<PlannerMetricsProto.Identifier, MetricsInfo> loadMetricsAtRef(Path yamlPath, String ref) throws RelationalException {
         try {
             final var yamlFile = GitMetricsFileFinder.getFileAtReference(
                     repositoryRoot.relativize(yamlPath).toString(), ref, repositoryRoot);
@@ -239,10 +236,10 @@ public final class MetricsDiffAnalyzer {
      * Compares metrics between base and head versions.
      */
     @VisibleForTesting
-    public void compareMetrics(@Nonnull final Map<PlannerMetricsProto.Identifier, MetricsInfo> baseMetrics,
-                               @Nonnull final Map<PlannerMetricsProto.Identifier, MetricsInfo> headMetrics,
-                               @Nonnull final Path filePath,
-                               @Nonnull final MetricsAnalysisResult.Builder analysisBuilder) {
+    public void compareMetrics(final Map<PlannerMetricsProto.Identifier, MetricsInfo> baseMetrics,
+                               final Map<PlannerMetricsProto.Identifier, MetricsInfo> headMetrics,
+                               final Path filePath,
+                               final MetricsAnalysisResult.Builder analysisBuilder) {
 
         // Find new and updated queries
         int newCount = 0;
@@ -258,8 +255,8 @@ public final class MetricsDiffAnalyzer {
             } else {
                 // Query in both old and new. Mark as changed
                 changedCount++;
-                final MetricsInfo baseInfo = baseMetrics.get(identifier);
-                final MetricsInfo headInfo = headMetrics.get(identifier);
+                final MetricsInfo baseInfo = baseMetricInfo;
+                final MetricsInfo headInfo = headMetricInfo;
 
                 final var planChanged = !baseInfo.getExplain().equals(headInfo.getExplain());
                 final var metricsChanged = MetricsInfo.areMetricsDifferent(baseInfo, headInfo);
@@ -298,7 +295,6 @@ public final class MetricsDiffAnalyzer {
         }
     }
 
-    @Nonnull
     public MetricsAnalysisResult.Builder newAnalysisBuilder() {
         return new MetricsAnalysisResult.Builder(baseRef, headRef, repositoryRoot, urlBase);
     }
@@ -314,22 +310,19 @@ public final class MetricsDiffAnalyzer {
         private final List<QueryChange> droppedQueries;
         private final List<QueryChange> planAndMetricsChanged;
         private final List<QueryChange> metricsOnlyChanged;
-        @Nonnull
         private final String baseRef;
-        @Nonnull
         private final String headRef;
-        @Nonnull
         private final Path repositoryRoot;
         @Nullable
         private final String urlBase;
 
-        private MetricsAnalysisResult(@Nonnull final List<QueryChange> newQueries,
-                                      @Nonnull final List<QueryChange> droppedQueries,
-                                      @Nonnull final List<QueryChange> planAndMetricsChanged,
-                                      @Nonnull final List<QueryChange> metricsOnlyChanged,
-                                      @Nonnull final String baseRef,
-                                      @Nonnull final String headRef,
-                                      @Nonnull final Path repositoryRoot,
+        private MetricsAnalysisResult(final List<QueryChange> newQueries,
+                                      final List<QueryChange> droppedQueries,
+                                      final List<QueryChange> planAndMetricsChanged,
+                                      final List<QueryChange> metricsOnlyChanged,
+                                      final String baseRef,
+                                      final String headRef,
+                                      final Path repositoryRoot,
                                       @Nullable final String urlBase) {
             this.newQueries = newQueries;
             this.droppedQueries = droppedQueries;
@@ -357,21 +350,18 @@ public final class MetricsDiffAnalyzer {
             return metricsOnlyChanged;
         }
 
-        @Nonnull
-        private Path relativePath(@Nonnull Path path) {
+        private Path relativePath(Path path) {
             return repositoryRoot.relativize(path);
         }
 
-        @Nonnull
-        private String formatQueryDisplay(@Nonnull final QueryChange change) {
+        private String formatQueryDisplay(final QueryChange change) {
             return formatQueryDisplay(change, true);
         }
 
         /**
          * Helper method to format a query change for display with relative path and line number.
          */
-        @Nonnull
-        private String formatQueryDisplay(@Nonnull final QueryChange change, boolean asLink) {
+        private String formatQueryDisplay(final QueryChange change, boolean asLink) {
             int lineNumber = -1;
             String ref = null;
             if (change.newInfo != null) {
@@ -401,7 +391,6 @@ public final class MetricsDiffAnalyzer {
          *
          * @return the contents of a report comparing query metrics
          */
-        @Nonnull
         public String generateReport() {
             final var report = new StringBuilder();
             report.append("# 📊 Metrics Diff Analysis Report\n\n");
@@ -422,7 +411,6 @@ public final class MetricsDiffAnalyzer {
                     .append(" - **Metrics only changed**: Same plan but different metrics\n\n")
                     .append("The last category in particular may indicate planner regressions that should be investigated.\n\n")
                     .append("</details>\n\n");
-
 
             if (!newQueries.isEmpty()) {
                 // Only list a count of new queries by file type. Having more test cases is generally a good thing,
@@ -485,7 +473,6 @@ public final class MetricsDiffAnalyzer {
          *
          * @return a report of outlier queries
          */
-        @Nonnull
         public String generateOutlierQueryReport() {
             final List<QueryChange> outliers = findAllOutliers();
             if (outliers.isEmpty()) {
@@ -502,20 +489,18 @@ public final class MetricsDiffAnalyzer {
             return report.toString();
         }
 
-        @Nonnull
         private String sign(double d) {
             // For adding an explicit plus to positive values. Rely on usual toString of negative values
             // to add the minus sign
             return d > 0 ? "+" : "";
         }
 
-        @Nonnull
         private String sign(long l) {
             // See: sign(double)
             return l > 0 ? "+" : "";
         }
 
-        private void appendStatisticalSummary(@Nonnull final StringBuilder report, @Nonnull final MetricsStatistics stats) {
+        private void appendStatisticalSummary(final StringBuilder report, final MetricsStatistics stats) {
             for (final var fieldName : YamlMetricsMaintainer.TRACKED_METRIC_FIELDS) {
                 final var fieldStats = stats.getFieldStatistics(fieldName);
                 final var regressionFieldStats = stats.getRegressionStatistics(fieldName);
@@ -549,9 +534,9 @@ public final class MetricsDiffAnalyzer {
             }
         }
 
-        private void appendHistogram(@Nonnull final StringBuilder report,
-                                     @Nonnull final String fieldName,
-                                     @Nonnull final List<Double> sortedPercentDiffs) {
+        private void appendHistogram(final StringBuilder report,
+                                     final String fieldName,
+                                     final List<Double> sortedPercentDiffs) {
             if (sortedPercentDiffs.size() < 3) {
                 return;
             }
@@ -559,8 +544,7 @@ public final class MetricsDiffAnalyzer {
             report.append(formatHistogram(fieldName, sortedPercentDiffs.size(), bins));
         }
 
-        @Nonnull
-        private static Map<Double, Integer> computeHistogramBins(@Nonnull final List<Double> sortedPercentDiffs) {
+        private static Map<Double, Integer> computeHistogramBins(final List<Double> sortedPercentDiffs) {
             final double lo = Math.floor(sortedPercentDiffs.get(0) / BIN_WIDTH) * BIN_WIDTH;
             final double hi = (Math.floor(sortedPercentDiffs.get(sortedPercentDiffs.size() - 1) / BIN_WIDTH) + 1) * BIN_WIDTH;
 
@@ -575,8 +559,7 @@ public final class MetricsDiffAnalyzer {
             return bins;
         }
 
-        @Nonnull
-        private static String formatHistogram(@Nonnull final String fieldName, final int totalCount, @Nonnull final Map<Double, Integer> bins) {
+        private static String formatHistogram(final String fieldName, final int totalCount, final Map<Double, Integer> bins) {
             final int labelWidth = bins.keySet().stream().mapToInt(b -> binLabel(b).length()).max().orElse(0);
             final int maxCount = bins.values().stream().mapToInt(Integer::intValue).max().orElse(1);
 
@@ -595,12 +578,11 @@ public final class MetricsDiffAnalyzer {
             return histogram.toString();
         }
 
-        @Nonnull
         private static String binLabel(final double b) {
             return String.format(Locale.ROOT, "[%+.0f%%, %+.0f%%)", b, b + BIN_WIDTH);
         }
 
-        private void appendChangesList(@Nonnull final StringBuilder report, @Nonnull List<QueryChange> changes, @Nonnull String title, @Nonnull String explanation) {
+        private void appendChangesList(final StringBuilder report, List<QueryChange> changes, String title, String explanation) {
             if (changes.isEmpty()) {
                 return;
             }
@@ -654,7 +636,7 @@ public final class MetricsDiffAnalyzer {
             }
         }
 
-        private MetricsStatistics calculateMetricsStatistics(@Nonnull final List<QueryChange> changes) {
+        private MetricsStatistics calculateMetricsStatistics(final List<QueryChange> changes) {
             final var statisticsBuilder = new MetricsStatistics.Builder();
 
             for (final var change : changes) {
@@ -678,7 +660,6 @@ public final class MetricsDiffAnalyzer {
             return statisticsBuilder.build();
         }
 
-        @Nonnull
         public List<QueryChange> findAllOutliers() {
             return ImmutableList.<QueryChange>builder()
                     .addAll(findOutliers(planAndMetricsChanged))
@@ -686,14 +667,12 @@ public final class MetricsDiffAnalyzer {
                     .build();
         }
 
-        @Nonnull
-        private List<QueryChange> findOutliers(@Nonnull final List<QueryChange> changes) {
+        private List<QueryChange> findOutliers(final List<QueryChange> changes) {
             final MetricsStatistics summary = calculateMetricsStatistics(changes);
             return findOutliers(changes, summary);
         }
 
-        @Nonnull
-        private List<QueryChange> findOutliers(@Nonnull final List<QueryChange> changes, @Nonnull final MetricsStatistics stats) {
+        private List<QueryChange> findOutliers(final List<QueryChange> changes, final MetricsStatistics stats) {
             if (changes.size() < 3) {
                 // Not enough data for meaningful outlier detection
                 return changes;
@@ -710,7 +689,7 @@ public final class MetricsDiffAnalyzer {
             return outliers.build();
         }
 
-        private boolean isOutlier(@Nonnull QueryChange change, @Nonnull MetricsStatistics stats) {
+        private boolean isOutlier(QueryChange change, MetricsStatistics stats) {
             if (change.oldInfo == null || change.newInfo == null) {
                 return false;
             }
@@ -743,13 +722,14 @@ public final class MetricsDiffAnalyzer {
             return zScore > 2.0 || isLargeAbsoluteChange;
         }
 
-        private void appendMetricsDiff(@Nonnull final StringBuilder report,
-                                       @Nonnull final QueryChange queryChange) {
+        private void appendMetricsDiff(final StringBuilder report,
+                                       final QueryChange queryChange) {
             Assert.thatUnchecked(queryChange.oldInfo != null, "old info must be set to display metrics diff");
             Assert.thatUnchecked(queryChange.newInfo != null, "new info must be set to display metrics diff");
-
-            final PlannerMetricsProto.CountersAndTimers oldMetrics = queryChange.oldInfo.getCountersAndTimers();
-            final PlannerMetricsProto.CountersAndTimers newMetrics = queryChange.newInfo.getCountersAndTimers();
+            // Assert.thatUnchecked above throws if either is null, but NullAway can't infer that, so re-assert
+            // non-null explicitly here.
+            final PlannerMetricsProto.CountersAndTimers oldMetrics = Objects.requireNonNull(queryChange.oldInfo).getCountersAndTimers();
+            final PlannerMetricsProto.CountersAndTimers newMetrics = Objects.requireNonNull(queryChange.newInfo).getCountersAndTimers();
 
             final var descriptor = oldMetrics.getDescriptorForType();
 
@@ -771,57 +751,49 @@ public final class MetricsDiffAnalyzer {
             private final ImmutableList.Builder<QueryChange> droppedQueries = ImmutableList.builder();
             private final ImmutableList.Builder<QueryChange> planAndMetricsChanged = ImmutableList.builder();
             private final ImmutableList.Builder<QueryChange> metricsOnlyChanged = ImmutableList.builder();
-            @Nonnull
             private final String baseRef;
-            @Nonnull
             private final String headRef;
-            @Nonnull
             private final Path repositoryRoot;
             @Nullable
             private final String urlBase;
 
-            public Builder(@Nonnull String baseRef, @Nonnull String headRef, @Nonnull final Path repositoryRoot, @Nullable final String urlBase) {
+            public Builder(String baseRef, String headRef, final Path repositoryRoot, @Nullable final String urlBase) {
                 this.baseRef = baseRef;
                 this.headRef = headRef;
                 this.repositoryRoot = repositoryRoot;
                 this.urlBase = urlBase;
             }
 
-            @Nonnull
-            public Builder addNewQuery(@Nonnull final Path filePath,
-                                       @Nonnull final PlannerMetricsProto.Identifier identifier,
-                                       @Nonnull final MetricsInfo info) {
+            public Builder addNewQuery(final Path filePath,
+                                       final PlannerMetricsProto.Identifier identifier,
+                                       final MetricsInfo info) {
                 newQueries.add(new QueryChange(filePath, identifier, null, info));
                 return this;
             }
 
-            @Nonnull
-            public Builder addDroppedQuery(@Nonnull final Path filePath,
-                                           @Nonnull final PlannerMetricsProto.Identifier identifier,
-                                           @Nonnull final MetricsInfo info) {
+            public Builder addDroppedQuery(final Path filePath,
+                                           final PlannerMetricsProto.Identifier identifier,
+                                           final MetricsInfo info) {
                 droppedQueries.add(new QueryChange(filePath, identifier, info, null));
                 return this;
             }
 
-            @Nonnull
-            public Builder addPlanAndMetricsChanged(@Nonnull final Path filePath,
-                                                    @Nonnull final PlannerMetricsProto.Identifier identifier,
-                                                    @Nonnull final MetricsInfo oldInfo,
-                                                    @Nonnull final MetricsInfo newInfo) {
+            public Builder addPlanAndMetricsChanged(final Path filePath,
+                                                    final PlannerMetricsProto.Identifier identifier,
+                                                    final MetricsInfo oldInfo,
+                                                    final MetricsInfo newInfo) {
                 planAndMetricsChanged.add(new QueryChange(filePath, identifier, oldInfo, newInfo));
                 return this;
             }
 
-            @Nonnull
-            public Builder addMetricsOnlyChanged(@Nonnull final Path filePath,
-                                                 @Nonnull final PlannerMetricsProto.Identifier identifier,
-                                                 @Nonnull final MetricsInfo oldInfo,
-                                                 @Nonnull final MetricsInfo newInfo) {
+            public Builder addMetricsOnlyChanged(final Path filePath,
+                                                 final PlannerMetricsProto.Identifier identifier,
+                                                 final MetricsInfo oldInfo,
+                                                 final MetricsInfo newInfo) {
                 metricsOnlyChanged.add(new QueryChange(filePath, identifier, oldInfo, newInfo));
                 return this;
             }
 
-            @Nonnull
             public MetricsAnalysisResult build() {
                 return new MetricsAnalysisResult(
                         newQueries.build(),
@@ -848,8 +820,8 @@ public final class MetricsDiffAnalyzer {
         @Nullable
         public final MetricsInfo newInfo;
 
-        public QueryChange(@Nonnull final Path filePath,
-                           @Nonnull final PlannerMetricsProto.Identifier identifier,
+        public QueryChange(final Path filePath,
+                           final PlannerMetricsProto.Identifier identifier,
                            @Nullable final MetricsInfo oldInfo,
                            @Nullable final MetricsInfo newInfo) {
             this.filePath = filePath;

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/MetricsInfo.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/MetricsInfo.java
@@ -23,32 +23,26 @@ package com.apple.foundationdb.relational.yamltests;
 import com.apple.foundationdb.relational.yamltests.generated.stats.PlannerMetricsProto;
 import com.google.protobuf.Descriptors;
 
-import javax.annotation.Nonnull;
 import java.nio.file.Path;
 import java.util.Objects;
 
 public final class MetricsInfo {
-    @Nonnull
     private final PlannerMetricsProto.Info underlying;
-    @Nonnull
     private final Path filePath;
     private final int lineNumber;
 
-    MetricsInfo(@Nonnull PlannerMetricsProto.Info metricsInfo,
-                @Nonnull Path filePath,
+    MetricsInfo(PlannerMetricsProto.Info metricsInfo,
+                Path filePath,
                 int lineNumber) {
         this.underlying = metricsInfo;
         this.filePath = filePath;
         this.lineNumber = lineNumber;
     }
 
-
-    @Nonnull
     public PlannerMetricsProto.Info getUnderlying() {
         return underlying;
     }
 
-    @Nonnull
     public Path getFilePath() {
         return filePath;
     }
@@ -57,12 +51,10 @@ public final class MetricsInfo {
         return lineNumber;
     }
 
-    @Nonnull
     public String getExplain() {
         return underlying.getExplain();
     }
 
-    @Nonnull
     public PlannerMetricsProto.CountersAndTimers getCountersAndTimers() {
         return underlying.getCountersAndTimers();
     }
@@ -93,8 +85,8 @@ public final class MetricsInfo {
      * @param actual the actual metrics values
      * @return true if any of the tracked metrics differ
      */
-    public static boolean areMetricsDifferent(@Nonnull final MetricsInfo expected,
-                                              @Nonnull final MetricsInfo actual) {
+    public static boolean areMetricsDifferent(final MetricsInfo expected,
+                                              final MetricsInfo actual) {
         final var metricsDescriptor = PlannerMetricsProto.CountersAndTimers.getDescriptor();
 
         return YamlMetricsMaintainer.TRACKED_METRIC_FIELDS.stream()
@@ -110,9 +102,9 @@ public final class MetricsInfo {
      * @param fieldDescriptor the field to compare
      * @return true if the metric values differ
      */
-    private static boolean isMetricDifferent(@Nonnull final MetricsInfo expected,
-                                             @Nonnull final MetricsInfo actual,
-                                             @Nonnull final Descriptors.FieldDescriptor fieldDescriptor) {
+    private static boolean isMetricDifferent(final MetricsInfo expected,
+                                             final MetricsInfo actual,
+                                             final Descriptors.FieldDescriptor fieldDescriptor) {
         final long expectedMetric = (long) expected.getUnderlying().getCountersAndTimers().getField(fieldDescriptor);
         final long actualMetric = (long) actual.getUnderlying().getCountersAndTimers().getField(fieldDescriptor);
         return expectedMetric != actualMetric;

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/MetricsStatistics.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/MetricsStatistics.java
@@ -23,7 +23,6 @@ package com.apple.foundationdb.relational.yamltests;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
-import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -38,19 +37,17 @@ public final class MetricsStatistics {
     private final Map<String, FieldStatistics> fieldStatistics;
     private final Map<String, FieldStatistics> regressionFieldStatistics;
 
-    private MetricsStatistics(@Nonnull final Map<String, FieldStatistics> fieldStatistics,
-                              @Nonnull final Map<String, FieldStatistics> regressionFieldStatistics) {
+    private MetricsStatistics(final Map<String, FieldStatistics> fieldStatistics,
+                              final Map<String, FieldStatistics> regressionFieldStatistics) {
         this.fieldStatistics = fieldStatistics;
         this.regressionFieldStatistics = regressionFieldStatistics;
     }
 
-    @Nonnull
-    public FieldStatistics getFieldStatistics(@Nonnull final String fieldName) {
+    public FieldStatistics getFieldStatistics(final String fieldName) {
         return fieldStatistics.getOrDefault(fieldName, FieldStatistics.EMPTY);
     }
 
-    @Nonnull
-    public FieldStatistics getRegressionStatistics(@Nonnull final String fieldName) {
+    public FieldStatistics getRegressionStatistics(final String fieldName) {
         return regressionFieldStatistics.getOrDefault(fieldName, FieldStatistics.EMPTY);
     }
 
@@ -58,18 +55,15 @@ public final class MetricsStatistics {
      * Statistics for a single metrics field across all queries.
      */
     public static class FieldStatistics {
-        @Nonnull
         public static final FieldStatistics EMPTY = new FieldStatistics(ImmutableList.of(), ImmutableList.of(), 0.0, 0.0);
 
-        @Nonnull
         public final List<Long> sortedValues;
-        @Nonnull
         public final List<Double> sortedPercentDiffs;
         public final double mean;
         public final double standardDeviation;
 
-        private FieldStatistics(@Nonnull final List<Long> sortedValues,
-                                @Nonnull final List<Double> sortedPercentDiffs,
+        private FieldStatistics(final List<Long> sortedValues,
+                                final List<Double> sortedPercentDiffs,
                                 final double mean,
                                 final double standardDeviation) {
             this.sortedValues = ImmutableList.copyOf(sortedValues);
@@ -132,15 +126,11 @@ public final class MetricsStatistics {
      * Builder for collecting metric differences and calculating statistics.
      */
     public static class Builder {
-        @Nonnull
         private final Map<String, List<Long>> differences = new HashMap<>();
-        @Nonnull
         private final Map<String, List<Long>> regressions = new HashMap<>();
-        @Nonnull
         private final Map<String, List<Double>> percentDifferences = new HashMap<>();
 
-        @Nonnull
-        public Builder addDifference(@Nonnull final String fieldName, final long baseValue, final long headValue) {
+        public Builder addDifference(final String fieldName, final long baseValue, final long headValue) {
             long difference = headValue - baseValue;
             differences.computeIfAbsent(fieldName, k -> new ArrayList<>()).add(difference);
             if (difference > 0) {
@@ -153,8 +143,7 @@ public final class MetricsStatistics {
             return this;
         }
 
-        @Nonnull
-        private Map<String, FieldStatistics> buildStats(@Nonnull final Map<String, List<Long>> baseMap) {
+        private Map<String, FieldStatistics> buildStats(final Map<String, List<Long>> baseMap) {
             final ImmutableMap.Builder<String, FieldStatistics> builder = ImmutableMap.builder();
 
             for (final var entry : baseMap.entrySet()) {
@@ -185,7 +174,6 @@ public final class MetricsStatistics {
             return builder.build();
         }
 
-        @Nonnull
         public MetricsStatistics build() {
             return new MetricsStatistics(buildStats(differences), buildStats(regressions));
         }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/RandomStringParser.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/RandomStringParser.java
@@ -20,7 +20,6 @@
 
 package com.apple.foundationdb.relational.yamltests;
 
-import javax.annotation.Nonnull;
 import java.util.Random;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -49,8 +48,7 @@ public final class RandomStringParser {
      * @return a deterministic random alphanumeric string of length {@code M}
      * @throws IllegalArgumentException if {@code descriptor} does not match the expected format
      */
-    @Nonnull
-    public static String parse(@Nonnull final String descriptor) {
+    public static String parse(final String descriptor) {
         final Matcher matcher = PATTERN.matcher(descriptor.trim());
         if (!matcher.matches()) {
             throw new IllegalArgumentException(
@@ -61,7 +59,6 @@ public final class RandomStringParser {
         return generate(seed, length);
     }
 
-    @Nonnull
     private static String generate(final long seed, final int length) {
         final Random random = new Random(seed);
         final StringBuilder sb = new StringBuilder(length);

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/SimpleYamlConnection.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/SimpleYamlConnection.java
@@ -30,8 +30,7 @@ import com.apple.foundationdb.relational.recordlayer.EmbeddedRelationalConnectio
 import com.apple.foundationdb.relational.yamltests.command.SQLFunction;
 import com.apple.foundationdb.relational.yamltests.server.SemanticVersion;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.List;
@@ -41,27 +40,22 @@ import java.util.Map;
  * A simple version of {@link YamlConnection} for interacting with a single {@link RelationalConnection}.
  */
 public class SimpleYamlConnection implements YamlConnection {
-    @Nonnull
     private final RelationalConnection underlying;
-    @Nonnull
     private final List<SemanticVersion> versions;
-    @Nonnull
     private final String connectionLabel;
-    @Nonnull
     private final String clusterFile;
 
-    public SimpleYamlConnection(@Nonnull Connection connection, @Nonnull SemanticVersion version, @Nonnull String clusterFile) throws SQLException {
+    public SimpleYamlConnection(Connection connection, SemanticVersion version, String clusterFile) throws SQLException {
         this(connection, version, version.toString(), clusterFile);
     }
 
-    public SimpleYamlConnection(@Nonnull Connection connection, @Nonnull SemanticVersion version, @Nonnull String connectionLabel, @Nonnull String clusterFile) throws SQLException {
+    public SimpleYamlConnection(Connection connection, SemanticVersion version, String connectionLabel, String clusterFile) throws SQLException {
         underlying = connection.unwrap(RelationalConnection.class);
         this.versions = List.of(version);
         this.connectionLabel = connectionLabel;
         this.clusterFile = clusterFile;
     }
 
-    @Nonnull
     protected RelationalConnection getUnderlying() {
         return underlying;
     }
@@ -73,7 +67,7 @@ public class SimpleYamlConnection implements YamlConnection {
 
     @Override
     @SuppressWarnings("PMD.CloseResource")
-    public void setConnectionOptions(@Nonnull final Options connectionOptions) throws SQLException {
+    public void setConnectionOptions(final Options connectionOptions) throws SQLException {
         final RelationalConnection underlying = getUnderlying();
         for (Map.Entry<Options.Name, ?> entry : connectionOptions.entries()) {
             underlying.setOption(entry.getKey(), entry.getValue());
@@ -111,20 +105,18 @@ public class SimpleYamlConnection implements YamlConnection {
         }
     }
 
-    @Nonnull
     @Override
     public List<SemanticVersion> getVersions() {
         return versions;
     }
 
-    @Nonnull
     @Override
     public SemanticVersion getInitialVersion() {
         return versions.get(0);
     }
 
     @Override
-    public <T> T executeTransactionally(final SQLFunction<YamlConnection, T> transactionalWork) throws SQLException, RelationalException {
+    public <T extends @Nullable Object> T executeTransactionally(final SQLFunction<YamlConnection, T> transactionalWork) throws SQLException, RelationalException {
         underlying.setAutoCommit(false);
         T result;
         try {

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlConnection.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlConnection.java
@@ -30,8 +30,7 @@ import com.apple.foundationdb.relational.recordlayer.EmbeddedRelationalConnectio
 import com.apple.foundationdb.relational.yamltests.command.SQLFunction;
 import com.apple.foundationdb.relational.yamltests.server.SemanticVersion;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.sql.SQLException;
 import java.util.List;
 
@@ -46,7 +45,7 @@ public interface YamlConnection extends AutoCloseable {
     @Override
     void close() throws SQLException;
 
-    void setConnectionOptions(@Nonnull Options connectionOptions) throws SQLException;
+    void setConnectionOptions(Options connectionOptions) throws SQLException;
 
     /**
      * Creates a statement (see {@link RelationalConnection#createStatement()}).
@@ -91,7 +90,6 @@ public interface YamlConnection extends AutoCloseable {
      * </p>
      * @return the ordered list of versions
      */
-    @Nonnull
     List<SemanticVersion> getVersions();
 
     /**
@@ -104,10 +102,9 @@ public interface YamlConnection extends AutoCloseable {
      *
      * @return the first version that an underlying connection will represent
      */
-    @Nonnull
     SemanticVersion getInitialVersion();
 
-    <T> T executeTransactionally(SQLFunction<YamlConnection, T> transactionalWork) throws SQLException, RelationalException;
+    <T extends @Nullable Object> T executeTransactionally(SQLFunction<YamlConnection, T> transactionalWork) throws SQLException, RelationalException;
 
     /**
      * The Cluster File that this connection is connected to, so that other connections can point to the same

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlConnectionFactory.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlConnectionFactory.java
@@ -23,7 +23,6 @@ package com.apple.foundationdb.relational.yamltests;
 import com.apple.foundationdb.relational.api.RelationalConnection;
 import com.apple.foundationdb.relational.yamltests.server.SemanticVersion;
 
-import javax.annotation.Nonnull;
 import java.net.URI;
 import java.sql.SQLException;
 import java.util.Set;
@@ -42,7 +41,7 @@ public interface YamlConnectionFactory {
      *
      * @throws SQLException if we cannot connect or the cluster index is not supported
      */
-    YamlConnection getNewConnection(@Nonnull URI connectPath, int clusterIndex) throws SQLException;
+    YamlConnection getNewConnection(URI connectPath, int clusterIndex) throws SQLException;
 
     /**
      * The versions that the connection has, other than the current code.

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlConnectionFactoryWithOptions.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlConnectionFactoryWithOptions.java
@@ -23,26 +23,23 @@ package com.apple.foundationdb.relational.yamltests;
 import com.apple.foundationdb.relational.api.Options;
 import com.apple.foundationdb.relational.yamltests.server.SemanticVersion;
 
-import javax.annotation.Nonnull;
 import java.net.URI;
 import java.sql.SQLException;
 import java.util.Set;
 
 public class YamlConnectionFactoryWithOptions implements YamlConnectionFactory {
 
-    @Nonnull
     private final YamlConnectionFactory underlying;
 
-    @Nonnull
     private final Options options;
 
-    public YamlConnectionFactoryWithOptions(@Nonnull final YamlConnectionFactory underlying, @Nonnull final Options options) {
+    public YamlConnectionFactoryWithOptions(final YamlConnectionFactory underlying, final Options options) {
         this.underlying = underlying;
         this.options = options;
     }
 
     @Override
-    public YamlConnection getNewConnection(@Nonnull final URI connectPath, int clusterIndex) throws SQLException {
+    public YamlConnection getNewConnection(final URI connectPath, int clusterIndex) throws SQLException {
         final var connection = underlying.getNewConnection(connectPath, clusterIndex);
         connection.setConnectionOptions(options);
         return connection;
@@ -63,9 +60,8 @@ public class YamlConnectionFactoryWithOptions implements YamlConnectionFactory {
         return underlying.isMultiServer();
     }
 
-    @Nonnull
-    public static YamlConnectionFactoryWithOptions newInstance(@Nonnull final YamlConnectionFactory underlying,
-                                                               @Nonnull final Options options) {
+    public static YamlConnectionFactoryWithOptions newInstance(final YamlConnectionFactory underlying,
+                                                               final Options options) {
         return new YamlConnectionFactoryWithOptions(underlying, options);
     }
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlCorrection.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlCorrection.java
@@ -20,7 +20,6 @@
 
 package com.apple.foundationdb.relational.yamltests;
 
-import javax.annotation.Nonnull;
 import java.util.List;
 
 /**
@@ -49,5 +48,5 @@ public interface YamlCorrection {
      * Apply this correction to the in-memory line list of the YAMSQL file.
      * @param lines mutable list of lines for the file (1-based line {@code n} is at index {@code n-1})
      */
-    void apply(@Nonnull List<String> lines);
+    void apply(List<String> lines);
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlExecutionContext.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlExecutionContext.java
@@ -37,8 +37,7 @@ import org.opentest4j.TestAbortedException;
 import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.io.BufferedInputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -73,23 +72,17 @@ public final class YamlExecutionContext {
 
     private static final URI SYSTEM_CATALOG_ADDRESS = URI.create("jdbc:embed:/__SYS?schema=CATALOG");
 
-    @Nonnull final YamlReference.YamlResource topLevelResource;
-    @Nonnull
+    final YamlReference.YamlResource topLevelResource;
     private final Set<YamlReference.YamlResource> registeredResources = new HashSet<>();
 
-    @Nonnull
     private final YamlMetricsMaintainer metricsMaintainer;
-    @Nonnull
     private final YamlFilesMaintainer filesMaintainer;
-    @Nonnull
     private final YamlConnectionFactory connectionFactory;
     @SuppressWarnings("AbbreviationAsWordInName")
     private final Map<YamlReference.YamlResource, List<String>> connectionURIs = new HashMap<>();
     // Additional options that can be set by the runners to impact test execution
-    @Nonnull
     private final ContextOptions additionalOptions;
     private final Map<String, String> transactionSetups = new HashMap<>();
-    @Nonnull
     private Options connectionOptions = Options.NONE;
 
     public static class YamlExecutionError extends RuntimeException {
@@ -102,7 +95,7 @@ public final class YamlExecutionContext {
         }
     }
 
-    YamlExecutionContext(@Nonnull YamlReference.YamlResource topLevelResource, @Nonnull YamlConnectionFactory factory, @Nonnull final ContextOptions additionalOptions) throws RelationalException {
+    YamlExecutionContext(YamlReference.YamlResource topLevelResource, YamlConnectionFactory factory, final ContextOptions additionalOptions) throws RelationalException {
         this.connectionFactory = factory;
         this.topLevelResource = topLevelResource;
         this.additionalOptions = additionalOptions;
@@ -122,7 +115,7 @@ public final class YamlExecutionContext {
         registeredResources.add(topLevelResource);
     }
 
-    public void registerResource(@Nonnull final YamlReference.YamlResource resource) throws RelationalException {
+    public void registerResource(final YamlReference.YamlResource resource) throws RelationalException {
         // topLevelResource is already registered in the constructor
         if (topLevelResource.equals(resource)) {
             return;
@@ -134,17 +127,16 @@ public final class YamlExecutionContext {
         registeredResources.add(resource);
     }
 
-    private void loadResourceForEditIfNeeded(@Nonnull YamlReference.YamlResource resource) throws RelationalException {
+    private void loadResourceForEditIfNeeded(YamlReference.YamlResource resource) throws RelationalException {
         if (shouldCorrectExplains() || shouldCorrectResultMetadata() || shouldAddResultMetadata() || shouldAddExplains()) {
             filesMaintainer.loadFile(resource);
         }
     }
 
-    public void setConnectionOptions(@Nonnull final Options connectionOptions) {
+    public void setConnectionOptions(final Options connectionOptions) {
         this.connectionOptions = connectionOptions;
     }
 
-    @Nonnull
     public YamlConnectionFactory getConnectionFactory() {
         return YamlConnectionFactoryWithOptions.newInstance(connectionFactory, connectionOptions);
     }
@@ -173,12 +165,10 @@ public final class YamlExecutionContext {
         return additionalOptions.getOrDefault(OPTION_ADD_EXPLAIN, false);
     }
 
-    @Nonnull
     public YamlMetricsMaintainer getMetricsMaintainer() {
         return metricsMaintainer;
     }
 
-    @Nonnull
     public YamlFilesMaintainer getFilesMaintainer() {
         return filesMaintainer;
     }
@@ -216,7 +206,7 @@ public final class YamlExecutionContext {
         filesMaintainer.saveIfNeeded();
     }
 
-    public void registerConnectionURI(@Nonnull YamlReference.YamlResource resource, @Nonnull String stringURI) {
+    public void registerConnectionURI(YamlReference.YamlResource resource, String stringURI) {
         Assert.thatUnchecked(registeredResources.contains(resource), "A YamlResource should be registered before registering available connection URIs");
         connectionURIs.computeIfAbsent(resource, ignore -> new ArrayList<>()).add(stringURI);
     }
@@ -247,7 +237,7 @@ public final class YamlExecutionContext {
      *
      * @return a valid connection target
      */
-    public ConnectionTarget inferConnectionTarget(@Nonnull final YamlReference.YamlResource resource, @Nullable Object connectObject) {
+    public ConnectionTarget inferConnectionTarget(final YamlReference.YamlResource resource, @Nullable Object connectObject) {
         Assert.thatUnchecked(registeredResources.contains(resource), "A YamlResource should be registered before registering available connection URIs");
         if (connectObject instanceof Map) {
             final Map<?, ?> connectMap = CustomYamlConstructor.LinedObject.unlineKeys(Matchers.map(connectObject, "connect"));
@@ -259,7 +249,7 @@ public final class YamlExecutionContext {
         return new ConnectionTarget(resolveConnectionURI(resource, connectObject), 0);
     }
 
-    private URI resolveConnectionURI(@Nonnull final YamlReference.YamlResource resource, @Nullable Object connectObject) {
+    private URI resolveConnectionURI(final YamlReference.YamlResource resource, @Nullable Object connectObject) {
         if (connectObject == null) {
             return getConnectionFromConnectionURIList(resource, true, -1, true);
         } else if (connectObject instanceof Integer) {
@@ -273,7 +263,7 @@ public final class YamlExecutionContext {
         }
     }
 
-    private URI getConnectionFromConnectionURIList(@Nonnull YamlReference.YamlResource resource, boolean defaultValue, int idx, boolean isGlobal) {
+    private URI getConnectionFromConnectionURIList(YamlReference.YamlResource resource, boolean defaultValue, int idx, boolean isGlobal) {
         if (defaultValue) {
             final var localList = connectionURIs.getOrDefault(resource, List.of());
             if (localList.size() == 1) {
@@ -296,10 +286,11 @@ public final class YamlExecutionContext {
         return URI.create(list.get(idx - 1));
     }
 
-    private List<String> getGlobalConnectionURIList(@Nonnull YamlReference.YamlResource resource) {
+    private List<String> getGlobalConnectionURIList(YamlReference.YamlResource resource) {
         final var resourcesBuilder = ImmutableList.<YamlReference.YamlResource>builder();
-        if (resource.getParentRef() != null) {
-            resourcesBuilder.addAll(resource.getParentRef().getCallStack().reverse().stream().map(YamlReference::getResource).iterator());
+        final var parentRef = resource.getParentRef();
+        if (parentRef != null) {
+            resourcesBuilder.addAll(parentRef.getCallStack().reverse().stream().map(YamlReference::getResource).iterator());
         }
         resourcesBuilder.add(resource);
         return resourcesBuilder.build().stream()
@@ -341,9 +332,8 @@ public final class YamlExecutionContext {
      *
      * @return wrapped {@link YamlExecutionError}
      */
-    @Nonnull
-    public static RuntimeException wrapContext(@Nonnull Throwable throwable, @Nonnull Supplier<String> msg,
-                                               @Nonnull String identifier, @Nonnull final YamlReference reference) {
+    public static RuntimeException wrapContext(Throwable throwable, Supplier<String> msg,
+                                               String identifier, final YamlReference reference) {
         if (throwable instanceof TestAbortedException) {
             return (TestAbortedException)throwable;
         } else if (throwable instanceof YamlExecutionError) {
@@ -362,7 +352,7 @@ public final class YamlExecutionContext {
         }
     }
 
-    private static StackTraceElement[] composeStackTrace(@Nonnull YamlReference reference, @Nonnull String identifier) {
+    private static StackTraceElement[] composeStackTrace(YamlReference reference, String identifier) {
         final var refList = reference.getCallStack();
         return Streams.mapWithIndex(refList.stream(),
                 (r, i) -> new StackTraceElement(
@@ -392,9 +382,8 @@ public final class YamlExecutionContext {
      * @return immutable map of identifier to info
      * @throws RelationalException if file cannot be read or parsed
      */
-    @Nonnull
     @SuppressWarnings("unchecked")
-    public static Map<PlannerMetricsProto.Identifier, MetricsInfo> loadMetricsFromYamlFile(@Nonnull final Path filePath) throws RelationalException {
+    public static Map<PlannerMetricsProto.Identifier, MetricsInfo> loadMetricsFromYamlFile(final Path filePath) throws RelationalException {
         final ImmutableMap.Builder<PlannerMetricsProto.Identifier, MetricsInfo> resultMapBuilder = ImmutableMap.builder();
         final Map<PlannerMetricsProto.Identifier, PlannerMetricsProto.Info> seen = new HashMap<>();
         if (!Files.exists(filePath)) {
@@ -526,10 +515,9 @@ public final class YamlExecutionContext {
     public static class ContextOptions {
         public static final ContextOptions EMPTY_OPTIONS = new ContextOptions(Map.of());
 
-        @Nonnull
         private final Map<ContextOption<?>, Object> map;
 
-        private ContextOptions(final @Nonnull Map<ContextOption<?>, Object> map) {
+        private ContextOptions(final Map<ContextOption<?>, Object> map) {
             this.map = map;
         }
 

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlFilesMaintainer.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlFilesMaintainer.java
@@ -28,7 +28,6 @@ import org.apache.logging.log4j.Logger;
 import org.assertj.core.util.VisibleForTesting;
 import org.junit.jupiter.api.Assertions;
 
-import javax.annotation.Nonnull;
 import java.io.BufferedReader;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -61,36 +60,32 @@ import java.util.stream.Collectors;
 public class YamlFilesMaintainer {
     private static final Logger logger = LogManager.getLogger(YamlFilesMaintainer.class);
 
-    @Nonnull
     private final Map<YamlReference.YamlResource, List<String>> editedFileStream = new HashMap<>();
-    @Nonnull
     private final Map<YamlReference.YamlResource, Boolean> isDirty = new HashMap<>();
     /**
      * Pending corrections (explain and result-metadata), buffered so they can be applied in descending
      * line-number order to avoid stale-offset corruption when multiple corrections target the same file.
      */
-    @Nonnull
     private final Map<YamlReference.YamlResource, List<YamlCorrection>> pendingCorrections = new HashMap<>();
 
     @VisibleForTesting
-    @Nonnull
-    List<YamlCorrection> getPendingCorrections(@Nonnull final YamlReference.YamlResource resource) {
+    List<YamlCorrection> getPendingCorrections(final YamlReference.YamlResource resource) {
         final List<YamlCorrection> corrections = pendingCorrections.get(resource);
         return corrections != null ? corrections : List.of();
     }
 
-    public void loadFile(@Nonnull YamlReference.YamlResource resource) throws RelationalException {
+    public void loadFile(YamlReference.YamlResource resource) throws RelationalException {
         this.editedFileStream.put(resource, loadYamlResource(resource));
     }
 
-    private void verifyFileLoaded(@Nonnull final YamlReference reference) {
+    private void verifyFileLoaded(final YamlReference reference) {
         if (editedFileStream.get(reference.getResource()) == null) {
             throw new IllegalStateException("‼️ YAMSQL file not loaded for resource: " + reference.getResource());
         }
     }
 
-    public void correctResultMetadata(@Nonnull final YamlReference reference,
-                                      @Nonnull final List<CheckResultMetadataConfig.ColumnDescriptor> actualColumns) {
+    public void correctResultMetadata(final YamlReference reference,
+                                      final List<CheckResultMetadataConfig.ColumnDescriptor> actualColumns) {
         verifyFileLoaded(reference);
         synchronized (this) {
             pendingCorrections
@@ -100,8 +95,8 @@ public class YamlFilesMaintainer {
         }
     }
 
-    public void addResultMetadata(@Nonnull final YamlReference queryReference,
-                                  @Nonnull final List<CheckResultMetadataConfig.ColumnDescriptor> actualColumns) {
+    public void addResultMetadata(final YamlReference queryReference,
+                                  final List<CheckResultMetadataConfig.ColumnDescriptor> actualColumns) {
         verifyFileLoaded(queryReference);
         synchronized (this) {
             final List<YamlCorrection> corrections = pendingCorrections
@@ -120,7 +115,7 @@ public class YamlFilesMaintainer {
         }
     }
 
-    public void correctExplain(@Nonnull final YamlReference reference, @Nonnull String actual) {
+    public void correctExplain(final YamlReference reference, String actual) {
         verifyFileLoaded(reference);
         synchronized (this) {
             pendingCorrections
@@ -130,7 +125,7 @@ public class YamlFilesMaintainer {
         }
     }
 
-    public void addExplain(@Nonnull final YamlReference queryReference, @Nonnull String actual) {
+    public void addExplain(final YamlReference queryReference, String actual) {
         verifyFileLoaded(queryReference);
         synchronized (this) {
             final List<YamlCorrection> corrections = pendingCorrections
@@ -145,7 +140,7 @@ public class YamlFilesMaintainer {
         }
     }
 
-    private void applyPendingCorrections(@Nonnull final YamlReference.YamlResource resource) {
+    private void applyPendingCorrections(final YamlReference.YamlResource resource) {
         final List<YamlCorrection> corrections = pendingCorrections.get(resource);
         if (corrections == null || corrections.isEmpty()) {
             return;
@@ -184,10 +179,12 @@ public class YamlFilesMaintainer {
         }
     }
 
-    private void saveYamlFile(@Nonnull final YamlReference.YamlResource resource) {
+    private void saveYamlFile(final YamlReference.YamlResource resource) {
         try {
             try (var writer = new PrintWriter(new FileWriter(Path.of(System.getProperty("user.dir")).resolve(Path.of("src", "test", "resources", resource.getPath())).toAbsolutePath().toString(), StandardCharsets.UTF_8))) {
-                for (var line : editedFileStream.get(resource)) {
+                // resource always comes from editedFileStream.keySet() (see saveIfNeeded()), so it is guaranteed
+                // to have an associated value here.
+                for (var line : Objects.requireNonNull(editedFileStream.get(resource))) {
                     writer.println(line);
                 }
             }
@@ -198,8 +195,7 @@ public class YamlFilesMaintainer {
         }
     }
 
-    @Nonnull
-    private static List<String> loadYamlResource(@Nonnull final YamlReference.YamlResource resource) throws RelationalException {
+    private static List<String> loadYamlResource(final YamlReference.YamlResource resource) throws RelationalException {
         final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         final List<String> inMemoryFile = new ArrayList<>();
         try (BufferedReader bufferedReader =
@@ -216,12 +212,10 @@ public class YamlFilesMaintainer {
     }
 
     static final class ExplainCorrection implements YamlCorrection {
-        @Nonnull
         private final YamlReference reference;
-        @Nonnull
         private final String actual;
 
-        ExplainCorrection(@Nonnull final YamlReference reference, @Nonnull final String actual) {
+        ExplainCorrection(final YamlReference reference, final String actual) {
             this.reference = reference;
             this.actual = actual;
         }
@@ -232,7 +226,7 @@ public class YamlFilesMaintainer {
         }
 
         @Override
-        public void apply(@Nonnull final List<String> lines) {
+        public void apply(final List<String> lines) {
             final int idx = reference.getLineNumber() - 1;
             if (idx >= 0 && idx < lines.size()) {
                 final String itemPrefix = " ".repeat(indentOf(lines.get(idx)));
@@ -242,12 +236,10 @@ public class YamlFilesMaintainer {
     }
 
     static final class AddExplainCorrection implements YamlCorrection {
-        @Nonnull
         private final YamlReference queryReference;
-        @Nonnull
         private final String actual;
 
-        public AddExplainCorrection(@Nonnull final YamlReference queryReference, @Nonnull final String actual) {
+        public AddExplainCorrection(final YamlReference queryReference, final String actual) {
             this.queryReference = queryReference;
             this.actual = actual;
         }
@@ -258,7 +250,7 @@ public class YamlFilesMaintainer {
         }
 
         @Override
-        public void apply(@Nonnull final List<String> lines) {
+        public void apply(final List<String> lines) {
             final int queryLineIdx = queryReference.getLineNumber() - 1; // 1-based → 0-based
             if (queryLineIdx < 0 || queryLineIdx >= lines.size()) {
                 return;
@@ -273,13 +265,11 @@ public class YamlFilesMaintainer {
     }
 
     static final class MetadataCorrection implements YamlCorrection {
-        @Nonnull
         private final YamlReference reference;
-        @Nonnull
         private final List<CheckResultMetadataConfig.ColumnDescriptor> actualColumns;
 
-        MetadataCorrection(@Nonnull final YamlReference reference,
-                           @Nonnull final List<CheckResultMetadataConfig.ColumnDescriptor> actualColumns) {
+        MetadataCorrection(final YamlReference reference,
+                           final List<CheckResultMetadataConfig.ColumnDescriptor> actualColumns) {
             this.reference = reference;
             this.actualColumns = actualColumns;
         }
@@ -290,7 +280,7 @@ public class YamlFilesMaintainer {
         }
 
         @Override
-        public void apply(@Nonnull final List<String> lines) {
+        public void apply(final List<String> lines) {
             final int startIdx = reference.getLineNumber() - 1; // 1-based → 0-based
             if (startIdx < 0 || startIdx >= lines.size()) {
                 return;
@@ -326,13 +316,11 @@ public class YamlFilesMaintainer {
     }
 
     static final class AddMetadataCorrection implements YamlCorrection {
-        @Nonnull
         private final YamlReference queryReference;
-        @Nonnull
         private final List<CheckResultMetadataConfig.ColumnDescriptor> actualColumns;
 
-        AddMetadataCorrection(@Nonnull final YamlReference queryReference,
-                              @Nonnull final List<CheckResultMetadataConfig.ColumnDescriptor> actualColumns) {
+        AddMetadataCorrection(final YamlReference queryReference,
+                              final List<CheckResultMetadataConfig.ColumnDescriptor> actualColumns) {
             this.queryReference = queryReference;
             this.actualColumns = actualColumns;
         }
@@ -343,7 +331,7 @@ public class YamlFilesMaintainer {
         }
 
         @Override
-        public void apply(@Nonnull final List<String> lines) {
+        public void apply(final List<String> lines) {
             final int queryLineIdx = queryReference.getLineNumber() - 1; // 1-based → 0-based
             if (queryLineIdx < 0 || queryLineIdx >= lines.size()) {
                 return;
@@ -359,7 +347,7 @@ public class YamlFilesMaintainer {
         }
     }
 
-    private static int indentOf(@Nonnull final String line) {
+    private static int indentOf(final String line) {
         int indent = 0;
         while (indent < line.length() && line.charAt(indent) == ' ') {
             indent++;
@@ -367,9 +355,9 @@ public class YamlFilesMaintainer {
         return indent;
     }
 
-    private static int findInsertionPoint(@Nonnull final List<String> lines, final int startIdx,
-                                  @Nonnull final String itemPrefix,
-                                  @Nonnull final Predicate<String> stopAt) {
+    private static int findInsertionPoint(final List<String> lines, final int startIdx,
+                                  final String itemPrefix,
+                                  final Predicate<String> stopAt) {
         for (int i = startIdx; i < lines.size(); i++) {
             final String line = lines.get(i);
             if (stopAt.test(line)) {
@@ -394,7 +382,7 @@ public class YamlFilesMaintainer {
      *   <li>Array-of-struct column (with type name): {@code {NAME: {array: [structTypeName, {FIELD: TYPE}, ...]}}}</li>
      * </ul>
      */
-    private static String buildInlineDescriptor(@Nonnull final CheckResultMetadataConfig.ColumnDescriptor col) {
+    private static String buildInlineDescriptor(final CheckResultMetadataConfig.ColumnDescriptor col) {
         if (col.isArray && col.fields != null) {
             final String typePrefix = col.structTypeName != null ? col.structTypeName + ", " : "";
             final String fields = col.fields.stream().map(YamlFilesMaintainer::buildInlineDescriptor)
@@ -419,7 +407,7 @@ public class YamlFilesMaintainer {
      *   <li>{@code "BIGINT"} → {@code "BIGINT"}</li>
      * </ul>
      */
-    private static String typeNameToInlineValue(@Nonnull final String typeName) {
+    private static String typeNameToInlineValue(final String typeName) {
         if (typeName.startsWith("ARRAY(") && typeName.endsWith(")")) {
             final String inner = typeName.substring(6, typeName.length() - 1);
             return "{array: " + typeNameToInlineValue(inner) + "}";

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlMetricsMaintainer.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlMetricsMaintainer.java
@@ -33,8 +33,9 @@ import org.junit.jupiter.api.Assertions;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
+
+import static com.apple.foundationdb.relational.yamltests.generated.stats.PlannerMetricsProto.Info;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -80,12 +81,9 @@ public class YamlMetricsMaintainer {
             "insert_reused_count"
     );
 
-    @Nonnull
     private final YamlReference.YamlResource resource;
-    @Nonnull
-    private final ImmutableMap<PlannerMetricsProto.Identifier, PlannerMetricsProto.Info> expectedMetricsMap;
-    @Nonnull
-    private final Map<QueryAndLocation, PlannerMetricsProto.Info> actualMetricsMap;
+    private final ImmutableMap<PlannerMetricsProto.Identifier, Info> expectedMetricsMap;
+    private final Map<QueryAndLocation, Info> actualMetricsMap;
     private volatile boolean isDirty = false;
 
     private static final Comparator<QueryAndLocation> ACTUAL_METRICS_ORDER =
@@ -93,15 +91,15 @@ public class YamlMetricsMaintainer {
                     .thenComparing(QueryAndLocation::getBlockName)
                     .thenComparing(QueryAndLocation::getQuery);
 
-    public YamlMetricsMaintainer(@Nonnull YamlReference.YamlResource resource) throws RelationalException {
+    public YamlMetricsMaintainer(YamlReference.YamlResource resource) throws RelationalException {
         this.resource = resource;
         this.expectedMetricsMap = loadMetricsResource(resource);
         this.actualMetricsMap = new TreeMap<>(ACTUAL_METRICS_ORDER);
     }
 
     /** Testing constructor: bypasses file loading. */
-    YamlMetricsMaintainer(@Nonnull YamlReference.YamlResource resource,
-                          @Nonnull ImmutableMap<PlannerMetricsProto.Identifier, PlannerMetricsProto.Info> expectedMetrics) {
+    YamlMetricsMaintainer(YamlReference.YamlResource resource,
+                          ImmutableMap<PlannerMetricsProto.Identifier, Info> expectedMetrics) {
         this.resource = resource;
         this.expectedMetricsMap = expectedMetrics;
         this.actualMetricsMap = new TreeMap<>(ACTUAL_METRICS_ORDER);
@@ -114,7 +112,7 @@ public class YamlMetricsMaintainer {
 
     @VisibleForTesting
     @Nullable
-    PlannerMetricsProto.Info getActualMetrics(@Nonnull final PlannerMetricsProto.Identifier identifier) {
+    Info getActualMetrics(final PlannerMetricsProto.Identifier identifier) {
         return actualMetricsMap.entrySet().stream()
                 .filter(e -> e.getKey().getIdentifier().equals(identifier))
                 .map(Map.Entry::getValue)
@@ -123,14 +121,14 @@ public class YamlMetricsMaintainer {
     }
 
     @Nullable
-    public PlannerMetricsProto.Info getMetrics(@Nonnull PlannerMetricsProto.Identifier identifier) {
+    public Info getMetrics(PlannerMetricsProto.Identifier identifier) {
         return expectedMetricsMap.get(identifier);
     }
 
     @SuppressWarnings("UnusedReturnValue")
-    public synchronized PlannerMetricsProto.Info putMetrics(@Nonnull final PlannerMetricsProto.Identifier identifier,
-                                                            @Nonnull final YamlReference reference,
-                                                            @Nonnull final PlannerMetricsProto.Info info) {
+    public synchronized Info putMetrics(final PlannerMetricsProto.Identifier identifier,
+                                                            final YamlReference reference,
+                                                            final Info info) {
         return actualMetricsMap.put(new QueryAndLocation(identifier, reference), info);
     }
 
@@ -156,7 +154,7 @@ public class YamlMetricsMaintainer {
         // query in the same block a second time, there will be pain. Don't do that! We log a warning for this case
         // but continue.
         //
-        final var condensedMetricsMap = new LinkedHashMap<PlannerMetricsProto.Identifier, PlannerMetricsProto.Info>();
+        final var condensedMetricsMap = new LinkedHashMap<PlannerMetricsProto.Identifier, Info>();
         for (final var entry : actualMetricsMap.entrySet()) {
             final var queryAndLocation = entry.getKey();
             final var identifier = queryAndLocation.getIdentifier();
@@ -230,12 +228,11 @@ public class YamlMetricsMaintainer {
         }
     }
 
-    @Nonnull
-    private static ImmutableMap<PlannerMetricsProto.Identifier, PlannerMetricsProto.Info> loadMetricsResource(@Nonnull final YamlReference.YamlResource resource) throws RelationalException {
+    private static ImmutableMap<PlannerMetricsProto.Identifier, Info> loadMetricsResource(final YamlReference.YamlResource resource) throws RelationalException {
         final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         final var fis = classLoader.getResourceAsStream(metricsBinaryProtoFileName(resource.getPath()));
         final var resultMapBuilder =
-                ImmutableMap.<PlannerMetricsProto.Identifier, PlannerMetricsProto.Info>builder();
+                ImmutableMap.<PlannerMetricsProto.Identifier, Info>builder();
         if (fis == null) {
             return resultMapBuilder.build();
         }
@@ -252,51 +249,42 @@ public class YamlMetricsMaintainer {
         }
     }
 
-    @Nonnull
-    private static String baseName(@Nonnull final String resourcePath) {
+    private static String baseName(final String resourcePath) {
         final var tokens = resourcePath.split("\\.(?=[^\\.]+$)");
         Verify.verify(tokens.length == 2);
         Verify.verify("yamsql".equals(tokens[1]));
         return tokens[0];
     }
 
-    @Nonnull
-    private static String metricsBinaryProtoFileName(@Nonnull final String resourcePath) {
+    private static String metricsBinaryProtoFileName(final String resourcePath) {
         return baseName(resourcePath) + ".metrics.binpb";
     }
 
-    @Nonnull
-    private static String metricsYamlFileName(@Nonnull final String resourcePath) {
+    private static String metricsYamlFileName(final String resourcePath) {
         return baseName(resourcePath) + ".metrics.yaml";
     }
 
     private static class QueryAndLocation {
-        @Nonnull
         private final PlannerMetricsProto.Identifier identifier;
-        @Nonnull
         private final YamlReference reference;
 
-        public QueryAndLocation(@Nonnull final PlannerMetricsProto.Identifier identifier, @Nonnull final YamlReference reference) {
+        public QueryAndLocation(final PlannerMetricsProto.Identifier identifier, final YamlReference reference) {
             this.identifier = identifier;
             this.reference = reference;
         }
 
-        @Nonnull
         public PlannerMetricsProto.Identifier getIdentifier() {
             return identifier;
         }
 
-        @Nonnull
         public String getBlockName() {
             return identifier.getBlockName();
         }
 
-        @Nonnull
         public String getQuery() {
             return identifier.getQuery();
         }
 
-        @Nonnull
         public YamlReference getReference() {
             return reference;
         }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlReference.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlReference.java
@@ -24,8 +24,7 @@ import com.apple.foundationdb.relational.util.Assert;
 import com.apple.foundationdb.tuple.Tuple;
 import com.google.common.collect.ImmutableList;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.Objects;
 import java.util.function.Supplier;
 
@@ -33,20 +32,16 @@ import java.util.function.Supplier;
  * This represents a location in a YAMSQL file.
  */
 public class YamlReference implements Comparable<YamlReference> {
-    @Nonnull
     private final YamlResource resource;
     private final int lineNumber;
-    @Nonnull
     private final Supplier<Tuple> tupleSupplier;
 
-
-    private YamlReference(@Nonnull final YamlResource resource, int lineNumber) {
+    private YamlReference(final YamlResource resource, int lineNumber) {
         this.resource = resource;
         this.lineNumber = lineNumber;
         this.tupleSupplier = () -> resource.tupleSupplier.get().add(lineNumber);
     }
 
-    @Nonnull
     public YamlResource getResource() {
         return resource;
     }
@@ -69,18 +64,17 @@ public class YamlReference implements Comparable<YamlReference> {
         return builder.build();
     }
 
-    public YamlResource newResource(@Nonnull String path) {
+    public YamlResource newResource(String path) {
         return new YamlResource(this, path);
     }
 
     @Override
-    @Nonnull
     public String toString() {
         return (getResource().parentRef == null ? "" : getResource().parentRef + " > ") + getResource().getFileName() + ":" + getLineNumber();
     }
 
     @Override
-    public boolean equals(Object object) {
+    public boolean equals(@Nullable Object object) {
         if (object == null) {
             return false;
         }
@@ -109,12 +103,10 @@ public class YamlReference implements Comparable<YamlReference> {
     public static class YamlResource {
         @Nullable
         private final YamlReference parentRef;
-        @Nonnull
         private final String path;
-        @Nonnull
         private final Supplier<Tuple> tupleSupplier;
 
-        private YamlResource(@Nullable final YamlReference parentRef, @Nonnull final String path) {
+        private YamlResource(@Nullable final YamlReference parentRef, final String path) {
             if (parentRef != null) {
                 assertNotCyclic(parentRef, path);
             }
@@ -136,19 +128,17 @@ public class YamlReference implements Comparable<YamlReference> {
             return parentRef;
         }
 
-        @Nonnull
         public String getPath() {
             return path;
         }
 
         @Override
-        @Nonnull
         public String toString() {
             return path + ((parentRef == null) ? "" : " via (" + parentRef + ")");
         }
 
         @Override
-        public boolean equals(Object object) {
+        public boolean equals(@Nullable Object object) {
             if (object == null) {
                 return false;
             }
@@ -170,7 +160,7 @@ public class YamlReference implements Comparable<YamlReference> {
             return Objects.hash(parentRef, path);
         }
 
-        public static YamlResource base(@Nonnull final String path) {
+        public static YamlResource base(final String path) {
             return new YamlResource(null, path);
         }
 
@@ -185,7 +175,7 @@ public class YamlReference implements Comparable<YamlReference> {
             return fileName;
         }
 
-        private static void assertNotCyclic(@Nonnull final YamlReference parentRef, @Nonnull final String path) {
+        private static void assertNotCyclic(final YamlReference parentRef, final String path) {
             final var asTuple = parentRef.tupleSupplier.get().getItems();
             Assert.thatUnchecked(asTuple.stream().noneMatch(path::equals), "Cyclic path detected at: " + parentRef);
         }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlRunner.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlRunner.java
@@ -26,7 +26,6 @@ import com.apple.foundationdb.relational.yamltests.block.TestBlock;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -42,14 +41,12 @@ public final class YamlRunner {
     static final String TEST_SEED = "tests.yaml.seed";
     static final String TEST_NIGHTLY_REPETITION = "tests.yaml.iterations";
 
-    @Nonnull
     private final YamlReference.YamlResource baseResource;
 
-    @Nonnull
     private final YamlExecutionContext executionContext;
 
-    public YamlRunner(@Nonnull String resourcePath, @Nonnull YamlConnectionFactory factory,
-                      @Nonnull final YamlExecutionContext.ContextOptions additionalOptions) throws RelationalException {
+    public YamlRunner(String resourcePath, YamlConnectionFactory factory,
+                      final YamlExecutionContext.ContextOptions additionalOptions) throws RelationalException {
         this.baseResource = YamlReference.YamlResource.base(resourcePath);
         this.executionContext = new YamlExecutionContext(baseResource, factory, additionalOptions);
     }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlTestExtension.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/YamlTestExtension.java
@@ -54,8 +54,7 @@ import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
 import org.opentest4j.TestAbortedException;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
@@ -69,12 +68,15 @@ import java.util.stream.Stream;
  */
 public class YamlTestExtension implements TestTemplateInvocationContextProvider, BeforeAllCallback, AfterAllCallback {
     private static final Logger logger = LogManager.getLogger(YamlTestExtension.class);
+    // Set by beforeAll(), which JUnit always calls before any test template method; null only if beforeAll hasn't
+    // run yet (or failed partway through), which afterAll() below accounts for.
+    @Nullable
     private List<YamlTestConfig> testConfigs;
+    @Nullable
     private List<YamlTestConfig> maintainConfigs;
     /** External servers grouped by jar version. Each {@link Clusters} has one server per cluster file (same order as {@link #clusterFiles}). */
     @Nullable
     private List<Clusters<ExternalServer>> externalServerGroups;
-    @Nonnull
     private final List<String> clusterFiles;
     private final boolean includeMethodInDescriptions;
 
@@ -91,7 +93,7 @@ public class YamlTestExtension implements TestTemplateInvocationContextProvider,
      * necessary, but if integrating some other tools this might be necessary.
      */
     @API(API.Status.DEPRECATED)
-    public YamlTestExtension(@Nonnull final String clusterFile, final boolean includeMethodInDescriptions) {
+    public YamlTestExtension(final String clusterFile, final boolean includeMethodInDescriptions) {
         this(List.of(clusterFile), includeMethodInDescriptions);
     }
 
@@ -101,7 +103,7 @@ public class YamlTestExtension implements TestTemplateInvocationContextProvider,
      * @param includeMethodInDescriptions Set this to {@code true} if publishing test results to something that cannot
      * handle complex test hierarchies.
      */
-    public YamlTestExtension(@Nonnull final List<String> clusterFiles, final boolean includeMethodInDescriptions) {
+    public YamlTestExtension(final List<String> clusterFiles, final boolean includeMethodInDescriptions) {
         this.clusterFiles = clusterFiles;
         this.includeMethodInDescriptions = includeMethodInDescriptions;
     }
@@ -156,7 +158,7 @@ public class YamlTestExtension implements TestTemplateInvocationContextProvider,
                     // The configs for multi-server testing
                     externalServerConfigs).collect(Collectors.toList());
         }
-        for (final YamlTestConfig testConfig : Iterables.concat(testConfigs, maintainConfigs)) {
+        for (final YamlTestConfig testConfig : Iterables.concat(Objects.requireNonNull(testConfigs), Objects.requireNonNull(maintainConfigs))) {
             testConfig.beforeAll();
         }
     }
@@ -170,15 +172,17 @@ public class YamlTestExtension implements TestTemplateInvocationContextProvider,
     }
 
     private Stream<YamlTestConfig> externalServerConfigs(final boolean singleExternalVersionOnly) {
+        // Only called from beforeAll(), after externalServerGroups has been populated a few lines above.
+        final List<Clusters<ExternalServer>> groups = Objects.requireNonNull(externalServerGroups);
         if (singleExternalVersionOnly) {
-            return externalServerGroups.stream()
+            return groups.stream()
                     // Create an ExternalServer config with two connections to the same servers for each version
                     // (with and without forced continuations)
                     .flatMap(group ->
                             Stream.of(new ExternalMultiServerConfig(0, group, group),
                                     new ForceContinuations(new ExternalMultiServerConfig(0, group, group))));
         } else {
-            return externalServerGroups.stream().flatMap(group ->
+            return groups.stream().flatMap(group ->
                     // (4 configs for each server version available)
                     Stream.of(new JDBCMultiServerConfig(0, group),
                             new ForceContinuations(new JDBCMultiServerConfig(0, group)),
@@ -248,7 +252,7 @@ public class YamlTestExtension implements TestTemplateInvocationContextProvider,
             // just not being there. This may waste some resources if all the tests being run exclude a config that has
             // expensive @BeforeAll.
             final var annotation = testMethod.getAnnotation(ExcludeYamlTestConfig.class);
-            return testConfigs
+            return Objects.requireNonNull(testConfigs)
                     .stream()
                     .map(config -> new Context(config, annotation.reason(), annotation.value(),
                             includeMethodInDescriptions, testMethod.getName()));
@@ -260,14 +264,14 @@ public class YamlTestExtension implements TestTemplateInvocationContextProvider,
                     testMethod.getAnnotation(MaintainYamlTestConfig.class);
             return provideInvocationContextsForMaintenance(annotation, testMethod.getName());
         }
-        return testConfigs
+        return Objects.requireNonNull(testConfigs)
                 .stream()
                 .map(config -> new Context(config, "", null, includeMethodInDescriptions, testMethod.getName()));
     }
 
     private Stream<TestTemplateInvocationContext> provideInvocationContextsForMaintenance(
-            @Nonnull final MaintainYamlTestConfig annotation, @Nonnull final String methodName) {
-        return maintainConfigs
+            final MaintainYamlTestConfig annotation, final String methodName) {
+        return Objects.requireNonNull(maintainConfigs)
                 .stream()
                 .map(config -> new Context(config, "maintenance not needed",
                         Objects.requireNonNull(annotation.value()), includeMethodInDescriptions, methodName));
@@ -278,19 +282,16 @@ public class YamlTestExtension implements TestTemplateInvocationContextProvider,
      * method and a {@link YamlTestConfig}).
      */
     private static class Context implements TestTemplateInvocationContext {
-        @Nonnull
         private final YamlTestConfig config;
-        @Nonnull
         private final String excludedReason;
         @Nullable
         private final YamlTestConfigFilters configFilters;
         private final boolean includeMethodInDescriptions;
-        @Nonnull
         private final String methodName;
 
-        public Context(@Nonnull final YamlTestConfig config, @Nonnull final String excludedReason,
+        public Context(final YamlTestConfig config, final String excludedReason,
                        @Nullable final YamlTestConfigFilters configFilters,
-                       final boolean includeMethodInDescriptions, @Nonnull final String methodName) {
+                       final boolean includeMethodInDescriptions, final String methodName) {
             this.config = config;
             this.excludedReason = excludedReason;
             this.configFilters = configFilters;
@@ -318,14 +319,13 @@ public class YamlTestExtension implements TestTemplateInvocationContextProvider,
      */
     private static final class ClassParameterResolver implements ParameterResolver {
 
-        @Nonnull
         private final YamlTestConfig config;
         @Nullable
         private final YamlTestConfigFilters filters;
         @Nullable
         private final String excludedReason;
 
-        public ClassParameterResolver(@Nonnull final YamlTestConfig config,
+        public ClassParameterResolver(final YamlTestConfig config,
                                       @Nullable final YamlTestConfigFilters filters,
                                       @Nullable final String excludedReason) {
             this.config = config;

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/Block.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/Block.java
@@ -26,7 +26,6 @@ import com.apple.foundationdb.relational.yamltests.Matchers;
 import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
 import com.apple.foundationdb.relational.yamltests.YamlReference;
 
-import javax.annotation.Nonnull;
 import java.util.List;
 
 /**
@@ -72,8 +71,8 @@ public interface Block {
      * @param executionContext information needed to carry out the execution
      * @return zero of more blocks
      */
-    static List<Block> parse(@Nonnull YamlReference.YamlResource resource, @Nonnull Object region, int blockNumber,
-                             @Nonnull YamlExecutionContext executionContext, boolean isTopLevel) {
+    static List<Block> parse(YamlReference.YamlResource resource, Object region, int blockNumber,
+                             YamlExecutionContext executionContext, boolean isTopLevel) {
         final var blockObject = Matchers.map(region, "block");
         Assert.thatUnchecked(blockObject.size() == 1,
                 "Illegal Format: A block is expected to be a map of size 1 ({" + resource + "}) keys: " + blockObject.keySet());
@@ -112,7 +111,6 @@ public interface Block {
      * stack that has led to the execution of this block.
      * @return the {@link YamlReference} of the current block.
      */
-    @Nonnull
     YamlReference getReference();
 
     /**
@@ -126,7 +124,6 @@ public interface Block {
      * decide the lifecycle of the resources.
      * @return the list of {@link Block}
      */
-    @Nonnull
     default List<Block> getAndClearFinalizingBlocks() {
         return List.of();
     }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/ConnectedBlock.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/ConnectedBlock.java
@@ -28,7 +28,6 @@ import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import javax.annotation.Nonnull;
 import java.sql.SQLException;
 import java.util.Collection;
 import java.util.List;
@@ -51,21 +50,18 @@ public abstract class ConnectedBlock extends ReferencedBlock implements Block {
 
     static final String BLOCK_CONNECT = "connect";
 
-    @Nonnull
     YamlExecutionContext executionContext;
-    @Nonnull
     private final ConnectionTarget connectionTarget;
-    @Nonnull
     final List<Consumer<YamlConnection>> executables;
 
-    ConnectedBlock(@Nonnull YamlReference reference, @Nonnull List<Consumer<YamlConnection>> executables, @Nonnull ConnectionTarget connectionTarget, @Nonnull YamlExecutionContext executionContext) {
+    ConnectedBlock(YamlReference reference, List<Consumer<YamlConnection>> executables, ConnectionTarget connectionTarget, YamlExecutionContext executionContext) {
         super(reference);
         this.executables = executables;
         this.connectionTarget = connectionTarget;
         this.executionContext = executionContext;
     }
 
-    protected final void executeExecutables(@Nonnull Collection<Consumer<YamlConnection>> list) {
+    protected final void executeExecutables(Collection<Consumer<YamlConnection>> list) {
         connectToDatabaseAndExecute(connection -> list.forEach(t -> t.accept(connection)));
     }
 

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/CopyBlock.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/CopyBlock.java
@@ -33,7 +33,6 @@ import com.apple.foundationdb.relational.yamltests.YamlReference;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import javax.annotation.Nonnull;
 import java.net.URI;
 import java.sql.Array;
 import java.sql.SQLException;
@@ -73,17 +72,16 @@ public class CopyBlock extends ReferencedBlock implements Block {
     public static final String COPY_BLOCK = "copy_block";
     private static final URI CATALOG_URI = URI.create("jdbc:embed:/__SYS?schema=CATALOG");
 
-    @Nonnull
     private final YamlExecutionContext executionContext;
     private final CopyInfoForCluster sourceInfo;
     private final CopyInfoForCluster destInfo;
 
     record CopyInfoForCluster(int cluster, String path, int chunkSize) { }
 
-    private CopyBlock(@Nonnull final YamlReference reference,
-                      @Nonnull final CopyInfoForCluster sourceInfo,
-                      @Nonnull final CopyInfoForCluster destInfo,
-                      @Nonnull final YamlExecutionContext executionContext) {
+    private CopyBlock(final YamlReference reference,
+                      final CopyInfoForCluster sourceInfo,
+                      final CopyInfoForCluster destInfo,
+                      final YamlExecutionContext executionContext) {
         super(reference);
         this.sourceInfo = sourceInfo;
         this.destInfo = destInfo;
@@ -98,9 +96,8 @@ public class CopyBlock extends ReferencedBlock implements Block {
      * @param executionContext the execution context
      * @return a singleton list containing the parsed {@link CopyBlock}
      */
-    @Nonnull
-    public static List<Block> parse(@Nonnull final YamlReference reference, @Nonnull final Object document,
-                                    @Nonnull final YamlExecutionContext executionContext) {
+    public static List<Block> parse(final YamlReference reference, final Object document,
+                                    final YamlExecutionContext executionContext) {
         try {
             final Map<?, ?> blockMap = CustomYamlConstructor.LinedObject.unlineKeys(Matchers.map(document, COPY_BLOCK));
 
@@ -122,20 +119,18 @@ public class CopyBlock extends ReferencedBlock implements Block {
                 getIntOrDefault(map, chunkSizeName, 0));
     }
 
-    @Nonnull
-    private static String getString(@Nonnull final Map<?, ?> sourceMap, @Nonnull final String key,
-                                    @Nonnull final String description) {
+    private static String getString(final Map<?, ?> sourceMap, final String key,
+                                    final String description) {
         final String fullDescription = COPY_BLOCK + " " + description;
         return Matchers.notNull(Matchers.string(sourceMap.get(key), fullDescription), fullDescription);
     }
 
-    private static int getIntOrDefault(@Nonnull final Map<?, ?> sourceMap, @Nonnull final String key,
+    private static int getIntOrDefault(final Map<?, ?> sourceMap, final String key,
                                        final int defaultValue) {
         return sourceMap.containsKey(key) ? ((Number)sourceMap.get(key)).intValue() : defaultValue;
     }
 
-    @Nonnull
-    private static Map<?, ?> getMap(@Nonnull final Map<?, ?> blockMap, @Nonnull final String name) {
+    private static Map<?, ?> getMap(final Map<?, ?> blockMap, final String name) {
         return CustomYamlConstructor.LinedObject.unlineKeys(Matchers.map(blockMap.get(name), COPY_BLOCK + " " + name));
     }
 
@@ -156,7 +151,6 @@ public class CopyBlock extends ReferencedBlock implements Block {
         }
     }
 
-    @Nonnull
     private List<byte[]> executeExport() throws SQLException {
         try (YamlConnection conn = executionContext.getConnectionFactory().getNewConnection(CATALOG_URI, sourceInfo.cluster)) {
             final List<byte[]> allData = new ArrayList<>();
@@ -180,9 +174,8 @@ public class CopyBlock extends ReferencedBlock implements Block {
         }
     }
 
-    @Nonnull
-    private Continuation executeContinuation(@Nonnull final YamlConnection conn, @Nonnull final Continuation continuation,
-                                             @Nonnull final List<byte[]> allData) throws SQLException {
+    private Continuation executeContinuation(final YamlConnection conn, final Continuation continuation,
+                                             final List<byte[]> allData) throws SQLException {
         try (RelationalPreparedStatement ps = conn.prepareStatement("EXECUTE CONTINUATION ?")) {
             ps.setBytes(1, continuation.serialize());
             // we'll only ever have a continuation if this was limited previously, no need to check chunkSize>0
@@ -193,9 +186,8 @@ public class CopyBlock extends ReferencedBlock implements Block {
         }
     }
 
-    @Nonnull
-    private Continuation collectExportBatch(@Nonnull RelationalResultSet rs,
-                                            @Nonnull List<byte[]> allData) throws SQLException {
+    private Continuation collectExportBatch(RelationalResultSet rs,
+                                            List<byte[]> allData) throws SQLException {
         final int sizeBefore = allData.size();
         while (rs.next()) {
             allData.add(rs.getBytes(1));
@@ -214,7 +206,7 @@ public class CopyBlock extends ReferencedBlock implements Block {
         return rs.getContinuation();
     }
 
-    private void executeImport(@Nonnull final List<byte[]> data) throws SQLException {
+    private void executeImport(final List<byte[]> data) throws SQLException {
         try (YamlConnection conn = executionContext.getConnectionFactory().getNewConnection(CATALOG_URI, destInfo.cluster)) {
             final List<List<byte[]>> chunks = partition(data);
             int totalCount = 0;
@@ -225,7 +217,7 @@ public class CopyBlock extends ReferencedBlock implements Block {
         }
     }
 
-    private int importChunk(@Nonnull final List<byte[]> chunk, @Nonnull final YamlConnection conn, int totalCount) throws SQLException {
+    private int importChunk(final List<byte[]> chunk, final YamlConnection conn, int totalCount) throws SQLException {
         try (RelationalPreparedStatement ps = conn.prepareStatement("COPY " + destInfo.path + " FROM ?")) {
             Array array = ps.getConnection().createArrayOf("BINARY", chunk.toArray(new byte[0][]));
             ps.setArray(1, array);
@@ -241,8 +233,7 @@ public class CopyBlock extends ReferencedBlock implements Block {
         return totalCount;
     }
 
-    @Nonnull
-    private List<List<byte[]>> partition(@Nonnull final List<byte[]> data) {
+    private List<List<byte[]>> partition(final List<byte[]> data) {
         if (destInfo.chunkSize <= 0 || destInfo.chunkSize >= data.size()) {
             return List.of(data);
         }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/IncludeBlock.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/IncludeBlock.java
@@ -35,7 +35,6 @@ import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.representer.Representer;
 import org.yaml.snakeyaml.resolver.Resolver;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
@@ -67,9 +66,8 @@ public class IncludeBlock extends SupportBlock {
 
     }
 
-    @Nonnull
-    public static List<Block> parse(@Nonnull final YamlReference reference, @Nonnull final Object document,
-                                    @Nonnull final YamlExecutionContext executionContext) {
+    public static List<Block> parse(final YamlReference reference, final Object document,
+                                    final YamlExecutionContext executionContext) {
         try {
             final var resourceName = Matchers.string(document, "resource name");
             return parse(reference.newResource(Objects.requireNonNull(resourceName)), executionContext);
@@ -78,8 +76,7 @@ public class IncludeBlock extends SupportBlock {
         }
     }
 
-    @Nonnull
-    public static List<Block> parse(@Nonnull final YamlReference.YamlResource resource, @Nonnull final YamlExecutionContext executionContext)
+    public static List<Block> parse(final YamlReference.YamlResource resource, final YamlExecutionContext executionContext)
             throws Exception {
         try {
             final var allBlocks = ImmutableList.<Block>builder();
@@ -105,8 +102,7 @@ public class IncludeBlock extends SupportBlock {
         }
     }
 
-    @Nonnull
-    private static InputStream getInputStream(@Nonnull final YamlReference.YamlResource resource) throws RelationalException {
+    private static InputStream getInputStream(final YamlReference.YamlResource resource) throws RelationalException {
         final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         InputStream inputStream = classLoader.getResourceAsStream(resource.getPath());
         Assert.notNull(inputStream, String.format(Locale.ROOT, "could not find '%s' in resources bundle", resource.getPath()));

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/PreambleBlock.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/PreambleBlock.java
@@ -30,7 +30,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assumptions;
 
-import javax.annotation.Nonnull;
+import org.jspecify.annotations.Nullable;
 import java.util.List;
 import java.util.Map;
 
@@ -50,8 +50,7 @@ public class PreambleBlock extends SupportBlock {
 
     }
 
-    @Nonnull
-    public static List<Block> parse(@Nonnull final Object document, @Nonnull final YamlExecutionContext executionContext) {
+    public static List<Block> parse(final Object document, final YamlExecutionContext executionContext) {
         final Map<?, ?> optionsMap = CustomYamlConstructor.LinedObject.unlineKeys(Matchers.map(document, OPTIONS));
 
         // read the supported version option, and immediately abort the test if the version check fails.
@@ -81,8 +80,7 @@ public class PreambleBlock extends SupportBlock {
         return List.of();
     }
 
-    @Nonnull
-    public static SemanticVersion parseVersion(Object rawVersion) {
+    public static SemanticVersion parseVersion(@Nullable Object rawVersion) {
         if (rawVersion instanceof CurrentVersion) {
             return SemanticVersion.current();
         } else if (rawVersion instanceof String) {

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/ReferencedBlock.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/ReferencedBlock.java
@@ -22,22 +22,18 @@ package com.apple.foundationdb.relational.yamltests.block;
 
 import com.apple.foundationdb.relational.yamltests.YamlReference;
 
-import javax.annotation.Nonnull;
-
 /**
  * A {@link Block} with a {@link YamlReference}.
  */
 public abstract class ReferencedBlock implements Block {
 
-    @Nonnull
     private final YamlReference blockReference;
 
-    ReferencedBlock(@Nonnull final YamlReference blockReference) {
+    ReferencedBlock(final YamlReference blockReference) {
         this.blockReference = blockReference;
     }
 
     @Override
-    @Nonnull
     public YamlReference getReference() {
         return blockReference;
     }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/SetupBlock.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/SetupBlock.java
@@ -37,7 +37,6 @@ import com.apple.foundationdb.relational.yamltests.server.SupportedVersionCheck;
 
 import com.google.common.collect.Range;
 
-import javax.annotation.Nonnull;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
@@ -64,8 +63,8 @@ public class SetupBlock extends ConnectedBlock {
 
     public static final String SETUP_BLOCK = "setup";
 
-    protected SetupBlock(@Nonnull YamlReference reference, @Nonnull List<Consumer<YamlConnection>> executables, @Nonnull ConnectionTarget connectionTarget,
-                         @Nonnull YamlExecutionContext executionContext) {
+    protected SetupBlock(YamlReference reference, List<Consumer<YamlConnection>> executables, ConnectionTarget connectionTarget,
+                         YamlExecutionContext executionContext) {
         super(reference, executables, connectionTarget, executionContext);
     }
 
@@ -86,7 +85,7 @@ public class SetupBlock extends ConnectedBlock {
         public static final String OPTIONS = "options";
         public static final String CONNECTION_OPTIONS = "connection_options";
 
-        public static List<Block> parse(@Nonnull YamlReference reference, @Nonnull Object document, @Nonnull YamlExecutionContext executionContext) {
+        public static List<Block> parse(YamlReference reference, Object document, YamlExecutionContext executionContext) {
             try {
                 Options connectionOptions = Options.none();
                 final var setupMap = CustomYamlConstructor.LinedObject.unlineKeys(Matchers.map(document, "setup"));
@@ -104,7 +103,7 @@ public class SetupBlock extends ConnectedBlock {
 
                 final var stepsObject = setupMap.getOrDefault(STEPS, null);
                 if (stepsObject == null) {
-                    Assert.failUnchecked("Illegal Format: No steps provided in setup block.");
+                    throw Assert.failUnchecked("Illegal Format: No steps provided in setup block.");
                 }
                 final var executables = new ArrayList<Consumer<YamlConnection>>();
                 for (final var step : Matchers.arrayList(stepsObject, "setup steps")) {
@@ -119,13 +118,12 @@ public class SetupBlock extends ConnectedBlock {
             }
         }
 
-        private ManualSetupBlock(@Nonnull YamlReference reference, @Nonnull List<Consumer<YamlConnection>> executables, @Nonnull ConnectionTarget connectionTarget,
-                                 @Nonnull YamlExecutionContext executionContext) {
+        private ManualSetupBlock(YamlReference reference, List<Consumer<YamlConnection>> executables, ConnectionTarget connectionTarget,
+                                 YamlExecutionContext executionContext) {
             super(reference, executables, connectionTarget, executionContext);
         }
 
-        @Nonnull
-        private static Consumer<YamlConnection> createSetupExecutable(Command setupCommand, @Nonnull Options connectionOptions) {
+        private static Consumer<YamlConnection> createSetupExecutable(Command setupCommand, Options connectionOptions) {
             return connection -> {
                 try {
                     connection.setConnectionOptions(connectionOptions);
@@ -145,9 +143,7 @@ public class SetupBlock extends ConnectedBlock {
         public static final String INITIAL_VERSION_AT_LEAST = "initialVersionAtLeast";
         public static final String INITIAL_VERSION_LESS_THAN = "initialVersionLessThan";
 
-        @Nonnull
         private List<Block> finalizingBlocks;
-
 
         /**
          * A {@code schema_template} variant specified in the .yamsql file.
@@ -157,17 +153,17 @@ public class SetupBlock extends ConnectedBlock {
          * @param createSchemaTemplateSql  the {@code CREATE SCHEMA TEMPLATE} statement built from the variant’s
          *                                 {@code definition} body
          */
-        private record Variant(@Nonnull YamlReference reference, @Nonnull Range<SemanticVersion> range,
-                               @Nonnull String createSchemaTemplateSql) {
+        private record Variant(YamlReference reference, Range<SemanticVersion> range,
+                               String createSchemaTemplateSql) {
         }
 
         /**
          * A resolved {@link Variant} holding the {@link QueryCommand} to execute.
          */
-        private record VariantCommands(@Nonnull Range<SemanticVersion> range, @Nonnull QueryCommand command) {
+        private record VariantCommands(Range<SemanticVersion> range, QueryCommand command) {
         }
 
-        public static List<Block> parse(@Nonnull final YamlReference reference, @Nonnull Object document, @Nonnull YamlExecutionContext executionContext) {
+        public static List<Block> parse(final YamlReference reference, Object document, YamlExecutionContext executionContext) {
             try {
                 final String identifier = "YAML_" + UUID.randomUUID().toString().toUpperCase(Locale.ROOT).replace("-", "").substring(0, 16);
                 final String schemaTemplateName = identifier + "_TEMPLATE";
@@ -212,27 +208,23 @@ public class SetupBlock extends ConnectedBlock {
             }
         }
 
-        @Nonnull
-        private static Consumer<YamlConnection> asExecutable(@Nonnull String step, @Nonnull YamlReference reference,
-                                                             @Nonnull YamlExecutionContext executionContext) {
+        private static Consumer<YamlConnection> asExecutable(String step, YamlReference reference,
+                                                             YamlExecutionContext executionContext) {
             return QueryCommand.withQueryString(reference, step, executionContext)::execute;
         }
 
-        @Nonnull
         private static String buildCreateSchemaTemplateSql(final String schemaTemplateName, final String body) {
             return "CREATE SCHEMA TEMPLATE " + schemaTemplateName + " " + body;
         }
 
-        @Nonnull
-        private static List<Variant> parseSingleVariant(@Nonnull Object document, @Nonnull YamlReference reference,
-                                                        @Nonnull String schemaTemplateName) {
+        private static List<Variant> parseSingleVariant(Object document, YamlReference reference,
+                                                        String schemaTemplateName) {
             final String body = Matchers.string(document, "schema template description");
             return List.of(new Variant(reference, SemanticVersionRanges.all(),
                     buildCreateSchemaTemplateSql(schemaTemplateName, body)));
         }
 
-        @Nonnull
-        private static List<Variant> parseVariantList(@Nonnull Object document, @Nonnull YamlReference reference, @Nonnull String schemaTemplateName) {
+        private static List<Variant> parseVariantList(Object document, YamlReference reference, String schemaTemplateName) {
             final List<?> rawVariants = Matchers.arrayList(document, "schema_template variants");
             Assert.thatUnchecked(!rawVariants.isEmpty(), "schema_template list form must declare at least one variant");
             final List<Variant> parsed = new ArrayList<>(rawVariants.size());
@@ -250,7 +242,7 @@ public class SetupBlock extends ConnectedBlock {
             return parsed;
         }
 
-        private static int extractVariantLineNumber(@Nonnull Map<?, ?> rawVariantMap, @Nonnull YamlReference outerReference) {
+        private static int extractVariantLineNumber(Map<?, ?> rawVariantMap, YamlReference outerReference) {
             return rawVariantMap.keySet().stream()
                     .filter(CustomYamlConstructor.LinedObject.class::isInstance)
                     .mapToInt(k -> ((CustomYamlConstructor.LinedObject) k).getLineNumber())
@@ -258,8 +250,7 @@ public class SetupBlock extends ConnectedBlock {
                     .orElse(outerReference.getLineNumber());
         }
 
-        @Nonnull
-        private static Range<SemanticVersion> parseVariantRange(@Nonnull Map<?, ?> variantMap) {
+        private static Range<SemanticVersion> parseVariantRange(Map<?, ?> variantMap) {
             final boolean hasAtLeast = variantMap.containsKey(INITIAL_VERSION_AT_LEAST);
             final boolean hasLessThan = variantMap.containsKey(INITIAL_VERSION_LESS_THAN);
             if (!hasAtLeast && !hasLessThan) {
@@ -278,7 +269,7 @@ public class SetupBlock extends ConnectedBlock {
             return Range.closedOpen(lowerBound, upperBound);
         }
 
-        private static void validateVariants(@Nonnull List<Variant> variants, @Nonnull YamlReference reference) {
+        private static void validateVariants(List<Variant> variants, YamlReference reference) {
             final List<Range<SemanticVersion>> ranges = variants.stream().map(Variant::range).collect(Collectors.toList());
 
             // Check for overlapping ranges.
@@ -300,15 +291,14 @@ public class SetupBlock extends ConnectedBlock {
             }
         }
 
-        private SchemaTemplateBlock(@Nonnull final YamlReference reference, @Nonnull final String schemaTemplateName,
-                                    @Nonnull final String databaseName, @Nonnull List<Consumer<YamlConnection>> executables,
-                                    @Nonnull YamlExecutionContext executionContext) {
+        private SchemaTemplateBlock(final YamlReference reference, final String schemaTemplateName,
+                                    final String databaseName, List<Consumer<YamlConnection>> executables,
+                                    YamlExecutionContext executionContext) {
             super(reference, executables, executionContext.inferConnectionTarget(reference.getResource(), 0), executionContext);
             this.finalizingBlocks = List.of(DestructTemplateBlock.withDatabaseAndSchema(reference, executionContext, schemaTemplateName, databaseName));
         }
 
         @Override
-        @Nonnull
         public List<Block> getAndClearFinalizingBlocks() {
             final var toReturn = List.copyOf(finalizingBlocks);
             finalizingBlocks = List.of();
@@ -318,8 +308,8 @@ public class SetupBlock extends ConnectedBlock {
 
     private static final class DestructTemplateBlock extends SetupBlock {
 
-        public static DestructTemplateBlock withDatabaseAndSchema(@Nonnull final YamlReference reference, @Nonnull YamlExecutionContext executionContext,
-                                                                  @Nonnull String schemaTemplateName, @Nonnull String databasePath) {
+        public static DestructTemplateBlock withDatabaseAndSchema(final YamlReference reference, YamlExecutionContext executionContext,
+                                                                  String schemaTemplateName, String databasePath) {
             try {
                 final var steps = new ArrayList<String>();
                 steps.add("DROP DATABASE " + databasePath);
@@ -335,7 +325,7 @@ public class SetupBlock extends ConnectedBlock {
             }
         }
 
-        private DestructTemplateBlock(@Nonnull final YamlReference reference, @Nonnull List<Consumer<YamlConnection>> executables, @Nonnull YamlExecutionContext executionContext) {
+        private DestructTemplateBlock(final YamlReference reference, List<Consumer<YamlConnection>> executables, YamlExecutionContext executionContext) {
             super(reference, executables, executionContext.inferConnectionTarget(reference.getResource(), 0), executionContext);
         }
     }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/SkipBlock.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/SkipBlock.java
@@ -24,17 +24,14 @@ import com.apple.foundationdb.relational.yamltests.YamlReference;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import javax.annotation.Nonnull;
-
 /**
  * A block that does nothing.
  */
 class SkipBlock extends ReferencedBlock implements Block {
     private static final Logger logger = LogManager.getLogger(SkipBlock.class);
-    @Nonnull
     private final String message;
 
-    SkipBlock(@Nonnull final YamlReference reference, @Nonnull String message) {
+    SkipBlock(final YamlReference reference, String message) {
         super(reference);
         this.message = message;
     }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/SupportBlock.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/SupportBlock.java
@@ -23,15 +23,11 @@ package com.apple.foundationdb.relational.yamltests.block;
 import com.apple.foundationdb.relational.util.Assert;
 import com.apple.foundationdb.relational.yamltests.YamlReference;
 
-import javax.annotation.Nonnull;
-
 public abstract class SupportBlock implements Block {
 
     @Override
-    @Nonnull
     public YamlReference getReference() {
-        Assert.failUnchecked("Support blocks do not have reference");
-        return null;
+        throw Assert.failUnchecked("Support blocks do not have reference");
     }
 
     @Override

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/TestBlock.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/TestBlock.java
@@ -41,8 +41,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opentest4j.TestAbortedException;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -156,13 +155,9 @@ public final class TestBlock extends ConnectedBlock {
         PREPARED
     }
 
-    @Nonnull
     final String blockName;
-    @Nonnull
     private final List<Consumer<YamlConnection>> executableTestsWithCacheCheck;
-    @Nonnull
     private final TestBlockOptions options;
-    @Nonnull
     private final List<QueryCommand> queryCommands;
     @Nullable
     private RuntimeException maybeFailureException;
@@ -199,7 +194,7 @@ public final class TestBlock extends ConnectedBlock {
         private SupportedVersionCheck supportedVersionCheck = SupportedVersionCheck.supported();
         private Options connectionOptions = Options.none();
 
-        private void verifyPreset(@Nonnull String preset) {
+        private void verifyPreset(String preset) {
             switch (preset) {
                 case PRESET_MULTI_REPETITION_ORDERED:
                 case PRESET_MULTI_REPETITION_RANDOMIZED:
@@ -214,7 +209,7 @@ public final class TestBlock extends ConnectedBlock {
             }
         }
 
-        private void setWithPreset(@Nonnull String preset) {
+        private void setWithPreset(String preset) {
             verifyPreset(preset);
             if (PRESET_MULTI_REPETITION_ORDERED.equals(preset) || PRESET_MULTI_REPETITION_RANDOMIZED.equals(preset) || PRESET_MULTI_REPETITION_PARALLELIZED.equals(preset)) {
                 repetition = 5;
@@ -231,7 +226,7 @@ public final class TestBlock extends ConnectedBlock {
             }
         }
 
-        private void setWithOptionsMap(@Nonnull Map<?, ?> optionsMap, Set<SemanticVersion> versionsUnderTest) {
+        private void setWithOptionsMap(Map<?, ?> optionsMap, Set<SemanticVersion> versionsUnderTest) {
             setOptionExecutionModeAndRepetition(optionsMap);
             if (optionsMap.containsKey(OPTION_SEED)) {
                 this.seed = Matchers.longValue(optionsMap.get(OPTION_SEED));
@@ -260,8 +255,7 @@ public final class TestBlock extends ConnectedBlock {
             }
         }
 
-        @Nonnull
-        public static Options parseConnectionOptions(@Nonnull final Map<?, ?> map) {
+        public static Options parseConnectionOptions(final Map<?, ?> map) {
             final var optionsBuilder = Options.builder();
             for (final var entry : map.entrySet()) {
                 final var name = Options.Name.valueOf(Matchers.string(entry.getKey()));
@@ -281,7 +275,7 @@ public final class TestBlock extends ConnectedBlock {
             return optionsBuilder.build();
         }
 
-        private void setWithExecutionContext(@Nonnull YamlExecutionContext executionContext) {
+        private void setWithExecutionContext(YamlExecutionContext executionContext) {
             // Use the system-provided seed if that is available from the context.
             executionContext.getSeed().ifPresent(s -> seed = Matchers.longValue(s));
             if (YamlExecutionContext.isNightly()) {
@@ -341,8 +335,8 @@ public final class TestBlock extends ConnectedBlock {
         }
     }
 
-    public static List<Block> parse(int blockNumber, @Nonnull final YamlReference reference, @Nonnull final Object document,
-                                    @Nonnull final YamlExecutionContext executionContext) {
+    public static List<Block> parse(int blockNumber, final YamlReference reference, final Object document,
+                                    final YamlExecutionContext executionContext) {
         try {
             // Since `options` is also a top-level block, the `CustomYamlConstructor` will add the line numbers,
             // changing it from a `String` to a `LinedObject` so that we know the line numbers when logging an error,
@@ -392,13 +386,16 @@ public final class TestBlock extends ConnectedBlock {
 
                 queryCommands.add(queryCommand);
                 var runAsPreparedMix = getRunAsPreparedMix(options.statementType, options.repetition, randomGenerator);
+                // getRunAsPreparedMix() always constructs its pair from non-null values.
+                final List<Boolean> perRepetitionPreparedFlags = Objects.requireNonNull(runAsPreparedMix.getLeft());
+                final boolean cacheCheckPreparedFlag = Objects.requireNonNull(runAsPreparedMix.getRight());
                 for (int i = 0; i < options.repetition; i++) {
                     executables.add(createTestExecutable(queryCommand, false, randomGenerator,
-                            runAsPreparedMix.getLeft().get(i), options.connectionOptions));
+                            perRepetitionPreparedFlags.get(i), options.connectionOptions));
                 }
                 if (options.checkCache) {
                     executableTestsWithCacheCheck.add(createTestExecutable(queryCommand, true,
-                            randomGenerator, runAsPreparedMix.getRight(), options.connectionOptions));
+                            randomGenerator, cacheCheckPreparedFlag, options.connectionOptions));
                 }
             }
             if (options.mode != ExecutionMode.ORDERED) {
@@ -414,10 +411,10 @@ public final class TestBlock extends ConnectedBlock {
         }
     }
 
-    private TestBlock(@Nonnull final YamlReference reference, @Nonnull final String blockName, @Nonnull final List<QueryCommand> queryCommands,
-                      @Nonnull final List<Consumer<YamlConnection>> executables,
-                      @Nonnull final List<Consumer<YamlConnection>> executableTestsWithCacheCheck, @Nonnull final ConnectionTarget connectionTarget,
-                      @Nonnull final TestBlockOptions options, @Nonnull final YamlExecutionContext executionContext) {
+    private TestBlock(final YamlReference reference, final String blockName, final List<QueryCommand> queryCommands,
+                      final List<Consumer<YamlConnection>> executables,
+                      final List<Consumer<YamlConnection>> executableTestsWithCacheCheck, final ConnectionTarget connectionTarget,
+                      final TestBlockOptions options, final YamlExecutionContext executionContext) {
         super(reference, executables, connectionTarget, executionContext);
         this.blockName = blockName;
         this.queryCommands = queryCommands;
@@ -460,8 +457,7 @@ public final class TestBlock extends ConnectedBlock {
         executableTestsWithCacheCheck.clear();
     }
 
-    @Nonnull
-    private Throwable unwrapExecutionExceptionIfNeeded(@Nonnull final Throwable t) {
+    private Throwable unwrapExecutionExceptionIfNeeded(final Throwable t) {
         if (t instanceof ExecutionException) {
             if (t.getCause() != null) {
                 return t.getCause();
@@ -470,7 +466,6 @@ public final class TestBlock extends ConnectedBlock {
         return t;
     }
 
-    @Nonnull
     public Optional<RuntimeException> getFailureExceptionIfPresent() {
         return maybeFailureException == null ? Optional.empty() : Optional.of(maybeFailureException);
     }
@@ -506,7 +501,7 @@ public final class TestBlock extends ConnectedBlock {
         }
     }
 
-    private static Pair<List<Boolean>, Boolean> getRunAsPreparedMix(StatementType type, int repetitions, @Nonnull Random random) {
+    private static Pair<List<Boolean>, Boolean> getRunAsPreparedMix(StatementType type, int repetitions, Random random) {
         if (type == StatementType.SIMPLE) {
             return Pair.of(Collections.nCopies(repetitions, false), false);
         }
@@ -528,10 +523,9 @@ public final class TestBlock extends ConnectedBlock {
         }
     }
 
-    @Nonnull
     private static Consumer<YamlConnection> createTestExecutable(QueryCommand queryCommand, boolean checkCache,
-                                                                 @Nonnull Random random, boolean runAsPreparedStatement,
-                                                                 @Nonnull Options connectionOptions) {
+                                                                 Random random, boolean runAsPreparedStatement,
+                                                                 Options connectionOptions) {
         final var executor = queryCommand.instantiateExecutor(random, runAsPreparedStatement);
         return connection -> {
             try {

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/TransactionSetupsBlock.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/TransactionSetupsBlock.java
@@ -23,7 +23,6 @@ package com.apple.foundationdb.relational.yamltests.block;
 import com.apple.foundationdb.relational.yamltests.Matchers;
 import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
 
-import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Map;
 
@@ -34,8 +33,8 @@ public class TransactionSetupsBlock extends SupportBlock {
     public TransactionSetupsBlock() {
     }
 
-    public static List<Block> parse(@Nonnull final Object document,
-                                    @Nonnull final YamlExecutionContext executionContext) {
+    public static List<Block> parse(final Object document,
+                                    final YamlExecutionContext executionContext) {
         final Map<?, ?> map = Matchers.map(document);
         for (final Map.Entry<?, ?> entry : map.entrySet()) {
             final String transactionSetupName = Matchers.string(entry.getKey(), "transaction setup name");

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/package-info.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/block/package-info.java
@@ -23,4 +23,7 @@
  * running the tests. This package holds all the blocks.
  */
 
+@NullMarked
 package com.apple.foundationdb.relational.yamltests.block;
+
+import org.jspecify.annotations.NullMarked;

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/Command.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/Command.java
@@ -45,8 +45,7 @@ import com.apple.foundationdb.relational.yamltests.generated.schemainstance.Sche
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.net.URI;
 import java.sql.SQLException;
 import java.util.Locale;
@@ -61,23 +60,19 @@ public abstract class Command {
 
     private static final Logger logger = LogManager.getLogger(Command.class);
 
-    @Nonnull
     private final YamlReference reference;
-    @Nonnull
     final YamlExecutionContext executionContext;
 
-    Command(@Nonnull final YamlReference reference, @Nonnull YamlExecutionContext executionContext) {
+    Command(final YamlReference reference, YamlExecutionContext executionContext) {
         this.reference = reference;
         this.executionContext = executionContext;
     }
 
-    @Nonnull
     public YamlReference getReference() {
         return reference;
     }
 
-    @Nonnull
-    public static Command parse(@Nonnull final YamlReference.YamlResource resource, @Nonnull Object object, @Nonnull final String blockName, @Nonnull final YamlExecutionContext executionContext) {
+    public static Command parse(final YamlReference.YamlResource resource, Object object, final String blockName, final YamlExecutionContext executionContext) {
         final var command = Matchers.notNull(Matchers.firstEntry(Matchers.arrayList(object, "command").get(0), "command"), "command");
         final var linedObject = CustomYamlConstructor.LinedObject.cast(command.getKey(), () -> "Invalid command key-value pair: " + command);
         final var reference = resource.withLineNumber(linedObject.getLineNumber());
@@ -92,15 +87,14 @@ public abstract class Command {
                 case COMMAND_QUERY:
                     return QueryCommand.parse(resource, object, blockName, executionContext);
                 default:
-                    Assert.failUnchecked(String.format(Locale.ROOT, "Could not find command '%s'", key));
-                    return null;
+                    throw Assert.failUnchecked(String.format(Locale.ROOT, "Could not find command '%s'", key));
             }
         } catch (Exception e) {
             throw YamlExecutionContext.wrapContext(e, () -> "‼️ Error parsing command at " + reference, "command", reference);
         }
     }
 
-    public final void execute(@Nonnull final YamlConnection connection) {
+    public final void execute(final YamlConnection connection) {
         try {
             executeInternal(connection);
         } catch (Throwable e) {
@@ -110,10 +104,10 @@ public abstract class Command {
         }
     }
 
-    abstract void executeInternal(@Nonnull YamlConnection connection) throws SQLException, RelationalException;
+    abstract void executeInternal(YamlConnection connection) throws SQLException, RelationalException;
 
-    private static void applyMetadataOperationEmbedded(@Nonnull EmbeddedRelationalConnection connection,
-                                                       @Nonnull RecordLayerConfig rlConfig, @Nonnull ApplyState applyState)
+    private static void applyMetadataOperationEmbedded(EmbeddedRelationalConnection connection,
+                                                       RecordLayerConfig rlConfig, ApplyState applyState)
             throws SQLException, RelationalException {
         StoreCatalog backingCatalog = connection.getBackingCatalog();
         RecordLayerMetadataOperationsFactory metadataOperationsFactory = new RecordLayerMetadataOperationsFactory.Builder()
@@ -129,7 +123,7 @@ public abstract class Command {
         connection.setAutoCommit(true);
     }
 
-    private static void applyMetadataOperationDirectly(@Nonnull RecordLayerConfig rlConfig, @Nonnull ApplyState applyState,
+    private static void applyMetadataOperationDirectly(RecordLayerConfig rlConfig, ApplyState applyState,
                                                        @Nullable String clusterFile) throws RelationalException {
         final FDBDatabase fdbDb = FDBDatabaseFactory.instance().getDatabase(clusterFile);
         final RelationalKeyspaceProvider keyspaceProvider = RelationalKeyspaceProvider.instance();
@@ -152,10 +146,10 @@ public abstract class Command {
     }
 
     @SuppressWarnings({"PMD.CloseResource"}) // We "borrow" from the connection via tryGetEmbedded, but the connection will close it
-    private static Command getLoadSchemaTemplateCommand(@Nonnull final YamlReference reference, @Nonnull final YamlExecutionContext executionContext, @Nonnull String value) {
+    private static Command getLoadSchemaTemplateCommand(final YamlReference reference, final YamlExecutionContext executionContext, String value) {
         return new Command(reference, executionContext) {
             @Override
-            public void executeInternal(@Nonnull YamlConnection connection) throws SQLException, RelationalException {
+            public void executeInternal(YamlConnection connection) throws SQLException, RelationalException {
                 logger.debug("⏳ Loading template '{}'", value);
                 // current connection should be __SYS/catalog
                 // save schema template
@@ -175,10 +169,10 @@ public abstract class Command {
     }
 
     @SuppressWarnings({"PMD.CloseResource"}) // We "borrow" from the connection via tryGetEmbedded, but the connection will close it
-    private static Command getSetSchemaStateCommand(@Nonnull final YamlReference reference, @Nonnull final YamlExecutionContext executionContext, @Nonnull String value) {
+    private static Command getSetSchemaStateCommand(final YamlReference reference, final YamlExecutionContext executionContext, String value) {
         return new Command(reference, executionContext) {
             @Override
-            public void executeInternal(@Nonnull YamlConnection connection) throws SQLException, RelationalException {
+            public void executeInternal(YamlConnection connection) throws SQLException, RelationalException {
                 logger.debug("⏳ Setting schema state '{}'", value);
                 SchemaInstanceOuterClass.SchemaInstance schemaInstance = CommandUtil.fromJson(value);
                 RecordLayerConfig rlConfig = new RecordLayerConfig.RecordLayerConfigBuilder()

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/CommandUtil.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/CommandUtil.java
@@ -35,7 +35,6 @@ import com.google.protobuf.Descriptors;
 import com.google.protobuf.util.JsonFormat;
 import org.junit.jupiter.api.Assertions;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -49,6 +48,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.regex.Matcher;
@@ -67,11 +67,14 @@ public class CommandUtil {
     public static SchemaTemplate fromProto(String loadCommandString) {
         RecordMetaData metaData;
         Pair<String, String> templateNameAndSourceName = parseLoadTemplateString(loadCommandString);
-        if (templateNameAndSourceName.getRight().endsWith(".json")) {
-            metaData = loadRecordMetaDataFromJson(templateNameAndSourceName.getRight());
+        // parseLoadTemplateString() always constructs its pair from two non-null tokens.
+        final String templateName = Objects.requireNonNull(templateNameAndSourceName.getLeft());
+        final String sourceName = Objects.requireNonNull(templateNameAndSourceName.getRight());
+        if (sourceName.endsWith(".json")) {
+            metaData = loadRecordMetaDataFromJson(sourceName);
         } else {
             try {
-                Class<?> act = Class.forName(templateNameAndSourceName.getRight());
+                Class<?> act = Class.forName(sourceName);
                 Method method = act.getMethod("getDescriptor");
                 Descriptors.FileDescriptor o = (Descriptors.FileDescriptor) method.invoke(null);
                 metaData = RecordMetaData.build(o);
@@ -80,7 +83,7 @@ public class CommandUtil {
                 throw new RuntimeException(e);
             }
         }
-        return RecordLayerSchemaTemplate.fromRecordMetadata(metaData, templateNameAndSourceName.getLeft(), 1);
+        return RecordLayerSchemaTemplate.fromRecordMetadata(metaData, templateName, 1);
     }
 
     public static SchemaInstanceOuterClass.SchemaInstance fromJson(String loadCommandString) {
@@ -233,10 +236,9 @@ public class CommandUtil {
         CYAN("\u001B[36m"),
         WHITE("\u001B[37m");
 
-        @Nonnull
         private final String ansi;
 
-        Color(@Nonnull final String ansi) {
+        Color(final String ansi) {
             this.ansi = ansi;
         }
 

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/DebuggerImplementation.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/DebuggerImplementation.java
@@ -26,7 +26,6 @@ import com.apple.foundationdb.record.query.plan.cascades.debug.PlannerRepl;
 import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
 import org.jline.terminal.TerminalBuilder;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.function.Supplier;
 
@@ -43,16 +42,14 @@ public enum DebuggerImplementation {
     });
 
     private final boolean allowedInCI;
-    @Nonnull
     private final Supplier<Debugger> debuggerSupplier;
 
-    DebuggerImplementation(boolean allowedInCI, @Nonnull final Supplier<Debugger> debuggerCreator) {
+    DebuggerImplementation(boolean allowedInCI, final Supplier<Debugger> debuggerCreator) {
         this.allowedInCI = allowedInCI;
         this.debuggerSupplier = debuggerCreator;
     }
 
-    @Nonnull
-    public Debugger newDebugger(@Nonnull YamlExecutionContext context) {
+    public Debugger newDebugger(YamlExecutionContext context) {
         if (!allowedInCI && YamlExecutionContext.isInCI()) {
             throw new UnsupportedOperationException("somebody checked in a test with a debugger option");
         }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryCommand.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryCommand.java
@@ -39,8 +39,7 @@ import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
 import org.opentest4j.TestAbortedException;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
@@ -69,11 +68,8 @@ import java.util.stream.Collectors;
 public final class QueryCommand extends Command {
     private static final Logger logger = LogManager.getLogger(QueryCommand.class);
 
-    @Nonnull
     private final List<QueryConfig> queryConfigs;
-    @Nonnull
     private final QueryInterpreter queryInterpreter;
-    @Nonnull
     private final AtomicReference<Throwable> maybeExecutionThrowable = new AtomicReference<>();
     private final boolean needsSerialEnvironment;
 
@@ -82,8 +78,7 @@ public final class QueryCommand extends Command {
         return maybeExecutionThrowable.get();
     }
 
-    @Nonnull
-    public static Command parse(@Nonnull final YamlReference.YamlResource resource, @Nonnull final Object object, @Nonnull final String blockName, @Nonnull final YamlExecutionContext executionContext) {
+    public static Command parse(final YamlReference.YamlResource resource, final Object object, final String blockName, final YamlExecutionContext executionContext) {
         final var queryCommand = Matchers.firstEntry(Matchers.first(Matchers.arrayList(object, "query command")), "query command");
         final var linedObject = CustomYamlConstructor.LinedObject.cast(queryCommand.getKey(), () -> "Invalid command key-value pair: " + queryCommand);
         final var reference = resource.withLineNumber(Matchers.notNull(linedObject, "query").getLineNumber());
@@ -160,14 +155,14 @@ public final class QueryCommand extends Command {
         }
     }
 
-    public static QueryCommand withQueryString(@Nonnull final YamlReference reference, @Nonnull String singleExecutableCommand,
-                                               @Nonnull final YamlExecutionContext executionContext) {
+    public static QueryCommand withQueryString(final YamlReference reference, String singleExecutableCommand,
+                                               final YamlExecutionContext executionContext) {
         return new QueryCommand(reference, QueryInterpreter.withQueryString(reference, singleExecutableCommand, executionContext),
                 List.of(QueryConfig.getNoCheckConfig(reference)), executionContext, false);
     }
 
-    private QueryCommand(@Nonnull final YamlReference reference, @Nonnull QueryInterpreter interpreter, @Nonnull List<QueryConfig> configs,
-                         @Nonnull final YamlExecutionContext executionContext, final boolean needsSerialEnvironment) {
+    private QueryCommand(final YamlReference reference, QueryInterpreter interpreter, List<QueryConfig> configs,
+                         final YamlExecutionContext executionContext, final boolean needsSerialEnvironment) {
         super(reference, executionContext);
         if (Debugger.getDebugger() != null) {
             Debugger.getDebugger().onSetup(); // clean all symbols before the next query.
@@ -179,7 +174,7 @@ public final class QueryCommand extends Command {
                 "SkipConfig should not have gotten into QueryCommand " + reference);
     }
 
-    public void execute(@Nonnull final YamlConnection connection, boolean checkCache, @Nonnull QueryExecutor executor) {
+    public void execute(final YamlConnection connection, boolean checkCache, QueryExecutor executor) {
         try {
             // checkCache implies that we are repeating the query to check that it hits the cache
             // If the underlying connection does not support access to the metric collector, we won't be able to
@@ -201,11 +196,11 @@ public final class QueryCommand extends Command {
     }
 
     @Override
-    void executeInternal(@Nonnull final YamlConnection connection) throws SQLException, RelationalException {
+    void executeInternal(final YamlConnection connection) throws SQLException, RelationalException {
         executeInternal(connection, false, instantiateExecutor(null, false));
     }
 
-    private void executeInternal(@Nonnull final YamlConnection connection, boolean checkCache, @Nonnull QueryExecutor executor)
+    private void executeInternal(final YamlConnection connection, boolean checkCache, QueryExecutor executor)
             throws SQLException, RelationalException {
         enableCascadesDebugger();
         boolean shouldExecute = true;
@@ -304,16 +299,15 @@ public final class QueryCommand extends Command {
         }
     }
 
-    @Nonnull
     public QueryExecutor instantiateExecutor(@Nullable Random random, boolean runAsPreparedStatement) {
         return queryInterpreter.getExecutor(random, runAsPreparedStatement);
     }
 
-    public static void reportTestFailure(@Nonnull String message) {
+    public static void reportTestFailure(String message) {
         reportTestFailure(message, null);
     }
 
-    static void reportTestFailure(@Nonnull String message, @Nullable Throwable throwable) {
+    static void reportTestFailure(String message, @Nullable Throwable throwable) {
         logger.error(message);
         if (throwable == null) {
             Assertions.fail(message);
@@ -326,9 +320,9 @@ public final class QueryCommand extends Command {
         return needsSerialEnvironment;
     }
 
-    private static void runWithDebugger(@Nonnull YamlExecutionContext executionContext,
-                                        @Nonnull DebuggerImplementation debuggerImplementation,
-                                        @Nonnull ThrowingRunnable r) throws SQLException {
+    private static void runWithDebugger(YamlExecutionContext executionContext,
+                                        DebuggerImplementation debuggerImplementation,
+                                        ThrowingRunnable r) throws SQLException {
         final var savedDebugger = Debugger.getDebugger();
         try {
             Debugger.setDebugger(debuggerImplementation.newDebugger(executionContext));

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryConfig.java
@@ -43,12 +43,12 @@ import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
 import org.opentest4j.AssertionFailedError;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Set;
 
 import static com.apple.foundationdb.relational.yamltests.command.QueryCommand.reportTestFailure;
@@ -116,16 +116,15 @@ public abstract class QueryConfig {
     private static final Set<String> RESULT_CONSUMING_CONFIGS = ImmutableSet.of(QUERY_CONFIG_ERROR, QUERY_CONFIG_COUNT, QUERY_CONFIG_RESULT, QUERY_CONFIG_UNORDERED_RESULT);
 
     @Nullable private final Object value;
-    @Nonnull private final YamlReference reference;
+    private final YamlReference reference;
     @Nullable private final String configName;
 
-    protected QueryConfig(@Nullable String configName, @Nullable Object value, @Nonnull final YamlReference reference) {
+    protected QueryConfig(@Nullable String configName, @Nullable Object value, final YamlReference reference) {
         this.configName = configName;
         this.value = value;
         this.reference = reference;
     }
 
-    @Nonnull
     protected YamlReference getReference() {
         return reference;
     }
@@ -142,7 +141,8 @@ public abstract class QueryConfig {
 
     protected String getValueString() {
         if (value instanceof byte[]) {
-            return ByteArrayUtil2.loggable((byte[]) value);
+            // loggable() only returns null for a null input array, which value is not, per the instanceof check above.
+            return Objects.requireNonNull(ByteArrayUtil2.loggable((byte[]) value));
         } else if (value != null) {
             return value.toString();
         } else {
@@ -150,12 +150,12 @@ public abstract class QueryConfig {
         }
     }
 
-    protected String decorateQuery(@Nonnull String query) {
+    protected String decorateQuery(String query) {
         return query;
     }
 
-    final void checkResult(@Nonnull String currentQuery, @Nonnull Object actual, @Nonnull String queryDescription,
-                           @Nonnull YamlConnection connection, @Nonnull List<String> setups) {
+    final void checkResult(String currentQuery, Object actual, String queryDescription,
+                           YamlConnection connection, List<String> setups) {
         try {
             checkResultInternal(currentQuery, actual, queryDescription, setups);
         } catch (AssertionFailedError e) {
@@ -169,7 +169,7 @@ public abstract class QueryConfig {
         }
     }
 
-    final void checkError(@Nonnull SQLException actual, @Nonnull String queryDescription, final YamlConnection connection) {
+    final void checkError(SQLException actual, String queryDescription, final YamlConnection connection) {
         try {
             checkErrorInternal(actual, queryDescription);
         } catch (AssertionFailedError e) {
@@ -183,10 +183,10 @@ public abstract class QueryConfig {
         }
     }
 
-    protected abstract void checkResultInternal(@Nonnull String currentQuery, @Nonnull Object actual,
-                                                @Nonnull String queryDescription, @Nonnull List<String> setups) throws SQLException;
+    protected abstract void checkResultInternal(String currentQuery, Object actual,
+                                                String queryDescription, List<String> setups) throws SQLException;
 
-    void checkErrorInternal(@Nonnull SQLException e, @Nonnull String queryDescription) throws SQLException {
+    void checkErrorInternal(SQLException e, String queryDescription) throws SQLException {
         final var diffMessage = "‼️ statement failed with the following error at " + getReference() + ":\n" +
                 "⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤\n" +
                 e.getMessage() + "\n" +
@@ -197,19 +197,21 @@ public abstract class QueryConfig {
     }
 
     private static QueryConfig getCheckResultConfig(boolean isExpectedOrdered, @Nullable String configName,
-                                                    @Nullable Object value, @Nonnull final YamlReference reference) {
+                                                    @Nullable Object value, final YamlReference reference) {
         return new QueryConfig(configName, value, reference) {
 
             @Override
-            protected void checkResultInternal(@Nonnull String currentQuery, @Nonnull Object actual,
-                                               @Nonnull String queryDescription, @Nonnull List<String> setups) throws SQLException {
+            protected void checkResultInternal(String currentQuery, Object actual,
+                                               String queryDescription, List<String> setups) throws SQLException {
                 logger.debug("⛳️ Matching results of query '{}'", queryDescription);
                 try (RelationalResultSet resultSet = (RelationalResultSet)actual) {
                     final var matchResult = Matchers.matchResultSet(getVal(), resultSet, isExpectedOrdered);
-                    if (!matchResult.getLeft().equals(Matchers.ResultSetMatchResult.success())) {
+                    // matchResultSet() always populates the left side of the pair with a match result.
+                    final var matchResultLeft = Matchers.notNull(matchResult.getLeft(), "match result");
+                    if (!matchResultLeft.equals(Matchers.ResultSetMatchResult.success())) {
                         var toReport = "‼️ result mismatch at " + getReference() + ":\n" +
                                 "⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤\n" +
-                                Matchers.notNull(matchResult.getLeft().getExplanation(), "failure error message") + "\n" +
+                                Matchers.notNull(matchResultLeft.getExplanation(), "failure error message") + "\n" +
                                 "⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤\n";
                         final var valueString = getValueString();
                         if (!valueString.isEmpty()) {
@@ -230,25 +232,25 @@ public abstract class QueryConfig {
         };
     }
 
-    private static QueryConfig getCheckExplainConfig(boolean isExact, @Nonnull String blockName,
-                                                     @Nonnull String configName, @Nullable Object value,
-                                                     @Nonnull final YamlReference reference, @Nonnull YamlExecutionContext executionContext) {
+    private static QueryConfig getCheckExplainConfig(boolean isExact, String blockName,
+                                                     String configName, @Nullable Object value,
+                                                     final YamlReference reference, YamlExecutionContext executionContext) {
         return new CheckExplainConfig(configName, value, reference, executionContext, isExact, blockName);
     }
 
-    private static QueryConfig getCheckResultMetadataConfig(@Nonnull String configName, @Nullable Object value,
-                                                            @Nonnull final YamlReference reference,
-                                                            @Nonnull YamlExecutionContext executionContext) {
+    private static QueryConfig getCheckResultMetadataConfig(String configName, @Nullable Object value,
+                                                            final YamlReference reference,
+                                                            YamlExecutionContext executionContext) {
         return new CheckResultMetadataConfig(configName, value, reference, executionContext);
     }
 
-    private static QueryConfig getCheckErrorConfig(@Nullable Object value, @Nonnull final YamlReference reference) {
+    private static QueryConfig getCheckErrorConfig(@Nullable Object value, final YamlReference reference) {
         final String expectedCode = resolveErrorCode(value, reference);
         return new QueryConfig(QUERY_CONFIG_ERROR, value, reference) {
 
             @Override
-            protected void checkResultInternal(@Nonnull String currentQuery, @Nonnull Object actual,
-                                               @Nonnull String queryDescription, @Nonnull List<String> setups) throws SQLException {
+            protected void checkResultInternal(String currentQuery, Object actual,
+                                               String queryDescription, List<String> setups) throws SQLException {
                 Matchers.ResultSetPrettyPrinter resultSetPrettyPrinter = new Matchers.ResultSetPrettyPrinter();
                 if (actual instanceof ErrorCapturingResultSet) {
                     Matchers.printRemaining((ErrorCapturingResultSet) actual, resultSetPrettyPrinter);
@@ -269,7 +271,7 @@ public abstract class QueryConfig {
             }
 
             @Override
-            void checkErrorInternal(@Nonnull SQLException e, @Nonnull String queryDescription) {
+            void checkErrorInternal(SQLException e, String queryDescription) {
                 logger.debug("⛳️ Checking error code resulted from executing '{}'", queryDescription);
                 final String actualCode = e.getSQLState();
                 if (!actualCode.equals(expectedCode)) {
@@ -286,9 +288,9 @@ public abstract class QueryConfig {
      * Accepts either a raw 5-character SQLSTATE code (e.g. {@code "42601"}) or an
      * {@link ErrorCode} enum name (e.g. {@code "SYNTAX_ERROR"}) for readability.
      */
-    private static String resolveErrorCode(@Nullable Object value, @Nonnull YamlReference reference) {
+    private static String resolveErrorCode(@Nullable Object value, YamlReference reference) {
         if (value == null) {
-            return null;
+            throw new IllegalArgumentException("'error' config at " + reference + " requires a SQLSTATE code or ErrorCode enum name, but no value was given");
         }
         final String str = value.toString();
         if (str.length() == 5) {
@@ -316,12 +318,12 @@ public abstract class QueryConfig {
         return errorCode.name() + " (" + code + ")";
     }
 
-    private static QueryConfig getCheckCountConfig(@Nullable Object value, @Nonnull final YamlReference reference) {
+    private static QueryConfig getCheckCountConfig(@Nullable Object value, final YamlReference reference) {
         return new QueryConfig(QUERY_CONFIG_COUNT, value, reference) {
 
             @Override
-            protected void checkResultInternal(@Nonnull String currentQuery, @Nonnull Object actual,
-                                               @Nonnull String queryDescription, @Nonnull List<String> setups) {
+            protected void checkResultInternal(String currentQuery, Object actual,
+                                               String queryDescription, List<String> setups) {
                 logger.debug("⛳️ Matching count of update query '{}'", queryDescription);
                 if (!Matchers.matches(getVal(), actual)) {
                     reportTestFailure("‼️ Expected count value " + getVal() + ", but got " + actual + " at line " + getReference());
@@ -332,18 +334,18 @@ public abstract class QueryConfig {
         };
     }
 
-    private static QueryConfig getCheckPlanHashConfig(@Nullable Object value, @Nonnull YamlReference reference) {
+    private static QueryConfig getCheckPlanHashConfig(@Nullable Object value, YamlReference reference) {
         return new QueryConfig(QUERY_CONFIG_PLAN_HASH, value, reference) {
 
             @Override
-            protected String decorateQuery(@Nonnull String query) {
+            protected String decorateQuery(String query) {
                 return "EXPLAIN " + query;
             }
 
             @SuppressWarnings("PMD.CloseResource") // lifetime of autocloseable persists beyond method
             @Override
-            protected void checkResultInternal(@Nonnull String currentQuery, @Nonnull Object actual,
-                                               @Nonnull String queryDescription, @Nonnull List<String> setups) throws SQLException {
+            protected void checkResultInternal(String currentQuery, Object actual,
+                                               String queryDescription, List<String> setups) throws SQLException {
                 logger.debug("⛳️ Matching plan hash of query '{}'", queryDescription);
                 final var resultSet = (RelationalResultSet) actual;
                 resultSet.next();
@@ -356,12 +358,12 @@ public abstract class QueryConfig {
         };
     }
 
-    public static QueryConfig getNoCheckConfig(@Nonnull final YamlReference reference) {
+    public static QueryConfig getNoCheckConfig(final YamlReference reference) {
         return new QueryConfig(QUERY_CONFIG_NO_CHECKS, null, reference) {
             @SuppressWarnings("PMD.CloseResource") // lifetime of autocloseable persists beyond method
             @Override
-            protected void checkResultInternal(@Nonnull String currentQuery, @Nonnull Object actual,
-                                               @Nonnull String queryDescription, @Nonnull List<String> setups) throws SQLException {
+            protected void checkResultInternal(String currentQuery, Object actual,
+                                               String queryDescription, List<String> setups) throws SQLException {
                 if (actual instanceof final RelationalResultSet resultSet) {
                     // slurp
                     boolean valid = true;
@@ -374,47 +376,46 @@ public abstract class QueryConfig {
         };
     }
 
-    private static QueryConfig getMaxRowConfig(@Nonnull Object value, @Nonnull final YamlReference reference) {
+    private static QueryConfig getMaxRowConfig(Object value, final YamlReference reference) {
         return new QueryConfig(QUERY_CONFIG_MAX_ROWS, value, reference) {
             @Override
-            protected void checkResultInternal(@Nonnull String currentQuery, @Nonnull Object actual,
-                                               @Nonnull String queryDescription, @Nonnull List<String> setups) {
+            protected void checkResultInternal(String currentQuery, Object actual,
+                                               String queryDescription, List<String> setups) {
                 Assert.failUnchecked("No results to check on a maxRow config");
             }
         };
     }
 
-    private static QueryConfig getSetupConfig(final Object value, @Nonnull final YamlReference reference) {
+    private static QueryConfig getSetupConfig(final Object value, final YamlReference reference) {
         return new QueryConfig(QUERY_CONFIG_SETUP, value, reference) {
             @Override
-            protected void checkResultInternal(@Nonnull final String currentQuery, @Nonnull final Object actual,
-                                               @Nonnull final String queryDescription, @Nonnull List<String> setups) {
+            protected void checkResultInternal(final String currentQuery, final Object actual,
+                                               final String queryDescription, List<String> setups) {
                 Assert.failUnchecked("No results to check on a setup config");
             }
         };
     }
 
-    private static QueryConfig getDebuggerConfig(@Nonnull Object value, @Nonnull final YamlReference reference) {
+    private static QueryConfig getDebuggerConfig(Object value, final YamlReference reference) {
         return new QueryConfig(QUERY_CONFIG_DEBUGGER, DebuggerImplementation.valueOf(((String)value).toUpperCase(Locale.ROOT)),
                 reference) {
             @Override
-            protected void checkResultInternal(@Nonnull String currentQuery, @Nonnull Object actual,
-                                               @Nonnull String queryDescription, @Nonnull List<String> setups) throws SQLException {
+            protected void checkResultInternal(String currentQuery, Object actual,
+                                               String queryDescription, List<String> setups) throws SQLException {
                 Assert.failUnchecked("No results to check on a debugger config");
             }
         };
     }
 
-    @Nonnull
-    public static QueryConfig getSupportedVersionConfig(Object rawVersion, @Nonnull final YamlReference reference, final YamlExecutionContext executionContext) {
+    public static QueryConfig getSupportedVersionConfig(Object rawVersion, final YamlReference reference, final YamlExecutionContext executionContext) {
         final SupportedVersionCheck check = SupportedVersionCheck.parse(rawVersion, executionContext.getConnectionFactory().getVersionsUnderTest());
         if (!check.isSupported()) {
             return new SkipConfig(QUERY_CONFIG_SUPPORTED_VERSION, rawVersion, reference, check.getMessage());
         }
         return new QueryConfig(QUERY_CONFIG_SUPPORTED_VERSION, rawVersion, reference) {
             @Override
-            protected void checkResultInternal(@Nonnull final String currentQuery, @Nonnull final Object actual,
-                                               @Nonnull final String queryDescription, @Nonnull final List<String> setups) {
+            protected void checkResultInternal(final String currentQuery, final Object actual,
+                                               final String queryDescription, final List<String> setups) {
                 // Nothing to do, this query is supported
                 // SupportedVersion configs are not executed
                 Assertions.fail("Supported version configs are not meant to be executed.");
@@ -429,21 +430,20 @@ public abstract class QueryConfig {
      * @param reference the {@link YamlReference} in the test file
      * @return an instance of a NoOp config
      */
-    public static QueryConfig getNoOpConfig(@Nonnull final YamlReference reference) {
+    public static QueryConfig getNoOpConfig(final YamlReference reference) {
         return new QueryConfig(QUERY_CONFIG_NO_OP, null, reference) {
             @SuppressWarnings("PMD.CloseResource") // lifetime of autocloseable persists beyond method
             @Override
-            protected void checkResultInternal(@Nonnull String currentQuery, @Nonnull Object actual,
-                                               @Nonnull String queryDescription, @Nonnull List<String> setups) throws SQLException {
+            protected void checkResultInternal(String currentQuery, Object actual,
+                                               String queryDescription, List<String> setups) throws SQLException {
                 // This should not be executed
                 Assertions.fail("NoOp Config should not be executed");
             }
         };
     }
 
-    @Nonnull
-    public static List<QueryConfig> parseConfigs(String blockName, @Nonnull final YamlReference commandReference,
-                                                 @Nonnull List<?> objects, @Nonnull YamlExecutionContext executionContext) {
+    public static List<QueryConfig> parseConfigs(String blockName, final YamlReference commandReference,
+                                                 List<?> objects, YamlExecutionContext executionContext) {
         List<QueryConfig> configs = new ArrayList<>();
         // After the first result config, require all future results are also result configs. That is, we should
         // not interleave explain, maxRows, etc., and result configurations, and the results should be the last
@@ -473,7 +473,7 @@ public abstract class QueryConfig {
         return configs;
     }
 
-    private static QueryConfig getInitialVersionCheckConfig(Object key, Object value, @Nonnull final YamlReference reference) {
+    private static QueryConfig getInitialVersionCheckConfig(Object key, Object value, final YamlReference reference) {
         try {
             SemanticVersion versionArgument = PreambleBlock.parseVersion(value);
             if (QUERY_CONFIG_INITIAL_VERSION_AT_LEAST.equals(key)) {
@@ -490,7 +490,7 @@ public abstract class QueryConfig {
         }
     }
 
-    private static QueryConfig parseConfig(String blockName, String key, Object value, @Nonnull final YamlReference reference, YamlExecutionContext executionContext) {
+    private static QueryConfig parseConfig(String blockName, String key, Object value, final YamlReference reference, YamlExecutionContext executionContext) {
         if (QUERY_CONFIG_SUPPORTED_VERSION.equals(key)) {
             return getSupportedVersionConfig(value, reference, executionContext);
         } else if (VERSION_DEPENDENT_RESULT_CONFIGS.contains(key)) {
@@ -536,7 +536,7 @@ public abstract class QueryConfig {
         }
     }
 
-    private static void validateConfigs(List<QueryConfig> configs, @Nonnull final YamlReference reference) {
+    private static void validateConfigs(List<QueryConfig> configs, final YamlReference reference) {
         Assert.thatUnchecked(configs.stream().skip(1)
                         .noneMatch(config -> QueryConfig.QUERY_CONFIG_SUPPORTED_VERSION.equals(config.getConfigName())),
                 "supported_version must be the first config in a query (after the query itself)");
@@ -565,14 +565,14 @@ public abstract class QueryConfig {
     public static class SkipConfig extends QueryConfig {
         private final String message;
 
-        public SkipConfig(final String configMap, final Object value, @Nonnull final YamlReference reference, final String message) {
+        public SkipConfig(final String configMap, final Object value, final YamlReference reference, final String message) {
             super(configMap, value, reference);
             this.message = message;
         }
 
         @Override
-        protected void checkResultInternal(@Nonnull final String currentQuery, @Nonnull final Object actual,
-                                           @Nonnull final String queryDescription, @Nonnull final List<String> setups) {
+        protected void checkResultInternal(final String currentQuery, final Object actual,
+                                           final String queryDescription, final List<String> setups) {
             Assertions.fail("Skipped config should not be executed: at " + getReference() + " " + message);
         }
 
@@ -585,7 +585,7 @@ public abstract class QueryConfig {
         private final SemanticVersion minVersion;
         private final SemanticVersion maxVersion;
 
-        public InitialVersionCheckConfig(final String configName, final Object value, @Nonnull final YamlReference reference,
+        public InitialVersionCheckConfig(final String configName, final Object value, final YamlReference reference,
                                          SemanticVersion minVersion, SemanticVersion maxVersion) {
             super(configName, value, reference);
             this.minVersion = minVersion;
@@ -598,17 +598,15 @@ public abstract class QueryConfig {
         }
 
         @Override
-        protected void checkResultInternal(@Nonnull final String currentQuery, @Nonnull final Object actual,
-                                           @Nonnull final String queryDescription, @Nonnull final List<String> setups) throws SQLException {
+        protected void checkResultInternal(final String currentQuery, final Object actual,
+                                           final String queryDescription, final List<String> setups) throws SQLException {
             Assertions.fail("Check version config should not be executed: at " + getReference());
         }
 
-        @Nonnull
         public SemanticVersion getMinVersion() {
             return minVersion;
         }
 
-        @Nonnull
         public SemanticVersion getMaxVersion() {
             return maxVersion;
         }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryExecutor.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryExecutor.java
@@ -38,8 +38,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -61,9 +60,7 @@ public class QueryExecutor {
     @SuppressWarnings("PMD.AvoidUsingHardCodedIP") // This is not an IP address
     private static final SemanticVersion STRICT_ASSERTIONS_CUTOFF = SemanticVersion.parse("4.1.9.0");
 
-    @Nonnull
     private final String query;
-    @Nonnull
     private final YamlReference reference;
     // Whether to force continuations if the query does not use continuations explicitly.
     private final boolean forceContinuations;
@@ -73,7 +70,6 @@ public class QueryExecutor {
      */
     @Nullable
     private final List<Parameter> parameters;
-    @Nonnull
     private final List<String> setup = new ArrayList<>();
 
     /**
@@ -83,7 +79,7 @@ public class QueryExecutor {
      * @param parameters the parameters to bind
      * @param forceContinuations Whether to force continuations in case the query does not explicitly specify maxRows.
      */
-    QueryExecutor(@Nonnull String query, @Nonnull final YamlReference reference, @Nullable List<Parameter> parameters, boolean forceContinuations) {
+    QueryExecutor(String query, final YamlReference reference, @Nullable List<Parameter> parameters, boolean forceContinuations) {
         this.reference = reference;
         this.query = query;
         this.parameters = parameters;
@@ -101,8 +97,8 @@ public class QueryExecutor {
      * @throws RelationalException in case of error
      */
     @Nullable
-    public Continuation execute(@Nonnull YamlConnection connection, @Nullable Continuation continuation,
-                                @Nonnull QueryConfig config, boolean checkCache, @Nullable Integer maxRows) throws RelationalException {
+    public Continuation execute(YamlConnection connection, @Nullable Continuation continuation,
+                                QueryConfig config, boolean checkCache, @Nullable Integer maxRows) throws RelationalException {
         return execute(connection, continuation, config, checkCache, maxRows, null);
     }
 
@@ -117,8 +113,8 @@ public class QueryExecutor {
      * @param inlineMetadataConfig metadata config to check before rows are consumed, or {@code null} to skip
      */
     @Nullable
-    public Continuation execute(@Nonnull YamlConnection connection, @Nullable Continuation continuation,
-                                @Nonnull QueryConfig config, boolean checkCache, @Nullable Integer maxRows,
+    public Continuation execute(YamlConnection connection, @Nullable Continuation continuation,
+                                QueryConfig config, boolean checkCache, @Nullable Integer maxRows,
                                 @Nullable CheckResultMetadataConfig inlineMetadataConfig) throws RelationalException {
         final var currentQuery = config.decorateQuery(query);
         if (continuation == null) {
@@ -149,8 +145,8 @@ public class QueryExecutor {
             "PMD.CloseResource", // lifetime of autocloseable resource persists beyond current method
             "PMD.CompareObjectsWithEquals" // pointer equality used on purpose
     })
-    private Object executeStatementAndCheckCacheIfNeeded(@Nonnull Statement s, final boolean statementHasQuery, @Nonnull YamlConnection connection,
-                                                         @Nonnull String queryString, boolean checkCache, @Nullable Integer maxRows) throws SQLException, RelationalException {
+    private Object executeStatementAndCheckCacheIfNeeded(Statement s, final boolean statementHasQuery, YamlConnection connection,
+                                                         String queryString, boolean checkCache, @Nullable Integer maxRows) throws SQLException, RelationalException {
         if (!checkCache) {
             return executeStatementAndCheckForceContinuations(s, statementHasQuery, queryString, connection, maxRows);
         }
@@ -174,8 +170,8 @@ public class QueryExecutor {
     }
 
     @Nullable
-    private Continuation executeQuery(@Nonnull YamlConnection connection, @Nonnull QueryConfig config,
-                                      @Nonnull String currentQuery, boolean checkCache, @Nullable Integer maxRows,
+    private Continuation executeQuery(YamlConnection connection, QueryConfig config,
+                                      String currentQuery, boolean checkCache, @Nullable Integer maxRows,
                                       @Nullable CheckResultMetadataConfig inlineMetadataConfig) throws RelationalException {
         Continuation continuationAfter = null;
         try {
@@ -215,10 +211,10 @@ public class QueryExecutor {
     }
 
     @Nullable
-    private Continuation executeWithSetup(final @Nonnull YamlConnection connection,
-                                          SQLFunction<YamlConnection, Continuation> execute) throws SQLException, RelationalException {
+    private Continuation executeWithSetup(final YamlConnection connection,
+                                          SQLFunction<YamlConnection, @Nullable Continuation> execute) throws SQLException, RelationalException {
         if (!setup.isEmpty()) {
-            return connection.executeTransactionally(singleConnection -> {
+            return connection.<@Nullable Continuation>executeTransactionally(singleConnection -> {
                 for (var setupStatement : setup) {
                     final RelationalStatement statement = singleConnection.createStatement();
                     statement.execute(setupStatement);
@@ -231,8 +227,8 @@ public class QueryExecutor {
     }
 
     @Nullable
-    private Continuation executeContinuation(@Nonnull YamlConnection connection, @Nonnull Continuation continuation,
-                                             @Nonnull QueryConfig config, final @Nonnull String currentQuery,
+    private Continuation executeContinuation(YamlConnection connection, Continuation continuation,
+                                             QueryConfig config, final String currentQuery,
                                              @Nullable Integer maxRows,
                                              @Nullable CheckResultMetadataConfig inlineMetadataConfig) {
         Continuation continuationAfter = null;
@@ -261,9 +257,9 @@ public class QueryExecutor {
      * and call {@link CheckResultMetadataConfig#checkInline} <em>before</em> any rows are consumed.
      */
     private static void checkInlineMetadataIfPresent(@Nullable CheckResultMetadataConfig inlineMetadataConfig,
-                                                     @Nonnull Object queryResult,
-                                                     @Nonnull String currentQuery,
-                                                     @Nonnull YamlConnection connection) throws SQLException {
+                                                     Object queryResult,
+                                                     String currentQuery,
+                                                     YamlConnection connection) throws SQLException {
         if (inlineMetadataConfig == null || !(queryResult instanceof RelationalResultSet)) {
             return;
         }
@@ -272,8 +268,8 @@ public class QueryExecutor {
         inlineMetadataConfig.checkInline(descriptors, currentQuery, connection);
     }
 
-    private RelationalPreparedStatement prepareContinuationStatement(@Nonnull YamlConnection connection,
-                                                                     @Nonnull Continuation continuation,
+    private RelationalPreparedStatement prepareContinuationStatement(YamlConnection connection,
+                                                                     Continuation continuation,
                                                                      @Nullable Integer maxRows) throws SQLException {
         var s = connection.prepareStatement("EXECUTE CONTINUATION ?;");
         if (maxRows != null) {
@@ -287,7 +283,7 @@ public class QueryExecutor {
         return s;
     }
 
-    private Object executeStatementAndCheckForceContinuations(@Nonnull Statement s, final boolean statementHasQuery, @Nonnull String queryString,
+    private Object executeStatementAndCheckForceContinuations(Statement s, final boolean statementHasQuery, String queryString,
                                                               final YamlConnection connection, @Nullable Integer maxRows) throws SQLException {
         // Check if we need to force continuations
         if ((maxRows == null) && forceContinuations && isForcedContinuationsEligible(queryString)) {
@@ -301,13 +297,13 @@ public class QueryExecutor {
         }
     }
 
-    private boolean isForcedContinuationsEligible(final @Nonnull String queryString) {
+    private boolean isForcedContinuationsEligible(final String queryString) {
         return (queryString.trim().toLowerCase(Locale.ROOT).startsWith("select"));
     }
 
-    private Object executeStatementWithForcedContinuations(final @Nonnull Statement s,
-                                                           final boolean statementHasQuery, final @Nonnull String queryString,
-                                                           final @Nonnull YamlConnection connection) throws SQLException {
+    private Object executeStatementWithForcedContinuations(final Statement s,
+                                                           final boolean statementHasQuery, final String queryString,
+                                                           final YamlConnection connection) throws SQLException {
         s.setMaxRows(FORCED_MAX_ROWS);
         Object result = executeStatement(s, statementHasQuery, queryString);
         if (result instanceof @SuppressWarnings("PMD.CloseResource") RelationalResultSet resultSet) {
@@ -374,19 +370,18 @@ public class QueryExecutor {
         return false;
     }
 
-    private static Object executeStatement(@Nonnull Statement s, final boolean statementHasQuery, @Nonnull String q) throws SQLException {
+    private static Object executeStatement(Statement s, final boolean statementHasQuery, String q) throws SQLException {
         final var execResult = statementHasQuery ? ((PreparedStatement) s).execute() : s.execute(q);
         return execResult ? s.getResultSet() : s.getUpdateCount();
     }
 
-    private void setParametersInPreparedStatement(@Nonnull RelationalPreparedStatement statement) throws SQLException {
+    private void setParametersInPreparedStatement(RelationalPreparedStatement statement) throws SQLException {
         int counter = 1;
         for (var parameter : Objects.requireNonNull(parameters)) {
             statement.setObject(counter++, parameter.getSqlObject(statement.getConnection()));
         }
     }
 
-    @Nonnull
     @Override
     public String toString() {
         if (parameters == null) {

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryInterpreter.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/QueryInterpreter.java
@@ -43,11 +43,11 @@ import org.yaml.snakeyaml.nodes.ScalarNode;
 import org.yaml.snakeyaml.nodes.SequenceNode;
 import org.yaml.snakeyaml.nodes.Tag;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Random;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -82,11 +82,8 @@ import static com.apple.foundationdb.relational.yamltests.Matchers.constructVect
  * Here, the parameter can randomly take different values between 2 and 9 in each binding.
  */
 public final class QueryInterpreter {
-    @Nonnull
     private final String query;
-    @Nonnull
     private final YamlReference reference;
-    @Nonnull
     private final YamlExecutionContext executionContext;
     /**
      * {@link List} of the snippet text and interpreted parameter injection. Note that the parameter can be a
@@ -168,7 +165,7 @@ public final class QueryInterpreter {
                     var values = ((MappingNode) node).getValue();
                     return new UnboundParameter.RandomSetParameter(values.stream().map(v -> constructObject(v.getKeyNode())).collect(Collectors.toList()));
                 }
-                return null;
+                throw Assert.failUnchecked("!r expects a sequence of 1 or 2 elements, or a set.");
             }
         }
 
@@ -200,7 +197,7 @@ public final class QueryInterpreter {
                     Assert.thatUnchecked(values.size() == 2, "!a expects a set to have 2 elements.");
                     return new UnboundParameter.ElementMultiplicityListParameter(constructObject(values.get(0).getKeyNode()), constructObject(values.get(1).getKeyNode()));
                 }
-                return null;
+                throw Assert.failUnchecked("!a expects a sequence of 1 or 2 elements, or a set.");
             }
         }
 
@@ -274,7 +271,7 @@ public final class QueryInterpreter {
         }
     }
 
-    private QueryInterpreter(@Nonnull final YamlReference reference, @Nonnull String query, @Nonnull final YamlExecutionContext executionContext) {
+    private QueryInterpreter(final YamlReference reference, String query, final YamlExecutionContext executionContext) {
         this.query = query;
         this.reference = reference;
         this.injections = getInjections(query);
@@ -284,12 +281,11 @@ public final class QueryInterpreter {
     /**
      * The original query string with embedded parameter injections.
      */
-    @Nonnull
     String getQuery() {
         return query;
     }
 
-    private List<Pair<String, Parameter>> getInjections(@Nonnull String query) {
+    private List<Pair<String, Parameter>> getInjections(String query) {
 
         final var lst = new ArrayList<Pair<String, Parameter>>();
         int cursor = 0;
@@ -306,7 +302,7 @@ public final class QueryInterpreter {
         return lst;
     }
 
-    public static QueryInterpreter withQueryString(@Nonnull final YamlReference reference, @Nonnull String query, @Nonnull final YamlExecutionContext executionContext) {
+    public static QueryInterpreter withQueryString(final YamlReference reference, String query, final YamlExecutionContext executionContext) {
         return new QueryInterpreter(reference, query, executionContext);
     }
 
@@ -321,7 +317,6 @@ public final class QueryInterpreter {
      * @param runAsPreparedStatement if the executor should execute the query using {@link com.apple.foundationdb.relational.api.RelationalPreparedStatement} API.
      * @return the executor that can execute the query.
      */
-    @Nonnull
     public QueryExecutor getExecutor(@Nullable Random random, boolean runAsPreparedStatement) {
         try {
             final boolean forceContinuations = executionContext.getOption(YamlExecutionContext.OPTION_FORCE_CONTINUATIONS, false);
@@ -330,7 +325,7 @@ public final class QueryInterpreter {
                 Assert.thatUnchecked(injections.isEmpty(), "Parameter injection is not allowed in query without a Random(generator)");
                 return new QueryExecutor(query, reference, null, forceContinuations);
             } else {
-                var boundInjections = injections.stream().map(i -> (Pair.of(i.getLeft(), i.getRight().bind(random)))).collect(Collectors.toList());
+                var boundInjections = injections.stream().map(i -> (Pair.of(i.getLeft(), Objects.requireNonNull(i.getRight()).bind(random)))).collect(Collectors.toList());
                 if (runAsPreparedStatement) {
                     return new QueryExecutor(adaptToPreparedStatement(query, boundInjections), reference, boundInjections.stream().map(Pair::getRight).collect(Collectors.toList()), forceContinuations);
                 } else {
@@ -342,8 +337,7 @@ public final class QueryInterpreter {
         }
     }
 
-    @Nonnull
-    private static String adaptToPreparedStatement(@Nonnull String query, @Nonnull List<Pair<String, Parameter>> injections) {
+    private static String adaptToPreparedStatement(String query, List<Pair<String, Parameter>> injections) {
         String adaptedString = query;
         for (var injection : injections) {
             adaptedString = adaptedString.replace(injection.getLeft(), "?");
@@ -351,11 +345,10 @@ public final class QueryInterpreter {
         return adaptedString;
     }
 
-    @Nonnull
-    private static String adaptToSimpleStatement(@Nonnull String query, @Nonnull List<Pair<String, Parameter>> injections) {
+    private static String adaptToSimpleStatement(String query, List<Pair<String, Parameter>> injections) {
         String adaptedString = query;
         for (var injection : injections) {
-            adaptedString = adaptedString.replace(injection.getLeft(), injection.getRight().getSqlText());
+            adaptedString = adaptedString.replace(injection.getLeft(), Objects.requireNonNull(injection.getRight()).getSqlText());
         }
         return adaptedString;
     }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/SQLFunction.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/SQLFunction.java
@@ -21,10 +21,11 @@
 package com.apple.foundationdb.relational.yamltests.command;
 
 import com.apple.foundationdb.relational.api.exceptions.RelationalException;
+import org.jspecify.annotations.Nullable;
 
 import java.sql.SQLException;
 
 @FunctionalInterface
-public interface SQLFunction<T, R> {
+public interface SQLFunction<T, R extends @Nullable Object> {
     R apply(T t) throws SQLException, RelationalException;
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/SkippedCommand.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/SkippedCommand.java
@@ -28,7 +28,6 @@ import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import javax.annotation.Nonnull;
 import java.sql.SQLException;
 
 /**
@@ -38,20 +37,18 @@ import java.sql.SQLException;
  */
 public class SkippedCommand extends Command {
     private static final Logger logger = LogManager.getLogger(SkippedCommand.class);
-    @Nonnull
     private final String message;
-    @Nonnull
     private final String query;
 
-    SkippedCommand(@Nonnull final YamlReference reference, @Nonnull final YamlExecutionContext executionContext,
-                   @Nonnull String message, @Nonnull final String query) {
+    SkippedCommand(final YamlReference reference, final YamlExecutionContext executionContext,
+                   String message, final String query) {
         super(reference, executionContext);
         this.message = message;
         this.query = query;
     }
 
     @Override
-    void executeInternal(@Nonnull final YamlConnection connection) throws SQLException, RelationalException {
+    void executeInternal(final YamlConnection connection) throws SQLException, RelationalException {
         Assert.fail("Skipped commands should not be called");
     }
 

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/package-info.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/package-info.java
@@ -22,4 +22,7 @@
  * This package contains all the action items that are available in the YAML testing framework.
  */
 
+@NullMarked
 package com.apple.foundationdb.relational.yamltests.command;
+
+import org.jspecify.annotations.NullMarked;

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/parameterinjection/InListParameter.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/parameterinjection/InListParameter.java
@@ -24,8 +24,7 @@ import com.apple.foundationdb.relational.util.Assert;
 
 import org.junit.jupiter.api.Assumptions;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Random;
@@ -33,16 +32,14 @@ import java.util.stream.Collectors;
 
 public class InListParameter implements Parameter {
 
-    @Nonnull
     private final Parameter parameter;
 
-    public InListParameter(@Nonnull Parameter parameter) {
+    public InListParameter(Parameter parameter) {
         this.parameter = parameter;
     }
 
-    @Nonnull
     @Override
-    public InListParameter bind(@Nonnull Random random) {
+    public InListParameter bind(Random random) {
         if (!isUnbound()) {
             return this;
         }
@@ -62,7 +59,6 @@ public class InListParameter implements Parameter {
         return parameter.getSqlObject(connection);
     }
 
-    @Nonnull
     @Override
     public String getSqlText() {
         ensureBoundedness();

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/parameterinjection/ListParameter.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/parameterinjection/ListParameter.java
@@ -22,9 +22,9 @@ package com.apple.foundationdb.relational.yamltests.command.parameterinjection;
 
 import com.apple.foundationdb.relational.api.SqlTypeNamesSupport;
 import com.apple.foundationdb.relational.util.Assert;
+import com.apple.foundationdb.relational.util.SpotBugsSuppressWarnings;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.sql.Array;
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -42,16 +42,14 @@ import java.util.stream.Collectors;
  */
 public class ListParameter implements Parameter {
 
-    @Nonnull
     private final List<Parameter> values;
 
-    public ListParameter(@Nonnull List<Parameter> values) {
+    public ListParameter(List<Parameter> values) {
         this.values = values;
     }
 
-    @Nonnull
     @Override
-    public ListParameter bind(@Nonnull Random random) {
+    public ListParameter bind(Random random) {
         if (!isUnbound()) {
             return this;
         }
@@ -63,14 +61,17 @@ public class ListParameter implements Parameter {
         return values.stream().anyMatch(Parameter::isUnbound);
     }
 
-    @Nonnull
     List<Parameter> getValues() {
         return this.values;
     }
 
     @Override
     @Nullable
-    public Object getSqlObject(Connection connection) throws SQLException {
+    @SuppressWarnings("NullAway") // NullAway/JSpecify does not currently track nullability of array element writes;
+    // array legitimately holds SQL NULL entries (see the Objects::nonNull filtering below), same as before this migration.
+    @SpotBugsSuppressWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE",
+            justification = "connection is @Nullable to match the wider Parameter#getSqlObject contract (other implementations, e.g. UnboundParameter, tolerate a null connection); this implementation happens to always need a real Connection to build the java.sql.Array.")
+    public Object getSqlObject(@Nullable Connection connection) throws SQLException {
         ensureBoundedness();
         var array = new Object[values.size()];
         for (int i = 0; i < values.size(); i++) {
@@ -80,8 +81,7 @@ public class ListParameter implements Parameter {
     }
 
     // Best-effort approach to determine the type of constituent elements.
-    @Nonnull
-    private String getSqlTypeName(@Nonnull Object[] array) {
+    private String getSqlTypeName(Object[] array) {
         if (array.length == 0) {
             return SqlTypeNamesSupport.getSqlTypeName(Types.NULL);
         }
@@ -107,11 +107,9 @@ public class ListParameter implements Parameter {
         } else if (firstNonNull instanceof Struct) {
             return SqlTypeNamesSupport.getSqlTypeName(Types.STRUCT);
         }
-        Assert.failUnchecked("ListParameter does not support array of type: " + array[0].getClass().getSimpleName());
-        return null;
+        throw Assert.failUnchecked("ListParameter does not support array of type: " + array[0].getClass().getSimpleName());
     }
 
-    @Nonnull
     @Override
     public String getSqlText() {
         ensureBoundedness();

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/parameterinjection/Parameter.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/parameterinjection/Parameter.java
@@ -24,8 +24,7 @@ import com.apple.foundationdb.relational.api.exceptions.UncheckedRelationalExcep
 import com.apple.foundationdb.relational.util.Assert;
 import com.apple.foundationdb.relational.yamltests.command.QueryCommand;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.sql.Array;
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -67,8 +66,7 @@ public interface Parameter {
      * @param random the {@link Random} instance used to bind the parameters
      * @return {@code this} if the parameter is already bound, else the bound {@link Parameter}
      */
-    @Nonnull
-    Parameter bind(@Nonnull Random random);
+    Parameter bind(Random random);
 
     /**
      * Returns {@code true} if this parameter is bound, else {@code false}.
@@ -100,6 +98,5 @@ public interface Parameter {
      * Returns the {@link String} that is the textual SQL representation of the value of this parameter.
      * @return the string
      */
-    @Nonnull
     String getSqlText();
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/parameterinjection/PrimitiveParameter.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/parameterinjection/PrimitiveParameter.java
@@ -22,8 +22,7 @@ package com.apple.foundationdb.relational.yamltests.command.parameterinjection;
 
 import com.apple.foundationdb.relational.recordlayer.util.Hex;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.sql.Connection;
 import java.util.Random;
 import java.util.UUID;
@@ -39,7 +38,6 @@ public class PrimitiveParameter implements Parameter {
         this.object = object;
     }
 
-    @Nonnull
     @Override
     public String getSqlText() {
         if (object == null) {
@@ -53,9 +51,8 @@ public class PrimitiveParameter implements Parameter {
         }
     }
 
-    @Nonnull
     @Override
-    public PrimitiveParameter bind(@Nonnull Random random) {
+    public PrimitiveParameter bind(Random random) {
         return this;
     }
 

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/parameterinjection/TupleParameter.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/parameterinjection/TupleParameter.java
@@ -20,8 +20,9 @@
 
 package com.apple.foundationdb.relational.yamltests.command.parameterinjection;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import com.apple.foundationdb.relational.util.SpotBugsSuppressWarnings;
+
+import org.jspecify.annotations.Nullable;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.List;
@@ -35,13 +36,12 @@ import java.util.stream.Collectors;
  */
 public class TupleParameter extends ListParameter {
 
-    public TupleParameter(@Nonnull List<Parameter> value) {
+    public TupleParameter(List<Parameter> value) {
         super(value);
     }
 
-    @Nonnull
     @Override
-    public TupleParameter bind(@Nonnull Random random) {
+    public TupleParameter bind(Random random) {
         if (!isUnbound()) {
             return this;
         }
@@ -50,7 +50,11 @@ public class TupleParameter extends ListParameter {
 
     @Override
     @Nullable
-    public Object getSqlObject(Connection connection) throws SQLException {
+    @SuppressWarnings("NullAway") // NullAway/JSpecify does not currently track nullability of array element writes;
+    // array legitimately holds SQL NULL entries, same as before this migration (see ListParameter.getSqlObject).
+    @SpotBugsSuppressWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE",
+            justification = "connection is @Nullable to match the wider Parameter#getSqlObject contract (other implementations, e.g. UnboundParameter, tolerate a null connection); this implementation happens to always need a real Connection to build the java.sql.Struct.")
+    public Object getSqlObject(@Nullable Connection connection) throws SQLException {
         ensureBoundedness();
         var array = new Object[getValues().size()];
         for (int i = 0; i < getValues().size(); i++) {
@@ -61,7 +65,6 @@ public class TupleParameter extends ListParameter {
         return Objects.requireNonNull(connection).createStruct("na", array);
     }
 
-    @Nonnull
     @Override
     public String getSqlText() {
         ensureBoundedness();

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/parameterinjection/UnboundParameter.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/parameterinjection/UnboundParameter.java
@@ -22,10 +22,10 @@ package com.apple.foundationdb.relational.yamltests.command.parameterinjection;
 
 import com.apple.foundationdb.relational.util.Assert;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.sql.Connection;
 import java.util.List;
+import java.util.Objects;
 import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -56,7 +56,6 @@ public abstract class UnboundParameter implements Parameter {
     /**
      * Invalid operation since this parameter is not bound.
      */
-    @Nonnull
     @Override
     public String getSqlText() {
         ensureBoundedness();
@@ -67,16 +66,14 @@ public abstract class UnboundParameter implements Parameter {
      * Given a set of {@link Parameter}s, {@link RandomSetParameter} chooses one of them and return it bound.
      */
     public static class RandomSetParameter extends UnboundParameter {
-        @Nonnull
         List<Parameter> items;
 
-        public RandomSetParameter(@Nonnull List<Parameter> items) {
+        public RandomSetParameter(List<Parameter> items) {
             this.items = items;
         }
 
-        @Nonnull
         @Override
-        public Parameter bind(@Nonnull Random random) {
+        public Parameter bind(Random random) {
             var idx = random.ints(1, 0, items.size()).findFirst().orElseThrow();
             return items.get(idx).bind(random);
         }
@@ -94,20 +91,18 @@ public abstract class UnboundParameter implements Parameter {
     public static class RandomRangeParameter extends UnboundParameter {
         @Nullable
         Parameter lowerBound;
-        @Nonnull
         Parameter upperBound;
 
-        public RandomRangeParameter(@Nonnull Parameter upperBound) {
+        public RandomRangeParameter(Parameter upperBound) {
             this(null, upperBound);
         }
 
-        public RandomRangeParameter(@Nullable Parameter lowerBound, @Nonnull Parameter upperBound) {
+        public RandomRangeParameter(@Nullable Parameter lowerBound, Parameter upperBound) {
             this.lowerBound = lowerBound;
             this.upperBound = upperBound;
         }
 
-        @Nonnull
-        private static Number bindAndVerifyNumberParameter(@Nullable Parameter parameter, @Nonnull Random random) {
+        private static Number bindAndVerifyNumberParameter(@Nullable Parameter parameter, Random random) {
             if (parameter == null) {
                 return 0;
             }
@@ -115,12 +110,12 @@ public abstract class UnboundParameter implements Parameter {
             Assert.thatUnchecked(bound instanceof PrimitiveParameter, "Expecting a Primitive or Random{Range/Set} Parameter");
             var sqlObject = ((PrimitiveParameter) bound).getSqlObject(null);
             Assert.thatUnchecked(sqlObject instanceof Integer || sqlObject instanceof Long || sqlObject instanceof Double, "The expected bound parameter of type Double, Integer or Long");
-            return (Number) sqlObject;
+            // The instanceof checks above imply sqlObject is non-null, but Assert.thatUnchecked doesn't tell NullAway that.
+            return (Number) Objects.requireNonNull(sqlObject);
         }
 
         @Override
-        @Nonnull
-        public Parameter bind(@Nonnull Random random) {
+        public Parameter bind(Random random) {
             final var lb = bindAndVerifyNumberParameter(lowerBound, random);
             final var ub = bindAndVerifyNumberParameter(upperBound, random);
             if (lb instanceof Double || ub instanceof Double) {
@@ -146,25 +141,24 @@ public abstract class UnboundParameter implements Parameter {
      * evaluates the multiplicity and returns a list of "bound" element repeated multiplicity number of time.
      */
     public static class ElementMultiplicityListParameter extends UnboundParameter {
-        @Nonnull
         Parameter element;
-        @Nonnull
         Parameter multiplicity;
 
-        public ElementMultiplicityListParameter(@Nonnull Parameter element, @Nonnull Parameter multiplicity) {
+        public ElementMultiplicityListParameter(Parameter element, Parameter multiplicity) {
             this.element = element;
             this.multiplicity = multiplicity;
         }
 
-        @Nonnull
         @Override
-        public ListParameter bind(@Nonnull Random random) {
+        public ListParameter bind(Random random) {
             var boundMultiplicity = multiplicity.bind(random);
             Assert.thatUnchecked(boundMultiplicity instanceof PrimitiveParameter, "The multiplicity in ElementMultiplicityListParameter can only be Primitive or Random{Range/Set} Parameter");
             var sqlTypeMultiplicity = ((PrimitiveParameter) boundMultiplicity).getSqlObject(null);
             Assert.thatUnchecked(sqlTypeMultiplicity instanceof Integer || sqlTypeMultiplicity instanceof Long || sqlTypeMultiplicity instanceof Double, "The multiplicity in ElementMultiplicityListParameter only allows Double, Integer or Long");
-            Assert.thatUnchecked(((Number) sqlTypeMultiplicity).intValue() > 0, "The multiplicity in ElementMultiplicityListParameter should be > 0");
-            return new ListParameter(IntStream.range(0, ((Number) sqlTypeMultiplicity).intValue())
+            // The instanceof checks above imply sqlTypeMultiplicity is non-null, but Assert.thatUnchecked doesn't tell NullAway that.
+            final Number multiplicity = (Number) Objects.requireNonNull(sqlTypeMultiplicity);
+            Assert.thatUnchecked(multiplicity.intValue() > 0, "The multiplicity in ElementMultiplicityListParameter should be > 0");
+            return new ListParameter(IntStream.range(0, multiplicity.intValue())
                     .mapToObj(ignored -> element.bind(random))
                     .collect(Collectors.toList()));
         }
@@ -182,21 +176,19 @@ public abstract class UnboundParameter implements Parameter {
     public static class ListRangeParameter extends UnboundParameter {
         @Nullable
         private final Parameter lowerBound;
-        @Nonnull
         private final Parameter upperBound;
 
-        public ListRangeParameter(@Nonnull Parameter upperbound) {
+        public ListRangeParameter(Parameter upperbound) {
             this(null, upperbound);
         }
 
-        public ListRangeParameter(@Nullable Parameter lowerBound, @Nonnull Parameter upperBound) {
+        public ListRangeParameter(@Nullable Parameter lowerBound, Parameter upperBound) {
             this.lowerBound = lowerBound;
             this.upperBound = upperBound;
         }
 
-        @Nonnull
         @Override
-        public ListParameter bind(@Nonnull Random random) {
+        public ListParameter bind(Random random) {
             final var lb = RandomRangeParameter.bindAndVerifyNumberParameter(lowerBound, random);
             final var ub = RandomRangeParameter.bindAndVerifyNumberParameter(upperBound, random);
             if (lb instanceof Double || ub instanceof Double) {

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/parameterinjection/package-info.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/parameterinjection/package-info.java
@@ -23,4 +23,7 @@
  * place. This package holds all the valid parameter descriptions.
  */
 
+@NullMarked
 package com.apple.foundationdb.relational.yamltests.command.parameterinjection;
+
+import org.jspecify.annotations.NullMarked;

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/queryconfigs/CheckExplainConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/queryconfigs/CheckExplainConfig.java
@@ -38,8 +38,9 @@ import com.google.protobuf.Descriptors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
+
+import static com.apple.foundationdb.relational.yamltests.generated.stats.PlannerMetricsProto.Info;
 import java.sql.SQLException;
 import java.util.Collections;
 import java.util.List;
@@ -64,7 +65,7 @@ public class CheckExplainConfig extends QueryConfig {
     private final boolean isExact;
     private final String blockName;
 
-    public CheckExplainConfig(final String configName, final Object value, @Nonnull final YamlReference reference, final YamlExecutionContext executionContext, final boolean isExact, final String blockName) {
+    public CheckExplainConfig(final String configName, @Nullable final Object value, final YamlReference reference, final YamlExecutionContext executionContext, final boolean isExact, final String blockName) {
         super(configName, value, reference);
         this.executionContext = executionContext;
         this.isExact = isExact;
@@ -72,14 +73,14 @@ public class CheckExplainConfig extends QueryConfig {
     }
 
     @Override
-    protected String decorateQuery(@Nonnull String query) {
+    protected String decorateQuery(String query) {
         return "EXPLAIN " + query;
     }
 
     @SuppressWarnings({"PMD.CloseResource", "PMD.EmptyWhileStmt"}) // lifetime of autocloseable resource persists beyond method
     @Override
-    protected void checkResultInternal(@Nonnull String currentQuery, @Nonnull Object actual,
-                                       @Nonnull String queryDescription, @Nonnull List<String> setups) throws SQLException {
+    protected void checkResultInternal(String currentQuery, Object actual,
+                                       String queryDescription, List<String> setups) throws SQLException {
         logger.debug("⛳️ Matching plan for query '{}'", queryDescription);
         final var resultSet = (RelationalResultSet) actual;
         resultSet.next();
@@ -100,8 +101,8 @@ public class CheckExplainConfig extends QueryConfig {
         }
     }
 
-    private static PlannerMetricsProto.Info createPlannerMetricsInfo(@Nonnull final RelationalResultSet resultSet) throws SQLException {
-        final var builder = PlannerMetricsProto.Info.newBuilder();
+    private static Info createPlannerMetricsInfo(final RelationalResultSet resultSet) throws SQLException {
+        final var builder = Info.newBuilder();
         final var plan = resultSet.getString(1);
         if (plan == null) {
             QueryCommand.reportTestFailure("‼️ EXPLAIN result is missing the plan string");
@@ -134,8 +135,8 @@ public class CheckExplainConfig extends QueryConfig {
     }
 
     private void addExplainAndMetrics(
-            @Nonnull final PlannerMetricsProto.Identifier identifier,
-            @Nonnull final PlannerMetricsProto.Info actualPlannerMetricsInfo) {
+            final PlannerMetricsProto.Identifier identifier,
+            final Info actualPlannerMetricsInfo) {
         try {
             executionContext.getFilesMaintainer().addExplain(getReference(), actualPlannerMetricsInfo.getExplain());
         } catch (Throwable throwable) {
@@ -145,9 +146,9 @@ public class CheckExplainConfig extends QueryConfig {
         recordMetrics(identifier, actualPlannerMetricsInfo, true);
     }
 
-    private void checkExplainContains(@Nonnull final String queryDescription,
-                                       @Nonnull final PlannerMetricsProto.Info actualPlannerMetricsInfo,
-                                       @Nullable final PlannerMetricsProto.Info expectedPlannerMetricsInfo) {
+    private void checkExplainContains(final String queryDescription,
+                                       final Info actualPlannerMetricsInfo,
+                                       @Nullable final Info expectedPlannerMetricsInfo) {
         final var actualPlan = actualPlannerMetricsInfo.getExplain();
         if (actualPlan.contains(Objects.requireNonNull((String) getVal()))) {
             logger.debug("✅️ plan fragment match!");
@@ -157,9 +158,9 @@ public class CheckExplainConfig extends QueryConfig {
         }
     }
 
-    private void showPlanDiffIfNeeded(@Nonnull final String queryDescription,
-                                      @Nonnull final PlannerMetricsProto.Info actualPlannerMetricsInfo,
-                                      @Nullable final PlannerMetricsProto.Info expectedPlannerMetricsInfo) {
+    private void showPlanDiffIfNeeded(final String queryDescription,
+                                      final Info actualPlannerMetricsInfo,
+                                      @Nullable final Info expectedPlannerMetricsInfo) {
         if (!executionContext.shouldShowPlanOnDiff()) {
             return;
         }
@@ -173,7 +174,7 @@ public class CheckExplainConfig extends QueryConfig {
         }
     }
 
-    private void calcPlanDiffAndReportFailure(@Nonnull final String actualPlan) {
+    private void calcPlanDiffAndReportFailure(final String actualPlan) {
         final var expectedPlan = getValueString();
         final var diffGenerator = DiffRowGenerator.create()
                 .showInlineDiffs(true)
@@ -198,10 +199,10 @@ public class CheckExplainConfig extends QueryConfig {
         QueryCommand.reportTestFailure(diffMessage);
     }
 
-    private void checkExplainAndMetrics(@Nonnull final String queryDescription,
-                                        @Nonnull final PlannerMetricsProto.Identifier identifier,
-                                        @Nonnull final PlannerMetricsProto.Info actualPlannerMetricsInfo,
-                                        @Nullable final PlannerMetricsProto.Info expectedPlannerMetricsInfo) {
+    private void checkExplainAndMetrics(final String queryDescription,
+                                        final PlannerMetricsProto.Identifier identifier,
+                                        final Info actualPlannerMetricsInfo,
+                                        @Nullable final Info expectedPlannerMetricsInfo) {
         final var actualPlan = actualPlannerMetricsInfo.getExplain();
         var explainIsChanged = false;
         if (Objects.requireNonNull(getVal()).equals(actualPlan)) {
@@ -254,14 +255,14 @@ public class CheckExplainConfig extends QueryConfig {
         }
     }
 
-    private void correctExplainAndRecordMetrics(@Nonnull final PlannerMetricsProto.Identifier identifier,
-                               @Nonnull final PlannerMetricsProto.Info info, @Nonnull String plan) {
+    private void correctExplainAndRecordMetrics(final PlannerMetricsProto.Identifier identifier,
+                               final Info info, String plan) {
         final var expectedMetricsWithActualPlan = info.toBuilder().setExplain(plan).build();
         recordMetrics(identifier, expectedMetricsWithActualPlan, true);
     }
 
-    private void recordMetrics(@Nonnull final PlannerMetricsProto.Identifier identifier,
-                               @Nonnull final PlannerMetricsProto.Info info,
+    private void recordMetrics(final PlannerMetricsProto.Identifier identifier,
+                               final Info info,
                                final boolean dirty) {
         try {
             executionContext.getMetricsMaintainer().putMetrics(identifier, getReference(), info);
@@ -273,8 +274,8 @@ public class CheckExplainConfig extends QueryConfig {
         }
     }
 
-    private boolean areMetricsDifferent(@Nonnull final PlannerMetricsProto.Info expectedPlannerMetricsInfo,
-                                        @Nonnull final PlannerMetricsProto.Info actualPlannerMetricsInfo) {
+    private boolean areMetricsDifferent(final Info expectedPlannerMetricsInfo,
+                                        final Info actualPlannerMetricsInfo) {
         final var expectedCountersAndTimers = expectedPlannerMetricsInfo.getCountersAndTimers();
         final var actualCountersAndTimers = actualPlannerMetricsInfo.getCountersAndTimers();
         final var metricsDescriptor = expectedCountersAndTimers.getDescriptorForType();
@@ -288,10 +289,10 @@ public class CheckExplainConfig extends QueryConfig {
         return different;
     }
 
-    private static boolean isMetricDifferent(@Nonnull final PlannerMetricsProto.CountersAndTimers expected,
-                                             @Nonnull final PlannerMetricsProto.CountersAndTimers actual,
-                                             @Nonnull final Descriptors.FieldDescriptor fieldDescriptor,
-                                             @Nonnull final YamlReference reference) {
+    private static boolean isMetricDifferent(final PlannerMetricsProto.CountersAndTimers expected,
+                                             final PlannerMetricsProto.CountersAndTimers actual,
+                                             final Descriptors.FieldDescriptor fieldDescriptor,
+                                             final YamlReference reference) {
         final long expectedMetric = (long)expected.getField(fieldDescriptor);
         final long actualMetric = (long)actual.getField(fieldDescriptor);
         if (expectedMetric != actualMetric) {

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/queryconfigs/CheckResultMetadataConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/queryconfigs/CheckResultMetadataConfig.java
@@ -34,8 +34,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opentest4j.AssertionFailedError;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.ArrayList;
@@ -70,12 +69,11 @@ import java.util.Map;
 public class CheckResultMetadataConfig extends QueryConfig {
     private static final Logger logger = LogManager.getLogger(CheckResultMetadataConfig.class);
 
-    @Nonnull
     private final YamlExecutionContext executionContext;
 
-    public CheckResultMetadataConfig(@Nonnull final String configName, @Nullable final Object value,
-                                     @Nonnull final YamlReference reference,
-                                     @Nonnull final YamlExecutionContext executionContext) {
+    public CheckResultMetadataConfig(final String configName, @Nullable final Object value,
+                                     final YamlReference reference,
+                                     final YamlExecutionContext executionContext) {
         super(configName, value, reference);
         this.executionContext = executionContext;
     }
@@ -84,14 +82,12 @@ public class CheckResultMetadataConfig extends QueryConfig {
      * Extract column descriptors from result-set metadata without consuming any rows.
      * This is a pure read of the schema; the result set remains positioned before the first row.
      */
-    @Nonnull
-    public static List<ColumnDescriptor> extractDescriptors(@Nonnull final RelationalResultSetMetaData metaData)
+    public static List<ColumnDescriptor> extractDescriptors(final RelationalResultSetMetaData metaData)
             throws SQLException {
         return extractDescriptors((StructMetaData)metaData);
     }
 
-    @Nonnull
-    private static List<ColumnDescriptor> extractDescriptors(@Nonnull final StructMetaData metaData)
+    private static List<ColumnDescriptor> extractDescriptors(final StructMetaData metaData)
             throws SQLException {
         final int count = metaData.getColumnCount();
         final List<ColumnDescriptor> descriptors = new ArrayList<>(count);
@@ -118,8 +114,7 @@ public class CheckResultMetadataConfig extends QueryConfig {
         return descriptors;
     }
 
-    @Nonnull
-    private static String buildArrayTypeName(@Nonnull final ArrayMetaData arrayMeta) throws SQLException {
+    private static String buildArrayTypeName(final ArrayMetaData arrayMeta) throws SQLException {
         final String elementTypeName;
         if (arrayMeta.getElementType() == Types.ARRAY) {
             elementTypeName = buildArrayTypeName(arrayMeta.getElementArrayMetaData());
@@ -134,7 +129,7 @@ public class CheckResultMetadataConfig extends QueryConfig {
      * Returns the associated value, or {@code null} if no such key exists.
      */
     @Nullable
-    private static Object getArrayValue(@Nonnull final Map<?, ?> map) {
+    private static Object getArrayValue(final Map<?, ?> map) {
         for (final Map.Entry<?, ?> e : map.entrySet()) {
             if (e.getKey() instanceof String && "array".equalsIgnoreCase((String)e.getKey())) {
                 return e.getValue();
@@ -153,8 +148,7 @@ public class CheckResultMetadataConfig extends QueryConfig {
      * The list case ({@code {array: [fields...]}}) is handled upstream in
      * {@link #matchesExpected} and never reaches this method.
      */
-    @Nonnull
-    private static String buildExpectedArrayTypeName(@Nonnull final Map<?, ?> arrayMap) {
+    private static String buildExpectedArrayTypeName(final Map<?, ?> arrayMap) {
         final Object arrayValue = getArrayValue(arrayMap);
         if (arrayValue instanceof String) {
             return "ARRAY(" + arrayValue + ")";
@@ -170,9 +164,9 @@ public class CheckResultMetadataConfig extends QueryConfig {
      * Inline metadata check: compare the given descriptors (already extracted from a live result set) against the
      * expected metadata declared in the YAMSQL file, without executing the query again.
      */
-    public void checkInline(@Nonnull final List<ColumnDescriptor> actualDescriptors,
-                            @Nonnull final String queryDescription,
-                            @Nonnull final YamlConnection connection) {
+    public void checkInline(final List<ColumnDescriptor> actualDescriptors,
+                            final String queryDescription,
+                            final YamlConnection connection) {
         try {
             checkDescriptorsInternal(actualDescriptors, queryDescription);
         } catch (AssertionFailedError e) {
@@ -188,9 +182,9 @@ public class CheckResultMetadataConfig extends QueryConfig {
 
     @Override
     @SuppressWarnings({"PMD.CloseResource", "PMD.EmptyWhileStmt"})
-    protected void checkResultInternal(@Nonnull final String currentQuery, @Nonnull final Object actual,
-                                       @Nonnull final String queryDescription,
-                                       @Nonnull final List<String> setups) throws SQLException {
+    protected void checkResultInternal(final String currentQuery, final Object actual,
+                                       final String queryDescription,
+                                       final List<String> setups) throws SQLException {
         if (!(actual instanceof RelationalResultSet)) {
             logger.warn("⚠️ resultMetadata check skipped: query returned a non-ResultSet result at {}", getReference());
             return;
@@ -211,8 +205,8 @@ public class CheckResultMetadataConfig extends QueryConfig {
      * Expects descriptors already extracted; does not touch the result set.
      */
     @SuppressWarnings("unchecked")
-    private void checkDescriptorsInternal(@Nonnull final List<ColumnDescriptor> actualDescriptors,
-                                          @Nonnull final String queryDescription) {
+    private void checkDescriptorsInternal(final List<ColumnDescriptor> actualDescriptors,
+                                          final String queryDescription) {
         final Object rawExpectedValue = getVal();
         logger.debug("⛳️ Checking result metadata for query '{}'", queryDescription);
 
@@ -247,7 +241,7 @@ public class CheckResultMetadataConfig extends QueryConfig {
         }
     }
 
-    private void addResultMetadata(@Nonnull final List<ColumnDescriptor> actualDescriptors) {
+    private void addResultMetadata(final List<ColumnDescriptor> actualDescriptors) {
         try {
             executionContext.getFilesMaintainer().addResultMetadata(getReference(), actualDescriptors);
         } catch (Throwable throwable) {
@@ -256,7 +250,7 @@ public class CheckResultMetadataConfig extends QueryConfig {
         logger.debug(() -> "⭐️ Successfully added resultMetadata at " + getReference());
     }
 
-    private void correctMetadata(@Nonnull final List<ColumnDescriptor> actualDescriptors) {
+    private void correctMetadata(final List<ColumnDescriptor> actualDescriptors) {
         try {
             executionContext.getFilesMaintainer().correctResultMetadata(getReference(), actualDescriptors);
         } catch (Throwable throwable) {
@@ -265,8 +259,8 @@ public class CheckResultMetadataConfig extends QueryConfig {
         logger.debug(() -> "⭐️ Successfully corrected resultMetadata at " + getReference());
     }
 
-    private void reportMetadataMismatch(@Nonnull final List<Map<?, ?>> expectedColumns,
-                                        @Nonnull final List<ColumnDescriptor> actualDescriptors) {
+    private void reportMetadataMismatch(final List<Map<?, ?>> expectedColumns,
+                                        final List<ColumnDescriptor> actualDescriptors) {
         final StringBuilder sb = new StringBuilder();
         sb.append("‼️ result metadata mismatch at ").append(getReference()).append(":\n")
                 .append("⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤⏤\n")
@@ -284,9 +278,9 @@ public class CheckResultMetadataConfig extends QueryConfig {
         QueryCommand.reportTestFailure(sb.toString());
     }
 
-    private static void appendDescriptorToMessage(@Nonnull final StringBuilder sb,
-                                                  @Nonnull final ColumnDescriptor desc,
-                                                  @Nonnull final String prefix) {
+    private static void appendDescriptorToMessage(final StringBuilder sb,
+                                                  final ColumnDescriptor desc,
+                                                  final String prefix) {
         sb.append(prefix).append(desc.name).append(": ").append(desc.typeName);
         if (desc.structTypeName != null) {
             sb.append('(').append(desc.structTypeName).append(')');
@@ -310,8 +304,8 @@ public class CheckResultMetadataConfig extends QueryConfig {
      * </p>
      */
     @Nullable
-    private static List<?> checkStructTypeName(@Nonnull final List<?> valueList,
-                                               @Nonnull final ColumnDescriptor actualCol) {
+    private static List<?> checkStructTypeName(final List<?> valueList,
+                                               final ColumnDescriptor actualCol) {
         if (!valueList.isEmpty() && valueList.get(0) instanceof String) {
             final String expectedTypeName = (String)valueList.get(0);
             if (actualCol.structTypeName == null || !expectedTypeName.equalsIgnoreCase(actualCol.structTypeName)) {
@@ -322,8 +316,8 @@ public class CheckResultMetadataConfig extends QueryConfig {
         return valueList;
     }
 
-    private static boolean matchesExpected(@Nonnull final List<Map<?, ?>> expected,
-                                           @Nonnull final List<ColumnDescriptor> actual) {
+    private static boolean matchesExpected(final List<Map<?, ?>> expected,
+                                           final List<ColumnDescriptor> actual) {
         if (expected.size() != actual.size()) {
             return false;
         }
@@ -397,13 +391,11 @@ public class CheckResultMetadataConfig extends QueryConfig {
      * and array-of-struct columns) the nested field descriptors.
      */
     public static final class ColumnDescriptor {
-        @Nonnull
         public final String name;
         /**
          * SQL type name: e.g. {@code "BIGINT"}, {@code "STRUCT"}, {@code "ARRAY(INTEGER)"},
          * {@code "ARRAY(STRUCT)"}.
          */
-        @Nonnull
         public final String typeName;
         /**
          * Declared struct type name (e.g. {@code "point"} from {@code CREATE TYPE AS STRUCT point(...)}).
@@ -423,9 +415,9 @@ public class CheckResultMetadataConfig extends QueryConfig {
          */
         public final boolean isArray;
 
-        ColumnDescriptor(@Nonnull final String name, @Nonnull final String typeName,
+        ColumnDescriptor(final String name, final String typeName,
                          @Nullable final String structTypeName,
-                         @Nonnull final List<ColumnDescriptor> fields, boolean isArray) {
+                         final List<ColumnDescriptor> fields, boolean isArray) {
             this.name = name;
             this.typeName = typeName;
             this.structTypeName = structTypeName;
@@ -433,7 +425,7 @@ public class CheckResultMetadataConfig extends QueryConfig {
             this.isArray = isArray;
         }
 
-        ColumnDescriptor(@Nonnull final String name, @Nonnull final String typeName) {
+        ColumnDescriptor(final String name, final String typeName) {
             this.name = name;
             this.typeName = typeName;
             this.structTypeName = null;

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/queryconfigs/package-info.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/command/queryconfigs/package-info.java
@@ -21,4 +21,7 @@
 /**
  * Implementations of {@link com.apple.foundationdb.relational.yamltests.command.QueryConfig}.
  */
+@NullMarked
 package com.apple.foundationdb.relational.yamltests.command.queryconfigs;
+
+import org.jspecify.annotations.NullMarked;

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/AddExplains.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/AddExplains.java
@@ -22,8 +22,6 @@ package com.apple.foundationdb.relational.yamltests.configs;
 
 import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
 
-import javax.annotation.Nonnull;
-
 /**
  * A configuration that runs an underlying configuration and adds {@code explain} blocks to all
  * queries in YAMSQL files that do not already have one, and corrects existing {@code explain} blocks
@@ -39,7 +37,7 @@ import javax.annotation.Nonnull;
  * </p>
  */
 public class AddExplains extends ConfigWithOptions {
-    public AddExplains(@Nonnull final YamlTestConfig underlying) {
+    public AddExplains(final YamlTestConfig underlying) {
         super(underlying, YamlExecutionContext.ContextOptions.of(YamlExecutionContext.OPTION_ADD_EXPLAIN, true));
     }
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/AddResultMetadata.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/AddResultMetadata.java
@@ -22,8 +22,6 @@ package com.apple.foundationdb.relational.yamltests.configs;
 
 import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
 
-import javax.annotation.Nonnull;
-
 /**
  * A configuration that runs an underlying configuration and adds {@code resultMetadata} blocks to all
  * queries in YAMSQL files that do not already have one.
@@ -38,7 +36,7 @@ import javax.annotation.Nonnull;
  * </p>
  */
 public class AddResultMetadata extends ConfigWithOptions {
-    public AddResultMetadata(@Nonnull final YamlTestConfig underlying) {
+    public AddResultMetadata(final YamlTestConfig underlying) {
         super(underlying, YamlExecutionContext.ContextOptions.of(YamlExecutionContext.OPTION_ADD_RESULT_METADATA, true));
     }
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/ConfigWithOptions.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/ConfigWithOptions.java
@@ -23,22 +23,17 @@ package com.apple.foundationdb.relational.yamltests.configs;
 import com.apple.foundationdb.relational.yamltests.YamlConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
 
-import javax.annotation.Nonnull;
-
 /**
  * An implementation of {@link YamlTestConfig} that sets additional options on top of a base config.
  */
 public class ConfigWithOptions implements YamlTestConfig {
-    @Nonnull
     private final YamlTestConfig underlying;
-    @Nonnull
     private final YamlExecutionContext.ContextOptions runnerOptions;
 
-    public ConfigWithOptions(@Nonnull final YamlTestConfig underlying, @Nonnull YamlExecutionContext.ContextOptions newOptions) {
+    public ConfigWithOptions(final YamlTestConfig underlying, YamlExecutionContext.ContextOptions newOptions) {
         this.underlying = underlying;
         this.runnerOptions = underlying.getRunnerOptions().mergeFrom(newOptions);
     }
-
 
     @Override
     public YamlConnectionFactory createConnectionFactory() {
@@ -46,7 +41,7 @@ public class ConfigWithOptions implements YamlTestConfig {
     }
 
     @Override
-    public @Nonnull YamlExecutionContext.ContextOptions getRunnerOptions() {
+    public YamlExecutionContext.ContextOptions getRunnerOptions() {
         return runnerOptions;
     }
 

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/CorrectExpectations.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/CorrectExpectations.java
@@ -22,8 +22,6 @@ package com.apple.foundationdb.relational.yamltests.configs;
 
 import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
 
-import javax.annotation.Nonnull;
-
 /**
  * A configuration that corrects all expected values in YAML files: explains, planner metrics, and result metadata.
  * <p>
@@ -32,7 +30,7 @@ import javax.annotation.Nonnull;
  * </p>
  */
 public class CorrectExpectations extends ConfigWithOptions {
-    public CorrectExpectations(@Nonnull final YamlTestConfig underlying) {
+    public CorrectExpectations(final YamlTestConfig underlying) {
         super(underlying, YamlExecutionContext.ContextOptions.of(
                 YamlExecutionContext.OPTION_CORRECT_EXPLAIN, true,
                 YamlExecutionContext.OPTION_CORRECT_METRICS, true,

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/CorrectExplains.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/CorrectExplains.java
@@ -22,8 +22,6 @@ package com.apple.foundationdb.relational.yamltests.configs;
 
 import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
 
-import javax.annotation.Nonnull;
-
 /**
  * A configuration that runs an underlying configuration, but heals expected explains in YAML files where
  * expected and actual explains differ.
@@ -32,7 +30,7 @@ import javax.annotation.Nonnull;
  * </p>
  */
 public class CorrectExplains extends ConfigWithOptions {
-    public CorrectExplains(@Nonnull final YamlTestConfig underlying) {
+    public CorrectExplains(final YamlTestConfig underlying) {
         super(underlying, YamlExecutionContext.ContextOptions.of(YamlExecutionContext.OPTION_CORRECT_EXPLAIN, true));
     }
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/CorrectExplainsAndMetrics.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/CorrectExplainsAndMetrics.java
@@ -22,8 +22,6 @@ package com.apple.foundationdb.relational.yamltests.configs;
 
 import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
 
-import javax.annotation.Nonnull;
-
 /**
  * A configuration that runs an underlying configuration, but heals expected explains in YAML files where
  * expected and actual explains differ.
@@ -32,7 +30,7 @@ import javax.annotation.Nonnull;
  * </p>
  */
 public class CorrectExplainsAndMetrics extends ConfigWithOptions {
-    public CorrectExplainsAndMetrics(@Nonnull final YamlTestConfig underlying) {
+    public CorrectExplainsAndMetrics(final YamlTestConfig underlying) {
         super(underlying, YamlExecutionContext.ContextOptions.of(YamlExecutionContext.OPTION_CORRECT_EXPLAIN, true,
                 YamlExecutionContext.OPTION_CORRECT_METRICS, true));
     }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/CorrectMetrics.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/CorrectMetrics.java
@@ -22,8 +22,6 @@ package com.apple.foundationdb.relational.yamltests.configs;
 
 import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
 
-import javax.annotation.Nonnull;
-
 /**
  * A configuration that runs an underlying configuration, but heals expected explains in YAML files where
  * expected and actual explains differ.
@@ -32,7 +30,7 @@ import javax.annotation.Nonnull;
  * </p>
  */
 public class CorrectMetrics extends ConfigWithOptions {
-    public CorrectMetrics(@Nonnull final YamlTestConfig underlying) {
+    public CorrectMetrics(final YamlTestConfig underlying) {
         super(underlying, YamlExecutionContext.ContextOptions.of(YamlExecutionContext.OPTION_CORRECT_METRICS, true));
     }
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/CorrectResultMetadata.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/CorrectResultMetadata.java
@@ -22,8 +22,6 @@ package com.apple.foundationdb.relational.yamltests.configs;
 
 import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
 
-import javax.annotation.Nonnull;
-
 /**
  * A configuration that runs an underlying configuration, but heals {@code resultMetadata} blocks in YAMSQL files
  * where expected and actual column metadata differ.
@@ -32,7 +30,7 @@ import javax.annotation.Nonnull;
  * </p>
  */
 public class CorrectResultMetadata extends ConfigWithOptions {
-    public CorrectResultMetadata(@Nonnull final YamlTestConfig underlying) {
+    public CorrectResultMetadata(final YamlTestConfig underlying) {
         super(underlying, YamlExecutionContext.ContextOptions.of(YamlExecutionContext.OPTION_CORRECT_RESULT_METADATA, true));
     }
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/EmbeddedConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/EmbeddedConfig.java
@@ -29,7 +29,6 @@ import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
 import com.apple.foundationdb.relational.yamltests.connectionfactory.Clusters;
 import com.apple.foundationdb.relational.yamltests.connectionfactory.EmbeddedYamlConnectionFactory;
 
-import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Objects;
 
@@ -40,17 +39,15 @@ import java.util.Objects;
  * (using {@code connect: { cluster: N }}) can route to the correct cluster.
  */
 public class EmbeddedConfig implements YamlTestConfig {
-    @Nonnull
     private final List<String> clusterFiles;
-    @Nonnull
     private Clusters<Clusters.Entry<FRL>> clusters = Clusters.empty();
 
     @API(API.Status.DEPRECATED)
-    public EmbeddedConfig(@Nonnull final String clusterFile) {
+    public EmbeddedConfig(final String clusterFile) {
         this(List.of(clusterFile));
     }
 
-    public EmbeddedConfig(@Nonnull final List<String> clusterFiles) {
+    public EmbeddedConfig(final List<String> clusterFiles) {
         this.clusterFiles = clusterFiles;
     }
 
@@ -91,7 +88,6 @@ public class EmbeddedConfig implements YamlTestConfig {
         return new EmbeddedYamlConnectionFactory(clusters.map(e -> Clusters.mapEntry(e, FRL::getDriver)));
     }
 
-    @Nonnull
     @Override
     public YamlExecutionContext.ContextOptions getRunnerOptions() {
         return YamlExecutionContext.ContextOptions.EMPTY_OPTIONS;

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/ExternalMultiServerConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/ExternalMultiServerConfig.java
@@ -28,7 +28,6 @@ import com.apple.foundationdb.relational.yamltests.connectionfactory.MultiServer
 import com.apple.foundationdb.relational.yamltests.server.ExternalServer;
 import com.apple.foundationdb.relational.yamltests.server.SemanticVersion;
 
-import javax.annotation.Nonnull;
 import java.util.List;
 
 /**
@@ -38,14 +37,12 @@ import java.util.List;
 public class ExternalMultiServerConfig implements YamlTestConfig {
 
     private final int initialConnection;
-    @Nonnull
     private final Clusters<ExternalServer> servers0;
-    @Nonnull
     private final Clusters<ExternalServer> servers1;
 
     public ExternalMultiServerConfig(final int initialConnection,
-                                     @Nonnull Clusters<ExternalServer> servers0,
-                                     @Nonnull Clusters<ExternalServer> servers1) {
+                                     Clusters<ExternalServer> servers0,
+                                     Clusters<ExternalServer> servers1) {
         super();
         this.initialConnection = initialConnection;
         this.servers0 = servers0;
@@ -81,7 +78,7 @@ public class ExternalMultiServerConfig implements YamlTestConfig {
     }
 
     @Override
-    public @Nonnull YamlExecutionContext.ContextOptions getRunnerOptions() {
+    public YamlExecutionContext.ContextOptions getRunnerOptions() {
         return YamlExecutionContext.ContextOptions.EMPTY_OPTIONS;
     }
 

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/ForceContinuations.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/ForceContinuations.java
@@ -22,8 +22,6 @@ package com.apple.foundationdb.relational.yamltests.configs;
 
 import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
 
-import javax.annotation.Nonnull;
-
 /**
  * A configuration that runs an underlying configuration, but forces every query to be executed with {@code maxRows: 1}.
  * <p>
@@ -31,7 +29,7 @@ import javax.annotation.Nonnull;
  * </p>
  */
 public class ForceContinuations extends ConfigWithOptions {
-    public ForceContinuations(@Nonnull final YamlTestConfig underlying) {
+    public ForceContinuations(final YamlTestConfig underlying) {
         super(underlying, YamlExecutionContext.ContextOptions.of(YamlExecutionContext.OPTION_FORCE_CONTINUATIONS, true));
     }
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCInProcessConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCInProcessConfig.java
@@ -26,7 +26,6 @@ import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
 import com.apple.foundationdb.relational.yamltests.connectionfactory.Clusters;
 import com.apple.foundationdb.relational.yamltests.connectionfactory.JDBCInProcessYamlConnectionFactory;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.List;
 
@@ -37,12 +36,10 @@ import java.util.List;
  * (using {@code connect: { cluster: N }}) can route to the correct cluster.
  */
 public class JDBCInProcessConfig implements YamlTestConfig {
-    @Nonnull
     private final List<String> clusterFiles;
-    @Nonnull
     private Clusters<Clusters.Entry<InProcessRelationalServer>> clusters = Clusters.empty();
 
-    public JDBCInProcessConfig(@Nonnull final List<String> clusterFiles) {
+    public JDBCInProcessConfig(final List<String> clusterFiles) {
         this.clusterFiles = clusterFiles;
     }
 
@@ -72,12 +69,10 @@ public class JDBCInProcessConfig implements YamlTestConfig {
         return new JDBCInProcessYamlConnectionFactory(clusters);
     }
 
-    @Nonnull
     protected Clusters<Clusters.Entry<InProcessRelationalServer>> getClusters() {
         return clusters;
     }
 
-    @Nonnull
     @Override
     public YamlExecutionContext.ContextOptions getRunnerOptions() {
         return YamlExecutionContext.ContextOptions.EMPTY_OPTIONS;

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCMultiServerConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/JDBCMultiServerConfig.java
@@ -27,7 +27,6 @@ import com.apple.foundationdb.relational.yamltests.connectionfactory.MultiServer
 import com.apple.foundationdb.relational.yamltests.server.ExternalServer;
 import com.apple.foundationdb.relational.yamltests.server.SemanticVersion;
 
-import javax.annotation.Nonnull;
 import java.util.List;
 
 /**
@@ -39,11 +38,10 @@ import java.util.List;
  */
 public class JDBCMultiServerConfig extends JDBCInProcessConfig {
 
-    @Nonnull
     private final Clusters<ExternalServer> externalServers;
     private final int initialConnection;
 
-    public JDBCMultiServerConfig(final int initialConnection, @Nonnull Clusters<ExternalServer> externalServers) {
+    public JDBCMultiServerConfig(final int initialConnection, Clusters<ExternalServer> externalServers) {
         super(externalServers.clusterFiles());
         this.initialConnection = initialConnection;
         this.externalServers = externalServers;

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/ShowPlanOnDiff.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/ShowPlanOnDiff.java
@@ -22,8 +22,6 @@ package com.apple.foundationdb.relational.yamltests.configs;
 
 import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
 
-import javax.annotation.Nonnull;
-
 /**
  * A configuration that runs an underlying configuration, but shows the dots of the expected and the actual plan where
  * expected and actual explains differ.
@@ -32,7 +30,7 @@ import javax.annotation.Nonnull;
  * </p>
  */
 public class ShowPlanOnDiff extends ConfigWithOptions {
-    public ShowPlanOnDiff(@Nonnull final YamlTestConfig underlying) {
+    public ShowPlanOnDiff(final YamlTestConfig underlying) {
         super(underlying, YamlExecutionContext.ContextOptions.of(YamlExecutionContext.OPTION_SHOW_PLAN_ON_DIFF, true));
     }
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/YamlTestConfig.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/YamlTestConfig.java
@@ -24,8 +24,6 @@ import com.apple.foundationdb.relational.yamltests.YamlConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.YamlExecutionContext;
 import com.apple.foundationdb.relational.yamltests.YamlRunner;
 
-import javax.annotation.Nonnull;
-
 /**
  * Interface for configuring how to run a {@code .yamsql} file.
  * <p>
@@ -45,7 +43,6 @@ public interface YamlTestConfig {
      * A list of options to be provided to {@link YamlRunner}.
      * @return the options for this config
      */
-    @Nonnull
     YamlExecutionContext.ContextOptions getRunnerOptions();
 
     void beforeAll() throws Exception;

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/package-info.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/configs/package-info.java
@@ -21,4 +21,7 @@
 /**
  * Configurations that provide different standard ways to run a test.
  */
+@NullMarked
 package com.apple.foundationdb.relational.yamltests.configs;
+
+import org.jspecify.annotations.NullMarked;

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/Clusters.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/Clusters.java
@@ -20,7 +20,6 @@
 
 package com.apple.foundationdb.relational.yamltests.connectionfactory;
 
-import javax.annotation.Nonnull;
 import java.sql.SQLException;
 import java.util.Iterator;
 import java.util.List;
@@ -35,7 +34,6 @@ import java.util.stream.Collectors;
  * @param <T> the type of server or driver held by each entry
  */
 public class Clusters<T extends Clusters.BoundToCluster> implements Iterable<T> {
-    @Nonnull
     private final List<T> entries;
 
     /** Private constructor to support the static {@link Clusters#empty()}. */
@@ -43,7 +41,7 @@ public class Clusters<T extends Clusters.BoundToCluster> implements Iterable<T> 
         this.entries = List.of();
     }
 
-    private Clusters(@Nonnull List<T> entries) {
+    private Clusters(List<T> entries) {
         if (entries.isEmpty()) {
             throw new IllegalArgumentException("At least one cluster entry is required");
         }
@@ -90,7 +88,6 @@ public class Clusters<T extends Clusters.BoundToCluster> implements Iterable<T> 
     /**
      * Returns the cluster files in order.
      */
-    @Nonnull
     public List<String> clusterFiles() {
         return entries.stream().map(BoundToCluster::clusterFile).collect(Collectors.toList());
     }
@@ -109,7 +106,6 @@ public class Clusters<T extends Clusters.BoundToCluster> implements Iterable<T> 
      * @return the entry at that index
      * @throws SQLException if the index is out of range
      */
-    @Nonnull
     public T get(int clusterIndex) throws SQLException {
         if (clusterIndex < 0 || clusterIndex >= entries.size()) {
             throw new SQLException("Cluster index " + clusterIndex + " not available (only " +
@@ -119,7 +115,6 @@ public class Clusters<T extends Clusters.BoundToCluster> implements Iterable<T> 
     }
 
     @Override
-    @Nonnull
     public Iterator<T> iterator() {
         return entries.iterator();
     }
@@ -130,22 +125,18 @@ public class Clusters<T extends Clusters.BoundToCluster> implements Iterable<T> 
      * @param <T> the type of server or driver
      */
     public static class Entry<T> implements BoundToCluster {
-        @Nonnull
         private final T server;
-        @Nonnull
         private final String clusterFile;
 
-        public Entry(@Nonnull T server, @Nonnull String clusterFile) {
+        public Entry(T server, String clusterFile) {
             this.server = server;
             this.clusterFile = clusterFile;
         }
 
-        @Nonnull
         public T server() {
             return server;
         }
 
-        @Nonnull
         @Override
         public String clusterFile() {
             return clusterFile;
@@ -156,7 +147,6 @@ public class Clusters<T extends Clusters.BoundToCluster> implements Iterable<T> 
      * An interface for a server (or driver) and its associated cluster file.
      */
     public interface BoundToCluster {
-        @Nonnull
         String clusterFile();
     }
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/EmbeddedYamlConnectionFactory.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/EmbeddedYamlConnectionFactory.java
@@ -27,7 +27,6 @@ import com.apple.foundationdb.relational.yamltests.YamlConnection;
 import com.apple.foundationdb.relational.yamltests.YamlConnectionFactory;
 import com.apple.foundationdb.relational.yamltests.server.SemanticVersion;
 
-import javax.annotation.Nonnull;
 import java.net.URI;
 import java.sql.DriverManager;
 import java.sql.SQLException;
@@ -35,15 +34,14 @@ import java.util.Objects;
 import java.util.Set;
 
 public class EmbeddedYamlConnectionFactory implements YamlConnectionFactory {
-    @Nonnull
     private final Clusters<Clusters.Entry<RelationalDriver>> clusters;
 
-    public EmbeddedYamlConnectionFactory(@Nonnull Clusters<Clusters.Entry<RelationalDriver>> clusters) {
+    public EmbeddedYamlConnectionFactory(Clusters<Clusters.Entry<RelationalDriver>> clusters) {
         this.clusters = clusters;
     }
 
     @Override
-    public YamlConnection getNewConnection(@Nonnull URI connectPath, int clusterIndex) throws SQLException {
+    public YamlConnection getNewConnection(URI connectPath, int clusterIndex) throws SQLException {
         final Clusters.Entry<RelationalDriver> entry = clusters.get(clusterIndex);
         if (clusterIndex == 0) {
             // The primary cluster's driver is registered in DriverManager, so use that path

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/ExternalServerYamlConnectionFactory.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/ExternalServerYamlConnectionFactory.java
@@ -29,7 +29,6 @@ import com.apple.foundationdb.relational.yamltests.server.SemanticVersion;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import javax.annotation.Nonnull;
 import java.net.URI;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -38,15 +37,14 @@ import java.util.Set;
 
 public class ExternalServerYamlConnectionFactory implements YamlConnectionFactory {
     private static final Logger LOG = LogManager.getLogger(ExternalServerYamlConnectionFactory.class);
-    @Nonnull
     private final Clusters<ExternalServer> clusters;
 
-    public ExternalServerYamlConnectionFactory(@Nonnull Clusters<ExternalServer> clusters) {
+    public ExternalServerYamlConnectionFactory(Clusters<ExternalServer> clusters) {
         this.clusters = clusters;
     }
 
     @Override
-    public YamlConnection getNewConnection(@Nonnull URI connectPath, int clusterIndex) throws SQLException {
+    public YamlConnection getNewConnection(URI connectPath, int clusterIndex) throws SQLException {
         return createConnection(connectPath, clusters.get(clusterIndex));
     }
 
@@ -55,7 +53,7 @@ public class ExternalServerYamlConnectionFactory implements YamlConnectionFactor
         return clusters.size();
     }
 
-    private YamlConnection createConnection(@Nonnull URI connectPath, @Nonnull ExternalServer server) throws SQLException {
+    private YamlConnection createConnection(URI connectPath, ExternalServer server) throws SQLException {
         String uriStr = connectPath.toString().replaceFirst("embed:", "relational://localhost:" + server.getPort());
         if (LOG.isInfoEnabled()) {
             LOG.info(KeyValueLogMessage.of("Rewrote connection string for external server",

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/JDBCInProcessYamlConnectionFactory.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/JDBCInProcessYamlConnectionFactory.java
@@ -30,7 +30,6 @@ import com.apple.foundationdb.relational.yamltests.server.SemanticVersion;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import javax.annotation.Nonnull;
 import java.net.URI;
 import java.sql.DriverManager;
 import java.sql.SQLException;
@@ -38,15 +37,14 @@ import java.util.Set;
 
 public class JDBCInProcessYamlConnectionFactory implements YamlConnectionFactory {
     private static final Logger LOG = LogManager.getLogger(JDBCInProcessYamlConnectionFactory.class);
-    @Nonnull
     private final Clusters<Clusters.Entry<InProcessRelationalServer>> clusters;
 
-    public JDBCInProcessYamlConnectionFactory(@Nonnull Clusters<Clusters.Entry<InProcessRelationalServer>> clusters) {
+    public JDBCInProcessYamlConnectionFactory(Clusters<Clusters.Entry<InProcessRelationalServer>> clusters) {
         this.clusters = clusters;
     }
 
     @Override
-    public YamlConnection getNewConnection(@Nonnull URI connectPath, int clusterIndex) throws SQLException {
+    public YamlConnection getNewConnection(URI connectPath, int clusterIndex) throws SQLException {
         final Clusters.Entry<InProcessRelationalServer> entry = clusters.get(clusterIndex);
         return createConnection(connectPath, entry.server(), entry.clusterFile());
     }
@@ -56,8 +54,8 @@ public class JDBCInProcessYamlConnectionFactory implements YamlConnectionFactory
         return clusters.size();
     }
 
-    private YamlConnection createConnection(@Nonnull URI connectPath, @Nonnull InProcessRelationalServer targetServer,
-                                            @Nonnull String targetClusterFile) throws SQLException {
+    private YamlConnection createConnection(URI connectPath, InProcessRelationalServer targetServer,
+                                            String targetClusterFile) throws SQLException {
         URI connectPathPlusServerName = JDBCURI.addQueryParameter(connectPath, JDBCURI.INPROCESS_URI_QUERY_SERVERNAME_KEY, targetServer.getServerName());
         String uriStr = connectPathPlusServerName.toString().replaceFirst("embed:", "relational://");
         if (LOG.isInfoEnabled()) {

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/MultiServerConnectionFactory.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/MultiServerConnectionFactory.java
@@ -35,8 +35,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.net.URI;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -64,20 +63,16 @@ public class MultiServerConnectionFactory implements YamlConnectionFactory {
      */
     public enum ConnectionSelectionPolicy { DEFAULT, ALTERNATE }
 
-    @Nonnull
     private final ConnectionSelectionPolicy connectionSelectionPolicy;
-    @Nonnull
     private final YamlConnectionFactory defaultFactory;
-    @Nonnull
     private final List<YamlConnectionFactory> alternateFactories;
     private final int totalFactories;
-    @Nonnull
     private final AtomicInteger currentConnectionSelector;
 
-    public MultiServerConnectionFactory(@Nonnull final ConnectionSelectionPolicy connectionSelectionPolicy,
+    public MultiServerConnectionFactory(final ConnectionSelectionPolicy connectionSelectionPolicy,
                                         final int initialConnection,
-                                        @Nonnull final YamlConnectionFactory defaultFactory,
-                                        @Nonnull final List<YamlConnectionFactory> alternateFactories) {
+                                        final YamlConnectionFactory defaultFactory,
+                                        final List<YamlConnectionFactory> alternateFactories) {
         this.connectionSelectionPolicy = connectionSelectionPolicy;
         this.defaultFactory = defaultFactory;
         this.alternateFactories = alternateFactories;
@@ -92,7 +87,7 @@ public class MultiServerConnectionFactory implements YamlConnectionFactory {
     }
 
     @Override
-    public YamlConnection getNewConnection(@Nonnull URI connectPath, int clusterIndex) throws SQLException {
+    public YamlConnection getNewConnection(URI connectPath, int clusterIndex) throws SQLException {
         if (connectionSelectionPolicy == ConnectionSelectionPolicy.DEFAULT) {
             return defaultFactory.getNewConnection(connectPath, clusterIndex);
         } else {
@@ -117,7 +112,6 @@ public class MultiServerConnectionFactory implements YamlConnectionFactory {
         return defaultFactory.getAvailableClusterCount();
     }
 
-    @Nonnull
     private List<YamlConnection> alternateConnections(URI connectPath, int clusterIndex) {
         return alternateFactories.stream().map(factory -> {
             try {
@@ -155,17 +149,14 @@ public class MultiServerConnectionFactory implements YamlConnectionFactory {
 
         private int currentConnectionSelector;
 
-        @Nonnull
         private final ConnectionSelectionPolicy connectionSelectionPolicy;
-        @Nonnull
         private final List<YamlConnection> underlyingConnections;
-        @Nonnull
         private final List<SemanticVersion> versions;
 
-        public MultiServerConnection(@Nonnull ConnectionSelectionPolicy connectionSelectionPolicy,
+        public MultiServerConnection(ConnectionSelectionPolicy connectionSelectionPolicy,
                                      final int initialConnecion,
-                                     @Nonnull final YamlConnection defaultConnection,
-                                     @Nonnull List<YamlConnection> alternateConnections) throws SQLException {
+                                     final YamlConnection defaultConnection,
+                                     List<YamlConnection> alternateConnections) throws SQLException {
             this.connectionSelectionPolicy = connectionSelectionPolicy;
             this.currentConnectionSelector = initialConnecion;
             underlyingConnections = new ArrayList<>();
@@ -198,20 +189,18 @@ public class MultiServerConnectionFactory implements YamlConnectionFactory {
             return null;
         }
 
-        @Nonnull
         @Override
         public List<SemanticVersion> getVersions() {
             return this.versions;
         }
 
-        @Nonnull
         @Override
         public SemanticVersion getInitialVersion() {
             return versions.get(0);
         }
 
         @Override
-        public <T> T executeTransactionally(final SQLFunction<YamlConnection, T> transactionalWork)
+        public <T extends @Nullable Object> T executeTransactionally(final SQLFunction<YamlConnection, T> transactionalWork)
                 throws SQLException, RelationalException {
             return getCurrentConnection(true, "transactional work").executeTransactionally(transactionalWork);
         }
@@ -225,7 +214,7 @@ public class MultiServerConnectionFactory implements YamlConnectionFactory {
         }
 
         @Override
-        public void setConnectionOptions(@Nonnull final Options connectionOptions) throws SQLException {
+        public void setConnectionOptions(final Options connectionOptions) throws SQLException {
             logger.info("Sending operation {} to all connections", "setConnectionOptions");
             for (var connection : underlyingConnections) {
                 connection.setConnectionOptions(connectionOptions);

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/package-info.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/connectionfactory/package-info.java
@@ -21,4 +21,7 @@
 /**
  * Connection factories that can be used to run various flavors of the YAML tests.
  */
+@NullMarked
 package com.apple.foundationdb.relational.yamltests.connectionfactory;
+
+import org.jspecify.annotations.NullMarked;

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/package-info.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/package-info.java
@@ -58,4 +58,7 @@
  * </ul>
  */
 
+@NullMarked
 package com.apple.foundationdb.relational.yamltests;
+
+import org.jspecify.annotations.NullMarked;

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/ExternalServer.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/ExternalServer.java
@@ -31,8 +31,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.net.ServerSocket;
@@ -60,13 +59,12 @@ public class ExternalServer implements Clusters.BoundToCluster {
     private static final Logger logger = LogManager.getLogger(ExternalServer.class);
     public static final String EXTERNAL_SERVER_PROPERTY_NAME = "yaml_testing_external_server";
 
-    @Nonnull
     private final File serverJar;
     private int grpcPort;
     private int httpPort;
     private final SemanticVersion version;
+    @Nullable
     private Process serverProcess;
-    @Nonnull
     private final String clusterFile;
 
     /**
@@ -74,8 +72,8 @@ public class ExternalServer implements Clusters.BoundToCluster {
      *
      * @param serverJar the path to the jar to run
      */
-    public ExternalServer(@Nonnull final File serverJar,
-                          @Nonnull final String clusterFile) throws IOException {
+    public ExternalServer(final File serverJar,
+                          final String clusterFile) throws IOException {
         this.clusterFile = clusterFile;
 
         this.serverJar = serverJar;
@@ -129,7 +127,6 @@ public class ExternalServer implements Clusters.BoundToCluster {
         return version;
     }
 
-    @Nonnull
     @Override
     public String clusterFile() {
         return clusterFile;
@@ -257,7 +254,8 @@ public class ExternalServer implements Clusters.BoundToCluster {
             validateConnectionVersion(connection);
             return true;
         } catch (RuntimeException e) {
-            if (e.getMessage().contains("UNAVAILABLE")) {
+            final String message = e.getMessage();
+            if (message != null && message.contains("UNAVAILABLE")) {
                 // Error returned when the server hasn't started yet. Currently, this comes directly from gRPC, though
                 // potentially we should be wrapping it with some kind of SQLException
                 return false;
@@ -266,7 +264,7 @@ public class ExternalServer implements Clusters.BoundToCluster {
         }
     }
 
-    public void validateConnectionVersion(@Nonnull Connection connection) throws SQLException {
+    public void validateConnectionVersion(Connection connection) throws SQLException {
         // Validate that the server has the expected version. Connect and make a request to the meta-data API,
         // and validate that the database product version matches the external server's version
         final DatabaseMetaData metaData = connection.getMetaData();
@@ -284,7 +282,7 @@ public class ExternalServer implements Clusters.BoundToCluster {
      * The provided set must be mutable, as it will be updated during run as ports are allocated
      * @return a port that is not currently in use on the system.
      */
-    private int getAvailablePort(@Nonnull final Set<Integer> unavailablePorts) {
+    private int getAvailablePort(final Set<Integer> unavailablePorts) {
         // running locally on my laptop, testing if a port is available takes 0 milliseconds, so no need to optimize
         for (int i = 1111; i < 9999; i++) {
             // Add the port immediately to the set of unavailable ports. We do this because there are
@@ -315,11 +313,11 @@ public class ExternalServer implements Clusters.BoundToCluster {
         }
     }
 
-    public static void startMultiple(@Nonnull Collection<ExternalServer> servers) throws Exception {
+    public static void startMultiple(Collection<ExternalServer> servers) throws Exception {
         startMultiple(servers, new HashSet<>());
     }
 
-    public static void startMultiple(@Nonnull Collection<ExternalServer> servers, @Nonnull Set<Integer> unavailablePorts) throws Exception {
+    public static void startMultiple(Collection<ExternalServer> servers, Set<Integer> unavailablePorts) throws Exception {
         final Map<Integer, ExternalServer> allocatedPorts = new HashMap<>();
         for (ExternalServer server : servers) {
             server.start(unavailablePorts);
@@ -330,7 +328,7 @@ public class ExternalServer implements Clusters.BoundToCluster {
         }
     }
 
-    private static void checkPortIsUnique(int port, @Nonnull ExternalServer server, @Nonnull Map<Integer, ExternalServer> allocatedPorts) throws RelationalException {
+    private static void checkPortIsUnique(int port, ExternalServer server, Map<Integer, ExternalServer> allocatedPorts) throws RelationalException {
         @Nullable ExternalServer preExistingServer = allocatedPorts.putIfAbsent(port, server);
         if (preExistingServer != null) {
             Assert.fail("allocated duplicate port (" + server.getPort() + ") to servers for versions " + server.getVersion() + " and " + preExistingServer.getVersion());

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/SemanticVersion.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/SemanticVersion.java
@@ -20,8 +20,6 @@
 
 package com.apple.foundationdb.relational.yamltests.server;
 
-
-import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -114,7 +112,6 @@ public class SemanticVersion implements Comparable<SemanticVersion> {
         MAX("!max_version", true),
         ;
 
-        @Nonnull
         private final String text;
         private final boolean singleton;
 
@@ -123,7 +120,6 @@ public class SemanticVersion implements Comparable<SemanticVersion> {
             this.singleton = singleton;
         }
 
-        @Nonnull
         public String getText() {
             return text;
         }
@@ -133,7 +129,6 @@ public class SemanticVersion implements Comparable<SemanticVersion> {
         }
     }
 
-    @Nonnull
     private static final EnumMap<SemanticVersionType, SemanticVersion> SINGLETONS = new EnumMap<>(SemanticVersionType.class);
 
     static {
@@ -150,7 +145,6 @@ public class SemanticVersion implements Comparable<SemanticVersion> {
      *
      * @see SemanticVersionType
      */
-    @Nonnull
     private final SemanticVersionType type;
 
     /**
@@ -160,7 +154,6 @@ public class SemanticVersion implements Comparable<SemanticVersion> {
      *     class supports any number of version components.
      *     When comparing, these are compared in order.
      */
-    @Nonnull
     private final List<Integer> versionNumbers;
     /**
      * The prerelease metadata, but only {@code SNAPSHOT} is supported.
@@ -169,10 +162,9 @@ public class SemanticVersion implements Comparable<SemanticVersion> {
      *     and gradle and maven have complicated comparison that disagrees. A version that has the same value
      *     {@link #versionNumbers} but an empty {@code prerelease} is greater than one with a non-empty {@code prerelease}.
      */
-    @Nonnull
     private final List<String> prerelease;
 
-    private SemanticVersion(@Nonnull SemanticVersionType type, @Nonnull List<Integer> versionNumbers, @Nonnull List<String> prerelease) {
+    private SemanticVersion(SemanticVersionType type, List<Integer> versionNumbers, List<String> prerelease) {
         this.type = type;
         this.versionNumbers = versionNumbers;
         this.prerelease = prerelease;
@@ -183,9 +175,9 @@ public class SemanticVersion implements Comparable<SemanticVersion> {
      *
      * @return a special version that is less than all other versions
      */
-    @Nonnull
     public static SemanticVersion min() {
-        return SINGLETONS.get(SemanticVersionType.MIN);
+        // MIN is a singleton type, so it is always populated by the static initializer above.
+        return Objects.requireNonNull(SINGLETONS.get(SemanticVersionType.MIN));
     }
 
     /**
@@ -194,9 +186,9 @@ public class SemanticVersion implements Comparable<SemanticVersion> {
      *
      * @return a special version that represents the current (potentially unreleased) code version
      */
-    @Nonnull
     public static SemanticVersion current() {
-        return SINGLETONS.get(SemanticVersionType.CURRENT);
+        // CURRENT is a singleton type, so it is always populated by the static initializer above.
+        return Objects.requireNonNull(SINGLETONS.get(SemanticVersionType.CURRENT));
     }
 
     /**
@@ -204,9 +196,9 @@ public class SemanticVersion implements Comparable<SemanticVersion> {
      *
      * @return a special version that is greater than all other versions
      */
-    @Nonnull
     public static SemanticVersion max() {
-        return SINGLETONS.get(SemanticVersionType.MAX);
+        // MAX is a singleton type, so it is always populated by the static initializer above.
+        return Objects.requireNonNull(SINGLETONS.get(SemanticVersionType.MAX));
     }
 
     /**
@@ -214,11 +206,11 @@ public class SemanticVersion implements Comparable<SemanticVersion> {
      * @param versionString a version in string form
      * @return a parsed version
      */
-    @Nonnull
-    public static SemanticVersion parse(@Nonnull String versionString) {
+    public static SemanticVersion parse(String versionString) {
         for (SemanticVersionType type : SemanticVersionType.values()) {
             if (type.isSingleton() && type.getText().equals(versionString)) {
-                return SINGLETONS.get(type);
+                // type.isSingleton() guarantees it was populated by the static initializer above.
+                return Objects.requireNonNull(SINGLETONS.get(type));
             }
         }
 
@@ -243,13 +235,11 @@ public class SemanticVersion implements Comparable<SemanticVersion> {
      * @return the type of this version
      * @see SemanticVersionType
      */
-    @Nonnull
     public SemanticVersionType getType() {
         return type;
     }
 
-    @Nonnull
-    private static String dotSeparated(@Nonnull String part) {
+    private static String dotSeparated(String part) {
         return part + "(." + part + ")*";
     }
 
@@ -284,15 +274,14 @@ public class SemanticVersion implements Comparable<SemanticVersion> {
         return Objects.hash(type.name(), versionNumbers, prerelease);
     }
 
-    @Nonnull
-    public List<SemanticVersion> lesserVersions(@Nonnull Collection<SemanticVersion> rawVersions) {
+    public List<SemanticVersion> lesserVersions(Collection<SemanticVersion> rawVersions) {
         return rawVersions.stream()
                 .filter(other -> other.compareTo(this) < 0)
                 .collect(Collectors.toList());
     }
 
     @Override
-    public int compareTo(@Nonnull SemanticVersion o) {
+    public int compareTo(SemanticVersion o) {
         // First, compare by type using ordinal position. Values in the enum are sorted according
         // to their expected precedence
         int typeCompare = type.compareTo(o.type);
@@ -313,7 +302,7 @@ public class SemanticVersion implements Comparable<SemanticVersion> {
         return comparePrerelease(o);
     }
 
-    private int compareVersionNumbers(@Nonnull SemanticVersion o) {
+    private int compareVersionNumbers(SemanticVersion o) {
         // semver only allows 3, we only use 4.
         // gradle supports an arbitrary number, but it gets complicated if there is a pre-release or build info
         if (versionNumbers.size() != o.versionNumbers.size()) {
@@ -329,7 +318,7 @@ public class SemanticVersion implements Comparable<SemanticVersion> {
         return 0;
     }
 
-    private int comparePrerelease(@Nonnull SemanticVersion o) {
+    private int comparePrerelease(SemanticVersion o) {
         if (!prerelease.isEmpty() && o.prerelease.isEmpty()) {
             return -1;
         } else if (prerelease.isEmpty() && !o.prerelease.isEmpty()) {

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/SemanticVersionRanges.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/SemanticVersionRanges.java
@@ -24,7 +24,6 @@ import com.google.common.collect.Range;
 import com.google.common.collect.RangeSet;
 import com.google.common.collect.TreeRangeSet;
 
-import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -43,8 +42,7 @@ public final class SemanticVersionRanges {
      * Returns the {@code [v, MAX)} range, meaning versions {@code v} and above.
      * Mirrors the {@code initialVersionAtLeast} directive.
      */
-    @Nonnull
-    public static Range<SemanticVersion> atLeast(@Nonnull SemanticVersion v) {
+    public static Range<SemanticVersion> atLeast(SemanticVersion v) {
         return Range.closedOpen(v, SemanticVersion.max());
     }
 
@@ -52,15 +50,13 @@ public final class SemanticVersionRanges {
      * The {@code [MIN, v)} range, meaning versions strictly below {@code v}.
      * Mirrors the {@code initialVersionLessThan} directive.
      */
-    @Nonnull
-    public static Range<SemanticVersion> lessThan(@Nonnull SemanticVersion v) {
+    public static Range<SemanticVersion> lessThan(SemanticVersion v) {
         return Range.closedOpen(SemanticVersion.min(), v);
     }
 
     /**
      * The full {@code [MIN, MAX)} range. This is the implicit range for an entry that declares no version constraint.
      */
-    @Nonnull
     public static Range<SemanticVersion> all() {
         return Range.closedOpen(SemanticVersion.min(), SemanticVersion.max());
     }
@@ -69,8 +65,7 @@ public final class SemanticVersionRanges {
      * Returns the sub-ranges of {@code [MIN, MAX)} that are not covered by any of the supplied ranges. An empty
      * result means the supplied ranges comprehensively cover every possible version.
      */
-    @Nonnull
-    public static Set<Range<SemanticVersion>> uncovered(@Nonnull Collection<Range<SemanticVersion>> ranges) {
+    public static Set<Range<SemanticVersion>> uncovered(Collection<Range<SemanticVersion>> ranges) {
         RangeSet<SemanticVersion> rangeSet = TreeRangeSet.create();
         ranges.forEach(rangeSet::add);
         return rangeSet.complement().subRangeSet(all()).asRanges();
@@ -80,8 +75,7 @@ public final class SemanticVersionRanges {
      * Returns the pairwise non-empty intersections of the supplied ranges, i.e. the regions where two or more ranges
      * overlap. An empty result means the supplied ranges are mutually exclusive.
      */
-    @Nonnull
-    public static Set<Range<SemanticVersion>> overlapping(@Nonnull List<Range<SemanticVersion>> ranges) {
+    public static Set<Range<SemanticVersion>> overlapping(List<Range<SemanticVersion>> ranges) {
         final Set<Range<SemanticVersion>> overlaps = new HashSet<>();
         for (int i = 0; i < ranges.size(); i++) {
             for (int j = i + 1; j < ranges.size(); j++) {

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/SupportedVersionCheck.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/SupportedVersionCheck.java
@@ -22,7 +22,6 @@ package com.apple.foundationdb.relational.yamltests.server;
 
 import com.apple.foundationdb.relational.yamltests.block.PreambleBlock;
 
-import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -78,7 +77,7 @@ public class SupportedVersionCheck {
         return SUPPORTED;
     }
 
-    public static SupportedVersionCheck unsupported(@Nonnull String message) {
+    public static SupportedVersionCheck unsupported(String message) {
         return new SupportedVersionCheck(false, message);
     }
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/package-info.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/server/package-info.java
@@ -21,4 +21,7 @@
 /**
  * Utilities for interacting with an external server while running yaml tests.
  */
+@NullMarked
 package com.apple.foundationdb.relational.yamltests.server;
+
+import org.jspecify.annotations.NullMarked;

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/tags/AbstractVectorTag.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/tags/AbstractVectorTag.java
@@ -27,19 +27,17 @@ import org.yaml.snakeyaml.nodes.Node;
 import org.yaml.snakeyaml.nodes.ScalarNode;
 import org.yaml.snakeyaml.nodes.SequenceNode;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.stream.Collectors;
 
 public abstract class AbstractVectorTag implements CustomTag {
 
     public static final class VectorMatcher<V> implements Matchable {
-        @Nonnull
         private final SequenceNode yamlNode;
 
         private final int precision;
 
-        public VectorMatcher(@Nonnull final Node node, int precision) {
+        public VectorMatcher(final Node node, int precision) {
             this.yamlNode = Assert.castUnchecked(node, SequenceNode.class);
             this.precision = precision;
         }
@@ -49,10 +47,9 @@ public abstract class AbstractVectorTag implements CustomTag {
             return prettyPrintYamlNode(yamlNode);
         }
 
-        @Nonnull
         @Override
         @SuppressWarnings("unchecked")
-        public Matchers.ResultSetMatchResult matches(@Nullable Object other, int rowNumber, @Nonnull String cellRef) {
+        public Matchers.ResultSetMatchResult matches(@Nullable Object other, int rowNumber, String cellRef) {
             final var maybeNull = Matchable.shouldNotBeNull(other, rowNumber, cellRef);
             if (maybeNull.isPresent()) {
                 return maybeNull.get();
@@ -64,8 +61,7 @@ public abstract class AbstractVectorTag implements CustomTag {
             return Matchable.prettyPrintError("expected vector '" + prettyPrintYamlNode(yamlNode) + "' got '" + other + "' instead", rowNumber, cellRef);
         }
 
-        @Nonnull
-        private static String prettyPrintYamlNode(@Nonnull final SequenceNode sequenceNode) {
+        private static String prettyPrintYamlNode(final SequenceNode sequenceNode) {
             return sequenceNode.getTag() + sequenceNode.getValue().stream()
                     .map(v -> Assert.castUnchecked(v, ScalarNode.class).getValue()).collect(Collectors.joining(",", "[", "]"));
         }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/tags/BytesTag.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/tags/BytesTag.java
@@ -30,8 +30,6 @@ import org.yaml.snakeyaml.nodes.Node;
 import org.yaml.snakeyaml.nodes.ScalarNode;
 import org.yaml.snakeyaml.nodes.Tag;
 
-import javax.annotation.Nonnull;
-
 /**
  * A custom YAML tag for byte array values in the {@code x'...'} hex format.
  * <p>
@@ -44,10 +42,8 @@ import javax.annotation.Nonnull;
 @AutoService(CustomTag.class)
 public class BytesTag implements CustomTag {
 
-    @Nonnull
     private static final Tag tag = new Tag("!b");
 
-    @Nonnull
     private static final Construct CONSTRUCT_INSTANCE = new AbstractConstruct() {
         @Override
         public byte[] construct(final Node node) {
@@ -68,13 +64,11 @@ public class BytesTag implements CustomTag {
     public BytesTag() {
     }
 
-    @Nonnull
     @Override
     public Tag getTag() {
         return tag;
     }
 
-    @Nonnull
     @Override
     public Construct getConstruct() {
         return CONSTRUCT_INSTANCE;

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/tags/CurrentVersionTag.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/tags/CurrentVersionTag.java
@@ -27,15 +27,11 @@ import org.yaml.snakeyaml.constructor.Construct;
 import org.yaml.snakeyaml.nodes.Node;
 import org.yaml.snakeyaml.nodes.Tag;
 
-import javax.annotation.Nonnull;
-
 @AutoService(CustomTag.class)
 public class CurrentVersionTag implements CustomTag {
 
-    @Nonnull
     private static final Tag tag = new Tag("!current_version");
 
-    @Nonnull
     private static final Construct CONSTRUCT_INSTANCE = new AbstractConstruct() {
         @Override
         public Object construct(Node node) {
@@ -46,13 +42,11 @@ public class CurrentVersionTag implements CustomTag {
     public CurrentVersionTag() {
     }
 
-    @Nonnull
     @Override
     public Tag getTag() {
         return tag;
     }
 
-    @Nonnull
     @Override
     public Construct getConstruct() {
         return CONSTRUCT_INSTANCE;

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/tags/CustomTag.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/tags/CustomTag.java
@@ -23,18 +23,15 @@ package com.apple.foundationdb.relational.yamltests.tags;
 import org.yaml.snakeyaml.constructor.Construct;
 import org.yaml.snakeyaml.nodes.Tag;
 
-import javax.annotation.Nonnull;
 import java.util.function.BiConsumer;
 
 public interface CustomTag {
 
-    default void accept(@Nonnull BiConsumer<Tag, Construct> visitor) {
+    default void accept(BiConsumer<Tag, Construct> visitor) {
         visitor.accept(getTag(), getConstruct());
     }
 
-    @Nonnull
     Tag getTag();
 
-    @Nonnull
     Construct getConstruct();
 }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/tags/FloatTag.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/tags/FloatTag.java
@@ -28,8 +28,6 @@ import org.yaml.snakeyaml.nodes.Node;
 import org.yaml.snakeyaml.nodes.ScalarNode;
 import org.yaml.snakeyaml.nodes.Tag;
 
-import javax.annotation.Nonnull;
-
 /**
  * A custom YAML tag for {@code float} values. Without this tag, YAML parses decimal numbers
  * as {@link Double}, which causes comparison failures against {@code float} column values
@@ -44,10 +42,8 @@ import javax.annotation.Nonnull;
 @AutoService(CustomTag.class)
 public class FloatTag implements CustomTag {
 
-    @Nonnull
     private static final Tag tag = new Tag("!f");
 
-    @Nonnull
     private static final Construct CONSTRUCT_INSTANCE = new AbstractConstruct() {
         @Override
         public Float construct(final Node node) {
@@ -61,13 +57,11 @@ public class FloatTag implements CustomTag {
     public FloatTag() {
     }
 
-    @Nonnull
     @Override
     public Tag getTag() {
         return tag;
     }
 
-    @Nonnull
     @Override
     public Construct getConstruct() {
         return CONSTRUCT_INSTANCE;

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/tags/IgnoreTag.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/tags/IgnoreTag.java
@@ -27,19 +27,15 @@ import org.yaml.snakeyaml.constructor.Construct;
 import org.yaml.snakeyaml.nodes.Node;
 import org.yaml.snakeyaml.nodes.Tag;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 
 @AutoService(CustomTag.class)
 public final class IgnoreTag implements CustomTag {
 
-    @Nonnull
     private static final Tag tag = new Tag("!ignore");
 
-    @Nonnull
     private static final Matchable INSTANCE = new IgnoreMatcher();
 
-    @Nonnull
     private static final Construct CONSTRUCT_INSTANCE = new AbstractConstruct() {
         @Override
         public Object construct(Node node) {
@@ -50,22 +46,19 @@ public final class IgnoreTag implements CustomTag {
     public IgnoreTag() {
     }
 
-    @Nonnull
     @Override
     public Tag getTag() {
         return tag;
     }
 
-    @Nonnull
     @Override
     public Construct getConstruct() {
         return CONSTRUCT_INSTANCE;
     }
 
     public static final class IgnoreMatcher implements Matchable {
-        @Nonnull
         @Override
-        public Matchers.ResultSetMatchResult matches(@Nullable final Object other, final int rowNumber, @Nonnull final String cellRef) {
+        public Matchers.ResultSetMatchResult matches(@Nullable final Object other, final int rowNumber, final String cellRef) {
             return Matchers.ResultSetMatchResult.success();
         }
 

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/tags/IsNullTag.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/tags/IsNullTag.java
@@ -27,19 +27,15 @@ import org.yaml.snakeyaml.constructor.Construct;
 import org.yaml.snakeyaml.nodes.Node;
 import org.yaml.snakeyaml.nodes.Tag;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 
 @AutoService(CustomTag.class)
 public final class IsNullTag implements CustomTag {
 
-    @Nonnull
     private static final Tag tag = new Tag("!null");
 
-    @Nonnull
     private static final Matchable INSTANCE = new IsNullMatcher();
 
-    @Nonnull
     private static final Construct CONSTRUCT_INSTANCE = new AbstractConstruct() {
         @Override
         public Object construct(Node node) {
@@ -50,27 +46,23 @@ public final class IsNullTag implements CustomTag {
     public IsNullTag() {
     }
 
-    @Nonnull
     @Override
     public Tag getTag() {
         return tag;
     }
 
-    @Nonnull
     @Override
     public Construct getConstruct() {
         return CONSTRUCT_INSTANCE;
     }
 
-    @Nonnull
     public static String usage() {
         return tag + " _";
     }
 
     public static final class IsNullMatcher implements Matchable {
-        @Nonnull
         @Override
-        public Matchers.ResultSetMatchResult matches(@Nullable final Object other, final int rowNumber, @Nonnull final String cellRef) {
+        public Matchers.ResultSetMatchResult matches(@Nullable final Object other, final int rowNumber, final String cellRef) {
             if (other == null) {
                 return Matchers.ResultSetMatchResult.success();
             }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/tags/LongTag.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/tags/LongTag.java
@@ -28,15 +28,11 @@ import org.yaml.snakeyaml.nodes.Node;
 import org.yaml.snakeyaml.nodes.ScalarNode;
 import org.yaml.snakeyaml.nodes.Tag;
 
-import javax.annotation.Nonnull;
-
 @AutoService(CustomTag.class)
 public class LongTag implements CustomTag {
 
-    @Nonnull
     private static final Tag tag = new Tag("!l");
 
-    @Nonnull
     private static final Construct CONSTRUCT_INSTANCE = new AbstractConstruct() {
         @Override
         public Long construct(final Node node) {
@@ -50,13 +46,11 @@ public class LongTag implements CustomTag {
     public LongTag() {
     }
 
-    @Nonnull
     @Override
     public Tag getTag() {
         return tag;
     }
 
-    @Nonnull
     @Override
     public Construct getConstruct() {
         return CONSTRUCT_INSTANCE;

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/tags/Matchable.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/tags/Matchable.java
@@ -22,22 +22,18 @@ package com.apple.foundationdb.relational.yamltests.tags;
 
 import com.apple.foundationdb.relational.yamltests.Matchers;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.Optional;
 
 public interface Matchable {
 
-    @Nonnull
-    Matchers.ResultSetMatchResult matches(@Nullable Object other, int rowNumber, @Nonnull String cellRef);
+    Matchers.ResultSetMatchResult matches(@Nullable Object other, int rowNumber, String cellRef);
 
-    @Nonnull
-    static Matchers.ResultSetMatchResult prettyPrintError(@Nonnull final String cause, int rowNumber, @Nonnull final String cellRef) {
+    static Matchers.ResultSetMatchResult prettyPrintError(final String cause, int rowNumber, final String cellRef) {
         return Matchers.ResultSetMatchResult.fail("wrong result at row: " + rowNumber + ", cell: " + cellRef + ", cause: " + cause);
     }
 
-    @Nonnull
-    static Optional<Matchers.ResultSetMatchResult> shouldNotBeNull(@Nullable final Object object, int rowNumber, @Nonnull final String cellRef) {
+    static Optional<Matchers.ResultSetMatchResult> shouldNotBeNull(@Nullable final Object object, int rowNumber, final String cellRef) {
         if (object != null) {
             return Optional.empty();
         }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/tags/NotNullTag.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/tags/NotNullTag.java
@@ -27,19 +27,14 @@ import org.yaml.snakeyaml.constructor.Construct;
 import org.yaml.snakeyaml.nodes.Node;
 import org.yaml.snakeyaml.nodes.Tag;
 
-import javax.annotation.Nonnull;
-
 @AutoService(CustomTag.class)
 public final class NotNullTag implements CustomTag {
 
-    @Nonnull
     private static final Tag tag = new Tag("!not_null");
 
-    @Nonnull
     private static final Matchable INSTANCE = (other, rowNumber, cellRef) ->
             Matchable.shouldNotBeNull(other, rowNumber, cellRef).orElse(Matchers.ResultSetMatchResult.success());
 
-    @Nonnull
     private static final Construct CONSTRUCT_INSTANCE = new AbstractConstruct() {
         @Override
         public Matchable construct(Node node) {
@@ -50,13 +45,11 @@ public final class NotNullTag implements CustomTag {
     public NotNullTag() {
     }
 
-    @Nonnull
     @Override
     public Tag getTag() {
         return tag;
     }
 
-    @Nonnull
     @Override
     public Construct getConstruct() {
         return CONSTRUCT_INSTANCE;

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/tags/PosTag.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/tags/PosTag.java
@@ -28,8 +28,6 @@ import org.yaml.snakeyaml.nodes.Node;
 import org.yaml.snakeyaml.nodes.ScalarNode;
 import org.yaml.snakeyaml.nodes.Tag;
 
-import javax.annotation.Nonnull;
-
 /**
  * YAML tag for ignoring column name validation in result sets.
  * <br>
@@ -38,10 +36,8 @@ import javax.annotation.Nonnull;
 @AutoService(CustomTag.class)
 public final class PosTag implements CustomTag {
 
-    @Nonnull
     private static final Tag tag = new Tag("!pos");
 
-    @Nonnull
     private static final Construct CONSTRUCT_INSTANCE = new AbstractConstruct() {
         @Override
         public Object construct(Node node) {
@@ -56,27 +52,23 @@ public final class PosTag implements CustomTag {
     public PosTag() {
     }
 
-    @Nonnull
     @Override
     public Tag getTag() {
         return tag;
     }
 
-    @Nonnull
     @Override
     public Construct getConstruct() {
         return CONSTRUCT_INSTANCE;
     }
 
     public static final class ColumnPosition {
-        @Nonnull
         private final Integer pos;
 
-        public ColumnPosition(@Nonnull final Integer columnPosition) {
+        public ColumnPosition(final Integer columnPosition) {
             this.pos = columnPosition;
         }
 
-        @Nonnull
         public Integer getValue() {
             return pos;
         }

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/tags/RandomStrTag.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/tags/RandomStrTag.java
@@ -30,8 +30,7 @@ import org.yaml.snakeyaml.nodes.Node;
 import org.yaml.snakeyaml.nodes.ScalarNode;
 import org.yaml.snakeyaml.nodes.Tag;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.Locale;
 
 /**
@@ -66,25 +65,20 @@ import java.util.Locale;
 @AutoService(CustomTag.class)
 public class RandomStrTag implements CustomTag {
 
-    @Nonnull
     private static final Tag tag = new Tag("!randomStr");
 
-    @Nonnull
     @Override
     public Tag getTag() {
         return tag;
     }
 
-    @Nonnull
     private static final Construct CONSTRUCT_INSTANCE = new AbstractConstruct() {
         @Override
-        @Nonnull
         public Matchable construct(Node node) {
             return new RandomStrMatcher(node);
         }
     };
 
-    @Nonnull
     @Override
     public Construct getConstruct() {
         return CONSTRUCT_INSTANCE;
@@ -93,13 +87,11 @@ public class RandomStrTag implements CustomTag {
     public static final class RandomStrMatcher implements Matchable {
         private static final int DIFF_CONTEXT = 10;
 
-        @Nonnull
         private final ScalarNode yamlNode;
 
-        @Nonnull
         private final String randomString;
 
-        public RandomStrMatcher(@Nonnull final Node node) {
+        public RandomStrMatcher(final Node node) {
             this.yamlNode = Assert.castUnchecked(node, ScalarNode.class);
             this.randomString = Matchers.constructRandomString(yamlNode);
         }
@@ -109,9 +101,8 @@ public class RandomStrTag implements CustomTag {
             return tag + " " + yamlNode.getValue() + " → " + Matchers.limitString(randomString);
         }
 
-        @Nonnull
         @Override
-        public Matchers.ResultSetMatchResult matches(@Nullable Object other, int rowNumber, @Nonnull String cellRef) {
+        public Matchers.ResultSetMatchResult matches(@Nullable Object other, int rowNumber, String cellRef) {
             final var maybeNull = Matchable.shouldNotBeNull(other, rowNumber, cellRef);
             if (maybeNull.isPresent()) {
                 return maybeNull.get();
@@ -123,8 +114,7 @@ public class RandomStrTag implements CustomTag {
             return Matchable.prettyPrintError(stringDiff(randomString, actual), rowNumber, cellRef);
         }
 
-        @Nonnull
-        private static String stringDiff(@Nonnull final String expected, @Nonnull final String actual) {
+        private static String stringDiff(final String expected, final String actual) {
             final int expLen = expected.length();
             final int actLen = actual.length();
             int firstDiff = -1;

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/tags/StringContainsTag.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/tags/StringContainsTag.java
@@ -29,16 +29,15 @@ import org.yaml.snakeyaml.nodes.Node;
 import org.yaml.snakeyaml.nodes.ScalarNode;
 import org.yaml.snakeyaml.nodes.Tag;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Objects;
 
 @AutoService(CustomTag.class)
 public final class StringContainsTag implements CustomTag {
 
-    @Nonnull
     private static final Tag tag = new Tag("!sc");
 
-    @Nonnull
     private static final Construct CONSTRUCT_INSTANCE = new AbstractConstruct() {
         @Override
         public Matchable construct(final Node node) {
@@ -52,38 +51,35 @@ public final class StringContainsTag implements CustomTag {
     public StringContainsTag() {
     }
 
-    @Nonnull
     @Override
     public Tag getTag() {
         return tag;
     }
 
-    @Nonnull
     @Override
     public Construct getConstruct() {
         return CONSTRUCT_INSTANCE;
     }
 
     public static final class StringContainsMatcher implements Matchable {
-        @Nonnull
         private final String value;
 
-        public StringContainsMatcher(@Nonnull final String value) {
+        public StringContainsMatcher(final String value) {
             this.value = value;
         }
 
-        @Nonnull
         public String getValue() {
             return value;
         }
 
-        @Nonnull
         @Override
-        public Matchers.ResultSetMatchResult matches(@Nullable final Object other, int rowNumber, @Nonnull final String cellRef) {
+        public Matchers.ResultSetMatchResult matches(@Nullable Object other, int rowNumber, final String cellRef) {
             final var maybeNull = Matchable.shouldNotBeNull(other, rowNumber, cellRef);
             if (maybeNull.isPresent()) {
                 return maybeNull.get();
             }
+            // shouldNotBeNull() above only returns an empty Optional when other is non-null.
+            other = Objects.requireNonNull(other);
             if (other instanceof String) {
                 final var otherStr = (String)other;
                 if (otherStr.contains(value)) {

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/tags/UuidTag.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/tags/UuidTag.java
@@ -29,17 +29,14 @@ import org.yaml.snakeyaml.nodes.Node;
 import org.yaml.snakeyaml.nodes.ScalarNode;
 import org.yaml.snakeyaml.nodes.Tag;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.UUID;
 
 @AutoService(CustomTag.class)
 public final class UuidTag implements CustomTag {
 
-    @Nonnull
     private static final Tag tag = new Tag("!uuid");
 
-    @Nonnull
     private static final Construct CONSTRUCT_INSTANCE = new AbstractConstruct() {
         @Override
         public Matchable construct(final Node node) {
@@ -53,34 +50,29 @@ public final class UuidTag implements CustomTag {
     public UuidTag() {
     }
 
-    @Nonnull
     @Override
     public Tag getTag() {
         return tag;
     }
 
-    @Nonnull
     @Override
     public Construct getConstruct() {
         return CONSTRUCT_INSTANCE;
     }
 
     public static final class UuidMatcher implements Matchable {
-        @Nonnull
         private final String value;
 
-        public UuidMatcher(@Nonnull final String value) {
+        public UuidMatcher(final String value) {
             this.value = value;
         }
 
-        @Nonnull
         public String getValue() {
             return value;
         }
 
-        @Nonnull
         @Override
-        public Matchers.ResultSetMatchResult matches(@Nullable Object other, int rowNumber, @Nonnull String cellRef) {
+        public Matchers.ResultSetMatchResult matches(@Nullable Object other, int rowNumber, String cellRef) {
             final var maybeNull = Matchable.shouldNotBeNull(other, rowNumber, cellRef);
             if (maybeNull.isPresent()) {
                 return maybeNull.get();

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/tags/Vector16Tag.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/tags/Vector16Tag.java
@@ -27,18 +27,13 @@ import org.yaml.snakeyaml.constructor.Construct;
 import org.yaml.snakeyaml.nodes.Node;
 import org.yaml.snakeyaml.nodes.Tag;
 
-import javax.annotation.Nonnull;
-
 @AutoService(CustomTag.class)
 public final class Vector16Tag extends AbstractVectorTag {
 
-    @Nonnull
     private static final Tag tag = new Tag("!v16");
 
-    @Nonnull
     private static final Construct CONSTRUCT_INSTANCE = new AbstractConstruct() {
         @Override
-        @Nonnull
         public Matchable construct(Node node) {
             return new VectorMatcher<HalfRealVector>(node, 16);
         }
@@ -47,13 +42,11 @@ public final class Vector16Tag extends AbstractVectorTag {
     public Vector16Tag() {
     }
 
-    @Nonnull
     @Override
     public Tag getTag() {
         return tag;
     }
 
-    @Nonnull
     @Override
     public Construct getConstruct() {
         return CONSTRUCT_INSTANCE;

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/tags/Vector32Tag.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/tags/Vector32Tag.java
@@ -27,18 +27,13 @@ import org.yaml.snakeyaml.constructor.Construct;
 import org.yaml.snakeyaml.nodes.Node;
 import org.yaml.snakeyaml.nodes.Tag;
 
-import javax.annotation.Nonnull;
-
 @AutoService(CustomTag.class)
 public final class Vector32Tag extends AbstractVectorTag {
 
-    @Nonnull
     private static final Tag tag = new Tag("!v32");
 
-    @Nonnull
     private static final Construct CONSTRUCT_INSTANCE = new AbstractConstruct() {
         @Override
-        @Nonnull
         public Matchable construct(Node node) {
             return new VectorMatcher<FloatRealVector>(node, 32);
         }
@@ -47,13 +42,11 @@ public final class Vector32Tag extends AbstractVectorTag {
     public Vector32Tag() {
     }
 
-    @Nonnull
     @Override
     public Tag getTag() {
         return tag;
     }
 
-    @Nonnull
     @Override
     public Construct getConstruct() {
         return CONSTRUCT_INSTANCE;

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/tags/Vector64Tag.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/tags/Vector64Tag.java
@@ -27,18 +27,13 @@ import org.yaml.snakeyaml.constructor.Construct;
 import org.yaml.snakeyaml.nodes.Node;
 import org.yaml.snakeyaml.nodes.Tag;
 
-import javax.annotation.Nonnull;
-
 @AutoService(CustomTag.class)
 public final class Vector64Tag extends AbstractVectorTag {
 
-    @Nonnull
     private static final Tag tag = new Tag("!v64");
 
-    @Nonnull
     private static final Construct CONSTRUCT_INSTANCE = new AbstractConstruct() {
         @Override
-        @Nonnull
         public Matchable construct(Node node) {
             return new VectorMatcher<DoubleRealVector>(node, 64);
         }
@@ -47,13 +42,11 @@ public final class Vector64Tag extends AbstractVectorTag {
     public Vector64Tag() {
     }
 
-    @Nonnull
     @Override
     public Tag getTag() {
         return tag;
     }
 
-    @Nonnull
     @Override
     public Construct getConstruct() {
         return CONSTRUCT_INSTANCE;

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/tags/package-info.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/tags/package-info.java
@@ -64,4 +64,7 @@
  * with {@code @AutoService(CustomTag.class)}, and update the list above. See existing tags in this package for examples.
  */
 
+@NullMarked
 package com.apple.foundationdb.relational.yamltests.tags;
+
+import org.jspecify.annotations.NullMarked;

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/utils/ExportSchemaTemplateUtil.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/utils/ExportSchemaTemplateUtil.java
@@ -24,7 +24,6 @@ import com.apple.foundationdb.record.RecordMetaData;
 import com.apple.foundationdb.record.RecordMetaDataProto;
 import com.google.protobuf.util.JsonFormat;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -48,7 +47,7 @@ public class ExportSchemaTemplateUtil {
      * @param exportLocation path to export location
      * @throws IOException any problem encountered writing the file
      */
-    public static void export(@Nonnull RecordMetaData metaData, @Nonnull Path exportLocation) throws IOException {
+    public static void export(RecordMetaData metaData, Path exportLocation) throws IOException {
         final RecordMetaDataProto.MetaData metaDataProto = metaData.toProto();
 
         // Ensure parent directory exists

--- a/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/utils/package-info.java
+++ b/yaml-tests/src/main/java/com/apple/foundationdb/relational/yamltests/utils/package-info.java
@@ -21,4 +21,7 @@
 /**
  * Utility methods to be used in conjunction with the YAML testing framework.
  */
+@NullMarked
 package com.apple.foundationdb.relational.yamltests.utils;
+
+import org.jspecify.annotations.NullMarked;

--- a/yaml-tests/src/test/java/CustomTagTest.java
+++ b/yaml-tests/src/test/java/CustomTagTest.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -52,7 +51,6 @@ class CustomTagTest {
         new YamlRunner(testName, connectionFactory, YamlExecutionContext.ContextOptions.EMPTY_OPTIONS).run();
     }
 
-    @Nonnull
     static Stream<String> shouldPass() {
         return Stream.of(
                 "ignore-tag",

--- a/yaml-tests/src/test/java/InitialVersionTest.java
+++ b/yaml-tests/src/test/java/InitialVersionTest.java
@@ -31,7 +31,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import javax.annotation.Nonnull;
 import java.net.URI;
 import java.sql.DriverManager;
 import java.sql.SQLException;
@@ -74,7 +73,7 @@ public class InitialVersionTest {
     YamlConnectionFactory createConnectionFactory() {
         return new YamlConnectionFactory() {
             @Override
-            public YamlConnection getNewConnection(@Nonnull URI connectPath, int clusterIndex) throws SQLException {
+            public YamlConnection getNewConnection(URI connectPath, int clusterIndex) throws SQLException {
                 return new SimpleYamlConnection(DriverManager.getConnection(connectPath.toString()), VERSION, CLUSTER_FILE);
             }
 

--- a/yaml-tests/src/test/java/MetaDataExportUtilityTests.java
+++ b/yaml-tests/src/test/java/MetaDataExportUtilityTests.java
@@ -32,7 +32,6 @@ import com.apple.foundationdb.relational.yamltests.utils.ExportSchemaTemplateUti
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.stream.Collectors;
@@ -60,12 +59,12 @@ import java.util.stream.Collectors;
 @Disabled("for updating test files that should be checked in")
 class MetaDataExportUtilityTests {
 
-    private static void exportMetaData(@Nonnull RecordMetaData metaData, @Nonnull String name) throws IOException {
+    private static void exportMetaData(RecordMetaData metaData, String name) throws IOException {
         Path path = Path.of("src", "test", "resources", name);
         ExportSchemaTemplateUtil.export(metaData, path);
     }
 
-    private void setAllPrimaryKeys(@Nonnull RecordMetaDataBuilder metaDataBuilder, @Nonnull KeyExpression primaryKey) {
+    private void setAllPrimaryKeys(RecordMetaDataBuilder metaDataBuilder, KeyExpression primaryKey) {
         metaDataBuilder.getUnionDescriptor().getFields().forEach( f -> {
             final String typeName = f.getMessageType().getName();
             metaDataBuilder.getRecordType(typeName).setPrimaryKey(primaryKey);

--- a/yaml-tests/src/test/java/MultiServerConnectionFactoryTest.java
+++ b/yaml-tests/src/test/java/MultiServerConnectionFactoryTest.java
@@ -30,7 +30,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mockito;
 
-import javax.annotation.Nonnull;
 import java.net.URI;
 import java.sql.SQLException;
 import java.util.List;
@@ -202,14 +201,14 @@ public class MultiServerConnectionFactoryTest {
         assertEquals(expectedVersions, connection.getVersions());
     }
 
-    YamlConnectionFactory dummyConnectionFactory(@Nonnull SemanticVersion version) {
+    YamlConnectionFactory dummyConnectionFactory(SemanticVersion version) {
         return dummyMultiClusterConnectionFactory(version, List.of(CLUSTER_FILE));
     }
 
-    YamlConnectionFactory dummyMultiClusterConnectionFactory(@Nonnull SemanticVersion version, @Nonnull List<String> clusterFiles) {
+    YamlConnectionFactory dummyMultiClusterConnectionFactory(SemanticVersion version, List<String> clusterFiles) {
         return new YamlConnectionFactory() {
             @Override
-            public YamlConnection getNewConnection(@Nonnull URI connectPath, int clusterIndex) throws SQLException {
+            public YamlConnection getNewConnection(URI connectPath, int clusterIndex) throws SQLException {
                 if (clusterIndex < 0 || clusterIndex >= clusterFiles.size()) {
                     throw new SQLException("Cluster index " + clusterIndex + " not available (only " +
                             clusterFiles.size() + " clusters configured)");
@@ -230,8 +229,7 @@ public class MultiServerConnectionFactoryTest {
         };
     }
 
-    @Nonnull
-    private static RelationalConnection dummyConnection(@Nonnull URI connectPath) throws SQLException {
+    private static RelationalConnection dummyConnection(URI connectPath) throws SQLException {
         final RelationalConnection connection = Mockito.mock(RelationalConnection.class);
         Mockito.when(connection.unwrap(RelationalConnection.class)).thenReturn(connection);
         Mockito.when(connection.getPath()).thenReturn(connectPath);

--- a/yaml-tests/src/test/java/SupportedVersionTest.java
+++ b/yaml-tests/src/test/java/SupportedVersionTest.java
@@ -31,7 +31,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import javax.annotation.Nonnull;
 import java.net.URI;
 import java.sql.DriverManager;
 import java.sql.SQLException;
@@ -67,7 +66,7 @@ public class SupportedVersionTest {
     YamlConnectionFactory createConnectionFactory() {
         return new YamlConnectionFactory() {
             @Override
-            public YamlConnection getNewConnection(@Nonnull URI connectPath, int clusterIndex) throws SQLException {
+            public YamlConnection getNewConnection(URI connectPath, int clusterIndex) throws SQLException {
                 return new SimpleYamlConnection(DriverManager.getConnection(connectPath.toString()), VERSION, CLUSTER_FILE);
             }
 

--- a/yaml-tests/src/test/java/com/apple/foundationdb/relational/yamltests/CheckExplainConfigTest.java
+++ b/yaml-tests/src/test/java/com/apple/foundationdb/relational/yamltests/CheckExplainConfigTest.java
@@ -34,11 +34,13 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 import org.opentest4j.AssertionFailedError;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
+
+import static com.apple.foundationdb.relational.yamltests.generated.stats.PlannerMetricsProto.Info;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -165,7 +167,7 @@ class CheckExplainConfigTest {
         final var struct = metricsMatch ? metricsStruct(10, 5) : metricsStruct(20, 5);
         final var err = assertThrows(AssertionFailedError.class,
                 () -> exactConfig(executionContext, PLAN_A).invoke(mockResultSet(PLAN_A, PLAN_DOT, struct)));
-        assertTrue(err.getMessage().contains("No planner metrics"));
+        assertTrue(Objects.requireNonNull(err.getMessage()).contains("No planner metrics"));
     }
 
     static Stream<Arguments> planMatchMetricsDifferCorrectMetricsArgs() {
@@ -199,7 +201,7 @@ class CheckExplainConfigTest {
         final var executionContext = mockExecutionContext(correctExplains, false, false, filesMaintainer, metricsMaintainer);
         final var err = assertThrows(AssertionFailedError.class,
                 () -> exactConfig(executionContext, PLAN_A).invoke(mockResultSet(PLAN_A, PLAN_DOT, metricsStruct(20, 5))));
-        assertTrue(err.getMessage().contains("Planner metrics have changed"));
+        assertTrue(Objects.requireNonNull(err.getMessage()).contains("Planner metrics have changed"));
     }
 
     static Stream<Arguments> planMatchBypassGuardArgs() {
@@ -231,7 +233,7 @@ class CheckExplainConfigTest {
         final var executionContext = mockExecutionContext(true, false, false, filesMaintainer, metricsMaintainer);
         final var err = assertThrows(AssertionFailedError.class,
                 () -> exactConfig(executionContext, PLAN_A).invoke(mockResultSet(PLAN_A, PLAN_DOT, metricsStruct(20, 5))));
-        assertTrue(err.getMessage().contains("No planner metrics"));
+        assertTrue(Objects.requireNonNull(err.getMessage()).contains("No planner metrics"));
     }
 
     static Stream<Arguments> planMismatchWritesExplainUpdatedMetricsArgs() {
@@ -275,7 +277,7 @@ class CheckExplainConfigTest {
         final var executionContext = mockExecutionContext(true, false, false, filesMaintainer, metricsMaintainer);
         final var err = assertThrows(AssertionFailedError.class,
                 () -> exactConfig(executionContext, PLAN_A).invoke(mockResultSet(PLAN_B, PLAN_DOT, metricsStruct(10, 5))));
-        assertTrue(err.getMessage().contains("No planner metrics"));
+        assertTrue(Objects.requireNonNull(err.getMessage()).contains("No planner metrics"));
         assertExplainCorrectionQueued(filesMaintainer, PLAN_B);
     }
 
@@ -342,7 +344,7 @@ class CheckExplainConfigTest {
         final var executionContext = mockExecutionContext(true, false, false, filesMaintainer, metricsMaintainer);
         final var err = assertThrows(AssertionFailedError.class,
                 () -> exactConfig(executionContext, PLAN_A).invoke(mockResultSet(PLAN_B, PLAN_DOT, metricsStruct(20, 5))));
-        assertTrue(err.getMessage().contains("No planner metrics"));
+        assertTrue(Objects.requireNonNull(err.getMessage()).contains("No planner metrics"));
         assertExplainCorrectionQueued(filesMaintainer, PLAN_B);
     }
 
@@ -355,7 +357,7 @@ class CheckExplainConfigTest {
         final var executionContext = mockExecutionContext(true, false, false, filesMaintainer, metricsMaintainer);
         final var err = assertThrows(AssertionFailedError.class,
                 () -> exactConfig(executionContext, PLAN_A).invoke(mockResultSet(PLAN_B, PLAN_DOT, metricsStruct(20, 5))));
-        assertTrue(err.getMessage().contains("Planner metrics have changed"));
+        assertTrue(Objects.requireNonNull(err.getMessage()).contains("Planner metrics have changed"));
         assertExplainCorrectionQueued(filesMaintainer, PLAN_B);
     }
 
@@ -395,26 +397,26 @@ class CheckExplainConfigTest {
         final var struct = hasActualMetrics ? (metricsMatch ? metricsStruct(10, 5) : metricsStruct(20, 5)) : null;
         final var err = assertThrows(AssertionFailedError.class,
                 () -> exactConfig(executionContext, PLAN_A).invoke(mockResultSet(PLAN_B, PLAN_DOT, struct)));
-        assertTrue(err.getMessage().contains("plan mismatch"));
+        assertTrue(Objects.requireNonNull(err.getMessage()).contains("plan mismatch"));
     }
 
-    private static void assertNoFileCorrections(@Nonnull YamlFilesMaintainer filesMaintainer) {
+    private static void assertNoFileCorrections(YamlFilesMaintainer filesMaintainer) {
         assertTrue(filesMaintainer.getPendingCorrections(RESOURCE).isEmpty());
     }
 
-    private static void assertMetricsNotWritten(@Nonnull YamlMetricsMaintainer metricsMaintainer) {
+    private static void assertMetricsNotWritten(YamlMetricsMaintainer metricsMaintainer) {
         assertFalse(metricsMaintainer.isMetricsDirty());
         Assertions.assertNull(metricsMaintainer.getActualMetrics(buildIdentifier()));
     }
 
-    private static void assertMetricsPreserved(@Nonnull YamlMetricsMaintainer metricsMaintainer,
-                                                @Nonnull PlannerMetricsProto.Info expected) {
+    private static void assertMetricsPreserved(YamlMetricsMaintainer metricsMaintainer,
+                                                PlannerMetricsProto.Info expected) {
         assertFalse(metricsMaintainer.isMetricsDirty());
         Assertions.assertEquals(expected, metricsMaintainer.getActualMetrics(buildIdentifier()));
     }
 
-    private static void assertMetricsWritten(@Nonnull YamlMetricsMaintainer metricsMaintainer,
-                                              @Nonnull String expectedPlan, long expectedTaskCount) {
+    private static void assertMetricsWritten(YamlMetricsMaintainer metricsMaintainer,
+                                              String expectedPlan, long expectedTaskCount) {
         assertTrue(metricsMaintainer.isMetricsDirty());
         final var stored = metricsMaintainer.getActualMetrics(buildIdentifier());
         Assertions.assertNotNull(stored);
@@ -425,8 +427,8 @@ class CheckExplainConfigTest {
     /** Builds a mocked context wiring in the provided maintainers and option flags. */
     private static YamlExecutionContext mockExecutionContext(boolean correctExplains, boolean correctMetrics,
                                                              boolean addExplains,
-                                                             @Nonnull YamlFilesMaintainer filesMaintainer,
-                                                             @Nonnull YamlMetricsMaintainer metricsMaintainer) {
+                                                             YamlFilesMaintainer filesMaintainer,
+                                                             YamlMetricsMaintainer metricsMaintainer) {
         final var executionContext = Mockito.mock(YamlExecutionContext.class);
         Mockito.when(executionContext.shouldCorrectExplains()).thenReturn(correctExplains);
         Mockito.when(executionContext.shouldCorrectMetrics()).thenReturn(correctMetrics);
@@ -443,26 +445,26 @@ class CheckExplainConfigTest {
         return filesMaintainer;
     }
 
-    private static YamlMetricsMaintainer getMetricsMaintainer(@Nullable PlannerMetricsProto.Info metricsInfo) {
+    private static YamlMetricsMaintainer getMetricsMaintainer(@Nullable Info metricsInfo) {
         final ImmutableMap<PlannerMetricsProto.Identifier, PlannerMetricsProto.Info> expectedMetricsMap =
                 metricsInfo == null ? ImmutableMap.of() :
                 ImmutableMap.of(buildIdentifier(), metricsInfo);
         return new YamlMetricsMaintainer(RESOURCE, expectedMetricsMap);
     }
 
-    private static TestableConfig syntheticConfig(@Nonnull YamlExecutionContext executionContext) {
+    private static TestableConfig syntheticConfig(YamlExecutionContext executionContext) {
         return new TestableConfig(REFERENCE, executionContext, null, true);
     }
 
-    private static TestableConfig exactConfig(@Nonnull YamlExecutionContext executionContext, @Nonnull String expected) {
+    private static TestableConfig exactConfig(YamlExecutionContext executionContext, String expected) {
         return new TestableConfig(REFERENCE, executionContext, expected, true);
     }
 
-    private static TestableConfig containsConfig(@Nonnull YamlExecutionContext executionContext, @Nonnull String fragment) {
+    private static TestableConfig containsConfig(YamlExecutionContext executionContext, String fragment) {
         return new TestableConfig(REFERENCE, executionContext, fragment, false);
     }
 
-    private static RelationalResultSet mockResultSet(@Nonnull String plan, @Nonnull String planDot,
+    private static RelationalResultSet mockResultSet(String plan, String planDot,
                                                      @Nullable RelationalStruct metricsStruct) throws SQLException {
         final var rs = Mockito.mock(RelationalResultSet.class);
         Mockito.when(rs.getString(1)).thenReturn(plan);
@@ -484,7 +486,7 @@ class CheckExplainConfigTest {
         return s;
     }
 
-    private static PlannerMetricsProto.Info metricsInfo(@Nonnull String plan, long taskCount, long transformCount) {
+    private static PlannerMetricsProto.Info metricsInfo(String plan, long taskCount, long transformCount) {
         return PlannerMetricsProto.Info.newBuilder()
                 .setExplain(plan)
                 .setDot(PLAN_DOT)
@@ -507,8 +509,8 @@ class CheckExplainConfigTest {
                 .build();
     }
 
-    private static void assertExplainCorrectionQueued(@Nonnull YamlFilesMaintainer filesMaintainer,
-                                                       @Nonnull String expectedPlan) {
+    private static void assertExplainCorrectionQueued(YamlFilesMaintainer filesMaintainer,
+                                                       String expectedPlan) {
         final var corrections = filesMaintainer.getPendingCorrections(RESOURCE);
         Assertions.assertEquals(1, corrections.size());
         final var correction = corrections.get(0);
@@ -520,12 +522,12 @@ class CheckExplainConfigTest {
     }
 
     static class TestableConfig extends CheckExplainConfig {
-        TestableConfig(@Nonnull YamlReference reference, @Nonnull YamlExecutionContext executionContext,
+        TestableConfig(YamlReference reference, YamlExecutionContext executionContext,
                        @Nullable Object value, boolean isExact) {
             super(QueryConfig.QUERY_CONFIG_EXPLAIN, value, reference, executionContext, isExact, "testBlock");
         }
 
-        void invoke(@Nonnull Object actual) throws SQLException {
+        void invoke(Object actual) throws SQLException {
             checkResultInternal("SELECT 1", actual, "SELECT 1", List.of());
         }
     }

--- a/yaml-tests/src/test/java/com/apple/foundationdb/relational/yamltests/MetricsDiffAnalyzerTest.java
+++ b/yaml-tests/src/test/java/com/apple/foundationdb/relational/yamltests/MetricsDiffAnalyzerTest.java
@@ -24,11 +24,11 @@ import com.apple.foundationdb.relational.yamltests.generated.stats.PlannerMetric
 import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
 
-import javax.annotation.Nonnull;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -36,7 +36,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 class MetricsDiffAnalyzerTest {
 
-    @Nonnull
     private static final PlannerMetricsProto.CountersAndTimers BASE_DUMMY_COUNTERS = PlannerMetricsProto.CountersAndTimers.newBuilder()
             .setTaskCount(10)
             .setTaskTotalTimeNs(1000000L)
@@ -63,15 +62,14 @@ class MetricsDiffAnalyzerTest {
                 .build();
 
         assertThat(metrics).containsKey(basicIdentifier);
-        final var metricsInfo = metrics.get(basicIdentifier);
+        final var metricsInfo = Objects.requireNonNull(metrics.get(basicIdentifier));
         assertThat(metricsInfo.getExplain()).isEqualTo("Index(users_by_id [[?, ?]])");
         assertThat(metricsInfo.getCountersAndTimers().getTaskCount()).isEqualTo(10);
         assertThat(metricsInfo.getCountersAndTimers().getTransformCount()).isEqualTo(5);
     }
 
-    @Nonnull
-    private MetricsDiffAnalyzer.MetricsAnalysisResult analyze(@Nonnull Map<PlannerMetricsProto.Identifier, MetricsInfo> baseMetrics,
-                                                              @Nonnull Map<PlannerMetricsProto.Identifier, MetricsInfo> headMetrics) {
+    private MetricsDiffAnalyzer.MetricsAnalysisResult analyze(Map<PlannerMetricsProto.Identifier, MetricsInfo> baseMetrics,
+                                                              Map<PlannerMetricsProto.Identifier, MetricsInfo> headMetrics) {
         final var analyzer = new MetricsDiffAnalyzer("base", "head", Paths.get("."), null);
         final var analysisBuilder = analyzer.newAnalysisBuilder();
         final var filePath = Paths.get("test.metrics.yaml");
@@ -80,14 +78,12 @@ class MetricsDiffAnalyzerTest {
         return analysisBuilder.build();
     }
 
-    @Nonnull
     private Path getTestResourcePath(String filename) {
         final var classLoader = Thread.currentThread().getContextClassLoader();
         final var resource = classLoader.getResource("metrics-diff/" + filename);
         assertNotNull(resource, "Test resource not found: metrics-diff/" + filename);
         return Paths.get(resource.getPath());
     }
-
 
     @Test
     void testCompareMetricsDetectsChanges() throws Exception {
@@ -112,8 +108,8 @@ class MetricsDiffAnalyzerTest {
             assertThat(planChanged.newInfo).isNotNull();
             assertThat(planChanged.oldInfo).isNotNull();
             final String query = planChanged.identifier.getQuery();
-            final String newExplain = planChanged.newInfo.getExplain();
-            final String oldExplain = planChanged.oldInfo.getExplain();
+            final String newExplain = Objects.requireNonNull(planChanged.newInfo).getExplain();
+            final String oldExplain = Objects.requireNonNull(planChanged.oldInfo).getExplain();
 
             if (query.contains("SELECT * FROM orders WHERE customer_id = ?")) {
                 assertThat(newExplain).contains("Covering_Index");
@@ -129,8 +125,8 @@ class MetricsDiffAnalyzerTest {
         final var metricsChanged = analysis.getMetricsOnlyChanged().get(0);
         assertThat(metricsChanged.newInfo).isNotNull();
         assertThat(metricsChanged.oldInfo).isNotNull();
-        assertThat(metricsChanged.newInfo.getExplain())
-                .isEqualTo(metricsChanged.oldInfo.getExplain())
+        assertThat(Objects.requireNonNull(metricsChanged.newInfo).getExplain())
+                .isEqualTo(Objects.requireNonNull(metricsChanged.oldInfo).getExplain())
                 .contains("GroupBy(Join(Index(users), Index(orders_by_customer)))");
     }
 
@@ -207,7 +203,7 @@ class MetricsDiffAnalyzerTest {
                 .hasSize(1);
         assertThat(outlierText[0])
                 .contains(expected.identifier.getQuery())
-                .contains("" + expected.newInfo.getLineNumber());
+                .contains("" + Objects.requireNonNull(expected.newInfo).getLineNumber());
     }
 
     @Test
@@ -256,7 +252,6 @@ class MetricsDiffAnalyzerTest {
                 .contains("[+100%, +102%)");
     }
 
-    @Nonnull
     private Map<PlannerMetricsProto.Identifier, MetricsInfo> createTestMetricsWithStatistics() {
         // Create metrics with predictable statistical properties
         final var builder = ImmutableMap.<PlannerMetricsProto.Identifier, MetricsInfo>builder();
@@ -290,7 +285,6 @@ class MetricsDiffAnalyzerTest {
         return builder.build();
     }
 
-    @Nonnull
     private Map<PlannerMetricsProto.Identifier, MetricsInfo> createModifiedTestMetrics() {
         // Create modified versions with predictable changes
         final var builder = ImmutableMap.<PlannerMetricsProto.Identifier, MetricsInfo>builder();
@@ -324,7 +318,6 @@ class MetricsDiffAnalyzerTest {
         return builder.build();
     }
 
-    @Nonnull
     private Map<PlannerMetricsProto.Identifier, MetricsInfo> createMetricsWithOutliers() {
         final var builder = ImmutableMap.<PlannerMetricsProto.Identifier, MetricsInfo>builder();
 
@@ -364,7 +357,6 @@ class MetricsDiffAnalyzerTest {
         return builder.build();
     }
 
-    @Nonnull
     private Map<PlannerMetricsProto.Identifier, MetricsInfo> createMetricsWithOutlierChanges() {
         final var builder = ImmutableMap.<PlannerMetricsProto.Identifier, MetricsInfo>builder();
 

--- a/yaml-tests/src/test/java/com/apple/foundationdb/relational/yamltests/MetricsDiffIntegrationTest.java
+++ b/yaml-tests/src/test/java/com/apple/foundationdb/relational/yamltests/MetricsDiffIntegrationTest.java
@@ -23,7 +23,6 @@ package com.apple.foundationdb.relational.yamltests;
 import com.apple.foundationdb.relational.api.exceptions.RelationalException;
 import org.junit.jupiter.api.Test;
 
-import javax.annotation.Nonnull;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -159,8 +158,7 @@ class MetricsDiffIntegrationTest {
                 .contains("- Plan unchanged + metrics changed: 0");
     }
 
-    @Nonnull
-    private static MetricsDiffAnalyzer.MetricsAnalysisResult analyze(@Nonnull String baseResource, @Nonnull String headResource) throws RelationalException {
+    private static MetricsDiffAnalyzer.MetricsAnalysisResult analyze(String baseResource, String headResource) throws RelationalException {
         // Load test resources
         final var baseMetrics = YamlExecutionContext.loadMetricsFromYamlFile(
                 getTestResourcePath(baseResource));
@@ -174,7 +172,6 @@ class MetricsDiffIntegrationTest {
         return analysisBuilder.build();
     }
 
-    @Nonnull
     private static Path getTestResourcePath(String filename) {
         final var classLoader = Thread.currentThread().getContextClassLoader();
         final var resource = classLoader.getResource("metrics-diff/" + filename);

--- a/yaml-tests/src/test/java/com/apple/foundationdb/relational/yamltests/server/ExternalServerTest.java
+++ b/yaml-tests/src/test/java/com/apple/foundationdb/relational/yamltests/server/ExternalServerTest.java
@@ -25,7 +25,6 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import javax.annotation.Nonnull;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -94,7 +93,7 @@ class ExternalServerTest {
         }
     }
 
-    private static void assertDistinctPorts(@Nonnull Collection<ExternalServer> servers) {
+    private static void assertDistinctPorts(Collection<ExternalServer> servers) {
         // we can't assert about the actual values, because one of the ports may be busy,
         // so assert that each server has its own port, and none of them have the same port
         assertThat(servers)

--- a/yaml-tests/src/test/java/com/apple/foundationdb/relational/yamltests/server/SemanticVersionTest.java
+++ b/yaml-tests/src/test/java/com/apple/foundationdb/relational/yamltests/server/SemanticVersionTest.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -131,6 +130,7 @@ class SemanticVersionTest {
     }
 
     @Test
+    @SuppressWarnings("NullAway") // Intentionally passing a null literal to verify compareTo() throws NPE, per the Comparable contract.
     void compareToNull() throws Exception {
         final SemanticVersion versionA = SemanticVersion.parse("4.0.559.0");
         assertThrows(NullPointerException.class,
@@ -158,6 +158,7 @@ class SemanticVersionTest {
     }
 
     @Test
+    @SuppressWarnings("NullAway") // Intentionally passing a null literal to verify parse() throws NPE.
     void parseNull() throws Exception {
         assertThrows(NullPointerException.class, () -> SemanticVersion.parse(null));
     }
@@ -177,7 +178,6 @@ class SemanticVersionTest {
         assertEquals(expectedLesserVersions, actualLesserVersions);
     }
 
-    @Nonnull
     private static String randomVersionString(Random r) {
         if (r.nextBoolean()) {
             List<SemanticVersion.SemanticVersionType> singletons = Arrays.stream(SemanticVersion.SemanticVersionType.values())

--- a/yaml-tests/yaml-tests.gradle
+++ b/yaml-tests/yaml-tests.gradle
@@ -22,6 +22,10 @@ import java.util.concurrent.ThreadLocalRandom
 import java.util.jar.JarFile
 import java.util.regex.Matcher
 
+plugins {
+    alias(libs.plugins.errorprone)
+}
+
 apply from: rootProject.file('gradle/proto.gradle')
 
 project.tasks.named("processResources") {
@@ -49,7 +53,7 @@ dependencies {
     implementation project(":fdb-relational-jdbc")
     implementation project(":fdb-relational-server")
     implementation(libs.jline)
-    implementation(libs.jsr305)
+    compileOnly(libs.jspecify)
     implementation(libs.junit.api)
     implementation(libs.junit.params)
     implementation(libs.junit.platform)
@@ -71,6 +75,24 @@ dependencies {
     implementation(libs.diffutils)
     compileOnly(libs.autoService)
     annotationProcessor(libs.autoService)
+
+    errorprone(libs.errorprone.core)
+    errorprone(libs.nullaway)
+}
+
+// jspecify + NullAway, scoped to this module only. See @NullMarked package-info.java files
+// under com.apple.foundationdb.relational.yamltests (and its sub-packages). Generated protobuf
+// code (com.apple.foundationdb.relational.yamltests.generated.*) is carved out via
+// UnannotatedSubPackages.
+tasks.withType(JavaCompile).configureEach {
+    options.errorprone {
+        disableAllChecks = true
+        error("NullAway")
+        option("NullAway:AnnotatedPackages", "com.apple.foundationdb.relational.yamltests")
+        option("NullAway:UnannotatedSubPackages", "com.apple.foundationdb.relational.yamltests.generated")
+        option("NullAway:JSpecifyMode", "true")
+        option("NullAway:AcknowledgeRestrictiveAnnotations", "true")
+    }
 }
 
 // Versions that should never be selected as an "other" external server when resolving dynamic versions for


### PR DESCRIPTION
14th (final) of a 14-PR stack adopting jspecify + NullAway null-checking, stacked on #4586 (`fdb-relational-server`). Same treatment applied to `yaml-tests`. See inline comments for specific findings.