### PR TITLE
Update `.idea/checkstyle-idea.xml`

### DIFF
--- a/.idea/checkstyle-idea.xml
+++ b/.idea/checkstyle-idea.xml
@@ -9,8 +9,8 @@
     </option>
     <option name="locations">
       <list>
-        <ConfigurationLocation id="bundled-sun-checks" type="BUNDLED" scope="All" description="Sun Checks">(bundled)</ConfigurationLocation>
-        <ConfigurationLocation id="bundled-google-checks" type="BUNDLED" scope="All" description="Google Checks">(bundled)</ConfigurationLocation>
+        <ConfigurationLocation id="bundled-sun-checks" type="BUNDLED" scope="All" description="Sun Checks">bundled-sun-checks</ConfigurationLocation>
+        <ConfigurationLocation id="bundled-google-checks" type="BUNDLED" scope="All" description="Google Checks">bundled-google-checks</ConfigurationLocation>
         <ConfigurationLocation id="aa820844-959a-4c2d-9ca2-9b049d907e43" type="PROJECT_RELATIVE" scope="All" description="Record Layer Checks">
           $PROJECT_DIR$/gradle/codequality/checkstyle.xml
           <option name="properties">


### PR DESCRIPTION
Newer versions of the CheckStyle-IDEA plugin, starting from 26.18.1, generate a slightly different `<ConfigurationLocation>` element body for the two `BUNDLED` entries. This is a benign cosmetic change; the element body does not affect the behavior of the plugin. So we can just check in the new version without having to worry about breaking developers who are still running with an older version. (Though older plugins will write the old text back, so everybody should update their plugin eventually.)