### PR TITLE
Disable the Gradle problems report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ hs_err_pid*
 /target
 */target
 **/*/build
+/build/reports/
 
 # IntelliJ specific files/directories
 out

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,6 +46,9 @@ org.gradle.configuration-cache.problems=fail
 # Don’t try to auto-provision JDKs. We prefer to only resolve Java toolchains from locally installed JDKs.
 org.gradle.java.installations.auto-download=false
 
+# Disable generation of the HTML problems report under `build/reports/`.
+org.gradle.problems.report=false
+
 url = 'https://github.com/FoundationDB/fdb-record-layer/'
 
 # Control which places we attempt to publish to


### PR DESCRIPTION
* Disable the automatic generation of the HTML report.
* Add `/build/reports/` to gitignore.

Since version 8.11, Gradle automatically generates a `problems-report.html` file if a build had any problems. However, since we are using an incubating module, _every_ build will have at least a `using incubating module(s): jdk.incubator.vector` warning, and there is no targeted compiler option to silence this warning. So a report will be generated for _every_ build, which is noisy. Given that the normal build output will already print any problems, we don’t need this report to be generated automatically. We can add it to `.gitignore` nevertheless, so it won’t show up as an untracked file in case a developer wants to override this option.