### PR TITLE
Reject `IN (SELECT …)` subqueries properly as `UNSUPPORTED_QUERY`

### DIFF
--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/AstNormalizer.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/AstNormalizer.java
@@ -452,25 +452,30 @@ public final class AstNormalizer extends RelationalParserBaseVisitor<Object> {
         } else if (ctx.inList().fullColumnName() != null) {
             visit(ctx.inList().fullColumnName());
         } else {
-            rejectNullItems(ctx.inList().expressions());
+            Assert.thatUnchecked(
+                    ctx.inList().queryExpressionBody() == null,
+                    ErrorCode.UNSUPPORTED_QUERY,
+                    "IN predicate does not support nested SELECT");
+            final RelationalParser.ExpressionsContext expressions = ctx.inList().expressions();
+            rejectNullItems(expressions);
             sqlCanonicalizer.append("( ");
-            if (ParseHelpers.isConstant(ctx.inList().expressions())) {
+            if (ParseHelpers.isConstant(expressions)) {
                 // todo (yhatem) we should prevent making the constant expressions
                 //   contribute to the hash or the canonical query representation.
                 queryHasherContextBuilder.getLiteralsBuilder().startArrayLiteral();
                 allowTokenAddition = false;
                 sqlCanonicalizer.append("[ ");
-                for (int i = 0; i < ctx.inList().expressions().expression().size(); i++) {
-                    visit(ctx.inList().expressions().expression(i));
+                for (int i = 0; i < expressions.expression().size(); i++) {
+                    visit(expressions.expression(i));
                 }
                 queryHasherContextBuilder.getLiteralsBuilder().finishArrayLiteral(null,
                         null, true, ctx.inList().getStart().getTokenIndex());
                 allowTokenAddition = true;
                 sqlCanonicalizer.append("] ");
             } else {
-                final var size = ctx.inList().expressions().expression().size();
+                final var size = expressions.expression().size();
                 for (int i = 0; i < size; i++) {
-                    visit(ctx.inList().expressions().expression(i));
+                    visit(expressions.expression(i));
                     if (i < size - 1) {
                         sqlCanonicalizer.append(", ");
                     }

--- a/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/ExpressionVisitor.java
+++ b/fdb-relational-core/src/main/java/com/apple/foundationdb/relational/recordlayer/query/visitors/ExpressionVisitor.java
@@ -689,7 +689,9 @@ public final class ExpressionVisitor extends DelegatingVisitor<BaseVisitor> {
 
     @Nonnull
     private Expression visitInPredicate(@Nonnull Expression operand, @Nonnull RelationalParser.InPredicateContext ctx) {
-        Assert.thatUnchecked(ctx.inList().queryExpressionBody() == null, ErrorCode.UNSUPPORTED_QUERY,
+        Assert.thatUnchecked(
+                ctx.inList().queryExpressionBody() == null,
+                ErrorCode.UNSUPPORTED_QUERY,
                 "IN predicate does not support nested SELECT");
         final var right = visitInList(ctx.inList());
         var in = getDelegate().resolveFunction(ctx.IN().getText(), operand, right);

--- a/yaml-tests/src/test/resources/in-predicate.yamsql
+++ b/yaml-tests/src/test/resources/in-predicate.yamsql
@@ -414,6 +414,16 @@ test_block:
       - unorderedResult: [
           {ID: 1, F: 'apple', IDX: 1},
           {ID: 3, F: 'apple', IDX: 1}, {ID: 3, F: 'mango', IDX: 3}]
+    -
+      # An IN list holding a subquery, i.e. the semi-join form of IN, is not supported yet.
+      - query: select a, b from ta where b in (select a from ta)
+      - supported_version: !current_version
+      - error: UNSUPPORTED_QUERY
+    -
+      # The NOT IN counterpart, i.e. the anti-join form, is rejected through the same code path.
+      - query: select a, b from ta where b not in (select a from ta)
+      - supported_version: !current_version
+      - error: UNSUPPORTED_QUERY
 ---
 # Following tests are run once because running them the second time around causes the error to be different. This is
 # "expected" as the point of error is different in both the cases.

--- a/yaml-tests/src/test/resources/join-tests-outer.yamsql
+++ b/yaml-tests/src/test/resources/join-tests-outer.yamsql
@@ -111,6 +111,12 @@ test_block:
       - explain: "ISCAN(emp$fname <,>) | FLATMAP q0 -> { SCAN([IS dept, EQUALS q0.dept_id]) | MAP (_.id AS id) | DEFAULT NULL | FILTER NOT _ NOT_NULL AS q1 RETURN (q0.fname AS fname, q0.lname AS lname) }"
       - result: [{'Dave', 'Kim'}]
     -
+      # The same anti-join expressed via NOT IN over a subquery, for completeness. However, a subquery IN list is not
+      # supported yet.
+      - query: SELECT "e"."fname", "e"."lname" FROM "emp" "e" WHERE "e"."dept_id" NOT IN (SELECT "d"."id" FROM "dept" "d");
+      - supported_version: !current_version
+      - error: UNSUPPORTED_QUERY
+    -
       # WHERE with a different null-accepting predicate on the null-producing side, projecting that side too.
       # Only Dave is unmatched, so only Dave should appear with a null name.
       - query: SELECT "e"."fname", "d"."name" FROM "emp" "e" LEFT JOIN "dept" "d" ON "e"."dept_id" = "d"."id" WHERE "d"."name" IS NULL;


### PR DESCRIPTION
In `AstNormalizer.visitInPredicate()`, add an assert that raises `UNSUPPORTED_QUERY` if the `IN` predicate has a nested `SELECT`, which isn’t supported yet. The same guard already exists in `ExpressionVisitor.visitInPredicate()`, but is effectively unreachable because normalization runs first and, as written, only handles `expressions()`, which is null in the `IN (SELECT …)` case and, prior to this change, would trigger a `NullPointerException`.