### PR TITLE
Add tests to pin Issue #4573

### DIFF
--- a/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBStreamAggregationTest.java
+++ b/fdb-record-layer-core/src/test/java/com/apple/foundationdb/record/provider/foundationdb/query/FDBStreamAggregationTest.java
@@ -45,6 +45,7 @@ import com.apple.foundationdb.record.query.plan.cascades.values.AggregateValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.ArrayAggValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.CountValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.FieldValue;
+import com.apple.foundationdb.record.query.plan.cascades.values.NullValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.NumericAggregationValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.RecordConstructorValue;
 import com.apple.foundationdb.record.query.plan.cascades.values.Value;
@@ -55,6 +56,7 @@ import com.apple.foundationdb.record.query.plan.plans.RecordQueryScanPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryStreamingAggregationPlan;
 import com.apple.foundationdb.record.query.plan.plans.RecordQueryTypeFilterPlan;
 import com.apple.test.Tags;
+import com.google.common.base.VerifyException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.ByteString;
@@ -385,6 +387,56 @@ class FDBStreamAggregationTest extends FDBRecordStoreQueryTestBase {
                     continuation4.toBytes(), this::assertResultWithArrays, resultOf("1", List.of(3, 4, 5)));
 
             Assertions.assertEquals(RecordCursorEndContinuation.END, continuation5);
+        }
+    }
+
+    /**
+     * Tests that resuming mid-group currently fails a {@code verify()} when one of two scalar aggregates has no value
+     * yet. Pins Issue #4573.
+     */
+    @Test
+    void partialAggregateTwoScalarsOneWithoutValue() {
+        try (final var context = openContext()) {
+            openSimpleRecordStore(context, NO_HOOK);
+
+            final var plan =
+                    new AggregationPlanBuilder(recordStore.getRecordMetaData(), "MySimpleRecord")
+                            .withAggregateValue("num_value_2", value -> new NumericAggregationValue.Sum(
+                                    NumericAggregationValue.PhysicalOperator.SUM_I, value))
+                            .withAggregateValue("num_value_2", ignored -> new NumericAggregationValue.Sum(
+                                    NumericAggregationValue.PhysicalOperator.SUM_I,
+                                    new NullValue(Type.primitiveType(Type.TypeCode.INT))))
+                            .withGroupCriterion("str_value_indexed")
+                            .build(false);
+
+            // Stops inside the first group, so the continuation carries only 1 state for 2 children.
+            final RecordCursorContinuation continuation = executePlanWithRecordScanLimit(plan, 5, null);
+            Assertions.assertThrows(VerifyException.class,
+                    () -> executePlanWithRecordScanLimit(plan, 1, continuation.toBytes()));
+        }
+    }
+
+    /**
+     * Tests that {@code ARRAY_AGG()} alongside a scalar aggregate without a value fails the same {@code verify()}
+     * as {@link #partialAggregateTwoScalarsOneWithoutValue}. Pins Issue #4573.
+     */
+    @Test
+    void partialAggregateArrayAggWithScalarWithoutValue() {
+        try (final var context = openContext()) {
+            openSimpleRecordStore(context, NO_HOOK);
+
+            final var plan =
+                    new AggregationPlanBuilder(recordStore.getRecordMetaData(), "MySimpleRecord")
+                            .withAggregateValue("num_value_2", ignored -> new NumericAggregationValue.Sum(
+                                    NumericAggregationValue.PhysicalOperator.SUM_I,
+                                    new NullValue(Type.primitiveType(Type.TypeCode.INT))))
+                            .withAggregateValue("num_value_2", value -> new ArrayAggValue(value, true))
+                            .withGroupCriterion("str_value_indexed")
+                            .build(false);
+
+            final RecordCursorContinuation continuation = executePlanWithRecordScanLimit(plan, 5, null);
+            Assertions.assertThrows(VerifyException.class,
+                    () -> executePlanWithRecordScanLimit(plan, 1, continuation.toBytes()));
         }
     }
 

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/GroupByQueryTests.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/GroupByQueryTests.java
@@ -26,7 +26,9 @@ import com.apple.foundationdb.relational.api.RelationalResultSet;
 import com.apple.foundationdb.relational.recordlayer.EmbeddedRelationalExtension;
 import com.apple.foundationdb.relational.recordlayer.Utils;
 import com.apple.foundationdb.relational.utils.Ddl;
+import com.apple.foundationdb.relational.utils.RelationalAssertions;
 import com.apple.foundationdb.relational.utils.ResultSetAssert;
+import com.google.common.base.VerifyException;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
@@ -38,6 +40,7 @@ import java.net.URI;
 
 import static com.apple.foundationdb.relational.recordlayer.query.QueryTestUtils.insertT1Record;
 import static com.apple.foundationdb.relational.recordlayer.query.QueryTestUtils.insertT1RecordColAIsNull;
+import static com.apple.foundationdb.relational.recordlayer.query.QueryTestUtils.insertT1RecordColBIsNull;
 
 public class GroupByQueryTests {
 
@@ -110,6 +113,49 @@ public class GroupByQueryTests {
                         continuation = resultSet.getContinuation();
                     }
                     Assertions.assertTrue(continuation.atEnd());
+                }
+            }
+        }
+    }
+
+    /**
+     * Tests that resuming a group mid-way currently fails a {@code verify()} when one of its aggregates has no value
+     * yet. Pins Issue #4573.
+     */
+    @Test
+    void groupByWithScanLimitAndAggregateWithoutValue() throws Exception {
+        final String schemaTemplate =
+                "CREATE TABLE T1(pk bigint, a bigint, b bigint, c bigint, PRIMARY KEY(pk))" +
+                        "CREATE INDEX idx1 ON t1(a, b, c)";
+        try (var ddl = Ddl.builder().database(URI.create("/TEST/QT")).relationalExtension(relationalExtension).schemaTemplate(schemaTemplate).build()) {
+            try (var conn = ddl.setSchemaAndGetConnection()) {
+                final Continuation continuation;
+                try (var statement = conn.createStatement()) {
+                    // Group `a = 1` holds 3 rows, so a scan limit of 2 stops inside the group, at which point `MAX(b)` has no value yet.
+                    insertT1RecordColBIsNull(statement, 2, 1, 20);
+                    insertT1RecordColBIsNull(statement, 3, 1, 5);
+                    insertT1RecordColBIsNull(statement, 4, 1, 15);
+                    insertT1RecordColBIsNull(statement, 5, 2, 10);
+                    insertT1RecordColBIsNull(statement, 6, 2, 40);
+                    insertT1RecordColBIsNull(statement, 7, 2, 90);
+                }
+
+                conn.setOption(Options.Name.EXECUTION_SCANNED_ROWS_LIMIT, 2);
+                try (var statement = conn.createStatement()) {
+                    Assertions.assertTrue(statement.execute("SELECT a, MAX(c), MAX(b) FROM T1 GROUP BY a"),
+                            "Did not return a result set from a select statement!");
+                    try (final RelationalResultSet resultSet = statement.getResultSet()) {
+                        ResultSetAssert.assertThat(resultSet).hasNoNextRow();
+                        continuation = resultSet.getContinuation();
+                    }
+                }
+                Assertions.assertFalse(continuation.atEnd(), "expected the scan to stop inside the first group");
+
+                try (var preparedStatement = conn.prepareStatement("EXECUTE CONTINUATION ?param")) {
+                    preparedStatement.setBytes("param", continuation.serialize());
+                    RelationalAssertions.assertThrowsSqlException(preparedStatement::executeQuery)
+                            .rootCause()
+                            .isInstanceOf(VerifyException.class);
                 }
             }
         }

--- a/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/QueryTestUtils.java
+++ b/fdb-relational-core/src/test/java/com/apple/foundationdb/relational/recordlayer/query/QueryTestUtils.java
@@ -53,4 +53,15 @@ public class QueryTestUtils {
         Assertions.assertEquals(1, cnt, "Incorrect insertion count");
         return result;
     }
+
+    public static RelationalStruct insertT1RecordColBIsNull(@Nonnull final RelationalStatement statement, long pk, long a, long c) throws SQLException {
+        var result = EmbeddedRelationalStruct.newBuilder()
+                .addLong("PK", pk)
+                .addLong("A", a)
+                .addLong("C", c)
+                .build();
+        int cnt = statement.executeInsert("T1", result);
+        Assertions.assertEquals(1, cnt, "Incorrect insertion count");
+        return result;
+    }
 }

--- a/yaml-tests/src/test/resources/groupby-tests.yamsql
+++ b/yaml-tests/src/test/resources/groupby-tests.yamsql
@@ -27,6 +27,8 @@ schema_template:
     create type as struct st4(s bigint, t bigint)
     create table nested(id bigint, q st4, r st3, primary key(q.s, r.u.w))
     create index i2 as select r.v.z from nested order by r.v.z
+    create table t2(pk bigint, a bigint, b bigint, c bigint, primary key(pk))
+    create index i3 as select a from t2 order by a
 ---
 setup:
   steps:
@@ -53,6 +55,13 @@ setup:
                (6, (329, 6), ((5, 15), (10, 140))),
                (7, (328, 7), ((5, 15), (10, 140))),
                (8, (327, 8), ((5, 15), (10, 140)))
+    - query: INSERT INTO T2
+        VALUES (2, 1, NULL, 20),
+               (3, 1, NULL, 5),
+               (4, 1, NULL, 15),
+               (5, 2, NULL, 10),
+               (6, 2, NULL, 40),
+               (7, 2, NULL, 90)
 ---
 test_block:
   name: group-by-tests
@@ -276,6 +285,20 @@ test_block:
       - result: [{!l 10, !l 5}]
       - result: []
       - result: [{!l 20, !l 8}]
+---
+# Resuming a group mid-way currently fails when one of its aggregates has no value yet. Pins Issue #4573.
+test_block:
+  name: group-by-with-aggregate-without-value
+  preset: single_repetition_ordered
+  options:
+    connection_options:
+      EXECUTION_SCANNED_ROWS_LIMIT: 2
+  tests:
+    -
+      # Group `a = 1` holds 3 rows, so a scan limit of 2 stops inside the group, at which point `MAX(b)` has no value yet.
+      - query: SELECT a, MAX(c), MAX(b) FROM T2 GROUP BY a
+      - result: []
+      - error: INTERNAL_ERROR
 ---
 # Aggregates over a record constructor. These are regression tests for Issue #4481. They exercise the interaction of
 # `collapseSimpleSelectMaybe()`, which collapses some of these record constructors, with the group-by pull-up logic.


### PR DESCRIPTION
While working on `ARRAY_AGG()` we uncovered an existing defect in the `RecordConstructorValue` composite accumulator, now tracked under Issue #4573. This change adds tests to document the issue.