### PR TITLE
Change OperationsTest to not use `join`

### DIFF
--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/common/CommonTestHelpers.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/common/CommonTestHelpers.java
@@ -20,6 +20,8 @@
 
 package com.apple.foundationdb.async.common;
 
+import com.apple.foundationdb.Database;
+import com.apple.foundationdb.Transaction;
 import com.apple.foundationdb.linear.DoubleRealVector;
 import com.apple.foundationdb.linear.HalfRealVector;
 import com.apple.foundationdb.linear.Metric;
@@ -36,13 +38,72 @@ import java.util.List;
 import java.util.NavigableSet;
 import java.util.Random;
 import java.util.TreeSet;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
 import java.util.function.ToDoubleBiFunction;
 
 import static com.apple.foundationdb.linear.RealVectorTest.createRandomHalfVector;
 
 public final class CommonTestHelpers {
+    /**
+     * Time budget for a single logical database operation in a test, including any retries.
+     * <p>
+     * A test must never block indefinitely. {@link CompletableFuture#join()} is uninterruptible, so JUnit's
+     * default per-test timeout ({@code junit.jupiter.execution.timeout.default}, see
+     * {@code gradle/testing.gradle}) cannot stop a test that blocks on it: the interrupt JUnit sends is
+     * swallowed, and the timeout failure is only reported once the test finishes on its own. Waiting with a
+     * bounded {@code get} instead fails the test rather than hanging the whole suite.
+     */
+    public static final long ASYNC_TO_SYNC_TIMEOUT_MINUTES = 2L;
+
     private CommonTestHelpers() {
         // nothing
+    }
+
+    /**
+     * Blocks until {@code future} completes, failing after {@link #ASYNC_TO_SYNC_TIMEOUT_MINUTES} minutes.
+     * <p>
+     * This module sits below {@code fdb-record-layer-core}, so the record layer's {@code asyncToSync} is not
+     * reachable from here; this is the stand-in for it.
+     *
+     * @param future the future to wait for
+     * @param <T> the type {@code future} completes with
+     *
+     * @return the result of {@code future}
+     *
+     * @throws ExecutionException if {@code future} completes exceptionally
+     * @throws InterruptedException if the current thread is interrupted while waiting
+     * @throws TimeoutException if {@code future} does not complete within the time budget
+     */
+    public static <T> T asyncToSync(@Nonnull final CompletableFuture<T> future)
+            throws ExecutionException, InterruptedException, TimeoutException {
+        return future.get(ASYNC_TO_SYNC_TIMEOUT_MINUTES, TimeUnit.MINUTES);
+    }
+
+    /**
+     * Runs {@code retryable} in a transaction and blocks for its result, bounding the wait as described in
+     * {@link #asyncToSync(CompletableFuture)}.
+     * <p>
+     * Prefer this over {@code db.run(tr -> something(tr).join())}: the time budget covers the entire
+     * {@link Database#runAsync(Function)} retry loop, which is otherwise unbounded.
+     *
+     * @param db the database to run against
+     * @param retryable the transactional operation to run
+     * @param <T> the type the operation completes with
+     *
+     * @return the result of {@code retryable}
+     *
+     * @throws ExecutionException if the operation completes exceptionally
+     * @throws InterruptedException if the current thread is interrupted while waiting
+     * @throws TimeoutException if the operation does not complete within the time budget
+     */
+    public static <T> T runAsyncToSync(@Nonnull final Database db,
+                                       @Nonnull final Function<? super Transaction, ? extends CompletableFuture<T>> retryable)
+            throws ExecutionException, InterruptedException, TimeoutException {
+        return asyncToSync(db.runAsync(retryable));
     }
 
     @Nonnull

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/OperationsTest.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/OperationsTest.java
@@ -21,7 +21,7 @@
 package com.apple.foundationdb.async.hnsw;
 
 import com.apple.foundationdb.Database;
-import com.apple.foundationdb.async.AsyncIterator;
+import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.async.common.BaseTest;
 import com.apple.foundationdb.async.common.CommonTestHelpers;
 import com.apple.foundationdb.async.common.PrimaryKeyAndVector;
@@ -79,6 +79,7 @@ import java.util.NavigableSet;
 import java.util.Objects;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -88,6 +89,7 @@ import java.util.stream.Stream;
 
 import static com.apple.foundationdb.async.common.CommonTestHelpers.orderedByDistances;
 import static com.apple.foundationdb.async.common.CommonTestHelpers.randomVectors;
+import static com.apple.foundationdb.async.common.CommonTestHelpers.runAsyncToSync;
 import static com.apple.foundationdb.linear.RealVectorTest.createRandomDoubleVector;
 import static com.apple.foundationdb.linear.RealVectorTest.createRandomHalfVector;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -161,7 +163,7 @@ class OperationsTest implements BaseTest {
                     return randomCompactNode;
                 });
 
-        db.run(tr -> storageAdapter.fetchNode(tr, StorageTransform.identity(), 0,
+        runAsyncToSync(db, tr -> storageAdapter.fetchNode(tr, StorageTransform.identity(), 0,
                         originalNode.getPrimaryKey())
                 .thenAccept(node ->
                         assertThat(node).satisfies(
@@ -179,7 +181,7 @@ class OperationsTest implements BaseTest {
                                     originalNeighbors.sort(Comparator.comparing(NodeReference::getPrimaryKey));
                                     assertThat(neighbors).isEqualTo(originalNeighbors);
                                 }
-                )).join());
+                )));
 
         assertThat(
                 TestHelpers.dumpLayer(getDb(), getSubspace(), HNSW.newConfigBuilder()
@@ -210,7 +212,7 @@ class OperationsTest implements BaseTest {
                     return randomInliningNode;
                 });
 
-        db.run(tr -> storageAdapter.fetchNode(tr, StorageTransform.identity(), 1,
+        runAsyncToSync(db, tr -> storageAdapter.fetchNode(tr, StorageTransform.identity(), 1,
                         originalNode.getPrimaryKey())
                 .thenAccept(node ->
                         assertThat(node).satisfies(
@@ -226,7 +228,7 @@ class OperationsTest implements BaseTest {
                                     originalNeighbors.sort(Comparator.comparing(NodeReference::getPrimaryKey));
                                     assertThat(neighbors).isEqualTo(originalNeighbors);
                                 }
-                        )).join());
+                        )));
 
         assertThat(
                 TestHelpers.dumpLayer(getDb(), getSubspace(), HNSW.newConfigBuilder()
@@ -363,8 +365,7 @@ class OperationsTest implements BaseTest {
         onReadListener.reset();
         final long beginTs = System.nanoTime();
         final List<? extends ResultEntry> results =
-                db.run(tr ->
-                        hnsw.kNearestNeighborsSearch(tr, k, 100, true, queryVector).join());
+                runAsyncToSync(db, tr -> hnsw.kNearestNeighborsSearch(tr, k, 100, true, queryVector));
         final long endTs = System.nanoTime();
 
         final ImmutableSet<Tuple> trueNN =
@@ -432,8 +433,8 @@ class OperationsTest implements BaseTest {
         onReadListener.reset();
         final long beginTs = System.nanoTime();
         final List<? extends ResultEntry> results =
-                db.run(tr ->
-                        hnsw.kNearestNeighborsRingSearch(tr, k, 100, true, queryVector, radius).join());
+                runAsyncToSync(db, tr ->
+                        hnsw.kNearestNeighborsRingSearch(tr, k, 100, true, queryVector, radius));
         final long endTs = System.nanoTime();
 
         final ImmutableSet<Tuple> trueNN =
@@ -482,14 +483,17 @@ class OperationsTest implements BaseTest {
                     CommonTestHelpers.pickRandomVectors(random, remainingData, numVectorsPerDeleteBatch);
 
             final long beginTs = System.nanoTime();
-            db.run(tr -> {
+            runAsyncToSync(db, tr -> {
                 onWriteListener.reset();
                 onReadListener.reset();
 
+                // Chain the deletes rather than issuing them concurrently: this test is about delete
+                // semantics, not about hnsw's handling of concurrent mutations within one transaction.
+                CompletableFuture<Void> future = AsyncUtil.DONE;
                 for (final PrimaryKeyAndVector primaryKeyAndVector : toBeDeleted) {
-                    hnsw.delete(tr, primaryKeyAndVector.primaryKey()).join();
+                    future = future.thenCompose(ignored -> hnsw.delete(tr, primaryKeyAndVector.primaryKey()));
                 }
-                return null;
+                return future;
             });
             long endTs = System.nanoTime();
 
@@ -517,8 +521,7 @@ class OperationsTest implements BaseTest {
 
                 final long beginTsQuery = System.nanoTime();
                 final List<? extends ResultEntry> results =
-                        db.run(tr ->
-                                hnsw.kNearestNeighborsSearch(tr, k, 100, true, queryVector).join());
+                        runAsyncToSync(db, tr -> hnsw.kNearestNeighborsSearch(tr, k, 100, true, queryVector));
                 final long endTsQuery = System.nanoTime();
 
                 int recallCount = 0;
@@ -543,8 +546,8 @@ class OperationsTest implements BaseTest {
         } while (!remainingData.isEmpty());
 
         final var accessInfo =
-                db.run(transaction -> StorageAdapter.fetchAccessInfo(hnsw.getConfig(),
-                        transaction, hnsw.getSubspace(), OnReadListener.NOOP).join());
+                runAsyncToSync(db, transaction -> StorageAdapter.fetchAccessInfo(hnsw.getConfig(),
+                        transaction, hnsw.getSubspace(), OnReadListener.NOOP));
         assertThat(accessInfo).isNull();
     }
 
@@ -594,8 +597,7 @@ class OperationsTest implements BaseTest {
         // Still run a kNN search to make sure that recall is satisfactory.
         //
         final List<? extends ResultEntry> results =
-                db.run(tr ->
-                        hnsw.kNearestNeighborsSearch(tr, k, 500, true, queryVector).join());
+                runAsyncToSync(db, tr -> hnsw.kNearestNeighborsSearch(tr, k, 500, true, queryVector));
 
         final ImmutableSet<Tuple> trueNN =
                 orderedByDistances(metric, insertedData, queryVector)
@@ -664,16 +666,11 @@ class OperationsTest implements BaseTest {
         onReadListener.reset();
 
         final List<ResultEntry> results =
-                db.run(tr -> {
-                    final AsyncIterator<ResultEntry> it =
-                            hnsw.orderByDistance(tr, 100, 1000, false,
-                                    queryVector, discriminator.distance(), discriminator.primaryKey(), false);
-                    final ImmutableList.Builder<ResultEntry> resultsBuilder = ImmutableList.builder();
-                    while (it.hasNext()) {
-                        resultsBuilder.add(it.next());
-                    }
-                    return resultsBuilder.build();
-                });
+                runAsyncToSync(db, tr ->
+                        AsyncUtil.collectRemaining(
+                                hnsw.orderByDistance(tr, 100, 1000, false,
+                                        queryVector, discriminator.distance(), discriminator.primaryKey(), false),
+                                TestExecutors.defaultThreadPool()));
 
         int numInversions = 0;
         for (int i = 1; i < results.size(); i++) {

--- a/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/TestHelpers.java
+++ b/fdb-extensions/src/test/java/com/apple/foundationdb/async/hnsw/TestHelpers.java
@@ -75,6 +75,7 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.ToDoubleBiFunction;
 
+import static com.apple.foundationdb.async.common.CommonTestHelpers.runAsyncToSync;
 import static com.apple.foundationdb.linear.RealVectorTest.createRandomHalfVector;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
@@ -104,7 +105,7 @@ class TestHelpers {
                                                       final long firstId,
                                                       @Nonnull final BiFunction<Transaction, Long, PrimaryKeyAndVector> insertFunction)
             throws ExecutionException, InterruptedException, TimeoutException {
-        return db.runAsync(tr -> {
+        return runAsyncToSync(db, tr -> {
             final TestOnWriteListener onWriteListener = (TestOnWriteListener)hnsw.getOnWriteListener();
             onWriteListener.reset();
             final TestOnReadListener onReadListener = (TestOnReadListener)hnsw.getOnReadListener();
@@ -135,7 +136,7 @@ class TestHelpers {
                                     onReadListener.getNodeCountByLayer(), onReadListener.getBytesReadByLayer());
                         }
                     });
-        }).get(2, TimeUnit.MINUTES); // set a timeout for inserting a single batch including retries so setup won't run forever
+        });
     }
 
     static List<PrimaryKeyAndVector> insertSIFTSmall(@Nonnull final Database db,
@@ -175,7 +176,7 @@ class TestHelpers {
     static void validateSIFTSmall(@Nonnull final Database db,
                                   @Nonnull final HNSW hnsw,
                                   @Nonnull final List<PrimaryKeyAndVector> data,
-                                  final int k) throws IOException {
+                                  final int k) throws IOException, ExecutionException, InterruptedException, TimeoutException {
         final Metric metric = hnsw.getConfig().metric();
         final Path siftSmallGroundTruthPath = Paths.get(".out/extracted/siftsmall/siftsmall_groundtruth.ivecs");
         final Path siftSmallQueryPath = Paths.get(".out/extracted/siftsmall/siftsmall_query.fvecs");
@@ -195,8 +196,8 @@ class TestHelpers {
                 onReadListener.reset();
                 final long beginTs = System.nanoTime();
                 final List<? extends ResultEntry> results =
-                        db.run(tr -> hnsw.kNearestNeighborsSearch(tr, k, 100,
-                                true, queryVector).join());
+                        runAsyncToSync(db, tr -> hnsw.kNearestNeighborsSearch(tr, k, 100,
+                                true, queryVector));
                 final long endTs = System.nanoTime();
                 logger.info("retrieved result in elapsedTimeMs={}, reading numNodes={}, readBytes={}",
                         TimeUnit.NANOSECONDS.toMillis(endTs - beginTs),
@@ -254,9 +255,10 @@ class TestHelpers {
 
     static int getEntryLayer(@Nonnull final Database db,
                              @Nonnull final Subspace subspace,
-                             @Nonnull final Config config) {
-        @Nullable final AccessInfo accessInfo = db.run(readTransaction ->
-                StorageAdapter.fetchAccessInfo(config, readTransaction, subspace, OnReadListener.NOOP).join());
+                             @Nonnull final Config config)
+            throws ExecutionException, InterruptedException, TimeoutException {
+        @Nullable final AccessInfo accessInfo = runAsyncToSync(db, readTransaction ->
+                StorageAdapter.fetchAccessInfo(config, readTransaction, subspace, OnReadListener.NOOP));
         return accessInfo == null
                ? -1
                : accessInfo.getEntryNodeReference().getLayer();
@@ -265,7 +267,8 @@ class TestHelpers {
     static void dumpLayers(@Nonnull final Database db,
                            @Nonnull final Subspace subspace,
                            @Nonnull final Config config,
-                           @Nonnull final Path tempDir) {
+                           @Nonnull final Path tempDir)
+            throws ExecutionException, InterruptedException, TimeoutException {
         final int entryLayer = getEntryLayer(db, subspace, config);
 
         if (entryLayer < 0) {
@@ -394,7 +397,7 @@ class TestHelpers {
 
     static class DumpLayersIfFailure implements AfterTestExecutionCallback {
         @Override
-        public void afterTestExecution(@Nonnull final ExtensionContext context) {
+        public void afterTestExecution(@Nonnull final ExtensionContext context) throws Exception {
             final Optional<Throwable> failure = context.getExecutionException();
             if (failure.isEmpty()) {
                 return;


### PR DESCRIPTION
JUNit test timeouts use interrupts on the test thread to abort the test when it goes past the timeout, but `join` is uninterruptible, so it can end up hanging indefintely.
This doesn't fix the underlying issue with why we are seeing `fdb-extensions` timeout, but it will scope it, and the run will fail faster.